### PR TITLE
fix: pin Bun version to 1.3.8 in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,20 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Debug tsc resolution
+        run: |
+          echo "=== tsc binary ==="
+          which tsc || echo "tsc not in PATH"
+          ls -la node_modules/.bin/tsc
+          echo "=== tsc version ==="
+          cd packages/shared && ../../node_modules/.bin/tsc --version
+          echo "=== effective config ==="
+          ../../node_modules/.bin/tsc --showConfig | head -30
+          echo "=== list files (first 10) ==="
+          ../../node_modules/.bin/tsc --listFiles --noEmit 2>&1 | head -10
+          echo "=== check a source file exists ==="
+          ls -la src/sources/types.ts src/sources/storage.ts src/sessions/index.ts
+
       - name: Typecheck all packages
         run: bun run typecheck:all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,20 +32,6 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Debug tsc resolution
-        run: |
-          echo "=== tsc binary ==="
-          which tsc || echo "tsc not in PATH"
-          ls -la node_modules/.bin/tsc
-          echo "=== tsc version ==="
-          cd packages/shared && ../../node_modules/.bin/tsc --version
-          echo "=== effective config ==="
-          ../../node_modules/.bin/tsc --showConfig | head -30
-          echo "=== list files (first 10) ==="
-          ../../node_modules/.bin/tsc --listFiles --noEmit 2>&1 | head -10
-          echo "=== check a source file exists ==="
-          ls -la src/sources/types.ts src/sources/storage.ts src/sessions/index.ts
-
       - name: Typecheck all packages
         run: bun run typecheck:all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        with:
+          bun-version: '1.3.8'
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
-
+        with:
+          bun-version: '1.3.8'
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
@@ -289,7 +290,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
-
+        with:
+          bun-version: '1.3.8'
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
@@ -387,7 +389,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
-
+        with:
+          bun-version: '1.3.8'
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,8 @@ credentials.enc
 *.credentials
 .secrets/
 demos/
-sources/
-sessions/
-statuses/config.json
-labels/
-config.json
+/sources/
+/sessions/
+/statuses/config.json
+/labels/
+/config.json

