### PR TITLE
feat(gateway): implement KAT-108 API server skeleton with auth middleware

### DIFF
--- a/docs/verification/kat-108-gateway-skeleton.md
+++ b/docs/verification/kat-108-gateway-skeleton.md
@@ -1,0 +1,25 @@
+# KAT-108 Verification
+
+- [x] gateway package tooling baseline verified
+- [x] health and global error handling validated
+- [x] auth middleware validated (api key + redis session fail-closed)
+- [x] route group placeholders + OpenAPI generation validated
+- [x] rate limiting + CORS + logging behavior validated
+- [x] typecheck and tests passing
+
+## Command Output Summary
+
+```bash
+$ node tests/scaffold/gateway-package.test.mjs
+# PASS
+
+$ pnpm --filter @kata/gateway typecheck
+> @kata/gateway@0.0.0 typecheck
+> tsc --noEmit
+# PASS
+
+$ pnpm --filter @kata/gateway test
+> @kata/gateway@0.0.0 test
+> vitest run
+# 4 passed, 10 passed
+```

--- a/docs/verification/kat-108-gateway-skeleton.md
+++ b/docs/verification/kat-108-gateway-skeleton.md
@@ -21,5 +21,5 @@ $ pnpm --filter @kata/gateway typecheck
 $ pnpm --filter @kata/gateway test
 > @kata/gateway@0.0.0 test
 > vitest run
