### PR TITLE
chore: add worktree sync script

### DIFF
--- a/scripts/sync-worktrees.sh
+++ b/scripts/sync-worktrees.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+die() { echo "FATAL: $*" >&2; exit 1; }
+REPO_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)" || true
+[ -n "$REPO_DIR" ] || die "could not detect git repo root from $SCRIPT_DIR"
+
+# Discover main and standby worktrees from git metadata.
+MAIN_DIR="${MAIN_DIR:-}"
+STANDBY_PATHS=()
+STANDBY_BRANCHES=()
+record_worktree=""
+record_branch=""
+while IFS= read -r line || [ -n "$line" ]; do
+  if [ -z "$line" ]; then
+    if [ -n "$record_worktree" ]; then
+      if [ "$record_branch" = "main" ] && [ -z "$MAIN_DIR" ]; then
+        MAIN_DIR="$record_worktree"
+      fi
+      case "$record_branch" in
+        wt-*-standby)
+          STANDBY_PATHS+=("$record_worktree")
+          STANDBY_BRANCHES+=("$record_branch")
+          ;;
+      esac
+    fi
+    record_worktree=""
+    record_branch=""
+    continue
+  fi
+
+  case "$line" in
+    worktree\ *) record_worktree="${line#worktree }" ;;
+    branch\ refs/heads/*) record_branch="${line#branch refs/heads/}" ;;
+  esac
+done < <(git -C "$REPO_DIR" worktree list --porcelain; echo "")
+[ -n "$MAIN_DIR" ] || die "could not detect worktree path for branch 'main'"
+[ "${#STANDBY_PATHS[@]}" -gt 0 ] || die "no standby worktrees found (expected branches named wt-*-standby)"
+
+errors=0
+warn() { echo "ERROR: $*" >&2; errors=$((errors + 1)); }
+is_dirty() {
+  [ -n "$(git -C "$1" status --porcelain --untracked-files=normal)" ]
+}
+
+# -- Step 1: Move main checkout to exactly origin/main --------------------
+echo "==> Switching $MAIN_DIR to main"
+if ! git -C "$MAIN_DIR" switch main 2>&1; then
+  die "switch to main failed"
+fi
+
+if is_dirty "$MAIN_DIR"; then
+  die "main worktree has local changes/untracked files; clean it before sync"
+fi
+
+echo "==> Fetching origin/main"
+if ! git -C "$MAIN_DIR" fetch origin main 2>&1; then
+  die "fetch failed"
+fi
+
+target_sha=$(git -C "$MAIN_DIR" rev-parse origin/main)
+echo "==> Resetting main checkout to ${target_sha:0:7}"
+if ! git -C "$MAIN_DIR" reset --hard "$target_sha" 2>&1; then
+  die "main reset failed"
+fi
+
+main_sha=$(git -C "$MAIN_DIR" rev-parse HEAD)
+if [ "$main_sha" != "$target_sha" ]; then
+  die "main expected ${target_sha:0:7} but got ${main_sha:0:7}"
+fi
+echo "    main is at ${target_sha:0:7}"
+
+# -- Step 2: Move each standby worktree to exactly target_sha -------------
+for i in "${!STANDBY_PATHS[@]}"; do
+  wt_path="${STANDBY_PATHS[$i]}"
+  branch="${STANDBY_BRANCHES[$i]}"
+  wt="$(basename "$wt_path")"
+
+  if [ ! -d "$wt_path" ]; then
+    warn "$wt: directory not found"
+    continue
+  fi
+
+  if is_dirty "$wt_path"; then
+    warn "$wt: has local changes/untracked files - skipping"
+    continue
+  fi
+
+  current=$(git -C "$wt_path" branch --show-current)
+  if [ "$current" != "$branch" ]; then
+    echo "==> Switching $wt to $branch"
+    if ! git -C "$wt_path" switch "$branch" 2>&1; then
+      warn "$wt: switch failed"
+      continue
+    fi
+  fi
+
+  echo "==> Resetting $wt to ${target_sha:0:7}"
+  if ! git -C "$wt_path" reset --hard "$target_sha" 2>&1; then
+    warn "$wt: reset failed"
+    continue
+  fi
+
+  if ! git -C "$wt_path" branch --set-upstream-to=origin/main "$branch" >/dev/null 2>&1; then
+    warn "$wt: failed to set upstream to origin/main"
+  fi
+
+  wt_sha=$(git -C "$wt_path" rev-parse HEAD)
+  if [ "$wt_sha" != "$target_sha" ]; then
+    warn "$wt: expected ${target_sha:0:7} but got ${wt_sha:0:7}"
+  else
+    echo "    $wt now at ${target_sha:0:7}"
+  fi
+done
+
+# -- Summary --------------------------------------------------------------
+echo ""
+if [ "$errors" -gt 0 ]; then
+  echo "FAILED: $errors error(s) above. Fix them before starting work."
+  exit 1
+else
+  echo "All worktrees switched to standby and synced to main (${target_sha:0:7})."
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/sync-worktrees.sh` to reset main and standby worktrees to `origin/main`
- Safely skips dirty worktrees, validates each reset, and reports errors

## Test plan
- [x] Script is self-contained with no project dependencies
- [ ] Run `bash scripts/sync-worktrees.sh` with and without standby worktrees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated git worktree synchronization script that streamlines management of main and standby worktrees, including repository updates, branch coordination, and integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `scripts/sync-worktrees.sh`, a self-contained Bash script that resets the `main` worktree and any `wt-*-standby` worktrees to `origin/main`. The script integrates cleanly with the existing `scripts/` collection and requires no project dependencies.

**Key findings:**
- **Logic bug (important):** Dirty standby worktrees are intended to be *safely skipped*, but the code routes them through `warn`, which increments `errors`. This causes the script to exit 1 and print `"FAILED"` whenever any standby is dirty — directly contradicting the stated "safely skips dirty worktrees" behavior.
- **Overly conservative dirty detection:** `is_dirty` includes `--untracked-files=normal`, so worktrees with only untracked files (which `git reset --hard` leaves untouched) are skipped unnecessarily.
- **Dirty check ordering for main:** The main worktree's dirty state is checked *after* `git switch main`, which can produce a confusing error message if the worktree is on another branch with conflicting changes; checking before the switch gives a clearer diagnostic.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor fixes recommended — the logic bug around dirty-standby error counting should be addressed before relying on this script in CI or automated workflows.
- The script is well-structured and handles most edge cases correctly (fetch before reset, SHA verification, guarded die/warn patterns). However, the dirty-standby skip incorrectly increments the error counter, causing false failures — a real behavioral discrepancy from the PR description. The other two issues are style-level and don't affect correctness in the common path.
- scripts/sync-worktrees.sh — specifically the warn() call on dirty standby skip (line 86) and the is_dirty helper (line 44).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/sync-worktrees.sh | New shell script to sync main and standby worktrees to origin/main. Contains a logic bug where dirty-standby skips are incorrectly counted as errors, causing false failure exits. Also has minor issues with untracked-file detection and dirty-check ordering. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start] --> B[Detect REPO_DIR via git rev-parse]
    B --> C[Parse git worktree list --porcelain]
    C --> D{Found MAIN_DIR\nbranch=main?}
    D -- No --> E[die: could not detect main worktree]
    D -- Yes --> F{Found wt-*-standby\nworktrees?}
    F -- No --> G[die: no standby worktrees found]
    F -- Yes --> H[git switch main on MAIN_DIR]
    H -- fail --> I[die: switch to main failed]
    H -- ok --> J{is_dirty MAIN_DIR?}
    J -- dirty --> K[die: main has local changes]
    J -- clean --> L[git fetch origin main]
    L -- fail --> M[die: fetch failed]
    L -- ok --> N[git reset --hard origin/main]
    N -- fail --> O[die: main reset failed]
    N -- ok --> P[Verify main SHA == target SHA]
    P --> Q[Loop over STANDBY_PATHS]
    Q --> R{dir exists?}
    R -- No --> S[warn: dir not found]
    R -- Yes --> T{is_dirty worktree?}
    T -- dirty --> U[warn: skipping\n⚠️ increments errors]
    T -- clean --> V[git switch to branch\nif not already on it]
    V --> W[git reset --hard target SHA]
    W --> X[set upstream to origin/main]
    X --> Y{SHA verified?}
    Y -- mismatch --> Z[warn: SHA mismatch]
    Y -- ok --> AA[echo: wt now at SHA]
    S & U & Z --> AB{More standbys?}
    AA --> AB
    AB -- Yes --> Q
    AB -- No --> AC{errors > 0?}
    AC -- Yes --> AD[exit 1: FAILED]
    AC -- No --> AE[exit 0: All synced]
```

<sub>Last reviewed commit: b530667</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->