### PR TITLE
fix(githooks): skip CI checks for branch deletions

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,14 @@
 #!/bin/sh
 set -eu
 
-echo "Running local CI checks before push..."
-pnpm ci:checks
+# Skip CI checks for branch deletions (zero SHA = delete ref)
+ZERO="0000000000000000000000000000000000000000"
+while read local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_sha" != "$ZERO" ]; then
+    echo "Running local CI checks before push..."
+    pnpm ci:checks
+    exit $?
+  fi
+done
+
+exit 0


### PR DESCRIPTION
The pre-push hook runs pnpm ci:checks on every push, including branch deletions. This causes LazyGit to crash when cleaning up branches. Detect delete refs (zero SHA) and skip checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the pre-push hook to skip unnecessary CI checks when deleting branches, improving push performance and reducing redundant build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the pre-push git hook to detect branch deletions (refs with zero SHA) and skip `pnpm ci:checks` in those cases. The hook now reads git's stdin to inspect each ref being pushed - if any ref is not a deletion, CI checks run once for the entire push operation. This prevents LazyGit from crashing during branch cleanup operations while maintaining CI validation for actual code pushes.

- Correctly handles multiple scenarios: pure deletions (skips checks), regular pushes (runs checks), and mixed operations (runs checks for non-deletions)
- Preserves existing behavior: checks still run once per push and block on failure
- Exit codes properly propagated to abort push on CI check failures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The implementation correctly addresses the stated problem with sound logic that handles all edge cases (deletions only, pushes only, mixed operations). The change is minimal, focused, and uses standard git pre-push hook patterns. No bugs or logical errors found.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .githooks/pre-push | Added branch deletion detection to skip CI checks when deleting refs, fixing LazyGit crashes |

</details>


</details>


<sub>Last reviewed commit: d3edd4b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->