### PR TITLE
KAT-153: productionize desktop application-shell1 baseline

### DIFF
--- a/apps/desktop/src/components/Layout.tsx
+++ b/apps/desktop/src/components/Layout.tsx
@@ -1,38 +1,29 @@
-import { Outlet, matchPath, useLocation } from 'react-router-dom';
+import {
+  ApplicationShellBreadcrumbs,
+  ApplicationShellFrame,
+  ApplicationShellHeader,
+  ApplicationShellMain,
+} from '@kata/ui';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import { Sidebar } from './Sidebar';
-import { routes } from '../routes';
+import { getBreadcrumbTrail } from '../routes';
 
 export function Layout() {
   const location = useLocation();
-  const activeRoute = routes.find((route) =>
-    matchPath({ path: route.path, end: route.end ?? true }, location.pathname),
-  );
+  const breadcrumbTrail = getBreadcrumbTrail(location.pathname).map((route) => route.breadcrumbLabel);
 
   return (
-    <div data-testid="desktop-shell-frame" className="flex h-screen bg-slate-950 text-slate-100">
+    <ApplicationShellFrame>
       <Sidebar />
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="flex h-16 shrink-0 items-center border-b border-slate-800 bg-slate-950/95 px-4">
-          <nav
-            aria-label="Breadcrumbs"
-            className="flex min-w-0 items-center gap-2 text-sm text-slate-400"
-          >
-            <span className="hidden sm:inline">Overview</span>
-            {activeRoute ? (
-              <>
-                <span aria-hidden="true" className="hidden sm:inline text-slate-600">
-                  /
-                </span>
-                <span className="truncate font-medium text-slate-100">{activeRoute.label}</span>
-              </>
-            ) : null}
-          </nav>
-        </header>
-        <main className="flex-1 overflow-auto bg-slate-950">
+        <ApplicationShellHeader>
+          <ApplicationShellBreadcrumbs items={breadcrumbTrail} />
+        </ApplicationShellHeader>
+        <ApplicationShellMain>
           <Outlet />
-        </main>
+        </ApplicationShellMain>
       </div>
-    </div>
+    </ApplicationShellFrame>
   );
 }

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -3,11 +3,12 @@ import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import { Button } from '@kata/ui/components/ui/button';
 
 import { useAppStore } from '../store/app';
