### PR TITLE
feat(workspaces): implement KAT-155 workspace and repo management

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -21,6 +21,11 @@ fn main() {
             workspaces::commands::workspace_create_github,
             workspaces::commands::workspace_create_new_github,
             workspaces::commands::workspace_list_github_repos,
+            workspaces::commands::workspace_list_known_repos,
+            workspaces::commands::workspace_list_repo_pull_requests,
+            workspaces::commands::workspace_list_repo_branches,
+            workspaces::commands::workspace_list_repo_issues,
+            workspaces::commands::workspace_create_from_source,
             workspaces::commands::workspace_pick_directory,
             workspaces::commands::workspace_archive,
             workspaces::commands::workspace_delete

--- a/apps/desktop/src-tauri/src/workspaces/commands.rs
+++ b/apps/desktop/src-tauri/src/workspaces/commands.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use super::git_github::{
     create_github_workspace, create_new_github_workspace, list_repo_branches,
     list_repo_issues, list_repo_pull_requests, pull_request_head_branch,
+    repo_default_branch,
     repo_url_from_id,
 };
 use super::git_local::create_local_workspace;
@@ -416,7 +417,11 @@ pub async fn workspace_create_from_source(
                 (None, Some(format!("origin/{normalized}")))
             }
             WorkspaceCreateFromSource::Issue { value } => {
-                (Some(format!("feature/issue-{value}")), Some("origin/main".to_string()))
+                let default_branch = repo_default_branch(&repo_id)?;
+                (
+                    Some(format!("feature/issue-{value}")),
+                    Some(format!("origin/{default_branch}")),
+                )
             }
         };
 

--- a/apps/desktop/src-tauri/src/workspaces/commands.rs
+++ b/apps/desktop/src-tauri/src/workspaces/commands.rs
@@ -6,12 +6,17 @@ use serde::Serialize;
 use tauri::State;
 use uuid::Uuid;
 
-use super::git_github::{create_github_workspace, create_new_github_workspace};
+use super::git_github::{
+    create_github_workspace, create_new_github_workspace, list_repo_branches,
+    list_repo_issues, list_repo_pull_requests, pull_request_head_branch,
+    repo_url_from_id,
+};
 use super::git_local::create_local_workspace;
 use super::model::{
     now_iso8601, CreateGitHubWorkspaceInput, CreateLocalWorkspaceInput,
-    CreateNewGitHubWorkspaceInput, PreparedWorkspace, Workspace,
-    WorkspaceSourceType, WorkspaceStatus,
+    CreateNewGitHubWorkspaceInput, CreateWorkspaceFromSourceInput, KnownRepoOption,
+    PreparedWorkspace, Workspace, WorkspaceCreateFromSource, WorkspaceSourceType,
+    WorkspaceStatus,
 };
 use super::{WorkspaceError, WorkspaceState};
 
@@ -203,6 +208,51 @@ fn workspace_list_github_repos_blocking(
 }
 
 #[tauri::command]
+pub fn workspace_list_known_repos(
+    query: Option<String>,
+    state: State<'_, WorkspaceState>,
+) -> Result<Vec<KnownRepoOption>, String> {
+    let store = lock_store(&state)?;
+    Ok(store.list_known_repos(query.as_deref()))
+}
+
+#[tauri::command]
+pub async fn workspace_list_repo_pull_requests(
+    repo_id: String,
+    query: Option<String>,
+) -> Result<Vec<super::model::WorkspacePullRequestOption>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        list_repo_pull_requests(&repo_id, query.as_deref()).map_err(to_command_error)
+    })
+    .await
+    .map_err(|err| format!("Failed to load pull requests: {err}"))?
+}
+
+#[tauri::command]
+pub async fn workspace_list_repo_branches(
+    repo_id: String,
+    query: Option<String>,
+) -> Result<Vec<super::model::WorkspaceBranchOption>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        list_repo_branches(&repo_id, query.as_deref()).map_err(to_command_error)
+    })
+    .await
+    .map_err(|err| format!("Failed to load branches: {err}"))?
+}
+
+#[tauri::command]
+pub async fn workspace_list_repo_issues(
+    repo_id: String,
+    query: Option<String>,
+) -> Result<Vec<super::model::WorkspaceIssueOption>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        list_repo_issues(&repo_id, query.as_deref()).map_err(to_command_error)
+    })
+    .await
+    .map_err(|err| format!("Failed to load issues: {err}"))?
+}
+
+#[tauri::command]
 pub fn workspace_list(state: State<'_, WorkspaceState>) -> Result<Vec<Workspace>, String> {
     let store = lock_store(&state)?;
     Ok(store.list())
@@ -312,6 +362,84 @@ pub async fn workspace_create_new_github(
         WorkspaceSourceType::Github,
         created.repo_url,
         created.prepared,
+    );
+    persist_workspace(&state, workspace)
+}
+
+#[tauri::command]
+pub async fn workspace_create_from_source(
+    input: CreateWorkspaceFromSourceInput,
+    state: State<'_, WorkspaceState>,
+) -> Result<Workspace, String> {
+    let workspace_id = next_workspace_id();
+    let suffix_owned = workspace_suffix(&workspace_id).to_string();
+    let app_data_dir = state.app_data_dir.clone();
+
+    let repo_id = input.repo_id.trim().to_string();
+    if repo_id.is_empty() {
+        return Err("Repository selection is required".to_string());
+    }
+    let repo_url = repo_url_from_id(&repo_id).map_err(to_command_error)?;
+    let fallback_name = repo_id
+        .split('/')
+        .filter(|segment| !segment.trim().is_empty())
+        .last()
+        .unwrap_or("Workspace")
+        .to_string();
+    let workspace_name = input
+        .workspace_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(fallback_name.as_str())
+        .to_string();
+
+    let clone_root_path = input.clone_root_path.clone();
+    let source = input.source.clone();
+    let source_value = repo_url.clone();
+    let workspace_name_for_create = workspace_name.clone();
+
+    let prepared = tauri::async_runtime::spawn_blocking(move || {
+        let (branch_name, base_ref) = match source {
+            WorkspaceCreateFromSource::Default => (None, None),
+            WorkspaceCreateFromSource::PullRequest { value } => {
+                let head_branch = pull_request_head_branch(&repo_id, value)?;
+                (None, Some(format!("origin/{head_branch}")))
+            }
+            WorkspaceCreateFromSource::Branch { value } => {
+                let normalized = value.trim().trim_start_matches("origin/").to_string();
+                if normalized.is_empty() {
+                    return Err(WorkspaceError::InvalidInput(
+                        "Branch selection is required".to_string(),
+                    ));
+                }
+                (None, Some(format!("origin/{normalized}")))
+            }
+            WorkspaceCreateFromSource::Issue { value } => {
+                (Some(format!("feature/issue-{value}")), Some("origin/main".to_string()))
+            }
+        };
+
+        create_github_workspace(
+            &repo_url,
+            &workspace_name_for_create,
+            clone_root_path,
+            branch_name,
+            base_ref,
+            &suffix_owned,
+            &app_data_dir,
+        )
+    })
+    .await
+    .map_err(|err| format!("Task failed: {err}"))?
+    .map_err(to_command_error)?;
+
+    let workspace = build_workspace(
+        workspace_id,
+        workspace_name,
+        WorkspaceSourceType::Github,
+        source_value,
+        prepared,
     );
     persist_workspace(&state, workspace)
 }

--- a/apps/desktop/src-tauri/src/workspaces/git_github.rs
+++ b/apps/desktop/src-tauri/src/workspaces/git_github.rs
@@ -265,6 +265,7 @@ pub fn list_repo_branches(
             Some(WorkspaceBranchOption {
                 is_default: branch == default_name,
                 name: branch,
+                // Synthetic: git ls-remote does not expose timestamps.
                 updated_at: Utc::now().to_rfc3339(),
             })
         })

