### PR TITLE
fix(db): address PR review feedback for convex adoption

### DIFF
--- a/docs/M0-dependency-graph.mermaid
+++ b/docs/M0-dependency-graph.mermaid
@@ -10,7 +10,7 @@ graph TD
     end
 
     subgraph "WAVE 3 — Depends on KAT-104 + KAT-105 (2 parallel tracks)"
-        KAT106["KAT-106<br/>PostgreSQL schema +<br/>Drizzle migrations<br/><b>P1 · ~2-3 days</b>"]
+        KAT106["KAT-106<br/>Legacy Postgres/Drizzle scaffold<br/>(superseded by Convex)<br/><b>P1 · ~2-3 days</b>"]
         KAT108["KAT-108<br/>API server skeleton (Hono)<br/>with auth middleware<br/><b>P1 · ~2-3 days</b>"]
     end
 

--- a/docs/plans/2026-02-27-kat-113-spec-versioning-design.md
+++ b/docs/plans/2026-02-27-kat-113-spec-versioning-design.md
@@ -1,5 +1,7 @@
 # KAT-113: Spec Versioning System - Design
 
+> **Stale:** KAT-152 replaced Drizzle/Postgres with Convex. Drizzle-specific guidance in this doc (queries, migrations, schema changes) must be revised before implementation.
+
 **Date:** 2026-02-27
 **Status:** Approved
 **Milestone:** M1: Spec Engine + Single Agent

--- a/docs/plans/2026-02-27-kat-113-spec-versioning-implementation.md
+++ b/docs/plans/2026-02-27-kat-113-spec-versioning-implementation.md
@@ -1,6 +1,6 @@
 # KAT-113: Spec Versioning System Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **Stale:** KAT-152 replaced Drizzle/Postgres with Convex. Drizzle-specific guidance in this doc (ORM calls, migrations, DATABASE_URL) must be revised before implementation.
 
 **Goal:** Add immutable version tracking to specs with create/list/get/diff/restore API endpoints, structured field-level diffing, and a desktop UI for browsing version history.
 

--- a/docs/plans/2026-02-28-kat-152-convex-adoption-implementation.md
+++ b/docs/plans/2026-02-28-kat-152-convex-adoption-implementation.md
@@ -1,7 +1,5 @@
 # Convex Adoption Migration Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Replace the current Postgres/Drizzle scaffold with a Convex-based baseline so future milestone work starts from the adopted data layer.
 
 **Architecture:** Keep `packages/db` as the repo’s data-layer package, but repurpose it from a SQL migration package into the Convex integration boundary. Update test contracts first, then replace package tooling and source files, then remove Postgres-specific infrastructure assumptions, and finally revise project documentation to reflect the new backend direction.

--- a/packages/db/convex/http.ts
+++ b/packages/db/convex/http.ts
@@ -1,3 +1,5 @@
+// Placeholder HTTP router required by Convex project configuration.
+// Add route handlers here as API surface grows.
 import { httpRouter } from 'convex/server';
 
 const http = httpRouter();

