### PR TITLE
feat: implement KAT-113 spec versioning system

### DIFF
--- a/apps/desktop/src/components/DiffView.tsx
+++ b/apps/desktop/src/components/DiffView.tsx
@@ -1,0 +1,73 @@
+interface DiffEntry {
+  path: string;
+  type: 'added' | 'removed' | 'changed';
+  oldValue?: unknown;
+  newValue?: unknown;
+}
+
+interface DiffViewProps {
+  entries: DiffEntry[];
+  fromVersion: number;
+  toVersion: number;
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') return `"${value}"`;
+  return JSON.stringify(value, null, 2);
+}
+
+export function DiffView({ entries, fromVersion, toVersion }: DiffViewProps) {
+  return (
+    <div className="p-4">
+      <h3 className="mb-3 text-sm font-medium text-slate-300">
+        Comparing v{fromVersion} to v{toVersion}
+      </h3>
+      {entries.length === 0 ? (
+        <p className="text-sm text-slate-400">No differences found.</p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {entries.map((entry) => (
+            <div
+              key={entry.path}
+              className={`rounded-lg border p-3 text-sm ${
+                entry.type === 'added'
+                  ? 'border-green-800 bg-green-950'
+                  : entry.type === 'removed'
+                    ? 'border-red-800 bg-red-950'
+                    : 'border-yellow-800 bg-yellow-950'
+              }`}
+            >
+              <div className="mb-1 flex items-center gap-2">
+                <code className="font-mono text-xs text-slate-300">{entry.path}</code>
+                <span className={`rounded px-1.5 py-0.5 text-xs ${
+                  entry.type === 'added'
+                    ? 'bg-green-900 text-green-300'
+                    : entry.type === 'removed'
+                      ? 'bg-red-900 text-red-300'
+                      : 'bg-yellow-900 text-yellow-300'
+                }`}
+                >
+                  {entry.type}
+                </span>
+              </div>
+              <div className="font-mono text-xs">
+                {entry.oldValue !== undefined ? (
+                  <div className="text-red-400">
+                    <span className="mr-1 text-red-600">-</span>
+                    {formatValue(entry.oldValue)}
+                  </div>
+                ) : null}
+                {entry.newValue !== undefined ? (
+                  <div className="text-green-400">
+                    <span className="mr-1 text-green-600">+</span>
+                    {formatValue(entry.newValue)}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/DiffView.tsx
+++ b/apps/desktop/src/components/DiffView.tsx
@@ -1,9 +1,4 @@
-interface DiffEntry {
-  path: string;
-  type: 'added' | 'removed' | 'changed';
-  oldValue?: unknown;
-  newValue?: unknown;
-}
+import type { DiffEntry } from '../types/versioning';
 
 interface DiffViewProps {
   entries: DiffEntry[];

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -22,7 +22,7 @@ export function Sidebar() {
         </button>
       </div>
       <div className="flex-1 py-2">
-        {routes.map((item) => (
+        {routes.filter((item) => item.nav !== false).map((item) => (
           <NavLink
             key={item.path}
             to={item.path}

--- a/apps/desktop/src/components/VersionHistory.tsx
+++ b/apps/desktop/src/components/VersionHistory.tsx
@@ -1,13 +1,4 @@
-interface SpecVersion {
-  id: string;
-  specId: string;
-  versionNumber: number;
-  content: Record<string, unknown>;
-  actorId: string;
-  actorType: 'user' | 'agent';
-  changeSummary: string;
-  createdAt: string;
-}
+import type { SpecVersion } from '../types/versioning';
 
 interface VersionHistoryProps {
   versions: SpecVersion[];
@@ -18,8 +9,9 @@ interface VersionHistoryProps {
 
 function formatRelativeTime(dateString: string): string {
   const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return 'unknown time';
   const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
   const diffMins = Math.floor(diffMs / 60_000);
   if (diffMins < 1) return 'just now';
   if (diffMins < 60) return `${diffMins}m ago`;

--- a/apps/desktop/src/components/VersionHistory.tsx
+++ b/apps/desktop/src/components/VersionHistory.tsx
@@ -1,0 +1,95 @@
+interface SpecVersion {
+  id: string;
+  specId: string;
+  versionNumber: number;
+  content: Record<string, unknown>;
+  actorId: string;
+  actorType: 'user' | 'agent';
+  changeSummary: string;
+  createdAt: string;
+}
+
+interface VersionHistoryProps {
+  versions: SpecVersion[];
+  onSelectVersion: (versionNumber: number) => void;
+  onCompare: (v1: number, v2: number) => void;
+  onRestore: (versionNumber: number) => void;
+}
+
+function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+export function VersionHistory({ versions, onSelectVersion, onCompare, onRestore }: VersionHistoryProps) {
+  if (versions.length === 0) {
+    return (
+      <div className="p-4 text-sm text-slate-400">
+        No versions yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      <h3 className="mb-2 text-sm font-medium text-slate-300">Version History</h3>
+      {versions.map((version, index) => (
+        <div
+          key={version.id}
+          className="rounded-lg border border-slate-700 bg-slate-800 p-3 transition-colors hover:border-slate-500"
+        >
+          <div className="mb-1 flex items-center justify-between">
+            <button
+              type="button"
+              className="text-sm font-medium text-blue-400 hover:text-blue-300"
+              onClick={() => onSelectVersion(version.versionNumber)}
+            >
+              v{version.versionNumber}
+            </button>
+            <span className={`rounded px-1.5 py-0.5 text-xs ${
+              version.actorType === 'agent'
+                ? 'bg-purple-900 text-purple-300'
+                : 'bg-blue-900 text-blue-300'
+            }`}
+            >
+              {version.actorType}
+            </span>
+          </div>
+          <p className="mb-2 text-xs text-slate-400">
+            {version.changeSummary || 'No summary'}
+          </p>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-slate-500">{formatRelativeTime(version.createdAt)}</span>
+            <div className="flex gap-1">
+              {index < versions.length - 1 ? (
+                <button
+                  type="button"
+                  className="rounded bg-slate-700 px-2 py-0.5 text-xs text-slate-400 hover:text-slate-200"
+                  onClick={() => onCompare(versions[index + 1].versionNumber, version.versionNumber)}
+                >
+                  Compare
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="rounded bg-slate-700 px-2 py-0.5 text-xs text-slate-400 hover:text-slate-200"
+                onClick={() => onRestore(version.versionNumber)}
+                aria-label={`Restore version ${version.versionNumber}`}
+              >
+                Restore
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/SpecDetail.tsx
+++ b/apps/desktop/src/pages/SpecDetail.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { DiffView } from '../components/DiffView';
+import { VersionHistory } from '../components/VersionHistory';
+import { useVersionStore } from '../store/versions';
+
+export function SpecDetail() {
+  const { specId } = useParams<{ specId: string }>();
+  const {
+    versions,
+    total,
+    loading,
+    selectedVersion,
+    diffResult,
+    fetchVersions,
+    fetchVersion,
+    fetchDiff,
+    restoreVersion,
+    reset,
+  } = useVersionStore();
+  const [diffRange, setDiffRange] = useState<{ from: number; to: number } | null>(null);
+
+  useEffect(() => {
+    if (specId) {
+      void fetchVersions(specId);
+    }
+    return () => reset();
+  }, [specId, fetchVersions, reset]);
+
+  const handleCompare = (v1: number, v2: number) => {
+    if (!specId) return;
+    setDiffRange({ from: v1, to: v2 });
+    void fetchDiff(specId, v1, v2);
+  };
+
+  const handleRestore = async (versionNumber: number) => {
+    if (!specId) return;
+    await restoreVersion(specId, versionNumber);
+    setDiffRange(null);
+  };
+
+  const handleSelectVersion = (versionNumber: number) => {
+    if (!specId) return;
+    void fetchVersion(specId, versionNumber);
+  };
+
+  if (!specId) return null;
+
+  return (
+    <div className="flex h-full">
+      <div className="flex-1 p-6">
+        <h1 className="text-2xl font-semibold">Spec Detail</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          {loading ? 'Loading versions…' : `${total} versions`}
+        </p>
+        {selectedVersion ? (
+          <div className="mt-4 rounded border border-slate-800 bg-slate-900/40 p-3 text-sm text-slate-300">
+            Viewing version v{selectedVersion.versionNumber}
+          </div>
+        ) : null}
+        {diffRange && diffResult ? (
+          <div className="mt-4">
+            <DiffView entries={diffResult} fromVersion={diffRange.from} toVersion={diffRange.to} />
+          </div>
+        ) : null}
+      </div>
+      <div className="w-80 overflow-y-auto border-l border-slate-700">
+        <h2 className="px-4 pt-4 text-sm font-medium text-slate-300">Version History</h2>
+        <VersionHistory
+          versions={versions}
+          onSelectVersion={handleSelectVersion}
+          onCompare={handleCompare}
+          onRestore={handleRestore}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/SpecDetail.tsx
+++ b/apps/desktop/src/pages/SpecDetail.tsx
@@ -27,24 +27,21 @@ export function SpecDetail() {
     return () => reset();
   }, [specId, fetchVersions, reset]);
 
+  if (!specId) return null;
+
   const handleCompare = (v1: number, v2: number) => {
-    if (!specId) return;
     setDiffRange({ from: v1, to: v2 });
     void fetchDiff(specId, v1, v2);
   };
 
   const handleRestore = async (versionNumber: number) => {
-    if (!specId) return;
     await restoreVersion(specId, versionNumber);
     setDiffRange(null);
   };
 
   const handleSelectVersion = (versionNumber: number) => {
-    if (!specId) return;
     void fetchVersion(specId, versionNumber);
   };
-
-  if (!specId) return null;
 
   return (
     <div className="flex h-full">

--- a/apps/desktop/src/pages/Specs.tsx
+++ b/apps/desktop/src/pages/Specs.tsx
@@ -1,8 +1,18 @@
+import { Link } from 'react-router-dom';
+
 export function Specs() {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-semibold">Specs</h1>
       <p className="mt-2 text-slate-400">Manage agent specifications.</p>
+      <div className="mt-6">
+        <Link
+          to="/specs/spec-1"
+          className="inline-flex rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-200 hover:border-slate-500 hover:bg-slate-800"
+        >
+          Open Spec Detail (demo)
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/routes.ts
+++ b/apps/desktop/src/routes.ts
@@ -11,6 +11,7 @@ import type { ComponentType } from 'react';
 
 import { Dashboard } from './pages/Dashboard';
 import { Specs } from './pages/Specs';
+import { SpecDetail } from './pages/SpecDetail';
 import { Agents } from './pages/Agents';
 import { Artifacts } from './pages/Artifacts';
 import { Fleet } from './pages/Fleet';
@@ -22,11 +23,13 @@ export interface AppRoute {
   icon: LucideIcon;
   component: ComponentType;
   end?: boolean;
+  nav?: boolean;
 }
 
 export const routes: AppRoute[] = [
   { path: '/', label: 'Dashboard', icon: LayoutDashboard, component: Dashboard, end: true },
   { path: '/specs', label: 'Specs', icon: FileText, component: Specs },
+  { path: '/specs/:specId', label: 'Spec Detail', icon: FileText, component: SpecDetail, nav: false },
   { path: '/agents', label: 'Agents', icon: Bot, component: Agents },
   { path: '/artifacts', label: 'Artifacts', icon: Package, component: Artifacts },
   { path: '/fleet', label: 'Fleet', icon: Server, component: Fleet },

--- a/apps/desktop/src/store/versions.ts
+++ b/apps/desktop/src/store/versions.ts
@@ -1,0 +1,78 @@
+import { create } from 'zustand';
+
+interface SpecVersion {
+  id: string;
+  specId: string;
+  versionNumber: number;
+  content: Record<string, unknown>;
+  actorId: string;
+  actorType: 'user' | 'agent';
+  changeSummary: string;
+  createdAt: string;
+}
+
+interface DiffEntry {
+  path: string;
+  type: 'added' | 'removed' | 'changed';
+  oldValue?: unknown;
+  newValue?: unknown;
+}
+
+interface VersionState {
+  versions: SpecVersion[];
+  total: number;
+  loading: boolean;
+  selectedVersion: SpecVersion | null;
+  diffResult: DiffEntry[] | null;
+  fetchVersions: (specId: string, limit?: number, offset?: number) => Promise<void>;
+  fetchVersion: (specId: string, versionNumber: number) => Promise<void>;
+  fetchDiff: (specId: string, v1: number, v2: number) => Promise<void>;
+  restoreVersion: (specId: string, versionNumber: number) => Promise<void>;
+  reset: () => void;
+}
+
+const API_BASE = '/api/specs';
+
+export const useVersionStore = create<VersionState>()((set, get) => ({
+  versions: [],
+  total: 0,
+  loading: false,
+  selectedVersion: null,
+  diffResult: null,
+
+  fetchVersions: async (specId, limit = 50, offset = 0) => {
+    set({ loading: true });
+    const res = await fetch(`${API_BASE}/${specId}/versions?limit=${limit}&offset=${offset}`);
+    const data = await res.json();
+    set({ versions: data.items, total: data.total, loading: false });
+  },
+
+  fetchVersion: async (specId, versionNumber) => {
+    set({ loading: true });
+    const res = await fetch(`${API_BASE}/${specId}/versions/${versionNumber}`);
+    const data = await res.json();
+    set({ selectedVersion: data, loading: false });
+  },
+
+  fetchDiff: async (specId, v1, v2) => {
+    set({ loading: true });
+    const res = await fetch(`${API_BASE}/${specId}/versions/${v1}/diff/${v2}`);
+    const data = await res.json();
+    set({ diffResult: data, loading: false });
+  },
+
+  restoreVersion: async (specId, versionNumber) => {
+    set({ loading: true });
+    await fetch(`${API_BASE}/${specId}/versions/${versionNumber}/restore`, { method: 'POST' });
+    await get().fetchVersions(specId);
+    set({ loading: false });
+  },
+
+  reset: () => set({
+    versions: [],
+    total: 0,
+    loading: false,
+    selectedVersion: null,
+    diffResult: null,
+  }),
+}));

--- a/apps/desktop/src/types/versioning.ts
+++ b/apps/desktop/src/types/versioning.ts
@@ -1,0 +1,24 @@
+export type ActorType = 'user' | 'agent';
+
+export interface SpecVersion {
+  id: string;
+  specId: string;
+  versionNumber: number;
+  content: Record<string, unknown>;
+  actorId: string;
+  actorType: ActorType;
+  changeSummary: string;
+  createdAt: string;
+}
+
+export interface DiffEntry {
+  path: string;
+  type: 'added' | 'removed' | 'changed';
+  oldValue?: unknown;
+  newValue?: unknown;
+}
+
+export interface VersionListResponse {
+  items: SpecVersion[];
+  total: number;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "turbo run test",
     "test:unit": "vitest run --config vitest.config.ts",
     "coverage": "vitest run --config vitest.config.ts --coverage",
-    "test:e2e": "playwright test",
+    "test:e2e": "pnpm vitest run --config vitest.e2e.config.ts && playwright test",
     "lint:biome": "biome check .",
     "check": "pnpm lint && pnpm typecheck && pnpm test"
   },

--- a/packages/db/drizzle/0002_mushy_vivisector.sql
+++ b/packages/db/drizzle/0002_mushy_vivisector.sql
@@ -1,0 +1,5 @@
+CREATE TYPE "public"."actor_type" AS ENUM('user', 'agent');--> statement-breakpoint
+ALTER TABLE "spec_versions" ALTER COLUMN "version_number" SET DATA TYPE integer;--> statement-breakpoint
+ALTER TABLE "spec_versions" ADD COLUMN "actor_id" uuid NOT NULL;--> statement-breakpoint
+ALTER TABLE "spec_versions" ADD COLUMN "actor_type" "actor_type" NOT NULL;--> statement-breakpoint
+ALTER TABLE "spec_versions" ADD COLUMN "change_summary" text DEFAULT '' NOT NULL;

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,984 @@
+{
+  "id": "020099d2-7234-4500-878f-202aa899a8ef",
+  "prevId": "305b552a-55cb-4270-9227-7020d2470438",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "spec_id": {
+          "name": "spec_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_role": {
+          "name": "agent_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_runs_spec_id_idx": {
+          "name": "agent_runs_spec_id_idx",
+          "columns": [
+            {
+              "expression": "spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_spec_id_specs_id_fk": {
+          "name": "agent_runs_spec_id_specs_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "specs",
+          "columnsFrom": [
+            "spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_team_id_idx": {
+          "name": "api_keys_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_created_by_idx": {
+          "name": "api_keys_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_team_id_teams_id_fk": {
+          "name": "api_keys_team_id_teams_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_users_id_fk": {
+          "name": "api_keys_created_by_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "artifacts_agent_run_id_idx": {
+          "name": "artifacts_agent_run_id_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_agent_run_id_agent_runs_id_fk": {
+          "name": "artifacts_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_team_id_idx": {
+          "name": "audit_log_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_team_id_teams_id_fk": {
+          "name": "audit_log_team_id_teams_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_agent_run_id_agent_runs_id_fk": {
+          "name": "audit_log_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spec_versions": {
+      "name": "spec_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "spec_id": {
+          "name": "spec_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "spec_versions_spec_id_idx": {
+          "name": "spec_versions_spec_id_idx",
+          "columns": [
+            {
+              "expression": "spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spec_versions_spec_id_specs_id_fk": {
+          "name": "spec_versions_spec_id_specs_id_fk",
+          "tableFrom": "spec_versions",
+          "tableTo": "specs",
+          "columnsFrom": [
+            "spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "spec_versions_spec_id_version_number_key": {
+          "name": "spec_versions_spec_id_version_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "spec_id",
+            "version_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.specs": {
+      "name": "specs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "spec_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "specs_team_id_idx": {
+          "name": "specs_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "specs_team_id_teams_id_fk": {
+          "name": "specs_team_id_teams_id_fk",
+          "tableFrom": "specs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "specs_created_by_users_id_fk": {
+          "name": "specs_created_by_users_id_fk",
+          "tableFrom": "specs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "spec_id": {
+          "name": "spec_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "depends_on": {
+          "name": "depends_on",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::uuid[]"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_spec_id_idx": {
+          "name": "tasks_spec_id_idx",
+          "columns": [
+            {
+              "expression": "spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_agent_run_id_idx": {
+          "name": "tasks_agent_run_id_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_spec_id_specs_id_fk": {
+          "name": "tasks_spec_id_specs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "specs",
+          "columnsFrom": [
+            "spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_agent_run_id_agent_runs_id_fk": {
+          "name": "tasks_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_members_team_id_idx": {
+          "name": "team_members_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_user_id_team_id_pk": {
+          "name": "team_members_user_id_team_id_pk",
+          "columns": [
+            "user_id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.agent_run_status": {
+      "name": "agent_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.spec_status": {
+      "name": "spec_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "in_progress",
+        "verifying",
+        "done",
+        "failed"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "assigned",
+        "running",
+        "completed",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.team_role": {
+      "name": "team_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1772151354999,
       "tag": "0001_thick_leech",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772206380754,
+      "tag": "0002_mushy_vivisector",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/schema-contract.test.ts
+++ b/packages/db/src/__tests__/schema-contract.test.ts
@@ -4,6 +4,7 @@ import {
   specStatusEnum,
   agentRunStatusEnum,
   taskStatusEnum,
+  actorTypeEnum,
   users,
   teams,
   teamMembers,
@@ -22,6 +23,7 @@ describe('db enums', () => {
     expect(specStatusEnum.enumValues).toEqual(['draft', 'approved', 'in_progress', 'verifying', 'done', 'failed']);
     expect(agentRunStatusEnum.enumValues).toEqual(['queued', 'running', 'completed', 'failed', 'cancelled']);
     expect(taskStatusEnum.enumValues).toEqual(['pending', 'assigned', 'running', 'completed', 'failed', 'skipped']);
+    expect(actorTypeEnum.enumValues).toEqual(['user', 'agent']);
   });
 });
 
@@ -49,7 +51,16 @@ describe('table exports', () => {
       expect.arrayContaining(['id', 'teamId', 'title', 'content', 'status', 'createdBy', 'createdAt', 'updatedAt']),
     );
     expect(cols(specVersions)).toEqual(
-      expect.arrayContaining(['id', 'specId', 'versionNumber', 'content', 'createdAt']),
+      expect.arrayContaining([
+        'id',
+        'specId',
+        'versionNumber',
+        'content',
+        'actorId',
+        'actorType',
+        'changeSummary',
+        'createdAt',
+      ]),
     );
     expect(cols(agentRuns)).toEqual(
       expect.arrayContaining(['id', 'specId', 'agentRole', 'status', 'environmentId', 'model', 'startedAt', 'completedAt']),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,5 +1,6 @@
 import { relations, sql } from 'drizzle-orm';
 import {
+  integer,
   index,
   jsonb,
   pgEnum,
@@ -15,6 +16,7 @@ export const teamRoleEnum = pgEnum('team_role', ['admin', 'member', 'viewer']);
 export const specStatusEnum = pgEnum('spec_status', ['draft', 'approved', 'in_progress', 'verifying', 'done', 'failed']);
 export const agentRunStatusEnum = pgEnum('agent_run_status', ['queued', 'running', 'completed', 'failed', 'cancelled']);
 export const taskStatusEnum = pgEnum('task_status', ['pending', 'assigned', 'running', 'completed', 'failed', 'skipped']);
+export const actorTypeEnum = pgEnum('actor_type', ['user', 'agent']);
 
 export const users = pgTable('users', {
   id: uuid('id').defaultRandom().primaryKey(),
@@ -65,8 +67,11 @@ export const specVersions = pgTable(
   {
     id: uuid('id').defaultRandom().primaryKey(),
     specId: uuid('spec_id').notNull().references(() => specs.id, { onDelete: 'cascade' }),
-    versionNumber: text('version_number').notNull(),
+    versionNumber: integer('version_number').notNull(),
     content: jsonb('content').$type<Record<string, unknown>>().notNull(),
+    actorId: uuid('actor_id').notNull(),
+    actorType: actorTypeEnum('actor_type').notNull(),
+    changeSummary: text('change_summary').notNull().default(''),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [

--- a/packages/gateway/src/__tests__/diff.test.ts
+++ b/packages/gateway/src/__tests__/diff.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { diffSpecs } from '../versioning/diff.js';
+
+describe('diffSpecs', () => {
+  it('returns empty array for identical objects', () => {
+    const obj = { title: 'test', intent: 'do stuff' };
+    expect(diffSpecs(obj, obj)).toEqual([]);
+  });
+
+  it('detects changed primitive field', () => {
+    const old = { title: 'old title', intent: 'same' };
+    const next = { title: 'new title', intent: 'same' };
+    expect(diffSpecs(old, next)).toEqual([
+      { path: 'title', type: 'changed', oldValue: 'old title', newValue: 'new title' },
+    ]);
+  });
+
+  it('detects added array element', () => {
+    const old = { constraints: ['a', 'b'] };
+    const next = { constraints: ['a', 'b', 'c'] };
+    expect(diffSpecs(old, next)).toEqual([
+      { path: 'constraints.2', type: 'added', newValue: 'c' },
+    ]);
+  });
+
+  it('detects removed array element', () => {
+    const old = { constraints: ['a', 'b', 'c'] };
+    const next = { constraints: ['a', 'b'] };
+    expect(diffSpecs(old, next)).toEqual([
+      { path: 'constraints.2', type: 'removed', oldValue: 'c' },
+    ]);
+  });
+
+  it('detects changed array element', () => {
+    const old = { constraints: ['a', 'b'] };
+    const next = { constraints: ['a', 'x'] };
+    expect(diffSpecs(old, next)).toEqual([
+      { path: 'constraints.1', type: 'changed', oldValue: 'b', newValue: 'x' },
+    ]);
+  });
+
+  it('recurses into nested objects', () => {
+    const old = { verification: { criteria: ['test1'], testPlan: 'plan A' } };
+    const next = { verification: { criteria: ['test1'], testPlan: 'plan B' } };
+    expect(diffSpecs(old, next)).toEqual([
+      { path: 'verification.testPlan', type: 'changed', oldValue: 'plan A', newValue: 'plan B' },
+    ]);
+  });
+
+  it('detects added top-level field', () => {
+    const old = { title: 'test' };
+    const next = { title: 'test', intent: 'new field' };
+    expect(diffSpecs(old, next)).toEqual([
+      { path: 'intent', type: 'added', newValue: 'new field' },
+    ]);
+  });
+
+  it('detects removed top-level field', () => {
+    const old = { title: 'test', intent: 'old' };
+    const next = { title: 'test' };
+    expect(diffSpecs(old, next)).toEqual([
+      { path: 'intent', type: 'removed', oldValue: 'old' },
+    ]);
+  });
+
+  it('ignores meta.updatedAt changes', () => {
+    const old = { meta: { version: 1, createdAt: '2026-01-01', updatedAt: '2026-01-01' } };
+    const next = { meta: { version: 1, createdAt: '2026-01-01', updatedAt: '2026-02-01' } };
+    expect(diffSpecs(old, next)).toEqual([]);
+  });
+
+  it('handles multiple changes across fields', () => {
+    const old = { title: 'a', intent: 'x', constraints: ['c1'] };
+    const next = { title: 'b', intent: 'x', constraints: ['c1', 'c2'] };
+    const result = diffSpecs(old, next);
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(expect.arrayContaining([
+      { path: 'title', type: 'changed', oldValue: 'a', newValue: 'b' },
+      { path: 'constraints.1', type: 'added', newValue: 'c2' },
+    ]));
+  });
+});

--- a/packages/gateway/src/__tests__/spec-versions.test.ts
+++ b/packages/gateway/src/__tests__/spec-versions.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGatewayApp } from '../app.js';
+import type { VersionStoreAdapter } from '../types.js';
+
+function makeConfig() {
+  return {
+    port: 3001,
+    allowedOrigins: ['http://localhost:1420'],
+    sessionCookieName: 'kata.sid',
+    redisUrl: 'redis://localhost:6379',
+    rateLimitWindowMs: 60_000,
+    rateLimitMaxRequests: 60,
+    wsHeartbeatIntervalMs: 15_000,
+    wsHeartbeatTimeoutMs: 30_000,
+    wsMaxSubscriptionsPerConnection: 100,
+  };
+}
+
+const specId = '00000000-0000-4000-8000-000000000001';
+const actorId = '00000000-0000-4000-8000-000000000002';
+const teamId = 'team-1';
+
+function makeVersionStore(overrides: Partial<VersionStoreAdapter> = {}): VersionStoreAdapter {
+  return {
+    getSpec: vi.fn(async () => ({ id: specId, teamId, content: { title: 'test' } })),
+    updateSpecContent: vi.fn(async () => {}),
+    createVersion: vi.fn(async (data) => ({
+      id: '00000000-0000-4000-8000-000000000099',
+      ...data,
+      createdAt: new Date('2026-02-27T00:00:00.000Z'),
+    })),
+    getVersion: vi.fn(async () => ({
+      id: '00000000-0000-4000-8000-000000000099',
+      specId,
+      versionNumber: 1,
+      content: { title: 'test' },
+      actorId,
+      actorType: 'user',
+      changeSummary: 'Initial',
+      createdAt: new Date('2026-02-27T00:00:00.000Z'),
+    })),
+    listVersions: vi.fn(async () => ({
+      items: [],
+      total: 0,
+    })),
+    getMaxVersionNumber: vi.fn(async () => 0),
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides = {}) {
+  return {
+    logger: { info: () => {}, error: () => {} },
+    apiKeyAuth: {
+      validateApiKey: vi.fn(async () => ({ teamId, keyId: 'key-1' })),
+    },
+    sessionStore: { getSession: vi.fn(async () => null) },
+    versionStore: makeVersionStore(),
+    now: () => new Date('2026-02-27T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function authedRequest(path: string, init: RequestInit = {}) {
+  return new Request(`http://localhost${path}`, {
+    ...init,
+    headers: { 'x-api-key': 'kat_live_123', ...init.headers },
+  });
+}
+
+describe('POST /api/specs/:specId/versions', () => {
+  it('creates a version and returns it', async () => {
+    const app = createGatewayApp(makeConfig(), makeDeps());
+    const res = await app.request(
+      authedRequest(`/api/specs/${specId}/versions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ content: { title: 'updated' }, changeSummary: 'Updated title' }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.versionNumber).toBe(1);
+    expect(body.changeSummary).toBe('Updated title');
+  });
+
+  it('returns 404 for nonexistent spec', async () => {
+    const store = makeVersionStore({ getSpec: vi.fn(async () => null) });
+    const app = createGatewayApp(makeConfig(), makeDeps({ versionStore: store }));
+    const res = await app.request(
+      authedRequest(`/api/specs/${specId}/versions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ content: { title: 'x' }, changeSummary: '' }),
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 without auth', async () => {
+    const app = createGatewayApp(makeConfig(), makeDeps());
+    const res = await app.request(`/api/specs/${specId}/versions`, { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/specs/:specId/versions', () => {
+  it('lists versions with pagination', async () => {
+    const store = makeVersionStore({
+      listVersions: vi.fn(async () => ({
+        items: [{
+          id: '00000000-0000-4000-8000-000000000099',
+          specId,
+          versionNumber: 1,
+          content: { title: 'test' },
+          actorId,
+          actorType: 'user',
+          changeSummary: 'Init',
+          createdAt: new Date('2026-02-27T00:00:00.000Z'),
+        }],
+        total: 1,
+      })),
+    });
+    const app = createGatewayApp(makeConfig(), makeDeps({ versionStore: store }));
+    const res = await app.request(authedRequest(`/api/specs/${specId}/versions?limit=10&offset=0`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.total).toBe(1);
+  });
+});
+
+describe('GET /api/specs/:specId/versions/:versionNumber', () => {
+  it('returns a single version', async () => {
+    const app = createGatewayApp(makeConfig(), makeDeps());
+    const res = await app.request(authedRequest(`/api/specs/${specId}/versions/1`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.versionNumber).toBe(1);
+  });
+
+  it('returns 404 for nonexistent version', async () => {
+    const store = makeVersionStore({ getVersion: vi.fn(async () => null) });
+    const app = createGatewayApp(makeConfig(), makeDeps({ versionStore: store }));
+    const res = await app.request(authedRequest(`/api/specs/${specId}/versions/999`));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/specs/:specId/versions/:v1/diff/:v2', () => {
+  it('returns structured diff between two versions', async () => {
+    const store = makeVersionStore({
+      getVersion: vi.fn()
+        .mockResolvedValueOnce({
+          id: 'v1-id',
+          specId,
+          versionNumber: 1,
+          content: { title: 'old' },
+          actorId,
+          actorType: 'user',
+          changeSummary: '',
+          createdAt: new Date(),
+        })
+        .mockResolvedValueOnce({
+          id: 'v2-id',
+          specId,
+          versionNumber: 2,
+          content: { title: 'new' },
+          actorId,
+          actorType: 'user',
+          changeSummary: '',
+          createdAt: new Date(),
+        }),
+    });
+    const app = createGatewayApp(makeConfig(), makeDeps({ versionStore: store }));
+    const res = await app.request(authedRequest(`/api/specs/${specId}/versions/1/diff/2`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([
+      { path: 'title', type: 'changed', oldValue: 'old', newValue: 'new' },
+    ]);
+  });
+
+  it('returns 404 if either version missing', async () => {
+    const store = makeVersionStore({
+      getVersion: vi.fn().mockResolvedValueOnce(null),
+    });
+    const app = createGatewayApp(makeConfig(), makeDeps({ versionStore: store }));
+    const res = await app.request(authedRequest(`/api/specs/${specId}/versions/1/diff/2`));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/specs/:specId/versions/:versionNumber/restore', () => {
+  it('creates a new version with restored content', async () => {
+    const store = makeVersionStore({
+      getVersion: vi.fn(async () => ({
+        id: 'v1-id',
+        specId,
+        versionNumber: 1,
+        content: { title: 'original' },
+        actorId,
+        actorType: 'user' as const,
+        changeSummary: 'First',
+        createdAt: new Date(),
+      })),
+      getMaxVersionNumber: vi.fn(async () => 3),
+    });
+    const app = createGatewayApp(makeConfig(), makeDeps({ versionStore: store }));
+    const res = await app.request(
+      authedRequest(`/api/specs/${specId}/versions/1/restore`, { method: 'POST' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.versionNumber).toBe(4);
+    expect(body.changeSummary).toBe('Restored from version 1');
+  });
+
+  it('returns 404 for nonexistent version', async () => {
+    const store = makeVersionStore({ getVersion: vi.fn(async () => null) });
+    const app = createGatewayApp(makeConfig(), makeDeps({ versionStore: store }));
+    const res = await app.request(
+      authedRequest(`/api/specs/${specId}/versions/999/restore`, { method: 'POST' }),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('team isolation', () => {
+  it('returns 404 when spec belongs to another team', async () => {
+    const store = makeVersionStore({
+      getSpec: vi.fn(async () => ({ id: specId, teamId: 'other-team', content: {} })),
+    });
+    const app = createGatewayApp(makeConfig(), makeDeps({ versionStore: store }));
+    const res = await app.request(authedRequest(`/api/specs/${specId}/versions`));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('missing version store', () => {
+  it('returns 500 when version store dependency is not configured', async () => {
+    const { versionStore: _ignored, ...depsWithoutStore } = makeDeps();
+    const app = createGatewayApp(makeConfig(), depsWithoutStore);
+    const res = await app.request(authedRequest(`/api/specs/${specId}/versions`));
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/gateway/src/__tests__/spec-versions.test.ts
+++ b/packages/gateway/src/__tests__/spec-versions.test.ts
@@ -239,7 +239,7 @@ describe('team isolation', () => {
 
 describe('missing version store', () => {
   it('returns 500 when version store dependency is not configured', async () => {
-    const { versionStore: _ignored, ...depsWithoutStore } = makeDeps();
+    const depsWithoutStore = makeDeps({ versionStore: undefined });
     const app = createGatewayApp(makeConfig(), depsWithoutStore);
     const res = await app.request(authedRequest(`/api/specs/${specId}/versions`));
     expect(res.status).toBe(500);

--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -24,7 +24,7 @@ export function createGatewayApp(config: GatewayConfig, deps: GatewayDeps) {
   app.use('/api/*', authMiddleware(config, deps));
 
   registerHealthRoute(app);
-  registerSpecsRoutes(app);
+  registerSpecsRoutes(app, deps);
   registerAgentsRoutes(app);
   registerTeamsRoutes(app);
   registerArtifactsRoutes(app);

--- a/packages/gateway/src/middleware/error-handler.ts
+++ b/packages/gateway/src/middleware/error-handler.ts
@@ -2,7 +2,12 @@ import type { Context } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import type { ErrorCode } from '../types.js';
 
-export function jsonError(c: Context, status: ContentfulStatusCode, code: ErrorCode, message: string) {
+export function jsonError<TStatus extends ContentfulStatusCode>(
+  c: Context,
+  status: TStatus,
+  code: ErrorCode,
+  message: string,
+) {
   return c.json(
     {
       error: {

--- a/packages/gateway/src/routes/specs.ts
+++ b/packages/gateway/src/routes/specs.ts
@@ -41,6 +41,14 @@ const CreateVersionBodySchema = z.object({
   changeSummary: z.string().default(''),
 });
 
+const ErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    requestId: z.string(),
+  }),
+});
+
 const specListRoute = createRoute({
   method: 'get',
   path: '/api/specs',
@@ -72,6 +80,18 @@ const createVersionRoute = createRoute({
       description: 'Version created',
       content: { 'application/json': { schema: SpecVersionSchema } },
     },
+    401: {
+      description: 'Authentication required',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: 'Spec not found',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    500: {
+      description: 'Version store unavailable',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
   },
 });
 
@@ -91,6 +111,18 @@ const listVersionsRoute = createRoute({
       description: 'Paginated list of versions',
       content: { 'application/json': { schema: VersionListResponseSchema } },
     },
+    401: {
+      description: 'Authentication required',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: 'Spec not found',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    500: {
+      description: 'Version store unavailable',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
   },
 });
 
@@ -108,6 +140,18 @@ const getVersionRoute = createRoute({
     200: {
       description: 'Single version',
       content: { 'application/json': { schema: SpecVersionSchema } },
+    },
+    401: {
+      description: 'Authentication required',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: 'Spec or version not found',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    500: {
+      description: 'Version store unavailable',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
     },
   },
 });
@@ -128,6 +172,18 @@ const diffVersionsRoute = createRoute({
       description: 'Structured diff between versions',
       content: { 'application/json': { schema: z.array(DiffEntrySchema) } },
     },
+    401: {
+      description: 'Authentication required',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: 'Spec or version not found',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    500: {
+      description: 'Version store unavailable',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
   },
 });
 
@@ -145,6 +201,18 @@ const restoreVersionRoute = createRoute({
     201: {
       description: 'New version created from restored content',
       content: { 'application/json': { schema: SpecVersionSchema } },
+    },
+    401: {
+      description: 'Authentication required',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: 'Spec or version not found',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    500: {
+      description: 'Version store unavailable',
+      content: { 'application/json': { schema: ErrorResponseSchema } },
     },
   },
 });

--- a/packages/gateway/src/routes/specs.ts
+++ b/packages/gateway/src/routes/specs.ts
@@ -1,5 +1,7 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
-import type { GatewayEnv } from '../types.js';
+import { jsonError } from '../middleware/error-handler.js';
+import type { GatewayDeps, GatewayEnv, VersionStoreVersionRecord } from '../types.js';
+import { diffSpecs } from '../versioning/diff.js';
 
 const SpecsListSchema = z.object({
   items: z.array(
@@ -11,7 +13,35 @@ const SpecsListSchema = z.object({
   message: z.literal('Not implemented yet'),
 });
 
-const route = createRoute({
+const SpecVersionSchema = z.object({
+  id: z.string().uuid(),
+  specId: z.string().uuid(),
+  versionNumber: z.number().int().positive(),
+  content: z.record(z.unknown()),
+  actorId: z.string(),
+  actorType: z.enum(['user', 'agent']),
+  changeSummary: z.string(),
+  createdAt: z.string().datetime(),
+});
+
+const DiffEntrySchema = z.object({
+  path: z.string(),
+  type: z.enum(['added', 'removed', 'changed']),
+  oldValue: z.unknown().optional(),
+  newValue: z.unknown().optional(),
+});
+
+const VersionListResponseSchema = z.object({
+  items: z.array(SpecVersionSchema),
+  total: z.number().int().nonnegative(),
+});
+
+const CreateVersionBodySchema = z.object({
+  content: z.record(z.unknown()),
+  changeSummary: z.string().default(''),
+});
+
+const specListRoute = createRoute({
   method: 'get',
   path: '/api/specs',
   tags: ['specs'],
@@ -23,6 +53,272 @@ const route = createRoute({
   },
 });
 
-export function registerSpecsRoutes(app: OpenAPIHono<GatewayEnv>) {
-  app.openapi(route, (c) => c.json({ items: [], message: 'Not implemented yet' }));
+const createVersionRoute = createRoute({
+  method: 'post',
+  path: '/api/specs/{specId}/versions',
+  tags: ['specs'],
+  request: {
+    params: z.object({ specId: z.string().uuid() }),
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateVersionBodySchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Version created',
+      content: { 'application/json': { schema: SpecVersionSchema } },
+    },
+  },
+});
+
+const listVersionsRoute = createRoute({
+  method: 'get',
+  path: '/api/specs/{specId}/versions',
+  tags: ['specs'],
+  request: {
+    params: z.object({ specId: z.string().uuid() }),
+    query: z.object({
+      limit: z.coerce.number().int().positive().max(200).default(50),
+      offset: z.coerce.number().int().nonnegative().default(0),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Paginated list of versions',
+      content: { 'application/json': { schema: VersionListResponseSchema } },
+    },
+  },
+});
+
+const getVersionRoute = createRoute({
+  method: 'get',
+  path: '/api/specs/{specId}/versions/{versionNumber}',
+  tags: ['specs'],
+  request: {
+    params: z.object({
+      specId: z.string().uuid(),
+      versionNumber: z.coerce.number().int().positive(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Single version',
+      content: { 'application/json': { schema: SpecVersionSchema } },
+    },
+  },
+});
+
+const diffVersionsRoute = createRoute({
+  method: 'get',
+  path: '/api/specs/{specId}/versions/{v1}/diff/{v2}',
+  tags: ['specs'],
+  request: {
+    params: z.object({
+      specId: z.string().uuid(),
+      v1: z.coerce.number().int().positive(),
+      v2: z.coerce.number().int().positive(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Structured diff between versions',
+      content: { 'application/json': { schema: z.array(DiffEntrySchema) } },
+    },
+  },
+});
+
+const restoreVersionRoute = createRoute({
+  method: 'post',
+  path: '/api/specs/{specId}/versions/{versionNumber}/restore',
+  tags: ['specs'],
+  request: {
+    params: z.object({
+      specId: z.string().uuid(),
+      versionNumber: z.coerce.number().int().positive(),
+    }),
+  },
+  responses: {
+    201: {
+      description: 'New version created from restored content',
+      content: { 'application/json': { schema: SpecVersionSchema } },
+    },
+  },
+});
+
+function normalizeActorType(value: string): 'user' | 'agent' {
+  return value === 'agent' ? 'agent' : 'user';
+}
+
+function toVersionResponse(version: VersionStoreVersionRecord) {
+  return {
+    id: version.id,
+    specId: version.specId,
+    versionNumber: version.versionNumber,
+    content: version.content,
+    actorId: version.actorId,
+    actorType: normalizeActorType(version.actorType),
+    changeSummary: version.changeSummary,
+    createdAt: version.createdAt.toISOString(),
+  };
+}
+
+function resolveActor(principal: GatewayEnv['Variables']['principal']) {
+  if (!principal) return null;
+  if (principal.type === 'session_user') {
+    return { actorId: principal.userId, actorType: 'user' as const };
+  }
+  return { actorId: principal.keyId, actorType: 'agent' as const };
+}
+
+export function registerSpecsRoutes(app: OpenAPIHono<GatewayEnv>, deps: GatewayDeps) {
+  app.openapi(specListRoute, (c) => c.json({ items: [], message: 'Not implemented yet' }));
+
+  app.openapi(createVersionRoute, async (c) => {
+    const store = deps.versionStore;
+    if (!store) {
+      return jsonError(c, 500, 'INTERNAL_ERROR', 'Version store unavailable');
+    }
+
+    const principal = c.get('principal');
+    if (!principal) return jsonError(c, 401, 'AUTH_REQUIRED', 'Authentication required');
+
+    const { specId } = c.req.valid('param');
+    const { content, changeSummary } = c.req.valid('json');
+
+    const spec = await store.getSpec(specId);
+    if (!spec || spec.teamId !== principal.teamId) {
+      return jsonError(c, 404, 'NOT_FOUND', 'Spec not found');
+    }
+
+    const actor = resolveActor(principal);
+    if (!actor) return jsonError(c, 401, 'AUTH_REQUIRED', 'Authentication required');
+
+    const versionNumber = (await store.getMaxVersionNumber(specId)) + 1;
+    const created = await store.createVersion({
+      specId,
+      versionNumber,
+      content,
+      actorId: actor.actorId,
+      actorType: actor.actorType,
+      changeSummary,
+    });
+    await store.updateSpecContent(specId, content);
+    return c.json(toVersionResponse(created), 201);
+  });
+
+  app.openapi(listVersionsRoute, async (c) => {
+    const store = deps.versionStore;
+    if (!store) {
+      return jsonError(c, 500, 'INTERNAL_ERROR', 'Version store unavailable');
+    }
+
+    const principal = c.get('principal');
+    if (!principal) return jsonError(c, 401, 'AUTH_REQUIRED', 'Authentication required');
+
+    const { specId } = c.req.valid('param');
+    const { limit, offset } = c.req.valid('query');
+    const spec = await store.getSpec(specId);
+    if (!spec || spec.teamId !== principal.teamId) {
+      return jsonError(c, 404, 'NOT_FOUND', 'Spec not found');
+    }
+
+    const result = await store.listVersions(specId, limit, offset);
+    return c.json(
+      {
+        items: result.items.map(toVersionResponse),
+        total: result.total,
+      },
+      200,
+    );
+  });
+
+  app.openapi(getVersionRoute, async (c) => {
+    const store = deps.versionStore;
+    if (!store) {
+      return jsonError(c, 500, 'INTERNAL_ERROR', 'Version store unavailable');
+    }
+
+    const principal = c.get('principal');
+    if (!principal) return jsonError(c, 401, 'AUTH_REQUIRED', 'Authentication required');
+
+    const { specId, versionNumber } = c.req.valid('param');
+    const spec = await store.getSpec(specId);
+    if (!spec || spec.teamId !== principal.teamId) {
+      return jsonError(c, 404, 'NOT_FOUND', 'Spec not found');
+    }
+
+    const version = await store.getVersion(specId, versionNumber);
+    if (!version) {
+      return jsonError(c, 404, 'NOT_FOUND', 'Version not found');
+    }
+
+    return c.json(toVersionResponse(version), 200);
+  });
+
+  app.openapi(diffVersionsRoute, async (c) => {
+    const store = deps.versionStore;
+    if (!store) {
+      return jsonError(c, 500, 'INTERNAL_ERROR', 'Version store unavailable');
+    }
+
+    const principal = c.get('principal');
+    if (!principal) return jsonError(c, 401, 'AUTH_REQUIRED', 'Authentication required');
+
+    const { specId, v1, v2 } = c.req.valid('param');
+    const spec = await store.getSpec(specId);
+    if (!spec || spec.teamId !== principal.teamId) {
+      return jsonError(c, 404, 'NOT_FOUND', 'Spec not found');
+    }
+
+    const [versionOne, versionTwo] = await Promise.all([
+      store.getVersion(specId, v1),
+      store.getVersion(specId, v2),
+    ]);
+
+    if (!versionOne || !versionTwo) {
+      return jsonError(c, 404, 'NOT_FOUND', 'Version not found');
+    }
+
+    return c.json(diffSpecs(versionOne.content, versionTwo.content), 200);
+  });
+
+  app.openapi(restoreVersionRoute, async (c) => {
+    const store = deps.versionStore;
+    if (!store) {
+      return jsonError(c, 500, 'INTERNAL_ERROR', 'Version store unavailable');
+    }
+
+    const principal = c.get('principal');
+    if (!principal) return jsonError(c, 401, 'AUTH_REQUIRED', 'Authentication required');
+
+    const { specId, versionNumber } = c.req.valid('param');
+    const spec = await store.getSpec(specId);
+    if (!spec || spec.teamId !== principal.teamId) {
+      return jsonError(c, 404, 'NOT_FOUND', 'Spec not found');
+    }
+
+    const sourceVersion = await store.getVersion(specId, versionNumber);
+    if (!sourceVersion) {
+      return jsonError(c, 404, 'NOT_FOUND', 'Version not found');
+    }
+
+    const actor = resolveActor(principal);
+    if (!actor) return jsonError(c, 401, 'AUTH_REQUIRED', 'Authentication required');
+
+    const nextVersion = (await store.getMaxVersionNumber(specId)) + 1;
+    const restored = await store.createVersion({
+      specId,
+      versionNumber: nextVersion,
+      content: sourceVersion.content,
+      actorId: actor.actorId,
+      actorType: actor.actorType,
+      changeSummary: `Restored from version ${sourceVersion.versionNumber}`,
+    });
+    await store.updateSpecContent(specId, sourceVersion.content);
+    return c.json(toVersionResponse(restored), 201);
+  });
 }

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -66,13 +66,15 @@ export type ChannelAccessAdapter = {
   resolveAgentTeamId: (agentId: string) => Promise<string | null>;
 };
 
+export type ActorType = 'user' | 'agent';
+
 export type VersionStoreVersionRecord = {
   id: string;
   specId: string;
   versionNumber: number;
   content: Record<string, unknown>;
   actorId: string;
-  actorType: string;
+  actorType: ActorType;
   changeSummary: string;
   createdAt: Date;
 };
@@ -82,15 +84,13 @@ export type VersionStoreAdapter = {
   updateSpecContent: (specId: string, content: Record<string, unknown>) => Promise<void>;
   createVersion: (data: {
     specId: string;
-    versionNumber: number;
     content: Record<string, unknown>;
     actorId: string;
-    actorType: 'user' | 'agent';
+    actorType: ActorType;
     changeSummary: string;
   }) => Promise<VersionStoreVersionRecord>;
   getVersion: (specId: string, versionNumber: number) => Promise<VersionStoreVersionRecord | null>;
   listVersions: (specId: string, limit: number, offset: number) => Promise<{ items: VersionStoreVersionRecord[]; total: number }>;
-  getMaxVersionNumber: (specId: string) => Promise<number>;
 };
 
 export type GatewayConfig = {

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -12,7 +12,8 @@ export type ErrorCode =
   | 'RATE_LIMITED'
   | 'NOT_FOUND'
   | 'INTERNAL_ERROR'
-  | 'HTTP_ERROR';
+  | 'HTTP_ERROR'
+  | 'VALIDATION_ERROR';
 
 export type ApiKeyPrincipal = {
   type: 'api_key';
@@ -65,6 +66,33 @@ export type ChannelAccessAdapter = {
   resolveAgentTeamId: (agentId: string) => Promise<string | null>;
 };
 
+export type VersionStoreVersionRecord = {
+  id: string;
+  specId: string;
+  versionNumber: number;
+  content: Record<string, unknown>;
+  actorId: string;
+  actorType: string;
+  changeSummary: string;
+  createdAt: Date;
+};
+
+export type VersionStoreAdapter = {
+  getSpec: (specId: string) => Promise<{ id: string; teamId: string; content: Record<string, unknown> } | null>;
+  updateSpecContent: (specId: string, content: Record<string, unknown>) => Promise<void>;
+  createVersion: (data: {
+    specId: string;
+    versionNumber: number;
+    content: Record<string, unknown>;
+    actorId: string;
+    actorType: 'user' | 'agent';
+    changeSummary: string;
+  }) => Promise<VersionStoreVersionRecord>;
+  getVersion: (specId: string, versionNumber: number) => Promise<VersionStoreVersionRecord | null>;
+  listVersions: (specId: string, limit: number, offset: number) => Promise<{ items: VersionStoreVersionRecord[]; total: number }>;
+  getMaxVersionNumber: (specId: string) => Promise<number>;
+};
+
 export type GatewayConfig = {
   port: number;
   allowedOrigins: string[];
@@ -82,6 +110,7 @@ export type GatewayDeps = {
   apiKeyAuth: ApiKeyAuthAdapter;
   sessionStore: SessionStoreAdapter;
   channelAccess?: ChannelAccessAdapter;
+  versionStore?: VersionStoreAdapter;
   now: () => Date;
 };
 

--- a/packages/gateway/src/versioning/diff.ts
+++ b/packages/gateway/src/versioning/diff.ts
@@ -1,0 +1,65 @@
+import type { DiffEntry } from '@kata/shared';
+
+const IGNORED_PATHS = new Set(['meta.updatedAt']);
+
+export function diffSpecs(
+  oldContent: Record<string, unknown>,
+  newContent: Record<string, unknown>,
+): DiffEntry[] {
+  const entries: DiffEntry[] = [];
+  diffRecursive(oldContent, newContent, '', entries);
+  return entries;
+}
+
+function diffRecursive(
+  oldVal: unknown,
+  newVal: unknown,
+  prefix: string,
+  entries: DiffEntry[],
+): void {
+  if (oldVal === newVal) return;
+
+  if (typeof oldVal !== typeof newVal || oldVal === null || newVal === null) {
+    if (!IGNORED_PATHS.has(prefix)) {
+      entries.push({ path: prefix, type: 'changed', oldValue: oldVal, newValue: newVal });
+    }
+    return;
+  }
+
+  if (Array.isArray(oldVal) && Array.isArray(newVal)) {
+    const maxLen = Math.max(oldVal.length, newVal.length);
+    for (let i = 0; i < maxLen; i++) {
+      const path = prefix ? `${prefix}.${i}` : `${i}`;
+      if (i >= oldVal.length) {
+        entries.push({ path, type: 'added', newValue: newVal[i] });
+      } else if (i >= newVal.length) {
+        entries.push({ path, type: 'removed', oldValue: oldVal[i] });
+      } else {
+        diffRecursive(oldVal[i], newVal[i], path, entries);
+      }
+    }
+    return;
+  }
+
+  if (typeof oldVal === 'object' && typeof newVal === 'object') {
+    const oldObj = oldVal as Record<string, unknown>;
+    const newObj = newVal as Record<string, unknown>;
+    const allKeys = new Set([...Object.keys(oldObj), ...Object.keys(newObj)]);
+    for (const key of allKeys) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      if (IGNORED_PATHS.has(path)) continue;
+      if (!(key in oldObj)) {
+        entries.push({ path, type: 'added', newValue: newObj[key] });
+      } else if (!(key in newObj)) {
+        entries.push({ path, type: 'removed', oldValue: oldObj[key] });
+      } else {
+        diffRecursive(oldObj[key], newObj[key], path, entries);
+      }
+    }
+    return;
+  }
+
+  if (!IGNORED_PATHS.has(prefix)) {
+    entries.push({ path: prefix, type: 'changed', oldValue: oldVal, newValue: newVal });
+  }
+}

--- a/packages/gateway/src/versioning/diff.ts
+++ b/packages/gateway/src/versioning/diff.ts
@@ -1,4 +1,9 @@
-import type { DiffEntry } from '@kata/shared';
+type DiffEntry = {
+  path: string;
+  type: 'added' | 'removed' | 'changed';
+  oldValue?: unknown;
+  newValue?: unknown;
+};
 
 const IGNORED_PATHS = new Set(['meta.updatedAt']);
 

--- a/packages/shared/src/__tests__/spec-version.test.ts
+++ b/packages/shared/src/__tests__/spec-version.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DiffEntrySchema,
+  SpecVersionSchema,
+  CreateVersionInputSchema,
+  VersionListResponseSchema,
+} from '../schemas/spec-version.js';
+
+const uuid = '00000000-0000-4000-8000-000000000001';
+const now = '2026-02-27T00:00:00.000Z';
+
+describe('SpecVersionSchema', () => {
+  const valid = {
+    id: uuid,
+    specId: uuid,
+    versionNumber: 1,
+    content: { title: 'test' },
+    actorId: uuid,
+    actorType: 'user' as const,
+    changeSummary: 'Initial version',
+    createdAt: now,
+  };
+
+  it('parses valid version', () => {
+    expect(SpecVersionSchema.parse(valid)).toEqual(valid);
+  });
+
+  it('rejects versionNumber < 1', () => {
+    expect(() => SpecVersionSchema.parse({ ...valid, versionNumber: 0 })).toThrow();
+  });
+
+  it('rejects invalid actorType', () => {
+    expect(() => SpecVersionSchema.parse({ ...valid, actorType: 'bot' })).toThrow();
+  });
+});
+
+describe('CreateVersionInputSchema', () => {
+  it('parses valid input', () => {
+    const input = { content: { title: 'test' }, changeSummary: 'Updated title' };
+    expect(CreateVersionInputSchema.parse(input)).toEqual(input);
+  });
+
+  it('defaults changeSummary to empty string', () => {
+    const result = CreateVersionInputSchema.parse({ content: { title: 'test' } });
+    expect(result.changeSummary).toBe('');
+  });
+});
+
+describe('DiffEntrySchema', () => {
+  it('parses changed entry', () => {
+    const entry = { path: 'title', type: 'changed' as const, oldValue: 'a', newValue: 'b' };
+    expect(DiffEntrySchema.parse(entry)).toEqual(entry);
+  });
+
+  it('parses added entry without oldValue', () => {
+    const entry = { path: 'constraints.3', type: 'added' as const, newValue: 'new rule' };
+    expect(DiffEntrySchema.parse(entry)).toEqual(entry);
+  });
+
+  it('parses removed entry without newValue', () => {
+    const entry = { path: 'blockers.0', type: 'removed' as const, oldValue: { id: uuid } };
+    expect(DiffEntrySchema.parse(entry)).toEqual(entry);
+  });
+});
+
+describe('VersionListResponseSchema', () => {
+  it('parses response with items and total', () => {
+    const response = { items: [], total: 0 };
+    expect(VersionListResponseSchema.parse(response)).toEqual(response);
+  });
+});

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,5 +1,6 @@
 export * from './auth.js';
 export * from './spec.js';
+export * from './spec-version.js';
 export * from './agent.js';
 export * from './environment.js';
 export * from './task.js';

--- a/packages/shared/src/schemas/spec-version.ts
+++ b/packages/shared/src/schemas/spec-version.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const ActorTypeSchema = z.enum(['user', 'agent']);
+export type ActorType = z.infer<typeof ActorTypeSchema>;
+
+export const SpecVersionSchema = z.object({
+  id: z.string().uuid(),
+  specId: z.string().uuid(),
+  versionNumber: z.number().int().positive(),
+  content: z.record(z.string(), z.unknown()),
+  actorId: z.string().uuid(),
+  actorType: ActorTypeSchema,
+  changeSummary: z.string(),
+  createdAt: z.string().datetime(),
+});
+export type SpecVersion = z.infer<typeof SpecVersionSchema>;
+
+export const CreateVersionInputSchema = z.object({
+  content: z.record(z.string(), z.unknown()),
+  changeSummary: z.string().default(''),
+});
+export type CreateVersionInput = z.infer<typeof CreateVersionInputSchema>;
+
+export const DiffEntrySchema = z.object({
+  path: z.string(),
+  type: z.enum(['added', 'removed', 'changed']),
+  oldValue: z.unknown().optional(),
+  newValue: z.unknown().optional(),
+});
+export type DiffEntry = z.infer<typeof DiffEntrySchema>;
+
+export const VersionListResponseSchema = z.object({
+  items: z.array(SpecVersionSchema),
+  total: z.number().int().nonnegative(),
+});
+export type VersionListResponse = z.infer<typeof VersionListResponseSchema>;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests/e2e',
+  testMatch: '**/*.spec.ts',
   timeout: 30_000,
   expect: {
     timeout: 5_000,

--- a/tests/e2e/spec-versions.test.ts
+++ b/tests/e2e/spec-versions.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGatewayApp } from '../../packages/gateway/src/app.js';
+import type { VersionStoreAdapter } from '../../packages/gateway/src/types.js';
+
+const specId = '00000000-0000-4000-8000-000000000001';
+const teamId = 'team-1';
+
+function makeConfig() {
+  return {
+    port: 3001,
+    allowedOrigins: ['*'],
+    sessionCookieName: 'kata.sid',
+    redisUrl: 'redis://localhost:6379',
+    rateLimitWindowMs: 60_000,
+    rateLimitMaxRequests: 1_000,
+    wsHeartbeatIntervalMs: 15_000,
+    wsHeartbeatTimeoutMs: 30_000,
+    wsMaxSubscriptionsPerConnection: 100,
+  };
+}
+
+function createInMemoryVersionStore(): VersionStoreAdapter {
+  const versions: Array<{
+    id: string;
+    specId: string;
+    versionNumber: number;
+    content: Record<string, unknown>;
+    actorId: string;
+    actorType: string;
+    changeSummary: string;
+    createdAt: Date;
+  }> = [];
+  let specContent: Record<string, unknown> = { title: 'Original' };
+  let idCounter = 0;
+
+  return {
+    getSpec: async (id) => (id === specId ? { id, teamId, content: specContent } : null),
+    updateSpecContent: async (_id, content) => {
+      specContent = content;
+    },
+    createVersion: async (data) => {
+      const version = {
+        id: `version-${++idCounter}`,
+        ...data,
+        createdAt: new Date(),
+      };
+      versions.push(version);
+      specContent = data.content;
+      return version;
+    },
+    getVersion: async (_specId, versionNumber) =>
+      versions.find((v) => v.versionNumber === versionNumber) ?? null,
+    listVersions: async (_specId, limit, offset) => ({
+      items: [...versions]
+        .sort((a, b) => b.versionNumber - a.versionNumber)
+        .slice(offset, offset + limit),
+      total: versions.length,
+    }),
+    getMaxVersionNumber: async () =>
+      (versions.length === 0 ? 0 : Math.max(...versions.map((v) => v.versionNumber))),
+  };
+}
+
+function makeDeps(versionStore: VersionStoreAdapter) {
+  return {
+    logger: { info: () => {}, error: () => {} },
+    apiKeyAuth: {
+      validateApiKey: vi.fn(async () => ({ teamId, keyId: 'key-1' })),
+    },
+    sessionStore: { getSession: vi.fn(async () => null) },
+    versionStore,
+    now: () => new Date('2026-02-27T00:00:00.000Z'),
+  };
+}
+
+function authedRequest(path: string, init: RequestInit = {}) {
+  return new Request(`http://localhost${path}`, {
+    ...init,
+    headers: { 'x-api-key': 'kat_live_123', 'content-type': 'application/json', ...init.headers },
+  });
+}
+
+describe('Spec version lifecycle (E2E)', () => {
+  it('create -> list -> diff -> restore full flow', async () => {
+    const store = createInMemoryVersionStore();
+    const app = createGatewayApp(makeConfig(), makeDeps(store));
+
+    const r1 = await app.request(authedRequest(`/api/specs/${specId}/versions`, {
+      method: 'POST',
+      body: JSON.stringify({ content: { title: 'Version 1' }, changeSummary: 'Initial' }),
+    }));
+    expect(r1.status).toBe(201);
+    const v1 = await r1.json();
+    expect(v1.versionNumber).toBe(1);
+
+    const r2 = await app.request(authedRequest(`/api/specs/${specId}/versions`, {
+      method: 'POST',
+      body: JSON.stringify({ content: { title: 'Version 2', intent: 'added field' }, changeSummary: 'Added intent' }),
+    }));
+    expect(r2.status).toBe(201);
+    const v2 = await r2.json();
+    expect(v2.versionNumber).toBe(2);
+
+    const r3 = await app.request(authedRequest(`/api/specs/${specId}/versions`, {
+      method: 'POST',
+      body: JSON.stringify({ content: { title: 'Version 3', intent: 'updated' }, changeSummary: 'Updated intent' }),
+    }));
+    expect(r3.status).toBe(201);
+
+    const listRes = await app.request(authedRequest(`/api/specs/${specId}/versions`));
+    expect(listRes.status).toBe(200);
+    const list = await listRes.json();
+    expect(list.total).toBe(3);
+    expect(list.items[0].versionNumber).toBe(3);
+
+    const diffRes = await app.request(authedRequest(`/api/specs/${specId}/versions/1/diff/2`));
+    expect(diffRes.status).toBe(200);
+    const diff = await diffRes.json();
+    expect(diff.length).toBeGreaterThan(0);
+    expect(diff).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: 'title', type: 'changed' }),
+    ]));
+
+    const restoreRes = await app.request(authedRequest(`/api/specs/${specId}/versions/1/restore`, {
+      method: 'POST',
+    }));
+    expect(restoreRes.status).toBe(201);
+    const restored = await restoreRes.json();
+    expect(restored.versionNumber).toBe(4);
+    expect(restored.changeSummary).toBe('Restored from version 1');
+    expect(restored.content).toEqual({ title: 'Version 1' });
+  });
+});
+
+describe('Auth boundary (E2E)', () => {
+  it('rejects unauthenticated requests on all version endpoints', async () => {
+    const store = createInMemoryVersionStore();
+    const app = createGatewayApp(makeConfig(), makeDeps(store));
+
+    const endpoints = [
+      { method: 'GET', path: `/api/specs/${specId}/versions` },
+      { method: 'GET', path: `/api/specs/${specId}/versions/1` },
+      { method: 'POST', path: `/api/specs/${specId}/versions` },
+      { method: 'GET', path: `/api/specs/${specId}/versions/1/diff/2` },
+      { method: 'POST', path: `/api/specs/${specId}/versions/1/restore` },
+    ];
+
+    for (const ep of endpoints) {
+      const res = await app.request(`http://localhost${ep.path}`, { method: ep.method });
+      expect(res.status).toBe(401);
+    }
+  });
+});
+
+describe('Team isolation (E2E)', () => {
+  it('returns 404 when spec belongs to different team', async () => {
+    const store = createInMemoryVersionStore();
+    store.getSpec = async () => ({ id: specId, teamId: 'other-team', content: {} });
+
+    const deps = makeDeps(store);
+    const app = createGatewayApp(makeConfig(), deps);
+
+    const res = await app.request(authedRequest(`/api/specs/${specId}/versions`));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('Edge cases (E2E)', () => {
+  it('diff returns empty array for identical versions', async () => {
+    const store = createInMemoryVersionStore();
+    const app = createGatewayApp(makeConfig(), makeDeps(store));
+
+    await app.request(authedRequest(`/api/specs/${specId}/versions`, {
+      method: 'POST',
+      body: JSON.stringify({ content: { title: 'Same' }, changeSummary: 'v1' }),
+    }));
+    await app.request(authedRequest(`/api/specs/${specId}/versions`, {
+      method: 'POST',
+      body: JSON.stringify({ content: { title: 'Same' }, changeSummary: 'v2' }),
+    }));
+
+    const diffRes = await app.request(authedRequest(`/api/specs/${specId}/versions/1/diff/2`));
+    expect(diffRes.status).toBe(200);
+    const diff = await diffRes.json();
+    expect(diff).toEqual([]);
+  });
+
+  it('returns 404 when creating version on nonexistent spec', async () => {
+    const store = createInMemoryVersionStore();
+    const app = createGatewayApp(makeConfig(), makeDeps(store));
+
+    const res = await app.request(authedRequest('/api/specs/00000000-0000-4000-8000-999999999999/versions', {
+      method: 'POST',
+      body: JSON.stringify({ content: { title: 'x' }, changeSummary: '' }),
+    }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when restoring nonexistent version', async () => {
+    const store = createInMemoryVersionStore();
+    const app = createGatewayApp(makeConfig(), makeDeps(store));
+
+    const res = await app.request(authedRequest(`/api/specs/${specId}/versions/999/restore`, {
+      method: 'POST',
+    }));
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/desktop/diff-view.test.tsx
+++ b/tests/unit/desktop/diff-view.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DiffView } from '../../../apps/desktop/src/components/DiffView';
+
+describe('DiffView', () => {
+  it('renders changed entries with old and new values', () => {
+    const entries = [
+      { path: 'title', type: 'changed' as const, oldValue: 'Old Title', newValue: 'New Title' },
+    ];
+    render(<DiffView entries={entries} fromVersion={1} toVersion={2} />);
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('"Old Title"')).toBeInTheDocument();
+    expect(screen.getByText('"New Title"')).toBeInTheDocument();
+  });
+
+  it('renders added entries', () => {
+    const entries = [
+      { path: 'constraints.2', type: 'added' as const, newValue: 'new constraint' },
+    ];
+    render(<DiffView entries={entries} fromVersion={1} toVersion={2} />);
+    expect(screen.getByText('constraints.2')).toBeInTheDocument();
+    expect(screen.getByText(/added/i)).toBeInTheDocument();
+  });
+
+  it('renders removed entries', () => {
+    const entries = [
+      { path: 'blockers.0', type: 'removed' as const, oldValue: { id: '123', description: 'stale' } },
+    ];
+    render(<DiffView entries={entries} fromVersion={1} toVersion={2} />);
+    expect(screen.getByText('blockers.0')).toBeInTheDocument();
+    expect(screen.getByText(/removed/i)).toBeInTheDocument();
+  });
+
+  it('renders empty state for no differences', () => {
+    render(<DiffView entries={[]} fromVersion={1} toVersion={2} />);
+    expect(screen.getByText(/no differences/i)).toBeInTheDocument();
+  });
+
+  it('shows version comparison header', () => {
+    render(<DiffView entries={[]} fromVersion={1} toVersion={2} />);
+    expect(screen.getByText(/v1.*v2/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/desktop/pages.test.tsx
+++ b/tests/unit/desktop/pages.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 
 import { Dashboard } from '../../../apps/desktop/src/pages/Dashboard';
 import { Specs } from '../../../apps/desktop/src/pages/Specs';
@@ -20,7 +21,11 @@ describe('placeholder pages', () => {
     ['Settings', Settings],
     ['Page not found', NotFound],
   ])('%s page renders heading', (name, Component) => {
-    render(<Component />);
+    render(
+      <MemoryRouter>
+        <Component />
+      </MemoryRouter>,
+    );
     expect(screen.getByRole('heading', { name })).toBeInTheDocument();
   });
 });

--- a/tests/unit/desktop/specs-page.test.tsx
+++ b/tests/unit/desktop/specs-page.test.tsx
@@ -1,22 +1,142 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { SpecDetail } from '../../../apps/desktop/src/pages/SpecDetail';
 
-const mockFetch = vi.fn();
-global.fetch = mockFetch as unknown as typeof fetch;
+const storeState = vi.hoisted(() => ({
+  versions: [] as Array<{
+    id: string;
+    specId: string;
+    versionNumber: number;
+    content: Record<string, unknown>;
+    actorId: string;
+    actorType: 'user' | 'agent';
+    changeSummary: string;
+    createdAt: string;
+  }>,
+  total: 0,
+  loading: false,
+  selectedVersion: null as null | {
+    id: string;
+    specId: string;
+    versionNumber: number;
+    content: Record<string, unknown>;
+    actorId: string;
+    actorType: 'user' | 'agent';
+    changeSummary: string;
+    createdAt: string;
+  },
+  diffResult: null as null | Array<{
+    path: string;
+    type: 'added' | 'removed' | 'changed';
+    oldValue?: unknown;
+    newValue?: unknown;
+  }>,
+  fetchVersions: vi.fn(),
+  fetchVersion: vi.fn(),
+  fetchDiff: vi.fn(),
+  restoreVersion: vi.fn(),
+  reset: vi.fn(),
+}));
+
+vi.mock('../../../apps/desktop/src/store/versions', () => ({
+  useVersionStore: () => storeState,
+}));
 
 describe('SpecDetail', () => {
   beforeEach(() => {
-    mockFetch.mockReset();
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({ items: [], total: 0 }),
-    });
+    storeState.versions = [];
+    storeState.total = 0;
+    storeState.loading = false;
+    storeState.selectedVersion = null;
+    storeState.diffResult = null;
+    storeState.fetchVersions.mockReset().mockResolvedValue(undefined);
+    storeState.fetchVersion.mockReset().mockResolvedValue(undefined);
+    storeState.fetchDiff.mockReset().mockResolvedValue(undefined);
+    storeState.restoreVersion.mockReset().mockResolvedValue(undefined);
+    storeState.reset.mockReset();
   });
 
-  it('renders version history panel', async () => {
+  it('returns null when route has no specId', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/specs']}>
+        <Routes>
+          <Route path="/specs" element={<SpecDetail />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(storeState.fetchVersions).not.toHaveBeenCalled();
+  });
+
+  it('fetches versions and handles select/compare/restore actions', async () => {
+    storeState.versions = [
+      {
+        id: 'v2',
+        specId: 'spec-1',
+        versionNumber: 2,
+        content: {},
+        actorId: 'user-1',
+        actorType: 'user',
+        changeSummary: 'Update',
+        createdAt: '2026-02-27T12:00:00Z',
+      },
+      {
+        id: 'v1',
+        specId: 'spec-1',
+        versionNumber: 1,
+        content: {},
+        actorId: 'agent-1',
+        actorType: 'agent',
+        changeSummary: 'Init',
+        createdAt: '2026-02-27T00:00:00Z',
+      },
+    ];
+    storeState.total = 2;
+    storeState.selectedVersion = {
+      id: 'v2',
+      specId: 'spec-1',
+      versionNumber: 2,
+      content: {},
+      actorId: 'user-1',
+      actorType: 'user',
+      changeSummary: 'Update',
+      createdAt: '2026-02-27T12:00:00Z',
+    };
+    storeState.diffResult = [{ path: 'title', type: 'changed', oldValue: 'old', newValue: 'new' }];
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/specs/spec-1']}>
+        <Routes>
+          <Route path="/specs/:specId" element={<SpecDetail />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(storeState.fetchVersions).toHaveBeenCalledWith('spec-1');
+    expect(screen.getByText('2 versions')).toBeInTheDocument();
+    expect(screen.getByText('Viewing version v2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'v2' }));
+    expect(storeState.fetchVersion).toHaveBeenCalledWith('spec-1', 2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+    expect(storeState.fetchDiff).toHaveBeenCalledWith('spec-1', 1, 2);
+    expect(screen.getByText('Comparing v1 to v2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restore version 2' }));
+    expect(storeState.restoreVersion).toHaveBeenCalledWith('spec-1', 2);
+    await waitFor(() => {
+      expect(screen.queryByText('Comparing v1 to v2')).not.toBeInTheDocument();
+    });
+
+    unmount();
+    expect(storeState.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders loading state and hides optional panels when data is absent', () => {
+    storeState.loading = true;
+
     render(
       <MemoryRouter initialEntries={['/specs/spec-1']}>
         <Routes>
@@ -24,6 +144,8 @@ describe('SpecDetail', () => {
         </Routes>
       </MemoryRouter>,
     );
-    expect(screen.getByText('Version History')).toBeInTheDocument();
+    expect(screen.getByText('Loading versions…')).toBeInTheDocument();
+    expect(screen.queryByText(/Viewing version v/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Comparing v/i)).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/desktop/specs-page.test.tsx
+++ b/tests/unit/desktop/specs-page.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SpecDetail } from '../../../apps/desktop/src/pages/SpecDetail';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('SpecDetail', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [], total: 0 }),
+    });
+  });
+
+  it('renders version history panel', async () => {
+    render(
+      <MemoryRouter initialEntries={['/specs/spec-1']}>
+        <Routes>
+          <Route path="/specs/:specId" element={<SpecDetail />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Version History')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/desktop/version-history.test.tsx
+++ b/tests/unit/desktop/version-history.test.tsx
@@ -84,6 +84,72 @@ describe('VersionHistory', () => {
     expect(onRestore).toHaveBeenCalledWith(2);
   });
 
+  it('calls onCompare for non-latest versions', () => {
+    const onCompare = vi.fn();
+    render(
+      <VersionHistory
+        versions={mockVersions}
+        onSelectVersion={() => {}}
+        onCompare={onCompare}
+        onRestore={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+    expect(onCompare).toHaveBeenCalledWith(1, 2);
+  });
+
+  it('renders fallback summary and day-based relative time', () => {
+    const now = new Date('2026-03-01T12:00:00Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    render(
+      <VersionHistory
+        versions={[{
+          ...mockVersions[0],
+          id: 'v4',
+          versionNumber: 4,
+          changeSummary: '',
+          createdAt: '2026-02-27T12:00:00Z',
+        }]}
+        onSelectVersion={() => {}}
+        onCompare={() => {}}
+        onRestore={() => {}}
+      />,
+    );
+    expect(screen.getByText('No summary')).toBeInTheDocument();
+    expect(screen.getByText('2d ago')).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it('renders minute and just-now relative time labels', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+    render(
+      <VersionHistory
+        versions={[
+          {
+            ...mockVersions[0],
+            id: 'v5',
+            versionNumber: 5,
+            createdAt: '2026-03-01T11:30:00Z',
+          },
+          {
+            ...mockVersions[1],
+            id: 'v6',
+            versionNumber: 6,
+            createdAt: '2026-03-01T12:00:00Z',
+          },
+        ]}
+        onSelectVersion={() => {}}
+        onCompare={() => {}}
+        onRestore={() => {}}
+      />,
+    );
+    expect(screen.getByText('30m ago')).toBeInTheDocument();
+    expect(screen.getByText('just now')).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
   it('renders empty state when no versions', () => {
     render(
       <VersionHistory

--- a/tests/unit/desktop/version-history.test.tsx
+++ b/tests/unit/desktop/version-history.test.tsx
@@ -150,6 +150,35 @@ describe('VersionHistory', () => {
     vi.useRealTimers();
   });
 
+  it('guards invalid and future timestamps', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+    render(
+      <VersionHistory
+        versions={[
+          {
+            ...mockVersions[0],
+            id: 'v7',
+            versionNumber: 7,
+            createdAt: 'not-a-date',
+          },
+          {
+            ...mockVersions[1],
+            id: 'v8',
+            versionNumber: 8,
+            createdAt: '2026-03-01T12:05:00Z',
+          },
+        ]}
+        onSelectVersion={() => {}}
+        onCompare={() => {}}
+        onRestore={() => {}}
+      />,
+    );
+    expect(screen.getByText('unknown time')).toBeInTheDocument();
+    expect(screen.getByText('just now')).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
   it('renders empty state when no versions', () => {
     render(
       <VersionHistory

--- a/tests/unit/desktop/version-history.test.tsx
+++ b/tests/unit/desktop/version-history.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { VersionHistory } from '../../../apps/desktop/src/components/VersionHistory';
+
+const mockVersions = [
+  {
+    id: 'v2',
+    specId: 'spec-1',
+    versionNumber: 2,
+    content: {},
+    actorId: 'user-1',
+    actorType: 'user' as const,
+    changeSummary: 'Updated constraints',
+    createdAt: '2026-02-27T12:00:00Z',
+  },
+  {
+    id: 'v1',
+    specId: 'spec-1',
+    versionNumber: 1,
+    content: {},
+    actorId: 'agent-1',
+    actorType: 'agent' as const,
+    changeSummary: 'Initial version',
+    createdAt: '2026-02-27T00:00:00Z',
+  },
+];
+
+describe('VersionHistory', () => {
+  it('renders version list', () => {
+    render(
+      <VersionHistory
+        versions={mockVersions}
+        onSelectVersion={() => {}}
+        onCompare={() => {}}
+        onRestore={() => {}}
+      />,
+    );
+    expect(screen.getByText('v2')).toBeInTheDocument();
+    expect(screen.getByText('v1')).toBeInTheDocument();
+    expect(screen.getByText('Updated constraints')).toBeInTheDocument();
+    expect(screen.getByText('Initial version')).toBeInTheDocument();
+  });
+
+  it('shows actor type badges', () => {
+    render(
+      <VersionHistory
+        versions={mockVersions}
+        onSelectVersion={() => {}}
+        onCompare={() => {}}
+        onRestore={() => {}}
+      />,
+    );
+    expect(screen.getByText('user')).toBeInTheDocument();
+    expect(screen.getByText('agent')).toBeInTheDocument();
+  });
+
+  it('calls onSelectVersion when clicking a version', () => {
+    const onSelect = vi.fn();
+    render(
+      <VersionHistory
+        versions={mockVersions}
+        onSelectVersion={onSelect}
+        onCompare={() => {}}
+        onRestore={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText('v2'));
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it('calls onRestore when clicking restore button', () => {
+    const onRestore = vi.fn();
+    render(
+      <VersionHistory
+        versions={mockVersions}
+        onSelectVersion={() => {}}
+        onCompare={() => {}}
+        onRestore={onRestore}
+      />,
+    );
+    const restoreButtons = screen.getAllByRole('button', { name: /restore/i });
+    fireEvent.click(restoreButtons[0]);
+    expect(onRestore).toHaveBeenCalledWith(2);
+  });
+
+  it('renders empty state when no versions', () => {
+    render(
+      <VersionHistory
+        versions={[]}
+        onSelectVersion={() => {}}
+        onCompare={() => {}}
+        onRestore={() => {}}
+      />,
+    );
+    expect(screen.getByText(/no versions/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/desktop/versions-store.test.ts
+++ b/tests/unit/desktop/versions-store.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVersionStore } from '../../../apps/desktop/src/store/versions';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+beforeEach(() => {
+  useVersionStore.getState().reset();
+  mockFetch.mockReset();
+});
+
+describe('useVersionStore', () => {
+  it('starts with empty state', () => {
+    const state = useVersionStore.getState();
+    expect(state.versions).toEqual([]);
+    expect(state.total).toBe(0);
+    expect(state.loading).toBe(false);
+    expect(state.selectedVersion).toBeNull();
+    expect(state.diffResult).toBeNull();
+  });
+
+  it('fetchVersions populates versions list', async () => {
+    const specId = 'spec-1';
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [{
+          id: 'v1',
+          specId,
+          versionNumber: 1,
+          content: {},
+          actorId: 'a',
+          actorType: 'user',
+          changeSummary: 'Init',
+          createdAt: '2026-01-01T00:00:00Z',
+        }],
+        total: 1,
+      }),
+    });
+
+    await useVersionStore.getState().fetchVersions(specId);
+    const state = useVersionStore.getState();
+    expect(state.versions).toHaveLength(1);
+    expect(state.total).toBe(1);
+    expect(state.loading).toBe(false);
+  });
+
+  it('fetchDiff populates diffResult', async () => {
+    const specId = 'spec-1';
+    const diffEntries = [{ path: 'title', type: 'changed', oldValue: 'a', newValue: 'b' }];
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => diffEntries });
+
+    await useVersionStore.getState().fetchDiff(specId, 1, 2);
+    expect(useVersionStore.getState().diffResult).toEqual(diffEntries);
+  });
+
+  it('restoreVersion calls POST and refreshes list', async () => {
+    const specId = 'spec-1';
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'v3', versionNumber: 3 }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [], total: 0 }) });
+
+    await useVersionStore.getState().restoreVersion(specId, 1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/desktop/versions-store.test.ts
+++ b/tests/unit/desktop/versions-store.test.ts
@@ -54,6 +54,25 @@ describe('useVersionStore', () => {
     expect(useVersionStore.getState().diffResult).toEqual(diffEntries);
   });
 
+  it('fetchVersion populates selectedVersion', async () => {
+    const specId = 'spec-1';
+    const version = {
+      id: 'v2',
+      specId,
+      versionNumber: 2,
+      content: {},
+      actorId: 'agent-1',
+      actorType: 'agent' as const,
+      changeSummary: 'Second version',
+      createdAt: '2026-01-02T00:00:00Z',
+    };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => version });
+
+    await useVersionStore.getState().fetchVersion(specId, 2);
+    expect(mockFetch).toHaveBeenCalledWith('/api/specs/spec-1/versions/2');
+    expect(useVersionStore.getState().selectedVersion).toEqual(version);
+  });
+
   it('restoreVersion calls POST and refreshes list', async () => {
     const specId = 'spec-1';
     mockFetch

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/e2e/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- implement KAT-113 spec versioning across DB, shared schemas, gateway APIs, and desktop UI
- add immutable `spec_versions` metadata (`actor_id`, `actor_type`, `change_summary`) and migration updates
- add gateway endpoints for create/list/get/diff/restore version flows with team/auth checks
- add desktop version history store/components (`VersionHistory`, `DiffView`) and wire `/specs/:specId` detail route
- add spec version lifecycle integration coverage in `tests/e2e/spec-versions.test.ts`

## Changes
- **DB**
  - extend `spec_versions` table and enum in Drizzle schema
  - generate migration `0002_mushy_vivisector.sql`
- **Shared**
  - add `spec-version` Zod schemas and tests
- **Gateway**
  - add structured diff logic (`diffSpecs`)
  - replace placeholder specs route with full version API route handlers
  - add route-level tests for success/error/auth/isolation paths
- **Desktop**
  - add Zustand version store
  - add version history sidebar + diff view components
  - add `SpecDetail` page and route wiring (non-nav route)
- **E2E**
  - add version lifecycle/auth/edge case tests
  - add `vitest.e2e.config.ts` for running e2e Vitest files (repo unit config only includes `tests/unit/**`)

## Verification
- `pnpm turbo test`
- `pnpm turbo typecheck`
- `pnpm turbo lint`
- `pnpm vitest run --config vitest.e2e.config.ts tests/e2e/spec-versions.test.ts`

## Linear
- KAT-113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full spec versioning: create, list, view, compare diffs, and restore previous versions.
  * UI: Spec detail page, version history panel, diff viewer, and a demo "Open Spec Detail" link.
  * API: new endpoints for managing and comparing spec versions.

* **Bug Fixes**
  * Navigation now omits routes marked as internal from the menu.

* **Tests**
  * Extensive unit, integration, and end-to-end tests added for versioning and diffing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

implements comprehensive spec versioning system across the full stack - database schema adds immutable version metadata (actor tracking, change summaries), gateway provides authenticated version lifecycle APIs with team isolation, and desktop UI delivers interactive version history with diff visualization.

**Key changes:**
- Database migration adds `actor_id`, `actor_type` enum, and `change_summary` columns; changes `version_number` from text to integer
- Gateway implements 5 REST endpoints: create, list, get, diff, and restore versions with proper auth boundaries
- Recursive diff algorithm handles nested objects/arrays and filters `meta.updatedAt` changes  
- Desktop components include version history sidebar, structured diff viewer, and Zustand state management
- Comprehensive test coverage with unit tests for diff logic, route-level tests for gateway, and E2E tests for full lifecycle

**Issues found:**
- Store fetch methods lack error handling - failed requests leave `loading: true` and swallow errors (4 methods affected: `fetchVersions`, `fetchVersion`, `fetchDiff`, `restoreVersion`)

<h3>Confidence Score: 4/5</h3>

- safe to merge with error handling improvements recommended
- score reflects well-structured implementation with proper auth/isolation, comprehensive tests, and clean separation of concerns - reduced from 5 due to missing error handling in desktop store that could cause UI state bugs (loading spinners stuck, silent failures)
- `apps/desktop/src/store/versions.ts` requires error handling in all fetch methods before production use

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/db/src/schema.ts | added actor metadata fields (actorId, actorType, changeSummary) and changed versionNumber from text to integer |
| packages/db/drizzle/0002_mushy_vivisector.sql | migration adds actor_type enum and three new columns to spec_versions with NOT NULL constraints |
| packages/gateway/src/versioning/diff.ts | recursive diff implementation handles objects, arrays, and primitives with meta.updatedAt filtering |
| packages/gateway/src/routes/specs.ts | full version API with create/list/get/diff/restore endpoints, includes team isolation and auth checks |
| apps/desktop/src/store/versions.ts | Zustand store for version management with fetchVersions, fetchDiff, and restoreVersion methods |
| apps/desktop/src/pages/SpecDetail.tsx | spec detail page with version history sidebar and diff view integration |
| tests/e2e/spec-versions.test.ts | comprehensive E2E tests covering lifecycle, auth boundaries, team isolation, and edge cases |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User creates spec version] --> B[Desktop UI calls store.createVersion]
    B --> C[POST to gateway endpoint]
    C --> D{Auth valid?}
    D -->|No| E[Return 401]
    D -->|Yes| F{Spec exists?}
    F -->|No| G[Return 404]
    F -->|Yes| H{Team matches?}
    H -->|No| I[Return 404]
    H -->|Yes| J[Get max version number]
    J --> K[Create new version record]
    K --> L[Update spec content]
    L --> M[Return 201 with version]
    
    N[User views diff] --> O[Desktop UI calls store.fetchDiff]
    O --> P[GET diff endpoint]
    P --> Q{Auth valid?}
    Q -->|Yes| R[Fetch both versions]
    Q -->|No| S[Return 401]
    R --> T[Run diffSpecs algorithm]
    T --> U[Return diff entries]
    U --> V[Display in DiffView component]
```

<sub>Last reviewed commit: c547374</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->