### PR TITLE
Desktop v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-03-11
+
+### Added
+- Multi-agent orchestration: sub-agent sessions nested under orchestrators in session list
+- Sub-agent state indicators with status dots (running/completed/failed) and tree lines
+- Expand/collapse controls for orchestrator parent sessions with child count badges
+- Sub-agent lifecycle events (spawn, complete, fail) with durable resume support
+- Hierarchy metadata threaded through session CRUD for parent-child relationships
+- Child chat navigation continuity and transcript rehydration
+- Spec elicitation system skill with structured choices and one-question-per-turn flow
+- Session lifecycle context injection on first message for new-project detection
+- Template loader for externalized system prompt sections (markdown templates)
+- `save_spec` session-scoped tool for spec persistence
+- System skills seeded on workspace creation
+- E2E tests for sub-agent state indicators, orchestration session tree, and project terminology
+- Claude Code Review and PR Assistant GitHub Actions workflows
+
+### Fixed
+- Session list: full-width sub-agent chips with text ellipsis and proper tree lines
+- Session list: collapse other parent groups on chat select
+- Workspace: set default working directory at creation, handle EPERM gracefully
+- Sessions: use workspace rootPath as fallback working directory
+- Child transcript state preserved across idle and resume
+- Session list unread crash prevented; child unread bubbles to orchestrators
+- Duplicate subagent spawn on resume suppressed
+- Pre-push hook skips validation for remote branch deletions
+- E2E: hide windows in test mode to prevent focus stealing
+- E2E: update color assertions for Tailwind v4 oklch output
+
+### Changed
+- Renamed "chats/conversations" to "projects" across UI
+- Rebranded to Kata Desktop (package name, artifact names, electron-builder config)
+- Release workflow split: `desktop-release.yml` (desktop-v* tags) and `cli-release.yml` (cli-v* tags)
+- Independent versioning per app (root package.json version is 0.0.0, unused)
+- Monorepo restructured: desktop at `apps/electron/`, CLI at `apps/cli/`
+
 ## [0.6.1] - 2026-02-07
 
 ### Changed

--- a/apps/cli/scripts/sync-pkg-version.cjs
+++ b/apps/cli/scripts/sync-pkg-version.cjs
@@ -15,10 +15,24 @@ const { readFileSync, writeFileSync } = require('fs')
 const { resolve, join } = require('path')
 
 const root = resolve(__dirname, '..')
-const piPkgPath = join(root, 'node_modules', '@mariozechner', 'pi-coding-agent', 'package.json')
 const kataPkgPath = join(root, 'pkg', 'package.json')
 
-const piPkg = JSON.parse(readFileSync(piPkgPath, 'utf-8'))
+// Walk up from workspace root to find hoisted dependency (bun/npm hoist to monorepo root)
+function findPiPkgJson() {
+  let dir = root
+  while (true) {
+    const candidate = join(dir, 'node_modules', '@mariozechner', 'pi-coding-agent', 'package.json')
+    try {
+      readFileSync(candidate, 'utf-8')
+      return candidate
+    } catch {}
+    const parent = resolve(dir, '..')
+    if (parent === dir) throw new Error('Could not find @mariozechner/pi-coding-agent in any node_modules')
+    dir = parent
+  }
+}
+
+const piPkg = JSON.parse(readFileSync(findPiPkgJson(), 'utf-8'))
 const kataPkg = JSON.parse(readFileSync(kataPkgPath, 'utf-8'))
 
 if (kataPkg.version !== piPkg.version) {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata/desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Kata Desktop — AI coding agent for desktop",
   "main": "dist/main.cjs",
   "private": true,


### PR DESCRIPTION
## Desktop v0.6.2

Version bump and changelog for the first proper release under the new monorepo structure.

### Changes
- Bump `apps/electron/package.json` to `0.6.2`
- Add changelog covering all work since v0.6.1 (multi-agent orchestration, sub-agent state indicators, spec elicitation, project terminology rename, monorepo restructuring)

See CHANGELOG.md for full details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal package version discovery and synchronization mechanism
  * Electron application updated to version 0.6.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->