--- a/packages/db/convex/schema.ts
+++ b/packages/db/convex/schema.ts
@@ -1,3 +1,5 @@
+// Canonical table name list. Replace with defineSchema/defineTable calls
+// when the first Convex function is implemented and a project is provisioned.
 export const convexTables = [
   'users',
   'teams',

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -27,7 +27,6 @@
     "db:codegen": "convex codegen --config ./convex.json"
   },
   "dependencies": {
-    "dotenv": "^17.3.1",
     "convex": "^1.32.0"
   },
   "devDependencies": {

--- a/packages/db/src/__tests__/schema-contract.test.ts
+++ b/packages/db/src/__tests__/schema-contract.test.ts
@@ -39,17 +39,81 @@ describe('convex scaffold contract', () => {
     expect(fs.existsSync(path.join(packageRoot, 'convex/http.ts'))).toBe(true);
   });
 
-  it('replaces the postgres client with convex helpers', () => {
+  it('uses convex client helpers instead of postgres', () => {
     const clientSource = fs.readFileSync(path.join(packageRoot, 'src/client.ts'), 'utf8');
 
     expect(clientSource).not.toContain('new pg.Pool');
     expect(clientSource).not.toContain('drizzle(');
+    expect(clientSource).toContain('getConvexClientConfig');
   });
 
-  it('replaces drizzle schema exports with convex-safe schema exports', () => {
+  it('exports convex schema contract instead of drizzle bindings', () => {
     const schemaSource = fs.readFileSync(path.join(packageRoot, 'src/schema.ts'), 'utf8');
 
     expect(schemaSource).not.toContain('drizzle-orm');
     expect(schemaSource).toContain('convexTables');
+  });
+
+  it('keeps convex table lists in sync between src and convex dirs', async () => {
+    const srcSchema = await import('../schema.js');
+    const convexSchema = await import('../../convex/schema.js');
+    expect([...srcSchema.convexTables]).toEqual([...convexSchema.convexTables]);
+  });
+});
+
+describe('convex schema subpath export', () => {
+  it('exports convexTables and ConvexDocument from ./schema', async () => {
+    const schemaModule = await import('../schema.js');
+    expect(schemaModule.convexTables).toBeDefined();
+    expect(Array.isArray(schemaModule.convexTables)).toBe(true);
+    expect(schemaModule.convexTables.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getConvexClientConfig', () => {
+  it('returns both values when set', async () => {
+    const { getConvexClientConfig } = await import('../client.js');
+    const env = { CONVEX_DEPLOYMENT: 'dev:abc', CONVEX_URL: 'https://abc.convex.cloud' };
+    const config = getConvexClientConfig(env as unknown as NodeJS.ProcessEnv);
+    expect(config).toEqual({ deployment: 'dev:abc', url: 'https://abc.convex.cloud' });
+  });
+
+  it('returns undefined values when env is empty', async () => {
+    const { getConvexClientConfig } = await import('../client.js');
+    const config = getConvexClientConfig({} as unknown as NodeJS.ProcessEnv);
+    expect(config).toEqual({ deployment: undefined, url: undefined });
+  });
+
+  it('returns partial config when only one var is set', async () => {
+    const { getConvexClientConfig } = await import('../client.js');
+    const env = { CONVEX_DEPLOYMENT: 'dev:abc' };
+    const config = getConvexClientConfig(env as unknown as NodeJS.ProcessEnv);
+    expect(config.deployment).toBe('dev:abc');
+    expect(config.url).toBeUndefined();
+  });
+});
+
+describe('hasConvexClientConfig', () => {
+  it('returns false when neither var is set', async () => {
+    const { hasConvexClientConfig } = await import('../client.js');
+    expect(hasConvexClientConfig({} as unknown as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it('returns true when only CONVEX_DEPLOYMENT is set', async () => {
+    const { hasConvexClientConfig } = await import('../client.js');
+    const env = { CONVEX_DEPLOYMENT: 'dev:abc' };
+    expect(hasConvexClientConfig(env as unknown as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it('returns true when only CONVEX_URL is set', async () => {
+    const { hasConvexClientConfig } = await import('../client.js');
+    const env = { CONVEX_URL: 'https://abc.convex.cloud' };
+    expect(hasConvexClientConfig(env as unknown as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it('returns false when vars are empty strings', async () => {
+    const { hasConvexClientConfig } = await import('../client.js');
+    const env = { CONVEX_DEPLOYMENT: '', CONVEX_URL: '' };
+    expect(hasConvexClientConfig(env as unknown as NodeJS.ProcessEnv)).toBe(false);
   });
 });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,8 +1,9 @@
 /**
- * Convex-oriented schema contract used by @kata/db exports.
+ * Convex table name contract used by @kata/db exports.
  *
- * This intentionally avoids Drizzle/Postgres bindings while the data layer
- * migration moves the package onto Convex.
+ * The canonical table list also appears in convex/schema.ts for the
+ * Convex runtime. A sync test in schema-contract.test.ts asserts
+ * both copies stay identical.
  */
 export const convexTables = [
   'users',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,9 +233,6 @@ importers:
       convex:
         specifier: ^1.32.0
         version: 1.32.0(react@18.3.1)
-      dotenv:
-        specifier: ^17.3.1
-        version: 17.3.1
     devDependencies:
       '@types/node':
         specifier: ^25.3.2
@@ -2279,10 +2276,6 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
-
-  dotenv@17.3.1:
-    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
@@ -5642,8 +5635,6 @@ snapshots:
   dom-accessibility-api@0.6.3: {}
 
   dotenv@16.6.1: {}
-
-  dotenv@17.3.1: {}
 
   eastasianwidth@0.2.0: {}
 

--- a/tests/scaffold/db-migration-artifacts.test.mjs
+++ b/tests/scaffold/db-migration-artifacts.test.mjs
@@ -5,5 +5,10 @@ assert.ok(fs.existsSync('packages/db/convex'), 'convex source directory missing'
 assert.ok(fs.existsSync('packages/db/convex/schema.ts'), 'convex schema file missing');
 assert.ok(fs.existsSync('packages/db/convex/http.ts'), 'convex http file missing');
 
+const schemaSource = fs.readFileSync('packages/db/convex/schema.ts', 'utf8');
+for (const table of ['users', 'teams', 'teamMembers', 'specs', 'specVersions', 'agentRuns', 'tasks', 'artifacts', 'auditLog', 'apiKeys']) {
+  assert.match(schemaSource, new RegExp(`'${table}'`), `convex schema missing table: ${table}`);
+}
+
 assert.ok(!fs.existsSync('packages/db/drizzle.config.ts'), 'drizzle config should be removed');
 assert.ok(!fs.existsSync('packages/db/drizzle'), 'drizzle output directory should be removed');


### PR DESCRIPTION
## Summary

Follow-up fixes from the comprehensive PR review of #22 (KAT-152 Convex adoption).

- Restore pre-push hook that was accidentally commented out
- Remove unused `dotenv` dependency
- Add functional tests for `getConvexClientConfig` and `hasConvexClientConfig` (8 new tests)
- Add table list sync test between `src/schema.ts` and `convex/schema.ts`
- Add scaffold content verification for convex table names
- Add placeholder comments to `convex/schema.ts` and `convex/http.ts`
- Update stale JSDoc in `src/schema.ts` to reflect settled state
- Rename migration-era test names to describe steady-state contract
- Update M0 dependency graph KAT-106 label to match M1
- Add deprecation headers to KAT-113 design/implementation docs
- Remove agent instruction from KAT-152 implementation doc

## Test plan

- [x] `pnpm --filter @kata/db test` — 13 tests pass (up from 5)
- [x] All scaffold tests pass
- [x] `pnpm ci:checks` passes (verified via pre-push hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated dependency diagram and schema module comments to reflect current architecture.

* **Chores**
  * Removed dotenv dependency.

* **New Features**
  * HTTP router module now available as an exported interface.

* **Tests**
  * Added comprehensive tests for Convex schema validation and client configuration verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Follow-up PR addressing review feedback from KAT-152 Convex adoption. Adds comprehensive test coverage (8 new tests for client config helpers and table sync validation), removes unused `dotenv` dependency, and updates documentation with deprecation notices for Drizzle-specific guidance.

**Key improvements:**
- Added functional tests for `getConvexClientConfig` and `hasConvexClientConfig` covering edge cases (empty env, partial config, empty strings)
- Added table list sync test between `src/schema.ts` and `convex/schema.ts` to prevent drift
- Added scaffold verification for convex table names in `tests/scaffold/db-migration-artifacts.test.mjs`
- Updated JSDoc in `src/schema.ts` to accurately reflect current Convex table contract
- Renamed migration-era test names to describe steady-state contract
- Added helpful placeholder comments to `convex/schema.ts` and `convex/http.ts`

**Documentation:**
- Added deprecation headers to KAT-113 design/implementation docs noting Drizzle-specific guidance is now stale
- Updated M0 dependency graph KAT-106 label to indicate legacy status
- Removed agent instruction directives from implementation docs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- All changes are non-breaking additions (tests, comments, documentation updates) and safe cleanup (removing unused dependency). The 8 new tests provide solid coverage for config helpers and table sync validation. No functional code changes that could introduce bugs.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/db/convex/schema.ts | Added comments explaining canonical table list and future migration path |
| packages/db/package.json | Removed unused `dotenv` dependency from dependencies list |
| packages/db/src/__tests__/schema-contract.test.ts | Added 8 new tests for client config helpers and table sync validation |
| packages/db/src/schema.ts | Updated JSDoc to accurately reflect current Convex table contract |
| tests/scaffold/db-migration-artifacts.test.mjs | Added verification that all expected table names appear in convex schema |

</details>


</details>


<sub>Last reviewed commit: 5693f09</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->