### PR TITLE
fix: skip pre-push validation when deleting remote branches

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,6 +15,22 @@ stdin_file="$(mktemp)"
 trap 'rm -f "$stdin_file"' EXIT
 cat >"$stdin_file"
 
+# Skip validation when only deleting remote branches (local sha is all zeros).
+zero="0000000000000000000000000000000000000000"
+only_deletes=true
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "$local_sha" != "$zero" ]]; then
+    only_deletes=false
+    break
+  fi
+done <"$stdin_file"
+if $only_deletes; then
+  if git lfs version >/dev/null 2>&1; then
+    git lfs pre-push "$@" <"$stdin_file"
+  fi
+  exit 0
+fi
+
 if ! command -v bun >/dev/null 2>&1; then
   echo "pre-push: Bun is required but was not found in PATH." >&2
   echo "Install Bun, then run 'bun install' and try pushing again." >&2


### PR DESCRIPTION
## Summary
- Adds early exit to the pre-push hook when all refs being pushed are deletions (local SHA is all zeros)
- Prevents `validate:local` from running unnecessarily on `git push --delete`

## Test plan
- [ ] `git push origin --delete <stale-branch>` completes without running validation
- [ ] Normal pushes still run the full `validate:local` gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the push process to streamline branch deletion operations by bypassing unnecessary validation steps in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a targeted early-exit path to the `.githooks/pre-push` hook so that `bun run validate:local` is not invoked when every pushed ref is a branch deletion (local SHA == all-zeros). `git lfs pre-push` is still forwarded in the deletion path when LFS is present, keeping LFS accounting correct.

**Key changes:**
- Initialises `only_deletes=true` and iterates the saved stdin file; flips to `false` on the first non-zero local SHA, then breaks.
- When `only_deletes` remains `true`, runs LFS pre-push (if LFS is installed) and exits `0`, skipping the bun validation gate entirely.
- Normal pushes are unaffected and continue through the existing bun + LFS path.

**Notes:**
- The implementation is consistent with the surrounding `set -euo pipefail` guard—if `git lfs pre-push` fails in the deletion path, the script will still exit non-zero.
- One theoretical edge case: if the hook were called with an empty stdin (no refs at all), `only_deletes` would remain `true` and validation would be silently skipped. In practice, git does not invoke the pre-push hook when there is nothing to push, so this is unlikely to be a real concern.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the change is narrowly scoped to the pre-push hook and only skips validation for explicit branch deletions.
- The logic is correct and complete: the zero-SHA check accurately identifies deletion refs per git documentation, the LFS forwarding is preserved, `set -euo pipefail` is already in place so error propagation is handled, and the normal-push path is completely unchanged. The only theoretical concern (empty stdin) cannot occur during normal git operation.
- No files require special attention.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([git push triggered]) --> B[Save stdin refs to tmp file]
    B --> C{Read each ref:\nlocal_sha == zero?}
    C -- "Yes, all zeros\n(only_deletes=true)" --> D{LFS installed?}
    C -- "No, at least one\nnon-zero SHA\n(only_deletes=false)" --> E{bun in PATH?}
    D -- Yes --> F[git lfs pre-push]
    D -- No --> G[exit 0]
    F --> G
    E -- No --> H[Error: bun required\nexit 1]
    E -- Yes --> I{node_modules\nexists?}
    I -- No --> J[Error: run bun install\nexit 1]
    I -- Yes --> K[bun run validate:local]
    K --> L{LFS installed?}
    L -- Yes --> M[git lfs pre-push]
    L -- No --> N([exit 0])
    M --> N
```

<sub>Last reviewed commit: 0644ab4</sub>

<!-- /greptile_comment -->