### PR TITLE
fix: sync-worktrees detects root worktree by position

### DIFF
--- a/scripts/sync-worktrees.sh
+++ b/scripts/sync-worktrees.sh
@@ -12,29 +12,35 @@ STANDBY_PATHS=()
 STANDBY_BRANCHES=()
 record_worktree=""
 record_branch=""
-while IFS= read -r line || [ -n "$line" ]; do
-  if [ -z "$line" ]; then
-    if [ -n "$record_worktree" ]; then
-      if [ "$record_branch" = "main" ] && [ -z "$MAIN_DIR" ]; then
-        MAIN_DIR="$record_worktree"
-      fi
-      case "$record_branch" in
-        wt-*-standby)
-          STANDBY_PATHS+=("$record_worktree")
-          STANDBY_BRANCHES+=("$record_branch")
-          ;;
-      esac
+
+flush_record() {
+  if [ -n "$record_worktree" ]; then
+    if [ -z "$MAIN_DIR" ]; then
+      MAIN_DIR="$record_worktree"
     fi
-    record_worktree=""
-    record_branch=""
+    case "$record_branch" in
+      wt-*-standby)
+        STANDBY_PATHS+=("$record_worktree")
+        STANDBY_BRANCHES+=("$record_branch")
+        ;;
+    esac
+  fi
+  record_worktree=""
+  record_branch=""
+}
+
+while IFS= read -r line; do
+  if [ -z "$line" ]; then
+    flush_record
     continue
   fi
-
   case "$line" in
     worktree\ *) record_worktree="${line#worktree }" ;;
     branch\ refs/heads/*) record_branch="${line#branch refs/heads/}" ;;
   esac
-done < <(git -C "$REPO_DIR" worktree list --porcelain; echo "")
+done < <(git -C "$REPO_DIR" worktree list --porcelain)
+flush_record  # flush final record (porcelain output may not end with blank line)
+
 [ -n "$MAIN_DIR" ] || die "could not detect worktree path for branch 'main'"
 [ "${#STANDBY_PATHS[@]}" -gt 0 ] || die "no standby worktrees found (expected branches named wt-*-standby)"
 


### PR DESCRIPTION
## Summary
- Detects root worktree as the first entry in `git worktree list --porcelain` instead of matching `branch refs/heads/main`, so the script works when the root is on a feature branch
- Flushes the final porcelain record after the parse loop to handle output that doesn't end with a trailing blank line

## Test plan
- [ ] Run `scripts/sync-worktrees.sh` from a non-main branch on the root worktree
- [ ] Verify all worktrees sync to latest origin/main

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `scripts/sync-worktrees.sh` so the root worktree is identified by its position (always the first entry in `git worktree list --porcelain`) rather than by matching `branch refs/heads/main`. This makes the script usable when the root worktree is checked out on any branch, not just `main`. A secondary fix ensures the final porcelain record is always processed by calling `flush_record` after the `while` loop, instead of appending a synthetic blank line with `; echo ""`.

Key changes:
- `flush_record()` helper extracted; sets `MAIN_DIR` on the **first** non-empty record, then classifies standby worktrees — called both on blank-line separators inside the loop and unconditionally after the loop ends.
- `while` loop simplified to `while IFS= read -r line` (old `|| [ -n "$line" ]` guard was only needed because the sentinel `echo ""` was not always reliable at the EOF boundary).
- The error message on line 44 still references `"branch 'main'"` even though detection is now positional — minor wording mismatch worth updating.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — logic is sound and the fix correctly handles root worktrees on non-main branches.
- The positional detection approach is correct (git always lists the main worktree first in porcelain output), `flush_record` safely handles both double-call and no-trailing-blank-line scenarios, and `set -euo pipefail` remains respected throughout. The only issue is a stale error message on line 44 that still mentions "branch 'main'", which is purely cosmetic.
- No files require special attention beyond the minor error-message wording in `scripts/sync-worktrees.sh`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/sync-worktrees.sh | Root-worktree detection refactored from branch-name matching to positional (first entry); final record now flushed explicitly after the loop instead of relying on a trailing blank-line sentinel. Logic is correct; minor stale error message on line 44 still references "branch 'main'". |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[git worktree list --porcelain] --> B[while read line]
    B -->|blank line| C[flush_record]
    B -->|worktree path| D[record_worktree = path]
    B -->|branch refs/heads/...| E[record_branch = branch]
    B -->|EOF| F[flush_record - final record]
    C --> G{record_worktree non-empty?}
    F --> G
    G -->|No| H[reset record vars - no-op]
    G -->|Yes - MAIN_DIR empty?| I[MAIN_DIR = record_worktree - first entry = root]
    G -->|Yes - MAIN_DIR set| J{branch matches wt-*-standby?}
    I --> J
    J -->|Yes| K[Append to STANDBY_PATHS / STANDBY_BRANCHES]
    J -->|No| L[reset record vars]
    K --> L
    L --> B
```

<sub>Last reviewed commit: cd179cc</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured worktree synchronization script with improved parsing architecture to enhance reliability and maintainability during worktree management operations, with better handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->