-# 4 passed, 10 passed
+# 6 passed (6 files), 21 passed (21 tests)
 ```

--- a/packages/gateway/.env.example
+++ b/packages/gateway/.env.example
@@ -1,0 +1,7 @@
+GATEWAY_PORT=3001
+GATEWAY_ALLOWED_ORIGINS=http://localhost:1420,http://localhost:5173
+SESSION_COOKIE_NAME=kata.sid
+SESSION_COOKIE_SECRET=replace-me-with-long-random-secret
+REDIS_URL=redis://localhost:6379
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX_REQUESTS=60

--- a/packages/gateway/.env.example
+++ b/packages/gateway/.env.example
@@ -1,7 +1,6 @@
 GATEWAY_PORT=3001
 GATEWAY_ALLOWED_ORIGINS=http://localhost:1420,http://localhost:5173
 SESSION_COOKIE_NAME=kata.sid
-SESSION_COOKIE_SECRET=replace-me-with-long-random-secret
 REDIS_URL=redis://localhost:6379
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX_REQUESTS=60

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -22,7 +22,7 @@
     "dotenv": "^16.4.5",
     "hono": "^4.6.10",
     "ioredis": "^5.4.1",
-    "zod": "^4.3.6"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -3,10 +3,30 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
-    "build": "node -e \"console.log('build not implemented yet')\"",
-    "lint": "node -e \"console.log('lint not implemented yet')\"",
-    "typecheck": "node -e \"console.log('typecheck not implemented yet')\"",
-    "test": "node -e \"console.log('tests not implemented yet')\""
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc --build",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "@hono/zod-openapi": "^0.16.4",
+    "dotenv": "^16.4.5",
+    "hono": "^4.6.10",
+    "ioredis": "^5.4.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "tsx": "^4.19.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/gateway/src/__tests__/api-key-adapter.test.ts
+++ b/packages/gateway/src/__tests__/api-key-adapter.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { createInMemoryApiKeyAdapter } from '../auth/api-key-adapter.js';
+
+describe('in-memory api key adapter', () => {
+  it('returns configured key details for known keys', async () => {
+    const adapter = createInMemoryApiKeyAdapter({
+      kat_live_123: { teamId: 'team-1', keyId: 'key-1' },
+    });
+
+    await expect(adapter.validateApiKey('kat_live_123')).resolves.toEqual({
+      teamId: 'team-1',
+      keyId: 'key-1',
+    });
+  });
+
+  it('rejects prototype-chain key lookups', async () => {
+    const adapter = createInMemoryApiKeyAdapter({
+      kat_live_123: { teamId: 'team-1', keyId: 'key-1' },
+    });
+
+    await expect(adapter.validateApiKey('__proto__')).resolves.toBeNull();
+    await expect(adapter.validateApiKey('constructor')).resolves.toBeNull();
+  });
+});

--- a/packages/gateway/src/__tests__/auth-middleware.test.ts
+++ b/packages/gateway/src/__tests__/auth-middleware.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGatewayApp } from '../app.js';
+
+function makeConfig() {
+  return {
+    port: 3001,
+    allowedOrigins: ['http://localhost:1420'],
+    sessionCookieName: 'kata.sid',
+    sessionCookieSecret: 'test-secret',
+    redisUrl: 'redis://localhost:6379',
+    rateLimitWindowMs: 60_000,
+    rateLimitMaxRequests: 60,
+  };
+}
+
+function makeDeps(overrides: Partial<Parameters<typeof createGatewayApp>[1]> = {}) {
+  return {
+    logger: {
+      info: () => {},
+      error: () => {},
+    },
+    apiKeyAuth: {
+      validateApiKey: vi.fn(async () => null),
+    },
+    sessionStore: {
+      getSession: vi.fn(async () => null),
+    },
+    now: () => new Date('2026-02-26T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('auth middleware', () => {
+  it('returns 401 on protected route without credentials', async () => {
+    const app = createGatewayApp(makeConfig(), makeDeps());
+    const res = await app.request('/api/teams');
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts valid API key', async () => {
+    const deps = makeDeps({
+      apiKeyAuth: {
+        validateApiKey: vi.fn(async () => ({ teamId: 'team-1', keyId: 'key-1' })),
+      },
+    });
+    const app = createGatewayApp(makeConfig(), deps);
+    const res = await app.request('/api/teams', {
+      headers: { 'x-api-key': 'kat_live_123' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('fails closed when session store throws', async () => {
+    const deps = makeDeps({
+      sessionStore: {
+        getSession: vi.fn(async () => {
+          throw new Error('redis down');
+        }),
+      },
+    });
+    const app = createGatewayApp(makeConfig(), deps);
+    const res = await app.request('/api/teams', {
+      headers: { cookie: 'kata.sid=sid-123' },
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTH_SERVICE_UNAVAILABLE');
+  });
+});

--- a/packages/gateway/src/__tests__/config.test.ts
+++ b/packages/gateway/src/__tests__/config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { loadGatewayConfig } from '../config.js';
+
+describe('loadGatewayConfig', () => {
+  it('throws readable error on missing required env vars', () => {
+    expect(() => loadGatewayConfig({} as NodeJS.ProcessEnv)).toThrow(
+      'Invalid gateway configuration',
+    );
+  });
+
+  it('returns valid config from complete env', () => {
+    const config = loadGatewayConfig({
+      REDIS_URL: 'redis://localhost:6379',
+    } as NodeJS.ProcessEnv);
+    expect(config.port).toBe(3001);
+    expect(config.redisUrl).toBe('redis://localhost:6379');
+    expect(config.sessionCookieName).toBe('kata.sid');
+  });
+});

--- a/packages/gateway/src/__tests__/health-and-errors.test.ts
+++ b/packages/gateway/src/__tests__/health-and-errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createGatewayApp } from '../app.js';
+
+const baseConfig = {
+  port: 3001,
+  allowedOrigins: ['http://localhost:1420'],
+  sessionCookieName: 'kata.sid',
+  sessionCookieSecret: 'test-secret',
+  redisUrl: 'redis://localhost:6379',
+  rateLimitWindowMs: 60_000,
+  rateLimitMaxRequests: 60,
+};
+
+const deps = {
+  logger: {
+    info: () => {},
+    error: () => {},
+  },
+  apiKeyAuth: {
+    validateApiKey: async () => null,
+  },
+  sessionStore: {
+    getSession: async () => null,
+  },
+  now: () => new Date('2026-02-26T00:00:00.000Z'),
+};
+
+describe('gateway app basics', () => {
+  it('returns health status', async () => {
+    const app = createGatewayApp(baseConfig, deps);
+    const res = await app.request('/health');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe('ok');
+  });
+
+  it('returns requestId on unknown route', async () => {
+    const app = createGatewayApp(baseConfig, deps);
+    const res = await app.request('/missing');
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe('NOT_FOUND');
+    expect(body.error.requestId).toBeTruthy();
+  });
+});

--- a/packages/gateway/src/__tests__/health-and-errors.test.ts
+++ b/packages/gateway/src/__tests__/health-and-errors.test.ts
@@ -5,7 +5,6 @@ const baseConfig = {
   port: 3001,
   allowedOrigins: ['http://localhost:1420'],
   sessionCookieName: 'kata.sid',
-  sessionCookieSecret: 'test-secret',
   redisUrl: 'redis://localhost:6379',
   rateLimitWindowMs: 60_000,
   rateLimitMaxRequests: 60,

--- a/packages/gateway/src/__tests__/openapi-and-routes.test.ts
+++ b/packages/gateway/src/__tests__/openapi-and-routes.test.ts
@@ -5,7 +5,6 @@ const config = {
   port: 3001,
   allowedOrigins: ['http://localhost:1420'],
   sessionCookieName: 'kata.sid',
-  sessionCookieSecret: 'test-secret',
   redisUrl: 'redis://localhost:6379',
   rateLimitWindowMs: 60_000,
   rateLimitMaxRequests: 60,

--- a/packages/gateway/src/__tests__/openapi-and-routes.test.ts
+++ b/packages/gateway/src/__tests__/openapi-and-routes.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { createGatewayApp } from '../app.js';
+
+const config = {
+  port: 3001,
+  allowedOrigins: ['http://localhost:1420'],
+  sessionCookieName: 'kata.sid',
+  sessionCookieSecret: 'test-secret',
+  redisUrl: 'redis://localhost:6379',
+  rateLimitWindowMs: 60_000,
+  rateLimitMaxRequests: 60,
+};
+
+const deps = {
+  logger: { info: () => {}, error: () => {} },
+  apiKeyAuth: {
+    validateApiKey: async () => ({ teamId: 'team-1', keyId: 'key-1' }),
+  },
+  sessionStore: {
+    getSession: async () => null,
+  },
+  now: () => new Date('2026-02-26T00:00:00.000Z'),
+};
+
+describe('openapi and route groups', () => {
+  it('serves openapi json', async () => {
+    const app = createGatewayApp(config, deps);
+    const res = await app.request('/openapi.json');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.openapi).toBe('3.0.0');
+    expect(body.paths['/api/specs']).toBeDefined();
+    expect(body.paths['/api/agents']).toBeDefined();
+    expect(body.paths['/api/teams']).toBeDefined();
+    expect(body.paths['/api/artifacts']).toBeDefined();
+  });
+
+  it('allows api-key-authenticated access to all route groups', async () => {
+    const app = createGatewayApp(config, deps);
+    const headers = { 'x-api-key': 'kat_test_1' };
+
+    const specs = await app.request('/api/specs', { headers });
+    const agents = await app.request('/api/agents', { headers });
+    const teams = await app.request('/api/teams', { headers });
+    const artifacts = await app.request('/api/artifacts', { headers });
+
+    expect(specs.status).toBe(200);
+    expect(agents.status).toBe(200);
+    expect(teams.status).toBe(200);
+    expect(artifacts.status).toBe(200);
+  });
+});

--- a/packages/gateway/src/__tests__/rate-limit-and-cors.test.ts
+++ b/packages/gateway/src/__tests__/rate-limit-and-cors.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGatewayApp } from '../app.js';
+
+function makeApp() {
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const app = createGatewayApp(
+    {
+      port: 3001,
+      allowedOrigins: ['http://localhost:1420'],
+      sessionCookieName: 'kata.sid',
+      sessionCookieSecret: 'test-secret',
+      redisUrl: 'redis://localhost:6379',
+      rateLimitWindowMs: 60_000,
+      rateLimitMaxRequests: 2,
+    },
+    {
+      logger,
+      apiKeyAuth: {
+        validateApiKey: async () => ({ teamId: 'team-1', keyId: 'key-1' }),
+      },
+      sessionStore: {
+        getSession: async () => null,
+      },
+      now: () => new Date('2026-02-26T00:00:00.000Z'),
+    },
+  );
+
+  return { app, logger };
+}
+
+describe('rate limit + cors + logging', () => {
+  it('enforces rate limit on protected routes', async () => {
+    const { app } = makeApp();
+    const headers = {
+      'x-api-key': 'kat_test_1',
+      'x-forwarded-for': '10.0.0.5',
+    };
+
+    expect((await app.request('/api/specs', { headers })).status).toBe(200);
+    expect((await app.request('/api/specs', { headers })).status).toBe(200);
+
+    const blocked = await app.request('/api/specs', { headers });
+    expect(blocked.status).toBe(429);
+    const body = await blocked.json();
+    expect(body.error.code).toBe('RATE_LIMITED');
+  });
+
+  it('sets allow-origin header for allowed origins', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/health', {
+      headers: { Origin: 'http://localhost:1420' },
+    });
+    expect(res.headers.get('access-control-allow-origin')).toBe('http://localhost:1420');
+  });
+
+  it('emits request logs', async () => {
+    const { app, logger } = makeApp();
+    await app.request('/health');
+    expect(logger.info).toHaveBeenCalled();
+  });
+});

--- a/packages/gateway/src/__tests__/rate-limit-and-cors.test.ts
+++ b/packages/gateway/src/__tests__/rate-limit-and-cors.test.ts
@@ -12,8 +12,7 @@ function makeApp() {
       port: 3001,
       allowedOrigins: ['http://localhost:1420'],
       sessionCookieName: 'kata.sid',
-      sessionCookieSecret: 'test-secret',
-      redisUrl: 'redis://localhost:6379',
+        redisUrl: 'redis://localhost:6379',
       rateLimitWindowMs: 60_000,
       rateLimitMaxRequests: 2,
     },
@@ -66,10 +65,10 @@ describe('rate limit + cors + logging', () => {
     expect((await app.request('/api/specs', { headers: clientTwoHeaders })).status).toBe(200);
 
     const blockedClientOne = await app.request('/api/specs', { headers: clientOneHeaders });
-    const allowedClientTwo = await app.request('/api/specs', { headers: clientTwoHeaders });
+    const blockedClientTwo = await app.request('/api/specs', { headers: clientTwoHeaders });
 
     expect(blockedClientOne.status).toBe(429);
-    expect(allowedClientTwo.status).toBe(429);
+    expect(blockedClientTwo.status).toBe(429);
   });
 
   it('sets allow-origin header for allowed origins', async () => {

--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -1,0 +1,33 @@
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { cors } from 'hono/cors';
+import { jsonError } from './middleware/error-handler.js';
+import { requestContextMiddleware } from './middleware/request-context.js';
+import { requestLoggerMiddleware } from './middleware/request-logger.js';
+import { registerHealthRoute } from './routes/health.js';
+import type { GatewayConfig, GatewayDeps } from './types.js';
+
+export function createGatewayApp(config: GatewayConfig, deps: GatewayDeps) {
+  const app = new OpenAPIHono();
+
+  app.use('*', requestContextMiddleware);
+  app.use('*', cors({ origin: config.allowedOrigins, credentials: true }));
+  app.use('*', requestLoggerMiddleware(deps.logger));
+
+  registerHealthRoute(app);
+
+  app.notFound((c) => jsonError(c, 404, 'NOT_FOUND', 'Route not found'));
+  app.onError((err, c) => {
+    deps.logger.error({ err }, 'unhandled gateway error');
+    return jsonError(c, 500, 'INTERNAL_ERROR', 'Internal server error');
+  });
+
+  app.doc('/openapi.json', {
+    openapi: '3.0.0',
+    info: {
+      title: 'Kata Gateway API',
+      version: '0.1.0',
+    },
+  });
+
+  return app;
+}

--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import { cors } from 'hono/cors';
 import { authMiddleware } from './middleware/auth.js';
 import { jsonError } from './middleware/error-handler.js';
+import { createRateLimitMiddleware } from './middleware/rate-limit.js';
 import { requestContextMiddleware } from './middleware/request-context.js';
 import { requestLoggerMiddleware } from './middleware/request-logger.js';
 import { registerAgentsRoutes } from './routes/agents.js';
@@ -17,6 +18,7 @@ export function createGatewayApp(config: GatewayConfig, deps: GatewayDeps) {
   app.use('*', requestContextMiddleware);
   app.use('*', cors({ origin: config.allowedOrigins, credentials: true }));
   app.use('*', requestLoggerMiddleware(deps.logger));
+  app.use('/api/*', createRateLimitMiddleware(config.rateLimitWindowMs, config.rateLimitMaxRequests));
   app.use('/api/*', authMiddleware(config, deps));
 
   registerHealthRoute(app);

--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { cors } from 'hono/cors';
+import { authMiddleware } from './middleware/auth.js';
 import { jsonError } from './middleware/error-handler.js';
 import { requestContextMiddleware } from './middleware/request-context.js';
 import { requestLoggerMiddleware } from './middleware/request-logger.js';
@@ -12,8 +13,10 @@ export function createGatewayApp(config: GatewayConfig, deps: GatewayDeps) {
   app.use('*', requestContextMiddleware);
   app.use('*', cors({ origin: config.allowedOrigins, credentials: true }));
   app.use('*', requestLoggerMiddleware(deps.logger));
+  app.use('/api/*', authMiddleware(config, deps));
 
   registerHealthRoute(app);
+  app.get('/api/teams', (c) => c.json({ ok: true }));
 
   app.notFound((c) => jsonError(c, 404, 'NOT_FOUND', 'Route not found'));
   app.onError((err, c) => {

--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -4,7 +4,11 @@ import { authMiddleware } from './middleware/auth.js';
 import { jsonError } from './middleware/error-handler.js';
 import { requestContextMiddleware } from './middleware/request-context.js';
 import { requestLoggerMiddleware } from './middleware/request-logger.js';
+import { registerAgentsRoutes } from './routes/agents.js';
+import { registerArtifactsRoutes } from './routes/artifacts.js';
 import { registerHealthRoute } from './routes/health.js';
+import { registerSpecsRoutes } from './routes/specs.js';
+import { registerTeamsRoutes } from './routes/teams.js';
 import type { GatewayConfig, GatewayDeps } from './types.js';
 
 export function createGatewayApp(config: GatewayConfig, deps: GatewayDeps) {
@@ -16,7 +20,10 @@ export function createGatewayApp(config: GatewayConfig, deps: GatewayDeps) {
   app.use('/api/*', authMiddleware(config, deps));
 
   registerHealthRoute(app);
-  app.get('/api/teams', (c) => c.json({ ok: true }));
+  registerSpecsRoutes(app);
+  registerAgentsRoutes(app);
+  registerTeamsRoutes(app);
+  registerArtifactsRoutes(app);
 
   app.notFound((c) => jsonError(c, 404, 'NOT_FOUND', 'Route not found'));
   app.onError((err, c) => {

--- a/packages/gateway/src/auth/api-key-adapter.ts
+++ b/packages/gateway/src/auth/api-key-adapter.ts
@@ -3,9 +3,11 @@ import type { ApiKeyAuthAdapter } from '../types.js';
 export function createInMemoryApiKeyAdapter(
   keys: Record<string, { teamId: string; keyId: string }>,
 ): ApiKeyAuthAdapter {
+  const keyMap = new Map(Object.entries(keys));
+
   return {
     async validateApiKey(rawKey: string) {
-      return keys[rawKey] ?? null;
+      return keyMap.get(rawKey) ?? null;
     },
   };
 }

--- a/packages/gateway/src/auth/api-key-adapter.ts
+++ b/packages/gateway/src/auth/api-key-adapter.ts
@@ -1,0 +1,11 @@
+import type { ApiKeyAuthAdapter } from '../types.js';
+
+export function createInMemoryApiKeyAdapter(
+  keys: Record<string, { teamId: string; keyId: string }>,
+): ApiKeyAuthAdapter {
+  return {
+    async validateApiKey(rawKey: string) {
+      return keys[rawKey] ?? null;
+    },
+  };
+}

--- a/packages/gateway/src/auth/session-store.ts
+++ b/packages/gateway/src/auth/session-store.ts
@@ -1,6 +1,6 @@
 import Redis from 'ioredis';
 import { z } from 'zod';
-import type { SessionStoreAdapter } from '../types.js';
+import type { Logger, SessionStoreAdapter } from '../types.js';
 
 const SessionSchema = z.object({
   userId: z.string().min(1),
@@ -8,14 +8,23 @@ const SessionSchema = z.object({
   expiresAt: z.string().min(1),
 });
 
-export function createRedisSessionStore(redisUrl: string): SessionStoreAdapter {
+export function createRedisSessionStore(redisUrl: string, logger: Logger): SessionStoreAdapter {
   const redis = new Redis(redisUrl, { lazyConnect: true });
+  let connectPromise: Promise<void> | null = null;
+
+  async function ensureConnected() {
+    if (redis.status === 'ready') return;
+    if (!connectPromise) {
+      connectPromise = redis.connect().finally(() => {
+        connectPromise = null;
+      });
+    }
+    await connectPromise;
+  }
 
   return {
     async getSession(sessionId: string) {
-      if (redis.status === 'wait') {
-        await redis.connect();
-      }
+      await ensureConnected();
       const raw = await redis.get(`session:${sessionId}`);
       if (!raw) {
         return null;
@@ -23,20 +32,18 @@ export function createRedisSessionStore(redisUrl: string): SessionStoreAdapter {
       let parsedRaw: unknown;
       try {
         parsedRaw = JSON.parse(raw);
-      } catch {
+      } catch (err) {
+        logger.error({ sessionId, err }, 'session JSON parse failure');
         return null;
       }
 
       const parsedSession = SessionSchema.safeParse(parsedRaw);
       if (!parsedSession.success) {
+        logger.error({ sessionId, issues: parsedSession.error.issues }, 'session schema validation failure');
         return null;
       }
 
-      const expiresAtMs = Date.parse(parsedSession.data.expiresAt);
-      if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
-        return null;
-      }
-
+      // Expiry is enforced by auth middleware using the injectable clock
       return parsedSession.data;
     },
   };

--- a/packages/gateway/src/auth/session-store.ts
+++ b/packages/gateway/src/auth/session-store.ts
@@ -1,0 +1,19 @@
+import Redis from 'ioredis';
+import type { SessionStoreAdapter } from '../types.js';
+
+export function createRedisSessionStore(redisUrl: string): SessionStoreAdapter {
+  const redis = new Redis(redisUrl, { lazyConnect: true });
+
+  return {
+    async getSession(sessionId: string) {
+      if (redis.status === 'wait') {
+        await redis.connect();
+      }
+      const raw = await redis.get(`session:${sessionId}`);
+      if (!raw) {
+        return null;
+      }
+      return JSON.parse(raw) as { userId: string; teamId: string; expiresAt: string };
+    },
+  };
+}

--- a/packages/gateway/src/auth/session-store.ts
+++ b/packages/gateway/src/auth/session-store.ts
@@ -1,5 +1,12 @@
 import Redis from 'ioredis';
+import { z } from 'zod';
 import type { SessionStoreAdapter } from '../types.js';
+
+const SessionSchema = z.object({
+  userId: z.string().min(1),
+  teamId: z.string().min(1),
+  expiresAt: z.string().min(1),
+});
 
 export function createRedisSessionStore(redisUrl: string): SessionStoreAdapter {
   const redis = new Redis(redisUrl, { lazyConnect: true });
@@ -13,7 +20,24 @@ export function createRedisSessionStore(redisUrl: string): SessionStoreAdapter {
       if (!raw) {
         return null;
       }
-      return JSON.parse(raw) as { userId: string; teamId: string; expiresAt: string };
+      let parsedRaw: unknown;
+      try {
+        parsedRaw = JSON.parse(raw);
+      } catch {
+        return null;
+      }
+
+      const parsedSession = SessionSchema.safeParse(parsedRaw);
+      if (!parsedSession.success) {
+        return null;
+      }
+
+      const expiresAtMs = Date.parse(parsedSession.data.expiresAt);
+      if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+        return null;
+      }
+
+      return parsedSession.data;
     },
   };
 }

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -6,7 +6,6 @@ const EnvSchema = z.object({
   GATEWAY_PORT: z.coerce.number().int().positive().default(3001),
   GATEWAY_ALLOWED_ORIGINS: z.string().default('http://localhost:1420,http://localhost:5173'),
   SESSION_COOKIE_NAME: z.string().min(1).default('kata.sid'),
-  SESSION_COOKIE_SECRET: z.string().min(1),
   REDIS_URL: z.string().url(),
   RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60000),
   RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(60),
@@ -17,14 +16,18 @@ export function loadGatewayConfig(env: NodeJS.ProcessEnv = process.env): Gateway
     loadEnv();
   }
 
-  const parsed = EnvSchema.parse(env);
+  const result = EnvSchema.safeParse(env);
+  if (!result.success) {
+    const missing = result.error.issues.map((i) => `  ${i.path.join('.')}: ${i.message}`).join('\n');
+    throw new Error(`Invalid gateway configuration:\n${missing}`);
+  }
+  const parsed = result.data;
   return {
     port: parsed.GATEWAY_PORT,
     allowedOrigins: parsed.GATEWAY_ALLOWED_ORIGINS.split(',')
       .map((v) => v.trim())
       .filter(Boolean),
     sessionCookieName: parsed.SESSION_COOKIE_NAME,
-    sessionCookieSecret: parsed.SESSION_COOKIE_SECRET,
     redisUrl: parsed.REDIS_URL,
     rateLimitWindowMs: parsed.RATE_LIMIT_WINDOW_MS,
     rateLimitMaxRequests: parsed.RATE_LIMIT_MAX_REQUESTS,

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -2,8 +2,6 @@ import { config as loadEnv } from 'dotenv';
 import { z } from 'zod';
 import type { GatewayConfig } from './types.js';
 
-loadEnv();
-
 const EnvSchema = z.object({
   GATEWAY_PORT: z.coerce.number().int().positive().default(3001),
   GATEWAY_ALLOWED_ORIGINS: z.string().default('http://localhost:1420,http://localhost:5173'),
@@ -15,6 +13,10 @@ const EnvSchema = z.object({
 });
 
 export function loadGatewayConfig(env: NodeJS.ProcessEnv = process.env): GatewayConfig {
+  if (env === process.env) {
+    loadEnv();
+  }
+
   const parsed = EnvSchema.parse(env);
   return {
     port: parsed.GATEWAY_PORT,

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,0 +1,30 @@
+import { config as loadEnv } from 'dotenv';
+import { z } from 'zod';
+import type { GatewayConfig } from './types.js';
+
+loadEnv();
+
+const EnvSchema = z.object({
+  GATEWAY_PORT: z.coerce.number().int().positive().default(3001),
+  GATEWAY_ALLOWED_ORIGINS: z.string().default('http://localhost:1420,http://localhost:5173'),
+  SESSION_COOKIE_NAME: z.string().min(1).default('kata.sid'),
+  SESSION_COOKIE_SECRET: z.string().min(1),
+  REDIS_URL: z.string().url(),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60000),
+  RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(60),
+});
+
+export function loadGatewayConfig(env: NodeJS.ProcessEnv = process.env): GatewayConfig {
+  const parsed = EnvSchema.parse(env);
+  return {
+    port: parsed.GATEWAY_PORT,
+    allowedOrigins: parsed.GATEWAY_ALLOWED_ORIGINS.split(',')
+      .map((v) => v.trim())
+      .filter(Boolean),
+    sessionCookieName: parsed.SESSION_COOKIE_NAME,
+    sessionCookieSecret: parsed.SESSION_COOKIE_SECRET,
+    redisUrl: parsed.REDIS_URL,
+    rateLimitWindowMs: parsed.RATE_LIMIT_WINDOW_MS,
+    rateLimitMaxRequests: parsed.RATE_LIMIT_MAX_REQUESTS,
+  };
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,0 +1,3 @@
+export * from './app.js';
+export * from './config.js';
+export * from './types.js';

--- a/packages/gateway/src/middleware/auth.ts
+++ b/packages/gateway/src/middleware/auth.ts
@@ -32,7 +32,7 @@ export function authMiddleware(config: GatewayConfig, deps: GatewayDeps): Middle
       }
       const expiresAtMs = Date.parse(session.expiresAt);
       if (!Number.isFinite(expiresAtMs) || expiresAtMs <= deps.now().getTime()) {
-        return jsonError(c, 401, 'INVALID_SESSION', 'Invalid session');
+        return jsonError(c, 401, 'SESSION_EXPIRED', 'Session expired');
       }
       c.set('principal', {
         type: 'session_user',

--- a/packages/gateway/src/middleware/auth.ts
+++ b/packages/gateway/src/middleware/auth.ts
@@ -1,0 +1,38 @@
+import { getCookie } from 'hono/cookie';
+import type { MiddlewareHandler } from 'hono';
+import { jsonError } from './error-handler.js';
+import type { GatewayConfig, GatewayDeps } from '../types.js';
+
+export function authMiddleware(config: GatewayConfig, deps: GatewayDeps): MiddlewareHandler {
+  return async (c, next) => {
+    const apiKey = c.req.header('x-api-key');
+    if (apiKey) {
+      const keyPrincipal = await deps.apiKeyAuth.validateApiKey(apiKey);
+      if (!keyPrincipal) {
+        return jsonError(c, 401, 'INVALID_API_KEY', 'Invalid API key');
+      }
+      c.set('principal', { type: 'api_key', ...keyPrincipal });
+      return next();
+    }
+
+    const sessionId = getCookie(c, config.sessionCookieName);
+    if (!sessionId) {
+      return jsonError(c, 401, 'AUTH_REQUIRED', 'Authentication required');
+    }
+
+    try {
+      const session = await deps.sessionStore.getSession(sessionId);
+      if (!session) {
+        return jsonError(c, 401, 'INVALID_SESSION', 'Invalid session');
+      }
+      c.set('principal', {
+        type: 'session_user',
+        teamId: session.teamId,
+        userId: session.userId,
+      });
+      return next();
+    } catch {
+      return jsonError(c, 503, 'AUTH_SERVICE_UNAVAILABLE', 'Authentication service unavailable');
+    }
+  };
+}

--- a/packages/gateway/src/middleware/error-handler.ts
+++ b/packages/gateway/src/middleware/error-handler.ts
@@ -1,7 +1,8 @@
 import type { Context } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
+import type { ErrorCode } from '../types.js';
 
-export function jsonError(c: Context, status: ContentfulStatusCode, code: string, message: string) {
+export function jsonError(c: Context, status: ContentfulStatusCode, code: ErrorCode, message: string) {
   return c.json(
     {
       error: {

--- a/packages/gateway/src/middleware/error-handler.ts
+++ b/packages/gateway/src/middleware/error-handler.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
-export function jsonError(c: Context, status: number, code: string, message: string) {
+export function jsonError(c: Context, status: ContentfulStatusCode, code: string, message: string) {
   return c.json(
     {
       error: {

--- a/packages/gateway/src/middleware/error-handler.ts
+++ b/packages/gateway/src/middleware/error-handler.ts
@@ -1,0 +1,14 @@
+import type { Context } from 'hono';
+
+export function jsonError(c: Context, status: number, code: string, message: string) {
+  return c.json(
+    {
+      error: {
+        code,
+        message,
+        requestId: c.get('requestId') ?? 'unknown',
+      },
+    },
+    status,
+  );
+}

--- a/packages/gateway/src/middleware/rate-limit.ts
+++ b/packages/gateway/src/middleware/rate-limit.ts
@@ -1,0 +1,26 @@
+import type { MiddlewareHandler } from 'hono';
+import { jsonError } from './error-handler.js';
+
+export function createRateLimitMiddleware(windowMs: number, maxRequests: number): MiddlewareHandler {
+  const buckets = new Map<string, { count: number; resetAt: number }>();
+
+  return async (c, next) => {
+    const now = Date.now();
+    const ip = c.req.header('x-forwarded-for') ?? 'unknown';
+    const key = `${ip}:${c.req.path}`;
+
+    const current = buckets.get(key);
+    if (!current || current.resetAt <= now) {
+      buckets.set(key, { count: 1, resetAt: now + windowMs });
+      return next();
+    }
+
+    if (current.count >= maxRequests) {
+      return jsonError(c, 429, 'RATE_LIMITED', 'Too many requests');
+    }
+
+    current.count += 1;
+    buckets.set(key, current);
+    return next();
+  };
+}

--- a/packages/gateway/src/middleware/rate-limit.ts
+++ b/packages/gateway/src/middleware/rate-limit.ts
@@ -25,7 +25,7 @@ export function createRateLimitMiddleware(windowMs: number, maxRequests: number)
   return async (c, next) => {
     const now = Date.now();
     const forwardedFor = c.req.header('x-forwarded-for')?.split(',')[0];
-    const ip = normalizeIp(c.req.header('x-real-ip')) ?? normalizeIp(forwardedFor) ?? 'unknown';
+    const ip = normalizeIp(forwardedFor) ?? normalizeIp(c.req.header('x-real-ip')) ?? 'unknown';
     const key = `${ip}:${c.req.path}`;
 
     const current = buckets.get(key);

--- a/packages/gateway/src/middleware/request-context.ts
+++ b/packages/gateway/src/middleware/request-context.ts
@@ -1,0 +1,9 @@
+import type { MiddlewareHandler } from 'hono';
+
+export const requestContextMiddleware: MiddlewareHandler = async (c, next) => {
+  const requestId = c.req.header('x-request-id') ?? crypto.randomUUID();
+  c.set('requestId', requestId);
+  c.set('startedAtMs', Date.now());
+  await next();
+  c.header('x-request-id', requestId);
+};

--- a/packages/gateway/src/middleware/request-context.ts
+++ b/packages/gateway/src/middleware/request-context.ts
@@ -4,6 +4,9 @@ export const requestContextMiddleware: MiddlewareHandler = async (c, next) => {
   const requestId = c.req.header('x-request-id') ?? crypto.randomUUID();
   c.set('requestId', requestId);
   c.set('startedAtMs', Date.now());
-  await next();
-  c.header('x-request-id', requestId);
+  try {
+    await next();
+  } finally {
+    c.header('x-request-id', requestId);
+  }
 };

--- a/packages/gateway/src/middleware/request-logger.ts
+++ b/packages/gateway/src/middleware/request-logger.ts
@@ -1,0 +1,19 @@
+import type { MiddlewareHandler } from 'hono';
+import type { Logger } from '../types.js';
+
+export function requestLoggerMiddleware(logger: Logger): MiddlewareHandler {
+  return async (c, next) => {
+    await next();
+    const startedAtMs = Number(c.get('startedAtMs') ?? Date.now());
+    logger.info(
+      {
+        requestId: c.get('requestId'),
+        method: c.req.method,
+        path: c.req.path,
+        status: c.res.status,
+        durationMs: Date.now() - startedAtMs,
+      },
+      'request completed',
+    );
+  };
+}

--- a/packages/gateway/src/middleware/request-logger.ts
+++ b/packages/gateway/src/middleware/request-logger.ts
@@ -3,17 +3,26 @@ import type { Logger } from '../types.js';
 
 export function requestLoggerMiddleware(logger: Logger): MiddlewareHandler {
   return async (c, next) => {
-    await next();
-    const startedAtMs = Number(c.get('startedAtMs') ?? Date.now());
-    logger.info(
-      {
-        requestId: c.get('requestId'),
-        method: c.req.method,
-        path: c.req.path,
-        status: c.res.status,
-        durationMs: Date.now() - startedAtMs,
-      },
-      'request completed',
-    );
+    const fallbackStartedAtMs = Date.now();
+    try {
+      await next();
+    } finally {
+      const startedAtFromContext = c.get('startedAtMs');
+      const startedAtMs =
+        typeof startedAtFromContext === 'number' && Number.isFinite(startedAtFromContext)
+          ? startedAtFromContext
+          : fallbackStartedAtMs;
+
+      logger.info(
+        {
+          requestId: c.get('requestId'),
+          method: c.req.method,
+          path: c.req.path,
+          status: c.res.status,
+          durationMs: Date.now() - startedAtMs,
+        },
+        'request completed',
+      );
+    }
   };
 }

--- a/packages/gateway/src/routes/agents.ts
+++ b/packages/gateway/src/routes/agents.ts
@@ -1,0 +1,27 @@
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+
+const AgentsListSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+  message: z.literal('Not implemented yet'),
+});
+
+const route = createRoute({
+  method: 'get',
+  path: '/api/agents',
+  tags: ['agents'],
+  responses: {
+    200: {
+      description: 'List agents placeholder',
+      content: { 'application/json': { schema: AgentsListSchema } },
+    },
+  },
+});
+
+export function registerAgentsRoutes(app: OpenAPIHono) {
+  app.openapi(route, (c) => c.json({ items: [], message: 'Not implemented yet' }));
+}

--- a/packages/gateway/src/routes/agents.ts
+++ b/packages/gateway/src/routes/agents.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import type { GatewayEnv } from '../types.js';
 
 const AgentsListSchema = z.object({
   items: z.array(
@@ -22,6 +23,6 @@ const route = createRoute({
   },
 });
 
-export function registerAgentsRoutes(app: OpenAPIHono) {
+export function registerAgentsRoutes(app: OpenAPIHono<GatewayEnv>) {
   app.openapi(route, (c) => c.json({ items: [], message: 'Not implemented yet' }));
 }

--- a/packages/gateway/src/routes/artifacts.ts
+++ b/packages/gateway/src/routes/artifacts.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import type { GatewayEnv } from '../types.js';
 
 const ArtifactsListSchema = z.object({
   items: z.array(
@@ -22,6 +23,6 @@ const route = createRoute({
   },
 });
 
-export function registerArtifactsRoutes(app: OpenAPIHono) {
+export function registerArtifactsRoutes(app: OpenAPIHono<GatewayEnv>) {
   app.openapi(route, (c) => c.json({ items: [], message: 'Not implemented yet' }));
 }

--- a/packages/gateway/src/routes/artifacts.ts
+++ b/packages/gateway/src/routes/artifacts.ts
@@ -1,0 +1,27 @@
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+
+const ArtifactsListSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string(),
+    }),
+  ),
+  message: z.literal('Not implemented yet'),
+});
+
+const route = createRoute({
+  method: 'get',
+  path: '/api/artifacts',
+  tags: ['artifacts'],
+  responses: {
+    200: {
+      description: 'List artifacts placeholder',
+      content: { 'application/json': { schema: ArtifactsListSchema } },
+    },
+  },
+});
+
+export function registerArtifactsRoutes(app: OpenAPIHono) {
+  app.openapi(route, (c) => c.json({ items: [], message: 'Not implemented yet' }));
+}

--- a/packages/gateway/src/routes/health.ts
+++ b/packages/gateway/src/routes/health.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import type { GatewayEnv } from '../types.js';
 
 const HealthResponseSchema = z.object({
   status: z.literal('ok'),
@@ -20,6 +21,6 @@ const healthRoute = createRoute({
   },
 });
 
-export function registerHealthRoute(app: OpenAPIHono) {
+export function registerHealthRoute(app: OpenAPIHono<GatewayEnv>) {
   app.openapi(healthRoute, (c) => c.json({ status: 'ok' }));
 }

--- a/packages/gateway/src/routes/health.ts
+++ b/packages/gateway/src/routes/health.ts
@@ -1,0 +1,25 @@
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+
+const HealthResponseSchema = z.object({
+  status: z.literal('ok'),
+});
+
+const healthRoute = createRoute({
+  method: 'get',
+  path: '/health',
+  tags: ['system'],
+  responses: {
+    200: {
+      description: 'Gateway health',
+      content: {
+        'application/json': {
+          schema: HealthResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+export function registerHealthRoute(app: OpenAPIHono) {
+  app.openapi(healthRoute, (c) => c.json({ status: 'ok' }));
+}

--- a/packages/gateway/src/routes/specs.ts
+++ b/packages/gateway/src/routes/specs.ts
@@ -1,0 +1,27 @@
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+
+const SpecsListSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  ),
+  message: z.literal('Not implemented yet'),
+});
+
+const route = createRoute({
+  method: 'get',
+  path: '/api/specs',
+  tags: ['specs'],
+  responses: {
+    200: {
+      description: 'List specs placeholder',
+      content: { 'application/json': { schema: SpecsListSchema } },
+    },
+  },
+});
+
+export function registerSpecsRoutes(app: OpenAPIHono) {
+  app.openapi(route, (c) => c.json({ items: [], message: 'Not implemented yet' }));
+}

--- a/packages/gateway/src/routes/specs.ts
+++ b/packages/gateway/src/routes/specs.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import type { GatewayEnv } from '../types.js';
 
 const SpecsListSchema = z.object({
   items: z.array(
@@ -22,6 +23,6 @@ const route = createRoute({
   },
 });
 
-export function registerSpecsRoutes(app: OpenAPIHono) {
+export function registerSpecsRoutes(app: OpenAPIHono<GatewayEnv>) {
   app.openapi(route, (c) => c.json({ items: [], message: 'Not implemented yet' }));
 }

--- a/packages/gateway/src/routes/teams.ts
+++ b/packages/gateway/src/routes/teams.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import type { GatewayEnv } from '../types.js';
 
 const TeamsListSchema = z.object({
   items: z.array(
@@ -22,6 +23,6 @@ const route = createRoute({
   },
 });
 
-export function registerTeamsRoutes(app: OpenAPIHono) {
+export function registerTeamsRoutes(app: OpenAPIHono<GatewayEnv>) {
   app.openapi(route, (c) => c.json({ items: [], message: 'Not implemented yet' }));
 }

--- a/packages/gateway/src/routes/teams.ts
+++ b/packages/gateway/src/routes/teams.ts
@@ -1,0 +1,27 @@
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+
+const TeamsListSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+  message: z.literal('Not implemented yet'),
+});
+
+const route = createRoute({
+  method: 'get',
+  path: '/api/teams',
+  tags: ['teams'],
+  responses: {
+    200: {
+      description: 'List teams placeholder',
+      content: { 'application/json': { schema: TeamsListSchema } },
+    },
+  },
+});
+
+export function registerTeamsRoutes(app: OpenAPIHono) {
+  app.openapi(route, (c) => c.json({ items: [], message: 'Not implemented yet' }));
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -4,11 +4,16 @@ import { loadGatewayConfig } from './config.js';
 
 const config = loadGatewayConfig();
 
+const logger = {
+  info: (meta: Record<string, unknown>, message: string) => console.log(message, meta),
+  error: (meta: Record<string, unknown>, message: string) => console.error(message, meta),
+};
+
+// Stub adapters reject all credentials — wire real adapters before production use
+logger.error({}, 'gateway started with stub auth adapters; all authenticated requests will be rejected');
+
 const app = createGatewayApp(config, {
-  logger: {
-    info: (meta, message) => console.log(message, meta),
-    error: (meta, message) => console.error(message, meta),
-  },
+  logger,
   apiKeyAuth: {
     validateApiKey: async () => null,
   },

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1,0 +1,22 @@
+import { serve } from '@hono/node-server';
+import { createGatewayApp } from './app.js';
+import { loadGatewayConfig } from './config.js';
+
+const config = loadGatewayConfig();
+
+const app = createGatewayApp(config, {
+  logger: {
+    info: (meta, message) => console.log(message, meta),
+    error: (meta, message) => console.error(message, meta),
+  },
+  apiKeyAuth: {
+    validateApiKey: async () => null,
+  },
+  sessionStore: {
+    getSession: async () => null,
+  },
+  now: () => new Date(),
+});
+
+serve({ fetch: app.fetch, port: config.port });
+console.log(`gateway listening on :${config.port}`);

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -42,3 +42,9 @@ export type GatewayDeps = {
   sessionStore: SessionStoreAdapter;
   now: () => Date;
 };
+
+export type GatewayVars = {
+  requestId: string;
+  startedAtMs: number;
+  principal?: AuthPrincipal;
+};

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -3,6 +3,17 @@ export type Logger = {
   error: (meta: Record<string, unknown>, message: string) => void;
 };
 
+export type ErrorCode =
+  | 'INVALID_API_KEY'
+  | 'AUTH_REQUIRED'
+  | 'INVALID_SESSION'
+  | 'SESSION_EXPIRED'
+  | 'AUTH_SERVICE_UNAVAILABLE'
+  | 'RATE_LIMITED'
+  | 'NOT_FOUND'
+  | 'INTERNAL_ERROR'
+  | 'HTTP_ERROR';
+
 export type ApiKeyPrincipal = {
   type: 'api_key';
   teamId: string;
@@ -18,19 +29,26 @@ export type SessionPrincipal = {
 
 export type AuthPrincipal = ApiKeyPrincipal | SessionPrincipal;
 
+export type ApiKeyIdentity = Omit<ApiKeyPrincipal, 'type'>;
+
+export type SessionData = {
+  userId: string;
+  teamId: string;
+  expiresAt: string;
+};
+
 export type ApiKeyAuthAdapter = {
-  validateApiKey: (rawKey: string) => Promise<{ teamId: string; keyId: string; scopes?: string[] } | null>;
+  validateApiKey: (rawKey: string) => Promise<ApiKeyIdentity | null>;
 };
 
 export type SessionStoreAdapter = {
-  getSession: (sessionId: string) => Promise<{ userId: string; teamId: string; expiresAt: string } | null>;
+  getSession: (sessionId: string) => Promise<SessionData | null>;
 };
 
 export type GatewayConfig = {
   port: number;
   allowedOrigins: string[];
   sessionCookieName: string;
-  sessionCookieSecret: string;
   redisUrl: string;
   rateLimitWindowMs: number;
   rateLimitMaxRequests: number;
@@ -48,3 +66,5 @@ export type GatewayVars = {
   startedAtMs: number;
   principal?: AuthPrincipal;
 };
+
+export type GatewayEnv = { Variables: GatewayVars };

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -1,0 +1,44 @@
+export type Logger = {
+  info: (meta: Record<string, unknown>, message: string) => void;
+  error: (meta: Record<string, unknown>, message: string) => void;
+};
+
+export type ApiKeyPrincipal = {
+  type: 'api_key';
+  teamId: string;
+  keyId: string;
+  scopes?: string[];
+};
+
+export type SessionPrincipal = {
+  type: 'session_user';
+  teamId: string;
+  userId: string;
+};
+
+export type AuthPrincipal = ApiKeyPrincipal | SessionPrincipal;
+
+export type ApiKeyAuthAdapter = {
+  validateApiKey: (rawKey: string) => Promise<{ teamId: string; keyId: string; scopes?: string[] } | null>;
+};
+
+export type SessionStoreAdapter = {
+  getSession: (sessionId: string) => Promise<{ userId: string; teamId: string; expiresAt: string } | null>;
+};
+
+export type GatewayConfig = {
+  port: number;
+  allowedOrigins: string[];
+  sessionCookieName: string;
+  sessionCookieSecret: string;
+  redisUrl: string;
+  rateLimitWindowMs: number;
+  rateLimitMaxRequests: number;
+};
+
+export type GatewayDeps = {
+  logger: Logger;
+  apiKeyAuth: ApiKeyAuthAdapter;
+  sessionStore: SessionStoreAdapter;
+  now: () => Date;
+};

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,7 +175,7 @@ importers:
         version: 1.19.9(hono@4.12.3)
       '@hono/zod-openapi':
         specifier: ^0.16.4
-        version: 0.16.4(hono@4.12.3)(zod@4.3.6)
+        version: 0.16.4(hono@4.12.3)(zod@3.25.76)
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -186,8 +186,8 @@ importers:
         specifier: ^5.4.1
         version: 5.9.3
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^22.13.10
@@ -2483,6 +2483,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -2523,10 +2526,10 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@asteasolutions/zod-to-openapi@7.3.4(zod@4.3.6)':
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
     dependencies:
       openapi3-ts: 4.5.0
-      zod: 4.3.6
+      zod: 3.25.76
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2896,17 +2899,17 @@ snapshots:
     dependencies:
       hono: 4.12.3
 
-  '@hono/zod-openapi@0.16.4(hono@4.12.3)(zod@4.3.6)':
+  '@hono/zod-openapi@0.16.4(hono@4.12.3)(zod@3.25.76)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 7.3.4(zod@4.3.6)
-      '@hono/zod-validator': 0.3.0(hono@4.12.3)(zod@4.3.6)
+      '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.76)
+      '@hono/zod-validator': 0.3.0(hono@4.12.3)(zod@3.25.76)
       hono: 4.12.3
-      zod: 4.3.6
+      zod: 3.25.76
 
-  '@hono/zod-validator@0.3.0(hono@4.12.3)(zod@4.3.6)':
+  '@hono/zod-validator@0.3.0(hono@4.12.3)(zod@3.25.76)':
     dependencies:
       hono: 4.12.3
-      zod: 4.3.6
+      zod: 3.25.76
 
   '@humanfs/core@0.19.1': {}
 
@@ -3313,6 +3316,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@22.19.13))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.13)
 
   '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.3.2))':
     dependencies:
@@ -4523,7 +4534,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.3.2))
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@22.19.13))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -4648,6 +4659,8 @@ snapshots:
   yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(jsdom@26.1.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@25.3.2)(jsdom@26.1.0))
       eslint:
         specifier: ^9.21.0
         version: 9.39.3(jiti@1.21.7)
@@ -61,7 +61,7 @@ importers:
         version: 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@26.1.0)
+        version: 3.2.4(@types/node@25.3.2)(jsdom@26.1.0)
 
   agents/coordinator: {}
 
@@ -98,7 +98,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.21)
+        version: 4.7.0(vite@5.4.21(@types/node@25.3.2))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.6)
@@ -107,10 +107,10 @@ importers:
         version: 8.5.6
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       vite:
         specifier: ^5.4.14
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.3.2)
 
   apps/mobile:
     dependencies:
@@ -129,10 +129,10 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.21)
+        version: 4.7.0(vite@5.4.21(@types/node@25.3.2))
       vite:
         specifier: ^5.4.14
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.3.2)
 
   apps/web:
     dependencies:
@@ -154,13 +154,13 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.21)
+        version: 4.7.0(vite@5.4.21(@types/node@25.3.2))
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       vite:
         specifier: ^5.4.14
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.3.2)
 
   packages/agent-runtime: {}
 
@@ -168,7 +168,36 @@ importers:
 
   packages/dispatcher: {}
 
-  packages/gateway: {}
+  packages/gateway:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.9(hono@4.12.3)
+      '@hono/zod-openapi':
+        specifier: ^0.16.4
+        version: 0.16.4(hono@4.12.3)(zod@4.3.6)
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      hono:
+        specifier: ^4.6.10
+        version: 4.12.3
+      ioredis:
+        specifier: ^5.4.1
+        version: 5.9.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.19.13
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.13)(jsdom@26.1.0)
 
   packages/governance: {}
 
@@ -182,7 +211,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@26.1.0)
+        version: 3.2.4(@types/node@25.3.2)(jsdom@26.1.0)
 
   packages/spec-engine: {}
 
@@ -226,6 +255,11 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@asteasolutions/zod-to-openapi@7.3.4':
+    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -405,9 +439,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -417,9 +463,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -429,9 +487,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -441,9 +511,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -453,9 +535,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -465,9 +559,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -477,9 +583,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -489,9 +607,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -501,11 +631,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -513,9 +667,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -525,15 +697,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -575,6 +765,25 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/zod-openapi@0.16.4':
+    resolution: {integrity: sha512-mnF6GthBaKex0D5PsY/4lYNtkaGJNE38bjeUI//EUqq7Ee4TNm2su35IUiFH4HcmJp5fWYMLyOJOpjnkClzEGw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: 3.*
+
+  '@hono/zod-validator@0.3.0':
+    resolution: {integrity: sha512-7XcTk3yYyk6ldrO/VuqsroE7stvDZxHJQcpATRAyha8rUxJNBPV3+6waDrARfgEqxOVlzIadm3/6sE/dPseXgQ==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.19.1
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -590,6 +799,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@ioredis/commands@1.5.0':
+    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -895,6 +1107,12 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node@22.19.13':
+    resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
+
+  '@types/node@25.3.2':
+    resolution: {integrity: sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -1150,6 +1368,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1209,6 +1431,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1224,6 +1450,10 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1247,6 +1477,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -1378,6 +1613,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1402,6 +1640,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hono@4.12.3:
+    resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -1441,6 +1683,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  ioredis@5.9.3:
+    resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
+    engines: {node: '>=12.22.0'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1554,6 +1800,12 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -1647,6 +1899,9 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1823,9 +2078,20 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
@@ -1887,6 +2153,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2003,6 +2272,11 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo-darwin-64@2.8.11:
     resolution: {integrity: sha512-XKaCWaz4OCt77oYYvGCIRpvYD4c/aNaKjRkUpv+e8rN3RZb+5Xsyew4yRO+gaHdMIUhQznXNXfHlhs+/p7lIhA==}
     cpu: [x64]
@@ -2052,6 +2326,12 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2194,6 +2474,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2237,6 +2522,11 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@4.3.6)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 4.3.6
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2412,70 +2702,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@1.21.7))':
@@ -2524,6 +2892,22 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/node-server@1.19.9(hono@4.12.3)':
+    dependencies:
+      hono: 4.12.3
+
+  '@hono/zod-openapi@0.16.4(hono@4.12.3)(zod@4.3.6)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 7.3.4(zod@4.3.6)
+      '@hono/zod-validator': 0.3.0(hono@4.12.3)(zod@4.3.6)
+      hono: 4.12.3
+      zod: 4.3.6
+
+  '@hono/zod-validator@0.3.0(hono@4.12.3)(zod@4.3.6)':
+    dependencies:
+      hono: 4.12.3
+      zod: 4.3.6
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -2534,6 +2918,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@ioredis/commands@1.5.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2778,6 +3164,15 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@22.19.13':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@25.3.2':
+    dependencies:
+      undici-types: 7.18.2
+    optional: true
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
@@ -2880,7 +3275,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@25.3.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2888,11 +3283,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(jsdom@26.1.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.3.2)(jsdom@26.1.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2907,7 +3302,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(jsdom@26.1.0)
+      vitest: 3.2.4(@types/node@25.3.2)(jsdom@26.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2919,13 +3314,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.21)':
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.3.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3084,6 +3479,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3128,6 +3525,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  denque@2.1.0: {}
+
   dequal@2.0.3: {}
 
   didyoumean@1.2.2: {}
@@ -3137,6 +3536,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dotenv@16.6.1: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -3175,6 +3576,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   escalade@3.2.0: {}
 
@@ -3315,6 +3745,10 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -3339,6 +3773,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.12.3: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -3376,6 +3812,20 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  ioredis@5.9.3:
+    dependencies:
+      '@ioredis/commands': 1.5.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   is-binary-path@2.1.0:
     dependencies:
@@ -3492,6 +3942,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
   lodash.merge@4.6.2: {}
 
   loose-envify@1.4.0:
@@ -3571,6 +4025,10 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3643,12 +4101,14 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
+      tsx: 4.21.0
+      yaml: 2.8.2
 
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
@@ -3719,7 +4179,15 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   resolve-from@4.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.11:
     dependencies:
@@ -3794,6 +4262,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standard-as-callback@2.1.0: {}
+
   std-env@3.10.0: {}
 
   string-width@4.2.3:
@@ -3846,7 +4316,7 @@ snapshots:
 
   tailwind-merge@2.6.1: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -3865,7 +4335,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -3927,6 +4397,13 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo-darwin-64@2.8.11:
     optional: true
 
@@ -3971,6 +4448,11 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@6.21.0: {}
+
+  undici-types@7.18.2:
+    optional: true
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -3983,13 +4465,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.2.4:
+  vite-node@3.2.4(@types/node@22.19.13):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@22.19.13)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -4001,19 +4483,47 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21:
+  vite-node@3.2.4(@types/node@25.3.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(@types/node@25.3.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.13):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.59.0
     optionalDependencies:
+      '@types/node': 22.19.13
       fsevents: 2.3.3
 
-  vitest@3.2.4(jsdom@26.1.0):
+  vite@5.4.21(@types/node@25.3.2):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.59.0
+    optionalDependencies:
+      '@types/node': 25.3.2
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.13)(jsdom@26.1.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21)
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.3.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -4031,10 +4541,50 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.21
-      vite-node: 3.2.4
+      vite: 5.4.21(@types/node@22.19.13)
+      vite-node: 3.2.4(@types/node@22.19.13)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 22.19.13
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@3.2.4(@types/node@25.3.2)(jsdom@26.1.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.3.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@25.3.2)
+      vite-node: 3.2.4(@types/node@25.3.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.3.2
       jsdom: 26.1.0
     transitivePeerDependencies:
       - less
@@ -4094,6 +4644,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
 

--- a/tests/scaffold/gateway-package.test.mjs
+++ b/tests/scaffold/gateway-package.test.mjs
@@ -18,3 +18,4 @@ assert.ok(pkg.dependencies['@hono/zod-openapi'], '@hono/zod-openapi dependency m
 assert.ok(fs.existsSync('packages/gateway/tsconfig.json'), 'tsconfig missing');
 assert.ok(fs.existsSync('packages/gateway/vitest.config.ts'), 'vitest config missing');
 assert.ok(fs.existsSync('packages/gateway/src/index.ts'), 'src/index.ts missing');
+assert.ok(fs.existsSync('packages/gateway/.env.example'), '.env example missing');

--- a/tests/scaffold/gateway-package.test.mjs
+++ b/tests/scaffold/gateway-package.test.mjs
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import assert from 'node:assert/strict';
+
+const pkg = JSON.parse(fs.readFileSync('packages/gateway/package.json', 'utf8'));
+
+assert.equal(pkg.name, '@kata/gateway');
+assert.equal(pkg.type, 'module');
+assert.ok(pkg.scripts.build, 'build script missing');
+assert.ok(pkg.scripts.typecheck, 'typecheck script missing');
+assert.ok(pkg.scripts.test, 'test script missing');
+assert.ok(pkg.scripts.dev, 'dev script missing');
+
+assert.ok(pkg.dependencies.hono, 'hono dependency missing');
+assert.ok(pkg.dependencies.ioredis, 'ioredis dependency missing');
+assert.ok(pkg.dependencies.zod, 'zod dependency missing');
+assert.ok(pkg.dependencies['@hono/zod-openapi'], '@hono/zod-openapi dependency missing');
+
+assert.ok(fs.existsSync('packages/gateway/tsconfig.json'), 'tsconfig missing');
+assert.ok(fs.existsSync('packages/gateway/vitest.config.ts'), 'vitest config missing');
+assert.ok(fs.existsSync('packages/gateway/src/index.ts'), 'src/index.ts missing');


### PR DESCRIPTION
## Summary
- bootstrap `@kata/gateway` package tooling, app factory, health endpoint, global error envelope, and server/config wiring
- add fail-closed auth middleware (API key + Redis-backed session adapter), protected route groups (`/api/specs`, `/api/agents`, `/api/teams`, `/api/artifacts`), OpenAPI generation, and basic rate limiting
- add scaffold/unit verification coverage plus env template and verification evidence doc for KAT-108

## Test Plan
- [x] node tests/scaffold/gateway-package.test.mjs
- [x] pnpm --filter @kata/gateway typecheck
- [x] pnpm --filter @kata/gateway test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new gateway service with health check endpoint, OpenAPI documentation, and rate limiting.
  * Added authentication support for API key and session-based access.
  * Enabled CORS configuration and request logging across all endpoints.
  * Added placeholder endpoints for specs, agents, teams, and artifacts (to be implemented).

* **Chores**
  * Set up gateway package configuration, environment settings, and TypeScript tooling.
  * Added comprehensive test coverage for gateway functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes a solid gateway skeleton with proper fail-closed authentication, rate limiting, and OpenAPI integration. The implementation follows good practices with dependency injection, middleware composition, and comprehensive test coverage.

**Key additions:**
- Dual authentication support (header-based tokens and Redis-backed sessions)
- In-memory rate limiting with per-IP-per-path buckets
- Protected route groups (`/api/specs`, `/api/agents`, `/api/teams`, `/api/artifacts`)
- OpenAPI schema generation and validation
- Global error envelope with request ID tracking

**Issues requiring attention:**
- Session expiry validation missing - expired sessions can still authenticate
- Rate limiter Map grows unbounded causing memory leak
- Auth errors not logged before returning 503

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge with fixes for session expiry validation and rate limiter memory leak
- Score reflects solid architecture and test coverage, but two critical bugs need fixing: missing session expiry check allows expired sessions to authenticate, and unbounded rate limiter Map will cause memory exhaustion over time
- Pay close attention to `packages/gateway/src/middleware/auth.ts` and `packages/gateway/src/middleware/rate-limit.ts` for the session expiry and memory leak fixes

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/gateway/src/auth/session-store.ts | Redis session store added but session expiry validation missing in auth middleware |
| packages/gateway/src/middleware/auth.ts | Fail-closed auth middleware with API key and session support, missing expiry check and error logging |
| packages/gateway/src/middleware/rate-limit.ts | In-memory rate limiter with unbounded Map causing memory leak |
| packages/gateway/src/app.ts | Clean app factory with proper middleware ordering and route registration |
| packages/gateway/src/config.ts | Clean config loading with Zod validation |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client Request] --> B[Gateway]
    B --> C{Rate Limit Check}
    C -->|Rate Limited| D[429 Response]
    C -->|Allowed| E{Auth Check}
    E -->|x-api-key header| F[Validate Token]
    E -->|Session Cookie| G[Redis Session Lookup]
    E -->|No Credentials| H[401 Response]
    F -->|Valid| I[Set Principal]
    F -->|Invalid| J[401 Response]
    G -->|Valid Session| I
    G -->|Invalid/Expired| K[401/503 Response]
    I --> L[Route Handler]
    L --> M[JSON Response]
```

<sub>Last reviewed commit: 4b62d4e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->