### PR TITLE
CLI v0.2.0

### DIFF
--- a/.agents/skills/releasing-kata/SKILL.md
+++ b/.agents/skills/releasing-kata/SKILL.md
@@ -110,22 +110,26 @@ The terminal coding agent, published to npm as `@kata-sh/cli`.
 
 4. **Update `apps/cli/CHANGELOG.md`** with the new version's changes
 
-5. **Commit and push to main**
+5. **Create release branch and PR**
    ```bash
+   git checkout -b release/cli-vX.Y.Z
    git add apps/cli/package.json apps/cli/CHANGELOG.md
    git commit -m "chore(release): bump cli to X.Y.Z"
-   git push
+   git push -u origin release/cli-vX.Y.Z
+   gh pr create --title "CLI vX.Y.Z" --body "CLI release vX.Y.Z"
    ```
 
-6. **Verify the release**
+6. **Merge PR to main** — CI takes over from here
+
+7. **Verify the release**
    ```bash
    gh release view cli-vX.Y.Z
    npm view @kata-sh/cli version
    ```
 
-### What CI does after push
+### What CI does after merge
 
-`cli-release.yml` triggers on push to main with changes in `apps/cli/`:
+`cli-release.yml` triggers on push to main:
 1. Compares `apps/cli/package.json` version against existing `cli-v*` tags — skips if tag exists
 2. Runs TypeScript check and tests
 3. Builds and publishes to npm (`npm publish --access public`)

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.0
+
+- Add MCP (Model Context Protocol) support via `pi-mcp-adapter` — connect to any MCP server (Linear, Figma, custom tools) from Kata
+- Auto-install `pi-mcp-adapter` on startup and scaffold starter `mcp.json` config
+- Inject `mcp-config` flag into extension runtime for seamless MCP server discovery
+- Fix inline `[]` and `{}` literal handling in preferences YAML parser
+- Add comprehensive MCP documentation and setup guide to README
+- Add MCP smoke tests to CI
+- Install `pi-mcp-adapter` globally in CI for test coverage
+
 ## 0.1.2
 
 - Fix `~/.kata/` paths to `~/.kata-cli/` to avoid collision with Kata Desktop config directory

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## CLI Release v0.2.0

### Changes
- Add MCP (Model Context Protocol) support via `pi-mcp-adapter` — connect to any MCP server (Linear, Figma, custom tools) from Kata
- Auto-install `pi-mcp-adapter` on startup and scaffold starter `mcp.json` config
- Inject `mcp-config` flag into extension runtime for seamless MCP server discovery
- Fix inline `[]` and `{}` literal handling in preferences YAML parser
- Add comprehensive MCP documentation and setup guide to README
- Add MCP smoke tests to CI
- Install `pi-mcp-adapter` globally in CI for test coverage
- Fix releasing-kata skill to use PR flow for CLI releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->