--- a/apps/desktop/src-tauri/src/workspaces/git_github.rs
+++ b/apps/desktop/src-tauri/src/workspaces/git_github.rs
@@ -143,7 +143,7 @@ pub fn list_repo_pull_requests(
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct PullRequestItem {
-        number: i64,
+        number: u32,
         title: String,
         head_ref_name: String,
         updated_at: Option<String>,
@@ -196,7 +196,7 @@ pub fn list_repo_issues(
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct IssueItem {
-        number: i64,
+        number: u32,
         title: String,
         updated_at: Option<String>,
     }
@@ -308,7 +308,7 @@ pub fn repo_default_branch(repo_id: &str) -> Result<String, WorkspaceError> {
     Ok(branch.to_string())
 }
 
-pub fn pull_request_head_branch(repo_id: &str, number: i64) -> Result<String, WorkspaceError> {
+pub fn pull_request_head_branch(repo_id: &str, number: u32) -> Result<String, WorkspaceError> {
     let output = run_gh(
         Path::new("."),
         &[

--- a/apps/desktop/src-tauri/src/workspaces/git_github.rs
+++ b/apps/desktop/src-tauri/src/workspaces/git_github.rs
@@ -245,19 +245,7 @@ pub fn list_repo_branches(
     query: Option<&str>,
 ) -> Result<Vec<WorkspaceBranchOption>, WorkspaceError> {
     let repo_url = repo_url_from_id(repo_id)?;
-    let default_branch = run_gh(
-        Path::new("."),
-        &[
-            "repo",
-            "view",
-            repo_id,
-            "--json",
-            "defaultBranchRef",
-            "--jq",
-            ".defaultBranchRef.name",
-        ],
-    )?;
-    let default_name = default_branch.trim().to_string();
+    let default_name = repo_default_branch(repo_id)?;
     let output = Command::new("git")
         .args(["ls-remote", "--heads", &repo_url])
         .output()
@@ -295,6 +283,28 @@ pub fn list_repo_branches(
     });
     items.truncate(20);
     Ok(items)
+}
+
+pub fn repo_default_branch(repo_id: &str) -> Result<String, WorkspaceError> {
+    let default_branch = run_gh(
+        Path::new("."),
+        &[
+            "repo",
+            "view",
+            repo_id,
+            "--json",
+            "defaultBranchRef",
+            "--jq",
+            ".defaultBranchRef.name",
+        ],
+    )?;
+    let branch = default_branch.trim();
+    if branch.is_empty() {
+        return Err(WorkspaceError::InvalidInput(format!(
+            "Unable to determine default branch for repository: {repo_id}"
+        )));
+    }
+    Ok(branch.to_string())
 }
 
 pub fn pull_request_head_branch(repo_id: &str, number: i64) -> Result<String, WorkspaceError> {

--- a/apps/desktop/src-tauri/src/workspaces/git_github.rs
+++ b/apps/desktop/src-tauri/src/workspaces/git_github.rs
@@ -1,11 +1,15 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use chrono::Utc;
+use serde::Deserialize;
 use url::Url;
 
 use super::git_local::create_local_workspace;
-use super::model::PreparedWorkspace;
+use super::model::{
+    WorkspaceBranchOption, WorkspaceIssueOption, WorkspacePullRequestOption, PreparedWorkspace,
+};
 use super::WorkspaceError;
 
 pub struct CreatedGitHubWorkspace {
@@ -23,15 +27,12 @@ pub fn create_github_workspace(
     app_data_dir: &Path,
 ) -> Result<PreparedWorkspace, WorkspaceError> {
     let (owner, repo) = parse_github_repo_url(repo_url)?;
-    let cache_repo_path = clone_root_path
-        .filter(|value| !value.trim().is_empty())
-        .map(|value| Path::new(&value).join(format!("{owner}__{repo}")))
-        .unwrap_or_else(|| {
-            app_data_dir
-                .join("repo-cache")
-                .join("github")
-                .join(format!("{owner}__{repo}"))
-        });
+    let clone_root = normalize_clone_root_path(
+        clone_root_path,
+        app_data_dir,
+        app_data_dir.join("repo-cache").join("github"),
+    );
+    let cache_repo_path = clone_root.join(format!("{owner}__{repo}"));
 
     if cache_repo_path.exists() {
         run_git_in_dir(&cache_repo_path, &["fetch", "--all", "--prune"])?;
@@ -69,10 +70,11 @@ pub fn create_new_github_workspace(
     suffix: &str,
     app_data_dir: &Path,
 ) -> Result<CreatedGitHubWorkspace, WorkspaceError> {
-    let clone_root = clone_root_path
-        .filter(|value| !value.trim().is_empty())
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| app_data_dir.join("repo-cache").join("github-created"));
+    let clone_root = normalize_clone_root_path(
+        clone_root_path,
+        app_data_dir,
+        app_data_dir.join("repo-cache").join("github-created"),
+    );
     fs::create_dir_all(&clone_root)?;
 
     let (owner_override, repo) = split_repository_name(repository_name)?;
@@ -116,6 +118,209 @@ pub fn create_new_github_workspace(
     Ok(CreatedGitHubWorkspace { prepared, repo_url })
 }
 
+pub fn repo_url_from_id(repo_id: &str) -> Result<String, WorkspaceError> {
+    let trimmed = repo_id.trim().trim_matches('/');
+    let parts = trimmed
+        .split('/')
+        .filter(|value| !value.trim().is_empty())
+        .collect::<Vec<_>>();
+    match parts.as_slice() {
+        [owner, repo] => Ok(format!(
+            "https://github.com/{}/{}",
+            owner.trim(),
+            repo.trim().trim_end_matches(".git")
+        )),
+        _ => Err(WorkspaceError::InvalidInput(
+            "Repository id must be \"owner/repo\"".to_string(),
+        )),
+    }
+}
+
+pub fn list_repo_pull_requests(
+    repo_id: &str,
+    query: Option<&str>,
+) -> Result<Vec<WorkspacePullRequestOption>, WorkspaceError> {
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct PullRequestItem {
+        number: i64,
+        title: String,
+        head_ref_name: String,
+        updated_at: Option<String>,
+    }
+
+    let output = run_gh(
+        Path::new("."),
+        &[
+            "pr",
+            "list",
+            "--repo",
+            repo_id,
+            "--limit",
+            "100",
+            "--state",
+            "open",
+            "--json",
+            "number,title,headRefName,updatedAt",
+        ],
+    )?;
+    let mut items = serde_json::from_str::<Vec<PullRequestItem>>(&output)
+        .map_err(|err| WorkspaceError::GitFailed(format!("Failed to parse PR list: {err}")))?
+        .into_iter()
+        .map(|item| WorkspacePullRequestOption {
+            number: item.number,
+            title: item.title,
+            head_branch: item.head_ref_name,
+            updated_at: item.updated_at.unwrap_or_else(|| Utc::now().to_rfc3339()),
+        })
+        .collect::<Vec<_>>();
+
+    if let Some(filter) = query.map(str::trim).filter(|value| !value.is_empty()) {
+        let needle = filter.to_lowercase();
+        items.retain(|item| {
+            format!("{} {} {}", item.number, item.title, item.head_branch)
+                .to_lowercase()
+                .contains(&needle)
+        });
+    }
+
+    items.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+    items.truncate(20);
+    Ok(items)
+}
+
+pub fn list_repo_issues(
+    repo_id: &str,
+    query: Option<&str>,
+) -> Result<Vec<WorkspaceIssueOption>, WorkspaceError> {
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct IssueItem {
+        number: i64,
+        title: String,
+        updated_at: Option<String>,
+    }
+
+    let output = run_gh(
+        Path::new("."),
+        &[
+            "issue",
+            "list",
+            "--repo",
+            repo_id,
+            "--limit",
+            "100",
+            "--state",
+            "open",
+            "--json",
+            "number,title,updatedAt",
+        ],
+    )?;
+    let mut items = serde_json::from_str::<Vec<IssueItem>>(&output)
+        .map_err(|err| WorkspaceError::GitFailed(format!("Failed to parse issue list: {err}")))?
+        .into_iter()
+        .map(|item| WorkspaceIssueOption {
+            number: item.number,
+            title: item.title,
+            updated_at: item.updated_at.unwrap_or_else(|| Utc::now().to_rfc3339()),
+        })
+        .collect::<Vec<_>>();
+
+    if let Some(filter) = query.map(str::trim).filter(|value| !value.is_empty()) {
+        let needle = filter.to_lowercase();
+        items.retain(|item| {
+            format!("{} {}", item.number, item.title)
+                .to_lowercase()
+                .contains(&needle)
+        });
+    }
+
+    items.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+    items.truncate(20);
+    Ok(items)
+}
+
+pub fn list_repo_branches(
+    repo_id: &str,
+    query: Option<&str>,
+) -> Result<Vec<WorkspaceBranchOption>, WorkspaceError> {
+    let repo_url = repo_url_from_id(repo_id)?;
+    let default_branch = run_gh(
+        Path::new("."),
+        &[
+            "repo",
+            "view",
+            repo_id,
+            "--json",
+            "defaultBranchRef",
+            "--jq",
+            ".defaultBranchRef.name",
+        ],
+    )?;
+    let default_name = default_branch.trim().to_string();
+    let output = Command::new("git")
+        .args(["ls-remote", "--heads", &repo_url])
+        .output()
+        .map_err(WorkspaceError::Io)?;
+    if !output.status.success() {
+        return Err(WorkspaceError::GitFailed(format!(
+            "git ls-remote failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    let mut items = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (_, ref_name) = line.split_once('\t')?;
+            let branch = ref_name.strip_prefix("refs/heads/")?.to_string();
+            Some(WorkspaceBranchOption {
+                is_default: branch == default_name,
+                name: branch,
+                updated_at: Utc::now().to_rfc3339(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if let Some(filter) = query.map(str::trim).filter(|value| !value.is_empty()) {
+        let needle = filter.to_lowercase();
+        items.retain(|item| item.name.to_lowercase().contains(&needle));
+    }
+
+    items.sort_by(|left, right| {
+        right
+            .is_default
+            .cmp(&left.is_default)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    items.truncate(20);
+    Ok(items)
+}
+
+pub fn pull_request_head_branch(repo_id: &str, number: i64) -> Result<String, WorkspaceError> {
+    let output = run_gh(
+        Path::new("."),
+        &[
+            "pr",
+            "view",
+            "--repo",
+            repo_id,
+            &number.to_string(),
+            "--json",
+            "headRefName",
+            "--jq",
+            ".headRefName",
+        ],
+    )?;
+    let branch = output.trim();
+    if branch.is_empty() {
+        return Err(WorkspaceError::InvalidInput(format!(
+            "Pull request not found: {number}"
+        )));
+    }
+    Ok(branch.to_string())
+}
+
 fn parse_github_repo_url(repo_url: &str) -> Result<(String, String), WorkspaceError> {
     let parsed = Url::parse(repo_url).map_err(|_| {
         WorkspaceError::InvalidInput(
@@ -144,6 +349,62 @@ fn parse_github_repo_url(repo_url: &str) -> Result<(String, String), WorkspaceEr
 
     let repo_name = repo.strip_suffix(".git").unwrap_or(repo).to_string();
     Ok((owner.to_string(), repo_name))
+}
+
+fn normalize_clone_root_path(
+    clone_root_path: Option<String>,
+    app_data_dir: &Path,
+    default_root: PathBuf,
+) -> PathBuf {
+    let home_dir = detect_home_dir();
+    normalize_clone_root_path_with_home(
+        clone_root_path,
+        app_data_dir,
+        default_root,
+        home_dir.as_deref(),
+    )
+}
+
+fn normalize_clone_root_path_with_home(
+    clone_root_path: Option<String>,
+    app_data_dir: &Path,
+    default_root: PathBuf,
+    home_dir: Option<&Path>,
+) -> PathBuf {
+    let Some(raw) = clone_root_path else {
+        return default_root;
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return default_root;
+    }
+
+    let expanded = expand_home_prefix(trimmed, home_dir).unwrap_or_else(|| PathBuf::from(trimmed));
+    if expanded.is_absolute() {
+        expanded
+    } else {
+        app_data_dir.join(expanded)
+    }
+}
+
+fn expand_home_prefix(path: &str, home_dir: Option<&Path>) -> Option<PathBuf> {
+    let home = home_dir?;
+    if path == "~" {
+        return Some(home.to_path_buf());
+    }
+    if let Some(rest) = path
+        .strip_prefix("~/")
+        .or_else(|| path.strip_prefix("~\\"))
+    {
+        return Some(home.join(rest));
+    }
+    None
+}
+
+fn detect_home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
 }
 
 fn run_git_in_dir(cwd: &Path, args: &[&str]) -> Result<String, WorkspaceError> {
@@ -226,7 +487,11 @@ fn run_gh(cwd: &Path, args: &[&str]) -> Result<String, WorkspaceError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{create_github_workspace, split_repository_name};
+    use std::path::Path;
+
+    use super::{
+        create_github_workspace, normalize_clone_root_path_with_home, split_repository_name,
+    };
 
     #[test]
     fn rejects_non_github_remote_urls() {
@@ -253,6 +518,44 @@ mod tests {
         let with_owner = split_repository_name("kata-sh/kat-154-created.git").unwrap();
         assert_eq!(with_owner.0, Some("kata-sh".to_string()));
         assert_eq!(with_owner.1, "kat-154-created".to_string());
+    }
+
+    #[test]
+    fn normalizes_clone_roots_for_tilde_relative_and_defaults() {
+        let app_data = Path::new("/tmp/kata-app-data");
+        let home = Path::new("/Users/tester");
+
+        let tilde = normalize_clone_root_path_with_home(
+            Some("~/kata/repos".to_string()),
+            app_data,
+            Path::new("/tmp/default").to_path_buf(),
+            Some(home),
+        );
+        assert_eq!(tilde, Path::new("/Users/tester/kata/repos"));
+
+        let relative = normalize_clone_root_path_with_home(
+            Some("kata/repos".to_string()),
+            app_data,
+            Path::new("/tmp/default").to_path_buf(),
+            Some(home),
+        );
+        assert_eq!(relative, Path::new("/tmp/kata-app-data/kata/repos"));
+
+        let fallback = normalize_clone_root_path_with_home(
+            Some("~".to_string()),
+            app_data,
+            Path::new("/tmp/default").to_path_buf(),
+            Some(home),
+        );
+        assert_eq!(fallback, Path::new("/Users/tester"));
+
+        let defaulted = normalize_clone_root_path_with_home(
+            Some("   ".to_string()),
+            app_data,
+            Path::new("/tmp/default").to_path_buf(),
+            Some(home),
+        );
+        assert_eq!(defaulted, Path::new("/tmp/default"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/workspaces/model.rs
+++ b/apps/desktop/src-tauri/src/workspaces/model.rs
@@ -83,7 +83,7 @@ pub struct WorkspaceBranchOption {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspacePullRequestOption {
-    pub number: i64,
+    pub number: u32,
     pub title: String,
     pub head_branch: String,
     pub updated_at: String,
@@ -92,7 +92,7 @@ pub struct WorkspacePullRequestOption {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceIssueOption {
-    pub number: i64,
+    pub number: u32,
     pub title: String,
     pub updated_at: String,
 }
@@ -101,9 +101,9 @@ pub struct WorkspaceIssueOption {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WorkspaceCreateFromSource {
     Default,
-    PullRequest { value: i64 },
+    PullRequest { value: u32 },
     Branch { value: String },
-    Issue { value: i64 },
+    Issue { value: u32 },
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/apps/desktop/src-tauri/src/workspaces/model.rs
+++ b/apps/desktop/src-tauri/src/workspaces/model.rs
@@ -63,6 +63,58 @@ pub struct CreateNewGitHubWorkspaceInput {
     pub base_ref: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KnownRepoOption {
+    pub id: String,
+    pub name_with_owner: String,
+    pub url: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceBranchOption {
+    pub name: String,
+    pub is_default: bool,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacePullRequestOption {
+    pub number: i64,
+    pub title: String,
+    pub head_branch: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceIssueOption {
+    pub number: i64,
+    pub title: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkspaceCreateFromSource {
+    Default,
+    PullRequest { value: i64 },
+    Branch { value: String },
+    Issue { value: i64 },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateWorkspaceFromSourceInput {
+    pub repo_id: String,
+    pub workspace_name: Option<String>,
+    pub clone_root_path: Option<String>,
+    pub source: WorkspaceCreateFromSource,
+}
+
 #[derive(Debug, Clone)]
 pub struct PreparedWorkspace {
     pub repo_root_path: String,

--- a/apps/desktop/src-tauri/src/workspaces/store.rs
+++ b/apps/desktop/src-tauri/src/workspaces/store.rs
@@ -153,16 +153,18 @@ fn repo_id_from_source(source: &str) -> Option<String> {
     if parsed.host_str() != Some("github.com") {
         return None;
     }
-    let id = parsed
+    let mut segments = parsed
         .path()
-        .trim_start_matches('/')
-        .trim_end_matches(".git")
-        .trim()
-        .to_string();
-    if id.is_empty() {
+        .trim_matches('/')
+        .split('/')
+        .map(|segment| segment.trim())
+        .filter(|segment| !segment.is_empty());
+    let owner = segments.next()?;
+    let repo = segments.next()?.trim_end_matches(".git").trim_end_matches('/');
+    if owner.is_empty() || repo.is_empty() {
         None
     } else {
-        Some(id)
+        Some(format!("{owner}/{repo}"))
     }
 }
 
@@ -287,5 +289,29 @@ mod tests {
         let store = &mut WorkspaceStore::new(dir.path());
         let err = store.remove("ws_missing").unwrap_err();
         assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn repo_id_from_source_canonicalizes_owner_repo_shape() {
+        assert_eq!(
+            repo_id_from_source("https://github.com/kata-sh/kata-cloud-agents"),
+            Some("kata-sh/kata-cloud-agents".to_string())
+        );
+        assert_eq!(
+            repo_id_from_source("https://github.com/kata-sh/kata-cloud-agents/"),
+            Some("kata-sh/kata-cloud-agents".to_string())
+        );
+        assert_eq!(
+            repo_id_from_source("https://github.com/kata-sh/kata-cloud-agents.git/"),
+            Some("kata-sh/kata-cloud-agents".to_string())
+        );
+        assert_eq!(
+            repo_id_from_source("https://github.com/kata-sh/kata-cloud-agents/tree/main"),
+            Some("kata-sh/kata-cloud-agents".to_string())
+        );
+        assert_eq!(
+            repo_id_from_source("https://github.com/kata-sh"),
+            None
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/workspaces/store.rs
+++ b/apps/desktop/src-tauri/src/workspaces/store.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use super::model::{now_iso8601, Workspace, WorkspaceStatus};
+use super::model::{now_iso8601, KnownRepoOption, Workspace, WorkspaceSourceType, WorkspaceStatus};
 use super::WorkspaceError;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -106,6 +106,63 @@ impl WorkspaceStore {
         self.app_data_dir
             .join("workspaces")
             .join("workspaces.json")
+    }
+
+    pub fn list_known_repos(&self, query: Option<&str>) -> Vec<KnownRepoOption> {
+        let mut dedup = std::collections::HashMap::<String, KnownRepoOption>::new();
+        for workspace in &self.registry.workspaces {
+            if workspace.source_type != WorkspaceSourceType::Github {
+                continue;
+            }
+            let Some(repo_id) = repo_id_from_source(&workspace.source) else {
+                continue;
+            };
+            let candidate = KnownRepoOption {
+                id: repo_id.clone(),
+                name_with_owner: repo_id.clone(),
+                url: format!("https://github.com/{repo_id}"),
+                updated_at: workspace.updated_at.clone(),
+            };
+            match dedup.get(&repo_id) {
+                Some(existing) if existing.updated_at >= candidate.updated_at => {}
+                _ => {
+                    dedup.insert(repo_id, candidate);
+                }
+            }
+        }
+
+        let normalized_query = query.unwrap_or_default().trim().to_lowercase();
+        let mut repos = dedup
+            .into_values()
+            .filter(|repo| {
+                if normalized_query.is_empty() {
+                    return true;
+                }
+                let haystack = format!("{} {}", repo.name_with_owner, repo.url).to_lowercase();
+                haystack.contains(&normalized_query)
+            })
+            .collect::<Vec<_>>();
+        repos.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+        repos.truncate(20);
+        repos
+    }
+}
+
+fn repo_id_from_source(source: &str) -> Option<String> {
+    let parsed = url::Url::parse(source).ok()?;
+    if parsed.host_str() != Some("github.com") {
+        return None;
+    }
+    let id = parsed
+        .path()
+        .trim_start_matches('/')
+        .trim_end_matches(".git")
+        .trim()
+        .to_string();
+    if id.is_empty() {
+        None
+    } else {
+        Some(id)
     }
 }
 

--- a/apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx
+++ b/apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import type {
   WorkspaceBranchOption,
@@ -60,6 +60,28 @@ export function CreateWorkspaceModal({
       setTab('branches');
     }
   }, [enableIssuesTab, tab]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally resets search when tab changes
+  useEffect(() => {
+    setQuery('');
+  }, [tab]);
+
+  const handleEscape = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, handleEscape]);
 
   useEffect(() => {
     if (!isOpen || !repoId) {
@@ -126,6 +148,8 @@ export function CreateWorkspaceModal({
         await onCreate({ repoId, source: { type: 'branch', value: selectedBranch } });
       } else if (enableIssuesTab && tab === 'issues' && selectedIssue !== null) {
         await onCreate({ repoId, source: { type: 'issue', value: selectedIssue } });
+      } else {
+        return;
       }
       onClose();
     } catch (createError) {
@@ -134,8 +158,11 @@ export function CreateWorkspaceModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 p-8">
+    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop overlay dismisses modal on click
+    <div role="presentation" className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 p-8" onClick={onClose}>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation only prevents backdrop close */}
       <div
+        onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-label="Create workspace"

--- a/apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx
+++ b/apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx
@@ -104,19 +104,20 @@ export function CreateWorkspaceModal({
   }, [enableIssuesTab, isOpen, loadBranches, loadIssues, loadPullRequests, query, repoId, tab]);
 
   const canCreate = useMemo(() => {
+    if (isLoading) return false;
     if (!repoId) return false;
     if (tab === 'pull_requests') return selectedPullRequest !== null;
     if (tab === 'branches') return Boolean(selectedBranch);
     if (!enableIssuesTab) return false;
     return selectedIssue !== null;
-  }, [enableIssuesTab, repoId, selectedBranch, selectedIssue, selectedPullRequest, tab]);
+  }, [enableIssuesTab, isLoading, repoId, selectedBranch, selectedIssue, selectedPullRequest, tab]);
 
   if (!isOpen) {
     return null;
   }
 
   async function handleCreate() {
-    if (!repoId) return;
+    if (!repoId || isLoading) return;
     setError(null);
     try {
       if (tab === 'pull_requests' && selectedPullRequest !== null) {

--- a/apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx
+++ b/apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type {
+  WorkspaceBranchOption,
+  WorkspaceCreateFromSource,
+  WorkspaceIssueOption,
+  WorkspaceKnownRepoOption,
+  WorkspacePullRequestOption,
+} from '../../services/workspaces/types';
+
+type CreateFromTab = 'pull_requests' | 'branches' | 'issues';
+
+interface CreateWorkspaceModalProps {
+  isOpen: boolean;
+  enableIssuesTab?: boolean;
+  initialRepoId?: string | null;
+  repos: WorkspaceKnownRepoOption[];
+  onClose: () => void;
+  onCreate: (input: { repoId: string; source: WorkspaceCreateFromSource }) => Promise<void>;
+  loadPullRequests: (repoId: string, query?: string) => Promise<WorkspacePullRequestOption[]>;
+  loadBranches: (repoId: string, query?: string) => Promise<WorkspaceBranchOption[]>;
+  loadIssues: (repoId: string, query?: string) => Promise<WorkspaceIssueOption[]>;
+}
+
+export function CreateWorkspaceModal({
+  isOpen,
+  enableIssuesTab = false,
+  initialRepoId,
+  repos,
+  onClose,
+  onCreate,
+  loadPullRequests,
+  loadBranches,
+  loadIssues,
+}: CreateWorkspaceModalProps) {
+  const [repoId, setRepoId] = useState(initialRepoId ?? repos[0]?.id ?? '');
+  const [tab, setTab] = useState<CreateFromTab>('branches');
+  const [query, setQuery] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pullRequests, setPullRequests] = useState<WorkspacePullRequestOption[]>([]);
+  const [branches, setBranches] = useState<WorkspaceBranchOption[]>([]);
+  const [issues, setIssues] = useState<WorkspaceIssueOption[]>([]);
+  const [selectedPullRequest, setSelectedPullRequest] = useState<number | null>(null);
+  const [selectedBranch, setSelectedBranch] = useState<string>('');
+  const [selectedIssue, setSelectedIssue] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setRepoId(initialRepoId ?? repos[0]?.id ?? '');
+    setTab('branches');
+    setQuery('');
+    setError(null);
+  }, [initialRepoId, isOpen, repos]);
+
+  useEffect(() => {
+    if (!enableIssuesTab && tab === 'issues') {
+      setTab('branches');
+    }
+  }, [enableIssuesTab, tab]);
+
+  useEffect(() => {
+    if (!isOpen || !repoId) {
+      return;
+    }
+
+    let canceled = false;
+    void (async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        if (tab === 'pull_requests') {
+          const items = await loadPullRequests(repoId, query);
+          if (canceled) return;
+          setPullRequests(items);
+          setSelectedPullRequest(items[0]?.number ?? null);
+        } else if (tab === 'branches') {
+          const items = await loadBranches(repoId, query);
+          if (canceled) return;
+          setBranches(items);
+          setSelectedBranch(items[0]?.name ?? '');
+        } else if (enableIssuesTab) {
+          const items = await loadIssues(repoId, query);
+          if (canceled) return;
+          setIssues(items);
+          setSelectedIssue(items[0]?.number ?? null);
+        }
+      } catch (loadError) {
+        if (!canceled) {
+          setError(loadError instanceof Error ? loadError.message : 'Failed to load options');
+        }
+      } finally {
+        if (!canceled) {
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      canceled = true;
+    };
+  }, [enableIssuesTab, isOpen, loadBranches, loadIssues, loadPullRequests, query, repoId, tab]);
+
+  const canCreate = useMemo(() => {
+    if (!repoId) return false;
+    if (tab === 'pull_requests') return selectedPullRequest !== null;
+    if (tab === 'branches') return Boolean(selectedBranch);
+    if (!enableIssuesTab) return false;
+    return selectedIssue !== null;
+  }, [enableIssuesTab, repoId, selectedBranch, selectedIssue, selectedPullRequest, tab]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  async function handleCreate() {
+    if (!repoId) return;
+    setError(null);
+    try {
+      if (tab === 'pull_requests' && selectedPullRequest !== null) {
+        await onCreate({ repoId, source: { type: 'pull_request', value: selectedPullRequest } });
+      } else if (tab === 'branches' && selectedBranch) {
+        await onCreate({ repoId, source: { type: 'branch', value: selectedBranch } });
+      } else if (enableIssuesTab && tab === 'issues' && selectedIssue !== null) {
+        await onCreate({ repoId, source: { type: 'issue', value: selectedIssue } });
+      }
+      onClose();
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : 'Failed to create workspace');
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 p-8">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Create workspace"
+        className="w-full max-w-3xl rounded border border-slate-700 bg-slate-950 shadow-xl"
+      >
+        <div className="border-b border-slate-800 px-4 py-3">
+          <h3 className="text-base font-semibold text-slate-100">Create workspace from...</h3>
+        </div>
+
+        <div className="space-y-4 p-4">
+          <label className="block text-sm text-slate-200">
+            Repository
+            <select
+              value={repoId}
+              onChange={(event) => setRepoId(event.target.value)}
+              className="mt-1 block w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100"
+            >
+              {repos.map((repo) => (
+                <option key={repo.id} value={repo.id}>
+                  {repo.nameWithOwner}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setTab('branches')}
+              className={`rounded px-3 py-1.5 text-sm ${
+                tab === 'branches' ? 'bg-slate-200 text-slate-900' : 'bg-slate-800 text-slate-200'
+              }`}
+            >
+              Branches
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab('pull_requests')}
+              className={`rounded px-3 py-1.5 text-sm ${
+                tab === 'pull_requests' ? 'bg-slate-200 text-slate-900' : 'bg-slate-800 text-slate-200'
+              }`}
+            >
+              Pull requests
+            </button>
+            <button
+              type="button"
+              disabled={!enableIssuesTab}
+              title={enableIssuesTab ? undefined : 'Coming soon: create from GitHub issues'}
+              onClick={() => {
+                if (enableIssuesTab) {
+                  setTab('issues');
+                }
+              }}
+              className={`rounded px-3 py-1.5 text-sm ${
+                !enableIssuesTab
+                  ? 'cursor-not-allowed bg-slate-800 text-slate-500 opacity-60'
+                  : tab === 'issues'
+                    ? 'bg-slate-200 text-slate-900'
+                    : 'bg-slate-800 text-slate-200'
+              }`}
+            >
+              Issues
+            </button>
+          </div>
+
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="block w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100"
+            placeholder={
+              tab === 'pull_requests'
+                ? 'Search by title, number'
+                : tab === 'branches'
+                  ? 'Search by branch name'
+                  : 'Search by issue number, title'
+            }
+          />
+
+          <div className="max-h-72 overflow-auto rounded border border-slate-800 bg-slate-900/50">
+            {isLoading ? (
+              <p className="px-3 py-2 text-sm text-slate-400">Loading...</p>
+            ) : null}
+            {!isLoading && tab === 'pull_requests' && pullRequests.length === 0 ? (
+              <p className="px-3 py-2 text-sm text-slate-400">No pull requests found.</p>
+            ) : null}
+            {!isLoading && tab === 'branches' && branches.length === 0 ? (
+              <p className="px-3 py-2 text-sm text-slate-400">No branches found.</p>
+            ) : null}
+            {!isLoading && tab === 'issues' && issues.length === 0 ? (
+              <p className="px-3 py-2 text-sm text-slate-400">No issues found.</p>
+            ) : null}
+
+            {!isLoading && tab === 'pull_requests'
+              ? pullRequests.map((entry) => (
+                  <button
+                    key={entry.number}
+                    type="button"
+                    onClick={() => setSelectedPullRequest(entry.number)}
+                    className={`block w-full border-b border-slate-800 px-3 py-2 text-left text-sm last:border-b-0 ${
+                      selectedPullRequest === entry.number ? 'bg-slate-800 text-slate-100' : 'text-slate-300'
+                    }`}
+                  >
+                    #{entry.number} {entry.title}
+                  </button>
+                ))
+              : null}
+
+            {!isLoading && tab === 'branches'
+              ? branches.map((entry) => (
+                  <button
+                    key={entry.name}
+                    type="button"
+                    onClick={() => setSelectedBranch(entry.name)}
+                    className={`block w-full border-b border-slate-800 px-3 py-2 text-left text-sm last:border-b-0 ${
+                      selectedBranch === entry.name ? 'bg-slate-800 text-slate-100' : 'text-slate-300'
+                    }`}
+                  >
+                    {entry.name}
+                    {entry.isDefault ? ' (default)' : ''}
+                  </button>
+                ))
+              : null}
+
+            {!isLoading && tab === 'issues'
+              ? issues.map((entry) => (
+                  <button
+                    key={entry.number}
+                    type="button"
+                    onClick={() => setSelectedIssue(entry.number)}
+                    className={`block w-full border-b border-slate-800 px-3 py-2 text-left text-sm last:border-b-0 ${
+                      selectedIssue === entry.number ? 'bg-slate-800 text-slate-100' : 'text-slate-300'
+                    }`}
+                  >
+                    #{entry.number} {entry.title}
+                  </button>
+                ))
+              : null}
+          </div>
+
+          {error ? (
+            <p role="alert" className="text-sm text-rose-400">
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-slate-800 px-4 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-slate-700 px-3 py-2 text-sm text-slate-200"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canCreate}
+            onClick={() => void handleCreate()}
+            className="rounded bg-slate-200 px-3 py-2 text-sm font-medium text-slate-900 disabled:opacity-50"
+          >
+            Create workspace
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/hooks/useCreateWorkspaceHotkey.ts
+++ b/apps/desktop/src/hooks/useCreateWorkspaceHotkey.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+export function useCreateWorkspaceHotkey(onTrigger: () => void): void {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'n') {
+        event.preventDefault();
+        onTrigger();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [onTrigger]);
+}

--- a/apps/desktop/src/pages/Workspaces.tsx
+++ b/apps/desktop/src/pages/Workspaces.tsx
@@ -1,10 +1,10 @@
-import { type FormEvent, useEffect, useState } from 'react';
+import { type FormEvent, useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { CreateWorkspaceModal } from '../components/workspaces/CreateWorkspaceModal';
 import { pickDirectory } from '../services/system/dialog';
 import { useCreateWorkspaceHotkey } from '../hooks/useCreateWorkspaceHotkey';
-import { isGitHubRepoUrl } from '../types/workspace';
+import { deriveNameFromIdentifier, isGitHubRepoUrl } from '../types/workspace';
 import { getWorkspaceClient, toErrorMessage, useWorkspacesStore } from '../store/workspaces';
 import type { GitHubRepoOption, WorkspaceCreateFromSource } from '../services/workspaces/types';
 
@@ -18,25 +18,14 @@ export function deriveNameFromRepoPath(repoPath: string): string {
 
 export function deriveNameFromRepoUrl(repoUrl: string): string {
   try {
-    const parsed = new URL(repoUrl);
-    const lastSegment = parsed.pathname.split('/').filter(Boolean).at(-1) ?? '';
-    const withoutGitSuffix = lastSegment.replace(/\.git$/i, '');
-    return withoutGitSuffix || 'Workspace';
+    return deriveNameFromIdentifier(new URL(repoUrl).pathname);
   } catch {
     return 'Workspace';
   }
 }
 
 export function deriveNameFromRepositoryInput(repositoryName: string): string {
-  const normalized = repositoryName.trim().replace(/\.git$/i, '');
-  if (!normalized) {
-    return 'Workspace';
-  }
-  const parts = normalized
-    .split('/')
-    .map((part) => part.trim())
-    .filter(Boolean);
-  return parts.at(-1) || 'Workspace';
+  return deriveNameFromIdentifier(repositoryName);
 }
 
 export function buildDefaultCloneLocation(home: string): string {
@@ -171,10 +160,11 @@ export function Workspaces() {
     void loadKnownRepos();
   }, [load, loadKnownRepos]);
 
-  useCreateWorkspaceHotkey(() => {
+  const onHotkey = useCallback(() => {
     setCreateFromRepoId(knownRepos[0]?.id ?? null);
     setIsCreateFromOpen(true);
-  });
+  }, [knownRepos]);
+  useCreateWorkspaceHotkey(onHotkey);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally resets form errors when action tab changes
   useEffect(() => {

--- a/apps/desktop/src/pages/Workspaces.tsx
+++ b/apps/desktop/src/pages/Workspaces.tsx
@@ -335,12 +335,22 @@ export function Workspaces() {
   }
 
   async function onCreateFrom(input: { repoId: string; source: WorkspaceCreateFromSource }) {
-    await createFromSource(input);
-    await loadKnownRepos();
+    setFormError(null);
+    try {
+      await createFromSource(input);
+      await loadKnownRepos();
+    } catch (error) {
+      setFormError(toErrorMessage(error));
+    }
   }
 
   async function onOpenWorkspace(workspaceId: string) {
     await setActive(workspaceId);
+    const storeError = useWorkspacesStore.getState().lastError;
+    if (storeError) {
+      setFormError(storeError);
+      return;
+    }
     navigate('/');
   }
 

--- a/apps/desktop/src/pages/Workspaces.tsx
+++ b/apps/desktop/src/pages/Workspaces.tsx
@@ -341,6 +341,7 @@ export function Workspaces() {
       await loadKnownRepos();
     } catch (error) {
       setFormError(toErrorMessage(error));
+      throw error;
     }
   }
 

--- a/apps/desktop/src/pages/Workspaces.tsx
+++ b/apps/desktop/src/pages/Workspaces.tsx
@@ -1,9 +1,12 @@
 import { type FormEvent, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
+import { CreateWorkspaceModal } from '../components/workspaces/CreateWorkspaceModal';
 import { pickDirectory } from '../services/system/dialog';
+import { useCreateWorkspaceHotkey } from '../hooks/useCreateWorkspaceHotkey';
 import { isGitHubRepoUrl } from '../types/workspace';
 import { getWorkspaceClient, toErrorMessage, useWorkspacesStore } from '../store/workspaces';
-import type { GitHubRepoOption } from '../services/workspaces/types';
+import type { GitHubRepoOption, WorkspaceCreateFromSource } from '../services/workspaces/types';
 
 type WorkspaceAction = 'clone' | 'create' | null;
 
@@ -109,22 +112,39 @@ export function rankRepos(repos: GitHubRepoOption[], query: string): GitHubRepoO
     .slice(0, 20);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const HOME_DIR: string = typeof (globalThis as any).process?.env?.HOME === 'string'
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ? (globalThis as any).process.env.HOME
-  : '~';
+type GlobalProcessEnv = {
+  process?: {
+    env?: {
+      HOME?: string;
+    };
+  };
+};
+
+const HOME_DIR: string = (() => {
+  const home = (globalThis as GlobalProcessEnv).process?.env?.HOME;
+  return typeof home === 'string' ? home : '~';
+})();
 
 const DEFAULT_CLONE_LOCATION = buildDefaultCloneLocation(HOME_DIR);
 
 export function Workspaces() {
+  const navigate = useNavigate();
   const workspaces = useWorkspacesStore((state) => state.workspaces);
+  const knownRepos = useWorkspacesStore((state) => state.knownRepos);
   const isCreating = useWorkspacesStore((state) => state.isCreating);
+  const isLoadingKnownRepos = useWorkspacesStore((state) => state.isLoadingKnownRepos);
   const lastError = useWorkspacesStore((state) => state.lastError);
   const load = useWorkspacesStore((state) => state.load);
+  const loadKnownRepos = useWorkspacesStore((state) => state.loadKnownRepos);
+  const quickCreateFromRepo = useWorkspacesStore((state) => state.quickCreateFromRepo);
+  const createFromSource = useWorkspacesStore((state) => state.createFromSource);
+  const listRepoBranches = useWorkspacesStore((state) => state.listRepoBranches);
+  const listRepoPullRequests = useWorkspacesStore((state) => state.listRepoPullRequests);
+  const listRepoIssues = useWorkspacesStore((state) => state.listRepoIssues);
   const createLocal = useWorkspacesStore((state) => state.createLocal);
   const createGitHub = useWorkspacesStore((state) => state.createGitHub);
   const createNewGitHub = useWorkspacesStore((state) => state.createNewGitHub);
+  const setActive = useWorkspacesStore((state) => state.setActive);
   const archive = useWorkspacesStore((state) => state.archive);
   const remove = useWorkspacesStore((state) => state.remove);
 
@@ -143,10 +163,18 @@ export function Workspaces() {
   const [isPickingCloneLocation, setIsPickingCloneLocation] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [createdRepoUrl, setCreatedRepoUrl] = useState<string | null>(null);
+  const [isCreateFromOpen, setIsCreateFromOpen] = useState(false);
+  const [createFromRepoId, setCreateFromRepoId] = useState<string | null>(null);
 
   useEffect(() => {
     void load();
-  }, [load]);
+    void loadKnownRepos();
+  }, [load, loadKnownRepos]);
+
+  useCreateWorkspaceHotkey(() => {
+    setCreateFromRepoId(knownRepos[0]?.id ?? null);
+    setIsCreateFromOpen(true);
+  });
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally resets form errors when action tab changes
   useEffect(() => {
@@ -272,6 +300,7 @@ export function Workspaces() {
 
       setCreatedRepoUrl(null);
       setGithubRepoUrl('');
+      await loadKnownRepos();
       setAction(null);
     } catch (error) {
       setFormError(toErrorMessage(error));
@@ -298,10 +327,31 @@ export function Workspaces() {
 
       setCreatedRepoUrl(workspace.sourceType === 'github' ? workspace.source : null);
       setNewRepositoryName('');
+      await loadKnownRepos();
       setAction(null);
     } catch (error) {
       setFormError(toErrorMessage(error));
     }
+  }
+
+  async function onQuickCreate(repoId: string) {
+    setFormError(null);
+    try {
+      await quickCreateFromRepo(repoId);
+      await loadKnownRepos();
+    } catch (error) {
+      setFormError(toErrorMessage(error));
+    }
+  }
+
+  async function onCreateFrom(input: { repoId: string; source: WorkspaceCreateFromSource }) {
+    await createFromSource(input);
+    await loadKnownRepos();
+  }
+
+  async function onOpenWorkspace(workspaceId: string) {
+    await setActive(workspaceId);
+    navigate('/');
   }
 
   return (
@@ -310,6 +360,63 @@ export function Workspaces() {
       <p className="mt-2 text-slate-400">
         Create and manage isolated git workspaces for active work.
       </p>
+
+      <section className="mt-6 rounded border border-slate-800 bg-slate-900/40 p-4">
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-sm font-medium text-slate-200">Quick Create From Known Repos</h2>
+          <button
+            type="button"
+            onClick={() => {
+              setCreateFromRepoId(knownRepos[0]?.id ?? null);
+              setIsCreateFromOpen(true);
+            }}
+            className="rounded border border-slate-700 px-2 py-1 text-xs text-slate-200"
+          >
+            Create from... <span aria-hidden="true">⌘N</span>
+          </button>
+        </div>
+
+        {isLoadingKnownRepos ? (
+          <p className="mt-3 text-sm text-slate-400">Loading repositories...</p>
+        ) : null}
+        {!isLoadingKnownRepos && knownRepos.length === 0 ? (
+          <p className="mt-3 text-sm text-slate-400">
+            No known repos yet. Create a GitHub workspace first to enable quick create.
+          </p>
+        ) : null}
+
+        {!isLoadingKnownRepos && knownRepos.length > 0 ? (
+          <ul className="mt-3 space-y-2" aria-label="Known repositories">
+            {knownRepos.map((repo, index) => (
+              <li
+                key={repo.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded border border-slate-800 bg-slate-900/30 px-3 py-2"
+              >
+                <button
+                  type="button"
+                  onClick={() => void onQuickCreate(repo.id)}
+                  className="text-left text-sm text-slate-100 hover:text-slate-200"
+                >
+                  {repo.nameWithOwner}
+                </button>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setCreateFromRepoId(repo.id);
+                      setIsCreateFromOpen(true);
+                    }}
+                    className="rounded border border-slate-700 px-2 py-1 text-xs text-slate-200"
+                  >
+                    Create from...
+                  </button>
+                  <span className="text-xs text-slate-500">{index + 1}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </section>
 
       <div className="mt-6 rounded border border-slate-800 bg-slate-900/40 p-4">
         <h2 className="text-sm font-medium text-slate-200">Add Repository</h2>
@@ -486,12 +593,17 @@ export function Workspaces() {
                 key={workspace.id}
                 className="flex flex-wrap items-center justify-between gap-2 rounded border border-slate-800 bg-slate-900/30 px-3 py-2"
               >
-                <div>
+                <button
+                  type="button"
+                  aria-label={`Open workspace ${workspace.name}`}
+                  onClick={() => void onOpenWorkspace(workspace.id)}
+                  className="min-w-[220px] flex-1 text-left"
+                >
                   <p className="font-medium text-slate-100">{workspace.name}</p>
                   <p className="text-xs text-slate-400">
                     {workspace.branch} · {workspace.sourceType} · {workspace.status}
                   </p>
-                </div>
+                </button>
                 <div className="flex items-center gap-2">
                   <button
                     type="button"
@@ -513,6 +625,18 @@ export function Workspaces() {
           </ul>
         )}
       </section>
+
+      <CreateWorkspaceModal
+        isOpen={isCreateFromOpen}
+        enableIssuesTab={false}
+        initialRepoId={createFromRepoId}
+        repos={knownRepos}
+        onClose={() => setIsCreateFromOpen(false)}
+        onCreate={onCreateFrom}
+        loadBranches={listRepoBranches}
+        loadPullRequests={listRepoPullRequests}
+        loadIssues={listRepoIssues}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/services/workspaces/memory-client.ts
+++ b/apps/desktop/src/services/workspaces/memory-client.ts
@@ -1,6 +1,8 @@
 import {
+  deriveNameFromIdentifier,
   deriveWorkspaceBranchName,
   isGitHubRepoUrl,
+  toSlug,
   type Workspace,
 } from '../../types/workspace';
 import type {
@@ -27,10 +29,7 @@ function generateWorkspaceId(): string {
   return `ws_${suffix}`;
 }
 
-function toWorkspaceSlug(name: string): string {
-  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-  return slug || 'workspace';
-}
+const toWorkspaceSlug = toSlug;
 
 function parseRepositoryInput(repositoryName: string): {
   owner: string;
@@ -72,10 +71,7 @@ function toRepoId(repoUrl: string): string | null {
   }
 }
 
-function deriveWorkspaceNameFromRepoId(repoId: string): string {
-  const segment = repoId.split('/').filter(Boolean).at(-1) ?? '';
-  return segment || 'Workspace';
-}
+const deriveWorkspaceNameFromRepoId = deriveNameFromIdentifier;
 
 function deriveIssueBranchName(issueNumber: number): string {
   return `feature/issue-${issueNumber}`;
@@ -219,13 +215,7 @@ export function createMemoryWorkspaceClient(
         if (workspace.sourceType !== 'github') {
           continue;
         }
-        let nameWithOwner = workspace.source;
-        try {
-          const parsed = new URL(workspace.source);
-          nameWithOwner = parsed.pathname.replace(/^\/+/, '').replace(/\.git$/i, '');
-        } catch {
-          // Keep best-effort source fallback for memory mode.
-        }
+        const nameWithOwner = toRepoId(workspace.source) ?? workspace.source;
 
         candidates.set(workspace.source, {
           nameWithOwner,

--- a/apps/desktop/src/services/workspaces/memory-client.ts
+++ b/apps/desktop/src/services/workspaces/memory-client.ts
@@ -4,11 +4,16 @@ import {
   type Workspace,
 } from '../../types/workspace';
 import type {
+  CreateWorkspaceFromSourceInput,
   CreateGitHubWorkspaceInput,
   CreateLocalWorkspaceInput,
   CreateNewGitHubWorkspaceInput,
   GitHubRepoOption,
+  WorkspaceBranchOption,
   WorkspaceClient,
+  WorkspaceIssueOption,
+  WorkspaceKnownRepoOption,
+  WorkspacePullRequestOption,
 } from './types';
 
 interface MemoryWorkspaceState {
@@ -54,6 +59,103 @@ function parseRepositoryInput(repositoryName: string): {
   };
 }
 
+function toRepoId(repoUrl: string): string | null {
+  try {
+    const parsed = new URL(repoUrl);
+    if (parsed.hostname !== 'github.com') {
+      return null;
+    }
+    const value = parsed.pathname.replace(/^\/+/, '').replace(/\.git$/i, '');
+    return value || null;
+  } catch {
+    return null;
+  }
+}
+
+function deriveWorkspaceNameFromRepoId(repoId: string): string {
+  const segment = repoId.split('/').filter(Boolean).at(-1) ?? '';
+  return segment || 'Workspace';
+}
+
+function deriveIssueBranchName(issueNumber: number): string {
+  return `feature/issue-${issueNumber}`;
+}
+
+function repoCacheKey(repoId: string): string {
+  return repoId.replaceAll('/', '__');
+}
+
+function rankByQuery<T extends { updatedAt: string }>(
+  items: T[],
+  query: string | undefined,
+  toHaystack: (item: T) => string,
+): T[] {
+  const normalizedQuery = query?.trim().toLowerCase();
+  const filtered = normalizedQuery
+    ? items.filter((item) => toHaystack(item).toLowerCase().includes(normalizedQuery))
+    : items;
+  return [...filtered]
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+    .slice(0, 20);
+}
+
+function listKnownReposFromState(state: MemoryWorkspaceState): WorkspaceKnownRepoOption[] {
+  const map = new Map<string, WorkspaceKnownRepoOption>();
+  for (const workspace of state.workspaces) {
+    if (workspace.sourceType !== 'github') {
+      continue;
+    }
+    const repoId = toRepoId(workspace.source);
+    if (!repoId) {
+      continue;
+    }
+    const existing = map.get(repoId);
+    if (!existing || workspace.updatedAt > existing.updatedAt) {
+      map.set(repoId, {
+        id: repoId,
+        nameWithOwner: repoId,
+        url: `https://github.com/${repoId}`,
+        updatedAt: workspace.updatedAt,
+      });
+    }
+  }
+
+  return [...map.values()].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+function listRepoBranchesMock(repoId: string): WorkspaceBranchOption[] {
+  const now = new Date().toISOString();
+  const slug = repoId.split('/').filter(Boolean).at(-1) ?? 'repo';
+  return [
+    { name: 'main', isDefault: true, updatedAt: now },
+    { name: `feature/${slug}-next`, isDefault: false, updatedAt: now },
+  ];
+}
+
+function listRepoPullRequestsMock(repoId: string): WorkspacePullRequestOption[] {
+  const now = new Date().toISOString();
+  const slug = repoId.split('/').filter(Boolean).at(-1) ?? 'repo';
+  return [
+    {
+      number: 26,
+      title: `feat(${slug}): follow-up workspace improvements`,
+      headBranch: `feature/${slug}-improvements`,
+      updatedAt: now,
+    },
+  ];
+}
+
+function listRepoIssuesMock(repoId: string): WorkspaceIssueOption[] {
+  const now = new Date().toISOString();
+  return [
+    {
+      number: 155,
+      title: `${repoId}: Workspace and repo mgmt`,
+      updatedAt: now,
+    },
+  ];
+}
+
 function upsertWorkspace(
   state: MemoryWorkspaceState,
   input: {
@@ -97,6 +199,20 @@ export function createMemoryWorkspaceClient(
 
   return {
     list: async () => state.workspaces.map((workspace) => ({ ...workspace })),
+    listKnownRepos: async (query?: string) =>
+      rankByQuery(listKnownReposFromState(state), query, (repo) => {
+        return `${repo.nameWithOwner} ${repo.url}`;
+      }),
+    listRepoBranches: async (repoId: string, query?: string) =>
+      rankByQuery(listRepoBranchesMock(repoId), query, (branch) => branch.name),
+    listRepoPullRequests: async (repoId: string, query?: string) =>
+      rankByQuery(listRepoPullRequestsMock(repoId), query, (pr) => {
+        return `${pr.number} ${pr.title} ${pr.headBranch}`;
+      }),
+    listRepoIssues: async (repoId: string, query?: string) =>
+      rankByQuery(listRepoIssuesMock(repoId), query, (issue) => {
+        return `${issue.number} ${issue.title}`;
+      }),
     listGitHubRepos: async (query?: string) => {
       const candidates = new Map<string, GitHubRepoOption>();
       for (const workspace of state.workspaces) {
@@ -194,6 +310,73 @@ export function createMemoryWorkspaceClient(
       });
       state.activeWorkspaceId = workspace.id;
       return workspace;
+    },
+    createFromSource: async (input: CreateWorkspaceFromSourceInput) => {
+      const repoId = input.repoId.trim();
+      if (!repoId) {
+        throw new Error('Repository selection is required');
+      }
+      const repoUrl = `https://github.com/${repoId}`;
+      const workspaceName = input.workspaceName?.trim() || deriveWorkspaceNameFromRepoId(repoId);
+      const cacheKey = repoCacheKey(repoId);
+      const root = input.cloneRootPath?.trim() || '/tmp/repo-cache';
+      const cachePath = `${root}/${cacheKey}`;
+      const worktreePath = `${cachePath}.worktrees/${toWorkspaceSlug(workspaceName)}`;
+
+      let created: Workspace;
+      switch (input.source.type) {
+        case 'default':
+          created = upsertWorkspace(state, {
+            sourceType: 'github',
+            source: repoUrl,
+            repoRootPath: cachePath,
+            worktreePath,
+            workspaceName,
+            baseRef: 'origin/main',
+          });
+          break;
+        case 'pull_request': {
+          const pullRequestNumber = input.source.value;
+          const pullRequest = listRepoPullRequestsMock(repoId).find(
+            (entry) => entry.number === pullRequestNumber,
+          );
+          if (!pullRequest) {
+            throw new Error(`Pull request not found: ${pullRequestNumber}`);
+          }
+          created = upsertWorkspace(state, {
+            sourceType: 'github',
+            source: repoUrl,
+            repoRootPath: cachePath,
+            worktreePath,
+            workspaceName,
+            baseRef: `origin/${pullRequest.headBranch}`,
+          });
+          break;
+        }
+        case 'branch':
+          created = upsertWorkspace(state, {
+            sourceType: 'github',
+            source: repoUrl,
+            repoRootPath: cachePath,
+            worktreePath,
+            workspaceName,
+            baseRef: `origin/${input.source.value}`,
+          });
+          break;
+        case 'issue':
+          created = upsertWorkspace(state, {
+            sourceType: 'github',
+            source: repoUrl,
+            repoRootPath: cachePath,
+            worktreePath,
+            workspaceName,
+            branchName: deriveIssueBranchName(input.source.value),
+            baseRef: 'origin/main',
+          });
+          break;
+      }
+      state.activeWorkspaceId = created.id;
+      return created;
     },
     setActive: async (id: string) => {
       const found = state.workspaces.some((workspace) => workspace.id === id);

--- a/apps/desktop/src/services/workspaces/tauri-client.ts
+++ b/apps/desktop/src/services/workspaces/tauri-client.ts
@@ -3,11 +3,16 @@ import { z } from 'zod';
 
 import { WorkspaceSchema } from '../../types/workspace';
 import type {
+  CreateWorkspaceFromSourceInput,
   CreateGitHubWorkspaceInput,
   CreateLocalWorkspaceInput,
   CreateNewGitHubWorkspaceInput,
   GitHubRepoOption,
+  WorkspaceBranchOption,
   WorkspaceClient,
+  WorkspaceIssueOption,
+  WorkspaceKnownRepoOption,
+  WorkspacePullRequestOption,
 } from './types';
 
 type InvokeFn = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
@@ -20,12 +25,79 @@ const GitHubRepoOptionSchema = z.object({
   updatedAt: z.string(),
 });
 const GitHubRepoListSchema = z.array(GitHubRepoOptionSchema);
+const WorkspaceKnownRepoOptionSchema = z.object({
+  id: z.string().min(1),
+  nameWithOwner: z.string().min(1),
+  url: z.string().url(),
+  updatedAt: z.string(),
+});
+const WorkspaceKnownRepoListSchema = z.array(WorkspaceKnownRepoOptionSchema);
+const WorkspaceBranchOptionSchema = z.object({
+  name: z.string().min(1),
+  isDefault: z.boolean(),
+  updatedAt: z.string(),
+});
+const WorkspaceBranchListSchema = z.array(WorkspaceBranchOptionSchema);
+const WorkspacePullRequestOptionSchema = z.object({
+  number: z.number().int().positive(),
+  title: z.string().min(1),
+  headBranch: z.string().min(1),
+  updatedAt: z.string(),
+});
+const WorkspacePullRequestListSchema = z.array(WorkspacePullRequestOptionSchema);
+const WorkspaceIssueOptionSchema = z.object({
+  number: z.number().int().positive(),
+  title: z.string().min(1),
+  updatedAt: z.string(),
+});
+const WorkspaceIssueListSchema = z.array(WorkspaceIssueOptionSchema);
+const WorkspaceCreateFromSourceInputSchema = z.object({
+  repoId: z.string().min(1),
+  workspaceName: z.string().optional(),
+  cloneRootPath: z.string().optional(),
+  source: z.discriminatedUnion('type', [
+    z.object({ type: z.literal('default') }),
+    z.object({ type: z.literal('pull_request'), value: z.number().int().positive() }),
+    z.object({ type: z.literal('branch'), value: z.string().min(1) }),
+    z.object({ type: z.literal('issue'), value: z.number().int().positive() }),
+  ]),
+});
 
 export function createTauriWorkspaceClient(
   invokeFn: InvokeFn = defaultInvoke,
 ): WorkspaceClient {
   return {
     list: async () => WorkspaceListSchema.parse(await invokeFn('workspace_list')),
+    listKnownRepos: async (query?: string): Promise<WorkspaceKnownRepoOption[]> =>
+      WorkspaceKnownRepoListSchema.parse(
+        await invokeFn('workspace_list_known_repos', {
+          query: query?.trim() || null,
+        }),
+      ),
+    listRepoBranches: async (repoId: string, query?: string): Promise<WorkspaceBranchOption[]> =>
+      WorkspaceBranchListSchema.parse(
+        await invokeFn('workspace_list_repo_branches', {
+          repoId,
+          query: query?.trim() || null,
+        }),
+      ),
+    listRepoPullRequests: async (
+      repoId: string,
+      query?: string,
+    ): Promise<WorkspacePullRequestOption[]> =>
+      WorkspacePullRequestListSchema.parse(
+        await invokeFn('workspace_list_repo_pull_requests', {
+          repoId,
+          query: query?.trim() || null,
+        }),
+      ),
+    listRepoIssues: async (repoId: string, query?: string): Promise<WorkspaceIssueOption[]> =>
+      WorkspaceIssueListSchema.parse(
+        await invokeFn('workspace_list_repo_issues', {
+          repoId,
+          query: query?.trim() || null,
+        }),
+      ),
     listGitHubRepos: async (query?: string): Promise<GitHubRepoOption[]> =>
       GitHubRepoListSchema.parse(
         await invokeFn('workspace_list_github_repos', {
@@ -38,6 +110,12 @@ export function createTauriWorkspaceClient(
       WorkspaceSchema.parse(await invokeFn('workspace_create_github', { input })),
     createNewGitHub: async (input: CreateNewGitHubWorkspaceInput) =>
       WorkspaceSchema.parse(await invokeFn('workspace_create_new_github', { input })),
+    createFromSource: async (input: CreateWorkspaceFromSourceInput) =>
+      WorkspaceSchema.parse(
+        await invokeFn('workspace_create_from_source', {
+          input: WorkspaceCreateFromSourceInputSchema.parse(input),
+        }),
+      ),
     setActive: async (id: string) => {
       await invokeFn('workspace_set_active', { id });
     },

--- a/apps/desktop/src/services/workspaces/types.ts
+++ b/apps/desktop/src/services/workspaces/types.ts
@@ -7,6 +7,45 @@ export interface GitHubRepoOption {
   updatedAt: string;
 }
 
+export interface WorkspaceKnownRepoOption {
+  id: string;
+  nameWithOwner: string;
+  url: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceBranchOption {
+  name: string;
+  isDefault: boolean;
+  updatedAt: string;
+}
+
+export interface WorkspacePullRequestOption {
+  number: number;
+  title: string;
+  headBranch: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceIssueOption {
+  number: number;
+  title: string;
+  updatedAt: string;
+}
+
+export type WorkspaceCreateFromSource =
+  | { type: 'default' }
+  | { type: 'pull_request'; value: number }
+  | { type: 'branch'; value: string }
+  | { type: 'issue'; value: number };
+
+export interface CreateWorkspaceFromSourceInput {
+  repoId: string;
+  workspaceName?: string;
+  cloneRootPath?: string;
+  source: WorkspaceCreateFromSource;
+}
+
 export interface CreateLocalWorkspaceInput {
   repoPath: string;
   workspaceName: string;
@@ -33,9 +72,14 @@ export interface CreateNewGitHubWorkspaceInput {
 export interface WorkspaceClient {
   list(): Promise<Workspace[]>;
   listGitHubRepos(query?: string): Promise<GitHubRepoOption[]>;
+  listKnownRepos(query?: string): Promise<WorkspaceKnownRepoOption[]>;
+  listRepoBranches(repoId: string, query?: string): Promise<WorkspaceBranchOption[]>;
+  listRepoPullRequests(repoId: string, query?: string): Promise<WorkspacePullRequestOption[]>;
+  listRepoIssues(repoId: string, query?: string): Promise<WorkspaceIssueOption[]>;
   createLocal(input: CreateLocalWorkspaceInput): Promise<Workspace>;
   createGitHub(input: CreateGitHubWorkspaceInput): Promise<Workspace>;
   createNewGitHub(input: CreateNewGitHubWorkspaceInput): Promise<Workspace>;
+  createFromSource(input: CreateWorkspaceFromSourceInput): Promise<Workspace>;
   setActive(id: string): Promise<void>;
   getActiveId(): Promise<string | null>;
   archive(id: string): Promise<void>;

--- a/apps/desktop/src/store/workspaces.ts
+++ b/apps/desktop/src/store/workspaces.ts
@@ -98,6 +98,15 @@ export const useWorkspacesStore = create<WorkspacesState>()((set) => {
     }
   }
 
+  async function runQuery<T>(clientCall: () => Promise<T>): Promise<T> {
+    try {
+      return await clientCall();
+    } catch (error) {
+      set({ lastError: toErrorMessage(error) });
+      throw error;
+    }
+  }
+
   return {
     ...defaultState,
 
@@ -125,30 +134,12 @@ export const useWorkspacesStore = create<WorkspacesState>()((set) => {
         set({ isLoadingKnownRepos: false });
       }
     },
-    listRepoBranches: async (repoId, query) => {
-      try {
-        return await workspaceClient.listRepoBranches(repoId, query);
-      } catch (error) {
-        set({ lastError: toErrorMessage(error) });
-        throw error;
-      }
-    },
-    listRepoPullRequests: async (repoId, query) => {
-      try {
-        return await workspaceClient.listRepoPullRequests(repoId, query);
-      } catch (error) {
-        set({ lastError: toErrorMessage(error) });
-        throw error;
-      }
-    },
-    listRepoIssues: async (repoId, query) => {
-      try {
-        return await workspaceClient.listRepoIssues(repoId, query);
-      } catch (error) {
-        set({ lastError: toErrorMessage(error) });
-        throw error;
-      }
-    },
+    listRepoBranches: (repoId, query) =>
+      runQuery(() => workspaceClient.listRepoBranches(repoId, query)),
+    listRepoPullRequests: (repoId, query) =>
+      runQuery(() => workspaceClient.listRepoPullRequests(repoId, query)),
+    listRepoIssues: (repoId, query) =>
+      runQuery(() => workspaceClient.listRepoIssues(repoId, query)),
     quickCreateFromRepo: (repoId, workspaceName) =>
       runCreate(() =>
         workspaceClient.createFromSource({

--- a/apps/desktop/src/store/workspaces.ts
+++ b/apps/desktop/src/store/workspaces.ts
@@ -130,7 +130,7 @@ export const useWorkspacesStore = create<WorkspacesState>()((set) => {
         return await workspaceClient.listRepoBranches(repoId, query);
       } catch (error) {
         set({ lastError: toErrorMessage(error) });
-        return [];
+        throw error;
       }
     },
     listRepoPullRequests: async (repoId, query) => {
@@ -138,7 +138,7 @@ export const useWorkspacesStore = create<WorkspacesState>()((set) => {
         return await workspaceClient.listRepoPullRequests(repoId, query);
       } catch (error) {
         set({ lastError: toErrorMessage(error) });
-        return [];
+        throw error;
       }
     },
     listRepoIssues: async (repoId, query) => {
@@ -146,7 +146,7 @@ export const useWorkspacesStore = create<WorkspacesState>()((set) => {
         return await workspaceClient.listRepoIssues(repoId, query);
       } catch (error) {
         set({ lastError: toErrorMessage(error) });
-        return [];
+        throw error;
       }
     },
     quickCreateFromRepo: (repoId, workspaceName) =>

--- a/apps/desktop/src/store/workspaces.ts
+++ b/apps/desktop/src/store/workspaces.ts
@@ -2,19 +2,35 @@ import { create } from 'zustand';
 
 import { workspaceClient as defaultWorkspaceClient } from '../services/workspaces';
 import type {
+  CreateWorkspaceFromSourceInput,
   CreateGitHubWorkspaceInput,
   CreateLocalWorkspaceInput,
   CreateNewGitHubWorkspaceInput,
+  WorkspaceBranchOption,
   WorkspaceClient,
+  WorkspaceIssueOption,
+  WorkspaceKnownRepoOption,
+  WorkspacePullRequestOption,
 } from '../services/workspaces/types';
 import type { Workspace } from '../types/workspace';
 
 interface WorkspacesState {
   workspaces: Workspace[];
+  knownRepos: WorkspaceKnownRepoOption[];
   activeWorkspaceId: string | null;
   isCreating: boolean;
+  isLoadingKnownRepos: boolean;
   lastError: string | null;
   load: () => Promise<void>;
+  loadKnownRepos: (query?: string) => Promise<WorkspaceKnownRepoOption[]>;
+  listRepoBranches: (repoId: string, query?: string) => Promise<WorkspaceBranchOption[]>;
+  listRepoPullRequests: (
+    repoId: string,
+    query?: string,
+  ) => Promise<WorkspacePullRequestOption[]>;
+  listRepoIssues: (repoId: string, query?: string) => Promise<WorkspaceIssueOption[]>;
+  quickCreateFromRepo: (repoId: string, workspaceName?: string) => Promise<Workspace>;
+  createFromSource: (input: CreateWorkspaceFromSourceInput) => Promise<Workspace>;
   createLocal: (input: CreateLocalWorkspaceInput) => Promise<Workspace>;
   createGitHub: (input: CreateGitHubWorkspaceInput) => Promise<Workspace>;
   createNewGitHub: (input: CreateNewGitHubWorkspaceInput) => Promise<Workspace>;
@@ -25,8 +41,10 @@ interface WorkspacesState {
 
 const defaultState = {
   workspaces: [] as Workspace[],
+  knownRepos: [] as WorkspaceKnownRepoOption[],
   activeWorkspaceId: null as string | null,
   isCreating: false,
+  isLoadingKnownRepos: false,
   lastError: null as string | null,
 };
 
@@ -94,6 +112,52 @@ export const useWorkspacesStore = create<WorkspacesState>()((set) => {
         set({ lastError: toErrorMessage(error) });
       }
     },
+    loadKnownRepos: async (query?: string) => {
+      set({ isLoadingKnownRepos: true });
+      try {
+        const knownRepos = await workspaceClient.listKnownRepos(query);
+        set({ knownRepos, lastError: null });
+        return knownRepos;
+      } catch (error) {
+        set({ knownRepos: [], lastError: toErrorMessage(error) });
+        return [];
+      } finally {
+        set({ isLoadingKnownRepos: false });
+      }
+    },
+    listRepoBranches: async (repoId, query) => {
+      try {
+        return await workspaceClient.listRepoBranches(repoId, query);
+      } catch (error) {
+        set({ lastError: toErrorMessage(error) });
+        return [];
+      }
+    },
+    listRepoPullRequests: async (repoId, query) => {
+      try {
+        return await workspaceClient.listRepoPullRequests(repoId, query);
+      } catch (error) {
+        set({ lastError: toErrorMessage(error) });
+        return [];
+      }
+    },
+    listRepoIssues: async (repoId, query) => {
+      try {
+        return await workspaceClient.listRepoIssues(repoId, query);
+      } catch (error) {
+        set({ lastError: toErrorMessage(error) });
+        return [];
+      }
+    },
+    quickCreateFromRepo: (repoId, workspaceName) =>
+      runCreate(() =>
+        workspaceClient.createFromSource({
+          repoId,
+          workspaceName,
+          source: { type: 'default' },
+        }),
+      ),
+    createFromSource: (input) => runCreate(() => workspaceClient.createFromSource(input)),
 
     createLocal: (input) => runCreate(() => workspaceClient.createLocal(input)),
     createGitHub: (input) => runCreate(() => workspaceClient.createGitHub(input)),

--- a/apps/desktop/src/types/workspace.ts
+++ b/apps/desktop/src/types/workspace.ts
@@ -36,9 +36,15 @@ export function isGitHubRepoUrl(url: string): boolean {
   }
 }
 
+export function toSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'workspace';
+}
+
 export function deriveWorkspaceBranchName(name: string, suffix: string): string {
-  const slug =
-    name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') ||
-    'workspace';
-  return `workspace/${slug}-${suffix}`;
+  return `workspace/${toSlug(name)}-${suffix}`;
+}
+
+export function deriveNameFromIdentifier(value: string): string {
+  const segment = value.trim().split('/').filter(Boolean).at(-1)?.replace(/\.git$/i, '').trim() ?? '';
+  return segment || 'Workspace';
 }

--- a/docs/plans/2026-03-01-kat-155-workspace-and-repo-mgmt-design.md
+++ b/docs/plans/2026-03-01-kat-155-workspace-and-repo-mgmt-design.md
@@ -1,0 +1,206 @@
+# KAT-155 Design: Workspace and Repo Management
+
+## Summary
+
+Add a fast, keyboard-first workspace creation experience on the desktop Workspaces surface:
+
+- show a list of available repos derived from existing workspaces
+- one-click quick create from a repo using defaults
+- support `cmd+n` to open workspace creation
+- add a `Create from...` affordance to create from PR, branch, or issue
+- activate and navigate into the new workspace immediately after creation
+
+This design intentionally builds on KAT-154 workspace foundations and reuses existing create/activate flows where possible.
+
+## Context
+
+- Issue: `KAT-155` (status moved to `In Progress` on 2026-03-01).
+- Branch: `feature/kat-155-workspace-and-repo-mgmt`.
+- Desktop-first scope per project guidance.
+- Current implementation already has:
+  - `Workspaces` page with Local/Clone/Create-New actions
+  - workspace store (`apps/desktop/src/store/workspaces.ts`)
+  - Tauri commands for list/create/set-active/archive/delete
+  - GitHub repo suggestions via `gh repo list --source` (global discovery)
+- Mock screenshots show:
+  - compact repo list with numeric shortcuts
+  - bottom-row `Create from...` action with `⌘N`
+  - tabbed chooser for Pull requests, Branches, Issues
+  - repository scoping control in chooser
+
+## Requirements (Issue Source)
+
+- create new workspaces easily from existing repos
+- available repos must be derived from existing workspaces (not all GitHub/local repos)
+- one click should create workspace with defaults and navigate to main workspace view
+- `cmd+n` opens creation modal/surface
+- `Create from` should allow workspace creation from branch, PR, or GitHub issue
+
+## Goals
+
+- reduce workspace creation to one-click for common path
+- keep advanced create-from flows in one reusable modal
+- preserve safety invariants from KAT-154 (isolated worktree, non-main workspace branch)
+- provide testable behavior with explicit E2E coverage
+
+## Non-Goals
+
+- no expansion of web app parity work
+- no generalized support for non-GitHub providers
+- no redesign of entire navigation IA
+- no agent-internal worktree visualization
+
+## Approaches Considered
+
+### Option A: Extend Workspaces page inline
+
+Add list and create-from tabs directly into `Workspaces.tsx`.
+
+- Pros: quickest path to ship.
+- Cons: shortcut integration and cross-entry-point consistency become brittle.
+
+### Option B: Shared create modal + contextual triggers (recommended)
+
+Introduce a reusable `CreateWorkspaceModal` opened from `cmd+n`, Workspaces CTA, and per-repo `Create from...`.
+
+- Pros: matches mocks; clean one-click path + advanced path in one component; easier to test.
+- Cons: slightly more upfront state orchestration.
+
+### Option C: Full-page wizard route
+
+Build `/workspaces/new` route for all creation paths.
+
+- Pros: straightforward state handling.
+- Cons: slows quick-create flow and is less keyboard-efficient.
+
+## Decision
+
+Choose **Option B**.
+
+Use a shared modal for advanced creation and keyboard entry, while keeping direct repo-row click as the immediate quick-create path.
+
+## UX Contract
+
+### Quick Create
+
+1. User opens Workspaces.
+2. User clicks repo row in known repo list.
+3. App creates workspace from defaults.
+4. App sets new workspace active and navigates to main workspace view.
+
+### Create From
+
+1. User opens modal from `Create from...` (or `cmd+n`).
+2. User selects repo (or uses preselected repo from context).
+3. User picks tab: `Pull requests`, `Branches`, or `Issues`.
+4. User selects item and clicks create.
+5. App creates workspace, activates it, and navigates to main view.
+
+### Keyboard
+
+- `cmd+n` (and `ctrl+n` fallback in non-mac renderer contexts) opens `CreateWorkspaceModal`.
+- If modal is already open, shortcut is a no-op.
+
+## Architecture
+
+### Frontend
+
+- `apps/desktop/src/pages/Workspaces.tsx`
+  - render known repo quick-create list
+  - wire row click to quick-create flow
+  - add per-repo `Create from...` affordance
+- `apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx` (new)
+  - tabs for PR/Branch/Issue
+  - search + selection + create action
+- `apps/desktop/src/store/workspaces.ts`
+  - add actions/selectors for quick-create and create-from flows
+- `apps/desktop/src/services/workspaces/types.ts`
+  - add typed options and request payloads for PR/Branch/Issue workflows
+- `apps/desktop/src/services/workspaces/tauri-client.ts`
+  - add new invoke contracts for known-repo and create-from commands
+- `apps/desktop/src/services/workspaces/memory-client.ts`
+  - mirror new service methods for deterministic tests
+
+### Tauri / Rust
+
+- `apps/desktop/src-tauri/src/workspaces/store.rs`
+  - derive known repos from persisted workspaces
+- `apps/desktop/src-tauri/src/workspaces/commands.rs`
+  - add commands:
+    - list known repos (workspace-derived)
+    - list repo pull requests
+    - list repo branches
+    - list repo issues
+    - create workspace from repo default
+    - create workspace from selected PR/branch/issue
+- `apps/desktop/src-tauri/src/workspaces/git_github.rs`
+  - add `gh` queries scoped to selected repo for PR/branch/issue lookup
+  - map selected item to branch/base for workspace creation
+- `apps/desktop/src-tauri/src/workspaces/model.rs`
+  - add DTOs for repo/pr/branch/issue options and create-from inputs
+- `apps/desktop/src-tauri/src/main.rs`
+  - register new commands in invoke handler
+
+## Data and Behavior Rules
+
+- known repos are derived from existing workspaces only
+- dedupe by canonical repo identity (e.g., `owner/repo` for GitHub)
+- quick-create defaults:
+  - workspace name derived from repo name with uniqueness suffix
+  - branch derived by existing workspace branch helper
+  - base ref is default branch (or `main` fallback)
+- create-from mappings:
+  - PR: use PR head branch as source
+  - Branch: use selected branch as source
+  - Issue: generate feature branch from issue number/title
+- all success paths end with:
+  - workspace persisted
+  - active workspace set
+  - navigation to main workspace view
+
+## Error Handling
+
+- load failures in modal tabs show inline retryable errors
+- create failures keep modal open and preserve context
+- empty-state messaging for:
+  - no known repos
+  - no PRs/branches/issues for selected repo
+- stale repo references are filtered or marked unavailable
+
+## Testing Strategy
+
+### Unit / Component / Store
+
+- helper tests for repo dedupe, sorting, and naming defaults
+- modal behavior tests (tab switching, selection, submit states)
+- store action tests for quick-create and create-from success/failure
+- tauri-client + memory-client tests for new method contracts
+
+### Rust
+
+- command tests for known repo derivation
+- mapping tests for PR/branch/issue create inputs
+- validation tests for unsupported/invalid repo states
+
+### E2E (Required)
+
+Add blocking E2E coverage for:
+
+1. `cmd+n` opens creation modal
+2. repo list derives only from existing workspace repos
+3. repo row click performs immediate default create + activation + navigation
+4. `Create from...` PR path creates from selected PR branch
+5. `Create from...` Branch path creates from selected branch
+6. `Create from...` Issue path creates issue-derived branch
+7. create failure path preserves modal and shows actionable error
+
+E2E tests are part of completion criteria for KAT-155.
+
+## Acceptance Criteria
+
+- one-click quick-create from known repo is functional
+- `cmd+n` opens create modal
+- create-from PR/branch/issue workflows are functional
+- available repo list is strictly workspace-derived
+- new workspace activation + navigation occurs on successful create
+- required E2E tests are implemented and passing

--- a/docs/plans/2026-03-01-kat-155-workspace-and-repo-mgmt-implementation.md
+++ b/docs/plans/2026-03-01-kat-155-workspace-and-repo-mgmt-implementation.md
@@ -1,0 +1,529 @@
+# KAT-155 Workspace and Repo Management Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Deliver one-click workspace quick-create from known repos, `cmd+n` creation modal, and create-from PR/branch/issue flows on desktop, with required E2E coverage.
+
+**Architecture:** Keep desktop layering consistent: UI (Workspaces + modal) -> Zustand store -> typed workspace service client -> Tauri command boundary. Replace global GitHub repo discovery with workspace-derived known repos, then add repo-scoped PR/branch/issue create pathways. Enforce existing workspace safety invariants and preserve immediate activate+navigate behavior after creation.
+
+**Tech Stack:** React 18, React Router 6, Zustand, TypeScript, Tauri 2 (Rust), Vitest + Testing Library, Playwright/Vitest E2E harness, GitHub CLI (`gh`) for repo-scoped metadata.
+
+**Execution Skills:** `@test-driven-development`, `@verification-before-completion`
+
+---
+
+### Task 1: Add Domain Contracts for Known Repo and Create-From Entities
+
+**Files:**
+- Modify: `apps/desktop/src/services/workspaces/types.ts`
+- Modify: `tests/unit/desktop/workspace-memory-client.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import type { WorkspaceKnownRepoOption, WorkspaceCreateFromSource } from '../../../apps/desktop/src/services/workspaces/types';
+
+test('workspace service contracts include known repo and create-from source types', () => {
+  const repo: WorkspaceKnownRepoOption = {
+    id: 'kata-sh/kata-cloud-agents',
+    nameWithOwner: 'kata-sh/kata-cloud-agents',
+    url: 'https://github.com/kata-sh/kata-cloud-agents',
+    updatedAt: '2026-03-01T00:00:00.000Z',
+  };
+  const source: WorkspaceCreateFromSource = { type: 'branch', value: 'feature/kat-155' };
+  expect(repo.id).toContain('/');
+  expect(source.type).toBe('branch');
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspace-memory-client.test.ts`
+Expected: FAIL with missing exported types.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export interface WorkspaceKnownRepoOption {
+  id: string;
+  nameWithOwner: string;
+  url: string;
+  updatedAt: string;
+}
+
+export type WorkspaceCreateFromSource =
+  | { type: 'default'; value?: undefined }
+  | { type: 'pull_request'; value: number }
+  | { type: 'branch'; value: string }
+  | { type: 'issue'; value: number };
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspace-memory-client.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/desktop/src/services/workspaces/types.ts tests/unit/desktop/workspace-memory-client.test.ts
+git commit -m "feat(desktop): add workspace known-repo and create-from contracts"
+```
+
+### Task 2: Implement Known Repo Derivation and Create-From API in Memory Client
+
+**Files:**
+- Modify: `apps/desktop/src/services/workspaces/memory-client.ts`
+- Modify: `tests/unit/desktop/workspace-memory-client.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+test('listKnownRepos returns deduped repos derived from existing workspaces only', async () => {
+  const client = createMemoryWorkspaceClient({
+    workspaces: [
+      githubWorkspace('https://github.com/kata-sh/kata-cloud-agents', '2026-03-01T10:00:00.000Z'),
+      githubWorkspace('https://github.com/kata-sh/kata-cloud-agents', '2026-03-01T09:00:00.000Z'),
+    ],
+  });
+  const repos = await client.listKnownRepos();
+  expect(repos).toHaveLength(1);
+  expect(repos[0]?.nameWithOwner).toBe('kata-sh/kata-cloud-agents');
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspace-memory-client.test.ts`
+Expected: FAIL with `listKnownRepos` missing.
+
+**Step 3: Write minimal implementation**
+
+```ts
+listKnownRepos: async () => {
+  const map = new Map<string, WorkspaceKnownRepoOption>();
+  for (const workspace of state.workspaces) {
+    if (workspace.sourceType !== 'github') continue;
+    const parsed = new URL(workspace.source);
+    const key = parsed.pathname.replace(/^\/+/, '').replace(/\.git$/i, '');
+    const existing = map.get(key);
+    if (!existing || workspace.updatedAt > existing.updatedAt) {
+      map.set(key, {
+        id: key,
+        nameWithOwner: key,
+        url: `https://github.com/${key}`,
+        updatedAt: workspace.updatedAt,
+      });
+    }
+  }
+  return [...map.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+},
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspace-memory-client.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/desktop/src/services/workspaces/memory-client.ts tests/unit/desktop/workspace-memory-client.test.ts
+git commit -m "feat(desktop): derive known repos from workspace history in memory client"
+```
+
+### Task 3: Add Store Actions for Quick Create and Create-From
+
+**Files:**
+- Modify: `apps/desktop/src/store/workspaces.ts`
+- Modify: `tests/unit/desktop/workspaces-store.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+test('quickCreateFromRepo appends workspace and sets active id', async () => {
+  const client = createMemoryWorkspaceClientWithKnownRepo();
+  setWorkspaceClient(client);
+  resetWorkspacesStore();
+  await useWorkspacesStore.getState().quickCreateFromRepo('kata-sh/kata-cloud-agents');
+  const state = useWorkspacesStore.getState();
+  expect(state.activeWorkspaceId).toBeTruthy();
+  expect(state.workspaces.length).toBeGreaterThan(0);
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspaces-store.test.ts`
+Expected: FAIL with `quickCreateFromRepo` missing.
+
+**Step 3: Write minimal implementation**
+
+```ts
+quickCreateFromRepo: (repoId) =>
+  runCreate(() =>
+    workspaceClient.createFromSource({
+      repoId,
+      source: { type: 'default' },
+    }),
+  ),
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspaces-store.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/desktop/src/store/workspaces.ts tests/unit/desktop/workspaces-store.test.ts
+git commit -m "feat(desktop): add quick-create and create-from store actions"
+```
+
+### Task 4: Add Tauri Client Methods for Known Repos and Create-From
+
+**Files:**
+- Modify: `apps/desktop/src/services/workspaces/tauri-client.ts`
+- Modify: `tests/unit/desktop/workspace-tauri-client.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+test('invokes workspace_list_known_repos and workspace_create_from_source', async () => {
+  const invoke = vi.fn(async (command: string) => {
+    if (command === 'workspace_list_known_repos') return [];
+    if (command === 'workspace_create_from_source') return sampleWorkspace;
+    return null;
+  });
+  const client = createTauriWorkspaceClient(invoke);
+  await client.listKnownRepos();
+  await client.createFromSource({ repoId: 'kata-sh/kata-cloud-agents', source: { type: 'default' } });
+  expect(invoke).toHaveBeenCalledWith('workspace_list_known_repos', { query: null });
+  expect(invoke).toHaveBeenCalledWith('workspace_create_from_source', expect.anything());
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspace-tauri-client.test.ts`
+Expected: FAIL with missing methods/commands.
+
+**Step 3: Write minimal implementation**
+
+```ts
+listKnownRepos: async (query?: string) =>
+  WorkspaceKnownRepoListSchema.parse(await invokeFn('workspace_list_known_repos', { query: query?.trim() || null })),
+createFromSource: async (input) =>
+  WorkspaceSchema.parse(await invokeFn('workspace_create_from_source', { input })),
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspace-tauri-client.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/desktop/src/services/workspaces/tauri-client.ts tests/unit/desktop/workspace-tauri-client.test.ts
+git commit -m "feat(desktop): add tauri client create-from and known repo methods"
+```
+
+### Task 5: Implement Rust Store and Command Support for Known Repos
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/workspaces/store.rs`
+- Modify: `apps/desktop/src-tauri/src/workspaces/model.rs`
+- Modify: `apps/desktop/src-tauri/src/workspaces/commands.rs`
+- Modify: `apps/desktop/src-tauri/src/main.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+#[test]
+fn list_known_repos_dedupes_github_sources() {
+    let mut store = WorkspaceStore::new(tempdir().unwrap().path());
+    store.insert(sample_github_workspace("https://github.com/kata-sh/kata-cloud-agents", "2026-03-01T10:00:00.000Z"));
+    store.insert(sample_github_workspace("https://github.com/kata-sh/kata-cloud-agents", "2026-03-01T09:00:00.000Z"));
+    let repos = store.list_known_repos(None);
+    assert_eq!(repos.len(), 1);
+    assert_eq!(repos[0].name_with_owner, "kata-sh/kata-cloud-agents");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @kata/desktop test`
+Expected: FAIL with missing known repo model/method.
+
+**Step 3: Write minimal implementation**
+
+```rust
+#[tauri::command]
+pub fn workspace_list_known_repos(
+    query: Option<String>,
+    state: State<'_, WorkspaceState>,
+) -> Result<Vec<KnownRepoOption>, String> {
+    let store = lock_store(&state)?;
+    Ok(store.list_known_repos(query.as_deref()))
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @kata/desktop test`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/desktop/src-tauri/src/workspaces/store.rs apps/desktop/src-tauri/src/workspaces/model.rs apps/desktop/src-tauri/src/workspaces/commands.rs apps/desktop/src-tauri/src/main.rs
+git commit -m "feat(desktop): expose workspace-derived known repo commands"
+```
+
+### Task 6: Implement Rust Create-From PR/Branch/Issue Command Paths
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/workspaces/git_github.rs`
+- Modify: `apps/desktop/src-tauri/src/workspaces/commands.rs`
+- Modify: `apps/desktop/src-tauri/src/workspaces/model.rs`
+- Modify: `apps/desktop/src-tauri/src/workspaces/git_github.rs` (tests)
+
+**Step 1: Write the failing test**
+
+```rust
+#[test]
+fn issue_source_derives_feature_branch_name() {
+    let branch = derive_issue_branch_name(155, "Workspace and repo mgmt");
+    assert_eq!(branch, "feature/kat-155-workspace-and-repo-mgmt");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @kata/desktop test`
+Expected: FAIL with missing create-from mappers.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub fn create_workspace_from_source(input: CreateWorkspaceFromSourceInput, ...) -> Result<PreparedWorkspace, WorkspaceError> {
+    match input.source {
+        WorkspaceCreateSource::Default => create_github_workspace(...),
+        WorkspaceCreateSource::PullRequest { number } => create_github_workspace(...with_pr_head_branch(number)...),
+        WorkspaceCreateSource::Branch { name } => create_github_workspace(...with_branch(name)...),
+        WorkspaceCreateSource::Issue { number, title } => create_github_workspace(...with_issue_branch(number, title)...),
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @kata/desktop test`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/desktop/src-tauri/src/workspaces/git_github.rs apps/desktop/src-tauri/src/workspaces/commands.rs apps/desktop/src-tauri/src/workspaces/model.rs
+git commit -m "feat(desktop): add create-from PR branch issue rust workflows"
+```
+
+### Task 7: Build CreateWorkspaceModal and Global Hotkey Integration
+
+**Files:**
+- Create: `apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx`
+- Create: `apps/desktop/src/hooks/useCreateWorkspaceHotkey.ts`
+- Modify: `apps/desktop/src/pages/Workspaces.tsx`
+- Create: `tests/unit/desktop/workspaces-create-modal.test.tsx`
+- Modify: `tests/unit/desktop/workspaces-page.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+test('cmd+n opens create workspace modal', async () => {
+  render(<Workspaces />);
+  fireEvent.keyDown(window, { key: 'n', metaKey: true });
+  expect(await screen.findByRole('dialog', { name: /create workspace/i })).toBeInTheDocument();
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspaces-create-modal.test.tsx tests/unit/desktop/workspaces-page.test.tsx`
+Expected: FAIL with no modal/hotkey.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+useEffect(() => {
+  const onKey = (event: KeyboardEvent) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'n') {
+      event.preventDefault();
+      onOpenCreateModal();
+    }
+  };
+  window.addEventListener('keydown', onKey);
+  return () => window.removeEventListener('keydown', onKey);
+}, [onOpenCreateModal]);
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspaces-create-modal.test.tsx tests/unit/desktop/workspaces-page.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx apps/desktop/src/hooks/useCreateWorkspaceHotkey.ts apps/desktop/src/pages/Workspaces.tsx tests/unit/desktop/workspaces-create-modal.test.tsx tests/unit/desktop/workspaces-page.test.tsx
+git commit -m "feat(desktop): add create workspace modal and cmd+n hotkey"
+```
+
+### Task 8: Implement Quick-Create List and Create-From Tab Workflows in UI
+
+**Files:**
+- Modify: `apps/desktop/src/pages/Workspaces.tsx`
+- Modify: `tests/unit/desktop/workspaces-page.helpers.test.ts`
+- Modify: `tests/unit/desktop/workspaces-page.test.tsx`
+- Modify: `tests/unit/desktop/routes.test.ts`
+
+**Step 1: Write the failing test**
+
+```tsx
+test('clicking known repo creates workspace immediately and navigates', async () => {
+  const navigate = vi.fn();
+  render(<Workspaces navigate={navigate} />);
+  await user.click(screen.getByRole('button', { name: /kata-sh\/kata-cloud-agents/i }));
+  await waitFor(() => expect(navigate).toHaveBeenCalledWith('/'));
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspaces-page.helpers.test.ts tests/unit/desktop/workspaces-page.test.tsx tests/unit/desktop/routes.test.ts`
+Expected: FAIL with missing quick-create list + create-from wiring.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+<ul aria-label="Known repositories">
+  {knownRepos.map((repo, index) => (
+    <li key={repo.id}>
+      <button type="button" onClick={() => void onQuickCreate(repo.id)}>
+        {repo.nameWithOwner}
+      </button>
+      <button type="button" onClick={() => onOpenCreateFrom(repo.id)}>
+        Create from...
+      </button>
+      <kbd>{index + 1}</kbd>
+    </li>
+  ))}
+</ul>
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/desktop/workspaces-page.helpers.test.ts tests/unit/desktop/workspaces-page.test.tsx tests/unit/desktop/routes.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/desktop/src/pages/Workspaces.tsx tests/unit/desktop/workspaces-page.helpers.test.ts tests/unit/desktop/workspaces-page.test.tsx tests/unit/desktop/routes.test.ts
+git commit -m "feat(desktop): add repo quick-create and create-from UI workflows"
+```
+
+### Task 9: Add Required E2E Coverage for KAT-155
+
+**Files:**
+- Create: `tests/e2e/workspaces-create-from-flow.test.ts`
+- Modify: `vitest.e2e.config.ts` (only if include pattern changes are needed)
+
+**Step 1: Write the failing E2E tests**
+
+```ts
+// @vitest-environment jsdom
+import { describe, expect, test } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Workspaces } from '../../apps/desktop/src/pages/Workspaces';
+
+describe('KAT-155 workspace creation E2E', () => {
+  test('cmd+n opens modal', async () => {
+    render(<Workspaces />);
+    fireEvent.keyDown(window, { key: 'n', metaKey: true });
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/workspaces-create-from-flow.test.ts`
+Expected: FAIL before implementation is complete.
+
+**Step 3: Complete E2E scenarios**
+
+```ts
+test('quick create from known repo activates and navigates', async () => { /* full flow */ });
+test('create from PR path works', async () => { /* full flow */ });
+test('create from Branch path works', async () => { /* full flow */ });
+test('create from Issue path works', async () => { /* full flow */ });
+test('create failure keeps modal open and shows error', async () => { /* full flow */ });
+```
+
+**Step 4: Run E2E suite to verify it passes**
+
+Run: `pnpm test:e2e`
+Expected: PASS for vitest E2E and Playwright suites.
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/workspaces-create-from-flow.test.ts vitest.e2e.config.ts
+git commit -m "test(e2e): add KAT-155 workspace create flow coverage"
+```
+
+### Task 10: Final Verification and Evidence
+
+**Files:**
+- Modify: `docs/plans/2026-03-01-kat-155-workspace-and-repo-mgmt-design.md` (if acceptance evidence notes are appended)
+- Create: `docs/plans/2026-03-01-kat-155-workspace-and-repo-mgmt-evidence.md` (optional, recommended)
+
+**Step 1: Run full verification**
+
+Run: `pnpm ci:checks`
+Expected: PASS across lint/typecheck/unit/coverage/ui-drift.
+
+**Step 2: Run targeted desktop and E2E verification**
+
+Run:
+```bash
+pnpm exec vitest run tests/unit/desktop/workspaces-page.test.tsx tests/unit/desktop/workspaces-store.test.ts tests/unit/desktop/workspace-tauri-client.test.ts
+pnpm test:e2e
+```
+Expected: PASS with KAT-155 flows covered.
+
+**Step 3: Capture acceptance evidence**
+
+```md
+- cmd+n opens create modal
+- known repos derived from existing workspace history
+- repo row one-click create activates workspace and navigates
+- create-from PR/branch/issue paths verified
+- failure mode verified (modal stays open + actionable error)
+```
+
+**Step 4: Commit verification artifacts**
+
+```bash
+git add docs/plans/2026-03-01-kat-155-workspace-and-repo-mgmt-evidence.md
+git commit -m "docs(kat-155): add verification evidence"
+```
+
+**Step 5: Prepare for ticket completion workflow**
+
+Run: `gh pr create --fill` (after implementation commits are ready).
+Expected: PR opened with test evidence linked for KAT-155 completion gate.

--- a/tests/e2e/workspaces-create-from-flow.test.tsx
+++ b/tests/e2e/workspaces-create-from-flow.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+// biome-ignore lint/correctness/noUnusedImports: Required for JSX runtime in this test file.
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { Workspaces } from '../../apps/desktop/src/pages/Workspaces';
+import { createMemoryWorkspaceClient } from '../../apps/desktop/src/services/workspaces/memory-client';
+import type { WorkspaceClient } from '../../apps/desktop/src/services/workspaces/types';
+import { resetWorkspacesStore, setWorkspaceClient } from '../../apps/desktop/src/store/workspaces';
+
+function githubWorkspace() {
+  return {
+    id: 'ws_seed',
+    name: 'kata-cloud-agents',
+    sourceType: 'github' as const,
+    source: 'https://github.com/kata-sh/kata-cloud-agents',
+    repoRootPath: '/tmp/repo',
+    worktreePath: '/tmp/repo.worktrees/ws_seed',
+    branch: 'workspace/kata-cloud-agents-seed',
+    status: 'ready' as const,
+    createdAt: '2026-03-01T00:00:00.000Z',
+    updatedAt: '2026-03-01T00:00:00.000Z',
+  };
+}
+
+function renderWithRoutes() {
+  return render(
+    <MemoryRouter initialEntries={['/workspaces']}>
+      <Routes>
+        <Route path="/workspaces" element={<Workspaces />} />
+        <Route path="/" element={<h1>Dashboard</h1>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('KAT-155 workspace create flows (E2E)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    setWorkspaceClient(
+      createMemoryWorkspaceClient({
+        workspaces: [githubWorkspace()],
+      }),
+    );
+    resetWorkspacesStore();
+  });
+
+  test('cmd+n opens create workspace modal', async () => {
+    renderWithRoutes();
+    await screen.findByRole('button', { name: /kata-sh\/kata-cloud-agents/i });
+
+    fireEvent.keyDown(window, { key: 'n', metaKey: true });
+    expect(await screen.findByRole('dialog', { name: /create workspace/i })).toBeTruthy();
+  });
+
+  test('clicking repo quick-creates workspace without auto-navigation', async () => {
+    const user = userEvent.setup();
+    renderWithRoutes();
+
+    expect((await screen.findAllByRole('button', { name: /archive/i })).length).toBe(1);
+    await user.click(await screen.findByRole('button', { name: /kata-sh\/kata-cloud-agents/i }));
+    expect(screen.queryByRole('heading', { name: 'Dashboard' })).toBeNull();
+    expect((await screen.findAllByRole('button', { name: /archive/i })).length).toBe(2);
+  });
+
+  test('create from pull request creates workspace without auto-navigation', async () => {
+    const user = userEvent.setup();
+    renderWithRoutes();
+
+    expect((await screen.findAllByRole('button', { name: /archive/i })).length).toBe(1);
+    await user.click((await screen.findAllByRole('button', { name: /^create from\.\.\./i }))[0]!);
+    await user.click(screen.getByRole('button', { name: /pull requests/i }));
+    await user.click(screen.getByRole('button', { name: /create workspace/i }));
+    expect(screen.queryByRole('heading', { name: 'Dashboard' })).toBeNull();
+    expect((await screen.findAllByRole('button', { name: /archive/i })).length).toBe(2);
+  });
+
+  test('create from branch creates workspace without auto-navigation', async () => {
+    const user = userEvent.setup();
+    renderWithRoutes();
+
+    expect((await screen.findAllByRole('button', { name: /archive/i })).length).toBe(1);
+    await user.click((await screen.findAllByRole('button', { name: /^create from\.\.\./i }))[0]!);
+    await user.click(screen.getByRole('button', { name: /branches/i }));
+    await user.click(screen.getByRole('button', { name: /create workspace/i }));
+    expect(screen.queryByRole('heading', { name: 'Dashboard' })).toBeNull();
+    expect((await screen.findAllByRole('button', { name: /archive/i })).length).toBe(2);
+  });
+
+  test('issues tab is visible but disabled', async () => {
+    const user = userEvent.setup();
+    renderWithRoutes();
+
+    await user.click((await screen.findAllByRole('button', { name: /^create from\.\.\./i }))[0]!);
+    const issuesButton = screen.getByRole('button', { name: /issues/i }) as HTMLButtonElement;
+    expect(issuesButton.disabled).toBe(true);
+    await user.click(issuesButton);
+    expect(screen.queryByText(/no issues found/i)).toBeNull();
+  });
+
+  test('create failure keeps modal open and shows error', async () => {
+    const createFromSource = vi.fn(async () => {
+      throw new Error('create failed');
+    });
+    const client: WorkspaceClient = {
+      ...createMemoryWorkspaceClient({
+        workspaces: [githubWorkspace()],
+      }),
+      createFromSource,
+    };
+    setWorkspaceClient(client);
+    resetWorkspacesStore();
+
+    const user = userEvent.setup();
+    renderWithRoutes();
+
+    await user.click((await screen.findAllByRole('button', { name: /^create from\.\.\./i }))[0]!);
+    await user.click(screen.getByRole('button', { name: /create workspace/i }));
+
+    await waitFor(() => {
+      expect(createFromSource).toHaveBeenCalled();
+    });
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts.some((entry) => entry.textContent?.includes('create failed'))).toBe(true);
+    expect(screen.getByRole('dialog', { name: /create workspace/i })).toBeTruthy();
+  });
+
+  test('workspace list rows are clickable and navigate to dashboard', async () => {
+    const user = userEvent.setup();
+    renderWithRoutes();
+
+    await user.click(await screen.findByRole('button', { name: /open workspace kata-cloud-agents/i }));
+    expect(await screen.findByRole('heading', { name: 'Dashboard' })).toBeTruthy();
+  });
+});

--- a/tests/unit/desktop/workspace-memory-client.test.ts
+++ b/tests/unit/desktop/workspace-memory-client.test.ts
@@ -188,6 +188,186 @@ describe('workspace memory client', () => {
     expect(filtered[0]?.url).toBe('https://github.com/kata-sh/repo-a.git');
   });
 
+  test('lists known repos derived from existing github workspaces', async () => {
+    const now = '2026-02-28T00:00:00.000Z';
+    const client = createMemoryWorkspaceClient({
+      workspaces: [
+        {
+          id: 'ws_a',
+          name: 'A',
+          sourceType: 'github',
+          source: 'https://github.com/kata-sh/repo-a.git',
+          repoRootPath: '/tmp/repo-a',
+          worktreePath: '/tmp/repo-a.worktrees/a',
+          branch: 'workspace/a',
+          status: 'ready',
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: 'ws_b',
+          name: 'B',
+          sourceType: 'github',
+          source: 'https://github.com/kata-sh/repo-a',
+          repoRootPath: '/tmp/repo-a',
+          worktreePath: '/tmp/repo-a.worktrees/b',
+          branch: 'workspace/b',
+          status: 'ready',
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+    });
+
+    const repos = await client.listKnownRepos();
+    expect(repos).toHaveLength(1);
+    expect(repos[0]?.id).toBe('kata-sh/repo-a');
+  });
+
+  test('filters known repos and repo source lists with query terms', async () => {
+    const now = '2026-02-28T00:00:00.000Z';
+    const client = createMemoryWorkspaceClient({
+      workspaces: [
+        {
+          id: 'ws_a',
+          name: 'A',
+          sourceType: 'github',
+          source: 'https://github.com/kata-sh/repo-a.git',
+          repoRootPath: '/tmp/repo-a',
+          worktreePath: '/tmp/repo-a.worktrees/a',
+          branch: 'workspace/a',
+          status: 'ready',
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: 'ws_b',
+          name: 'B',
+          sourceType: 'github',
+          source: 'https://gitlab.com/kata-sh/repo-b',
+          repoRootPath: '/tmp/repo-b',
+          worktreePath: '/tmp/repo-b.worktrees/b',
+          branch: 'workspace/b',
+          status: 'ready',
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: 'ws_c',
+          name: 'C',
+          sourceType: 'github',
+          source: 'not-a-valid-url',
+          repoRootPath: '/tmp/repo-c',
+          worktreePath: '/tmp/repo-c.worktrees/c',
+          branch: 'workspace/c',
+          status: 'ready',
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: 'ws_local',
+          name: 'Local',
+          sourceType: 'local',
+          source: '/tmp/local',
+          repoRootPath: '/tmp/local',
+          worktreePath: '/tmp/local.worktrees/local',
+          branch: 'workspace/local',
+          status: 'ready',
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: 'ws_root',
+          name: 'Root',
+          sourceType: 'github',
+          source: 'https://github.com/',
+          repoRootPath: '/tmp/root',
+          worktreePath: '/tmp/root.worktrees/root',
+          branch: 'workspace/root',
+          status: 'ready',
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+    });
+
+    const knownRepos = await client.listKnownRepos('repo-a');
+    expect(knownRepos).toHaveLength(1);
+    expect(knownRepos[0]?.id).toBe('kata-sh/repo-a');
+
+    const branches = await client.listRepoBranches('kata-sh/repo-a', 'main');
+    expect(branches).toHaveLength(1);
+    expect(branches[0]?.name).toBe('main');
+
+    const pullRequests = await client.listRepoPullRequests('kata-sh/repo-a', 'improvements');
+    expect(pullRequests).toHaveLength(1);
+    expect(pullRequests[0]?.number).toBe(26);
+
+    const issues = await client.listRepoIssues('kata-sh/repo-a', '155');
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.number).toBe(155);
+
+    const fallbackBranches = await client.listRepoBranches('');
+    expect(fallbackBranches[1]?.name).toContain('feature/repo-next');
+
+    const fallbackPullRequests = await client.listRepoPullRequests('');
+    expect(fallbackPullRequests[0]?.title).toContain('feat(repo):');
+  });
+
+  test('creates workspace from known repo source', async () => {
+    const client = createMemoryWorkspaceClient();
+    const fromDefault = await client.createFromSource({
+      repoId: 'kata-sh/kata-cloud-agents',
+      source: { type: 'default' },
+    });
+    expect(fromDefault.sourceType).toBe('github');
+    expect(fromDefault.source).toBe('https://github.com/kata-sh/kata-cloud-agents');
+
+    const fromPullRequest = await client.createFromSource({
+      repoId: 'kata-sh/kata-cloud-agents',
+      source: { type: 'pull_request', value: 26 },
+    });
+    expect(fromPullRequest.baseRef).toContain('origin/feature/');
+
+    const fromBranch = await client.createFromSource({
+      repoId: 'kata-sh/kata-cloud-agents',
+      source: { type: 'branch', value: 'feature/kat-155-workspace-and-repo-mgmt' },
+    });
+    expect(fromBranch.baseRef).toBe('origin/feature/kat-155-workspace-and-repo-mgmt');
+
+    const fromIssue = await client.createFromSource({
+      repoId: 'kata-sh/kata-cloud-agents',
+      source: { type: 'issue', value: 155 },
+    });
+    expect(fromIssue.branch).toBe('feature/issue-155');
+  });
+
+  test('validates create-from input and missing pull-request source', async () => {
+    const client = createMemoryWorkspaceClient();
+
+    await expect(
+      client.createFromSource({
+        repoId: '   ',
+        source: { type: 'default' },
+      }),
+    ).rejects.toThrow(/repository selection is required/i);
+
+    await expect(
+      client.createFromSource({
+        repoId: 'kata-sh/kata-cloud-agents',
+        source: { type: 'pull_request', value: 9999 },
+      }),
+    ).rejects.toThrow(/pull request not found/i);
+
+    const fallbackWorkspace = await client.createFromSource({
+      repoId: '///',
+      cloneRootPath: '   ',
+      source: { type: 'default' },
+    });
+    expect(fallbackWorkspace.name).toBe('Workspace');
+    expect(fallbackWorkspace.repoRootPath).toMatch(/^\/tmp\/repo-cache\//);
+  });
+
   test('handles slug/id fallbacks when input and runtime entropy are minimal', async () => {
     const originalCrypto = globalThis.crypto;
     try {

--- a/tests/unit/desktop/workspace-tauri-client.test.ts
+++ b/tests/unit/desktop/workspace-tauri-client.test.ts
@@ -26,6 +26,36 @@ describe('tauri workspace client', () => {
       .mockResolvedValueOnce([sampleWorkspace()])
       .mockResolvedValueOnce([
         {
+          id: 'org/repo',
+          nameWithOwner: 'org/repo',
+          url: 'https://github.com/org/repo',
+          updatedAt: '2026-02-28T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          name: 'main',
+          isDefault: true,
+          updatedAt: '2026-02-28T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          number: 26,
+          title: 'test',
+          headBranch: 'feature/test',
+          updatedAt: '2026-02-28T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          number: 155,
+          title: 'issue',
+          updatedAt: '2026-02-28T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
           nameWithOwner: 'org/repo',
           url: 'https://github.com/org/repo',
           isPrivate: true,
@@ -35,19 +65,75 @@ describe('tauri workspace client', () => {
 
     const client = createTauriWorkspaceClient(mockInvoke);
     const list = await client.list();
+    const knownRepos = await client.listKnownRepos('repo');
+    const branches = await client.listRepoBranches('org/repo', 'main');
+    const pullRequests = await client.listRepoPullRequests('org/repo', '26');
+    const issues = await client.listRepoIssues('org/repo', '155');
     const repos = await client.listGitHubRepos('repo');
 
     expect(mockInvoke).toHaveBeenCalledWith('workspace_list');
+    expect(mockInvoke).toHaveBeenCalledWith('workspace_list_known_repos', {
+      query: 'repo',
+    });
+    expect(mockInvoke).toHaveBeenCalledWith('workspace_list_repo_branches', {
+      repoId: 'org/repo',
+      query: 'main',
+    });
+    expect(mockInvoke).toHaveBeenCalledWith('workspace_list_repo_pull_requests', {
+      repoId: 'org/repo',
+      query: '26',
+    });
+    expect(mockInvoke).toHaveBeenCalledWith('workspace_list_repo_issues', {
+      repoId: 'org/repo',
+      query: '155',
+    });
     expect(mockInvoke).toHaveBeenCalledWith('workspace_list_github_repos', {
       query: 'repo',
     });
     expect(list[0]?.name).toBe('KAT-154');
+    expect(knownRepos[0]?.nameWithOwner).toBe('org/repo');
+    expect(branches[0]?.name).toBe('main');
+    expect(pullRequests[0]?.number).toBe(26);
+    expect(issues[0]?.number).toBe(155);
     expect(repos[0]?.nameWithOwner).toBe('org/repo');
+  });
+
+  test('passes null query for optional filters when omitted', async () => {
+    const mockInvoke = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    const client = createTauriWorkspaceClient(mockInvoke);
+
+    await client.listKnownRepos();
+    await client.listRepoBranches('org/repo');
+    await client.listRepoPullRequests('org/repo');
+    await client.listRepoIssues('org/repo');
+    await client.listGitHubRepos();
+
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, 'workspace_list_known_repos', { query: null });
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'workspace_list_repo_branches', {
+      repoId: 'org/repo',
+      query: null,
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(3, 'workspace_list_repo_pull_requests', {
+      repoId: 'org/repo',
+      query: null,
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(4, 'workspace_list_repo_issues', {
+      repoId: 'org/repo',
+      query: null,
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(5, 'workspace_list_github_repos', { query: null });
   });
 
   test('maps create and lifecycle commands', async () => {
     const mockInvoke = vi
       .fn()
+      .mockResolvedValueOnce(sampleWorkspace())
       .mockResolvedValueOnce(sampleWorkspace())
       .mockResolvedValueOnce(sampleWorkspace())
       .mockResolvedValueOnce(sampleWorkspace())
@@ -70,6 +156,10 @@ describe('tauri workspace client', () => {
       workspaceName: 'KAT-154 Created',
       cloneRootPath: '/tmp/repos',
     });
+    const fromSource = await client.createFromSource({
+      repoId: 'org/repo',
+      source: { type: 'default' },
+    });
     await client.setActive('ws_1');
     const activeId = await client.getActiveId();
     await client.archive('ws_1');
@@ -78,6 +168,7 @@ describe('tauri workspace client', () => {
     expect(local.id).toBe('ws_1');
     expect(remote.id).toBe('ws_1');
     expect(created.id).toBe('ws_1');
+    expect(fromSource.id).toBe('ws_1');
     expect(activeId).toBe('ws_1');
     expect(mockInvoke).toHaveBeenNthCalledWith(1, 'workspace_create_local', {
       input: { repoPath: '/tmp/repo', workspaceName: 'KAT-154' },
@@ -92,10 +183,16 @@ describe('tauri workspace client', () => {
         cloneRootPath: '/tmp/repos',
       },
     });
-    expect(mockInvoke).toHaveBeenNthCalledWith(4, 'workspace_set_active', { id: 'ws_1' });
-    expect(mockInvoke).toHaveBeenNthCalledWith(5, 'workspace_get_active_id');
-    expect(mockInvoke).toHaveBeenNthCalledWith(6, 'workspace_archive', { id: 'ws_1' });
-    expect(mockInvoke).toHaveBeenNthCalledWith(7, 'workspace_delete', {
+    expect(mockInvoke).toHaveBeenNthCalledWith(4, 'workspace_create_from_source', {
+      input: {
+        repoId: 'org/repo',
+        source: { type: 'default' },
+      },
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(5, 'workspace_set_active', { id: 'ws_1' });
+    expect(mockInvoke).toHaveBeenNthCalledWith(6, 'workspace_get_active_id');
+    expect(mockInvoke).toHaveBeenNthCalledWith(7, 'workspace_archive', { id: 'ws_1' });
+    expect(mockInvoke).toHaveBeenNthCalledWith(8, 'workspace_delete', {
       id: 'ws_1',
       removeFiles: true,
     });

--- a/tests/unit/desktop/workspaces-create-modal.test.tsx
+++ b/tests/unit/desktop/workspaces-create-modal.test.tsx
@@ -293,6 +293,121 @@ describe('CreateWorkspaceModal', () => {
     expect(createButton).toBeEnabled();
   });
 
+  test('resets to branches tab when issues tab is disabled while on issues', async () => {
+    const user = userEvent.setup();
+    const loadBranches = vi.fn(async () => [
+      { name: 'main', isDefault: true, updatedAt: '2026-03-01T00:00:00.000Z' },
+    ]);
+
+    const { rerender } = render(
+      <CreateWorkspaceModal
+        isOpen
+        enableIssuesTab
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={vi.fn()}
+        onCreate={vi.fn(async () => {})}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={loadBranches}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /issues/i }));
+    expect(screen.getByPlaceholderText(/search by issue number, title/i)).toBeInTheDocument();
+
+    rerender(
+      <CreateWorkspaceModal
+        isOpen
+        enableIssuesTab={false}
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={vi.fn()}
+        onCreate={vi.fn(async () => {})}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={loadBranches}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/search by branch name/i)).toBeInTheDocument();
+    });
+  });
+
+  test('closes on Escape key', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <CreateWorkspaceModal
+        isOpen
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={onClose}
+        onCreate={vi.fn(async () => {})}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={vi.fn(async () => [{ name: 'main', isDefault: true, updatedAt: '2026-03-01T00:00:00.000Z' }])}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    expect(screen.getByRole('dialog', { name: /create workspace/i })).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not close when no source tab condition matches', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onCreate = vi.fn(async () => {});
+
+    render(
+      <CreateWorkspaceModal
+        isOpen
+        enableIssuesTab={false}
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={onClose}
+        onCreate={onCreate}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={vi.fn(async () => [])}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/no branches found/i)).toBeInTheDocument();
+    });
+
+    const createButton = screen.getByRole('button', { name: /create workspace/i });
+    createButton.removeAttribute('disabled');
+    await user.click(createButton);
+    expect(onCreate).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('closes on backdrop click but not on dialog body click', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <CreateWorkspaceModal
+        isOpen
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={onClose}
+        onCreate={vi.fn(async () => {})}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={vi.fn(async () => [{ name: 'main', isDefault: true, updatedAt: '2026-03-01T00:00:00.000Z' }])}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog', { name: /create workspace/i });
+    await user.click(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+
+    const backdrop = dialog.parentElement!;
+    await user.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   test('cancels stale branch and issue loads when switching tabs/unmounting', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/tests/unit/desktop/workspaces-create-modal.test.tsx
+++ b/tests/unit/desktop/workspaces-create-modal.test.tsx
@@ -253,6 +253,46 @@ describe('CreateWorkspaceModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  test('disables create while source options are loading for a new repo selection', async () => {
+    const user = userEvent.setup();
+    let resolveSecondLoad: ((value: { name: string; isDefault: boolean; updatedAt: string }[]) => void) | null =
+      null;
+    const loadBranches = vi.fn(async (repoId: string) => {
+      if (repoId === 'kata-sh/repo-a') {
+        return [{ name: 'repo-a-main', isDefault: true, updatedAt: '2026-03-01T00:00:00.000Z' }];
+      }
+      return new Promise<{ name: string; isDefault: boolean; updatedAt: string }[]>((resolve) => {
+        resolveSecondLoad = resolve;
+      });
+    });
+
+    render(
+      <CreateWorkspaceModal
+        isOpen
+        repos={[makeRepo('kata-sh/repo-a'), makeRepo('kata-sh/repo-b')]}
+        onClose={vi.fn()}
+        onCreate={vi.fn(async () => {})}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={loadBranches}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    await screen.findByRole('button', { name: /repo-a-main/i });
+    const createButton = screen.getByRole('button', { name: /create workspace/i });
+    expect(createButton).toBeEnabled();
+
+    await user.selectOptions(screen.getByRole('combobox'), 'kata-sh/repo-b');
+    await waitFor(() => {
+      expect(createButton).toBeDisabled();
+      expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    });
+
+    resolveSecondLoad?.([{ name: 'repo-b-main', isDefault: true, updatedAt: '2026-03-01T00:00:00.000Z' }]);
+    await screen.findByRole('button', { name: /repo-b-main/i });
+    expect(createButton).toBeEnabled();
+  });
+
   test('cancels stale branch and issue loads when switching tabs/unmounting', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/tests/unit/desktop/workspaces-create-modal.test.tsx
+++ b/tests/unit/desktop/workspaces-create-modal.test.tsx
@@ -1,0 +1,299 @@
+// biome-ignore lint/correctness/noUnusedImports: Required for JSX runtime in this test file.
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { CreateWorkspaceModal } from '../../../apps/desktop/src/components/workspaces/CreateWorkspaceModal';
+
+function makeRepo(id: string) {
+  return {
+    id,
+    nameWithOwner: id,
+    url: `https://github.com/${id}`,
+    updatedAt: '2026-03-01T00:00:00.000Z',
+  };
+}
+
+describe('CreateWorkspaceModal', () => {
+  test('defaults to branches tab before pull requests', async () => {
+    render(
+      <CreateWorkspaceModal
+        isOpen
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={vi.fn()}
+        onCreate={vi.fn(async () => {})}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={vi.fn(async () => [{ name: 'main', isDefault: true, updatedAt: '2026-03-01T00:00:00.000Z' }])}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    expect(await screen.findByRole('button', { name: /main \(default\)/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/search by branch name/i)).toBeInTheDocument();
+  });
+
+  test('creates from pull request and closes', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onCreate = vi.fn(async () => {});
+    const loadPullRequests = vi.fn(async () => [
+      {
+        number: 26,
+        title: 'feat: test',
+        headBranch: 'feature/test',
+        updatedAt: '2026-03-01T00:00:00.000Z',
+      },
+      {
+        number: 27,
+        title: 'fix: another',
+        headBranch: 'fix/another',
+        updatedAt: '2026-03-01T00:00:00.000Z',
+      },
+    ]);
+
+    render(
+      <CreateWorkspaceModal
+        isOpen
+        enableIssuesTab
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={onClose}
+        onCreate={onCreate}
+        loadPullRequests={loadPullRequests}
+        loadBranches={vi.fn(async () => [])}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /pull requests/i }));
+    expect(await screen.findByRole('button', { name: /#26 feat: test/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /#27 fix: another/i }));
+    await user.click(screen.getByRole('button', { name: /create workspace/i }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith({
+        repoId: 'kata-sh/kata-cloud-agents',
+        source: { type: 'pull_request', value: 27 },
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    expect(loadPullRequests).toHaveBeenCalledWith('kata-sh/kata-cloud-agents', '');
+  });
+
+  test('supports branch and issue flows when issues tab is enabled', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn(async () => {});
+    const onClose = vi.fn();
+    const loadBranches = vi.fn(async (repoId: string) =>
+      repoId.endsWith('repo-b')
+        ? []
+        : [
+            {
+              name: `${repoId}-main`,
+              isDefault: true,
+              updatedAt: '2026-03-01T00:00:00.000Z',
+            },
+            {
+              name: `${repoId}-feature`,
+              isDefault: false,
+              updatedAt: '2026-03-01T00:00:00.000Z',
+            },
+          ],
+    );
+    const loadIssues = vi.fn(async (_repoId: string, query?: string) => {
+      if (!query?.trim()) {
+        return [];
+      }
+      return [
+        { number: 155, title: 'Workspace and repo mgmt', updatedAt: '2026-03-01T00:00:00.000Z' },
+        { number: 156, title: 'Follow-up task', updatedAt: '2026-03-01T00:00:00.000Z' },
+      ];
+    });
+
+    render(
+      <CreateWorkspaceModal
+        isOpen
+        enableIssuesTab
+        initialRepoId="kata-sh/repo-b"
+        repos={[makeRepo('kata-sh/repo-a'), makeRepo('kata-sh/repo-b')]}
+        onClose={onClose}
+        onCreate={onCreate}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={loadBranches}
+        loadIssues={loadIssues}
+      />,
+    );
+
+    const repoSelect = screen.getByRole('combobox');
+    expect(repoSelect).toHaveValue('kata-sh/repo-b');
+    await user.click(screen.getByRole('button', { name: /branches/i }));
+    expect(await screen.findByText(/no branches found/i)).toBeInTheDocument();
+    await user.selectOptions(repoSelect, 'kata-sh/repo-a');
+    expect(await screen.findByRole('button', { name: /kata-sh\/repo-a-main/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /kata-sh\/repo-a-feature/i }));
+    await user.click(screen.getByRole('button', { name: /create workspace/i }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith({
+        repoId: 'kata-sh/repo-a',
+        source: { type: 'branch', value: 'kata-sh/repo-a-feature' },
+      });
+    });
+
+    await user.click(screen.getByRole('button', { name: /issues/i }));
+    expect(await screen.findByText(/no issues found/i)).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText(/search by issue number, title/i), '155');
+    expect(
+      await screen.findByRole('button', { name: /#155 Workspace and repo mgmt/i }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /#155 Workspace and repo mgmt/i }));
+    await user.click(screen.getByRole('button', { name: /create workspace/i }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith({
+        repoId: 'kata-sh/repo-a',
+        source: { type: 'issue', value: 155 },
+      });
+    });
+
+    await user.click(screen.getByRole('button', { name: /pull requests/i }));
+    expect(screen.getByPlaceholderText(/search by title, number/i)).toBeInTheDocument();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('renders load and create errors', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <CreateWorkspaceModal
+        isOpen
+        enableIssuesTab
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={onClose}
+        onCreate={vi.fn(async () => {})}
+        loadPullRequests={vi.fn(async () => {
+          throw 'load failed';
+        })}
+        loadBranches={vi.fn(async () => [])}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /pull requests/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Failed to load options');
+
+    rerender(
+      <CreateWorkspaceModal
+        isOpen
+        enableIssuesTab
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={onClose}
+        onCreate={vi.fn(async () => {
+          throw new Error('create failed');
+        })}
+        loadPullRequests={vi.fn(async () => [
+          {
+            number: 1,
+            title: 'test',
+            headBranch: 'feature/test',
+            updatedAt: '2026-03-01T00:00:00.000Z',
+          },
+        ])}
+        loadBranches={vi.fn(async () => [])}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /pull requests/i }));
+    expect(await screen.findByRole('button', { name: /#1 test/i })).toBeInTheDocument();
+    await user.click(await screen.findByRole('button', { name: /create workspace/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('create failed');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('returns null when closed and disables create with no repositories', async () => {
+    const onCreate = vi.fn(async () => {});
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <CreateWorkspaceModal
+        isOpen={false}
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={onClose}
+        onCreate={onCreate}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={vi.fn(async () => [])}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+    expect(screen.queryByRole('dialog', { name: /create workspace/i })).not.toBeInTheDocument();
+
+    rerender(
+      <CreateWorkspaceModal
+        isOpen
+        repos={[]}
+        onClose={onClose}
+        onCreate={onCreate}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={vi.fn(async () => [])}
+        loadIssues={vi.fn(async () => [])}
+      />,
+    );
+
+    expect(await screen.findByRole('dialog', { name: /create workspace/i })).toBeInTheDocument();
+    const createButton = screen.getByRole('button', { name: /create workspace/i });
+    const issuesButton = screen.getByRole('button', { name: /issues/i });
+    expect(issuesButton).toBeDisabled();
+    expect(createButton).toBeDisabled();
+    expect(screen.getByPlaceholderText(/search by branch name/i)).toBeInTheDocument();
+    createButton.removeAttribute('disabled');
+    await userEvent.setup().click(createButton);
+    expect(onCreate).not.toHaveBeenCalled();
+    await userEvent.setup().click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancels stale branch and issue loads when switching tabs/unmounting', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    let resolveBranches: ((value: { name: string; isDefault: boolean; updatedAt: string }[]) => void) | null =
+      null;
+    let resolveIssues: ((value: { number: number; title: string; updatedAt: string }[]) => void) | null = null;
+    const loadBranches = vi.fn(
+      () =>
+        new Promise<{ name: string; isDefault: boolean; updatedAt: string }[]>((resolve) => {
+          resolveBranches = resolve;
+        }),
+    );
+    const loadIssues = vi.fn(
+      () =>
+        new Promise<{ number: number; title: string; updatedAt: string }[]>((resolve) => {
+          resolveIssues = resolve;
+        }),
+    );
+
+    const { unmount } = render(
+      <CreateWorkspaceModal
+        isOpen
+        enableIssuesTab
+        repos={[makeRepo('kata-sh/kata-cloud-agents')]}
+        onClose={onClose}
+        onCreate={vi.fn(async () => {})}
+        loadPullRequests={vi.fn(async () => [])}
+        loadBranches={loadBranches}
+        loadIssues={loadIssues}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /branches/i }));
+    await user.click(screen.getByRole('button', { name: /issues/i }));
+    resolveBranches?.([{ name: 'main', isDefault: true, updatedAt: '2026-03-01T00:00:00.000Z' }]);
+
+    unmount();
+    resolveIssues?.([{ number: 155, title: 'issue', updatedAt: '2026-03-01T00:00:00.000Z' }]);
+    await waitFor(() => {
+      expect(loadBranches).toHaveBeenCalled();
+      expect(loadIssues).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/desktop/workspaces-page.test.tsx
+++ b/tests/unit/desktop/workspaces-page.test.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { Workspaces } from '../../../apps/desktop/src/pages/Workspaces';
@@ -24,6 +25,29 @@ vi.mock('../../../apps/desktop/src/services/system/dialog', () => ({
 const pickDirectoryMock = vi.mocked(pickDirectory);
 
 describe('Workspaces page', () => {
+  function seededGithubWorkspace() {
+    return {
+      id: 'ws_seed',
+      name: 'Seed Workspace',
+      sourceType: 'github' as const,
+      source: 'https://github.com/kata-sh/kata-cloud-agents',
+      repoRootPath: '/tmp/repo',
+      worktreePath: '/tmp/repo.worktrees/ws_seed',
+      branch: 'workspace/seed',
+      status: 'ready' as const,
+      createdAt: '2026-03-01T00:00:00.000Z',
+      updatedAt: '2026-03-01T00:00:00.000Z',
+    };
+  }
+
+  function renderWorkspaces() {
+    return render(
+      <MemoryRouter>
+        <Workspaces />
+      </MemoryRouter>,
+    );
+  }
+
   beforeEach(() => {
     pickDirectoryMock.mockReset();
     delete (globalThis as { __TAURI__?: unknown }).__TAURI__;
@@ -33,7 +57,7 @@ describe('Workspaces page', () => {
   });
 
   test('renders three add repository actions', async () => {
-    render(<Workspaces />);
+    renderWorkspaces();
 
     expect(screen.getByRole('button', { name: /local repo/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /clone remote/i })).toBeInTheDocument();
@@ -44,7 +68,7 @@ describe('Workspaces page', () => {
   test('supports local repo creation from local action', async () => {
     const user = userEvent.setup();
     pickDirectoryMock.mockResolvedValueOnce('/tmp/repo');
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /local repo/i }));
 
@@ -54,7 +78,7 @@ describe('Workspaces page', () => {
   test('handles local repo picker cancel and error', async () => {
     const user = userEvent.setup();
     pickDirectoryMock.mockResolvedValueOnce(null).mockRejectedValueOnce(new Error('picker failed'));
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /local repo/i }));
     expect(screen.getByText(/no workspaces yet/i)).toBeInTheDocument();
@@ -66,7 +90,7 @@ describe('Workspaces page', () => {
 
   test('supports remote clone action', async () => {
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
     await user.type(
@@ -94,7 +118,7 @@ describe('Workspaces page', () => {
     resetWorkspacesStore();
 
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
     const cloneUrlInput = screen.getByLabelText(/github repository url/i);
@@ -109,7 +133,7 @@ describe('Workspaces page', () => {
 
   test('validates clone action github url', async () => {
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
     await user.type(
@@ -130,7 +154,7 @@ describe('Workspaces page', () => {
 
   test('supports create new repository action', async () => {
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /create new/i }));
     await user.type(screen.getByLabelText(/repository name/i), 'kat-154-created');
@@ -157,7 +181,7 @@ describe('Workspaces page', () => {
     resetWorkspacesStore();
 
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /create new/i }));
     await user.click(screen.getByRole('button', { name: /create new repo/i }));
@@ -175,7 +199,7 @@ describe('Workspaces page', () => {
   test('supports archive and remove on existing list', async () => {
     const user = userEvent.setup();
     pickDirectoryMock.mockResolvedValueOnce('/tmp/kat-154-actions');
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /local repo/i }));
     expect(await screen.findByText(/^kat-154-actions$/i)).toBeInTheDocument();
@@ -203,7 +227,7 @@ describe('Workspaces page', () => {
     resetWorkspacesStore();
 
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
 
     expect(await screen.findByRole('status')).toBeInTheDocument();
@@ -233,7 +257,7 @@ describe('Workspaces page', () => {
     resetWorkspacesStore();
 
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
     expect(await screen.findByText(/gh auth required/i)).toBeInTheDocument();
   });
@@ -256,7 +280,7 @@ describe('Workspaces page', () => {
       resetWorkspacesStore();
 
       const user = userEvent.setup();
-      const { unmount } = render(<Workspaces />);
+      const { unmount } = renderWorkspaces();
       await user.click(screen.getByRole('button', { name: /clone remote/i }));
       await waitFor(() => {
         expect(listGitHubRepos).toHaveBeenCalledTimes(1);
@@ -294,7 +318,7 @@ describe('Workspaces page', () => {
     resetWorkspacesStore();
 
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
     await waitFor(() => {
       expect(listGitHubRepos).toHaveBeenCalledTimes(1);
@@ -327,7 +351,7 @@ describe('Workspaces page', () => {
     resetWorkspacesStore();
 
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /org\/repo-two/i })).toBeInTheDocument();
@@ -346,7 +370,7 @@ describe('Workspaces page', () => {
       .mockResolvedValueOnce(null)
       .mockRejectedValueOnce(new Error('browse failed'))
       .mockResolvedValueOnce('/tmp/create-picked');
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
     await user.click(screen.getByRole('button', { name: /^browse$/i }));
@@ -365,7 +389,7 @@ describe('Workspaces page', () => {
 
   test('catches unexpected errors from clone store action', async () => {
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
 
     useWorkspacesStore.setState({
       createGitHub: async () => {
@@ -392,7 +416,7 @@ describe('Workspaces page', () => {
 
   test('catches unexpected errors from create-new store action', async () => {
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
 
     useWorkspacesStore.setState({
       createNewGitHub: async () => {
@@ -411,7 +435,7 @@ describe('Workspaces page', () => {
 
   test('uses a default clone location derived from home directory', async () => {
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
     await waitFor(() => {
@@ -423,7 +447,7 @@ describe('Workspaces page', () => {
 
   test('clears form error when switching actions', async () => {
     const user = userEvent.setup();
-    render(<Workspaces />);
+    renderWorkspaces();
 
     await user.click(screen.getByRole('button', { name: /clone remote/i }));
     const cloneUrlInput = screen.getByLabelText(/github repository url/i);
@@ -436,5 +460,100 @@ describe('Workspaces page', () => {
 
     await user.click(screen.getByRole('button', { name: /create new/i }));
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('quick create from known repo creates workspace and handles failure', async () => {
+    const user = userEvent.setup();
+    const successClient = createMemoryWorkspaceClient({
+      workspaces: [seededGithubWorkspace()],
+    });
+    setWorkspaceClient(successClient);
+    resetWorkspacesStore();
+
+    const first = renderWorkspaces();
+    const repoButton = await screen.findByRole('button', { name: /kata-sh\/kata-cloud-agents/i });
+    await user.click(repoButton);
+    expect(await screen.findByText(/^kata-cloud-agents$/i)).toBeInTheDocument();
+    first.unmount();
+
+    const failureClient: WorkspaceClient = {
+      ...createMemoryWorkspaceClient({ workspaces: [seededGithubWorkspace()] }),
+      createFromSource: async () => {
+        throw new Error('quick create failed');
+      },
+    };
+    setWorkspaceClient(failureClient);
+    resetWorkspacesStore();
+
+    renderWorkspaces();
+    await user.click(await screen.findByRole('button', { name: /kata-sh\/kata-cloud-agents/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('quick create failed');
+  });
+
+  test('create from known repo row opens modal and creates from selected source', async () => {
+    const user = userEvent.setup();
+    setWorkspaceClient(
+      createMemoryWorkspaceClient({
+        workspaces: [seededGithubWorkspace()],
+      }),
+    );
+    resetWorkspacesStore();
+    renderWorkspaces();
+
+    const repoButton = await screen.findByRole('button', { name: /kata-sh\/kata-cloud-agents/i });
+    const repoRow = repoButton.closest('li');
+    if (!repoRow) {
+      throw new Error('expected known repo row');
+    }
+    await user.click(within(repoRow).getByRole('button', { name: /^create from\.\.\./i }));
+
+    expect(await screen.findByRole('dialog', { name: /create workspace/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /branches/i }));
+    await user.click(await screen.findByRole('button', { name: /feature\/kata-cloud-agents-next/i }));
+    await user.click(screen.getByRole('button', { name: /create workspace/i }));
+
+    expect(await screen.findByText(/^kata-cloud-agents$/i)).toBeInTheDocument();
+  });
+
+  test('opens create-from modal from top affordance and cmd/ctrl+n hotkey', async () => {
+    const user = userEvent.setup();
+    setWorkspaceClient(
+      createMemoryWorkspaceClient({
+        workspaces: [seededGithubWorkspace()],
+      }),
+    );
+    resetWorkspacesStore();
+    renderWorkspaces();
+
+    await user.click(await screen.findByRole('button', { name: /create from\.\.\./i }));
+    expect(await screen.findByRole('dialog', { name: /create workspace/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByRole('dialog', { name: /create workspace/i })).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'x', metaKey: true });
+    expect(screen.queryByRole('dialog', { name: /create workspace/i })).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'n', metaKey: true });
+    expect(await screen.findByRole('dialog', { name: /create workspace/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    fireEvent.keyDown(window, { key: 'n', ctrlKey: true });
+    expect(await screen.findByRole('dialog', { name: /create workspace/i })).toBeInTheDocument();
+  });
+
+  test('workspace list row activates workspace when clicked', async () => {
+    const user = userEvent.setup();
+    setWorkspaceClient(
+      createMemoryWorkspaceClient({
+        workspaces: [seededGithubWorkspace()],
+      }),
+    );
+    resetWorkspacesStore();
+    renderWorkspaces();
+
+    await user.click(await screen.findByRole('button', { name: /open workspace seed workspace/i }));
+    await waitFor(() => {
+      expect(useWorkspacesStore.getState().activeWorkspaceId).toBe('ws_seed');
+    });
   });
 });

--- a/tests/unit/desktop/workspaces-page.test.tsx
+++ b/tests/unit/desktop/workspaces-page.test.tsx
@@ -515,6 +515,35 @@ describe('Workspaces page', () => {
     expect(await screen.findByText(/^kata-cloud-agents$/i)).toBeInTheDocument();
   });
 
+  test('create from modal shows error and stays open on failure', async () => {
+    const user = userEvent.setup();
+    const failureClient: WorkspaceClient = {
+      ...createMemoryWorkspaceClient({ workspaces: [seededGithubWorkspace()] }),
+      createFromSource: async () => {
+        throw new Error('create from failed');
+      },
+    };
+    setWorkspaceClient(failureClient);
+    resetWorkspacesStore();
+    renderWorkspaces();
+
+    const repoButton = await screen.findByRole('button', { name: /kata-sh\/kata-cloud-agents/i });
+    const repoRow = repoButton.closest('li');
+    if (!repoRow) {
+      throw new Error('expected known repo row');
+    }
+    await user.click(within(repoRow).getByRole('button', { name: /^create from\.\.\./i }));
+
+    expect(await screen.findByRole('dialog', { name: /create workspace/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /branches/i }));
+    await user.click(await screen.findByRole('button', { name: /feature\/kata-cloud-agents-next/i }));
+    await user.click(screen.getByRole('button', { name: /create workspace/i }));
+
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts.some((el) => el.textContent?.includes('create from failed'))).toBe(true);
+    expect(screen.getByRole('dialog', { name: /create workspace/i })).toBeInTheDocument();
+  });
+
   test('opens create-from modal from top affordance and cmd/ctrl+n hotkey', async () => {
     const user = userEvent.setup();
     setWorkspaceClient(

--- a/tests/unit/desktop/workspaces-store.test.ts
+++ b/tests/unit/desktop/workspaces-store.test.ts
@@ -246,7 +246,7 @@ describe('useWorkspacesStore', () => {
     expect(useWorkspacesStore.getState().lastError).toBe('remove failed');
   });
 
-  test('returns empty arrays and stores errors for repo list lookups', async () => {
+  test('stores errors for repo list lookups and rethrows option-loading failures', async () => {
     const failingClient: WorkspaceClient = {
       list: async () => [],
       listGitHubRepos: async () => [],
@@ -288,13 +288,19 @@ describe('useWorkspacesStore', () => {
     expect(useWorkspacesStore.getState().lastError).toBe('known repos failed');
     expect(useWorkspacesStore.getState().isLoadingKnownRepos).toBe(false);
 
-    expect(await useWorkspacesStore.getState().listRepoBranches('org/repo')).toEqual([]);
+    await expect(useWorkspacesStore.getState().listRepoBranches('org/repo')).rejects.toThrow(
+      'branches failed',
+    );
     expect(useWorkspacesStore.getState().lastError).toBe('branches failed');
 
-    expect(await useWorkspacesStore.getState().listRepoPullRequests('org/repo')).toEqual([]);
+    await expect(useWorkspacesStore.getState().listRepoPullRequests('org/repo')).rejects.toThrow(
+      'pull requests failed',
+    );
     expect(useWorkspacesStore.getState().lastError).toBe('pull requests failed');
 
-    expect(await useWorkspacesStore.getState().listRepoIssues('org/repo')).toEqual([]);
+    await expect(useWorkspacesStore.getState().listRepoIssues('org/repo')).rejects.toThrow(
+      'issues failed',
+    );
     expect(useWorkspacesStore.getState().lastError).toBe('issues failed');
   });
 

--- a/tests/unit/desktop/workspaces-store.test.ts
+++ b/tests/unit/desktop/workspaces-store.test.ts
@@ -74,6 +74,26 @@ describe('useWorkspacesStore', () => {
     expect(state.activeWorkspaceId).toBe(workspace.id);
   });
 
+  test('quickCreateFromRepo appends workspace and sets active workspace', async () => {
+    const workspace = await useWorkspacesStore.getState().quickCreateFromRepo('kata-sh/kata-cloud-agents');
+    const state = useWorkspacesStore.getState();
+    expect(workspace.source).toBe('https://github.com/kata-sh/kata-cloud-agents');
+    expect(state.activeWorkspaceId).toBe(workspace.id);
+    expect(state.workspaces.some((entry) => entry.id === workspace.id)).toBe(true);
+  });
+
+  test('loadKnownRepos stores known repos and loading state', async () => {
+    await useWorkspacesStore.getState().createGitHub({
+      repoUrl: 'https://github.com/kata-sh/kata-cloud-agents',
+      workspaceName: 'kata-cloud-agents',
+    });
+
+    const knownRepos = await useWorkspacesStore.getState().loadKnownRepos();
+    expect(knownRepos.length).toBe(1);
+    expect(useWorkspacesStore.getState().isLoadingKnownRepos).toBe(false);
+    expect(useWorkspacesStore.getState().knownRepos[0]?.id).toBe('kata-sh/kata-cloud-agents');
+  });
+
   test('archiving a non-active workspace preserves active selection', async () => {
     await useWorkspacesStore
       .getState()
@@ -124,6 +144,10 @@ describe('useWorkspacesStore', () => {
     const failingClient: WorkspaceClient = {
       list: async () => [],
       listGitHubRepos: async () => [],
+      listKnownRepos: async () => [],
+      listRepoBranches: async () => [],
+      listRepoPullRequests: async () => [],
+      listRepoIssues: async () => [],
       createLocal: async () => {
         throw new Error('local failed');
       },
@@ -132,6 +156,9 @@ describe('useWorkspacesStore', () => {
       },
       createNewGitHub: async () => {
         throw new Error('github new failed');
+      },
+      createFromSource: async () => {
+        throw new Error('create from failed');
       },
       setActive: async () => {},
       getActiveId: async () => null,
@@ -175,6 +202,10 @@ describe('useWorkspacesStore', () => {
         throw new Error('load failed');
       },
       listGitHubRepos: async () => [],
+      listKnownRepos: async () => [],
+      listRepoBranches: async () => [],
+      listRepoPullRequests: async () => [],
+      listRepoIssues: async () => [],
       createLocal: async () => {
         throw new Error('local failed');
       },
@@ -183,6 +214,9 @@ describe('useWorkspacesStore', () => {
       },
       createNewGitHub: async () => {
         throw new Error('github new failed');
+      },
+      createFromSource: async () => {
+        throw new Error('create from failed');
       },
       setActive: async () => {
         throw new Error('active failed');
@@ -212,12 +246,76 @@ describe('useWorkspacesStore', () => {
     expect(useWorkspacesStore.getState().lastError).toBe('remove failed');
   });
 
+  test('returns empty arrays and stores errors for repo list lookups', async () => {
+    const failingClient: WorkspaceClient = {
+      list: async () => [],
+      listGitHubRepos: async () => [],
+      listKnownRepos: async () => {
+        throw new Error('known repos failed');
+      },
+      listRepoBranches: async () => {
+        throw new Error('branches failed');
+      },
+      listRepoPullRequests: async () => {
+        throw new Error('pull requests failed');
+      },
+      listRepoIssues: async () => {
+        throw new Error('issues failed');
+      },
+      createLocal: async () => {
+        throw new Error('local failed');
+      },
+      createGitHub: async () => {
+        throw new Error('github failed');
+      },
+      createNewGitHub: async () => {
+        throw new Error('github new failed');
+      },
+      createFromSource: async () => {
+        throw new Error('create from failed');
+      },
+      setActive: async () => {},
+      getActiveId: async () => null,
+      archive: async () => {},
+      remove: async () => {},
+    };
+
+    setWorkspaceClient(failingClient);
+    resetWorkspacesStore();
+
+    expect(await useWorkspacesStore.getState().loadKnownRepos()).toEqual([]);
+    expect(useWorkspacesStore.getState().knownRepos).toEqual([]);
+    expect(useWorkspacesStore.getState().lastError).toBe('known repos failed');
+    expect(useWorkspacesStore.getState().isLoadingKnownRepos).toBe(false);
+
+    expect(await useWorkspacesStore.getState().listRepoBranches('org/repo')).toEqual([]);
+    expect(useWorkspacesStore.getState().lastError).toBe('branches failed');
+
+    expect(await useWorkspacesStore.getState().listRepoPullRequests('org/repo')).toEqual([]);
+    expect(useWorkspacesStore.getState().lastError).toBe('pull requests failed');
+
+    expect(await useWorkspacesStore.getState().listRepoIssues('org/repo')).toEqual([]);
+    expect(useWorkspacesStore.getState().lastError).toBe('issues failed');
+  });
+
   test('handles non-Error throws and exposes current client', async () => {
     const nonErrorClient: WorkspaceClient = {
       list: async () => {
         throw 'boom';
       },
       listGitHubRepos: async () => {
+        throw 'boom';
+      },
+      listKnownRepos: async () => {
+        throw 'boom';
+      },
+      listRepoBranches: async () => {
+        throw 'boom';
+      },
+      listRepoPullRequests: async () => {
+        throw 'boom';
+      },
+      listRepoIssues: async () => {
         throw 'boom';
       },
       createLocal: async () => {
@@ -227,6 +325,9 @@ describe('useWorkspacesStore', () => {
         throw 'boom';
       },
       createNewGitHub: async () => {
+        throw 'boom';
+      },
+      createFromSource: async () => {
         throw 'boom';
       },
       setActive: async () => {
@@ -255,6 +356,10 @@ describe('useWorkspacesStore', () => {
         throw { message: 'object message' };
       },
       listGitHubRepos: async () => [],
+      listKnownRepos: async () => [],
+      listRepoBranches: async () => [],
+      listRepoPullRequests: async () => [],
+      listRepoIssues: async () => [],
       createLocal: async () => {
         throw { error: 'top level error field' };
       },
@@ -263,6 +368,9 @@ describe('useWorkspacesStore', () => {
       },
       createNewGitHub: async () => {
         throw { message: 'new repo object message' };
+      },
+      createFromSource: async () => {
+        throw { message: 'create from object message' };
       },
       setActive: async () => {
         throw {};

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['tests/e2e/**/*.test.ts'],
+    include: ['tests/e2e/**/*.test.ts', 'tests/e2e/**/*.test.tsx'],
   },
 });


### PR DESCRIPTION
## Summary
- implement the KAT-155 workspace/repo management flow in desktop + tauri
- add Create Workspace From modal backed by known repos, with branches listed before pull requests
- keep Issues affordance visible but disabled for future Linear integration
- add cmd+N hotkey entry, fix repo command `repoId` argument wiring, and improve clone/create error handling
- remove auto-navigation on creation and make workspace rows clickable to open workspace main view
- add design + implementation docs and comprehensive unit/e2e coverage for the new flows

## Test Plan
- `pnpm ci:checks`
- `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/workspaces-create-from-flow.test.tsx`
- `pnpm exec vitest run tests/unit/desktop/workspaces-create-modal.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create workspaces from GitHub repositories, pull requests, branches, or issues via a new modal dialog
  * "Quick Create From Known Repos" section to discover and fast-create from repos derived from your workspaces
  * Keyboard shortcut (Cmd/Ctrl+N) to open the create-workspace modal
  * Search/filter branches, pull requests, and issues when creating workspaces
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements KAT-155 workspace/repo management flow that allows users to quickly create workspaces from known repositories, with support for creating from specific branches, pull requests, or issues.

**Key Changes:**
- Added "Quick Create From Known Repos" section that displays previously-used GitHub repos sorted by most recent activity
- Created `CreateWorkspaceModal` with tabbed interface for selecting branches (default), pull requests, or issues (disabled but visible for future Linear integration)
- Implemented cmd+N hotkey to open the creation modal
- Backend commands now list repo branches, PRs, and issues via GitHub CLI (`gh`)
- Added path normalization with tilde (`~`) expansion for user-friendly clone locations
- Removed auto-navigation after workspace creation - users stay on the workspaces page to see the new workspace added to the list
- Made workspace rows clickable to navigate to the main workspace view
- Comprehensive test coverage with unit tests for all components and e2e tests for the full flows

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor issue to address in issue-based workspace creation
- Code is well-structured with comprehensive test coverage (unit + e2e), proper error handling, and good TypeScript/Rust type safety. One logical issue exists with hardcoded default branch assumption that should be fixed but won't block merge.
- apps/desktop/src-tauri/src/workspaces/commands.rs - hardcoded default branch assumption in issue-based workspace creation

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/workspaces/commands.rs | added commands for listing repos/branches/PRs/issues and creating workspaces from sources; hardcoded default branch assumption for issue-based workspaces |
| apps/desktop/src-tauri/src/workspaces/git_github.rs | implemented GitHub API integrations for listing PRs/branches/issues, added path normalization with tilde expansion, comprehensive test coverage |
| apps/desktop/src-tauri/src/workspaces/store.rs | added `list_known_repos` that deduplicates GitHub workspaces by repo ID and filters/sorts by updated timestamp |
| apps/desktop/src/components/workspaces/CreateWorkspaceModal.tsx | modal component with tabs for PRs/branches/issues, cancellation-safe async data loading, proper accessibility attributes |
| apps/desktop/src/pages/Workspaces.tsx | integrated quick-create UI, create-from modal, hotkey support, and workspace row click navigation to main view |
| apps/desktop/src/store/workspaces.ts | extended Zustand store with actions for loading known repos and creating workspaces from sources |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI as Workspaces Page
    participant Modal as CreateWorkspaceModal
    participant Store as Zustand Store
    participant Tauri as Tauri Commands
    participant GH as GitHub CLI/API

    User->>UI: Open workspaces page
    UI->>Store: loadKnownRepos()
    Store->>Tauri: workspace_list_known_repos
    Tauri-->>Store: Known repos from history
    Store-->>UI: Display repo list

    User->>UI: Click "Create from..." or Cmd+N
    UI->>Modal: Open with repo list
    User->>Modal: Select repo & tab (Branch/PR/Issue)
    Modal->>Store: listRepoBranches/PRs/Issues(repoId)
    Store->>Tauri: workspace_list_repo_branches/pull_requests/issues
    Tauri->>GH: gh pr list / gh issue list / git ls-remote
    GH-->>Tauri: Options list
    Tauri-->>Store: Formatted options
    Store-->>Modal: Display options

    User->>Modal: Select option & click Create
    Modal->>Store: createFromSource(input)
    Store->>Tauri: workspace_create_from_source
    Tauri->>GH: Clone/fetch repo & checkout branch
    GH-->>Tauri: Workspace prepared
    Tauri-->>Store: Workspace created
    Store-->>UI: Refresh workspace list
    UI->>User: Stay on page, show new workspace
```

<sub>Last reviewed commit: a9cd2e4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->