--- a/packages/shared/src/labels/auto/evaluator.ts
+++ b/packages/shared/src/labels/auto/evaluator.ts
@@ -1,0 +1,148 @@
+/**
+ * Auto-Label Evaluator
+ *
+ * Core evaluation engine for auto-label rules. Scans user messages against
+ * configured regex patterns, producing label matches.
+ *
+ * Evaluation flow:
+ * 1. Strip code blocks from message (avoid matching inside code)
+ * 2. Walk the label tree, collect all labels with autoRules
+ * 3. For each rule: run regex with forced 'g' flag, substitute capture groups
+ * 4. Normalize extracted values based on the label's valueType
+ * 5. Deduplicate matches (same labelId + value = keep only first)
+ * 6. Cap at MAX_MATCHES_PER_MESSAGE to prevent label explosion
+ * 7. Return array of AutoLabelMatch ready for session storage
+ */
+
+import type { LabelConfig, AutoLabelRule } from '../types.ts'
+import type { AutoLabelMatch } from './types.ts'
+import { normalizeValue } from './normalize.ts'
+
+/** Maximum number of auto-label matches per message to prevent label explosion from pasted logs/data */
+const MAX_MATCHES_PER_MESSAGE = 10
+
+/**
+ * Recursively collect all labels that have autoRules defined.
+ * Walks the entire label tree depth-first.
+ */
+export function collectAutoLabelRules(labels: LabelConfig[]): Array<{
+  label: LabelConfig
+  rule: AutoLabelRule
+}> {
+  const result: Array<{ label: LabelConfig; rule: AutoLabelRule }> = []
+
+  function walk(nodes: LabelConfig[]) {
+    for (const label of nodes) {
+      if (label.autoRules) {
+        for (const rule of label.autoRules) {
+          result.push({ label, rule })
+        }
+      }
+      if (label.children) {
+        walk(label.children)
+      }
+    }
+  }
+
+  walk(labels)
+  return result
+}
+
+/**
+ * Strip fenced code blocks and inline code from message text.
+ * Prevents regex patterns from matching inside code examples, logs, etc.
+ */
+function stripCodeBlocks(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, '')  // fenced code blocks
+    .replace(/`[^`]+`/g, '')          // inline code
+}
+
+/**
+ * Evaluate all auto-label rules against a user message.
+ * Returns deduplicated matches with normalized values, capped at MAX_MATCHES_PER_MESSAGE.
+ *
+ * @param message - The user's message text to scan
+ * @param labels - The workspace label tree (from config)
+ */
+export function evaluateAutoLabels(
+  message: string,
+  labels: LabelConfig[],
+): AutoLabelMatch[] {
+  // Strip code blocks before scanning to avoid matching inside code
+  const cleanMessage = stripCodeBlocks(message)
+
+  const rules = collectAutoLabelRules(labels)
+  const matches: AutoLabelMatch[] = []
+  // Track seen entries to deduplicate (same label + same value = skip)
+  const seen = new Set<string>()
+
+  for (const { label, rule } of rules) {
+    // Stop if we've hit the match limit
+    if (matches.length >= MAX_MATCHES_PER_MESSAGE) break
+
+    const ruleMatches = evaluateRegexRule(cleanMessage, label, rule)
+
+    // Deduplicate and add to results (respecting match limit)
+    for (const match of ruleMatches) {
+      if (matches.length >= MAX_MATCHES_PER_MESSAGE) break
+
+      const key = `${match.labelId}::${match.value}`
+      if (!seen.has(key)) {
+        seen.add(key)
+        matches.push(match)
+      }
+    }
+  }
+
+  return matches
+}
+
+/**
+ * Evaluate a regex-based auto-label rule.
+ * Always enforces the 'g' flag to prevent infinite exec() loops.
+ * Uses single-pass $N substitution to prevent injection.
+ */
+function evaluateRegexRule(
+  message: string,
+  label: LabelConfig,
+  rule: AutoLabelRule
+): AutoLabelMatch[] {
+  const matches: AutoLabelMatch[] = []
+
+  try {
+    // Ensure global flag is always present to prevent infinite exec() loops
+    const flags = rule.flags
+      ? (rule.flags.includes('g') ? rule.flags : rule.flags + 'g')
+      : 'gi'
+    const regex = new RegExp(rule.pattern, flags)
+    let match: RegExpExecArray | null
+
+    while ((match = regex.exec(message)) !== null) {
+      // Single-pass $N substitution: prevents injection where captured text
+      // contains $N patterns that would be double-substituted
+      let value = rule.valueTemplate
+        ? rule.valueTemplate.replace(/\$(\d+)/g, (_, n) => match![parseInt(n)] ?? '')
+        : match[1] ?? match[0]
+
+      // Normalize based on the label's declared valueType
+      value = normalizeValue(value, label.valueType)
+
+      matches.push({
+        labelId: label.id,
+        value,
+        matchedText: match[0],
+      })
+
+      // Prevent infinite loop on zero-length matches
+      if (match[0].length === 0) {
+        regex.lastIndex++
+      }
+    }
+  } catch (e) {
+    // Invalid regex — skip silently (validation should catch this at config time)
+    console.warn(`[AutoLabel] Invalid regex for label "${label.id}": ${rule.pattern}`, e)
+  }
+
+  return matches
+}

--- a/packages/shared/src/labels/auto/index.ts
+++ b/packages/shared/src/labels/auto/index.ts
@@ -1,0 +1,4 @@
+export type { AutoLabelMatch } from './types.ts'
+export { evaluateAutoLabels, collectAutoLabelRules } from './evaluator.ts'
+export { normalizeValue } from './normalize.ts'
+export { validateAutoLabelRule } from './validation.ts'

--- a/packages/shared/src/labels/auto/normalize.ts
+++ b/packages/shared/src/labels/auto/normalize.ts
@@ -1,0 +1,67 @@
+/**
+ * Auto-Label Value Normalization
+ *
+ * Normalizes raw extracted values based on the label's valueType.
+ * Called after regex capture groups are substituted into the valueTemplate.
+ *
+ * Normalization rules:
+ * - string: pass-through (no transformation)
+ * - number: strip commas, expand suffixes (k/K → ×1000, M → ×1000000)
+ * - date: pass-through (regex captures already produce ISO format)
+ */
+
+/**
+ * Normalize a raw extracted value based on the target label's valueType.
+ * Returns the normalized string ready for storage in the session label entry.
+ *
+ * @param raw - Raw value string from regex valueTemplate substitution
+ * @param valueType - The label's declared valueType (determines normalization strategy)
+ */
+export function normalizeValue(raw: string, valueType?: 'string' | 'number' | 'date'): string {
+  switch (valueType) {
+    case 'number':
+      return normalizeNumber(raw)
+    case 'date':
+      // Date values from regex capture are expected to already be in ISO format
+      return raw
+    case 'string':
+    default:
+      return raw
+  }
+}
+
+/**
+ * Normalize a number string:
+ * - Strip commas (thousands separators): "45,000" → "45000"
+ * - Strip leading currency symbols: "$45000" → "45000"
+ * - Expand k/K suffix: "45k" → "45000"
+ * - Expand M suffix: "1.5M" → "1500000"
+ * - Expand B suffix: "2B" → "2000000000"
+ */
+function normalizeNumber(raw: string): string {
+  // Strip leading currency symbols
+  let cleaned = raw.replace(/^[$€£¥]/, '')
+
+  // Strip commas
+  cleaned = cleaned.replace(/,/g, '')
+
+  // Expand suffixes (case-insensitive)
+  const suffixMatch = cleaned.match(/^(-?\d+\.?\d*)\s*([kKmMbB])$/)
+  if (suffixMatch) {
+    const num = parseFloat(suffixMatch[1]!)
+    const suffix = suffixMatch[2]!.toLowerCase()
+    const multiplier = suffix === 'k' ? 1_000 : suffix === 'm' ? 1_000_000 : 1_000_000_000
+    const result = num * multiplier
+    // Avoid floating point artifacts: use integer if whole number
+    return Number.isInteger(result) ? result.toString() : result.toFixed(2)
+  }
+
+  // Try to parse as a plain number (validates it's actually numeric)
+  const parsed = parseFloat(cleaned)
+  if (!isNaN(parsed) && isFinite(parsed)) {
+    return Number.isInteger(parsed) ? parsed.toString() : parsed.toString()
+  }
+
+  // Fallback: return cleaned string if it doesn't parse as a number
+  return cleaned
+}

--- a/packages/shared/src/labels/auto/types.ts
+++ b/packages/shared/src/labels/auto/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Auto-Label Types
+ *
+ * Result types for the auto-label evaluation pipeline.
+ * An AutoLabelMatch represents a single extracted label+value from a user message.
+ */
+
+/**
+ * A single match from auto-label evaluation.
+ * Represents a label that should be applied to the session.
+ */
+export interface AutoLabelMatch {
+  /** Label ID to apply */
+  labelId: string
+  /** Normalized value ready for storage (already formatted per valueType) */
+  value: string
+  /** The original text in the message that triggered this match */
+  matchedText: string
+}

--- a/packages/shared/src/labels/auto/validation.ts
+++ b/packages/shared/src/labels/auto/validation.ts
@@ -1,0 +1,76 @@
+/**
+ * Auto-Label Rule Validation
+ *
+ * Validates auto-label rule patterns at config-save time to catch
+ * invalid regex syntax and catastrophic backtracking patterns early.
+ *
+ * Called from the label config validator (validators.ts) when labels/config.json
+ * is being written.
+ */
+
+export interface AutoLabelValidationResult {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+}
+
+/**
+ * Known catastrophic backtracking patterns (nested quantifiers).
+ * These can cause ReDoS (Regular Expression Denial of Service) by making
+ * the regex engine take exponential time on non-matching inputs.
+ *
+ * Matches patterns like: (a+)+, (a*)+, (\w+)*, ([a-z]+)+
+ */
+const CATASTROPHIC_BACKTRACKING_PATTERNS = [
+  /\([^)]*[+*][^)]*\)[+*]/, // (x+)+ or (x*)+ or (x+)* etc.
+  /\([^)]*[+*][^)]*\)\{/,   // (x+){n} quantified groups with inner quantifier
+]
+
+/**
+ * Validate a single auto-label rule.
+ * Checks regex syntax, flags, and known problematic patterns.
+ *
+ * @param pattern - The regex pattern string
+ * @param flags - Optional flags (defaults to 'gi')
+ * @returns Validation result with errors/warnings
+ */
+export function validateAutoLabelRule(pattern: string, flags?: string): AutoLabelValidationResult {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  // 1. Check regex compiles without errors
+  try {
+    const effectiveFlags = flags
+      ? (flags.includes('g') ? flags : flags + 'g')
+      : 'gi'
+    new RegExp(pattern, effectiveFlags)
+  } catch (e) {
+    errors.push(`Invalid regex pattern: ${e instanceof Error ? e.message : 'Unknown error'}`)
+    return { valid: false, errors, warnings }
+  }
+
+  // 2. Check for catastrophic backtracking patterns (nested quantifiers)
+  for (const badPattern of CATASTROPHIC_BACKTRACKING_PATTERNS) {
+    if (badPattern.test(pattern)) {
+      errors.push(
+        `Pattern contains nested quantifiers which can cause catastrophic backtracking (ReDoS). ` +
+        `Simplify the pattern to avoid nested repetition like (a+)+.`
+      )
+      break
+    }
+  }
+
+  // 3. Warn about missing capture groups when no valueTemplate could use $1
+  if (!pattern.includes('(') || pattern.replace(/\(\?[:<!=]/g, '').indexOf('(') === -1) {
+    warnings.push(
+      'Pattern has no capture groups. The entire match will be used as the label value. ' +
+      'Add capture groups (parentheses) to extract specific parts.'
+    )
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  }
+}

--- a/packages/shared/src/labels/crud.ts
+++ b/packages/shared/src/labels/crud.ts
@@ -1,0 +1,269 @@
+/**
+ * Label CRUD Operations
+ *
+ * Create, Read, Update, Delete, Move, Reorder operations for the label tree.
+ * All operations work on the nested JSON tree structure.
+ * Delete cascade strips the label (and descendants) from all sessions.
+ */
+
+import { loadLabelConfig, saveLabelConfig } from './storage.ts';
+import { findLabelById, collectAllIds, getDescendantIds } from './tree.ts';
+import { extractLabelId } from './values.ts';
+import type { LabelConfig, CreateLabelInput, UpdateLabelInput } from './types.ts';
+
+/**
+ * Generate URL-safe slug from name
+ */
+function generateLabelSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 30);
+}
+
+/**
+ * Create a new label.
+ * Inserts into the specified parent's children array, or at root level.
+ * Generates a globally unique slug from the name.
+ */
+export function createLabel(
+  workspaceRootPath: string,
+  input: CreateLabelInput
+): LabelConfig {
+  const config = loadLabelConfig(workspaceRootPath);
+
+  // Generate unique ID across the entire tree
+  const existingIds = collectAllIds(config.labels);
+  let id = generateLabelSlug(input.name);
+  let suffix = 2;
+  while (existingIds.has(id)) {
+    id = `${generateLabelSlug(input.name)}-${suffix}`;
+    suffix++;
+  }
+
+  const label: LabelConfig = {
+    id,
+    name: input.name,
+    color: input.color,
+    ...(input.valueType && { valueType: input.valueType }),
+  };
+
+  if (input.parentId) {
+    // Insert as child of the specified parent
+    const parent = findLabelById(config.labels, input.parentId);
+    if (!parent) {
+      throw new Error(`Parent label '${input.parentId}' not found`);
+    }
+    if (!parent.children) parent.children = [];
+    parent.children.push(label);
+  } else {
+    // Insert at root level
+    config.labels.push(label);
+  }
+
+  saveLabelConfig(workspaceRootPath, config);
+  return label;
+}
+
+/**
+ * Update an existing label (name, color, valueType).
+ * Cannot change the ID or hierarchy position.
+ * @throws Error if label not found
+ */
+export function updateLabel(
+  workspaceRootPath: string,
+  labelId: string,
+  updates: UpdateLabelInput
+): LabelConfig {
+  const config = loadLabelConfig(workspaceRootPath);
+  const label = findLabelById(config.labels, labelId);
+
+  if (!label) {
+    throw new Error(`Label '${labelId}' not found`);
+  }
+
+  if (updates.name !== undefined) label.name = updates.name;
+  if (updates.color !== undefined) label.color = updates.color;
+  // valueType: set to new value, or delete to revert to boolean label
+  if (updates.valueType !== undefined) label.valueType = updates.valueType || undefined;
+
+  saveLabelConfig(workspaceRootPath, config);
+  return label;
+}
+
+/**
+ * Delete a label and all its descendants.
+ * Strips removed labels from all sessions that reference them.
+ * @returns Number of sessions that had labels stripped
+ */
+export function deleteLabel(
+  workspaceRootPath: string,
+  labelId: string
+): { stripped: number } {
+  const config = loadLabelConfig(workspaceRootPath);
+
+  // Collect all IDs that will be removed (the label + all descendants)
+  const descendantIds = getDescendantIds(config.labels, labelId);
+  const removedIds = [labelId, ...descendantIds];
+
+  // Remove the node from its parent's children array (or from root)
+  const removed = removeNodeFromTree(config.labels, labelId);
+  if (!removed) {
+    throw new Error(`Label '${labelId}' not found`);
+  }
+
+  saveLabelConfig(workspaceRootPath, config);
+
+  // Strip all removed IDs from sessions
+  let stripped = 0;
+  for (const id of removedIds) {
+    stripped += stripLabelFromSessions(workspaceRootPath, id);
+  }
+
+  return { stripped };
+}
+
+/**
+ * Reorder labels within a parent's children (or root level).
+ * Provide the full ordered list of sibling IDs at that level.
+ * @param parentId - null for root level, or the parent label's ID
+ * @param orderedIds - New order of child IDs at that level
+ */
+export function reorderLabels(
+  workspaceRootPath: string,
+  parentId: string | null,
+  orderedIds: string[]
+): void {
+  const config = loadLabelConfig(workspaceRootPath);
+
+  // Get the target array (root labels or a parent's children)
+  let siblings: LabelConfig[];
+  if (parentId) {
+    const parent = findLabelById(config.labels, parentId);
+    if (!parent) throw new Error(`Parent label '${parentId}' not found`);
+    if (!parent.children) throw new Error(`Parent label '${parentId}' has no children`);
+    siblings = parent.children;
+  } else {
+    siblings = config.labels;
+  }
+
+  // Validate that orderedIds match the current siblings
+  const siblingIds = new Set(siblings.map(l => l.id));
+  for (const id of orderedIds) {
+    if (!siblingIds.has(id)) {
+      throw new Error(`Invalid label ID for reorder: '${id}'`);
+    }
+  }
+
+  // Build a map for quick lookup, then reorder the array in place
+  const map = new Map(siblings.map(l => [l.id, l]));
+  const reordered = orderedIds.map(id => map.get(id)!);
+
+  // Replace the array contents (preserving the same reference for root)
+  if (parentId) {
+    const parent = findLabelById(config.labels, parentId)!;
+    parent.children = reordered;
+  } else {
+    config.labels.length = 0;
+    config.labels.push(...reordered);
+  }
+
+  saveLabelConfig(workspaceRootPath, config);
+}
+
+/**
+ * Move a label to a different parent (or to root level).
+ * The label keeps its ID and children intact.
+ * @param newParentId - null to move to root, or target parent's ID
+ */
+export function moveLabel(
+  workspaceRootPath: string,
+  labelId: string,
+  newParentId: string | null
+): void {
+  const config = loadLabelConfig(workspaceRootPath);
+
+  // Prevent moving a label into its own descendant (would create a cycle)
+  if (newParentId) {
+    const descendants = getDescendantIds(config.labels, labelId);
+    if (descendants.includes(newParentId)) {
+      throw new Error(`Cannot move label '${labelId}' into its own descendant '${newParentId}'`);
+    }
+  }
+
+  // Remove from current location (preserving the node reference)
+  const node = removeNodeFromTree(config.labels, labelId);
+  if (!node) {
+    throw new Error(`Label '${labelId}' not found`);
+  }
+
+  // Insert into new location
+  if (newParentId) {
+    const newParent = findLabelById(config.labels, newParentId);
+    if (!newParent) throw new Error(`Target parent '${newParentId}' not found`);
+    if (!newParent.children) newParent.children = [];
+    newParent.children.push(node);
+  } else {
+    config.labels.push(node);
+  }
+
+  saveLabelConfig(workspaceRootPath, config);
+}
+
+// ============================================================
+// Internal Helpers
+// ============================================================
+
+/**
+ * Remove a node from the tree by ID. Returns the removed node or null.
+ * Mutates the tree in place (removes from parent's children or root array).
+ */
+function removeNodeFromTree(labels: LabelConfig[], targetId: string): LabelConfig | null {
+  // Check root level
+  const rootIndex = labels.findIndex(l => l.id === targetId);
+  if (rootIndex !== -1) {
+    return labels.splice(rootIndex, 1)[0]!;
+  }
+
+  // Recurse into children
+  for (const node of labels) {
+    if (node.children) {
+      const childIndex = node.children.findIndex(c => c.id === targetId);
+      if (childIndex !== -1) {
+        return node.children.splice(childIndex, 1)[0]!;
+      }
+      const found = removeNodeFromTree(node.children, targetId);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Strip a deleted label from all sessions.
+ * Removes entries matching the label ID, including valued entries (e.g., "priority::3").
+ * Uses extractLabelId to match both "bug" and "priority::3" style entries.
+ */
+function stripLabelFromSessions(
+  workspaceRootPath: string,
+  deletedLabelId: string
+): number {
+  // Dynamic import to avoid circular dependency with sessions module
+  const { listSessions, updateSessionMetadata } = require('../sessions/storage.ts');
+
+  const sessions = listSessions(workspaceRootPath);
+  let strippedCount = 0;
+
+  for (const session of sessions) {
+    // Check if any entry matches the deleted label ID (handles both boolean and valued entries)
+    if (session.labels && session.labels.some((entry: string) => extractLabelId(entry) === deletedLabelId)) {
+      const updatedLabels = session.labels.filter((entry: string) => extractLabelId(entry) !== deletedLabelId);
+      updateSessionMetadata(workspaceRootPath, session.id, { labels: updatedLabels });
+      strippedCount++;
+    }
+  }
+
+  return strippedCount;
+}

--- a/packages/shared/src/labels/index.ts
+++ b/packages/shared/src/labels/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Labels Module
+ *
+ * Configurable session labels for workspaces.
+ * Labels are additive tags (many-per-session), unlike statuses which are exclusive.
+ * Hierarchy is encoded as a nested JSON tree (children arrays).
+ *
+ * This barrel is browser-safe (no Node.js dependencies).
+ * For filesystem operations, import from '@craft-agent/shared/labels/storage'.
+ */
+
+// Types
+export * from './types.ts';
+
+// Tree utilities (recursive operations on the nested label tree)
+export * from './tree.ts';
+
+// Value utilities (parse/format label::value entries)
+export * from './values.ts';
+
+// Auto-labels: import directly from '@craft-agent/shared/labels/auto' to keep
+// regex evaluation code out of the renderer bundle (backend-only concern).

--- a/packages/shared/src/labels/storage.ts
+++ b/packages/shared/src/labels/storage.ts
@@ -1,0 +1,205 @@
+/**
+ * Label Storage
+ *
+ * Filesystem-based storage for workspace label configurations.
+ * Labels are stored at {workspaceRootPath}/labels/config.json
+ *
+ * Hierarchy: Labels form a nested JSON tree. IDs are simple slugs.
+ * New workspaces are seeded with default labels (Development + Content groups).
+ * Labels are visual by color only (colored circles in the UI).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { WorkspaceLabelConfig, LabelConfig } from './types.ts';
+import { flattenLabels, findLabelById } from './tree.ts';
+import { migrateLabelColors } from '../colors/migrate.ts';
+import { debug } from '../utils/debug.ts';
+
+const LABEL_CONFIG_DIR = 'labels';
+const LABEL_CONFIG_FILE = 'labels/config.json';
+
+/**
+ * Get default label configuration.
+ * Provides a starter set of labels organized into two complementary color families:
+ * - Development (blue family): Code, Bug, Automation
+ * - Content (purple family): Writing, Research, Design
+ * Plus flat valued labels: Priority (number), Project (string)
+ *
+ * Children use hue-shifted shades of their parent color to show visual hierarchy.
+ */
+export function getDefaultLabelConfig(): WorkspaceLabelConfig {
+  return {
+    version: 1,
+    labels: [
+      {
+        id: 'development',
+        name: 'Development',
+        color: { light: '#3B82F6', dark: '#60A5FA' },
+        children: [
+          {
+            id: 'code',
+            name: 'Code',
+            color: { light: '#4F46E5', dark: '#818CF8' }, // indigo shift
+          },
+          {
+            id: 'bug',
+            name: 'Bug',
+            color: { light: '#0EA5E9', dark: '#38BDF8' }, // sky shift
+          },
+          {
+            id: 'automation',
+            name: 'Automation',
+            color: { light: '#06B6D4', dark: '#22D3EE' }, // cyan shift
+          },
+        ],
+      },
+      {
+        id: 'content',
+        name: 'Content',
+        color: { light: '#8B5CF6', dark: '#A78BFA' },
+        children: [
+          {
+            id: 'writing',
+            name: 'Writing',
+            color: { light: '#7C3AED', dark: '#C4B5FD' }, // deeper violet
+          },
+          {
+            id: 'research',
+            name: 'Research',
+            color: { light: '#A855F7', dark: '#C084FC' }, // lighter purple
+          },
+          {
+            id: 'design',
+            name: 'Design',
+            color: { light: '#D946EF', dark: '#E879F9' }, // fuchsia shift
+          },
+        ],
+      },
+      {
+        id: 'priority',
+        name: 'Priority',
+        color: { light: '#F59E0B', dark: '#FBBF24' },
+        valueType: 'number',
+      },
+      {
+        id: 'project',
+        name: 'Project',
+        color: 'foreground/50',
+        valueType: 'string',
+      },
+    ],
+  };
+}
+
+/**
+ * Load workspace label configuration.
+ * Returns empty config if no file exists or parsing fails.
+ * Auto-migrates old Tailwind color format to EntityColor on first load.
+ */
+export function loadLabelConfig(workspaceRootPath: string): WorkspaceLabelConfig {
+  const configPath = join(workspaceRootPath, LABEL_CONFIG_FILE);
+
+  // If no config file exists, seed with defaults and persist to disk.
+  // This ensures existing workspaces (created before default labels existed) get populated.
+  if (!existsSync(configPath)) {
+    const defaults = getDefaultLabelConfig();
+    debug('[loadLabelConfig] No config found, seeding with default labels');
+    saveLabelConfig(workspaceRootPath, defaults);
+    return defaults;
+  }
+
+  try {
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as WorkspaceLabelConfig;
+
+    // Auto-migrate old Tailwind class colors (e.g., "text-accent") to new EntityColor format.
+    // If migration occurs, write the updated config back to disk.
+    const migrated = migrateLabelColors(config);
+    if (migrated) {
+      debug('[loadLabelConfig] Migrated old color format, writing back');
+      saveLabelConfig(workspaceRootPath, config);
+    }
+
+    return config;
+  } catch (error) {
+    debug('[loadLabelConfig] Failed to parse config:', error);
+    return getDefaultLabelConfig();
+  }
+}
+
+/**
+ * Save workspace label configuration to disk.
+ * Creates the labels directory if missing.
+ */
+export function saveLabelConfig(
+  workspaceRootPath: string,
+  config: WorkspaceLabelConfig
+): void {
+  const labelDir = join(workspaceRootPath, LABEL_CONFIG_DIR);
+  const configPath = join(workspaceRootPath, LABEL_CONFIG_FILE);
+
+  if (!existsSync(labelDir)) {
+    mkdirSync(labelDir, { recursive: true });
+  }
+
+  try {
+    writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+  } catch (error) {
+    debug('[saveLabelConfig] Failed to save config:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get the label tree (root-level labels with nested children).
+ * Primary accessor for the UI — returns the tree structure as-is from config.
+ */
+export function listLabels(workspaceRootPath: string): LabelConfig[] {
+  const config = loadLabelConfig(workspaceRootPath);
+  return config.labels;
+}
+
+/**
+ * Get all labels as a flat list (tree flattened depth-first).
+ * Useful for lookups, session label validation, and non-hierarchical display.
+ */
+export function listLabelsFlat(workspaceRootPath: string): LabelConfig[] {
+  const config = loadLabelConfig(workspaceRootPath);
+  return flattenLabels(config.labels);
+}
+
+/**
+ * Get a single label by ID (searches the entire tree).
+ * Returns null if not found.
+ */
+export function getLabel(
+  workspaceRootPath: string,
+  labelId: string
+): LabelConfig | null {
+  const config = loadLabelConfig(workspaceRootPath);
+  return findLabelById(config.labels, labelId) || null;
+}
+
+/**
+ * Check if a label ID exists in this workspace (searches entire tree)
+ */
+export function isValidLabelId(
+  workspaceRootPath: string,
+  labelId: string
+): boolean {
+  const config = loadLabelConfig(workspaceRootPath);
+  return !!findLabelById(config.labels, labelId);
+}
+
+/**
+ * Validate label ID format.
+ * Simple slug: lowercase alphanumeric + hyphens, no leading/trailing hyphens.
+ * Examples: "bug", "frontend", "my-label"
+ */
+export function isValidLabelIdFormat(labelId: string): boolean {
+  if (!labelId) return false;
+  const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+  return SLUG_PATTERN.test(labelId);
+}
+
+

--- a/packages/shared/src/labels/tree.ts
+++ b/packages/shared/src/labels/tree.ts
@@ -1,0 +1,145 @@
+/**
+ * Label Tree Utilities
+ *
+ * The label config IS a nested JSON tree — no conversion from flat list needed.
+ * These utilities provide recursive operations on the tree:
+ * - flattenLabels: collect all labels into a flat array (for ID lookups, validation)
+ * - findLabelById: locate a label node anywhere in the tree
+ * - getDescendantIds: get all child/grandchild IDs (for hierarchical filtering)
+ * - findParent: find the parent label of a given label ID
+ *
+ * Sessions reference labels by simple slug IDs (e.g., ["react", "bug"]).
+ * Filtering by a parent includes all descendants.
+ */
+
+import type { LabelConfig } from './types.ts';
+
+/**
+ * Flatten the entire label tree into a one-dimensional array.
+ * Useful for ID lookups, uniqueness validation, and session label checks.
+ * Traverses depth-first (parent before children).
+ */
+export function flattenLabels(labels: LabelConfig[]): LabelConfig[] {
+  const result: LabelConfig[] = [];
+
+  function walk(nodes: LabelConfig[]): void {
+    for (const node of nodes) {
+      result.push(node);
+      if (node.children && node.children.length > 0) {
+        walk(node.children);
+      }
+    }
+  }
+
+  walk(labels);
+  return result;
+}
+
+/**
+ * Find a label by ID anywhere in the tree.
+ * Returns the label config or undefined if not found.
+ */
+export function findLabelById(labels: LabelConfig[], id: string): LabelConfig | undefined {
+  for (const node of labels) {
+    if (node.id === id) return node;
+    if (node.children && node.children.length > 0) {
+      const found = findLabelById(node.children, id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Get all descendant label IDs for a given label.
+ * Used for hierarchical filtering — clicking a parent label shows sessions
+ * tagged with it OR any of its descendants.
+ * Does NOT include the label itself, only its children/grandchildren.
+ */
+export function getDescendantIds(labels: LabelConfig[], parentId: string): string[] {
+  // First find the parent node in the tree
+  const parent = findLabelById(labels, parentId);
+  if (!parent || !parent.children || parent.children.length === 0) {
+    return [];
+  }
+
+  // Collect all descendant IDs recursively
+  const result: string[] = [];
+  function collectIds(nodes: LabelConfig[]): void {
+    for (const node of nodes) {
+      result.push(node.id);
+      if (node.children && node.children.length > 0) {
+        collectIds(node.children);
+      }
+    }
+  }
+
+  collectIds(parent.children);
+  return result;
+}
+
+/**
+ * Find the parent of a given label ID in the tree.
+ * Returns the parent LabelConfig or undefined if the label is at root level.
+ */
+export function findParent(labels: LabelConfig[], targetId: string): LabelConfig | undefined {
+  for (const node of labels) {
+    if (node.children) {
+      // Check if any direct child matches
+      if (node.children.some(child => child.id === targetId)) {
+        return node;
+      }
+      // Recurse into children
+      const found = findParent(node.children, targetId);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Collect all IDs that exist in the tree.
+ * Convenience wrapper around flattenLabels for quick membership checks.
+ */
+export function collectAllIds(labels: LabelConfig[]): Set<string> {
+  return new Set(flattenLabels(labels).map(l => l.id));
+}
+
+/**
+ * UI-friendly tree node wrapping LabelConfig.
+ * Used by the sidebar to render hierarchical label navigation.
+ */
+export interface LabelTreeNode {
+  /** Full unique identifier (same as label.id in tree-based config) */
+  fullId: string;
+  /** The slug segment of this node */
+  segment: string;
+  /** Associated LabelConfig (always present in tree-based config) */
+  label: LabelConfig;
+  /** Child tree nodes */
+  children: LabelTreeNode[];
+}
+
+/**
+ * Convert a LabelConfig[] tree into LabelTreeNode[] for the UI.
+ * Since the config is already a nested tree, this maps each node
+ * to the UI shape with fullId/segment fields.
+ */
+export function buildLabelTree(labels: LabelConfig[]): LabelTreeNode[] {
+  return labels.map(label => ({
+    fullId: label.id,
+    segment: label.id,
+    label,
+    children: label.children ? buildLabelTree(label.children) : [],
+  }));
+}
+
+/**
+ * Get the display name for a label by its ID.
+ * Falls back to titlecased slug if label not found in the tree.
+ */
+export function getLabelDisplayName(labels: LabelConfig[], labelId: string): string {
+  const label = findLabelById(labels, labelId);
+  if (label) return label.name;
+  return labelId.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+}

--- a/packages/shared/src/labels/types.ts
+++ b/packages/shared/src/labels/types.ts
@@ -1,0 +1,127 @@
+/**
+ * Label Types
+ *
+ * Types for configurable session labels.
+ * Labels are additive tags (many-per-session), unlike statuses which are exclusive (one-per-session).
+ * Stored at {workspaceRootPath}/labels/config.json
+ *
+ * Hierarchy: Labels form a recursive JSON tree via the `children` array.
+ * Array position determines display order (no separate order field).
+ * IDs are simple slugs, globally unique across the entire tree.
+ *
+ * Visual: Labels are identified by color only (rendered as colored circles).
+ *
+ * Color format: EntityColor (system color string or custom color object)
+ * - System: "accent", "foreground/50", "info/80" (uses CSS variables, auto light/dark)
+ * - Custom: { light: "#EF4444", dark: "#F87171" } (explicit values)
+ */
+
+import type { EntityColor } from '../colors/types.ts'
+
+/**
+ * Auto-label rule: regex pattern that scans user messages and automatically
+ * applies labels with extracted values.
+ *
+ * Uses capture groups ($1, $2, etc.) in the pattern and substitutes them
+ * into the valueTemplate. Rules are evaluated in order. Multiple rules on
+ * the same label means multiple ways to trigger it (e.g., URL regex + bare
+ * key regex for issue IDs).
+ */
+export interface AutoLabelRule {
+  /** Regex pattern with capture groups for value extraction */
+  pattern: string
+  /** Regex flags (default: 'gi' for global, case-insensitive). 'g' is always enforced. */
+  flags?: string
+  /** Template for the label value using $1, $2, etc. for capture group substitution */
+  valueTemplate?: string
+  /** Human-readable description of what this rule matches */
+  description?: string
+}
+
+/**
+ * Label configuration (stored in labels/config.json).
+ * Recursive: each label can have nested children forming a tree.
+ * Array position = display order (no explicit order field needed).
+ */
+export interface LabelConfig {
+  /** Unique ID — simple slug, globally unique across the tree (e.g., 'bug', 'frontend') */
+  id: string;
+
+  /** Display name */
+  name: string;
+
+  /** Optional color. Rendered as a colored circle in the UI. */
+  color?: EntityColor;
+
+  /** Child labels forming a sub-tree. Array position = display order. */
+  children?: LabelConfig[];
+
+  /**
+   * Optional value type hint for UI rendering and agent affordances.
+   * When set, indicates this label carries a typed value (e.g., "priority::3").
+   * Parser always infers the type from raw value, but this hint tells UI
+   * what input widget to show and tells the agent what format to write.
+   * Omit for boolean (presence-only) labels.
+   */
+  valueType?: 'string' | 'number' | 'date';
+
+  /**
+   * Auto-label rules: regex patterns that scan user messages and automatically
+   * apply this label with extracted values.
+   * Multiple rules = multiple ways to trigger (evaluated in order, all matches collected).
+   */
+  autoRules?: AutoLabelRule[];
+}
+
+/**
+ * Complete label configuration for a workspace
+ */
+export interface WorkspaceLabelConfig {
+  /** Schema version (start at 1) */
+  version: number;
+
+  /** Root-level labels. Array position = display order. May contain nested children. */
+  labels: LabelConfig[];
+}
+
+/**
+ * Input for creating a new label (via CRUD operations).
+ * parentId determines where in the tree to insert (null/undefined = root level).
+ */
+export interface CreateLabelInput {
+  name: string;
+  color?: EntityColor;
+  parentId?: string; // Target parent label ID (null = root)
+  valueType?: 'string' | 'number' | 'date';
+}
+
+/**
+ * Input for updating an existing label (name, color, valueType — cannot change ID or hierarchy)
+ */
+export interface UpdateLabelInput {
+  name?: string;
+  color?: EntityColor;
+  valueType?: 'string' | 'number' | 'date';
+}
+
+/**
+ * Parsed session label entry (after splitting on ::).
+ * Session labels are stored as flat strings like "bug" or "priority::3".
+ * This interface represents the parsed form for typed access.
+ */
+export interface ParsedLabelEntry {
+  /** Label ID (the part before ::, or the entire string for boolean labels) */
+  id: string;
+
+  /** Raw string value (the part after ::), undefined for boolean labels */
+  rawValue?: string;
+
+  /**
+   * Typed value inferred from rawValue:
+   * - number: if rawValue parses as a finite number
+   * - Date: if rawValue matches ISO date format (YYYY-MM-DD)
+   * - string: otherwise
+   * - undefined: for boolean labels (no :: separator)
+   */
+  value?: string | number | Date;
+}

--- a/packages/shared/src/labels/validation.ts
+++ b/packages/shared/src/labels/validation.ts
@@ -1,0 +1,33 @@
+/**
+ * Label Validation
+ *
+ * Session-level validation for label references.
+ * Checks that session label IDs exist in the workspace's label tree.
+ * Invalid IDs are silently filtered out (handles deleted labels gracefully).
+ */
+
+import { isValidLabelId } from './storage.ts';
+import { extractLabelId } from './values.ts';
+
+/**
+ * Validate a session's labels array.
+ * Filters out any label IDs that no longer exist in the workspace config.
+ * Handles valued entries (e.g., "priority::3") by extracting the ID before checking.
+ * Returns the cleaned array (invalid IDs silently removed, values preserved).
+ *
+ * @param workspaceRootPath - Workspace root path
+ * @param labels - Array of label entries to validate (may contain :: values)
+ * @returns Array of valid label entries only
+ */
+export function validateSessionLabels(
+  workspaceRootPath: string,
+  labels: string[] | undefined
+): string[] {
+  if (!labels || labels.length === 0) {
+    return [];
+  }
+
+  // Extract label ID from entries (handles "priority::3" → "priority")
+  // then validate the ID exists in config. Preserves the full entry string.
+  return labels.filter(entry => isValidLabelId(workspaceRootPath, extractLabelId(entry)));
+}

--- a/packages/shared/src/labels/values.ts
+++ b/packages/shared/src/labels/values.ts
@@ -1,0 +1,150 @@
+/**
+ * Label Value Utilities
+ *
+ * Parser and formatter for label entries that carry typed values.
+ * Session labels are stored as flat strings: "bug" (boolean) or "priority::3" (valued).
+ * The :: separator splits label ID from value. Values are type-inferred at parse time.
+ *
+ * Value type inference order:
+ * 1. ISO date (YYYY-MM-DD) → Date
+ * 2. Finite number → number
+ * 3. Everything else → string
+ */
+
+import type { ParsedLabelEntry } from './types.ts';
+
+/** Separator between label ID and value in session label entries */
+const VALUE_SEPARATOR = '::';
+
+/** ISO date pattern: YYYY-MM-DD (date-only, strict format) */
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+/** ISO datetime pattern: YYYY-MM-DDTHH:mm (date + time, no seconds) */
+const ISO_DATETIME_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+
+/** Simple decimal number: optional negative, digits, optional decimal portion */
+const DECIMAL_NUMBER_REGEX = /^-?\d+(\.\d+)?$/;
+
+/**
+ * Parse a session label entry into its structured form.
+ * Splits on the first :: only (values may themselves contain ::).
+ *
+ * Examples:
+ *   "bug"                  → { id: "bug" }
+ *   "priority::3"          → { id: "priority", rawValue: "3", value: 3 }
+ *   "due::2026-01-30"      → { id: "due", rawValue: "2026-01-30", value: Date }
+ *   "url::https://a::b"    → { id: "url", rawValue: "https://a::b", value: "https://a::b" }
+ */
+export function parseLabelEntry(entry: string): ParsedLabelEntry {
+  const separatorIndex = entry.indexOf(VALUE_SEPARATOR);
+
+  // No separator → boolean label
+  if (separatorIndex === -1) {
+    return { id: entry };
+  }
+
+  const id = entry.substring(0, separatorIndex);
+  const rawValue = entry.substring(separatorIndex + VALUE_SEPARATOR.length);
+
+  return {
+    id,
+    rawValue,
+    value: inferTypedValue(rawValue),
+  };
+}
+
+/**
+ * Format a label ID and optional value into the stored string form.
+ * Handles Date serialization to ISO date string (YYYY-MM-DD).
+ *
+ * Examples:
+ *   formatLabelEntry("bug")              → "bug"
+ *   formatLabelEntry("priority", 3)      → "priority::3"
+ *   formatLabelEntry("due", new Date())  → "due::2026-01-23"
+ *   formatLabelEntry("link", "https://") → "link::https://"
+ */
+export function formatLabelEntry(id: string, value?: string | number | Date): string {
+  if (value === undefined) {
+    return id;
+  }
+
+  // Serialize Date to ISO string — include time if not midnight UTC
+  if (value instanceof Date) {
+    const hours = value.getUTCHours();
+    const minutes = value.getUTCMinutes();
+    const hasTime = hours !== 0 || minutes !== 0;
+    const serialized = hasTime
+      ? `${value.toISOString().split('T')[0]}T${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`
+      : value.toISOString().split('T')[0];
+    return `${id}${VALUE_SEPARATOR}${serialized}`;
+  }
+
+  return `${id}${VALUE_SEPARATOR}${String(value)}`;
+}
+
+/**
+ * Quick extraction of label ID from an entry string.
+ * Use this when you only need the ID (e.g., for validation/filtering)
+ * without the overhead of full parsing.
+ *
+ * "priority::3" → "priority"
+ * "bug"         → "bug"
+ */
+export function extractLabelId(entry: string): string {
+  const separatorIndex = entry.indexOf(VALUE_SEPARATOR);
+  return separatorIndex === -1 ? entry : entry.substring(0, separatorIndex);
+}
+
+/**
+ * Format a raw label value for human-readable display.
+ * Dates get locale-formatted (e.g. "Jan 30, 2026"), numbers and strings pass through.
+ * Used by UI badge components to render the value portion after the interpunct.
+ */
+export function formatDisplayValue(rawValue: string, valueType?: 'string' | 'number' | 'date'): string {
+  if (valueType === 'date') {
+    // Parse date-only or datetime strings (matching the storage formats in parseLabelEntry)
+    const date = new Date(rawValue.includes('T') ? rawValue + ':00Z' : rawValue + 'T00:00:00Z');
+    if (!isNaN(date.getTime())) {
+      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    }
+  }
+  return rawValue;
+}
+
+// ============================================================
+// Internal Helpers
+// ============================================================
+
+/**
+ * Infer the typed value from a raw string.
+ * Order matters: date check first (dates also parse as numbers in some cases),
+ * then number, then fallback to string.
+ */
+function inferTypedValue(raw: string): string | number | Date {
+  // 1. Check ISO datetime format (YYYY-MM-DDTHH:mm) — must check before date-only
+  if (ISO_DATETIME_REGEX.test(raw)) {
+    const date = new Date(raw + ':00Z');
+    if (!isNaN(date.getTime())) {
+      return date;
+    }
+  }
+
+  // 2. Check ISO date format (YYYY-MM-DD)
+  if (ISO_DATE_REGEX.test(raw)) {
+    const date = new Date(raw + 'T00:00:00Z');
+    // Validate the date is real by round-tripping: prevents JS Date clamping
+    // invalid dates (e.g., 2026-02-29 → 2026-03-01) from being silently accepted
+    const roundTrip = date.toISOString().split('T')[0];
+    if (roundTrip === raw) {
+      return date;
+    }
+  }
+
+  // 3. Check if it's a simple decimal number (reject hex, octal, binary, scientific notation)
+  if (DECIMAL_NUMBER_REGEX.test(raw)) {
+    return Number(raw);
+  }
+
+  // 4. Fallback: plain string
+  return raw;
+}

--- a/packages/shared/src/sessions/index.ts
+++ b/packages/shared/src/sessions/index.ts
@@ -1,0 +1,91 @@
+/**
+ * Sessions Module
+ *
+ * Public exports for workspace-scoped session management.
+ *
+ * Sessions are stored in JSONL format:
+ * - Line 1: SessionHeader (metadata for fast list loading)
+ * - Lines 2+: StoredMessage (one message per line)
+ */
+
+// Types
+export type {
+  TodoState,
+  SessionTokenUsage,
+  StoredMessage,
+  SessionConfig,
+  StoredSession,
+  SessionMetadata,
+  SessionHeader,
+} from './types.ts';
+
+// Storage functions
+export {
+  // Directory utilities
+  ensureSessionsDir,
+  ensureSessionDir,
+  getSessionPath,
+  getSessionFilePath,
+  getSessionAttachmentsPath,
+  getSessionPlansPath,
+  ensureAttachmentsDir,
+  // ID generation
+  generateSessionId,
+  // Session CRUD
+  createSession,
+  getOrCreateSessionById,
+  saveSession,
+  loadSession,
+  listSessions,
+  deleteSession,
+  clearSessionMessages,
+  getOrCreateLatestSession,
+  // Metadata updates
+  updateSessionSdkId,
+  updateSessionMetadata,
+  flagSession,
+  unflagSession,
+  setSessionTodoState,
+  // Pending plan execution (Accept & Compact flow)
+  setPendingPlanExecution,
+  markCompactionComplete,
+  clearPendingPlanExecution,
+  getPendingPlanExecution,
+  // Session filtering
+  listFlaggedSessions,
+  listCompletedSessions,
+  listInboxSessions,
+  // Plan storage
+  formatPlanAsMarkdown,
+  parsePlanFromMarkdown,
+  savePlanToFile,
+  loadPlanFromFile,
+  loadPlanFromPath,
+  listPlanFiles,
+  deletePlanFile,
+  getMostRecentPlanFile,
+  // Async persistence queue
+  sessionPersistenceQueue,
+} from './storage.ts';
+
+// JSONL helpers (for direct access if needed)
+export {
+  readSessionHeader,
+  readSessionJsonl,
+  writeSessionJsonl,
+  createSessionHeader,
+} from './jsonl.ts';
+
+// Slug generator utilities
+export {
+  generateDatePrefix,
+  generateHumanSlug,
+  generateUniqueSessionId,
+  parseSessionId,
+  isHumanReadableId,
+} from './slug-generator.ts';
+
+// Word lists (for customization if needed)
+export { ADJECTIVES, NOUNS } from './word-lists.ts';
+
+

--- a/packages/shared/src/sessions/jsonl.ts
+++ b/packages/shared/src/sessions/jsonl.ts
@@ -1,0 +1,250 @@
+/**
+ * JSONL Session Storage
+ *
+ * Helpers for reading/writing sessions in JSONL format.
+ * Format: Line 1 = SessionHeader, Lines 2+ = StoredMessage (one per line)
+ */
+
+import { openSync, readSync, closeSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'fs';
+import { open, readFile } from 'fs/promises';
+import type { SessionHeader, StoredSession, StoredMessage, SessionTokenUsage } from './types.ts';
+import { toPortablePath, expandPath } from '../utils/paths.ts';
+import { debug } from '../utils/debug.ts';
+
+/**
+ * Read only the header (first line) from a session.jsonl file.
+ * Uses low-level fs to read minimal bytes for fast list loading.
+ */
+export function readSessionHeader(sessionFile: string): SessionHeader | null {
+  try {
+    const fd = openSync(sessionFile, 'r');
+    const buffer = Buffer.alloc(8192); // 8KB is plenty for metadata header
+    const bytesRead = readSync(fd, buffer, 0, 8192, 0);
+    closeSync(fd);
+
+    const content = buffer.toString('utf-8', 0, bytesRead);
+    const firstNewline = content.indexOf('\n');
+    const firstLine = firstNewline > 0 ? content.slice(0, firstNewline) : content;
+
+    return JSON.parse(firstLine) as SessionHeader;
+  } catch (error) {
+    debug('[jsonl] Failed to read session header:', sessionFile, error);
+    return null;
+  }
+}
+
+/**
+ * Read full session from JSONL file.
+ * Parses header and all message lines.
+ */
+export function readSessionJsonl(sessionFile: string): StoredSession | null {
+  try {
+    const content = readFileSync(sessionFile, 'utf-8');
+    const lines = content.split('\n').filter(Boolean);
+
+    const firstLine = lines[0];
+    if (!firstLine) return null;
+
+    const header = JSON.parse(firstLine) as SessionHeader;
+    // Parse messages resiliently: skip lines that fail to parse (e.g. truncated by crash)
+    // rather than losing the entire session's messages
+    const messages = parseMessagesResilient(lines.slice(1));
+
+    // Migration: For sessions created before sdkCwd was added, use workingDirectory as fallback.
+    // This is correct because the old code used workingDirectory for SDK's cwd parameter.
+    const workingDir = header.workingDirectory ? expandPath(header.workingDirectory) : undefined;
+    const sdkCwd = header.sdkCwd ? expandPath(header.sdkCwd) : workingDir;
+
+    return {
+      id: header.id,
+      workspaceRootPath: expandPath(header.workspaceRootPath),
+      createdAt: header.createdAt,
+      lastUsedAt: header.lastUsedAt,
+      name: header.name,
+      sdkSessionId: header.sdkSessionId,
+      isFlagged: header.isFlagged,
+      todoState: header.todoState,
+      labels: header.labels,
+      permissionMode: header.permissionMode,
+      lastReadMessageId: header.lastReadMessageId,
+      hasUnread: header.hasUnread,  // Explicit unread flag for NEW badge state machine
+      enabledSourceSlugs: header.enabledSourceSlugs,
+      workingDirectory: workingDir,
+      sdkCwd,
+      sharedUrl: header.sharedUrl,
+      sharedId: header.sharedId,
+      model: header.model,
+      channel: header.channel,
+      messages,
+      tokenUsage: header.tokenUsage,
+    };
+  } catch (error) {
+    debug('[jsonl] Failed to read session:', sessionFile, error);
+    return null;
+  }
+}
+
+/**
+ * Write session to JSONL format using atomic write (write-to-temp-then-rename).
+ * Prevents file corruption if the process crashes mid-write: either the old
+ * file remains intact or the new file is fully written. Never a partial file.
+ *
+ * Line 1: Header with pre-computed metadata
+ * Lines 2+: Messages (one per line)
+ */
+export function writeSessionJsonl(sessionFile: string, session: StoredSession): void {
+  const header = createSessionHeader(session);
+
+  const lines = [
+    JSON.stringify(header),
+    ...session.messages.map(m => JSON.stringify(m)),
+  ];
+
+  const tmpFile = sessionFile + '.tmp';
+  writeFileSync(tmpFile, lines.join('\n') + '\n');
+  // On Windows, rename fails if target exists. Delete first for cross-platform compatibility.
+  try { unlinkSync(sessionFile); } catch { /* ignore if doesn't exist */ }
+  renameSync(tmpFile, sessionFile);
+}
+
+/**
+ * Create a SessionHeader from a StoredSession.
+ * Pre-computes messageCount, preview, and lastMessageRole for fast list loading.
+ */
+export function createSessionHeader(session: StoredSession): SessionHeader {
+  return {
+    id: session.id,
+    workspaceRootPath: toPortablePath(session.workspaceRootPath),
+    createdAt: session.createdAt,
+    lastUsedAt: Date.now(),
+    lastMessageAt: session.lastMessageAt,  // Actual message time, distinct from lastUsedAt (persist time)
+    name: session.name,
+    sdkSessionId: session.sdkSessionId,
+    isFlagged: session.isFlagged,
+    todoState: session.todoState,
+    labels: session.labels,
+    permissionMode: session.permissionMode,
+    lastReadMessageId: session.lastReadMessageId,
+    hasUnread: session.hasUnread,  // Explicit unread flag for NEW badge state machine
+    enabledSourceSlugs: session.enabledSourceSlugs,
+    workingDirectory: session.workingDirectory,
+    sdkCwd: session.sdkCwd,
+    sharedUrl: session.sharedUrl,
+    sharedId: session.sharedId,
+    model: session.model,
+    channel: session.channel,
+    // Pre-computed fields
+    messageCount: session.messages.length,
+    lastMessageRole: extractLastMessageRole(session.messages),
+    preview: extractPreview(session.messages),
+    tokenUsage: session.tokenUsage,
+    lastFinalMessageId: extractLastFinalMessageId(session.messages),
+  };
+}
+
+/**
+ * Extract the role of the last message for badge display.
+ * Only returns roles that are meaningful for UI display (user, assistant, plan, tool, error).
+ */
+function extractLastMessageRole(messages: StoredMessage[]): SessionHeader['lastMessageRole'] {
+  const lastMessage = messages[messages.length - 1];
+  if (!lastMessage) return undefined;
+  // Map message types to the subset we care about for display
+  const role = lastMessage.type;
+  if (role === 'user' || role === 'assistant' || role === 'plan' || role === 'tool' || role === 'error') {
+    return role;
+  }
+  return undefined;
+}
+
+/**
+ * Extract the ID of the last final (non-intermediate) assistant message.
+ * Used for unread detection in session list without loading all messages.
+ */
+function extractLastFinalMessageId(messages: StoredMessage[]): string | undefined {
+  // Walk backwards to find the last assistant message that isn't intermediate
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.type === 'assistant' && !msg.isIntermediate) {
+      return msg.id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract preview from first user message.
+ * Sanitizes by stripping special blocks and normalizing whitespace.
+ * Returns first 150 chars.
+ */
+function extractPreview(messages: StoredMessage[]): string | undefined {
+  const firstUserMessage = messages.find(m => m.type === 'user');
+  if (!firstUserMessage?.content) return undefined;
+
+  // Sanitize: strip special blocks and tags, normalize whitespace
+  const sanitized = firstUserMessage.content
+    .replace(/<edit_request>[\s\S]*?<\/edit_request>/g, '') // Strip entire edit_request blocks
+    .replace(/<[^>]+>/g, '')     // Strip remaining XML/HTML tags
+    .replace(/\s+/g, ' ')        // Collapse whitespace (including newlines)
+    .trim();
+
+  return sanitized.substring(0, 150) || undefined;
+}
+
+/**
+ * Async version of readSessionHeader for parallel I/O.
+ * Uses fs/promises for non-blocking reads.
+ */
+export async function readSessionHeaderAsync(sessionFile: string): Promise<SessionHeader | null> {
+  try {
+    const handle = await open(sessionFile, 'r');
+    try {
+      const buffer = Buffer.alloc(8192);
+      const { bytesRead } = await handle.read(buffer, 0, 8192, 0);
+      const content = buffer.toString('utf-8', 0, bytesRead);
+      const firstNewline = content.indexOf('\n');
+      const firstLine = firstNewline > 0 ? content.slice(0, firstNewline) : content;
+      return JSON.parse(firstLine) as SessionHeader;
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    debug('[jsonl] Failed to read session header async:', sessionFile, error);
+    return null;
+  }
+}
+
+/**
+ * Read only messages from a JSONL file (skips header).
+ * Used for lazy loading when session is selected.
+ * Resilient to corrupted/truncated lines (skips them instead of failing entirely).
+ */
+export function readSessionMessages(sessionFile: string): StoredMessage[] {
+  try {
+    const content = readFileSync(sessionFile, 'utf-8');
+    const lines = content.split('\n').filter(Boolean);
+    // Skip first line (header), parse rest as messages resiliently
+    return parseMessagesResilient(lines.slice(1));
+  } catch (error) {
+    debug('[jsonl] Failed to read session messages:', sessionFile, error);
+    return [];
+  }
+}
+
+/**
+ * Parse message lines resiliently: skip lines that fail JSON.parse
+ * (e.g. truncated by a crash mid-write) rather than losing all messages.
+ */
+function parseMessagesResilient(lines: string[]): StoredMessage[] {
+  const messages: StoredMessage[] = [];
+  for (const line of lines) {
+    try {
+      messages.push(JSON.parse(line) as StoredMessage);
+    } catch {
+      // Corrupted/truncated line (likely from a crash during write).
+      // Skip it and continue — losing one message is better than losing all.
+      debug('[jsonl] Skipping corrupted message line (truncated?):', line.substring(0, 100));
+    }
+  }
+  return messages;
+}

--- a/packages/shared/src/sessions/persistence-queue.ts
+++ b/packages/shared/src/sessions/persistence-queue.ts
@@ -1,0 +1,140 @@
+import { writeFile, rename, unlink } from 'fs/promises'
+import type { StoredSession, SessionHeader } from './types.js'
+import { getSessionFilePath, ensureSessionsDir, ensureSessionDir } from './storage.js'
+import { toPortablePath } from '../utils/paths.js'
+import { createSessionHeader } from './jsonl.js'
+import { debug } from '../utils/debug.js'
+
+interface PendingWrite {
+  data: StoredSession
+  timer: ReturnType<typeof setTimeout>
+}
+
+/**
+ * Debounced async session persistence queue.
+ * Prevents main thread blocking by using async writes and coalescing
+ * rapid successive persist calls into a single write.
+ */
+class SessionPersistenceQueue {
+  private pending = new Map<string, PendingWrite>()
+  private debounceMs: number
+
+  constructor(debounceMs = 500) {
+    this.debounceMs = debounceMs
+  }
+
+  /**
+   * Queue a session for persistence. If a write is already pending for this
+   * session, it will be replaced with the new data and the timer reset.
+   */
+  enqueue(session: StoredSession): void {
+    const existing = this.pending.get(session.id)
+    if (existing) {
+      clearTimeout(existing.timer)
+    }
+
+    const timer = setTimeout(() => {
+      void this.write(session.id)
+    }, this.debounceMs)
+
+    this.pending.set(session.id, { data: session, timer })
+  }
+
+  /**
+   * Write a session to disk immediately in JSONL format.
+   * Uses atomic write (write-to-temp-then-rename) to prevent corruption on crash.
+   */
+  private async write(sessionId: string): Promise<void> {
+    const entry = this.pending.get(sessionId)
+    if (!entry) return
+
+    this.pending.delete(sessionId)
+
+    try {
+      const { data } = entry
+      ensureSessionsDir(data.workspaceRootPath)
+      ensureSessionDir(data.workspaceRootPath, sessionId)
+
+      const filePath = getSessionFilePath(data.workspaceRootPath, sessionId)
+
+      // Prepare session with portable paths for cross-machine compatibility
+      const storageSession: StoredSession = {
+        ...data,
+        workspaceRootPath: toPortablePath(data.workspaceRootPath),
+        workingDirectory: data.workingDirectory ? toPortablePath(data.workingDirectory) : undefined,
+        sdkCwd: data.sdkCwd ? toPortablePath(data.sdkCwd) : undefined,
+        lastUsedAt: Date.now(),
+      }
+
+      // Create JSONL content: header + messages (one per line)
+      const header = createSessionHeader(storageSession)
+      const lines = [
+        JSON.stringify(header),
+        ...storageSession.messages.map(m => JSON.stringify(m)),
+      ]
+
+      // Atomic write: write to .tmp then rename over the real file.
+      // If the process crashes mid-write, only the .tmp is corrupted —
+      // the original session.jsonl remains intact.
+      const tmpFile = filePath + '.tmp'
+      await writeFile(tmpFile, lines.join('\n') + '\n', 'utf-8')
+      // On Windows, rename fails if target exists. Delete first for cross-platform compatibility.
+      try { await unlink(filePath) } catch { /* ignore if doesn't exist */ }
+      await rename(tmpFile, filePath)
+      debug(`[PersistenceQueue] Wrote session ${sessionId}`)
+    } catch (error) {
+      console.error(`[PersistenceQueue] Failed to write session ${sessionId}:`, error)
+    }
+  }
+
+  /**
+   * Immediately flush a specific session if pending.
+   */
+  async flush(sessionId: string): Promise<void> {
+    const entry = this.pending.get(sessionId)
+    if (entry) {
+      clearTimeout(entry.timer)
+      await this.write(sessionId)
+    }
+  }
+
+  /**
+   * Cancel a pending write for a session (e.g., when deleting the session).
+   */
+  cancel(sessionId: string): void {
+    const entry = this.pending.get(sessionId)
+    if (entry) {
+      clearTimeout(entry.timer)
+      this.pending.delete(sessionId)
+      debug(`[PersistenceQueue] Cancelled pending write for session ${sessionId}`)
+    }
+  }
+
+  /**
+   * Flush all pending sessions. Call this on app quit.
+   */
+  async flushAll(): Promise<void> {
+    const sessionIds = [...this.pending.keys()]
+    await Promise.all(sessionIds.map(id => this.flush(id)))
+  }
+
+  /**
+   * Check if a session has a pending write.
+   */
+  hasPending(sessionId: string): boolean {
+    return this.pending.has(sessionId)
+  }
+
+  /**
+   * Get count of pending writes.
+   */
+  get pendingCount(): number {
+    return this.pending.size
+  }
+}
+
+// Singleton instance
+export const sessionPersistenceQueue = new SessionPersistenceQueue()
+
+// Named exports for testing/customization
+export { SessionPersistenceQueue }

--- a/packages/shared/src/sessions/slug-generator.ts
+++ b/packages/shared/src/sessions/slug-generator.ts
@@ -1,0 +1,122 @@
+/**
+ * Human-Readable Session ID Generator
+ *
+ * Generates session IDs in the format: YYMMDD-adjective-noun
+ * Example: 260111-swift-river
+ *
+ * - Time-sortable by date prefix
+ * - Human-readable and memorable
+ * - ~20,000 unique combinations per day
+ * - Collision handling with numeric suffix
+ */
+
+import { ADJECTIVES, NOUNS } from './word-lists.ts';
+
+/**
+ * Generate date prefix in YYMMDD format
+ */
+export function generateDatePrefix(date: Date = new Date()): string {
+  const year = date.getFullYear().toString().slice(-2);
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+/**
+ * Get a random element from an array using crypto.getRandomValues
+ */
+function getRandomElement<T>(array: readonly T[]): T {
+  const randomIndex = crypto.getRandomValues(new Uint32Array(1))[0]! % array.length;
+  return array[randomIndex]!;
+}
+
+/**
+ * Generate a random adjective-noun slug
+ */
+export function generateHumanSlug(): string {
+  const adjective = getRandomElement(ADJECTIVES);
+  const noun = getRandomElement(NOUNS);
+  return `${adjective}-${noun}`;
+}
+
+/**
+ * Generate a unique session ID, handling collisions
+ *
+ * @param existingIds - Set or array of existing session IDs in the workspace
+ * @param date - Optional date for the prefix (defaults to now)
+ * @returns A unique session ID like "260111-swift-river" or "260111-swift-river-2"
+ */
+export function generateUniqueSessionId(
+  existingIds: Set<string> | string[],
+  date: Date = new Date()
+): string {
+  const existingSet = existingIds instanceof Set ? existingIds : new Set(existingIds);
+  const datePrefix = generateDatePrefix(date);
+
+  // Try up to 100 times to find a unique slug
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const slug = generateHumanSlug();
+    const baseId = `${datePrefix}-${slug}`;
+
+    // Check if base ID is available
+    if (!existingSet.has(baseId)) {
+      return baseId;
+    }
+
+    // Try with numeric suffixes
+    for (let suffix = 2; suffix <= 99; suffix++) {
+      const suffixedId = `${baseId}-${suffix}`;
+      if (!existingSet.has(suffixedId)) {
+        return suffixedId;
+      }
+    }
+  }
+
+  // Fallback: append random hex if all attempts fail (extremely unlikely)
+  const fallbackSuffix = crypto.getRandomValues(new Uint32Array(1))[0]!.toString(16).slice(0, 4);
+  return `${datePrefix}-${generateHumanSlug()}-${fallbackSuffix}`;
+}
+
+/**
+ * Parse a session ID to extract its components
+ *
+ * @param sessionId - A session ID like "260111-swift-river" or legacy UUID
+ * @returns Parsed components or null if not in human-readable format
+ */
+export function parseSessionId(sessionId: string): {
+  datePrefix: string;
+  date: Date;
+  slug: string;
+  suffix?: number;
+} | null {
+  // Match YYMMDD-word-word or YYMMDD-word-word-N pattern
+  const match = sessionId.match(/^(\d{6})-([a-z]+-[a-z]+)(?:-(\d+))?$/);
+  if (!match) {
+    return null;
+  }
+
+  const [, datePrefix, slug, suffixStr] = match;
+  if (!datePrefix || !slug) {
+    return null;
+  }
+
+  // Parse date from YYMMDD
+  const year = 2000 + parseInt(datePrefix.slice(0, 2), 10);
+  const month = parseInt(datePrefix.slice(2, 4), 10) - 1;
+  const day = parseInt(datePrefix.slice(4, 6), 10);
+  const date = new Date(year, month, day);
+
+  return {
+    datePrefix,
+    date,
+    slug,
+    suffix: suffixStr ? parseInt(suffixStr, 10) : undefined,
+  };
+}
+
+/**
+ * Check if a session ID is in the new human-readable format
+ */
+export function isHumanReadableId(sessionId: string): boolean {
+  return parseSessionId(sessionId) !== null;
+}

--- a/packages/shared/src/sessions/storage.ts
+++ b/packages/shared/src/sessions/storage.ts
@@ -1,0 +1,960 @@
+/**
+ * Session Storage
+ *
+ * Workspace-scoped session CRUD operations.
+ * Sessions are stored at {workspaceRootPath}/sessions/{id}/session.jsonl
+ * Each session folder contains:
+ * - session.jsonl (main data in JSONL format: line 1 = header, lines 2+ = messages)
+ * - attachments/ (file attachments)
+ * - plans/ (plan files for Safe Mode)
+ * - long_responses/ (full tool results that were summarized due to size limits)
+ * - downloads/ (binary files downloaded from API sources: PDFs, images, archives, etc.)
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+} from 'fs';
+import { join } from 'path';
+import { getWorkspaceSessionsPath } from '../workspaces/storage.ts';
+import { generateUniqueSessionId } from './slug-generator.ts';
+import { toPortablePath, expandPath } from '../utils/paths.ts';
+import { perf } from '../utils/perf.ts';
+import type {
+  SessionConfig,
+  StoredSession,
+  SessionMetadata,
+  SessionTokenUsage,
+  SessionHeader,
+  TodoState,
+} from './types.ts';
+import type { Plan } from '../agent/plan-types.ts';
+import { validateSessionStatus } from '../statuses/validation.ts';
+import { getStatusCategory } from '../statuses/storage.ts';
+import { readSessionHeader, readSessionJsonl } from './jsonl.ts';
+import { sessionPersistenceQueue } from './persistence-queue.ts';
+
+// Re-export types for convenience
+export type { SessionConfig } from './types.ts';
+
+// ============================================================
+// Directory Utilities
+// ============================================================
+
+/**
+ * Ensure sessions directory exists for a workspace
+ */
+export function ensureSessionsDir(workspaceRootPath: string): string {
+  const dir = getWorkspaceSessionsPath(workspaceRootPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+/**
+ * Get path to a session's directory
+ */
+export function getSessionPath(workspaceRootPath: string, sessionId: string): string {
+  return join(getWorkspaceSessionsPath(workspaceRootPath), sessionId);
+}
+
+/**
+ * Get path to a session's JSONL file (inside session folder)
+ */
+export function getSessionFilePath(workspaceRootPath: string, sessionId: string): string {
+  return join(getSessionPath(workspaceRootPath, sessionId), 'session.jsonl');
+}
+
+/**
+ * Ensure session directory exists with all subdirectories
+ */
+export function ensureSessionDir(workspaceRootPath: string, sessionId: string): string {
+  const sessionDir = getSessionPath(workspaceRootPath, sessionId);
+  if (!existsSync(sessionDir)) {
+    mkdirSync(sessionDir, { recursive: true });
+  }
+  // Also create plans, attachments, long_responses, and downloads directories
+  const plansDir = join(sessionDir, 'plans');
+  if (!existsSync(plansDir)) {
+    mkdirSync(plansDir, { recursive: true });
+  }
+  const attachmentsDir = join(sessionDir, 'attachments');
+  if (!existsSync(attachmentsDir)) {
+    mkdirSync(attachmentsDir, { recursive: true });
+  }
+  const longResponsesDir = join(sessionDir, 'long_responses');
+  if (!existsSync(longResponsesDir)) {
+    mkdirSync(longResponsesDir, { recursive: true });
+  }
+  // Downloads directory for binary files from API responses (PDFs, images, etc.)
+  const downloadsDir = join(sessionDir, 'downloads');
+  if (!existsSync(downloadsDir)) {
+    mkdirSync(downloadsDir, { recursive: true });
+  }
+  return sessionDir;
+}
+
+/**
+ * Get the attachments directory for a session
+ */
+export function getSessionAttachmentsPath(workspaceRootPath: string, sessionId: string): string {
+  return join(getSessionPath(workspaceRootPath, sessionId), 'attachments');
+}
+
+/**
+ * Get the plans directory for a session
+ */
+export function getSessionPlansPath(workspaceRootPath: string, sessionId: string): string {
+  return join(getSessionPath(workspaceRootPath, sessionId), 'plans');
+}
+
+/**
+ * Get the downloads directory for a session (binary files from API responses)
+ */
+export function getSessionDownloadsPath(workspaceRootPath: string, sessionId: string): string {
+  return join(getSessionPath(workspaceRootPath, sessionId), 'downloads');
+}
+
+// ============================================================
+// Session ID Generation
+// ============================================================
+
+/**
+ * Get existing session IDs for collision detection
+ */
+function getExistingSessionIds(workspaceRootPath: string): Set<string> {
+  const sessionsDir = getWorkspaceSessionsPath(workspaceRootPath);
+  if (!existsSync(sessionsDir)) {
+    return new Set();
+  }
+  const entries = readdirSync(sessionsDir, { withFileTypes: true });
+  return new Set(entries.filter(e => e.isDirectory()).map(e => e.name));
+}
+
+/**
+ * Generate a human-readable session ID
+ * Format: YYMMDD-adjective-noun (e.g., 260111-swift-river)
+ */
+export function generateSessionId(workspaceRootPath: string): string {
+  const existingIds = getExistingSessionIds(workspaceRootPath);
+  return generateUniqueSessionId(existingIds);
+}
+
+// ============================================================
+// Session CRUD
+// ============================================================
+
+/**
+ * Create a new session for a workspace
+ */
+export async function createSession(
+  workspaceRootPath: string,
+  options?: {
+    name?: string;
+    workingDirectory?: string;
+    permissionMode?: SessionConfig['permissionMode'];
+    enabledSourceSlugs?: string[];
+    model?: string;
+    channel?: SessionConfig['channel'];
+  }
+): Promise<SessionConfig> {
+  ensureSessionsDir(workspaceRootPath);
+
+  const now = Date.now();
+  const sessionId = generateSessionId(workspaceRootPath);
+
+  // Create session directory with all subdirectories (plans, attachments)
+  ensureSessionDir(workspaceRootPath, sessionId);
+
+  // Set sdkCwd to initial working directory or session path - this never changes
+  // The SDK stores session transcripts at ~/.claude/projects/{cwd-slugified}/
+  // If workingDirectory changes later, sdkCwd stays the same to preserve session resumption
+  const sdkCwd = options?.workingDirectory ?? getSessionPath(workspaceRootPath, sessionId);
+
+  const session: SessionConfig = {
+    id: sessionId,
+    workspaceRootPath,
+    name: options?.name,
+    createdAt: now,
+    lastUsedAt: now,
+    workingDirectory: options?.workingDirectory,
+    sdkCwd,
+    permissionMode: options?.permissionMode,
+    enabledSourceSlugs: options?.enabledSourceSlugs,
+    model: options?.model,
+    channel: options?.channel,
+  };
+
+  // Save empty session
+  const storedSession: StoredSession = {
+    ...session,
+    messages: [],
+    tokenUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      contextTokens: 0,
+      costUsd: 0,
+    },
+  };
+  await saveSession(storedSession);
+
+  return session;
+}
+
+/**
+ * Get or create a session with a specific ID
+ * Used for --session <id> flag to allow user-defined session IDs
+ */
+export async function getOrCreateSessionById(
+  workspaceRootPath: string,
+  sessionId: string
+): Promise<SessionConfig> {
+  const existing = loadSession(workspaceRootPath, sessionId);
+  if (existing) {
+    return {
+      id: existing.id,
+      sdkSessionId: existing.sdkSessionId,
+      workspaceRootPath: existing.workspaceRootPath,
+      name: existing.name,
+      createdAt: existing.createdAt,
+      lastUsedAt: existing.lastUsedAt,
+      sdkCwd: existing.sdkCwd,
+      workingDirectory: existing.workingDirectory,
+    };
+  }
+
+  // Create new session with the specified ID
+  ensureSessionsDir(workspaceRootPath);
+
+  // Create session directory with all subdirectories (plans, attachments)
+  ensureSessionDir(workspaceRootPath, sessionId);
+
+  const now = Date.now();
+  // Set sdkCwd to session path - this never changes (ensures SDK can find session transcripts)
+  const sdkCwd = getSessionPath(workspaceRootPath, sessionId);
+
+  const session: SessionConfig = {
+    id: sessionId,
+    workspaceRootPath,
+    sdkCwd,
+    createdAt: now,
+    lastUsedAt: now,
+  };
+
+  const storedSession: StoredSession = {
+    ...session,
+    messages: [],
+    tokenUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      contextTokens: 0,
+      costUsd: 0,
+    },
+  };
+  await saveSession(storedSession);
+
+  return session;
+}
+
+/**
+ * Save session immediately using the persistence queue.
+ * Enqueues the session and flushes to ensure immediate write.
+ *
+ * This unified approach ensures all session writes go through the same
+ * async code path, which is more reliable on Windows.
+ *
+ * Writes in JSONL format: line 1 = header, lines 2+ = messages
+ */
+export async function saveSession(session: StoredSession): Promise<void> {
+  sessionPersistenceQueue.enqueue(session);
+  await sessionPersistenceQueue.flush(session.id);
+}
+
+/**
+ * Queue session for async persistence with debouncing.
+ * Multiple rapid calls are coalesced into a single write.
+ * Use this during active sessions to avoid blocking the main thread.
+ */
+export { sessionPersistenceQueue } from './persistence-queue.js'
+
+/**
+ * Load session by ID
+ * Loads session from folder structure in JSONL format.
+ */
+export function loadSession(workspaceRootPath: string, sessionId: string): StoredSession | null {
+  const end = perf.start('session.loadSession', { sessionId });
+
+  const jsonlPath = getSessionFilePath(workspaceRootPath, sessionId);
+  if (existsSync(jsonlPath)) {
+    const session = readSessionJsonl(jsonlPath);
+    if (session) {
+      end();
+      return session;
+    }
+  }
+
+  end();
+  return null;
+}
+
+/**
+ * List sessions for a workspace
+ * Lists sessions from folder structure.
+ *
+ * Uses JSONL header for fast loading (only reads first line of each file).
+ */
+export function listSessions(workspaceRootPath: string): SessionMetadata[] {
+  const span = perf.span('session.listSessions');
+  const sessionsDir = getWorkspaceSessionsPath(workspaceRootPath);
+  if (!existsSync(sessionsDir)) {
+    span.end();
+    return [];
+  }
+
+  const entries = readdirSync(sessionsDir, { withFileTypes: true });
+  span.mark('readdir');
+  const sessions: SessionMetadata[] = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const sessionId = entry.name;
+      const sessionDir = join(sessionsDir, sessionId);
+      const jsonlFile = join(sessionDir, 'session.jsonl');
+
+      // Clean up orphaned .tmp files from crashed atomic writes.
+      // These are harmless but waste disk space.
+      const tmpFile = jsonlFile + '.tmp';
+      if (existsSync(tmpFile)) {
+        try { unlinkSync(tmpFile); } catch { /* ignore */ }
+      }
+
+      if (existsSync(jsonlFile)) {
+        const header = readSessionHeader(jsonlFile);
+        if (header) {
+          const metadata = headerToMetadata(header, workspaceRootPath);
+          if (metadata) sessions.push(metadata);
+        }
+      }
+    }
+  }
+  span.mark('parsed');
+  span.setMetadata('count', sessions.length);
+
+  // Sort by lastUsedAt descending (most recent first)
+  const sorted = sessions.sort((a, b) => b.lastUsedAt - a.lastUsedAt);
+  span.end();
+  return sorted;
+}
+
+/**
+ * Convert SessionHeader to SessionMetadata
+ * Used for fast session list loading from JSONL format.
+ */
+function headerToMetadata(header: SessionHeader, workspaceRootPath: string): SessionMetadata | null {
+  try {
+    // Validate todoState against workspace status config
+    const validatedTodoState = validateSessionStatus(workspaceRootPath, header.todoState);
+
+    // Count plan files for this session
+    const planCount = listPlanFiles(workspaceRootPath, header.id).length;
+
+    // Migration: For sessions created before sdkCwd was added, use workingDirectory as fallback.
+    const workingDir = header.workingDirectory ? expandPath(header.workingDirectory) : undefined;
+    const sdkCwd = header.sdkCwd ? expandPath(header.sdkCwd) : workingDir;
+
+    return {
+      id: header.id,
+      workspaceRootPath,
+      name: header.name,
+      createdAt: header.createdAt,
+      lastUsedAt: header.lastUsedAt,
+      lastMessageAt: header.lastMessageAt,
+      messageCount: header.messageCount,
+      preview: header.preview,
+      sdkSessionId: header.sdkSessionId,
+      isFlagged: header.isFlagged,
+      todoState: validatedTodoState,
+      labels: header.labels,
+      permissionMode: header.permissionMode,
+      planCount: planCount > 0 ? planCount : undefined,
+      lastMessageRole: header.lastMessageRole,
+      workingDirectory: workingDir,
+      sdkCwd,
+      model: header.model,
+      // Shared viewer state - must be included for persistence across app restarts
+      sharedUrl: header.sharedUrl,
+      sharedId: header.sharedId,
+      // Token usage from JSONL header (available without loading messages)
+      tokenUsage: header.tokenUsage,
+      // Unread detection fields - pre-computed for session list display without loading messages
+      lastReadMessageId: header.lastReadMessageId,
+      lastFinalMessageId: header.lastFinalMessageId,
+      // Explicit unread flag - single source of truth for NEW badge (state machine approach)
+      hasUnread: header.hasUnread,
+      // Channel origin for daemon-created sessions
+      channel: header.channel,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete a session and its associated files
+ * Deletes session folder and all associated files
+ */
+export function deleteSession(workspaceRootPath: string, sessionId: string): boolean {
+  try {
+    // Delete session directory (includes session.json, attachments, plans)
+    const sessionDir = getSessionPath(workspaceRootPath, sessionId);
+    if (existsSync(sessionDir)) {
+      rmSync(sessionDir, { recursive: true });
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Clear messages from a session while preserving metadata.
+ * Used for /clear command to reset conversation without creating a new session.
+ * Also clears the SDK session ID to start a fresh Claude conversation.
+ */
+export async function clearSessionMessages(workspaceRootPath: string, sessionId: string): Promise<void> {
+  const session = loadSession(workspaceRootPath, sessionId);
+  if (session) {
+    // Clear messages and SDK session ID but preserve metadata
+    session.messages = [];
+    session.sdkSessionId = undefined;
+    // Reset token usage to zero
+    session.tokenUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      contextTokens: 0,
+      costUsd: 0,
+    };
+    await saveSession(session);
+  }
+}
+
+/**
+ * Get or create the latest session for a workspace
+ */
+export async function getOrCreateLatestSession(workspaceRootPath: string): Promise<SessionConfig> {
+  const sessions = listSessions(workspaceRootPath);
+  if (sessions.length > 0 && sessions[0]) {
+    const latest = sessions[0];
+    return {
+      id: latest.id,
+      sdkSessionId: latest.sdkSessionId,
+      workspaceRootPath: latest.workspaceRootPath,
+      name: latest.name,
+      createdAt: latest.createdAt,
+      lastUsedAt: latest.lastUsedAt,
+    };
+  }
+  return createSession(workspaceRootPath);
+}
+
+// ============================================================
+// Session Metadata Updates
+// ============================================================
+
+/**
+ * Update SDK session ID for a session
+ */
+export async function updateSessionSdkId(
+  workspaceRootPath: string,
+  sessionId: string,
+  sdkSessionId: string
+): Promise<void> {
+  const session = loadSession(workspaceRootPath, sessionId);
+  if (session) {
+    session.sdkSessionId = sdkSessionId;
+    await saveSession(session);
+  }
+}
+
+/**
+ * Update session metadata
+ */
+export async function updateSessionMetadata(
+  workspaceRootPath: string,
+  sessionId: string,
+  updates: Partial<Pick<SessionConfig,
+    | 'isFlagged'
+    | 'name'
+    | 'todoState'
+    | 'labels'
+    | 'lastReadMessageId'
+    | 'hasUnread'
+    | 'enabledSourceSlugs'
+    | 'workingDirectory'
+    | 'permissionMode'
+    | 'sharedUrl'
+    | 'sharedId'
+    | 'model'
+  >>
+): Promise<void> {
+  const session = loadSession(workspaceRootPath, sessionId);
+  if (!session) return;
+
+  if (updates.isFlagged !== undefined) session.isFlagged = updates.isFlagged;
+  if (updates.name !== undefined) session.name = updates.name;
+  if (updates.todoState !== undefined) session.todoState = updates.todoState;
+  if (updates.labels !== undefined) session.labels = updates.labels;
+  if (updates.enabledSourceSlugs !== undefined) session.enabledSourceSlugs = updates.enabledSourceSlugs;
+  if (updates.workingDirectory !== undefined) session.workingDirectory = updates.workingDirectory;
+  if (updates.permissionMode !== undefined) session.permissionMode = updates.permissionMode;
+  if ('lastReadMessageId' in updates) session.lastReadMessageId = updates.lastReadMessageId;
+  if ('hasUnread' in updates) session.hasUnread = updates.hasUnread;
+  if ('sharedUrl' in updates) session.sharedUrl = updates.sharedUrl;
+  if ('sharedId' in updates) session.sharedId = updates.sharedId;
+  if (updates.model !== undefined) session.model = updates.model;
+
+  await saveSession(session);
+}
+
+/**
+ * Flag a session
+ */
+export async function flagSession(workspaceRootPath: string, sessionId: string): Promise<void> {
+  await updateSessionMetadata(workspaceRootPath, sessionId, { isFlagged: true });
+}
+
+/**
+ * Unflag a session
+ */
+export async function unflagSession(workspaceRootPath: string, sessionId: string): Promise<void> {
+  await updateSessionMetadata(workspaceRootPath, sessionId, { isFlagged: false });
+}
+
+/**
+ * Set todo state for a session
+ */
+export async function setSessionTodoState(
+  workspaceRootPath: string,
+  sessionId: string,
+  todoState: TodoState
+): Promise<void> {
+  await updateSessionMetadata(workspaceRootPath, sessionId, { todoState });
+}
+
+/**
+ * Set labels for a session
+ */
+export async function setSessionLabels(
+  workspaceRootPath: string,
+  sessionId: string,
+  labels: string[]
+): Promise<void> {
+  await updateSessionMetadata(workspaceRootPath, sessionId, { labels });
+}
+
+// ============================================================
+// Pending Plan Execution (Accept & Compact flow)
+// ============================================================
+
+/**
+ * Set pending plan execution state.
+ * Called when user clicks "Accept & Compact" - stores the plan path
+ * so it can be executed after compaction, even if the page reloads.
+ */
+export async function setPendingPlanExecution(
+  workspaceRootPath: string,
+  sessionId: string,
+  planPath: string
+): Promise<void> {
+  const session = loadSession(workspaceRootPath, sessionId);
+  if (!session) return;
+
+  session.pendingPlanExecution = {
+    planPath,
+    awaitingCompaction: true,
+  };
+  await saveSession(session);
+}
+
+/**
+ * Mark compaction as complete for pending plan execution.
+ * Called when compaction_complete event fires - sets awaitingCompaction to false
+ * so reload recovery knows compaction finished and can trigger execution.
+ */
+export async function markCompactionComplete(
+  workspaceRootPath: string,
+  sessionId: string
+): Promise<void> {
+  const session = loadSession(workspaceRootPath, sessionId);
+  if (!session?.pendingPlanExecution) return;
+
+  session.pendingPlanExecution.awaitingCompaction = false;
+  await saveSession(session);
+}
+
+/**
+ * Clear pending plan execution state.
+ * Called after plan execution is sent, on new user message, or when
+ * the pending execution is no longer relevant.
+ */
+export async function clearPendingPlanExecution(
+  workspaceRootPath: string,
+  sessionId: string
+): Promise<void> {
+  const session = loadSession(workspaceRootPath, sessionId);
+  if (!session) return;
+
+  delete session.pendingPlanExecution;
+  await saveSession(session);
+}
+
+/**
+ * Get pending plan execution state for a session.
+ * Used on reload to check if we need to resume plan execution.
+ */
+export function getPendingPlanExecution(
+  workspaceRootPath: string,
+  sessionId: string
+): { planPath: string; awaitingCompaction: boolean } | null {
+  const session = loadSession(workspaceRootPath, sessionId);
+  return session?.pendingPlanExecution ?? null;
+}
+
+// ============================================================
+// Session Filtering
+// ============================================================
+
+/**
+ * List flagged sessions
+ */
+export function listFlaggedSessions(workspaceRootPath: string): SessionMetadata[] {
+  return listSessions(workspaceRootPath).filter(s => s.isFlagged === true);
+}
+
+/**
+ * List completed sessions (category: closed)
+ * Includes done, cancelled, and any custom "closed" statuses
+ */
+export function listCompletedSessions(workspaceRootPath: string): SessionMetadata[] {
+  return listSessions(workspaceRootPath).filter(s => {
+    const category = getStatusCategory(workspaceRootPath, s.todoState || 'todo');
+    return category === 'closed';
+  });
+}
+
+/**
+ * List inbox sessions (category: open)
+ * Includes todo, in-progress, needs-review, and any custom "open" statuses
+ */
+export function listInboxSessions(workspaceRootPath: string): SessionMetadata[] {
+  return listSessions(workspaceRootPath).filter(s => {
+    const category = getStatusCategory(workspaceRootPath, s.todoState || 'todo');
+    return category === 'open';
+  });
+}
+
+// ============================================================
+// Plan Storage (Session-Scoped)
+// ============================================================
+
+/**
+ * Slugify a string for file names
+ */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[/\\:*?"<>|]/g, '')
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .trim();
+}
+
+/**
+ * Generate a unique, readable file name for a plan
+ */
+function generatePlanFileName(plan: Plan, plansDir: string): string {
+  let name = plan.title || plan.context?.substring(0, 50) || 'untitled';
+  let slug = slugify(name);
+
+  if (slug.length > 40) {
+    slug = slug.substring(0, 40).replace(/-$/, '');
+  }
+
+  const date = new Date().toISOString().split('T')[0];
+  const baseName = `${date}-${slug}`;
+
+  let fileName = baseName;
+  let counter = 2;
+
+  while (existsSync(join(plansDir, `${fileName}.md`))) {
+    fileName = `${baseName}-${counter}`;
+    counter++;
+  }
+
+  return fileName;
+}
+
+/**
+ * Ensure the plans directory exists
+ */
+function ensurePlansDir(workspaceRootPath: string, sessionId: string): string {
+  const plansDir = getSessionPlansPath(workspaceRootPath, sessionId);
+  if (!existsSync(plansDir)) {
+    mkdirSync(plansDir, { recursive: true });
+  }
+  return plansDir;
+}
+
+/**
+ * Format a plan as markdown
+ */
+export function formatPlanAsMarkdown(plan: Plan): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${plan.title}`);
+  lines.push('');
+  lines.push(`**Status:** ${plan.state}`);
+  lines.push(`**Created:** ${new Date(plan.createdAt).toISOString()}`);
+  if (plan.updatedAt !== plan.createdAt) {
+    lines.push(`**Updated:** ${new Date(plan.updatedAt).toISOString()}`);
+  }
+  lines.push('');
+
+  if (plan.context) {
+    lines.push('## Summary');
+    lines.push('');
+    lines.push(plan.context);
+    lines.push('');
+  }
+
+  lines.push('## Steps');
+  lines.push('');
+  for (const step of plan.steps) {
+    const checkbox = step.status === 'completed' ? '[x]' : '[ ]';
+    const status = step.status === 'in_progress' ? ' *(in progress)*' : '';
+    lines.push(`- ${checkbox} ${step.description}${status}`);
+    if (step.details) {
+      lines.push(`  - Tools: ${step.details}`);
+    }
+  }
+  lines.push('');
+
+  if (plan.refinementHistory && plan.refinementHistory.length > 0) {
+    lines.push('## Refinement History');
+    lines.push('');
+    for (const entry of plan.refinementHistory) {
+      lines.push(`### Round ${entry.round}`);
+      lines.push(`**Feedback:** ${entry.feedback}`);
+      if (entry.questions && entry.questions.length > 0) {
+        lines.push(`**Questions:** ${entry.questions.join(', ')}`);
+      }
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Parse a markdown plan file back to a Plan object
+ */
+export function parsePlanFromMarkdown(content: string, planId: string): Plan | null {
+  try {
+    const lines = content.split('\n');
+
+    const titleLine = lines.find(l => l.startsWith('# '));
+    const title = titleLine ? titleLine.substring(2).trim() : 'Untitled Plan';
+
+    const statusLine = lines.find(l => l.startsWith('**Status:**'));
+    const stateStr = statusLine ? statusLine.replace('**Status:**', '').trim() : 'ready';
+    const state = (['creating', 'refining', 'ready', 'executing', 'completed', 'cancelled'].includes(stateStr)
+      ? stateStr
+      : 'ready') as Plan['state'];
+
+    const summaryIdx = lines.findIndex(l => l === '## Summary');
+    const stepsIdx = lines.findIndex(l => l === '## Steps');
+    let context = '';
+    if (summaryIdx !== -1 && stepsIdx !== -1) {
+      context = lines.slice(summaryIdx + 2, stepsIdx).join('\n').trim();
+    }
+
+    const steps: Plan['steps'] = [];
+    if (stepsIdx !== -1) {
+      for (let i = stepsIdx + 2; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line || line.startsWith('##')) break;
+        if (line.startsWith('- [')) {
+          const isCompleted = line.startsWith('- [x]');
+          const isInProgress = line.includes('*(in progress)*');
+          const description = line
+            .replace(/^- \[[ x]\] /, '')
+            .replace(' *(in progress)*', '')
+            .trim();
+          steps.push({
+            id: `step-${steps.length + 1}`,
+            description,
+            status: isCompleted ? 'completed' : isInProgress ? 'in_progress' : 'pending',
+          });
+        }
+      }
+    }
+
+    return {
+      id: planId,
+      title,
+      state,
+      context,
+      steps,
+      refinementRound: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save a plan to a markdown file
+ */
+export function savePlanToFile(
+  workspaceRootPath: string,
+  sessionId: string,
+  plan: Plan,
+  fileName?: string
+): string {
+  const plansDir = ensurePlansDir(workspaceRootPath, sessionId);
+  const name = fileName || generatePlanFileName(plan, plansDir);
+  const filePath = join(plansDir, `${name}.md`);
+  const content = formatPlanAsMarkdown(plan);
+
+  writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+/**
+ * Load a plan from a markdown file by name
+ */
+export function loadPlanFromFile(
+  workspaceRootPath: string,
+  sessionId: string,
+  fileName: string
+): Plan | null {
+  const plansDir = getSessionPlansPath(workspaceRootPath, sessionId);
+  const filePath = join(plansDir, `${fileName}.md`);
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    return parsePlanFromMarkdown(content, fileName);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load a plan from a full file path
+ */
+export function loadPlanFromPath(filePath: string): Plan | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const fileName = filePath.split('/').pop()?.replace('.md', '') || 'unknown';
+    return parsePlanFromMarkdown(content, fileName);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List all plan files in a session
+ */
+export function listPlanFiles(
+  workspaceRootPath: string,
+  sessionId: string
+): Array<{ name: string; path: string; modifiedAt: number }> {
+  const plansDir = getSessionPlansPath(workspaceRootPath, sessionId);
+  if (!existsSync(plansDir)) {
+    return [];
+  }
+
+  try {
+    const files = readdirSync(plansDir)
+      .filter(f => f.endsWith('.md'))
+      .map(f => {
+        const filePath = join(plansDir, f);
+        const stats = existsSync(filePath) ? statSync(filePath) : null;
+        return {
+          name: f.replace('.md', ''),
+          path: filePath,
+          modifiedAt: stats?.mtimeMs || 0,
+        };
+      })
+      .sort((a, b) => b.modifiedAt - a.modifiedAt);
+
+    return files;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Delete a plan file
+ */
+export function deletePlanFile(
+  workspaceRootPath: string,
+  sessionId: string,
+  fileName: string
+): boolean {
+  const plansDir = getSessionPlansPath(workspaceRootPath, sessionId);
+  const filePath = join(plansDir, `${fileName}.md`);
+  if (existsSync(filePath)) {
+    unlinkSync(filePath);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Get the most recent plan file for a session
+ */
+export function getMostRecentPlanFile(
+  workspaceRootPath: string,
+  sessionId: string
+): { name: string; path: string } | null {
+  const files = listPlanFiles(workspaceRootPath, sessionId);
+  return files.length > 0 ? files[0]! : null;
+}
+
+// ============================================================
+// Attachments Directory
+// ============================================================
+
+/**
+ * Ensure attachments directory exists
+ */
+export function ensureAttachmentsDir(workspaceRootPath: string, sessionId: string): string {
+  const dir = getSessionAttachmentsPath(workspaceRootPath, sessionId);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}

--- a/packages/shared/src/sessions/types.ts
+++ b/packages/shared/src/sessions/types.ts
@@ -1,0 +1,260 @@
+/**
+ * Session Types
+ *
+ * Types for workspace-scoped sessions.
+ * Sessions are stored at {workspaceRootPath}/sessions/{id}/session.jsonl
+ *
+ * JSONL Format:
+ * - Line 1: SessionHeader (metadata + pre-computed fields for fast list loading)
+ * - Lines 2+: StoredMessage (one message per line)
+ */
+
+import type { PermissionMode } from '../agent/mode-manager.ts';
+import type { ThinkingLevel } from '../agent/thinking-levels.ts';
+import type { StoredAttachment, MessageRole, ToolStatus, AuthRequestType, AuthStatus, CredentialInputMode, StoredMessage } from '@craft-agent/core/types';
+
+/**
+ * Todo state for sessions (user-controlled, never automatic)
+ *
+ * Dynamic status ID referencing workspace status config.
+ * Validated at runtime via validateSessionStatus().
+ * Falls back to 'todo' if status doesn't exist.
+ */
+export type TodoState = string;
+
+/**
+ * Built-in status IDs (for TypeScript consumers)
+ * These are the default statuses but users can add/remove custom ones
+ */
+export type BuiltInStatusId = 'todo' | 'in-progress' | 'needs-review' | 'done' | 'cancelled';
+
+/**
+ * Session token usage tracking
+ */
+export interface SessionTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  contextTokens: number;
+  costUsd: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+  /** Model's context window size in tokens (from SDK modelUsage) */
+  contextWindow?: number;
+}
+
+/**
+ * Stored message format (simplified for persistence)
+ * Re-exported from @craft-agent/core for convenience
+ */
+export type { StoredMessage } from '@craft-agent/core/types';
+
+/**
+ * Session configuration (persisted metadata)
+ */
+export interface SessionConfig {
+  id: string;
+  /** SDK session ID (captured after first message) */
+  sdkSessionId?: string;
+  /** Workspace root path this session belongs to */
+  workspaceRootPath: string;
+  /** Optional user-defined name */
+  name?: string;
+  createdAt: number;
+  lastUsedAt: number;
+  /** Timestamp of last meaningful message (user or final assistant). Used for date grouping in session list.
+   *  Separate from lastUsedAt which tracks any session access (auto-save, open to read, etc.). */
+  lastMessageAt?: number;
+  /** Whether this session is flagged */
+  isFlagged?: boolean;
+  /** Permission mode for this session ('safe', 'ask', 'allow-all') */
+  permissionMode?: PermissionMode;
+  /** User-controlled todo state - determines inbox vs completed */
+  todoState?: TodoState;
+  /** Labels applied to this session (bare IDs or "id::value" entries) */
+  labels?: string[];
+  /** ID of last message user has read */
+  lastReadMessageId?: string;
+  /**
+   * Explicit unread flag - single source of truth for NEW badge.
+   * Set to true when assistant message completes while user is NOT viewing.
+   * Set to false when user views the session (and not processing).
+   */
+  hasUnread?: boolean;
+  /** Per-session source selection (source slugs) */
+  enabledSourceSlugs?: string[];
+  /** Working directory for this session (used by agent for bash commands and context) */
+  workingDirectory?: string;
+  /** SDK cwd for session storage - set once at creation, never changes. Ensures SDK can find session transcripts regardless of workingDirectory changes. */
+  sdkCwd?: string;
+  /** Shared viewer URL (if shared via viewer) */
+  sharedUrl?: string;
+  /** Shared session ID in viewer (for revoke) */
+  sharedId?: string;
+  /** Model to use for this session (overrides global config if set) */
+  model?: string;
+  /** Thinking level for this session ('off', 'think', 'max') */
+  thinkingLevel?: ThinkingLevel;
+  /**
+   * Pending plan execution state - tracks "Accept & Compact" flow.
+   * When set, indicates a plan needs to be executed after compaction completes.
+   * Cleared on: successful execution, new user message, or manual clear.
+   */
+  pendingPlanExecution?: {
+    /** Path to the plan file to execute */
+    planPath: string;
+    /** Whether we're still waiting for compaction to complete */
+    awaitingCompaction: boolean;
+  };
+  /** Channel origin for daemon-created sessions (absent for direct/interactive sessions) */
+  channel?: {
+    adapter: string;
+    slug: string;
+    displayName?: string;
+  };
+}
+
+/**
+ * Stored session with conversation data
+ */
+export interface StoredSession extends SessionConfig {
+  messages: StoredMessage[];
+  tokenUsage: SessionTokenUsage;
+}
+
+/**
+ * Session header - line 1 of session.jsonl
+ *
+ * Contains all metadata needed for list views (pre-computed at save time).
+ * This enables fast session listing without parsing message content.
+ */
+export interface SessionHeader {
+  id: string;
+  /** SDK session ID (captured after first message) */
+  sdkSessionId?: string;
+  /** Workspace root path (stored as portable path, e.g., ~/.kata-agents/...) */
+  workspaceRootPath: string;
+  /** Optional user-defined name */
+  name?: string;
+  createdAt: number;
+  lastUsedAt: number;
+  /** Timestamp of last meaningful message — persisted separately from lastUsedAt for stable date grouping across restarts. */
+  lastMessageAt?: number;
+  /** Whether this session is flagged */
+  isFlagged?: boolean;
+  /** Permission mode for this session ('safe', 'ask', 'allow-all') */
+  permissionMode?: PermissionMode;
+  /** User-controlled todo state - determines inbox vs completed */
+  todoState?: TodoState;
+  /** Labels applied to this session (bare IDs or "id::value" entries) */
+  labels?: string[];
+  /** ID of last message user has read */
+  lastReadMessageId?: string;
+  /**
+   * Explicit unread flag - single source of truth for NEW badge.
+   * Set to true when assistant message completes while user is NOT viewing.
+   * Set to false when user views the session (and not processing).
+   */
+  hasUnread?: boolean;
+  /** Per-session source selection (source slugs) */
+  enabledSourceSlugs?: string[];
+  /** Working directory for this session (used by agent for bash commands and context) */
+  workingDirectory?: string;
+  /** SDK cwd for session storage - set once at creation, never changes */
+  sdkCwd?: string;
+  /** Shared viewer URL (if shared via viewer) */
+  sharedUrl?: string;
+  /** Shared session ID in viewer (for revoke) */
+  sharedId?: string;
+  /** Model to use for this session (overrides global config if set) */
+  model?: string;
+  /** Thinking level for this session ('off', 'think', 'max') */
+  thinkingLevel?: ThinkingLevel;
+  /**
+   * Pending plan execution state - tracks "Accept & Compact" flow.
+   * When set, indicates a plan needs to be executed after compaction completes.
+   * Cleared on: successful execution, new user message, or manual clear.
+   */
+  pendingPlanExecution?: {
+    /** Path to the plan file to execute */
+    planPath: string;
+    /** Whether we're still waiting for compaction to complete */
+    awaitingCompaction: boolean;
+  };
+  // Pre-computed fields for fast list loading
+  /** Number of messages in session */
+  messageCount: number;
+  /** Role/type of the last message (for badge display without loading messages) */
+  lastMessageRole?: 'user' | 'assistant' | 'plan' | 'tool' | 'error';
+  /** Preview of first user message (first 150 chars) */
+  preview?: string;
+  /** Token usage statistics */
+  tokenUsage: SessionTokenUsage;
+  /** ID of the last final (non-intermediate) assistant message - for unread detection without loading messages */
+  lastFinalMessageId?: string;
+  /** Channel origin for daemon-created sessions */
+  channel?: {
+    adapter: string;
+    slug: string;
+    displayName?: string;
+  };
+}
+
+/**
+ * Session metadata (lightweight, for lists)
+ */
+export interface SessionMetadata {
+  id: string;
+  workspaceRootPath: string;
+  name?: string;
+  createdAt: number;
+  lastUsedAt: number;
+  /** Timestamp of last meaningful message — used for date grouping. Falls back to lastUsedAt for pre-fix sessions. */
+  lastMessageAt?: number;
+  messageCount: number;
+  /** Preview of first user message */
+  preview?: string;
+  sdkSessionId?: string;
+  /** Whether this session is flagged */
+  isFlagged?: boolean;
+  /** User-controlled todo state */
+  todoState?: TodoState;
+  /** Labels applied to this session (bare IDs or "id::value" entries) */
+  labels?: string[];
+  /** Permission mode for this session */
+  permissionMode?: PermissionMode;
+  /** Number of plan files for this session */
+  planCount?: number;
+  /** Shared viewer URL (if shared via viewer) */
+  sharedUrl?: string;
+  /** Shared session ID in viewer (for revoke) */
+  sharedId?: string;
+  /** Working directory for this session */
+  workingDirectory?: string;
+  /** SDK cwd for session storage - set once at creation, never changes */
+  sdkCwd?: string;
+  /** Role/type of the last message (for badge display without loading messages) */
+  lastMessageRole?: 'user' | 'assistant' | 'plan' | 'tool' | 'error';
+  /** Model to use for this session (overrides global config if set) */
+  model?: string;
+  /** Thinking level for this session ('off', 'think', 'max') */
+  thinkingLevel?: ThinkingLevel;
+  /** ID of last message user has read - for unread detection */
+  lastReadMessageId?: string;
+  /** ID of the last final (non-intermediate) assistant message - for unread detection */
+  lastFinalMessageId?: string;
+  /**
+   * Explicit unread flag - single source of truth for NEW badge.
+   * Set to true when assistant message completes while user is NOT viewing.
+   * Set to false when user views the session (and not processing).
+   */
+  hasUnread?: boolean;
+  /** Token usage statistics (from JSONL header, available without loading messages) */
+  tokenUsage?: SessionTokenUsage;
+  /** Channel origin for daemon-created sessions */
+  channel?: {
+    adapter: string;
+    slug: string;
+    displayName?: string;
+  };
+}

--- a/packages/shared/src/sessions/word-lists.ts
+++ b/packages/shared/src/sessions/word-lists.ts
@@ -1,0 +1,81 @@
+/**
+ * Word Lists for Human-Readable Session IDs
+ *
+ * Curated lists of adjectives and nouns for generating memorable,
+ * URL-safe session identifiers in the format: YYMMDD-adjective-noun
+ */
+
+/**
+ * Adjectives: Short, positive/neutral, easy to spell
+ * ~100 words for good variety
+ */
+export const ADJECTIVES = [
+  // Nature/Weather
+  'bright', 'calm', 'clear', 'cool', 'crisp', 'fresh', 'gentle', 'golden', 'misty', 'sunny',
+  'warm', 'wild', 'windy', 'frosty', 'mild', 'soft', 'swift', 'quiet', 'silent', 'still',
+
+  // Colors (abstract)
+  'azure', 'coral', 'amber', 'jade', 'ruby', 'ivory', 'onyx', 'pearl', 'silver', 'copper',
+
+  // Qualities
+  'bold', 'brave', 'clever', 'eager', 'fair', 'fleet', 'grand', 'keen', 'noble', 'proud',
+  'quick', 'sharp', 'smart', 'steady', 'strong', 'true', 'vivid', 'wise', 'witty', 'zesty',
+
+  // Size/Shape
+  'broad', 'deep', 'high', 'long', 'tall', 'vast', 'wide', 'slim', 'lean', 'agile',
+
+  // Texture/Feel
+  'smooth', 'light', 'airy', 'sleek', 'polished', 'refined', 'pure', 'prime', 'fine', 'neat',
+
+  // Energy/Motion
+  'active', 'brisk', 'lively', 'nimble', 'rapid', 'ready', 'spry', 'vital', 'dynamic', 'fluid',
+
+  // Time/State
+  'early', 'first', 'fresh', 'new', 'prime', 'young', 'alert', 'awake', 'aware', 'focal',
+
+  // Abstract positive
+  'apt', 'deft', 'fit', 'apt', 'lucid', 'open', 'plain', 'safe', 'snug', 'tidy',
+] as const;
+
+/**
+ * Nouns: Nature-themed, concrete, memorable
+ * ~200 words for variety (100 adj × 200 noun = 20,000 combos/day)
+ */
+export const NOUNS = [
+  // Landscape
+  'canyon', 'cliff', 'coast', 'cove', 'creek', 'delta', 'dune', 'field', 'fjord', 'forest',
+  'glade', 'glen', 'gorge', 'grove', 'harbor', 'heath', 'hill', 'island', 'lagoon', 'lake',
+  'marsh', 'meadow', 'mesa', 'moor', 'mountain', 'oasis', 'ocean', 'pass', 'peak', 'plain',
+  'plateau', 'pond', 'prairie', 'ravine', 'reef', 'ridge', 'river', 'shore', 'spring', 'stream',
+  'summit', 'swamp', 'trail', 'valley', 'vista', 'waterfall', 'woods', 'bay', 'beach', 'bluff',
+
+  // Sky/Space
+  'aurora', 'cloud', 'comet', 'cosmos', 'dawn', 'dusk', 'eclipse', 'galaxy', 'halo', 'horizon',
+  'meteor', 'moon', 'nebula', 'nova', 'orbit', 'pulsar', 'quasar', 'rainbow', 'sky', 'star',
+  'storm', 'sun', 'sunset', 'thunder', 'twilight', 'zenith', 'breeze', 'gust', 'mist', 'frost',
+
+  // Animals
+  'bear', 'crane', 'crow', 'deer', 'dove', 'eagle', 'elk', 'falcon', 'finch', 'fox',
+  'hawk', 'heron', 'horse', 'lark', 'lion', 'lynx', 'otter', 'owl', 'panther', 'puma',
+  'raven', 'robin', 'salmon', 'seal', 'shark', 'sparrow', 'stag', 'swan', 'tiger', 'trout',
+  'whale', 'wolf', 'wren', 'badger', 'beaver', 'bison', 'bobcat', 'coyote', 'dolphin', 'gecko',
+
+  // Plants
+  'aspen', 'bamboo', 'birch', 'bloom', 'blossom', 'bonsai', 'branch', 'cedar', 'cherry', 'clover',
+  'cypress', 'elm', 'fern', 'flower', 'grove', 'hazel', 'holly', 'ivy', 'jasmine', 'laurel',
+  'leaf', 'lily', 'lotus', 'maple', 'moss', 'oak', 'olive', 'orchid', 'palm', 'pine',
+  'poplar', 'reed', 'rose', 'sage', 'sequoia', 'spruce', 'thistle', 'tulip', 'vine', 'willow',
+
+  // Elements/Materials
+  'amber', 'bronze', 'carbon', 'chrome', 'cobalt', 'copper', 'coral', 'crystal', 'diamond', 'ember',
+  'flint', 'garnet', 'gem', 'glass', 'gold', 'granite', 'iron', 'jade', 'jasper', 'marble',
+  'nickel', 'obsidian', 'opal', 'pearl', 'quartz', 'ruby', 'sand', 'sapphire', 'silver', 'slate',
+  'steel', 'stone', 'titanium', 'topaz', 'zinc', 'basalt', 'clay', 'cobble', 'pebble', 'boulder',
+
+  // Water features
+  'brook', 'cascade', 'channel', 'current', 'eddy', 'falls', 'flood', 'flow', 'fountain', 'geyser',
+  'glacier', 'inlet', 'rapids', 'ripple', 'shoal', 'spray', 'surge', 'tide', 'torrent', 'wave',
+] as const;
+
+export type Adjective = typeof ADJECTIVES[number];
+export type Noun = typeof NOUNS[number];

--- a/packages/shared/src/sources/__tests__/authScheme-empty.test.ts
+++ b/packages/shared/src/sources/__tests__/authScheme-empty.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Test that buildAuthorizationHeader correctly handles empty authScheme
+ *
+ * This tests the actual exported function from api-tools.ts to ensure
+ * the production code behaves correctly.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { buildAuthorizationHeader } from '../api-tools.ts';
+
+describe('buildAuthorizationHeader', () => {
+  const token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test';
+
+  it('defaults to Bearer prefix when authScheme is undefined', () => {
+    expect(buildAuthorizationHeader(undefined, token)).toBe(`Bearer ${token}`);
+  });
+
+  it('uses custom prefix when authScheme is provided', () => {
+    expect(buildAuthorizationHeader('Token', token)).toBe(`Token ${token}`);
+    expect(buildAuthorizationHeader('ApiKey', token)).toBe(`ApiKey ${token}`);
+  });
+
+  it('sends token without prefix when authScheme is empty string', () => {
+    // This is the critical case: empty string should NOT add a prefix
+    // Some APIs (GraphQL endpoints, internal services) expect raw tokens
+    expect(buildAuthorizationHeader('', token)).toBe(token);
+    expect(buildAuthorizationHeader('', token)).not.toContain('Bearer');
+    expect(buildAuthorizationHeader('', token)).not.toContain(' ');
+  });
+
+  it('handles null by defaulting to Bearer (via nullish coalescing)', () => {
+    // TypeScript wouldn't allow null, but test runtime behavior
+    expect(buildAuthorizationHeader(null as unknown as undefined, token)).toBe(`Bearer ${token}`);
+  });
+});

--- a/packages/shared/src/sources/__tests__/basic-auth.test.ts
+++ b/packages/shared/src/sources/__tests__/basic-auth.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for basic auth credential storage and retrieval
+ *
+ * Tests the fix for the bug where basic auth credentials were stored as
+ * pre-encoded base64 instead of JSON {username, password} format.
+ *
+ * The correct flow is:
+ * 1. sessions.ts stores: { value: JSON.stringify({ username, password }) }
+ * 2. credential-manager.ts retrieves and parses: JSON.parse(value) → { username, password }
+ * 3. api-tools.ts encodes at request time: Buffer.from(`${username}:${password}`).toString('base64')
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+// Type definitions matching the actual code
+interface BasicAuthCredential {
+  username: string;
+  password: string;
+}
+
+type ApiCredential = string | BasicAuthCredential;
+
+/**
+ * Type guard from api-tools.ts
+ */
+function isBasicAuthCredential(cred: ApiCredential): cred is BasicAuthCredential {
+  return typeof cred === 'object' && cred !== null && 'username' in cred && 'password' in cred;
+}
+
+/**
+ * Simulates how sessions.ts stores basic auth credentials (FIXED version)
+ */
+function storeBasicAuthCredential(username: string, password: string): { value: string } {
+  // Store value as JSON string {username, password}
+  return { value: JSON.stringify({ username, password }) };
+}
+
+/**
+ * Simulates how credential-manager.ts retrieves basic auth credentials
+ * (from getApiCredential method, lines 190-207)
+ */
+function getApiCredential(storedValue: string, isBasicAuth: boolean): ApiCredential | null {
+  if (!storedValue) return null;
+
+  if (isBasicAuth) {
+    try {
+      const parsed = JSON.parse(storedValue);
+      if (parsed.username && parsed.password) {
+        return parsed as BasicAuthCredential;
+      }
+    } catch {
+      // Not JSON, treat as regular credential
+    }
+  }
+
+  return storedValue;
+}
+
+/**
+ * Simulates how api-tools.ts builds headers with basic auth
+ * (from buildHeaders function, lines 59-65)
+ */
+function buildBasicAuthHeader(credential: ApiCredential): string | null {
+  if (isBasicAuthCredential(credential)) {
+    const encoded = Buffer.from(`${credential.username}:${credential.password}`).toString('base64');
+    return `Basic ${encoded}`;
+  }
+  return null;
+}
+
+describe('Basic Auth Credential Storage', () => {
+  test('stores credentials as JSON with username and password', () => {
+    const stored = storeBasicAuthCredential('user@example.com/token', 'api-key-123');
+
+    expect(stored.value).toBeDefined();
+
+    // Should be valid JSON
+    const parsed = JSON.parse(stored.value);
+    expect(parsed.username).toBe('user@example.com/token');
+    expect(parsed.password).toBe('api-key-123');
+  });
+
+  test('does NOT store credentials as pre-encoded base64', () => {
+    const stored = storeBasicAuthCredential('user@example.com/token', 'api-key-123');
+
+    // The stored value should NOT be base64-encoded credentials
+    // It should be a JSON string
+    const isBase64 = /^[A-Za-z0-9+/=]+$/.test(stored.value);
+    expect(isBase64).toBe(false);
+
+    // Should start with { since it's JSON
+    expect(stored.value.startsWith('{')).toBe(true);
+  });
+});
+
+describe('Basic Auth Credential Retrieval', () => {
+  test('retrieves credentials as BasicAuthCredential object', () => {
+    const stored = storeBasicAuthCredential('user@example.com/token', 'api-key-123');
+    const credential = getApiCredential(stored.value, true);
+
+    expect(credential).not.toBeNull();
+    expect(isBasicAuthCredential(credential!)).toBe(true);
+
+    if (isBasicAuthCredential(credential!)) {
+      expect(credential.username).toBe('user@example.com/token');
+      expect(credential.password).toBe('api-key-123');
+    }
+  });
+
+  test('handles Zendesk-style credentials (email/token format)', () => {
+    // Zendesk uses email/token as username and API key as password
+    const stored = storeBasicAuthCredential('support@company.com/token', 'zendesk-api-key');
+    const credential = getApiCredential(stored.value, true);
+
+    expect(isBasicAuthCredential(credential!)).toBe(true);
+    if (isBasicAuthCredential(credential!)) {
+      expect(credential.username).toBe('support@company.com/token');
+      expect(credential.password).toBe('zendesk-api-key');
+    }
+  });
+
+  test('returns string credential when not basic auth', () => {
+    const bearerToken = 'some-bearer-token';
+    const credential = getApiCredential(bearerToken, false);
+
+    expect(credential).toBe(bearerToken);
+    expect(isBasicAuthCredential(credential!)).toBe(false);
+  });
+
+  test('handles malformed JSON gracefully', () => {
+    const malformed = 'not-valid-json';
+    const credential = getApiCredential(malformed, true);
+
+    // Should fall back to returning the raw string
+    expect(credential).toBe(malformed);
+    expect(isBasicAuthCredential(credential!)).toBe(false);
+  });
+});
+
+describe('Basic Auth Header Building', () => {
+  test('encodes credentials as base64 at request time', () => {
+    const stored = storeBasicAuthCredential('user@example.com/token', 'api-key-123');
+    const credential = getApiCredential(stored.value, true);
+    const header = buildBasicAuthHeader(credential!);
+
+    expect(header).not.toBeNull();
+    expect(header!.startsWith('Basic ')).toBe(true);
+
+    // Decode and verify
+    const base64Part = header!.replace('Basic ', '');
+    const decoded = Buffer.from(base64Part, 'base64').toString('utf-8');
+    expect(decoded).toBe('user@example.com/token:api-key-123');
+  });
+
+  test('produces correct base64 for Zendesk credentials', () => {
+    const stored = storeBasicAuthCredential('support@company.com/token', 'zendesk-api-key');
+    const credential = getApiCredential(stored.value, true);
+    const header = buildBasicAuthHeader(credential!);
+
+    const base64Part = header!.replace('Basic ', '');
+    const decoded = Buffer.from(base64Part, 'base64').toString('utf-8');
+    expect(decoded).toBe('support@company.com/token:zendesk-api-key');
+  });
+
+  test('returns null for non-basic-auth credentials', () => {
+    const header = buildBasicAuthHeader('bearer-token-string');
+    expect(header).toBeNull();
+  });
+});
+
+describe('End-to-End Basic Auth Flow', () => {
+  test('full flow: store → retrieve → build header', () => {
+    // 1. Store credentials (as sessions.ts does)
+    const username = 'admin@zendesk.com/token';
+    const password = 'super-secret-api-key';
+    const stored = storeBasicAuthCredential(username, password);
+
+    // 2. Retrieve credentials (as credential-manager.ts does)
+    const credential = getApiCredential(stored.value, true);
+
+    // 3. Build auth header (as api-tools.ts does)
+    const header = buildBasicAuthHeader(credential!);
+
+    // 4. Verify the final result
+    const base64Part = header!.replace('Basic ', '');
+    const decoded = Buffer.from(base64Part, 'base64').toString('utf-8');
+    expect(decoded).toBe(`${username}:${password}`);
+  });
+
+  test('credentials with special characters are handled correctly', () => {
+    const username = 'user+test@example.com/token';
+    const password = 'p@$$w0rd!#$%^&*()';
+
+    const stored = storeBasicAuthCredential(username, password);
+    const credential = getApiCredential(stored.value, true);
+    const header = buildBasicAuthHeader(credential!);
+
+    const base64Part = header!.replace('Basic ', '');
+    const decoded = Buffer.from(base64Part, 'base64').toString('utf-8');
+    expect(decoded).toBe(`${username}:${password}`);
+  });
+});
+
+describe('Bug Regression: Pre-encoded Base64 Storage', () => {
+  test('OLD BUG: pre-encoded base64 fails to parse as BasicAuthCredential', () => {
+    // This simulates the OLD buggy behavior
+    const username = 'user@example.com/token';
+    const password = 'api-key-123';
+
+    // OLD BUGGY way: store as pre-encoded base64
+    const buggyStored = {
+      value: Buffer.from(`${username}:${password}`).toString('base64'),
+    };
+
+    // When we try to retrieve it as basic auth...
+    const credential = getApiCredential(buggyStored.value, true);
+
+    // It FAILS to parse as BasicAuthCredential because it's not JSON
+    expect(isBasicAuthCredential(credential!)).toBe(false);
+
+    // It falls back to treating it as a string
+    expect(typeof credential).toBe('string');
+  });
+
+  test('NEW FIX: JSON storage correctly parses as BasicAuthCredential', () => {
+    const username = 'user@example.com/token';
+    const password = 'api-key-123';
+
+    // NEW FIXED way: store as JSON
+    const fixedStored = storeBasicAuthCredential(username, password);
+
+    // Retrieval works correctly
+    const credential = getApiCredential(fixedStored.value, true);
+
+    // It correctly parses as BasicAuthCredential
+    expect(isBasicAuthCredential(credential!)).toBe(true);
+
+    if (isBasicAuthCredential(credential!)) {
+      expect(credential.username).toBe(username);
+      expect(credential.password).toBe(password);
+    }
+  });
+});

--- a/packages/shared/src/sources/__tests__/server-builder-authScheme.test.ts
+++ b/packages/shared/src/sources/__tests__/server-builder-authScheme.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Test that SourceServerBuilder.buildApiConfig correctly handles empty authScheme
+ *
+ * This complements authScheme-empty.test.ts by testing the server-builder layer
+ * which transforms source configs before they reach buildAuthorizationHeader.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { SourceServerBuilder } from '../server-builder.ts';
+import type { LoadedSource } from '../types.ts';
+
+describe('SourceServerBuilder.buildApiConfig', () => {
+  const builder = new SourceServerBuilder();
+
+  // Helper to create a minimal LoadedSource for testing
+  function createMockSource(authType: string, authScheme?: string): LoadedSource {
+    return {
+      config: {
+        id: 'test-source',
+        name: 'Test Source',
+        slug: 'test-source',
+        type: 'api',
+        enabled: true,
+        provider: 'test',
+        api: {
+          baseUrl: 'https://api.example.com/',
+          authType: authType as 'bearer' | 'header' | 'query' | 'basic' | 'none',
+          authScheme,
+        },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      guide: null,
+      folderPath: '/test/sources/test-source',
+      workspaceRootPath: '/test',
+      workspaceId: 'test-workspace',
+    };
+  }
+
+  it('defaults to Bearer when authScheme is undefined', () => {
+    const source = createMockSource('bearer', undefined);
+    const config = builder.buildApiConfig(source);
+
+    expect(config.auth).toEqual({ type: 'bearer', authScheme: 'Bearer' });
+  });
+
+  it('uses custom authScheme when provided', () => {
+    const source = createMockSource('bearer', 'Token');
+    const config = builder.buildApiConfig(source);
+
+    expect(config.auth).toEqual({ type: 'bearer', authScheme: 'Token' });
+  });
+
+  it('preserves empty string authScheme for APIs without Bearer prefix', () => {
+    // This is the critical case that was broken before the fix
+    // APIs like Craft Admin expect raw JWT tokens without any prefix
+    const source = createMockSource('bearer', '');
+    const config = builder.buildApiConfig(source);
+
+    // Empty string should be preserved, NOT converted to 'Bearer'
+    expect(config.auth).toEqual({ type: 'bearer', authScheme: '' });
+    expect((config.auth as { authScheme: string }).authScheme).toBe('');
+    expect((config.auth as { authScheme: string }).authScheme).not.toBe('Bearer');
+  });
+
+  it('handles null by defaulting to Bearer (via nullish coalescing)', () => {
+    // Test runtime behavior with null (TypeScript wouldn't allow this)
+    const source = createMockSource('bearer', null as unknown as undefined);
+    const config = builder.buildApiConfig(source);
+
+    expect(config.auth).toEqual({ type: 'bearer', authScheme: 'Bearer' });
+  });
+
+  it('does not add authScheme for non-bearer auth types', () => {
+    const headerSource = createMockSource('header');
+    const headerConfig = builder.buildApiConfig(headerSource);
+    expect(headerConfig.auth).toEqual({ type: 'header', headerName: 'x-api-key' });
+
+    const querySource = createMockSource('query');
+    const queryConfig = builder.buildApiConfig(querySource);
+    expect(queryConfig.auth).toEqual({ type: 'query', queryParam: 'api_key' });
+
+    const basicSource = createMockSource('basic');
+    const basicConfig = builder.buildApiConfig(basicSource);
+    expect(basicConfig.auth).toEqual({ type: 'basic' });
+
+    const noneSource = createMockSource('none');
+    const noneConfig = builder.buildApiConfig(noneSource);
+    expect(noneConfig.auth).toEqual({ type: 'none' });
+  });
+});

--- a/packages/shared/src/sources/api-tools.ts
+++ b/packages/shared/src/sources/api-tools.ts
@@ -1,0 +1,842 @@
+/**
+ * Dynamic API Tool Factory
+ *
+ * Creates a single flexible MCP tool per API configuration.
+ * Each tool accepts { path, method, params } and auto-injects authentication.
+ */
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { ApiConfig } from './types.ts';
+import { debug } from '../utils/debug.ts';
+import { estimateTokens, summarizeLargeResult, TOKEN_LIMIT, MAX_SUMMARIZATION_INPUT } from '../utils/summarize.ts';
+import type { ApiCredential, BasicAuthCredential } from './credential-manager.ts';
+
+// Maximum file size for binary downloads (500MB)
+// Prevents memory exhaustion from malicious or unexpectedly large API responses
+const MAX_DOWNLOAD_SIZE = 500 * 1024 * 1024;
+
+// Re-export for convenience
+export type { ApiCredential, BasicAuthCredential } from './credential-manager.ts';
+
+/**
+ * Build an Authorization header value for bearer-style authentication.
+ *
+ * Supports three cases:
+ * - `authScheme: undefined` → defaults to "Bearer {token}"
+ * - `authScheme: "Token"` → "Token {token}" (custom prefix)
+ * - `authScheme: ""` → "{token}" (no prefix, for APIs that expect raw tokens)
+ *
+ * The empty string case is needed for APIs like some GraphQL endpoints or
+ * internal services that expect the raw JWT/token without a "Bearer" prefix.
+ *
+ * @param authScheme - The auth scheme prefix (undefined defaults to "Bearer", empty string means no prefix)
+ * @param token - The authentication token
+ * @returns The full Authorization header value
+ */
+export function buildAuthorizationHeader(authScheme: string | undefined, token: string): string {
+  // Use nullish coalescing (??) so empty string "" is preserved, only undefined/null falls back to 'Bearer'
+  const scheme = authScheme ?? 'Bearer';
+  // If scheme is empty string, return just the token; otherwise prefix with scheme
+  return scheme ? `${scheme} ${token}` : token;
+}
+
+/**
+ * API credential source - can be a static credential or a function that returns a token.
+ * Token getter functions are used for OAuth sources that need auto-refresh.
+ */
+export type ApiCredentialSource = ApiCredential | (() => Promise<string>);
+
+/**
+ * Type guard to check if credential is BasicAuthCredential
+ */
+function isBasicAuthCredential(cred: ApiCredential): cred is BasicAuthCredential {
+  return typeof cred === 'object' && cred !== null && 'username' in cred && 'password' in cred;
+}
+
+/**
+ * Type guard to check if credential source is a token getter function
+ */
+function isTokenGetter(cred: ApiCredentialSource): cred is () => Promise<string> {
+  return typeof cred === 'function';
+}
+
+/**
+ * Save large API response to session's responses folder.
+ * Creates the folder if it doesn't exist.
+ * Returns the file path where the response was saved.
+ *
+ * @param sessionPath - Path to the session folder
+ * @param toolName - Name of the API tool (e.g., "gmail")
+ * @param apiPath - API endpoint path (e.g., "/users/me/messages")
+ * @param content - The full response content to save
+ * @returns The absolute path to the saved file
+ */
+function saveLargeResponse(
+  sessionPath: string,
+  toolName: string,
+  apiPath: string,
+  content: string
+): string {
+  // Create responses directory under the session folder (mkdirSync with recursive is idempotent)
+  const responsesDir = join(sessionPath, 'responses');
+  mkdirSync(responsesDir, { recursive: true });
+
+  // Generate a filename with timestamp (including ms to avoid collisions) and sanitized path
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 23);
+  const safePath = apiPath.replace(/[^a-zA-Z0-9]/g, '_').slice(0, 30);
+  const filename = `${timestamp}_${toolName}_${safePath}.txt`;
+  const filePath = join(responsesDir, filename);
+
+  writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+
+// ============================================================
+// Binary Response Detection and Handling
+// ============================================================
+
+/**
+ * Text MIME types that should be processed as text.
+ * We whitelist text types because they're finite and well-defined.
+ * Everything else is treated as binary - this is future-proof since
+ * new binary types (application/vnd.x-whatever) automatically work.
+ */
+const TEXT_MIME_TYPES = [
+  'text/',                    // text/plain, text/html, text/css, etc.
+  'application/json',
+  'application/xml',
+  'application/javascript',
+  'application/x-javascript',
+  'application/ecmascript',
+  'application/x-www-form-urlencoded',
+  'application/ld+json',      // JSON-LD
+  'application/graphql',
+  'application/x-yaml',
+  'application/yaml',
+];
+
+/**
+ * Check if a Content-Type indicates text content.
+ * Returns true for text types, false for binary.
+ * If no Content-Type, defaults to true (safer for APIs that typically return JSON).
+ */
+function isTextContentType(contentType: string | null): boolean {
+  if (!contentType) return true; // Assume text if unknown (safer for APIs)
+
+  const normalized = (contentType.toLowerCase().split(';')[0] ?? '').trim();
+
+  // Handle +json, +xml suffixes (application/vnd.api+json, image/svg+xml)
+  if (normalized.endsWith('+json') || normalized.endsWith('+xml')) {
+    return true;
+  }
+
+  return TEXT_MIME_TYPES.some(t =>
+    t.endsWith('/') ? normalized.startsWith(t) : normalized === t
+  );
+}
+
+/**
+ * Inspect buffer contents to detect binary data.
+ * Used as fallback when Content-Type is missing or ambiguous.
+ * Checks for null bytes and high ratio of non-printable characters.
+ *
+ * UTF-8 handling: We skip ALL bytes >= 0x80 (multibyte sequences) to avoid
+ * misclassifying international text (accented chars, emojis, CJK) as binary.
+ * Only ASCII bytes (0x00-0x7F) are analyzed for printability.
+ */
+function looksLikeBinary(buffer: Buffer): boolean {
+  // Check first 8KB for binary indicators
+  const sample = buffer.slice(0, 8192);
+
+  // Null bytes are a dead giveaway for binary
+  if (sample.includes(0x00)) return true;
+
+  // Count non-printable ASCII characters (skip UTF-8 multibyte entirely)
+  let nonPrintable = 0;
+  let asciiCount = 0;
+  for (const byte of sample) {
+    // Skip UTF-8 multibyte sequences (both leading and continuation bytes)
+    // This ensures files with non-ASCII text aren't misclassified as binary
+    if (byte >= 0x80) continue;
+
+    asciiCount++;
+    // Check if ASCII byte is non-printable (excluding common whitespace)
+    if (byte < 0x09 || (byte > 0x0D && byte < 0x20)) {
+      nonPrintable++;
+    }
+  }
+
+  // If >10% of ASCII bytes are non-printable, likely binary
+  // Use asciiCount as denominator to avoid false positives on UTF-8 heavy files
+  return asciiCount > 0 && (nonPrintable / asciiCount) > 0.10;
+}
+
+/**
+ * MIME type to file extension mapping for binary downloads.
+ * Used when extracting filename from Content-Type.
+ */
+const MIME_TO_EXT: Record<string, string> = {
+  'application/pdf': '.pdf',
+  'application/zip': '.zip',
+  'application/gzip': '.gz',
+  'application/x-gzip': '.gz',
+  'application/x-tar': '.tar',
+  'application/x-rar-compressed': '.rar',
+  'application/x-7z-compressed': '.7z',
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/svg+xml': '.svg',
+  'image/x-icon': '.ico',
+  'image/bmp': '.bmp',
+  'image/tiff': '.tiff',
+  'audio/mpeg': '.mp3',
+  'audio/wav': '.wav',
+  'audio/ogg': '.ogg',
+  'audio/flac': '.flac',
+  'video/mp4': '.mp4',
+  'video/webm': '.webm',
+  'video/quicktime': '.mov',
+  'video/x-msvideo': '.avi',
+  'application/msword': '.doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/vnd.ms-excel': '.xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+  'application/vnd.ms-powerpoint': '.ppt',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': '.pptx',
+  'application/octet-stream': '.bin',
+};
+
+/**
+ * Magic bytes (file signatures) for common binary formats.
+ * Used to detect file type when MIME type is unknown or generic.
+ * Each entry has the byte sequence to match and the resulting extension.
+ */
+const MAGIC_SIGNATURES: Array<{ bytes: number[]; ext: string }> = [
+  { bytes: [0x25, 0x50, 0x44, 0x46], ext: '.pdf' },           // %PDF
+  { bytes: [0x89, 0x50, 0x4E, 0x47], ext: '.png' },           // .PNG
+  { bytes: [0xFF, 0xD8, 0xFF], ext: '.jpg' },                  // JPEG
+  { bytes: [0x47, 0x49, 0x46, 0x38], ext: '.gif' },           // GIF8
+  { bytes: [0x50, 0x4B, 0x03, 0x04], ext: '.zip' },           // PK.. (also docx, xlsx, pptx)
+  { bytes: [0x52, 0x61, 0x72, 0x21], ext: '.rar' },           // Rar!
+  { bytes: [0x1F, 0x8B], ext: '.gz' },                         // gzip
+  { bytes: [0x42, 0x4D], ext: '.bmp' },                        // BM
+  { bytes: [0x49, 0x44, 0x33], ext: '.mp3' },                  // ID3 (MP3 with ID3 tag)
+  { bytes: [0xFF, 0xFB], ext: '.mp3' },                        // MP3 frame sync
+  { bytes: [0x52, 0x49, 0x46, 0x46], ext: '.wav' },           // RIFF (WAV container)
+  { bytes: [0x4F, 0x67, 0x67, 0x53], ext: '.ogg' },           // OggS
+  { bytes: [0x66, 0x4C, 0x61, 0x43], ext: '.flac' },          // fLaC
+];
+
+/**
+ * Detect file extension from magic bytes (file signature).
+ * Inspects first bytes of buffer to identify common file formats.
+ * Returns extension with dot (e.g., '.pdf') or empty string if unknown.
+ */
+function detectExtensionFromMagic(buffer: Buffer): string {
+  if (buffer.length < 8) return '';
+
+  for (const sig of MAGIC_SIGNATURES) {
+    if (sig.bytes.every((byte, i) => buffer[i] === byte)) {
+      return sig.ext;
+    }
+  }
+  return '';
+}
+
+/**
+ * Get file extension from MIME type, with optional magic byte fallback.
+ * First tries MIME type mapping, then falls back to buffer inspection.
+ */
+function getMimeExtension(mimeType: string | null, buffer?: Buffer): string {
+  // First try MIME type mapping (fastest)
+  if (mimeType) {
+    const normalized = (mimeType.toLowerCase().split(';')[0] ?? '').trim();
+    const ext = MIME_TO_EXT[normalized];
+    if (ext && ext !== '.bin') return ext; // Don't use .bin from MIME, let magic detect
+  }
+
+  // Fallback to magic byte detection
+  if (buffer) {
+    return detectExtensionFromMagic(buffer);
+  }
+
+  return '';
+}
+
+/**
+ * Sanitize filename by removing unsafe characters.
+ */
+function sanitizeFilename(filename: string): string {
+  return filename
+    .replace(/[/\\:*?"<>|]/g, '_') // Replace unsafe chars with underscore
+    .replace(/\s+/g, '_')          // Replace whitespace with underscore
+    .replace(/_+/g, '_')           // Collapse multiple underscores
+    .replace(/^_|_$/g, '')         // Trim leading/trailing underscores
+    .slice(0, 200);                // Limit length
+}
+
+/**
+ * Extract filename from response headers or URL path.
+ * Priority: Content-Disposition > URL path > generated name (with magic byte detection)
+ *
+ * @param buffer - Optional buffer for magic byte detection when mime type is unknown
+ */
+function extractFilename(
+  response: Response,
+  apiPath: string,
+  mimeType: string | null,
+  buffer?: Buffer
+): string {
+  // Priority 1: Content-Disposition header
+  const disposition = response.headers.get('content-disposition');
+  if (disposition) {
+    // Handle both filename="name" and filename*=UTF-8''name formats
+    const match = disposition.match(/filename\*?=(?:UTF-8'')?["']?([^"';\n]+)/i);
+    if (match && match[1]) {
+      const decoded = decodeURIComponent(match[1]);
+      return sanitizeFilename(decoded);
+    }
+  }
+
+  // Priority 2: URL path - extract filename if it has an extension
+  const urlPart = apiPath.split('/').pop()?.split('?')[0];
+  if (urlPart && urlPart.includes('.')) {
+    return sanitizeFilename(urlPart);
+  }
+
+  // Priority 3: Generate from timestamp + detected extension
+  // Uses MIME type first, falls back to magic byte detection from buffer
+  const ext = getMimeExtension(mimeType, buffer) || '.bin';
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  return `download_${timestamp}${ext}`;
+}
+
+/**
+ * Format bytes to human-readable string.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const size = bytes / Math.pow(k, i);
+  return `${size.toFixed(i > 0 ? 1 : 0)} ${sizes[i]}`;
+}
+
+/**
+ * Binary download result returned to the agent.
+ * Contains file metadata instead of content - agents can reference the file path.
+ */
+interface BinaryDownloadResult {
+  type: 'file_download';
+  path: string;
+  filename: string;
+  mimeType: string | null;
+  size: number;
+  sizeHuman: string;
+}
+
+/**
+ * Error result returned when binary save fails.
+ */
+interface BinaryDownloadError {
+  type: 'file_download_error';
+  error: string;
+}
+
+/**
+ * Save binary response to session's downloads folder.
+ * Uses atomic file creation (O_EXCL) to prevent TOCTOU race conditions.
+ * Returns structured metadata for the agent, or error if save fails.
+ */
+function saveBinaryResponse(
+  sessionPath: string,
+  filename: string,
+  buffer: Buffer,
+  mimeType: string | null
+): BinaryDownloadResult | BinaryDownloadError {
+  const downloadsDir = join(sessionPath, 'downloads');
+
+  // Create downloads directory with error handling
+  try {
+    mkdirSync(downloadsDir, { recursive: true });
+  } catch (err) {
+    return {
+      type: 'file_download_error',
+      error: `Failed to create downloads directory: ${(err as Error).message}`,
+    };
+  }
+
+  // Atomic file creation with collision handling
+  // Uses 'wx' flag (O_CREAT | O_EXCL) which fails if file exists - no TOCTOU race
+  let finalFilename = filename;
+  let filePath = join(downloadsDir, finalFilename);
+  let counter = 0;
+  const maxAttempts = 100;
+
+  while (counter < maxAttempts) {
+    try {
+      // 'wx' = exclusive creation, fails atomically if file exists
+      writeFileSync(filePath, buffer, { flag: 'wx' });
+      // Success - file was created
+      return {
+        type: 'file_download',
+        path: filePath,
+        filename: finalFilename,
+        mimeType,
+        size: buffer.length,
+        sizeHuman: formatBytes(buffer.length),
+      };
+    } catch (err: unknown) {
+      const error = err as NodeJS.ErrnoException;
+      if (error.code === 'EEXIST') {
+        // File exists - try next numbered filename
+        counter++;
+        const dotIdx = filename.lastIndexOf('.');
+        if (dotIdx > 0) {
+          const base = filename.slice(0, dotIdx);
+          const ext = filename.slice(dotIdx);
+          finalFilename = `${base}-${counter}${ext}`;
+        } else {
+          finalFilename = `${filename}-${counter}`;
+        }
+        filePath = join(downloadsDir, finalFilename);
+      } else {
+        // Other error (permissions, disk full, etc.)
+        return {
+          type: 'file_download_error',
+          error: `Failed to save file: ${error.message}`,
+        };
+      }
+    }
+  }
+
+  return {
+    type: 'file_download_error',
+    error: `Failed to save file after ${maxAttempts} attempts - too many collisions`,
+  };
+}
+
+/**
+ * Check if JSON response looks like a Gmail attachment (base64-wrapped binary).
+ * Gmail attachments have format: { size: number, data: "base64string" }
+ */
+function isGmailAttachment(json: unknown): json is { size: number; data: string } {
+  if (!json || typeof json !== 'object') return false;
+  const obj = json as Record<string, unknown>;
+  return (
+    typeof obj.data === 'string' &&
+    typeof obj.size === 'number' &&
+    obj.data.length > 100 // Real attachments have substantial base64 data
+  );
+}
+
+
+/**
+ * Build headers for an API request, injecting authentication and default headers
+ */
+function buildHeaders(
+  auth: ApiConfig['auth'],
+  credential: ApiCredential,
+  defaultHeaders?: Record<string, string>
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    // Merge default headers (e.g., beta feature flags)
+    ...defaultHeaders,
+  };
+
+  // No auth needed for type='none' or missing auth
+  if (!auth || auth.type === 'none') {
+    return headers;
+  }
+
+  // Basic auth requires username:password credential
+  if (auth.type === 'basic') {
+    if (isBasicAuthCredential(credential)) {
+      const encoded = Buffer.from(`${credential.username}:${credential.password}`).toString('base64');
+      headers['Authorization'] = `Basic ${encoded}`;
+    }
+    return headers;
+  }
+
+  // Other types use string credential (API key/token)
+  const apiKey = typeof credential === 'string' ? credential : '';
+  if (!apiKey) {
+    return headers;
+  }
+
+  if (auth.type === 'header') {
+    headers[auth.headerName || 'x-api-key'] = apiKey;
+  } else if (auth.type === 'bearer') {
+    headers['Authorization'] = buildAuthorizationHeader(auth.authScheme, apiKey);
+  }
+  // Query type is handled in buildUrl
+
+  return headers;
+}
+
+/**
+ * Build the full URL for an API request
+ */
+function buildUrl(
+  baseUrl: string,
+  path: string,
+  method: string,
+  params: Record<string, unknown> | undefined,
+  auth: ApiConfig['auth'],
+  credential: ApiCredential
+): string {
+  // Normalize: remove trailing slash from baseUrl and ensure path starts with /
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  let url = `${normalizedBase}${normalizedPath}`;
+
+  // Handle query param auth (only for string credentials)
+  const apiKey = typeof credential === 'string' ? credential : '';
+  if (auth?.type === 'query' && auth.queryParam && apiKey) {
+    const separator = url.includes('?') ? '&' : '?';
+    url += `${separator}${auth.queryParam}=${encodeURIComponent(apiKey)}`;
+  }
+
+  // Handle GET params in query string
+  if (method === 'GET' && params && Object.keys(params).length > 0) {
+    const urlParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        // Handle arrays and objects
+        if (typeof value === 'object') {
+          urlParams.append(key, JSON.stringify(value));
+        } else {
+          urlParams.append(key, String(value));
+        }
+      }
+    }
+    const queryString = urlParams.toString();
+    if (queryString) {
+      const separator = url.includes('?') ? '&' : '?';
+      url += `${separator}${queryString}`;
+    }
+  }
+
+  return url;
+}
+
+/**
+ * Build tool description from API config
+ */
+function buildToolDescription(config: ApiConfig): string {
+  let desc = `Make authenticated requests to ${config.name} API (${config.baseUrl})\n\n`;
+  desc += `Authentication is handled automatically - just specify path, method, and params.\n\n`;
+
+  // Check for old cache format (no documentation field)
+  if (!config.documentation) {
+    desc += `⚠️ This API was cached with an older format. You can still make requests but you'll need to figure out the endpoints yourself.`;
+    return desc;
+  }
+
+  // Include the rich documentation extracted from the agent definition
+  desc += config.documentation;
+
+  if (config.docsUrl) {
+    desc += `\n\nOfficial docs: ${config.docsUrl}`;
+  }
+
+  // Inform agent about binary file handling
+  desc += `\n\n**Binary Files:** Binary responses (PDFs, images, archives, etc.) are automatically saved to the session downloads folder. You'll receive: { type: "file_download", path, filename, mimeType, size, sizeHuman }. Reference the path when telling users about downloaded files.`;
+
+  return desc;
+}
+
+/**
+ * Create a single flexible MCP tool for an API configuration.
+ * The tool accepts { path, method, params } and handles auth automatically.
+ *
+ * @param config - API configuration with documentation
+ * @param credential - API credential source (string for API key/token, BasicAuthCredential for basic auth,
+ *                     empty string for public APIs, or async function for OAuth token refresh)
+ * @param sessionPath - Optional path to session folder for saving large responses
+ * @returns SDK tool that can be included in an MCP server
+ */
+export function createApiTool(
+  config: ApiConfig,
+  credential: ApiCredentialSource,
+  sessionPath?: string
+) {
+  const toolName = `api_${config.name}`;
+  debug(`[api-tools] Creating flexible tool: ${toolName}`);
+
+  const description = buildToolDescription(config);
+
+  return tool(
+    toolName,
+    description,
+    {
+      path: z.string().describe('API endpoint path, e.g., "/search" or "/v1/completions"'),
+      method: z.enum(['GET', 'POST', 'PUT', 'DELETE', 'PATCH']).describe('HTTP method - check documentation for correct method per endpoint'),
+      params: z.record(z.string(), z.unknown()).optional().describe('Request body (POST/PUT/PATCH) or query parameters (GET)'),
+      _intent: z.string().optional().describe('REQUIRED: Describe what you are trying to accomplish with this API call (1-2 sentences)'),
+    },
+    async (args) => {
+      const { path, method, params, _intent } = args;
+
+      try {
+        // Resolve credential - if it's a token getter function, call it to get fresh token
+        const resolvedCredential: ApiCredential = isTokenGetter(credential)
+          ? await credential()
+          : credential;
+
+        const url = buildUrl(config.baseUrl, path, method, params, config.auth, resolvedCredential);
+        const headers = buildHeaders(config.auth, resolvedCredential, config.defaultHeaders);
+
+        debug(`[api-tools] ${config.name}: ${method} ${url}`);
+
+        const fetchOptions: RequestInit = {
+          method,
+          headers,
+        };
+
+        // Add body for non-GET requests
+        if (method !== 'GET' && params && Object.keys(params).length > 0) {
+          fetchOptions.body = JSON.stringify(params);
+        }
+
+        const response = await fetch(url, fetchOptions);
+
+        // ============================================================
+        // Binary Detection: Check Content-Type and handle binary responses
+        // ============================================================
+        const contentType = response.headers.get('content-type');
+
+        // Memory safety: Check Content-Length before loading response into memory
+        // This prevents OOM crashes from malicious or unexpectedly large responses
+        const contentLength = response.headers.get('content-length');
+        if (contentLength) {
+          const size = parseInt(contentLength, 10);
+          if (!isNaN(size) && size > MAX_DOWNLOAD_SIZE) {
+            return {
+              content: [{
+                type: 'text' as const,
+                text: `Response too large: ${formatBytes(size)} exceeds ${formatBytes(MAX_DOWNLOAD_SIZE)} limit. Use a streaming download tool for large files.`,
+              }],
+              isError: true,
+            };
+          }
+        }
+
+        // Step 1: If Content-Type clearly indicates binary, save directly to disk
+        // This skips text processing entirely for PDFs, images, etc.
+        if (contentType && !isTextContentType(contentType) && sessionPath) {
+          debug(`[api-tools] ${config.name}: Binary content-type detected: ${contentType}`);
+          const buffer = Buffer.from(await response.arrayBuffer());
+          const filename = extractFilename(response, path, contentType, buffer);
+          const result = saveBinaryResponse(sessionPath, filename, buffer, contentType);
+          if (result.type === 'file_download_error') {
+            return {
+              content: [{ type: 'text' as const, text: result.error }],
+              isError: true,
+            };
+          }
+          debug(`[api-tools] ${config.name}: Binary file saved: ${result.path} (${result.sizeHuman})`);
+          return {
+            content: [{
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            }],
+          };
+        }
+
+        // Step 2: For text types or unknown, get content as buffer first
+        // This allows us to inspect for binary content even if Content-Type is wrong
+        const buffer = Buffer.from(await response.arrayBuffer());
+
+        // Step 3: Content inspection fallback for ambiguous cases
+        // If Content-Type was missing/text but content looks binary, save as file
+        if (sessionPath && looksLikeBinary(buffer)) {
+          debug(`[api-tools] ${config.name}: Binary content detected via inspection`);
+          const filename = extractFilename(response, path, contentType, buffer);
+          const result = saveBinaryResponse(sessionPath, filename, buffer, contentType);
+          if (result.type === 'file_download_error') {
+            return {
+              content: [{ type: 'text' as const, text: result.error }],
+              isError: true,
+            };
+          }
+          debug(`[api-tools] ${config.name}: Binary file saved: ${result.path} (${result.sizeHuman})`);
+          return {
+            content: [{
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            }],
+          };
+        }
+
+        // Step 4: It's text - convert to string and continue with normal flow
+        const text = buffer.toString('utf-8');
+
+        // Check for error responses
+        if (!response.ok) {
+          debug(`[api-tools] ${config.name} error ${response.status}: ${text.substring(0, 200)}`);
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `API Error ${response.status}: ${text}`,
+            }],
+            isError: true,
+          };
+        }
+
+        // Step 5: Check for Gmail-style base64-wrapped binary attachments
+        // Gmail attachments return JSON like: { size: 31934, data: "JVBERi0xLjQ..." }
+        if (sessionPath && contentType?.includes('application/json')) {
+          try {
+            const json = JSON.parse(text);
+            if (isGmailAttachment(json)) {
+              const decoded = Buffer.from(json.data, 'base64');
+              // Verify size roughly matches (allow small variance for padding)
+              if (decoded.length > 0 && Math.abs(decoded.length - json.size) < 100) {
+                debug(`[api-tools] ${config.name}: Gmail attachment detected, decoding base64`);
+                // Pass decoded buffer for magic byte detection since Gmail doesn't provide mime type
+                const filename = extractFilename(response, path, null, decoded);
+                const result = saveBinaryResponse(sessionPath, filename, decoded, null);
+                if (result.type === 'file_download_error') {
+                  return {
+                    content: [{ type: 'text' as const, text: result.error }],
+                    isError: true,
+                  };
+                }
+                debug(`[api-tools] ${config.name}: Gmail attachment saved: ${result.path} (${result.sizeHuman})`);
+                return {
+                  content: [{
+                    type: 'text' as const,
+                    text: JSON.stringify(result, null, 2),
+                  }],
+                };
+              }
+            }
+          } catch {
+            // Not valid JSON or not attachment format - continue with normal flow
+          }
+        }
+
+        // ============================================================
+        // Text Response Handling (existing flow)
+        // ============================================================
+
+        // Check if response is too large and needs summarization
+        // TOKEN_LIMIT (~15k tokens / ~60KB) triggers summarization
+        // MAX_SUMMARIZATION_INPUT (~100k tokens / ~400KB) is Haiku's limit
+        const estimatedTokens = estimateTokens(text);
+
+        if (estimatedTokens > TOKEN_LIMIT) {
+          // Log when large response handling is triggered
+          debug(`[api-tools] ${config.name} large response: ${text.length} bytes, ~${estimatedTokens} tokens (limit=${TOKEN_LIMIT}, max=${MAX_SUMMARIZATION_INPUT})`);
+
+          // Always save full response to file first (if sessionPath is available)
+          let filePath: string | undefined;
+          if (sessionPath) {
+            try {
+              filePath = saveLargeResponse(sessionPath, config.name, path, text);
+              debug(`[api-tools] Full response saved to: ${filePath}`);
+            } catch (e) {
+              console.error(`[api-tools] Failed to save response: ${e}`);
+            }
+          }
+
+          // Check if response is too large even for Haiku to summarize
+          if (estimatedTokens > MAX_SUMMARIZATION_INPUT) {
+            debug(`[api-tools] Too large for Haiku summarization, providing file reference + preview...`);
+            const preview = text.substring(0, 2000);
+            const fileRef = filePath
+              ? `Full response saved to: ${filePath}\nUse Read tool to view, or Grep to search.\n\n`
+              : '';
+            return {
+              content: [{
+                type: 'text' as const,
+                text: `[Response too large for summarization (~${estimatedTokens} tokens, max is ~${MAX_SUMMARIZATION_INPUT}). ${fileRef}Preview:\n${preview}...`,
+              }],
+            };
+          }
+
+          if (_intent) {
+            debug(`[api-tools] Using intent for summarization: ${_intent}`);
+          }
+
+          // Try summarization (now works with OAuth via SDK query())
+          try {
+            const summary = await summarizeLargeResult(text, {
+              toolName: `api_${config.name}`,
+              path,
+              input: params,
+              modelIntent: _intent,
+            });
+
+            // Return file path + summary
+            const fileRef = filePath
+              ? `Full response saved to: ${filePath}\nUse Read/Grep to access specific content.\n\n`
+              : '';
+            return {
+              content: [{
+                type: 'text' as const,
+                text: `[Large response (~${estimatedTokens} tokens) summarized. ${fileRef}]\n\n${summary}`,
+              }],
+            };
+          } catch (summarizeError) {
+            // Fallback: file path + preview (no large truncation in context)
+            console.error(`[api-tools] Summarization failed: ${summarizeError}`);
+            const preview = text.substring(0, 2000);
+            const fileRef = filePath
+              ? `Full response saved to: ${filePath}\nUse Read tool to view, or Grep to search.\n\n`
+              : '';
+            return {
+              content: [{
+                type: 'text' as const,
+                text: `[Response too large (~${estimatedTokens} tokens). Summarization failed. ${fileRef}Preview:\n${preview}...`,
+              }],
+            };
+          }
+        }
+
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        debug(`[api-tools] ${config.name} request failed: ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: `Request failed: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}
+
+/**
+ * Create an in-process MCP server with a single flexible API tool.
+ *
+ * @param config - API configuration
+ * @param credential - API credential source (string for API key/token, BasicAuthCredential for basic auth,
+ *                     empty string for public APIs, or async function for OAuth token refresh)
+ * @param sessionPath - Optional path to session folder for saving large responses
+ * @returns SDK MCP server that can be passed to query()
+ */
+export function createApiServer(
+  config: ApiConfig,
+  credential: ApiCredentialSource,
+  sessionPath?: string
+): ReturnType<typeof createSdkMcpServer> {
+  debug(`[api-tools] Creating server for ${config.name}${sessionPath ? ` (session: ${sessionPath})` : ''}`);
+
+  const apiTool = createApiTool(config, credential, sessionPath);
+
+  return createSdkMcpServer({
+    name: `api_${config.name}`,
+    version: '1.0.0',
+    tools: [apiTool],
+  });
+}

--- a/packages/shared/src/sources/builtin-sources.ts
+++ b/packages/shared/src/sources/builtin-sources.ts
@@ -1,0 +1,79 @@
+/**
+ * Built-in Sources
+ *
+ * System-level sources that are always available in every workspace.
+ * These sources are not shown in the sources list UI but are available
+ * for the agent to use.
+ *
+ * NOTE: craft-agents-docs is now an always-available MCP server configured
+ * directly in craft-agent.ts, not a source. This file is kept for backwards
+ * compatibility but returns empty results.
+ */
+
+import type { LoadedSource, FolderSourceConfig } from './types.ts';
+
+/**
+ * Get all built-in sources for a workspace.
+ *
+ * Currently returns empty array - craft-agents-docs has been moved to
+ * an always-available MCP server in craft-agent.ts.
+ *
+ * @param _workspaceId - The workspace ID (unused)
+ * @param _workspaceRootPath - Absolute path to workspace root folder (unused)
+ * @returns Empty array (no built-in sources)
+ */
+export function getBuiltinSources(_workspaceId: string, _workspaceRootPath: string): LoadedSource[] {
+  return [];
+}
+
+/**
+ * Get the built-in Kata Agentss docs source.
+ *
+ * @deprecated craft-agents-docs is now an always-available MCP server
+ * configured directly in craft-agent.ts. This function is kept for
+ * backwards compatibility but returns a placeholder.
+ */
+export function getDocsSource(workspaceId: string, workspaceRootPath: string): LoadedSource {
+  // Return a placeholder - this shouldn't be called anymore
+  const placeholderConfig: FolderSourceConfig = {
+    id: 'builtin-craft-agents-docs',
+    name: 'Kata Agentss Docs',
+    slug: 'craft-agents-docs',
+    enabled: false,
+    provider: 'mintlify',
+    type: 'mcp',
+    // MCP docs server disabled until Kata infrastructure ready
+    // Was: url: 'https://agents.craft.do/docs/mcp'
+    mcp: {
+      transport: 'http',
+      url: '',  // DISABLED: No Kata docs MCP server yet
+      authType: 'none',
+    },
+    tagline: 'Search Kata Agentss documentation and source setup guides',
+    icon: '📚',
+    isAuthenticated: true,
+    connectionStatus: 'connected',
+  };
+
+  return {
+    workspaceId,
+    workspaceRootPath,
+    folderPath: '',
+    config: placeholderConfig,
+    guide: { raw: '' },
+    isBuiltin: true,
+  };
+}
+
+/**
+ * Check if a source slug is a built-in source.
+ *
+ * Returns false - craft-agents-docs is now an always-available MCP server,
+ * not a source in the sources system.
+ *
+ * @param _slug - Source slug to check (unused)
+ * @returns false (no built-in sources)
+ */
+export function isBuiltinSource(_slug: string): boolean {
+  return false;
+}

--- a/packages/shared/src/sources/credential-manager.ts
+++ b/packages/shared/src/sources/credential-manager.ts
@@ -1,0 +1,852 @@
+/**
+ * SourceCredentialManager
+ *
+ * Unified credential management for sources. Consolidates credential CRUD,
+ * credential ID resolution, expiry checking, and OAuth flows.
+ *
+ * This replaces scattered credential logic across:
+ * - SourceService.getSourceToken()
+ * - SourceService.getApiCredential()
+ * - SourceService.getCredentialId()
+ * - session-scoped-tools OAuth triggers
+ * - IPC handlers for credential storage
+ */
+
+import {
+  inferGoogleServiceFromUrl,
+  inferSlackServiceFromUrl,
+  inferMicrosoftServiceFromUrl,
+  isApiOAuthProvider,
+  type LoadedSource,
+  type GoogleService,
+  type SlackService,
+  type MicrosoftService,
+} from './types.ts';
+import type { CredentialId, StoredCredential } from '../credentials/types.ts';
+import { getCredentialManager } from '../credentials/index.ts';
+import { CraftOAuth, getMcpBaseUrl, type OAuthCallbacks, type OAuthTokens } from '../auth/oauth.ts';
+import {
+  startGoogleOAuth,
+  refreshGoogleToken,
+  type GoogleOAuthResult,
+  type GoogleOAuthOptions,
+} from '../auth/google-oauth.ts';
+import {
+  startSlackOAuth,
+  refreshSlackToken,
+  type SlackOAuthResult,
+  type SlackOAuthOptions,
+} from '../auth/slack-oauth.ts';
+import {
+  startMicrosoftOAuth,
+  refreshMicrosoftToken,
+  type MicrosoftOAuthResult,
+  type MicrosoftOAuthOptions,
+} from '../auth/microsoft-oauth.ts';
+import { debug } from '../utils/debug.ts';
+import { markSourceAuthenticated, loadSourceConfig, saveSourceConfig } from './storage.ts';
+
+/**
+ * Result of authentication attempt
+ */
+export interface AuthResult {
+  success: boolean;
+  error?: string;
+  /** For Gmail OAuth, includes user's email */
+  email?: string;
+}
+
+/**
+ * API credential types (string for simple auth, object for basic auth)
+ */
+export type ApiCredential = string | BasicAuthCredential;
+
+export interface BasicAuthCredential {
+  username: string;
+  password: string;
+}
+
+/**
+ * SourceCredentialManager - unified credential operations for sources
+ *
+ * Usage:
+ * ```typescript
+ * const credManager = new SourceCredentialManager();
+ *
+ * // Save credentials
+ * await credManager.save(source, { value: 'token123' });
+ *
+ * // Load credentials
+ * const cred = await credManager.load(source);
+ *
+ * // Run OAuth flow
+ * const result = await credManager.authenticate(source, {
+ *   onStatus: (msg) => console.log(msg),
+ *   onError: (err) => console.error(err),
+ * });
+ * ```
+ */
+export class SourceCredentialManager {
+  // Track in-flight refresh promises to prevent concurrent refreshes for the same source
+  // This prevents race conditions (especially important for Microsoft which rotates refresh tokens)
+  private pendingRefreshes = new Map<string, Promise<string | null>>();
+
+  // ============================================================
+  // Core CRUD Operations
+  // ============================================================
+
+  /**
+   * Save credential for a source
+   */
+  async save(source: LoadedSource, credential: StoredCredential): Promise<void> {
+    const credentialId = this.getCredentialId(source);
+    const manager = getCredentialManager();
+    await manager.set(credentialId, credential);
+    debug(`[SourceCredentialManager] Saved ${credentialId.type} for ${source.config.slug}`);
+  }
+
+  /**
+   * Load credential for a source
+   *
+   * For MCP sources, tries both OAuth and bearer credentials as fallback
+   * (credentials may have been stored via different auth modes)
+   */
+  async load(source: LoadedSource): Promise<StoredCredential | null> {
+    const manager = getCredentialManager();
+
+    // For MCP sources, try both OAuth and bearer credentials
+    // (stdio transport doesn't need credentials)
+    if (source.config.type === 'mcp' && source.config.mcp?.transport !== 'stdio' && source.config.mcp?.authType !== 'none') {
+      return this.loadMcpCredential(source);
+    }
+
+    // For other sources, use the credential ID based on authType
+    const credentialId = this.getCredentialId(source);
+    const cred = await manager.get(credentialId);
+
+    if (cred) {
+      debug(`[SourceCredentialManager] Found ${credentialId.type} for ${source.config.slug}`);
+    }
+
+    return cred;
+  }
+
+  /**
+   * Load MCP credential with fallback (OAuth -> bearer)
+   */
+  private async loadMcpCredential(source: LoadedSource): Promise<StoredCredential | null> {
+    const manager = getCredentialManager();
+    const baseId = {
+      workspaceId: source.workspaceId,
+      sourceId: source.config.slug,
+    };
+
+    // Try OAuth first
+    const oauthCreds = await manager.get({ type: 'source_oauth', ...baseId });
+    if (oauthCreds?.value) {
+      debug(`[SourceCredentialManager] Found source_oauth for ${source.config.slug}`);
+      return oauthCreds;
+    }
+
+    // Fall back to bearer
+    const bearerCreds = await manager.get({ type: 'source_bearer', ...baseId });
+    if (bearerCreds?.value) {
+      debug(`[SourceCredentialManager] Found source_bearer for ${source.config.slug}`);
+      return bearerCreds;
+    }
+
+    debug(`[SourceCredentialManager] No credential found for MCP source ${source.config.slug}`);
+    return null;
+  }
+
+  /**
+   * Delete credential for a source
+   */
+  async delete(source: LoadedSource): Promise<boolean> {
+    const credentialId = this.getCredentialId(source);
+    const manager = getCredentialManager();
+    const deleted = await manager.delete(credentialId);
+    if (deleted) {
+      debug(`[SourceCredentialManager] Deleted ${credentialId.type} for ${source.config.slug}`);
+    }
+    return deleted;
+  }
+
+  /**
+   * Get token value for a source (convenience method)
+   * Returns null if no credential exists or if expired
+   */
+  async getToken(source: LoadedSource): Promise<string | null> {
+    const cred = await this.load(source);
+    if (!cred?.value) return null;
+
+    // Check expiry
+    if (this.isExpired(cred)) {
+      debug(`[SourceCredentialManager] Token expired for ${source.config.slug}`);
+      return null;
+    }
+
+    return cred.value;
+  }
+
+  /**
+   * Get API credential for a source (handles basic auth JSON parsing)
+   */
+  async getApiCredential(source: LoadedSource): Promise<ApiCredential | null> {
+    const cred = await this.load(source);
+    if (!cred?.value) return null;
+
+    // Check for basic auth (JSON with username/password)
+    if (source.config.api?.authType === 'basic') {
+      try {
+        const parsed = JSON.parse(cred.value);
+        if (parsed.username && parsed.password) {
+          return parsed as BasicAuthCredential;
+        }
+      } catch {
+        // Not JSON, treat as regular credential
+      }
+    }
+
+    return cred.value;
+  }
+
+  // ============================================================
+  // Credential ID Resolution
+  // ============================================================
+
+  /**
+   * Get the credential ID for a source
+   *
+   * Determines the correct credential type based on:
+   * - Source type (mcp, api, local)
+   * - Auth type (oauth, bearer, header, etc.)
+   */
+  getCredentialId(source: LoadedSource): CredentialId {
+    const mcp = source.config.mcp;
+    const api = source.config.api;
+
+    let type: CredentialId['type'];
+
+    if (source.config.type === 'mcp') {
+      type = mcp?.authType === 'bearer' ? 'source_bearer' : 'source_oauth';
+    } else if (source.config.type === 'api') {
+      // OAuth providers (Google/Slack/Microsoft) store credentials as source_oauth.
+      // This separates HOW we get credentials (OAuth flow) from HOW we send them (Bearer header).
+      if (isApiOAuthProvider(source.config.provider)) {
+        type = 'source_oauth';
+      } else if (api?.authType === 'bearer') {
+        type = 'source_bearer';
+      } else if (api?.authType === 'basic') {
+        type = 'source_basic';
+      } else {
+        // header, query, or other → stored as apikey
+        type = 'source_apikey';
+      }
+    } else {
+      type = 'source_oauth';
+    }
+
+    return {
+      type,
+      workspaceId: source.workspaceId,
+      sourceId: source.config.slug,
+    };
+  }
+
+  // ============================================================
+  // Expiry Checking
+  // ============================================================
+
+  /**
+   * Check if a credential is expired
+   */
+  isExpired(credential: StoredCredential): boolean {
+    if (!credential.expiresAt) return false;
+    return Date.now() > credential.expiresAt;
+  }
+
+  /**
+   * Check if a credential needs refresh (within 5 min of expiry)
+   */
+  needsRefresh(credential: StoredCredential): boolean {
+    if (!credential.expiresAt) return false;
+    const fiveMinutes = 5 * 60 * 1000;
+    return Date.now() > credential.expiresAt - fiveMinutes;
+  }
+
+  /**
+   * Mark a source as needing re-authentication.
+   * Called when token is missing/expired or token refresh fails.
+   * Updates config.json so the UI shows "needs auth" and the agent gets proper context.
+   */
+  markSourceNeedsReauth(source: LoadedSource, errorMessage: string): void {
+    try {
+      const config = loadSourceConfig(source.workspaceRootPath, source.config.slug);
+      if (config) {
+        config.isAuthenticated = false;
+        config.connectionStatus = 'needs_auth';
+        config.connectionError = errorMessage;
+        saveSourceConfig(source.workspaceRootPath, config);
+        debug(`[SourceCredentialManager] Marked ${source.config.slug} as needing re-auth: ${errorMessage}`);
+      }
+    } catch (error) {
+      debug(`[SourceCredentialManager] Failed to mark ${source.config.slug} as needing re-auth:`, error);
+    }
+  }
+
+  /**
+   * Check if source has valid (non-expired) credentials
+   */
+  async hasValidCredentials(source: LoadedSource): Promise<boolean> {
+    const token = await this.getToken(source);
+    return token !== null;
+  }
+
+  // ============================================================
+  // OAuth Authentication
+  // ============================================================
+
+  /**
+   * Authenticate source via OAuth
+   *
+   * Handles both MCP OAuth and Gmail OAuth flows.
+   * On success, credentials are automatically saved.
+   */
+  async authenticate(
+    source: LoadedSource,
+    callbacks?: OAuthCallbacks
+  ): Promise<AuthResult> {
+    const defaultCallbacks: OAuthCallbacks = {
+      onStatus: (msg) => debug(`[SourceCredentialManager] ${msg}`),
+      onError: (err) => debug(`[SourceCredentialManager] Error: ${err}`),
+    };
+    const cb = callbacks || defaultCallbacks;
+
+    // Google APIs use Google OAuth
+    if (source.config.provider === 'google') {
+      return this.authenticateGoogle(source, cb);
+    }
+
+    // Slack APIs use Slack OAuth
+    if (source.config.provider === 'slack') {
+      return this.authenticateSlack(source, cb);
+    }
+
+    // Microsoft APIs use Microsoft OAuth
+    if (source.config.provider === 'microsoft') {
+      return this.authenticateMicrosoft(source, cb);
+    }
+
+    // MCP OAuth flow
+    if (source.config.type === 'mcp' && source.config.mcp?.authType === 'oauth') {
+      return this.authenticateMcp(source, cb);
+    }
+
+    return {
+      success: false,
+      error: `Source ${source.config.slug} does not use OAuth authentication`,
+    };
+  }
+
+  /**
+   * Authenticate MCP source via OAuth
+   */
+  private async authenticateMcp(
+    source: LoadedSource,
+    callbacks: OAuthCallbacks
+  ): Promise<AuthResult> {
+    if (!source.config.mcp?.url) {
+      return { success: false, error: 'MCP URL not configured' };
+    }
+
+    try {
+      const oauth = new CraftOAuth(
+        { mcpBaseUrl: getMcpBaseUrl(source.config.mcp.url) },
+        callbacks
+      );
+
+      const { tokens, clientId } = await oauth.authenticate();
+
+      // Save the credentials
+      await this.save(source, {
+        value: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        expiresAt: tokens.expiresAt,
+        clientId,
+        tokenType: tokens.tokenType,
+      });
+
+      // Mark source as authenticated in config.json
+      markSourceAuthenticated(source.workspaceRootPath, source.config.slug);
+
+      return { success: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      callbacks.onError(message);
+      return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Authenticate Google API source via Google OAuth
+   *
+   * Supports multiple Google services (Gmail, Calendar, Drive) via:
+   * - provider: "google" with googleService field
+   * - provider: "google" with custom googleScopes
+   * - Inferred from baseUrl (e.g., gmail.googleapis.com → gmail)
+   */
+  private async authenticateGoogle(
+    source: LoadedSource,
+    callbacks: OAuthCallbacks
+  ): Promise<AuthResult> {
+    try {
+      // Determine service/scopes from config
+      const api = source.config.api;
+      let service: GoogleService | undefined;
+      let scopes: string[] | undefined;
+
+      if (api?.googleScopes && api.googleScopes.length > 0) {
+        // Custom scopes take precedence
+        scopes = api.googleScopes;
+      } else if (api?.googleService) {
+        // Use predefined service scopes
+        service = api.googleService;
+      } else {
+        // Infer from baseUrl
+        service = inferGoogleServiceFromUrl(api?.baseUrl);
+        if (!service) {
+          return {
+            success: false,
+            error: `Cannot determine Google service for source '${source.config.slug}'. Set googleService ('gmail', 'calendar', or 'drive') in api config.`,
+          };
+        }
+      }
+
+      const serviceName = service || 'Google API';
+      callbacks.onStatus(`Starting ${serviceName} OAuth flow...`);
+
+      const options: GoogleOAuthOptions = {
+        service,
+        scopes,
+        appType: 'electron',
+      };
+
+      const result: GoogleOAuthResult = await startGoogleOAuth(options);
+
+      if (!result.success) {
+        return { success: false, error: result.error || 'Google OAuth failed' };
+      }
+
+      // Save the credentials
+      await this.save(source, {
+        value: result.accessToken!,
+        refreshToken: result.refreshToken,
+        expiresAt: result.expiresAt,
+      });
+
+      // Mark source as authenticated in config.json
+      markSourceAuthenticated(source.workspaceRootPath, source.config.slug);
+
+      callbacks.onStatus(`${serviceName} authentication successful`);
+      return { success: true, email: result.email };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      callbacks.onError(message);
+      return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Authenticate Slack API source via Slack OAuth
+   *
+   * Supports multiple Slack services via:
+   * - provider: "slack" with slackService field
+   * - provider: "slack" with custom slackBotScopes/slackUserScopes
+   * - Inferred from baseUrl (slack.com → full)
+   */
+  private async authenticateSlack(
+    source: LoadedSource,
+    callbacks: OAuthCallbacks
+  ): Promise<AuthResult> {
+    try {
+      // Determine service/scopes from config
+      const api = source.config.api;
+      let service: SlackService | undefined;
+      let userScopes: string[] | undefined;
+
+      if (api?.slackUserScopes && api.slackUserScopes.length > 0) {
+        // Custom scopes take precedence
+        userScopes = api.slackUserScopes;
+      } else if (api?.slackService) {
+        // Use predefined service scopes
+        service = api.slackService;
+      } else {
+        // Infer from baseUrl (defaults to 'full')
+        service = inferSlackServiceFromUrl(api?.baseUrl) || 'full';
+      }
+
+      const serviceName = service ? `Slack ${service}` : 'Slack';
+      callbacks.onStatus(`Starting ${serviceName} OAuth flow...`);
+
+      const options: SlackOAuthOptions = {
+        service,
+        userScopes,
+        appType: 'electron',
+      };
+
+      const result: SlackOAuthResult = await startSlackOAuth(options);
+
+      if (!result.success) {
+        return { success: false, error: result.error || 'Slack OAuth failed' };
+      }
+
+      // Save the credentials
+      await this.save(source, {
+        value: result.accessToken!,
+        refreshToken: result.refreshToken,
+        expiresAt: result.expiresAt,
+      });
+
+      // Mark source as authenticated in config.json
+      markSourceAuthenticated(source.workspaceRootPath, source.config.slug);
+
+      callbacks.onStatus(`${serviceName} authentication successful`);
+      // Use teamName as the identifier (similar to email for Google)
+      return { success: true, email: result.teamName };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      callbacks.onError(message);
+      return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Authenticate Microsoft API source via Microsoft OAuth
+   *
+   * Supports multiple Microsoft services (Outlook, OneDrive, Calendar, Teams) via:
+   * - provider: "microsoft" with microsoftService field
+   * - provider: "microsoft" with custom microsoftScopes
+   * - Inferred from baseUrl (e.g., graph.microsoft.com → outlook)
+   */
+  private async authenticateMicrosoft(
+    source: LoadedSource,
+    callbacks: OAuthCallbacks
+  ): Promise<AuthResult> {
+    try {
+      // Determine service/scopes from config
+      const api = source.config.api;
+      let service: MicrosoftService | undefined;
+      let scopes: string[] | undefined;
+
+      if (api?.microsoftScopes && api.microsoftScopes.length > 0) {
+        // Custom scopes take precedence
+        scopes = api.microsoftScopes;
+      } else if (api?.microsoftService) {
+        // Use predefined service scopes
+        service = api.microsoftService;
+      } else {
+        // Infer from baseUrl
+        service = inferMicrosoftServiceFromUrl(api?.baseUrl);
+        if (!service) {
+          return {
+            success: false,
+            error: `Cannot determine Microsoft service for source '${source.config.slug}'. Set microsoftService ('outlook', 'calendar', 'onedrive', 'teams', or 'sharepoint') in api config.`,
+          };
+        }
+      }
+
+      const serviceName = service || 'Microsoft API';
+      callbacks.onStatus(`Starting ${serviceName} OAuth flow...`);
+
+      const options: MicrosoftOAuthOptions = {
+        service,
+        scopes,
+        appType: 'electron',
+      };
+
+      const result: MicrosoftOAuthResult = await startMicrosoftOAuth(options);
+
+      if (!result.success) {
+        return { success: false, error: result.error || 'Microsoft OAuth failed' };
+      }
+
+      // Save the credentials
+      await this.save(source, {
+        value: result.accessToken!,
+        refreshToken: result.refreshToken,
+        expiresAt: result.expiresAt,
+      });
+
+      // Mark source as authenticated in config.json
+      markSourceAuthenticated(source.workspaceRootPath, source.config.slug);
+
+      callbacks.onStatus(`${serviceName} authentication successful`);
+      return { success: true, email: result.email };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      callbacks.onError(message);
+      return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Refresh token for a source
+   *
+   * Returns the new access token, or null if refresh fails.
+   * On success, credentials are automatically updated.
+   *
+   * Uses promise deduplication to prevent concurrent refresh requests for the same source.
+   * This is important because:
+   * - Multiple API calls may hit refresh simultaneously when token is expiring
+   * - Microsoft rotates refresh tokens, so concurrent refreshes could cause token invalidation
+   */
+  async refresh(source: LoadedSource): Promise<string | null> {
+    const key = source.config.slug;
+
+    // Return existing refresh promise if one is in progress
+    const pending = this.pendingRefreshes.get(key);
+    if (pending) {
+      debug(`[SourceCredentialManager] Reusing pending refresh for ${key}`);
+      return pending;
+    }
+
+    // Create and track new refresh promise
+    const refreshPromise = this.doRefresh(source).finally(() => {
+      this.pendingRefreshes.delete(key);
+    });
+
+    this.pendingRefreshes.set(key, refreshPromise);
+    return refreshPromise;
+  }
+
+  /**
+   * Internal refresh implementation
+   */
+  private async doRefresh(source: LoadedSource): Promise<string | null> {
+    const cred = await this.load(source);
+    if (!cred?.refreshToken) {
+      debug(`[SourceCredentialManager] No refresh token for ${source.config.slug}`);
+      return null;
+    }
+
+    // Google API refresh
+    if (source.config.provider === 'google') {
+      return this.refreshGoogle(source, cred);
+    }
+
+    // Slack API refresh
+    if (source.config.provider === 'slack') {
+      return this.refreshSlack(source, cred);
+    }
+
+    // Microsoft API refresh
+    if (source.config.provider === 'microsoft') {
+      return this.refreshMicrosoft(source, cred);
+    }
+
+    // MCP refresh
+    if (source.config.type === 'mcp' && source.config.mcp?.url) {
+      return this.refreshMcp(source, cred);
+    }
+
+    return null;
+  }
+
+  /**
+   * Refresh Google OAuth token
+   */
+  private async refreshGoogle(
+    source: LoadedSource,
+    cred: StoredCredential
+  ): Promise<string | null> {
+    try {
+      const result = await refreshGoogleToken(cred.refreshToken!);
+
+      // Update stored credentials
+      await this.save(source, {
+        ...cred,
+        value: result.accessToken,
+        expiresAt: result.expiresAt,
+      });
+
+      debug(`[SourceCredentialManager] Refreshed Google token for ${source.config.slug}`);
+      return result.accessToken;
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      debug(`[SourceCredentialManager] Google token refresh failed:`, error);
+      this.markSourceNeedsReauth(source, `Token refresh failed: ${errorMsg}`);
+      return null;
+    }
+  }
+
+  /**
+   * Refresh Slack OAuth token
+   */
+  private async refreshSlack(
+    source: LoadedSource,
+    cred: StoredCredential
+  ): Promise<string | null> {
+    try {
+      const result = await refreshSlackToken(cred.refreshToken!, cred.clientId);
+
+      // Update stored credentials
+      await this.save(source, {
+        ...cred,
+        value: result.accessToken,
+        expiresAt: result.expiresAt,
+      });
+
+      debug(`[SourceCredentialManager] Refreshed Slack token for ${source.config.slug}`);
+      return result.accessToken;
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      debug(`[SourceCredentialManager] Slack token refresh failed:`, error);
+      this.markSourceNeedsReauth(source, `Token refresh failed: ${errorMsg}`);
+      return null;
+    }
+  }
+
+  /**
+   * Refresh Microsoft OAuth token
+   */
+  private async refreshMicrosoft(
+    source: LoadedSource,
+    cred: StoredCredential
+  ): Promise<string | null> {
+    try {
+      const result = await refreshMicrosoftToken(cred.refreshToken!);
+
+      // Update stored credentials (Microsoft may rotate refresh tokens)
+      await this.save(source, {
+        ...cred,
+        value: result.accessToken,
+        refreshToken: result.refreshToken || cred.refreshToken,
+        expiresAt: result.expiresAt,
+      });
+
+      debug(`[SourceCredentialManager] Refreshed Microsoft token for ${source.config.slug}`);
+      return result.accessToken;
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      debug(`[SourceCredentialManager] Microsoft token refresh failed:`, error);
+      this.markSourceNeedsReauth(source, `Token refresh failed: ${errorMsg}`);
+      return null;
+    }
+  }
+
+  /**
+   * Refresh MCP OAuth token
+   */
+  private async refreshMcp(
+    source: LoadedSource,
+    cred: StoredCredential
+  ): Promise<string | null> {
+    if (!cred.clientId) {
+      debug(`[SourceCredentialManager] No clientId for MCP token refresh`);
+      this.markSourceNeedsReauth(source, 'Missing clientId for token refresh');
+      return null;
+    }
+
+    try {
+      // Only HTTP/SSE transport can refresh tokens - stdio doesn't use OAuth
+      if (!source.config.mcp?.url) {
+        // This is expected for stdio transport - not an error
+        debug(`[SourceCredentialManager] No URL for MCP token refresh (stdio transport)`);
+        return null;
+      }
+
+      const oauth = new CraftOAuth(
+        { mcpBaseUrl: getMcpBaseUrl(source.config.mcp.url) },
+        {
+          onStatus: () => {},
+          onError: () => {},
+        }
+      );
+
+      const tokens = await oauth.refreshAccessToken(cred.refreshToken!, cred.clientId);
+
+      // Update stored credentials
+      await this.save(source, {
+        ...cred,
+        value: tokens.accessToken,
+        refreshToken: tokens.refreshToken || cred.refreshToken,
+        expiresAt: tokens.expiresAt,
+      });
+
+      debug(`[SourceCredentialManager] Refreshed MCP token for ${source.config.slug}`);
+      return tokens.accessToken;
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      debug(`[SourceCredentialManager] MCP token refresh failed:`, error);
+      this.markSourceNeedsReauth(source, `Token refresh failed: ${errorMsg}`);
+      return null;
+    }
+  }
+}
+
+// ============================================================
+// Helper Functions
+// ============================================================
+
+/**
+ * Check if a single source needs authentication.
+ * Returns true if the source requires auth but isn't yet authenticated.
+ *
+ * This correctly handles:
+ * - MCP sources with authType: "none" → never needs auth
+ * - MCP sources with stdio transport → never needs auth (runs locally)
+ * - MCP sources with oauth/bearer → needs auth if not authenticated
+ * - API sources with authType: "none" → never needs auth
+ * - API sources with bearer/basic/header/query auth → needs auth if not authenticated
+ */
+export function sourceNeedsAuthentication(source: LoadedSource): boolean {
+  const mcp = source.config.mcp;
+  const api = source.config.api;
+
+  // MCP sources with oauth/bearer auth (stdio transport never needs auth)
+  if (source.config.type === 'mcp' && mcp) {
+    if (mcp.transport === 'stdio') {
+      // Stdio sources run locally and don't need authentication
+      return false;
+    }
+    // Only require auth if authType is explicitly set to 'oauth' or 'bearer'
+    // Undefined or 'none' means no authentication required
+    if (mcp.authType && mcp.authType !== 'none' && !source.config.isAuthenticated) {
+      return true;
+    }
+  }
+
+  // API sources with auth requirements
+  if (source.config.type === 'api' && api) {
+    if (api.authType !== 'none' && api.authType !== undefined && !source.config.isAuthenticated) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Get sources that need authentication
+ * Returns enabled sources that require auth but aren't yet authenticated
+ */
+export function getSourcesNeedingAuth(sources: LoadedSource[]): LoadedSource[] {
+  return sources.filter((source) => {
+    if (!source.config.enabled) return false;
+    return sourceNeedsAuthentication(source);
+  });
+}
+
+// Singleton instance
+let instance: SourceCredentialManager | null = null;
+
+/**
+ * Get shared SourceCredentialManager instance
+ */
+export function getSourceCredentialManager(): SourceCredentialManager {
+  if (!instance) {
+    instance = new SourceCredentialManager();
+  }
+  return instance;
+}

--- a/packages/shared/src/sources/index.ts
+++ b/packages/shared/src/sources/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Sources Module
+ *
+ * Public exports for source management.
+ */
+
+// Types
+export type {
+  SourceType,
+  SourceMcpAuthType,
+  ApiAuthType,
+  KnownProvider,
+  ApiOAuthProvider,
+  McpSourceConfig,
+  ApiSourceConfig,
+  LocalSourceConfig,
+  SourceConnectionStatus,
+  FolderSourceConfig,
+  SourceGuide,
+  LoadedSource,
+  CreateSourceInput,
+} from './types.ts';
+
+// Constants and helpers
+export {
+  API_OAUTH_PROVIDERS,
+  isApiOAuthProvider,
+} from './types.ts';
+
+// Storage functions
+export {
+  // Directory utilities
+  ensureSourcesDir,
+  getSourcePath,
+  // Config operations
+  loadSourceConfig,
+  saveSourceConfig,
+  markSourceAuthenticated,
+  // Guide operations
+  loadSourceGuide,
+  saveSourceGuide,
+  // Icon operations
+  findSourceIcon,
+  downloadSourceIcon,
+  sourceNeedsIconDownload,
+  isIconUrl,
+  // Load operations
+  loadSource,
+  loadWorkspaceSources,
+  loadAllSources,
+  getEnabledSources,
+  getSourcesBySlugs,
+  // Create/Delete operations
+  generateSourceSlug,
+  createSource,
+  deleteSource,
+  sourceExists,
+  // Parsing utilities
+  parseGuideMarkdown,
+} from './storage.ts';
+
+// Credential Manager (unified credential operations)
+export {
+  SourceCredentialManager,
+  getSourceCredentialManager,
+  getSourcesNeedingAuth,
+} from './credential-manager.ts';
+export type {
+  AuthResult,
+  ApiCredential,
+  BasicAuthCredential,
+} from './credential-manager.ts';
+
+// Server Builder (builds MCP/API servers from sources)
+export {
+  SourceServerBuilder,
+  getSourceServerBuilder,
+  normalizeMcpUrl,
+  SERVER_BUILD_ERRORS,
+} from './server-builder.ts';
+export type {
+  McpServerConfig,
+  SourceWithCredential,
+  BuiltServers,
+} from './server-builder.ts';
+
+// Built-in Sources (always available in every workspace)
+export {
+  getDocsSource,
+  getBuiltinSources,
+  isBuiltinSource,
+} from './builtin-sources.ts';

--- a/packages/shared/src/sources/server-builder.ts
+++ b/packages/shared/src/sources/server-builder.ts
@@ -1,0 +1,319 @@
+/**
+ * SourceServerBuilder
+ *
+ * Builds MCP and API server configurations from LoadedSource objects.
+ * This module handles URL normalization and server config creation,
+ * but does NOT fetch credentials - credentials are passed in.
+ *
+ * This replaces SourceService's server building logic with a cleaner
+ * separation of concerns:
+ * - SourceCredentialManager: handles credentials
+ * - SourceServerBuilder: handles server configuration
+ */
+
+import type { LoadedSource, ApiConfig } from './types.ts';
+import type { ApiCredential } from './credential-manager.ts';
+import { createApiServer } from './api-tools.ts';
+import { createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import { debug } from '../utils/debug.ts';
+
+/**
+ * Standard error messages for server build failures.
+ * Use these constants instead of string literals to ensure consistent matching.
+ */
+export const SERVER_BUILD_ERRORS = {
+  AUTH_REQUIRED: 'Authentication required',
+  CREDENTIALS_NEEDED: 'Credentials needed',
+} as const;
+
+/**
+ * MCP server configuration compatible with Claude Agent SDK
+ * Supports HTTP/SSE (remote) and stdio (local subprocess) transports.
+ */
+export type McpServerConfig =
+  | { type: 'http' | 'sse'; url: string; headers?: Record<string, string> }
+  | { type: 'stdio'; command: string; args?: string[]; env?: Record<string, string> };
+
+/**
+ * Source with its credential pre-loaded
+ */
+export interface SourceWithCredential {
+  source: LoadedSource;
+  /** Token for MCP sources, or ApiCredential for API sources */
+  token?: string | null;
+  credential?: ApiCredential | null;
+}
+
+/**
+ * Result of building servers from sources
+ */
+export interface BuiltServers {
+  /** MCP server configs keyed by source slug */
+  mcpServers: Record<string, McpServerConfig>;
+  /** In-process API servers keyed by source slug */
+  apiServers: Record<string, ReturnType<typeof createSdkMcpServer>>;
+  /** Sources that failed to build (missing auth, etc.) */
+  errors: Array<{ sourceSlug: string; error: string }>;
+}
+
+/**
+ * SourceServerBuilder - builds server configs from sources
+ *
+ * Usage:
+ * ```typescript
+ * const builder = new SourceServerBuilder();
+ *
+ * // Build MCP server config
+ * const mcpConfig = builder.buildMcpServer(source, token);
+ *
+ * // Build all servers from sources with credentials
+ * const { mcpServers, apiServers, errors } = await builder.buildAll([
+ *   { source, token: 'abc123' },
+ *   { source: apiSource, credential: 'api-key' },
+ * ]);
+ * ```
+ */
+export class SourceServerBuilder {
+  /**
+   * Build MCP server config from a source
+   *
+   * @param source - The source configuration
+   * @param token - Authentication token (null for public/stdio sources)
+   */
+  buildMcpServer(source: LoadedSource, token: string | null): McpServerConfig | null {
+    if (source.config.type !== 'mcp' || !source.config.mcp) {
+      return null;
+    }
+
+    const mcp = source.config.mcp;
+
+    // Handle stdio transport (local subprocess servers)
+    if (mcp.transport === 'stdio') {
+      if (!mcp.command) {
+        debug(`[SourceServerBuilder] Stdio source ${source.config.slug} missing command`);
+        return null;
+      }
+      return {
+        type: 'stdio',
+        command: mcp.command,
+        args: mcp.args,
+        env: mcp.env,
+      };
+    }
+
+    // Handle HTTP/SSE transport (remote servers)
+    if (!mcp.url) {
+      debug(`[SourceServerBuilder] HTTP/SSE source ${source.config.slug} missing URL`);
+      return null;
+    }
+
+    const url = normalizeMcpUrl(mcp.url);
+
+    const config: McpServerConfig = {
+      type: url.includes('/sse') ? 'sse' : 'http',
+      url,
+    };
+
+    // Handle authentication for HTTP/SSE
+    if (mcp.authType !== 'none') {
+      if (token) {
+        (config as { headers?: Record<string, string> }).headers = { Authorization: `Bearer ${token}` };
+      } else if (source.config.isAuthenticated) {
+        // Expected token but not provided - needs re-auth
+        debug(`[SourceServerBuilder] Source ${source.config.slug} needs re-authentication`);
+        return null;
+      }
+    }
+
+    return config;
+  }
+
+  /**
+   * Build API server from a source
+   *
+   * @param source - The source configuration
+   * @param credential - API credential (null for public APIs)
+   * @param getToken - Token getter for OAuth APIs (Google, etc.) - supports auto-refresh
+   * @param sessionPath - Optional path to session folder for saving large responses
+   */
+  async buildApiServer(
+    source: LoadedSource,
+    credential: ApiCredential | null,
+    getToken?: () => Promise<string>,
+    sessionPath?: string
+  ): Promise<ReturnType<typeof createSdkMcpServer> | null> {
+    if (source.config.type !== 'api') return null;
+    if (!source.config.api) {
+      debug(`[SourceServerBuilder] API source ${source.config.slug} missing api config`);
+      return null;
+    }
+
+    const apiConfig = source.config.api;
+    const authType = apiConfig.authType;
+    const provider = source.config.provider;
+
+    // Google APIs - use token getter with auto-refresh
+    if (provider === 'google') {
+      if (!source.config.isAuthenticated || !getToken) {
+        debug(`[SourceServerBuilder] Google API source ${source.config.slug} not authenticated`);
+        return null;
+      }
+      debug(`[SourceServerBuilder] Building Google API server for ${source.config.slug}`);
+      const config = this.buildApiConfig(source);
+      // Pass the token getter function - it will be called before each request
+      // to get a fresh token (with auto-refresh if expired)
+      return createApiServer(config, getToken, sessionPath);
+    }
+
+    // Slack APIs - use token getter with auto-refresh
+    if (provider === 'slack') {
+      if (!source.config.isAuthenticated || !getToken) {
+        debug(`[SourceServerBuilder] Slack API source ${source.config.slug} not authenticated`);
+        return null;
+      }
+      debug(`[SourceServerBuilder] Building Slack API server for ${source.config.slug}`);
+      const config = this.buildApiConfig(source);
+      // Pass the token getter function - it will be called before each request
+      // to get a fresh token (with auto-refresh if expired)
+      return createApiServer(config, getToken, sessionPath);
+    }
+
+    // Public APIs (no auth) can be used immediately
+    if (authType === 'none') {
+      debug(`[SourceServerBuilder] Building public API server for ${source.config.slug}`);
+      const config = this.buildApiConfig(source);
+      return createApiServer(config, '', sessionPath);
+    }
+
+    // API key/bearer/header/query/basic auth - use static credential
+    if (!credential) {
+      debug(`[SourceServerBuilder] API source ${source.config.slug} needs credentials`);
+      return null;
+    }
+
+    debug(`[SourceServerBuilder] Building API server for ${source.config.slug} (auth: ${authType})`);
+    const config = this.buildApiConfig(source);
+    return createApiServer(config, credential, sessionPath);
+  }
+
+  /**
+   * Build ApiConfig from a LoadedSource
+   */
+  buildApiConfig(source: LoadedSource): ApiConfig {
+    const api = source.config.api!;
+
+    const config: ApiConfig = {
+      name: source.config.slug,
+      baseUrl: api.baseUrl,
+      documentation: source.guide?.raw || '',
+      defaultHeaders: api.defaultHeaders,
+    };
+
+    // Map auth type
+    switch (api.authType) {
+      case 'bearer':
+        config.auth = { type: 'bearer', authScheme: api.authScheme ?? 'Bearer' };
+        break;
+      case 'header':
+        config.auth = { type: 'header', headerName: api.headerName || 'x-api-key' };
+        break;
+      case 'query':
+        config.auth = { type: 'query', queryParam: api.queryParam || 'api_key' };
+        break;
+      case 'basic':
+        config.auth = { type: 'basic' };
+        break;
+      case 'none':
+      default:
+        config.auth = { type: 'none' };
+    }
+
+    return config;
+  }
+
+  /**
+   * Build all MCP and API servers for enabled sources
+   *
+   * @param sourcesWithCredentials - Sources with their pre-loaded credentials
+   * @param getTokenForSource - Function to get token getter for OAuth sources
+   * @param sessionPath - Optional path to session folder for saving large API responses
+   */
+  async buildAll(
+    sourcesWithCredentials: SourceWithCredential[],
+    getTokenForSource?: (source: LoadedSource) => (() => Promise<string>) | undefined,
+    sessionPath?: string
+  ): Promise<BuiltServers> {
+    const mcpServers: Record<string, McpServerConfig> = {};
+    const apiServers: Record<string, ReturnType<typeof createSdkMcpServer>> = {};
+    const errors: BuiltServers['errors'] = [];
+
+    for (const { source, token, credential } of sourcesWithCredentials) {
+      if (!source.config.enabled) continue;
+
+      try {
+        if (source.config.type === 'mcp') {
+          const config = this.buildMcpServer(source, token ?? null);
+          if (config) {
+            debug(`[SourceServerBuilder] Built MCP server for ${source.config.slug}`);
+            mcpServers[source.config.slug] = config;
+          } else if (source.config.mcp?.transport !== 'stdio' && source.config.mcp?.authType !== 'none') {
+            // Only report auth error for HTTP/SSE sources that need auth
+            // Stdio sources don't need auth
+            debug(`[SourceServerBuilder] MCP server ${source.config.slug} needs auth`);
+            errors.push({
+              sourceSlug: source.config.slug,
+              error: SERVER_BUILD_ERRORS.AUTH_REQUIRED,
+            });
+          }
+        } else if (source.config.type === 'api') {
+          const getToken = getTokenForSource?.(source);
+          const server = await this.buildApiServer(source, credential ?? null, getToken, sessionPath);
+          if (server) {
+            apiServers[source.config.slug] = server;
+          }
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        debug(`[SourceServerBuilder] Failed to build server for ${source.config.slug}: ${message}`);
+        errors.push({ sourceSlug: source.config.slug, error: message });
+      }
+    }
+
+    return { mcpServers, apiServers, errors };
+  }
+}
+
+/**
+ * Normalize MCP URL to standard format
+ * - Removes trailing slashes
+ * - Preserves /sse suffix for SSE type detection
+ * - Ensures /mcp suffix for HTTP type
+ */
+export function normalizeMcpUrl(url: string): string {
+  url = url.replace(/\/+$/, '');
+
+  // If URL ends with /sse, keep it for SSE type detection
+  if (url.endsWith('/sse')) {
+    return url;
+  }
+
+  // Ensure /mcp suffix for HTTP type
+  if (!url.endsWith('/mcp')) {
+    url = url + '/mcp';
+  }
+
+  return url;
+}
+
+// Singleton instance
+let instance: SourceServerBuilder | null = null;
+
+/**
+ * Get shared SourceServerBuilder instance
+ */
+export function getSourceServerBuilder(): SourceServerBuilder {
+  if (!instance) {
+    instance = new SourceServerBuilder();
+  }
+  return instance;
+}

--- a/packages/shared/src/sources/storage.ts
+++ b/packages/shared/src/sources/storage.ts
@@ -1,0 +1,565 @@
+/**
+ * Source Storage
+ *
+ * CRUD operations for workspace-scoped sources.
+ * Sources are stored at {workspaceRootPath}/sources/{sourceSlug}/
+ *
+ * Note: All functions take `workspaceRootPath` (absolute path to workspace folder),
+ * NOT a workspace slug. The `LoadedSource.workspaceId` is derived via basename().
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, rmSync } from 'fs';
+import { join, basename } from 'path';
+import { randomUUID } from 'crypto';
+import type {
+  FolderSourceConfig,
+  SourceGuide,
+  LoadedSource,
+  CreateSourceInput,
+} from './types.ts';
+import { validateSourceConfig } from '../config/validators.ts';
+import { debug } from '../utils/debug.ts';
+import { getBuiltinSources, isBuiltinSource, getDocsSource } from './builtin-sources.ts';
+import { expandPath, toPortablePath } from '../utils/paths.ts';
+import { getWorkspaceSourcesPath } from '../workspaces/storage.ts';
+import {
+  validateIconValue,
+  findIconFile,
+  downloadIcon,
+  needsIconDownload,
+  isIconUrl,
+} from '../utils/icon.ts';
+
+// ============================================================
+// Directory Utilities
+// ============================================================
+
+/**
+ * Get path to a source folder within a workspace
+ */
+export function getSourcePath(workspaceRootPath: string, sourceSlug: string): string {
+  return join(getWorkspaceSourcesPath(workspaceRootPath), sourceSlug);
+}
+
+/**
+ * Ensure sources directory exists for a workspace
+ */
+export function ensureSourcesDir(workspaceRootPath: string): void {
+  const dir = getWorkspaceSourcesPath(workspaceRootPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+// ============================================================
+// Config Operations
+// ============================================================
+
+/**
+ * Load source config.json
+ */
+export function loadSourceConfig(
+  workspaceRootPath: string,
+  sourceSlug: string
+): FolderSourceConfig | null {
+  const configPath = join(getSourcePath(workspaceRootPath, sourceSlug), 'config.json');
+  if (!existsSync(configPath)) return null;
+
+  try {
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as FolderSourceConfig;
+
+    // Expand path variables in local source paths for portability
+    if (config.type === 'local' && config.local?.path) {
+      config.local.path = expandPath(config.local.path);
+    }
+
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mark a source as authenticated and connected.
+ * Updates isAuthenticated, connectionStatus, and clears any connection error.
+ *
+ * @returns true if the source was found and updated, false otherwise
+ */
+export function markSourceAuthenticated(
+  workspaceRootPath: string,
+  sourceSlug: string
+): boolean {
+  const config = loadSourceConfig(workspaceRootPath, sourceSlug);
+  if (!config) {
+    debug(`[markSourceAuthenticated] Source ${sourceSlug} not found`);
+    return false;
+  }
+
+  config.isAuthenticated = true;
+  config.connectionStatus = 'connected';
+  config.connectionError = undefined;
+
+  saveSourceConfig(workspaceRootPath, config);
+  debug(`[markSourceAuthenticated] Marked ${sourceSlug} as authenticated`);
+  return true;
+}
+
+/**
+ * Save source config.json
+ * @throws Error if config is invalid
+ */
+export function saveSourceConfig(
+  workspaceRootPath: string,
+  config: FolderSourceConfig
+): void {
+  // Validate config before writing
+  const validation = validateSourceConfig(config);
+  if (!validation.valid) {
+    const errorMessages = validation.errors.map((e) => `${e.path}: ${e.message}`).join(', ');
+    debug('[saveSourceConfig] Validation failed:', errorMessages);
+    throw new Error(`Invalid source config: ${errorMessages}`);
+  }
+
+  const dir = getSourcePath(workspaceRootPath, config.slug);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  // Convert local source paths to portable form
+  const storageConfig: FolderSourceConfig = { ...config, updatedAt: Date.now() };
+  if (storageConfig.type === 'local' && storageConfig.local?.path) {
+    storageConfig.local = {
+      ...storageConfig.local,
+      path: toPortablePath(storageConfig.local.path),
+    };
+  }
+
+  writeFileSync(join(dir, 'config.json'), JSON.stringify(storageConfig, null, 2));
+}
+
+// ============================================================
+// Guide Operations
+// ============================================================
+
+/**
+ * Parse guide markdown.
+ * Extracts sections (Scope, Guidelines, Context, API Notes) and Cache (JSON in code block).
+ */
+function parseGuideMarkdown(raw: string): SourceGuide {
+  const guide: SourceGuide = { raw };
+
+  // Extract sections by headers (including Cache)
+  const sectionRegex = /^## (Scope|Guidelines|Context|API Notes|Cache)\n([\s\S]*?)(?=\n## |\Z)/gim;
+  let match;
+  while ((match = sectionRegex.exec(raw)) !== null) {
+    const sectionName = (match[1] ?? '').toLowerCase().replace(/\s+/g, '');
+    const content = (match[2] ?? '').trim();
+
+    switch (sectionName) {
+      case 'scope':
+        guide.scope = content;
+        break;
+      case 'guidelines':
+        guide.guidelines = content;
+        break;
+      case 'context':
+        guide.context = content;
+        break;
+      case 'apinotes':
+        guide.apiNotes = content;
+        break;
+      case 'cache':
+        // Parse JSON from code block: ```json ... ```
+        const jsonMatch = content.match(/```json\n([\s\S]*?)\n```/);
+        if (jsonMatch && jsonMatch[1]) {
+          try {
+            guide.cache = JSON.parse(jsonMatch[1]);
+          } catch {
+            // Invalid JSON, ignore
+          }
+        }
+        break;
+    }
+  }
+
+  return guide;
+}
+
+/**
+ * Load and parse guide.md with frontmatter cache
+ */
+export function loadSourceGuide(workspaceRootPath: string, sourceSlug: string): SourceGuide | null {
+  const guidePath = join(getSourcePath(workspaceRootPath, sourceSlug), 'guide.md');
+  if (!existsSync(guidePath)) return null;
+
+  try {
+    const raw = readFileSync(guidePath, 'utf-8');
+    return parseGuideMarkdown(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract a short tagline from guide.md content
+ * Looks for the first non-empty paragraph after the title, or falls back to scope section
+ * @returns Tagline string (max 100 chars) or null if not found
+ */
+export function extractTagline(guide: SourceGuide | null): string | null {
+  if (!guide?.raw) return null;
+
+  const content = guide.raw;
+
+  // Try to get first paragraph after the title (# Title)
+  // Match: # Title\n\n<first paragraph>
+  const titleMatch = content.match(/^#[^\n]+\n+([^\n#][^\n]*)/);
+  if (titleMatch?.[1]?.trim()) {
+    const tagline = titleMatch[1].trim();
+    // Skip if it looks like a section or placeholder
+    if (!tagline.startsWith('##') && !tagline.startsWith('(')) {
+      return tagline.slice(0, 100);
+    }
+  }
+
+  // Fallback to first line of scope section
+  if (guide.scope) {
+    const firstLine = guide.scope.split('\n')[0]?.trim();
+    if (firstLine && !firstLine.startsWith('(')) {
+      return firstLine.slice(0, 100);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Save guide.md
+ */
+export function saveSourceGuide(
+  workspaceRootPath: string,
+  sourceSlug: string,
+  guide: SourceGuide
+): void {
+  const dir = getSourcePath(workspaceRootPath, sourceSlug);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  writeFileSync(join(dir, 'guide.md'), guide.raw);
+}
+
+// ============================================================
+// Icon Operations (uses shared utilities from utils/icon.ts)
+// ============================================================
+
+/**
+ * Find icon file for a source
+ * Returns absolute path to icon file or undefined
+ */
+export function findSourceIcon(workspaceRootPath: string, sourceSlug: string): string | undefined {
+  return findIconFile(getSourcePath(workspaceRootPath, sourceSlug));
+}
+
+/**
+ * Download an icon from a URL and save it to the source directory.
+ * Returns the path to the downloaded icon, or null on failure.
+ */
+export async function downloadSourceIcon(
+  workspaceRootPath: string,
+  sourceSlug: string,
+  iconUrl: string
+): Promise<string | null> {
+  const sourceDir = getSourcePath(workspaceRootPath, sourceSlug);
+  return downloadIcon(sourceDir, iconUrl, 'Sources');
+}
+
+/**
+ * Check if a source needs its icon downloaded.
+ * Returns true if config has a URL icon and no local icon file exists.
+ */
+export function sourceNeedsIconDownload(
+  workspaceRootPath: string,
+  sourceSlug: string,
+  config: FolderSourceConfig
+): boolean {
+  const iconPath = findSourceIcon(workspaceRootPath, sourceSlug);
+  return needsIconDownload(config.icon, iconPath);
+}
+
+// Re-export icon utilities for convenience
+export { isIconUrl } from '../utils/icon.ts';
+
+// ============================================================
+// Load Operations
+// ============================================================
+
+/**
+ * Load complete source with all files
+ * @param workspaceRootPath - Absolute path to workspace folder (e.g., ~/.kata-agents/workspaces/xxx)
+ * @param sourceSlug - Source folder name
+ */
+export function loadSource(workspaceRootPath: string, sourceSlug: string): LoadedSource | null {
+  const folderPath = getSourcePath(workspaceRootPath, sourceSlug);
+  const config = loadSourceConfig(workspaceRootPath, sourceSlug);
+  if (!config) return null;
+
+  // Extract workspace folder name for credential lookup
+  // Credentials are keyed by folder name (e.g., "046a02d0-..."), not full path
+  const workspaceId = basename(workspaceRootPath);
+
+  // Pre-compute icon path for renderer (avoids fs access in browser)
+  const iconPath = findIconFile(folderPath);
+
+  return {
+    config,
+    guide: loadSourceGuide(workspaceRootPath, sourceSlug),
+    folderPath,
+    workspaceRootPath,
+    workspaceId,
+    iconPath,
+  };
+}
+
+/**
+ * Load all sources for a workspace
+ */
+export function loadWorkspaceSources(workspaceRootPath: string): LoadedSource[] {
+  ensureSourcesDir(workspaceRootPath);
+
+  const sources: LoadedSource[] = [];
+  const sourcesDir = getWorkspaceSourcesPath(workspaceRootPath);
+
+  if (!existsSync(sourcesDir)) return sources;
+
+  const entries = readdirSync(sourcesDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const source = loadSource(workspaceRootPath, entry.name);
+      if (source) {
+        sources.push(source);
+      }
+    }
+  }
+
+  return sources;
+}
+
+/**
+ * Get enabled sources for a workspace
+ */
+export function getEnabledSources(workspaceRootPath: string): LoadedSource[] {
+  return loadWorkspaceSources(workspaceRootPath).filter((s) => s.config.enabled);
+}
+
+/**
+ * Get sources by slugs for a workspace.
+ * Includes both user-configured sources from disk and builtin sources
+ * (like craft-agents-docs) that don't have filesystem folders.
+ */
+export function getSourcesBySlugs(workspaceRootPath: string, slugs: string[]): LoadedSource[] {
+  const workspaceId = basename(workspaceRootPath);
+  const sources: LoadedSource[] = [];
+  for (const slug of slugs) {
+    // Check builtin sources first (they don't exist on disk)
+    if (isBuiltinSource(slug)) {
+      // Currently only craft-agents-docs is a builtin source
+      if (slug === 'craft-agents-docs') {
+        sources.push(getDocsSource(workspaceId, workspaceRootPath));
+      }
+      continue;
+    }
+    // Load user-configured source from disk
+    const source = loadSource(workspaceRootPath, slug);
+    if (source) {
+      sources.push(source);
+    }
+  }
+  return sources;
+}
+
+/**
+ * Load all sources for a workspace INCLUDING built-in sources.
+ * Built-in sources (like craft-agents-docs) are always available and merged
+ * with user-configured sources from the workspace.
+ *
+ * Use this when the agent needs visibility into all available sources,
+ * including system-provided ones that don't live on disk.
+ */
+export function loadAllSources(workspaceRootPath: string): LoadedSource[] {
+  const workspaceId = basename(workspaceRootPath);
+  const userSources = loadWorkspaceSources(workspaceRootPath);
+  const builtinSources = getBuiltinSources(workspaceId, workspaceRootPath);
+  return [...userSources, ...builtinSources];
+}
+
+// ============================================================
+// Create/Delete Operations
+// ============================================================
+
+/**
+ * Generate URL-safe slug from name
+ */
+export function generateSourceSlug(workspaceRootPath: string, name: string): string {
+  let slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 50);
+
+  // Ensure slug is not empty
+  if (!slug) {
+    slug = 'source';
+  }
+
+  // Check for existing slugs and append number if needed
+  const sourcesDir = getWorkspaceSourcesPath(workspaceRootPath);
+  const existingSlugs = new Set<string>();
+  if (existsSync(sourcesDir)) {
+    const entries = readdirSync(sourcesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        existingSlugs.add(entry.name);
+      }
+    }
+  }
+
+  if (!existingSlugs.has(slug)) {
+    return slug;
+  }
+
+  // Find next available number
+  let counter = 2;
+  while (existingSlugs.has(`${slug}-${counter}`)) {
+    counter++;
+  }
+
+  return `${slug}-${counter}`;
+}
+
+/**
+ * Create a new source in a workspace
+ */
+export async function createSource(
+  workspaceRootPath: string,
+  input: CreateSourceInput
+): Promise<FolderSourceConfig> {
+  const slug = generateSourceSlug(workspaceRootPath, input.name);
+  const now = Date.now();
+
+  const config: FolderSourceConfig = {
+    // ID format: {slug}_{random} for easy identification (e.g., "linear_a1b2c3d4")
+    id: `${slug}_${randomUUID().slice(0, 8)}`,
+    name: input.name,
+    slug,
+    enabled: input.enabled ?? true,
+    provider: input.provider,
+    type: input.type,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  // Add type-specific config
+  switch (input.type) {
+    case 'mcp':
+      if (input.mcp) {
+        config.mcp = input.mcp;
+      }
+      break;
+    case 'api':
+      if (input.api) {
+        config.api = input.api;
+      }
+      break;
+    case 'local':
+      if (input.local) {
+        config.local = input.local;
+      }
+      break;
+  }
+
+  // Validate and store icon (emoji or URL)
+  // URL icons are downloaded on first config change via watcher
+  if (input.icon) {
+    const validatedIcon = validateIconValue(input.icon, 'Sources');
+    if (validatedIcon) {
+      config.icon = validatedIcon;
+    }
+  }
+
+  // Save config first to create the directory
+  saveSourceConfig(workspaceRootPath, config);
+
+  // If icon is a URL, download it immediately
+  // (watcher will also handle this, but doing it here provides immediate feedback)
+  const sourcePath = getSourcePath(workspaceRootPath, slug);
+  if (config.icon && isIconUrl(config.icon)) {
+    const iconPath = await downloadIcon(sourcePath, config.icon, 'Sources');
+    if (iconPath) {
+      debug(`[createSource] Icon downloaded for ${slug}: ${iconPath}`);
+    }
+  } else if (!config.icon) {
+    // No icon provided - try to auto-fetch from service URL
+    const { deriveServiceUrl, getHighQualityLogoUrl } = await import('../utils/logo.ts');
+    const { downloadIcon } = await import('../utils/icon.ts');
+    const serviceUrl = deriveServiceUrl(input);
+    if (serviceUrl) {
+      const logoUrl = await getHighQualityLogoUrl(serviceUrl, input.provider);
+      if (logoUrl) {
+        const iconPath = await downloadIcon(sourcePath, logoUrl, `createSource:${slug}`);
+        if (iconPath) {
+          // Store the source URL for reference (not the cached path)
+          config.icon = logoUrl;
+          saveSourceConfig(workspaceRootPath, config);
+        }
+      }
+    }
+  }
+
+  // Create guide.md with skeleton template
+  // (bundled guides removed - agent should search craft-agents-docs MCP for service-specific guidance)
+  const guideContent = `# ${input.name}
+
+## Guidelines
+
+(Add usage guidelines here)
+
+## Context
+
+(Add context about this source)
+`;
+  saveSourceGuide(workspaceRootPath, slug, { raw: guideContent });
+
+  return config;
+}
+
+/**
+ * Delete a source from a workspace
+ */
+export function deleteSource(workspaceRootPath: string, sourceSlug: string): void {
+  const dir = getSourcePath(workspaceRootPath, sourceSlug);
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true });
+  }
+}
+
+/**
+ * Check if a source exists in a workspace
+ */
+export function sourceExists(workspaceRootPath: string, sourceSlug: string): boolean {
+  return existsSync(join(getSourcePath(workspaceRootPath, sourceSlug), 'config.json'));
+}
+
+// ============================================================
+// Source Loading/Saving Helpers
+// ============================================================
+
+// Note: SourceWithContext and wrapper functions were removed in this PR.
+// Use loadSourceConfig and saveSourceConfig directly instead.
+
+// ============================================================
+// Re-export parseGuideMarkdown for use in other modules
+// ============================================================
+
+export { parseGuideMarkdown };
+

--- a/packages/shared/src/sources/types.ts
+++ b/packages/shared/src/sources/types.ts
@@ -1,0 +1,411 @@
+/**
+ * Source Types
+ *
+ * Sources are external data connections (MCP servers, APIs, local filesystems).
+ * They replace the old "connections" concept with a more flexible, folder-based architecture.
+ *
+ * File structure:
+ * ~/.kata-agents/workspaces/{workspaceId}/sources/{sourceSlug}/
+ *   ├── config.json   - Source settings
+ *   └── guide.md      - Usage guidelines + cached data (in YAML frontmatter)
+ */
+
+/**
+ * Source types - how we connect to the source
+ */
+export type SourceType = 'mcp' | 'api' | 'local';
+
+/**
+ * MCP source authentication types (for individual source connections)
+ * Note: Different from workspace McpAuthType which uses 'workspace_oauth' | 'workspace_bearer' | 'public'
+ */
+export type SourceMcpAuthType = 'oauth' | 'bearer' | 'none';
+
+/**
+ * API authentication types
+ */
+export type ApiAuthType = 'bearer' | 'header' | 'query' | 'basic' | 'none';
+
+/**
+ * Google service types for OAuth scope selection
+ */
+export type GoogleService = 'gmail' | 'calendar' | 'drive' | 'docs' | 'sheets';
+
+/**
+ * Slack service types for OAuth scope selection
+ */
+export type SlackService = 'messaging' | 'channels' | 'users' | 'files' | 'full';
+
+/**
+ * Microsoft service types for OAuth scope selection
+ */
+export type MicrosoftService = 'outlook' | 'microsoft-calendar' | 'onedrive' | 'teams' | 'sharepoint';
+
+/**
+ * Infer Google service from API baseUrl.
+ * Returns undefined if URL doesn't match a known Google API pattern.
+ *
+ * Uses proper URL parsing to avoid false positives from arbitrary path matching.
+ */
+export function inferGoogleServiceFromUrl(baseUrl: string | undefined): GoogleService | undefined {
+  if (!baseUrl) return undefined;
+
+  let hostname: string;
+  let pathname: string;
+  try {
+    const parsed = new URL(baseUrl);
+    hostname = parsed.hostname.toLowerCase();
+    pathname = parsed.pathname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+
+  // Match by hostname (most reliable)
+  if (hostname === 'calendar.googleapis.com') return 'calendar';
+  if (hostname === 'drive.googleapis.com') return 'drive';
+  if (hostname === 'gmail.googleapis.com') return 'gmail';
+  if (hostname === 'docs.googleapis.com') return 'docs';
+  if (hostname === 'sheets.googleapis.com') return 'sheets';
+
+  // Fallback: check path patterns only on googleapis.com domains
+  if (hostname === 'www.googleapis.com' || hostname === 'googleapis.com') {
+    if (pathname.startsWith('/calendar/')) return 'calendar';
+    if (pathname.startsWith('/drive/')) return 'drive';
+    if (pathname.startsWith('/gmail/')) return 'gmail';
+    if (pathname.startsWith('/v1/documents') || pathname.startsWith('/documents/')) return 'docs';
+    if (pathname.startsWith('/v4/spreadsheets') || pathname.startsWith('/spreadsheets/')) return 'sheets';
+  }
+
+  return undefined;
+}
+
+/**
+ * Infer Slack service from API baseUrl.
+ * Returns 'full' by default if URL matches Slack API pattern.
+ */
+export function inferSlackServiceFromUrl(baseUrl: string | undefined): SlackService | undefined {
+  if (!baseUrl) return undefined;
+
+  let hostname: string;
+  try {
+    const parsed = new URL(baseUrl);
+    hostname = parsed.hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+
+  // Match Slack API hostname
+  if (hostname === 'slack.com' || hostname === 'api.slack.com') {
+    return 'full'; // Default to full service for Slack
+  }
+
+  return undefined;
+}
+
+/**
+ * Infer Microsoft service from API baseUrl.
+ * Microsoft Graph API uses graph.microsoft.com for all services.
+ * Returns 'outlook' by default if URL matches Microsoft Graph pattern.
+ */
+export function inferMicrosoftServiceFromUrl(baseUrl: string | undefined): MicrosoftService | undefined {
+  if (!baseUrl) return undefined;
+
+  let hostname: string;
+  let pathname: string;
+  try {
+    const parsed = new URL(baseUrl);
+    hostname = parsed.hostname.toLowerCase();
+    pathname = parsed.pathname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+
+  // Match Microsoft Graph API hostname
+  if (hostname === 'graph.microsoft.com') {
+    // Try to infer service from path
+    if (pathname.includes('/me/messages') || pathname.includes('/me/mailfolders') || pathname.includes('/mail')) {
+      return 'outlook';
+    }
+    if (pathname.includes('/me/calendar') || pathname.includes('/me/events')) {
+      return 'microsoft-calendar';
+    }
+    if (pathname.includes('/me/drive') || pathname.includes('/drives')) {
+      return 'onedrive';
+    }
+    if (pathname.includes('/teams') || pathname.includes('/chats')) {
+      return 'teams';
+    }
+    if (pathname.includes('/sites')) {
+      return 'sharepoint';
+    }
+    // Default to outlook for general Graph API access
+    return 'outlook';
+  }
+
+  // Match Outlook-specific API (legacy, but still used)
+  if (hostname === 'outlook.office.com' || hostname === 'outlook.office365.com') {
+    return 'outlook';
+  }
+
+  return undefined;
+}
+
+/**
+ * Known providers for special handling (OAuth flows, icons, etc.)
+ * These have well-known OAuth endpoints or special behavior.
+ */
+export type KnownProvider =
+  | 'google' // Google APIs (Gmail, etc.) - uses Google OAuth
+  | 'microsoft' // Microsoft APIs (Outlook, OneDrive, etc.) - uses Microsoft OAuth
+  | 'linear' // Linear - standard MCP OAuth
+  | 'github' // GitHub - standard MCP OAuth
+  | 'notion' // Notion - standard MCP OAuth
+  | 'slack' // Slack - standard MCP OAuth
+  | 'exa'; // Exa search API
+
+/**
+ * API providers that use OAuth for authentication.
+ * These providers store credentials as source_oauth and use SourceCredentialManager.
+ */
+export const API_OAUTH_PROVIDERS = ['google', 'microsoft', 'slack'] as const;
+export type ApiOAuthProvider = typeof API_OAUTH_PROVIDERS[number];
+
+/**
+ * Check if a provider uses OAuth for API authentication
+ */
+export function isApiOAuthProvider(provider: string | undefined): provider is ApiOAuthProvider {
+  return API_OAUTH_PROVIDERS.includes(provider as ApiOAuthProvider);
+}
+
+/**
+ * MCP transport type for sources
+ * - 'http': HTTP-based MCP server (URL endpoint)
+ * - 'sse': Server-Sent Events MCP server (URL endpoint)
+ * - 'stdio': Local subprocess MCP server (spawned command)
+ */
+export type McpTransport = 'http' | 'sse' | 'stdio';
+
+/**
+ * MCP-specific configuration
+ * Supports both HTTP-based and local stdio-based MCP servers.
+ */
+export interface McpSourceConfig {
+  /**
+   * Transport type. Defaults to 'http' if not specified.
+   */
+  transport?: McpTransport;
+
+  // === HTTP/SSE transport fields ===
+  /**
+   * URL endpoint for HTTP or SSE transport.
+   * Required when transport is 'http' or 'sse' (or undefined).
+   */
+  url?: string;
+
+  /**
+   * Authentication type for HTTP/SSE servers.
+   */
+  authType?: SourceMcpAuthType;
+
+  /**
+   * OAuth client ID (stored in config, not secret).
+   */
+  clientId?: string;
+
+  // === Stdio transport fields ===
+  /**
+   * Command to spawn for stdio transport.
+   * Required when transport is 'stdio'.
+   */
+  command?: string;
+
+  /**
+   * Arguments to pass to the command.
+   */
+  args?: string[];
+
+  /**
+   * Environment variables for the spawned process.
+   */
+  env?: Record<string, string>;
+}
+
+/**
+ * API test endpoint configuration for connection validation
+ */
+export interface ApiTestEndpoint {
+  method: 'GET' | 'POST';
+  path: string;
+  body?: Record<string, unknown>; // For POST requests
+  headers?: Record<string, string>; // Custom headers for the test request
+}
+
+/**
+ * API-specific configuration
+ */
+export interface ApiSourceConfig {
+  baseUrl: string;
+  authType: ApiAuthType;
+  headerName?: string; // For 'header' auth (e.g., "X-API-Key")
+  queryParam?: string; // For 'query' auth (e.g., "api_key")
+  authScheme?: string; // For 'bearer' auth (default: "Bearer", could be "Token")
+  defaultHeaders?: Record<string, string>; // Headers to include with every request
+  testEndpoint?: ApiTestEndpoint; // Endpoint to use for connection testing
+
+  // Google OAuth fields (used when provider is 'google')
+  googleService?: GoogleService; // Predefined service for scope selection
+  googleScopes?: string[]; // Custom scopes (overrides googleService)
+
+  // Slack OAuth fields (used when provider is 'slack')
+  // Uses user_scope for user authentication (posts as the user, not a bot)
+  slackService?: SlackService; // Predefined service for scope selection
+  slackUserScopes?: string[]; // Custom user scopes (overrides slackService)
+
+  // Microsoft OAuth fields (used when provider is 'microsoft')
+  microsoftService?: MicrosoftService; // Predefined service for scope selection
+  microsoftScopes?: string[]; // Custom scopes (overrides microsoftService)
+}
+
+/**
+ * Local filesystem/app configuration
+ */
+export interface LocalSourceConfig {
+  path: string;
+  format?: string; // Optional hint: 'filesystem' | 'obsidian' | 'git' | 'sqlite' | etc.
+}
+
+/**
+ * Source connection status
+ * - 'connected': Source is connected and working
+ * - 'needs_auth': Source requires authentication
+ * - 'failed': Connection failed with error
+ * - 'untested': Connection has not been tested
+ * - 'local_disabled': Stdio source is disabled (local MCP servers off)
+ */
+export type SourceConnectionStatus = 'connected' | 'needs_auth' | 'failed' | 'untested' | 'local_disabled';
+
+/**
+ * Main source configuration (stored in config.json)
+ */
+export interface FolderSourceConfig {
+  id: string;
+  name: string;
+  slug: string;
+  enabled: boolean;
+
+  // Provider is a freeform label (e.g., "linear", "todoist", "my-custom-api")
+  provider: string;
+
+  // Connection type determines which config block is used
+  type: SourceType;
+
+  // Type-specific configuration (exactly one should be present)
+  mcp?: McpSourceConfig;
+  api?: ApiSourceConfig;
+  local?: LocalSourceConfig;
+
+  // Icon: emoji or URL (auto-downloaded to icon.* file)
+  // Local icon files (icon.svg, icon.png) are auto-discovered
+  // Priority: local file > URL (downloaded) > emoji
+  icon?: string;
+
+  // Short description for agent context (e.g., "Issue tracking, bugs, tasks, sprints")
+  // If not set, extracted from guide.md first paragraph
+  tagline?: string;
+
+  // Status tracking
+  isAuthenticated?: boolean;
+  connectionStatus?: SourceConnectionStatus;
+  connectionError?: string; // Error message if status is 'failed'
+  lastTestedAt?: number;
+
+  // Metadata (optional - manually created configs may not have them)
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+/**
+ * Parsed guide.md content with embedded cache
+ */
+export interface SourceGuide {
+  // Full raw markdown
+  raw: string;
+
+  // Parsed sections (extracted via regex/parsing)
+  scope?: string;
+  guidelines?: string;
+  context?: string;
+  apiNotes?: string;
+
+  // Embedded cache data (from YAML frontmatter)
+  cache?: Record<string, unknown>;
+}
+
+/**
+ * Fully loaded source with all files
+ */
+export interface LoadedSource {
+  config: FolderSourceConfig;
+  guide: SourceGuide | null;
+
+  /** Absolute path to source folder (for resolving relative icon paths) */
+  folderPath: string;
+
+  /** Absolute path to workspace folder (e.g., ~/.kata-agents/workspaces/xxx) */
+  workspaceRootPath: string;
+
+  /**
+   * Workspace this source belongs to.
+   * Used for credential lookups: source_oauth::{workspaceId}::{sourceSlug}
+   */
+  workspaceId: string;
+
+  /**
+   * Whether this is a built-in source (e.g., craft-agents-docs).
+   * Built-in sources are always available and not shown in the sources UI.
+   */
+  isBuiltin?: boolean;
+
+  /**
+   * Pre-computed path to local icon file (icon.svg, icon.png, etc.) if it exists.
+   * Computed during source loading so renderer doesn't need filesystem access.
+   */
+  iconPath?: string;
+}
+
+/**
+ * Source creation input (without auto-generated fields)
+ */
+export interface CreateSourceInput {
+  name: string;
+  provider: string;
+  type: SourceType;
+  mcp?: McpSourceConfig;
+  api?: ApiSourceConfig;
+  local?: LocalSourceConfig;
+  icon?: string; // Emoji or URL (auto-downloaded)
+  enabled?: boolean;
+}
+
+/**
+ * REST API configuration for API sources
+ * Used by api-tools.ts to create dynamic API tools
+ */
+export interface ApiConfig {
+  name: string;
+  baseUrl: string;
+  auth?: {
+    type: 'none' | 'header' | 'bearer' | 'query' | 'basic';
+    headerName?: string;
+    queryParam?: string;
+    authScheme?: string;
+    credentialLabel?: string;
+    secretLabel?: string;
+  };
+  headers?: Record<string, string>;
+  documentation?: string;
+  docsUrl?: string;
+  defaultHeaders?: Record<string, string>;
+  logo?: string;
+  workspaceId?: string;
+}


### PR DESCRIPTION
## Summary
- Pin Bun to 1.3.8 in CI and release workflows to prevent typecheck failures
- CI was downloading latest Bun (1.3.10) which breaks TypeScript module resolution for `.ts` extension imports despite `allowImportingTsExtensions: true`
- All 4 `setup-bun` steps across `ci.yml` and `release.yml` are now pinned

## Test plan
- [ ] CI typecheck passes on this PR
- [ ] Verify `bun install` no longer regenerates lockfile on CI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins the Bun runtime to version `1.3.8` in all active CI and release workflow jobs to prevent TypeScript module resolution failures introduced by later Bun versions, specifically around `.ts` extension imports.

**Changes:**
- `ci.yml`: Added `bun-version: '1.3.8'` to the single active `validate` job's `Setup Bun` step.
- `release.yml`: Added `bun-version: '1.3.8'` to all three build jobs — `build-macos`, `build-windows`, and `build-linux`.

**Notes:**
- The `check-version` and `release` jobs in `release.yml` do not invoke Bun, so they correctly need no changes.
- The commented-out `e2e-tests` and `build-mac` jobs in `ci.yml` still reference `setup-bun` without a version pin. While harmless today, these will silently use the latest Bun if re-enabled, potentially reintroducing the same issue.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it makes a minimal, targeted change to pin Bun versions with no functional risk.
- The change is purely additive (adding `bun-version` inputs to existing `setup-bun` steps), covers all 4 active `setup-bun` calls as described, and directly addresses a reproducible CI failure. There is no logic change, no new dependencies, and no risk of regression.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Pins Bun to 1.3.8 in the active `validate` job's `Setup Bun` step. Commented-out jobs (e2e-tests, build-mac) still have unpinned `setup-bun` but they are inactive. |
| .github/workflows/release.yml | Pins Bun to 1.3.8 in all three build jobs (build-macos, build-windows, build-linux). The `check-version` and `release` jobs don't use Bun, so they correctly do not need pinning. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main / PR opened] --> B{Workflow triggered}
    B --> C[ci.yml: validate job]
    B --> D[release.yml: check-version]
    C --> C1["Setup Bun @ 1.3.8 ✅"]
    C1 --> C2[bun install]
    C2 --> C3[typecheck / lint / test / build]
    D --> E{New version?}
    E -- Yes --> F[build-macos]
    E -- Yes --> G[build-windows]
    E -- Yes --> H[build-linux]
    E -- No --> Z[Skip release]
    F --> F1["Setup Bun @ 1.3.8 ✅"]
    G --> G1["Setup Bun @ 1.3.8 ✅"]
    H --> H1["Setup Bun @ 1.3.8 ✅"]
    F1 --> F2[Build & notarize macOS]
    G1 --> G2[Build Windows]
    H1 --> H2[Build Linux]
    F2 & G2 & H2 --> I[release job: Create GitHub Release]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/ci.yml`, line 60-61 ([link](https://github.com/gannonh/kata-cloud-agents/blob/978c786cc795d988a173d8626fd72d08f575ea49/.github/workflows/ci.yml#L60-L61)) 

   **Unpinned Bun in commented-out jobs**

   The commented-out `e2e-tests` job (line 60) and `build-mac` job (line 107) still have `setup-bun` without a `bun-version` pin. If either job is re-enabled in the future, it will silently pull the latest Bun version and could reproduce the same TypeScript module resolution breakage this PR is fixing. It would be safer to add `bun-version: '1.3.8'` now so the fix is preserved if the jobs are uncommented later.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 978c786</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and release build workflows to use a standardized Bun version (1.3.8), ensuring consistent build behavior across development and release environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->