### PR TITLE
CLI v0.1.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
Bump CLI version to 0.1.1 — 0.1.0 was already published to npm during the scope rename.
