### PR TITLE
chore: add Electron CDP and Figma capture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,70 @@ import type { Session, Message, AgentEvent } from '@craft-agent/core';
 - If a selected child chat renders empty or answers as if it has no prior context, treat that as a transcript hydration / binding bug, not a cosmetic UI issue.
 - When using live UAT with the user, let the user handle workspace switching inside the running app when that is faster or more reliable than automation.
 
+## Agent Browser + Electron CDP
+
+The dev script supports `ELECTRON_EXTRA_ARGS` to pass flags to the Electron binary:
+
+```bash
+# Launch with Chrome DevTools Protocol on port 9222
+ELECTRON_EXTRA_ARGS="--remote-debugging-port=9222" bun run electron:dev
+```
+
+Once CDP is active, connect `agent-browser`:
+
+```bash
+agent-browser connect 9222
+agent-browser tab                    # List targets (windows/webviews)
+agent-browser snapshot -i            # Accessibility tree with refs
+agent-browser screenshot output.png  # Capture current state
+agent-browser eval "expression"      # Run JS in the renderer
+```
+
+Key details:
+
+- The app must be quit and relaunched with the `--remote-debugging-port` flag; it cannot be added after launch.
+- `agent-browser eval` does not support top-level `await`. Wrap async code in an IIFE: `(async () => { ... })()`
+- Avoid smart quotes in eval strings; they cause `SyntaxError: Invalid or unexpected token`.
+- The `eval` command is useful for reading computed styles, injecting scripts, and triggering actions in the running app.
+
+## Figma Capture for Electron Apps
+
+The Figma MCP `generate_figma_design` tool captures live pages and converts them to editable Figma designs. For Electron apps, the standard "open in browser" approach fails because the app depends on `window.electronAPI` and other Electron-only APIs. Use the CDP injection method instead.
+
+### Workflow
+
+1. Launch the app with CDP enabled (see above).
+2. Connect `agent-browser connect 9222`.
+3. Get a capture ID from `generate_figma_design` with `outputMode: "existingFile"` (or `"newFile"`).
+4. Inject the Figma capture script via eval:
+
+   ```
+   agent-browser eval "(function(){var r=new XMLHttpRequest();r.open('GET','https://mcp.figma.com/mcp/html-to-design/capture.js',false);r.send();var el=document.createElement('script');el.textContent=r.responseText;document.head.appendChild(el);return 'injected'})()"
+   ```
+
+5. Trigger the capture:
+
+   ```
+   agent-browser eval "(function(){window.figma.captureForDesign({captureId:'<ID>',endpoint:'https://mcp.figma.com/mcp/capture/<ID>/submit',selector:'body'});return 'triggered'})()"
+   ```
+
+6. Poll with `generate_figma_design(captureId: '<ID>')` every 5s until `completed`.
+
+### Dark background fix
+
+The app uses Electron's transparent window with OS-level vibrancy. The Figma capture script sees `rgba(0, 0, 0, 0)` on `<html>` and `<body>`, producing a transparent/white background. Fix by setting an explicit background before capture:
+
+```
+agent-browser eval "(function(){document.documentElement.style.backgroundColor='#27272c';document.body.style.backgroundColor='#27272c';return 'set'})()"
+```
+
+The color `#27272c` corresponds to the dark theme's `--background: oklch(0.2 0.005 270)`.
+
+### Existing Figma file
+
+- **File:** `cloud agents` (fileKey: `CodOOXxIAJ0Tsd3ll6ulz6`)
+- Captures are added as new pages/frames. Each capture ID is single-use.
+
 ## e2e Testing
 
 `apps/electron/e2e/README.md`
@@ -175,6 +239,10 @@ import type { Session, Message, AgentEvent } from '@craft-agent/core';
 ### Linear MCP Usage
 
 Use the `save_issue` tool for both creating and updating issues. When creating, `title` and `team` are required.
+
+### PR Naming
+
+Always prefix the PR name with the ticket number for traceability, e.g. `KAT-1234: Implement new agent execution model`. This ensures the PR is linked to the correct issue in Linear and maintains a clear history of changes.
 
 **Common pitfalls:**
 