-import { routes } from '../routes';
+import { getGroupedNavRoutes, navGroupLabels } from '../routes';
 
 export function Sidebar() {
   const collapsed = useAppStore((s) => s.sidebarCollapsed);
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
+  const groupedNav = getGroupedNavRoutes();
 
   return (
     <nav
@@ -26,24 +27,33 @@ export function Sidebar() {
           {collapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
         </Button>
       </div>
-      <div className="flex-1 py-2">
-        {routes.filter((item) => item.nav !== false).map((item) => (
-          <NavLink
-            key={item.path}
-            to={item.path}
-            end={item.end}
-            title={collapsed ? item.label : undefined}
-            className={({ isActive }) =>
-              `flex items-center gap-3 ${collapsed ? 'justify-center px-2' : 'px-4'} py-2 text-sm ${
-                isActive
-                  ? 'bg-slate-800 text-white'
-                  : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800/50'
-              }`
-            }
-          >
-            <item.icon className="h-4 w-4 shrink-0" />
-            {!collapsed && item.label}
-          </NavLink>
+      <div className="flex-1 space-y-4 overflow-y-auto py-2">
+        {groupedNav.map(({ group, routes }) => (
+          <section key={group}>
+            {!collapsed ? (
+              <h2 className="px-4 pb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                {navGroupLabels[group]}
+              </h2>
+            ) : null}
+            {routes.map((item) => (
+              <NavLink
+                key={item.path}
+                to={item.path}
+                end={item.end}
+                title={collapsed ? item.navLabel : undefined}
+                className={({ isActive }) =>
+                  `flex items-center gap-3 ${collapsed ? 'justify-center px-2' : 'px-4'} py-2 text-sm ${
+                    isActive
+                      ? 'bg-slate-800 text-white'
+                      : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800/50'
+                  }`
+                }
+              >
+                <item.icon className="h-4 w-4 shrink-0" />
+                {!collapsed && item.navLabel}
+              </NavLink>
+            ))}
+          </section>
         ))}
       </div>
     </nav>

--- a/apps/desktop/src/routes.ts
+++ b/apps/desktop/src/routes.ts
@@ -8,6 +8,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import type { ComponentType } from 'react';
+import { matchPath } from 'react-router-dom';
 
 import { Dashboard } from './pages/Dashboard';
 import { Specs } from './pages/Specs';
@@ -17,21 +18,141 @@ import { Artifacts } from './pages/Artifacts';
 import { Fleet } from './pages/Fleet';
 import { Settings as SettingsPage } from './pages/Settings';
 
+export type RouteId =
+  | 'dashboard'
+  | 'specs'
+  | 'spec-detail'
+  | 'agents'
+  | 'artifacts'
+  | 'fleet'
+  | 'settings';
+
+export type NavGroup = 'command-center' | 'admin';
+
 export interface AppRoute {
+  id: RouteId;
   path: string;
-  label: string;
   icon: LucideIcon;
   component: ComponentType;
   end?: boolean;
   nav?: boolean;
+  navGroup?: NavGroup;
+  navLabel: string;
+  breadcrumbLabel: string;
+  breadcrumbParentId?: RouteId;
 }
 
 export const routes: AppRoute[] = [
-  { path: '/', label: 'Dashboard', icon: LayoutDashboard, component: Dashboard, end: true },
-  { path: '/specs', label: 'Specs', icon: FileText, component: Specs },
-  { path: '/specs/:specId', label: 'Spec Detail', icon: FileText, component: SpecDetail, nav: false },
-  { path: '/agents', label: 'Agents', icon: Bot, component: Agents },
-  { path: '/artifacts', label: 'Artifacts', icon: Package, component: Artifacts },
-  { path: '/fleet', label: 'Fleet', icon: Server, component: Fleet },
-  { path: '/settings', label: 'Settings', icon: Settings, component: SettingsPage },
+  {
+    id: 'dashboard',
+    path: '/',
+    icon: LayoutDashboard,
+    component: Dashboard,
+    end: true,
+    navGroup: 'command-center',
+    navLabel: 'Dashboard',
+    breadcrumbLabel: 'Dashboard',
+  },
+  {
+    id: 'specs',
+    path: '/specs',
+    icon: FileText,
+    component: Specs,
+    navGroup: 'command-center',
+    navLabel: 'Specs',
+    breadcrumbLabel: 'Spec Editor',
+  },
+  {
+    id: 'spec-detail',
+    path: '/specs/:specId',
+    icon: FileText,
+    component: SpecDetail,
+    nav: false,
+    navLabel: 'Spec Detail',
+    breadcrumbLabel: 'Spec Detail',
+    breadcrumbParentId: 'specs',
+  },
+  {
+    id: 'agents',
+    path: '/agents',
+    icon: Bot,
+    component: Agents,
+    navGroup: 'command-center',
+    navLabel: 'Agents',
+    breadcrumbLabel: 'Agent Monitor',
+  },
+  {
+    id: 'artifacts',
+    path: '/artifacts',
+    icon: Package,
+    component: Artifacts,
+    navGroup: 'command-center',
+    navLabel: 'Artifacts',
+    breadcrumbLabel: 'Artifacts',
+  },
+  {
+    id: 'fleet',
+    path: '/fleet',
+    icon: Server,
+    component: Fleet,
+    navGroup: 'command-center',
+    navLabel: 'Fleet',
+    breadcrumbLabel: 'Fleet',
+  },
+  {
+    id: 'settings',
+    path: '/settings',
+    icon: Settings,
+    component: SettingsPage,
+    navGroup: 'admin',
+    navLabel: 'Settings',
+    breadcrumbLabel: 'Settings',
+  },
 ];
+
+const routeById = new Map<RouteId, AppRoute>(routes.map((route) => [route.id, route]));
+
+export const navGroupLabels: Record<NavGroup, string> = {
+  'command-center': 'Command Center',
+  admin: 'Administration',
+};
+
+export const navGroupOrder: NavGroup[] = ['command-center', 'admin'];
+
+export function findRouteByPath(pathname: string): AppRoute | undefined {
+  return routes.find((route) =>
+    matchPath({ path: route.path, end: route.end ?? true }, pathname),
+  );
+}
+
+export function getBreadcrumbTrail(pathname: string): AppRoute[] {
+  const activeRoute = findRouteByPath(pathname);
+  if (!activeRoute) {
+    return [];
+  }
+
+  const chain: AppRoute[] = [];
+  const seen = new Set<RouteId>();
+  let currentRoute: AppRoute | undefined = activeRoute;
+
+  while (currentRoute && !seen.has(currentRoute.id)) {
+    chain.unshift(currentRoute);
+    seen.add(currentRoute.id);
+    currentRoute = currentRoute.breadcrumbParentId
+      ? routeById.get(currentRoute.breadcrumbParentId)
+      : undefined;
+  }
+
+  return chain;
+}
+
+export function getGroupedNavRoutes(): Array<{ group: NavGroup; routes: AppRoute[] }> {
+  const navRoutes = routes.filter((route) => route.nav !== false);
+
+  return navGroupOrder
+    .map((group) => ({
+      group,
+      routes: navRoutes.filter((route) => route.navGroup === group),
+    }))
+    .filter((entry) => entry.routes.length > 0);
+}

--- a/packages/ui/src/components/shell/application-shell-primitives.tsx
+++ b/packages/ui/src/components/shell/application-shell-primitives.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+export type ApplicationShellFrameProps = React.HTMLAttributes<HTMLDivElement>;
+
+// Adapted from the application-shell1 baseline: shared shell frame primitives live in @kata/ui.
+export function ApplicationShellFrame({
+  className,
+  children,
+  ...props
+}: ApplicationShellFrameProps) {
+  return (
+    <div
+      data-testid="desktop-shell-frame"
+      className={cn('flex h-screen bg-slate-950 text-slate-100', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export type ApplicationShellHeaderProps = React.HTMLAttributes<HTMLElement>;
+
+export function ApplicationShellHeader({
+  className,
+  children,
+  ...props
+}: ApplicationShellHeaderProps) {
+  return (
+    <header
+      className={cn('flex h-16 shrink-0 items-center border-b border-slate-800 bg-slate-950/95 px-4', className)}
+      {...props}
+    >
+      {children}
+    </header>
+  );
+}
+
+export type ApplicationShellMainProps = React.HTMLAttributes<HTMLElement>;
+
+export function ApplicationShellMain({ className, children, ...props }: ApplicationShellMainProps) {
+  return (
+    <main className={cn('flex-1 overflow-auto bg-slate-950', className)} {...props}>
+      {children}
+    </main>
+  );
+}
+
+export interface ApplicationShellBreadcrumbsProps extends React.HTMLAttributes<HTMLElement> {
+  rootLabel?: string;
+  items: string[];
+}
+
+export function ApplicationShellBreadcrumbs({
+  className,
+  items,
+  rootLabel = 'Overview',
+  ...props
+}: ApplicationShellBreadcrumbsProps) {
+  return (
+    <nav
+      aria-label="Breadcrumbs"
+      className={cn('flex min-w-0 items-center gap-2 text-sm text-slate-400', className)}
+      {...props}
+    >
+      <span className="hidden sm:inline">{rootLabel}</span>
+      {items.map((itemLabel, index) => (
+        <React.Fragment key={`${itemLabel}-${index.toString()}`}>
+          <span aria-hidden="true" className="hidden sm:inline text-slate-600">
+            /
+          </span>
+          <span className="truncate font-medium text-slate-100">{itemLabel}</span>
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components/ui/button';
+export * from './components/shell/application-shell-primitives';

--- a/tests/unit/desktop/layout.test.tsx
+++ b/tests/unit/desktop/layout.test.tsx
@@ -41,4 +41,22 @@ describe('Layout', () => {
     expect(breadcrumbs).not.toHaveTextContent('Dashboard');
     expect(screen.getByText('child content')).toBeInTheDocument();
   });
+
+  test('renders metadata-driven breadcrumb chain for spec detail routes', () => {
+    renderLayout('/specs/spec-1', '/specs/:specId');
+    const breadcrumbs = screen.getByRole('navigation', { name: /breadcrumbs/i });
+
+    expect(breadcrumbs).toHaveTextContent('Overview');
+    expect(breadcrumbs).toHaveTextContent('Spec Editor');
+    expect(breadcrumbs).toHaveTextContent('Spec Detail');
+  });
+
+  test('uses long-form breadcrumb labels for command-center sections', () => {
+    renderLayout('/agents', '/agents');
+    const breadcrumbs = screen.getByRole('navigation', { name: /breadcrumbs/i });
+
+    expect(breadcrumbs).toHaveTextContent('Overview');
+    expect(breadcrumbs).toHaveTextContent('Agent Monitor');
+    expect(breadcrumbs).not.toHaveTextContent('Agents');
+  });
 });

--- a/tests/unit/desktop/navigation.test.tsx
+++ b/tests/unit/desktop/navigation.test.tsx
@@ -12,7 +12,10 @@ describe('desktop app navigation', () => {
 
   test('renders breadcrumb scaffolding for the active route', () => {
     render(<App />);
-    expect(screen.getByRole('navigation', { name: /breadcrumbs/i })).toBeInTheDocument();
+    const breadcrumbs = screen.getByRole('navigation', { name: /breadcrumbs/i });
+    expect(breadcrumbs).toBeInTheDocument();
+    expect(breadcrumbs).toHaveTextContent('Overview');
+    expect(breadcrumbs).toHaveTextContent('Dashboard');
   });
 
   test.each([
@@ -25,5 +28,24 @@ describe('desktop app navigation', () => {
     render(<App />);
     fireEvent.click(screen.getByRole('link', { name: new RegExp(name, 'i') }));
     expect(screen.getByRole('heading', { name })).toBeInTheDocument();
+  });
+
+  test('uses long breadcrumb label for Specs route', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('link', { name: /specs/i }));
+
+    const breadcrumbs = screen.getByRole('navigation', { name: /breadcrumbs/i });
+    expect(breadcrumbs).toHaveTextContent('Spec Editor');
+    expect(breadcrumbs).not.toHaveTextContent('Overview / Specs');
+  });
+
+  test('builds breadcrumb parent chain for spec detail route', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('link', { name: /specs/i }));
+    fireEvent.click(screen.getByRole('link', { name: /open spec detail/i }));
+
+    const breadcrumbs = screen.getByRole('navigation', { name: /breadcrumbs/i });
+    expect(breadcrumbs).toHaveTextContent('Spec Editor');
+    expect(breadcrumbs).toHaveTextContent('Spec Detail');
   });
 });

--- a/tests/unit/desktop/routes.test.ts
+++ b/tests/unit/desktop/routes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+
+import { routes } from '../../../apps/desktop/src/routes';
+
+describe('desktop route metadata', () => {
+  test('all navigable routes expose nav and breadcrumb metadata', () => {
+    for (const route of routes.filter((item) => item.nav !== false)) {
+      expect(route.navLabel).toBeTruthy();
+      expect(route.breadcrumbLabel).toBeTruthy();
+      expect(route.navGroup).toBeTruthy();
+    }
+  });
+
+  test('spec detail route is excluded from nav and chains breadcrumbs to specs', () => {
+    const specDetailRoute = routes.find((route) => route.id === 'spec-detail');
+
+    expect(specDetailRoute).toBeDefined();
+    expect(specDetailRoute?.nav).toBe(false);
+    expect(specDetailRoute?.breadcrumbParentId).toBe('specs');
+  });
+});

--- a/tests/unit/desktop/sidebar.test.tsx
+++ b/tests/unit/desktop/sidebar.test.tsx
@@ -40,6 +40,14 @@ describe('Sidebar', () => {
     expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument();
   });
 
+  test('groups navigation by command-center and admin sections', () => {
+    renderSidebar();
+    const commandCenter = screen.getByText('Command Center');
+    const administration = screen.getByText('Administration');
+
+    expect(commandCenter.compareDocumentPosition(administration)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
   test('dashboard link points to root path', () => {
     renderSidebar();
     const link = screen.getByRole('link', { name: /dashboard/i });
@@ -72,6 +80,7 @@ describe('Sidebar', () => {
     renderSidebar();
     expect(screen.queryByText('Kata Cloud Agents')).not.toBeInTheDocument();
     expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByText('Command Center')).not.toBeInTheDocument();
   });
 
   test('toggle button collapses and expands sidebar', async () => {


### PR DESCRIPTION
## Summary
- productionize the selected `application-shell1` desktop shell baseline using shared `@kata/ui` shell primitives
- normalize desktop route metadata with durable nav/breadcrumb fields (`id`, `navGroup`, `navLabel`, `breadcrumbLabel`, `breadcrumbParentId`)
- replace hard-coded breadcrumb behavior with metadata-driven breadcrumb chains (including `Spec Editor > Spec Detail`)
- add grouped sidebar navigation sections (`Command Center`, `Administration`) driven from route metadata
- add route metadata contract tests and update desktop shell tests for long-form breadcrumb labels

## Test Plan
- [x] `pnpm exec vitest run tests/unit/desktop/layout.test.tsx tests/unit/desktop/sidebar.test.tsx tests/unit/desktop/navigation.test.tsx tests/unit/desktop/routes.test.ts`
- [x] `pnpm exec vitest run tests/unit/desktop tests/unit/apps-smoke.test.tsx`
- [x] `pnpm ci:checks`
- [ ] `pnpm desktop:tauri:dev` (blocked in this worktree because port `1420` is already in use by another local Vite process)

Linear: KAT-153


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumb navigation displays hierarchical page path for easier navigation between sections
  * Sidebar navigation organized into functional groups (Command Center and Administration)
  * Restructured application layout with improved header and content organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully productionizes the desktop application shell by migrating from hard-coded navigation to a metadata-driven architecture. The refactor introduces route metadata with dedicated `navLabel` and `breadcrumbLabel` fields, enabling different text for navigation vs. breadcrumbs (e.g., "Specs" in sidebar shows as "Spec Editor" in breadcrumbs). 

Key improvements:
- Extracted reusable shell primitives (`ApplicationShellFrame`, `ApplicationShellHeader`, `ApplicationShellMain`, `ApplicationShellBreadcrumbs`) to `@kata/ui` for cross-app reuse
- Implemented grouped navigation sections (Command Center, Administration) with automatic ordering
- Added breadcrumb parent chaining via `breadcrumbParentId` (e.g., spec-detail → specs)
- Includes comprehensive contract tests ensuring all navigable routes have required metadata
- Achieved 100% test coverage with 74 passing tests

Note: The PR description contains accidentally pasted shell output (uid/gid information) and empty placeholders that should be cleaned up before merging.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The implementation is well-architected with excellent test coverage (74 passing tests, 100% coverage). All changes are backwards-compatible, thoroughly tested with contract tests enforcing metadata requirements, and include protection against edge cases like circular breadcrumb references. The refactor cleanly separates concerns and follows established patterns.
- No files require special attention - the PR description should be cleaned up to remove the accidentally pasted shell output

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes.ts | Added route metadata system with IDs, nav groups, breadcrumb chains, and helper functions for metadata-driven navigation |
| apps/desktop/src/components/Layout.tsx | Refactored to use shared shell primitives from `@kata/ui` and metadata-driven breadcrumb trails |
| apps/desktop/src/components/Sidebar.tsx | Updated to render grouped navigation sections with section headers driven by route metadata |
| packages/ui/src/components/shell/application-shell-primitives.tsx | Created reusable application shell primitives (Frame, Header, Main, Breadcrumbs) for shared use across apps |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Route Metadata in routes.ts] --> B{Route Type}
    B -->|nav !== false| C[Navigation]
    B -->|All routes| D[Breadcrumbs]
    
    C --> E[getGroupedNavRoutes]
    E --> F[Filter by navGroup]
    F --> G[Sidebar renders groups]
    G --> H[Command Center section]
    G --> I[Administration section]
    H --> J[Display navLabel]
    I --> J
    
    D --> K[getBreadcrumbTrail]
    K --> L[findRouteByPath]
    L --> M{Found route?}
    M -->|Yes| N[Build chain via breadcrumbParentId]
    M -->|No| O[Empty trail]
    N --> P[ApplicationShellBreadcrumbs]
    P --> Q[Display breadcrumbLabel]
    
    style A fill:#4a5568
    style G fill:#2d3748
    style P fill:#2d3748
```

<sub>Last reviewed commit: 475dfa9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->