--- a/scripts/electron-dev.ts
+++ b/scripts/electron-dev.ts
@@ -376,8 +376,10 @@ async function main(): Promise<void> {
   // 4. Start Electron (build already verified)
   console.log("🚀 Starting Electron...\n");
 
+  // Pass extra Electron args (e.g., --remote-debugging-port) from env
+  const extraArgs = process.env.ELECTRON_EXTRA_ARGS?.split(" ").filter(Boolean) ?? [];
   const electronProc = spawn({
-    cmd: [ELECTRON_BIN, "apps/electron"],
+    cmd: [ELECTRON_BIN, "apps/electron", ...extraArgs],
     cwd: ROOT_DIR,
     stdin: "ignore",
     stdout: "inherit",


### PR DESCRIPTION
## Summary
- Add `ELECTRON_EXTRA_ARGS` support to `electron-dev.ts` so extra flags (e.g. `--remote-debugging-port=9222`) can be passed to the Electron binary at dev time
- Document the agent-browser + Electron CDP workflow and Figma capture via CDP injection in CLAUDE.md

## Test plan
- [ ] Verify `ELECTRON_EXTRA_ARGS="--remote-debugging-port=9222" bun run electron:dev` launches with CDP active
- [ ] Verify `agent-browser connect 9222` connects to the running app
- [ ] Confirm Figma capture workflow produces correct output with dark background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Electron development environment to support additional configuration options via environment variables, enabling more flexible development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `ELECTRON_EXTRA_ARGS` support to the `electron-dev.ts` dev script so flags like `--remote-debugging-port=9222` can be passed to the Electron binary at startup, and documents the resulting CDP + Figma capture workflows in `AGENTS.md`.

- `scripts/electron-dev.ts`: Reads `ELECTRON_EXTRA_ARGS` from the environment, splits it on spaces, and appends the resulting tokens to the Electron spawn command. The change is minimal and correct for the documented use case, though the naive `split(" ")` won't handle arguments that contain embedded spaces.
- `AGENTS.md`: Adds clear, well-organized sections covering the CDP launch workflow, `agent-browser` usage, the Figma capture injection pattern (including synchronous XHR script loading and the transparent-background fix), and a new **PR Naming** convention requiring a `KAT-XXXX:` ticket prefix on all PR titles. Note that this PR's own title (`chore: add Electron CDP and Figma capture docs`) does not include a ticket number prefix, which is inconsistent with the rule being introduced.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; changes are additive documentation and a small, low-risk dev-script enhancement.
- Both changes are low-risk: the script change is a one-liner that only affects the dev workflow and has no production impact, and the documentation additions are clear and accurate. The only minor concerns are the naive arg-splitting (style) and the PR title not following the new naming convention it introduces.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/electron-dev.ts | Adds `ELECTRON_EXTRA_ARGS` env var support; implementation is functional for the documented use case but uses a naive space-split that could silently misbehave for quoted arguments with spaces. |
| AGENTS.md | Adds well-structured documentation for the CDP/Figma workflow and a PR naming convention; the PR itself does not follow the newly introduced naming rule (missing KAT-XXXX prefix). |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Script as electron-dev.ts
    participant Electron as Electron App
    participant AgentBrowser as agent-browser
    participant FigmaMCP as Figma MCP

    Dev->>Script: ELECTRON_EXTRA_ARGS="--remote-debugging-port=9222" bun run electron:dev
    Script->>Script: split(ELECTRON_EXTRA_ARGS) → ["--remote-debugging-port=9222"]
    Script->>Electron: spawn(ELECTRON_BIN, "apps/electron", ...extraArgs)
    Electron-->>Dev: CDP listening on :9222

    Dev->>AgentBrowser: agent-browser connect 9222
    AgentBrowser-->>Dev: connected

    Dev->>FigmaMCP: generate_figma_design(outputMode: "existingFile")
    FigmaMCP-->>Dev: captureId

    Dev->>AgentBrowser: eval inject capture.js via XHR
    AgentBrowser->>Electron: synchronous XHR fetch + script injection
    Electron-->>AgentBrowser: "injected"

    Dev->>AgentBrowser: eval figma.captureForDesign({captureId, endpoint})
    AgentBrowser->>Electron: trigger capture
    Electron->>FigmaMCP: POST /mcp/capture/<ID>/submit

    loop Poll every 5s
        Dev->>FigmaMCP: generate_figma_design(captureId)
        FigmaMCP-->>Dev: status (pending / completed)
    end
```

<sub>Last reviewed commit: e9968e4</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=c2e44450-ea26-458f-a087-4930182823f6))

<!-- /greptile_comment -->