### PR TITLE
CLI v0.2.1

### DIFF
--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -38,5 +38,8 @@ dist/
 AGENTS.md
 !src/resources/AGENTS.md
 
+# ── Build artifacts ──
+pkg/CHANGELOG.md
+
 # ── Kata baseline (auto-generated) ──
 .kata/STATE.md

--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -37,3 +37,6 @@ dist/
 .artifacts/
 AGENTS.md
 !src/resources/AGENTS.md
+
+# ── Kata baseline (auto-generated) ──
+.kata/STATE.md

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1
+
+- Fix `/changelog` command — symlink `pkg/CHANGELOG.md` so Kata can find it
+- Rewrite README for consumers: quick start with `npx`, getting started flow, how it works, mode comparison, full command reference
+
 ## 0.2.0
 
 - Add MCP (Model Context Protocol) support via `pi-mcp-adapter` — connect to any MCP server (Linear, Figma, custom tools) from Kata

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -49,7 +49,27 @@ Pick from available models across your authenticated providers.
 
 ### 4. Start working
 
-Tell Kata what you want to build, or use `/kata` to enter the structured planning workflow.
+Tell Kata what you want to build. Kata has three modes of operation:
+
+**Step mode** — `/kata` — human in the loop (recommended for new or risk-averse users). Kata proposes each step, you approve or redirect.
+
+**Autonomous mode** — `/kata auto` — researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete.
+
+**Steering mode** — two terminals for supervised autonomy:
+
+```
+# Terminal 1: autonomous execution
+/kata auto
+
+# Terminal 2: observe and steer
+/kata status          — check progress
+/kata discuss         — discuss decisions
+/kata queue           — manage upcoming work
+
+# When you need to interrupt and redirect:
+# Terminal 1:
+/kata stop
+```
 
 ## How It Works
 
@@ -72,36 +92,6 @@ Each slice flows through phases automatically:
 - **Reassess** checks if the roadmap still makes sense given what was learned
 
 All planning state lives in `.kata/` at the project root — human-readable markdown files that track milestones, slices, tasks, decisions, and progress.
-
-## Modes
-
-### Interactive: `/kata`
-
-The default mode. A contextual wizard that looks at your project state and suggests the next step — whether that's creating a milestone, planning a slice, or executing a task.
-
-You drive each step. Kata proposes, you approve or redirect. Good for:
-
-- Starting a new project or milestone
-- Working through complex decisions that need human judgment
-- Tasks where you want to stay in the loop
-
-### Autonomous: `/kata auto`
-
-Hands-off mode. Kata loops through the full workflow — research, plan, execute, complete, reassess — in fresh context windows until the milestone is done.
-
-Each task gets a clean context window with only what it needs. Summaries compress prior work so context stays sharp. If something goes wrong, Kata writes a blocker and replans.
-
-```
-/kata auto       — start autonomous execution
-/kata stop       — stop gracefully after the current task
-/kata status     — check progress while it runs
-```
-
-Good for:
-
-- Well-scoped milestones with clear requirements
-- Overnight or background execution
-- Grinding through implementation after the architecture is settled
 
 ## Commands
 
@@ -146,6 +136,37 @@ Good for:
 | `/hotkeys` | Show all keyboard shortcuts |
 | `/create-extension` | Scaffold a new extension with interview-driven setup |
 | `/create-slash-command` | Generate a new slash command from a plain-English description |
+
+## Preferences
+
+Kata preferences live in `~/.kata-cli/preferences.md` (global) or `.kata-cli/preferences.md` (project-local). Manage with `/kata prefs`.
+
+```yaml
+---
+version: 1
+models:
+  research: claude-sonnet-4-6
+  planning: claude-opus-4-6
+  execution: claude-sonnet-4-6
+  completion: claude-sonnet-4-6
+skill_discovery: suggest
+auto_supervisor:
+  soft_timeout_minutes: 20
+  idle_timeout_minutes: 10
+  hard_timeout_minutes: 30
+budget_ceiling: 50.00
+---
+```
+
+| Setting | What it controls |
+|---------|-----------------|
+| `models.*` | Per-phase model selection (Opus for planning, Sonnet for execution, etc.) |
+| `skill_discovery` | `auto` / `suggest` / `off` — how Kata finds and applies skills |
+| `auto_supervisor.*` | Timeout thresholds for auto-mode supervision |
+| `budget_ceiling` | USD ceiling — auto mode pauses when reached |
+| `uat_dispatch` | Enable automatic UAT runs after slice completion |
+| `always_use_skills` | Skills to always load when relevant |
+| `skill_rules` | Situational rules for skill routing |
 
 ## Project State
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -205,6 +205,16 @@ Kata comes with extensions for:
 - **macOS tools** — Native app automation via Accessibility APIs
 - **MCP servers** — Connect to any [Model Context Protocol](https://modelcontextprotocol.io/) server
 
+## Bundled Agents
+
+Three specialized subagents for delegated work:
+
+| Agent | Role |
+|-------|------|
+| **Scout** | Fast codebase recon — returns compressed context for handoff |
+| **Researcher** | Web research — finds and synthesizes current information |
+| **Worker** | General-purpose execution in an isolated context window |
+
 ## MCP Support
 
 Kata integrates with MCP servers via [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter), auto-installed on first launch. Connect to Linear, Figma, or any MCP-compatible service.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,106 +1,199 @@
 # Kata CLI
 
-A terminal coding agent built on [pi](https://github.com/badlogic/pi-mono) (`@mariozechner/pi-coding-agent`). Kata CLI bundles a curated set of extensions for structured planning, browser automation, web search, subagent orchestration, MCP server integration, and more.
+A terminal coding agent that decomposes projects into milestones, slices, and tasks — then executes them autonomously with structured planning, verification, and fresh context windows.
+
+Built on [pi](https://github.com/badlogic/pi-mono) (`@mariozechner/pi-coding-agent`).
 
 ## Quick Start
 
 ```bash
-# From the monorepo root
-bun install
-cd apps/cli
-npx tsc
-npm run copy-themes
-node dist/loader.js
+npx @kata-sh/cli
 ```
 
-Authenticate with an API key:
+Or install globally:
 
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-...
-node dist/loader.js
+npm install -g @kata-sh/cli
+kata-cli
 ```
 
-## Architecture
+On first launch, Kata will prompt you to authenticate with an AI provider.
 
-Kata CLI is a thin wrapper around pi-coding-agent. It does not fork pi — it consumes it as an npm dependency and layers on branding, config, and bundled extensions.
+## Getting Started
 
-```
-apps/cli/
-  src/
-    loader.ts              — Entry point: sets KATA_* env vars, imports cli.ts
-    cli.ts                 — Calls createAgentSession() + InteractiveMode
-    app-paths.ts           — ~/.kata-cli/ path constants
-    resource-loader.ts     — Syncs bundled resources to ~/.kata-cli/agent/
-    wizard.ts              — First-run setup, env key hydration
-    resources/
-      KATA-WORKFLOW.md     — The Kata planning methodology
-      AGENTS.md            — System prompt instructions (synced to agent dir)
-      agents/              — Agent templates (worker, scout, researcher)
-      extensions/          — Bundled extensions (see below)
-      skills/              — Bundled skills
-  pkg/
-    package.json           — piConfig shim (name: "kata", configDir: ".kata-cli")
-    dist/                  — Theme assets copied from pi-coding-agent
+### 1. Start Kata
+
+```bash
+npx @kata-sh/cli
 ```
 
-### How It Works
+### 2. Log in to a provider
 
-1. `loader.ts` sets `PI_PACKAGE_DIR` to `pkg/` so pi reads Kata's branding config
-2. `loader.ts` sets `KATA_CODING_AGENT_DIR` so pi uses `~/.kata-cli/agent/` instead of `~/.pi/agent/`
-3. `loader.ts` injects `--mcp-config ~/.kata-cli/agent/mcp.json` into `process.argv` for the MCP adapter
-4. `resource-loader.ts` syncs bundled extensions, agents, skills, and `AGENTS.md` to `~/.kata-cli/agent/` on every launch
-5. `resource-loader.ts` scaffolds a starter `mcp.json` on first launch (never overwrites existing config)
-6. `cli.ts` seeds `npm:pi-mcp-adapter` into settings so pi auto-installs it
-7. `cli.ts` injects the `mcp-config` flag into the extension runtime (required because Kata bypasses pi's `main()` and its two-pass argv parsing)
-8. `cli.ts` calls `createAgentSession()` + `InteractiveMode` — pi handles everything from there
+```
+/login
+```
 
-## Bundled Extensions
+This opens an interactive prompt to authenticate with Anthropic, OpenAI, Google, or any supported provider. You can also set an API key directly:
 
-| Extension | Description |
-|-----------|-------------|
-| `kata/` | Main extension: `/kata` command, auto-mode, planning, state management |
-| `browser-tools/` | Playwright-based browser automation |
-| `subagent/` | Spawns child Kata processes for parallel work |
-| `slash-commands/` | `/kata-run` and other slash commands |
-| `bg-shell/` | Background shell execution |
-| `context7/` | Context7 library documentation lookup |
-| `search-the-web/` | Web search via Brave API |
-| `mac-tools/` | macOS-specific utilities |
-| `shared/` | Shared UI components (library, not an entry point) |
+```bash
+ANTHROPIC_API_KEY=sk-ant-... npx @kata-sh/cli
+```
+
+### 3. Select a model
+
+```
+/model
+```
+
+Pick from available models across your authenticated providers.
+
+### 4. Start working
+
+Tell Kata what you want to build, or use `/kata` to enter the structured planning workflow.
+
+## How It Works
+
+Kata breaks work into three levels:
+
+```
+Milestone  →  a shippable version (4–10 slices)
+  Slice    →  one demoable vertical capability (1–7 tasks)
+    Task   →  one context-window-sized unit of work
+```
+
+Each slice flows through phases automatically:
+
+**Research** → **Plan** → **Execute** (per task) → **Complete** → **Reassess** → **Next Slice**
+
+- **Research** scouts the codebase and relevant docs
+- **Plan** decomposes the slice into tasks with must-haves — mechanically verifiable outcomes
+- **Execute** runs each task in a fresh context window with only the relevant files pre-loaded
+- **Complete** writes the summary, UAT script, marks the roadmap, and commits
+- **Reassess** checks if the roadmap still makes sense given what was learned
+
+All planning state lives in `.kata/` at the project root — human-readable markdown files that track milestones, slices, tasks, decisions, and progress.
+
+## Modes
+
+### Interactive: `/kata`
+
+The default mode. A contextual wizard that looks at your project state and suggests the next step — whether that's creating a milestone, planning a slice, or executing a task.
+
+You drive each step. Kata proposes, you approve or redirect. Good for:
+
+- Starting a new project or milestone
+- Working through complex decisions that need human judgment
+- Tasks where you want to stay in the loop
+
+### Autonomous: `/kata auto`
+
+Hands-off mode. Kata loops through the full workflow — research, plan, execute, complete, reassess — in fresh context windows until the milestone is done.
+
+Each task gets a clean context window with only what it needs. Summaries compress prior work so context stays sharp. If something goes wrong, Kata writes a blocker and replans.
+
+```
+/kata auto       — start autonomous execution
+/kata stop       — stop gracefully after the current task
+/kata status     — check progress while it runs
+```
+
+Good for:
+
+- Well-scoped milestones with clear requirements
+- Overnight or background execution
+- Grinding through implementation after the architecture is settled
+
+## Commands
+
+### Kata workflow
+
+| Command | Description |
+|---------|-------------|
+| `/kata` | Contextual wizard — suggests next step based on project state |
+| `/kata auto` | Start autonomous mode |
+| `/kata stop` | Stop auto-mode after current task |
+| `/kata status` | Progress dashboard |
+| `/kata queue` | View/manage milestone queue |
+| `/kata discuss` | Discuss gray areas before planning |
+| `/kata prefs` | Manage preferences (global/project) |
+| `/kata doctor` | Diagnose and fix project state |
+| `/audit` | Audit the codebase against a goal, writes report to `.kata/audits/` |
+
+### Session & model
+
+| Command | Description |
+|---------|-------------|
+| `/login` | Authenticate with an AI provider (OAuth) |
+| `/model` | Select a model |
+| `/scoped-models` | Enable/disable models for `Ctrl+P` cycling |
+| `/new` | Start a new session |
+| `/resume` | Resume a previous session |
+| `/compact` | Manually compact the session context |
+| `/fork` | Create a new fork from a previous message |
+| `/tree` | Navigate session tree (switch branches) |
+| `/session` | Show session info and stats |
+
+### Utilities
+
+| Command | Description |
+|---------|-------------|
+| `/mcp` | Show MCP server status and tools |
+| `/gh` | GitHub helper — issues, PRs, labels, milestones, status |
+| `/subagent` | List available subagents |
+| `/export` | Export session to HTML file |
+| `/share` | Share session as a secret GitHub gist |
+| `/copy` | Copy last agent message to clipboard |
+| `/hotkeys` | Show all keyboard shortcuts |
+| `/create-extension` | Scaffold a new extension with interview-driven setup |
+| `/create-slash-command` | Generate a new slash command from a plain-English description |
+
+## Project State
+
+Kata stores all planning artifacts in `.kata/` at the project root:
+
+```
+.kata/
+  STATE.md                — Quick-glance dashboard
+  PROJECT.md              — What the project is (living doc)
+  DECISIONS.md            — Append-only architecture decisions
+  REQUIREMENTS.md         — Requirements tracking
+  milestones/
+    M001/
+      M001-ROADMAP.md     — Slices with risk levels and dependencies
+      M001-SUMMARY.md     — Milestone rollup
+      slices/
+        S01/
+          S01-PLAN.md     — Tasks with must-haves and estimates
+          S01-SUMMARY.md  — What was built, what changed
+          tasks/
+            T01-PLAN.md   — Steps, verification, files touched
+            T01-SUMMARY.md
+```
+
+Everything is markdown. You can read it, edit it, or use it as context for other tools.
+
+## Bundled Tools
+
+Kata comes with extensions for:
+
+- **Browser automation** — Playwright-based interaction with web pages
+- **Subagents** — Spawn parallel Kata processes for independent tasks
+- **Background shell** — Long-running processes (servers, watchers, builds)
+- **Web search** — Brave Search API for current external facts
+- **Library docs** — Context7 for up-to-date framework/library documentation
+- **macOS tools** — Native app automation via Accessibility APIs
+- **MCP servers** — Connect to any [Model Context Protocol](https://modelcontextprotocol.io/) server
 
 ## MCP Support
 
-Kata ships with [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) support via [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter), auto-installed on first launch. One proxy `mcp` tool (~200 tokens in context) gives the agent on-demand access to any MCP server's tools without burning context on individual tool definitions.
+Kata integrates with MCP servers via [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter), auto-installed on first launch. Connect to Linear, Figma, or any MCP-compatible service.
 
-### How It Works
-
-The MCP integration has three parts:
-
-1. **Package seeding**: `cli.ts` ensures `npm:pi-mcp-adapter` is in the settings packages list on every startup. Pi's package manager auto-installs it globally if missing.
-2. **Config path injection**: `loader.ts` pushes `--mcp-config` into `process.argv` and `cli.ts` sets the flag on `runtime.flagValues` — both are needed because the adapter reads the config path at two different points in its lifecycle.
-3. **Config scaffolding**: `resource-loader.ts` creates a starter `~/.kata-cli/agent/mcp.json` on first launch. Never overwrites existing config.
-
-### Adding MCP Servers
+### Adding a server
 
 Edit `~/.kata-cli/agent/mcp.json`:
 
 ```json
 {
-  "settings": {
-    "toolPrefix": "server",
-    "idleTimeout": 10
-  },
-  "mcpServers": {}
-}
-```
-
-#### Example: Linear (OAuth via mcp-remote)
-
-Many hosted MCP servers (Linear, etc.) use OAuth 2.1 authentication. These require [`mcp-remote`](https://github.com/geelen/mcp-remote) as a stdio proxy that handles the browser-based OAuth flow:
-
-```json
-{
-  "settings": { "toolPrefix": "server", "idleTimeout": 10 },
   "mcpServers": {
     "linear": {
       "command": "npx",
@@ -110,57 +203,17 @@ Many hosted MCP servers (Linear, etc.) use OAuth 2.1 authentication. These requi
 }
 ```
 
-After adding the config and restarting Kata:
+Restart Kata, then connect:
 
-1. Connect the server (opens browser for OAuth):
-   ```
-   mcp({ connect: "linear" })
-   ```
-2. Authorize in the browser when prompted by Linear.
-3. Use tools:
-   ```
-   mcp({ server: "linear" })              — list all Linear tools
-   mcp({ search: "issues" })              — search for issue-related tools
-   mcp({ tool: "linear_list_teams" })     — call a tool
-   ```
-
-Tokens are cached in `~/.mcp-auth/` for subsequent sessions. If you hit errors, clear cached auth with `rm -rf ~/.mcp-auth` and reconnect.
-
-#### Example: Stdio server with env vars
-
-```json
-{
-  "mcpServers": {
-    "my-server": {
-      "command": "npx",
-      "args": ["-y", "some-mcp-server"],
-      "env": {
-        "API_KEY": "${MY_API_KEY}"
-      }
-    }
-  }
-}
+```
+mcp({ connect: "linear" })
 ```
 
-Environment variables support `${VAR}` interpolation from `process.env`.
+OAuth servers (Linear, etc.) open a browser window for authorization on first connect. Tokens are cached for subsequent sessions.
 
-#### Example: HTTP server with bearer token
+### Importing existing configs
 
-```json
-{
-  "mcpServers": {
-    "my-api": {
-      "url": "https://api.example.com/mcp",
-      "auth": "bearer",
-      "bearerTokenEnv": "MY_API_KEY"
-    }
-  }
-}
-```
-
-#### Importing existing configs
-
-Pull in your existing Claude Code, Cursor, or VS Code MCP configuration:
+Pull in MCP configs from other tools:
 
 ```json
 {
@@ -171,121 +224,50 @@ Pull in your existing Claude Code, Cursor, or VS Code MCP configuration:
 
 Supported: `cursor`, `claude-code`, `claude-desktop`, `vscode`, `windsurf`, `codex`.
 
-### Server Lifecycle
-
-| Mode | Behavior |
-|------|----------|
-| `lazy` (default) | Connect on first tool call. Disconnect after idle timeout. Cached metadata keeps search/list working offline. |
-| `eager` | Connect at startup. No auto-reconnect on drop. |
-| `keep-alive` | Connect at startup. Auto-reconnect via health checks. |
-
-### Usage Reference
+### Usage
 
 | Command | Description |
 |---------|-------------|
 | `mcp({ })` | Show server status |
 | `mcp({ server: "name" })` | List tools from a server |
-| `mcp({ search: "query" })` | Search tools (space-separated words OR'd) |
-| `mcp({ describe: "tool_name" })` | Show tool parameters |
-| `mcp({ tool: "name", args: '{}' })` | Call a tool (args is a JSON string) |
-| `mcp({ connect: "name" })` | Force connect/reconnect a server |
-| `/mcp` | Interactive panel (status, tools, reconnect) |
+| `mcp({ search: "query" })` | Search tools across servers |
+| `mcp({ tool: "name", args: '{}' })` | Call a tool |
+| `/mcp` | Interactive panel |
 
-### Known Limitations
+## Configuration
 
-- **OAuth servers require `mcp-remote`**: The adapter doesn't implement the MCP OAuth browser flow natively. Use `mcp-remote` as a stdio proxy for OAuth servers.
-- **Figma remote MCP** (`mcp.figma.com`): Blocks dynamic client registration — only whitelisted clients can connect via OAuth. Use Figma's desktop app local MCP server instead (`http://127.0.0.1:3845/mcp`), which requires Dev Mode (paid plan).
-- **Metadata cache**: `pi-mcp-adapter` caches tool metadata to `~/.pi/agent/mcp-cache.json` (hardcoded path, doesn't affect functionality).
-- **OAuth token storage**: `mcp-remote` stores tokens in `~/.mcp-auth/`, separate from Kata's config dir.
-
-## The /kata Command
-
-The main extension registers `/kata` with subcommands:
-
-| Command | Description |
-|---------|-------------|
-| `/kata` | Contextual wizard — smart entry point based on project state |
-| `/kata auto` | Start auto-mode (loops fresh sessions until milestone complete) |
-| `/kata stop` | Stop auto-mode gracefully |
-| `/kata status` | Progress dashboard |
-| `/kata queue` | View/manage work queue |
-| `/kata discuss` | Discuss gray areas before planning |
-| `/kata prefs` | Manage preferences (global/project/status) |
-| `/kata doctor` | Diagnose and fix project state |
-
-### Project State
-
-Kata stores planning state in `.kata/` at the project root:
-
-```
-.kata/
-  STATE.md              — Dashboard (read first)
-  DECISIONS.md          — Append-only decisions register
-  PROJECT.md            — Project description
-  REQUIREMENTS.md       — Requirements tracking
-  milestones/
-    M001/
-      M001-ROADMAP.md   — Milestone plan with slices
-      slices/
-        S01/
-          S01-PLAN.md   — Task decomposition
-          tasks/
-            T01-PLAN.md
-            T01-SUMMARY.md
-```
-
-## Config Directory
-
-Kata uses `~/.kata-cli/` (not `~/.kata/`) to avoid collision with other Kata apps (desktop, etc.):
+Kata stores config in `~/.kata-cli/`:
 
 ```
 ~/.kata-cli/
   agent/
-    extensions/          — Synced from src/resources/extensions/
-    agents/              — Synced from src/resources/agents/
-    skills/              — Synced from src/resources/skills/
-    AGENTS.md            — Synced from src/resources/AGENTS.md
-    mcp.json             — MCP server configuration (scaffolded on first launch, never overwritten)
-    auth.json            — API keys
-    settings.json        — User settings (includes packages: ["npm:pi-mcp-adapter"])
-    models.json          — Custom model definitions
+    mcp.json             — MCP server configuration
+    auth.json            — Provider API keys
+    settings.json        — User settings
+    extensions/          — Bundled extensions (synced on launch)
+    skills/              — Bundled skills
   sessions/              — Session history
-  preferences.md         — Global Kata preferences
+  preferences.md         — Global preferences
 ```
-
-## Environment Variables
-
-Set by `loader.ts` before pi starts:
-
-| Variable | Purpose |
-|----------|---------|
-| `PI_PACKAGE_DIR` | Points to `pkg/` for Kata's piConfig |
-| `KATA_CODING_AGENT_DIR` | Tells pi to use `~/.kata-cli/agent/` |
-| `KATA_VERSION` | Package version for display |
-| `KATA_BIN_PATH` | Absolute path to loader, used by subagent |
-| `KATA_WORKFLOW_PATH` | Absolute path to bundled KATA-WORKFLOW.md |
-| `KATA_BUNDLED_EXTENSION_PATHS` | Colon-joined extension entry points for subagent |
-| `KATA_MCP_CONFIG_PATH` | Absolute path to `~/.kata-cli/agent/mcp.json` |
 
 ## Development
 
+For contributing or running from source:
+
 ```bash
-# Build
+# From the monorepo root
+bun install
+cd apps/cli
 npx tsc
-
-# Copy theme assets (required once, or after pi-coding-agent updates)
 npm run copy-themes
-
-# Run
 node dist/loader.js
-
-# Test (37 tests: app smoke, resource sync, MCP integration, package validation)
-npm test
 ```
 
-### Key Dependency
+Run tests:
 
-`@mariozechner/pi-coding-agent` is consumed via npm (hoisted to monorepo root `node_modules/`). Never fork — run `npm update` to pick up upstream changes.
+```bash
+cd apps/cli && npm test
+```
 
 ## License
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,7 +29,8 @@
     "node": ">=20.6.0"
   },
   "scripts": {
-    "build": "tsc && npm run copy-themes",
+    "build": "tsc && npm run copy-themes && npm run copy-changelog",
+    "copy-changelog": "node -e \"require('fs').cpSync('CHANGELOG.md','pkg/CHANGELOG.md')\"",
     "copy-themes": "node -e \"const{mkdirSync,cpSync}=require('fs');const{resolve}=require('path');const candidates=[resolve(__dirname,'node_modules/@mariozechner/pi-coding-agent/dist/modes/interactive/theme'),resolve(__dirname,'..','..','node_modules/@mariozechner/pi-coding-agent/dist/modes/interactive/theme')];const src=candidates.find(p=>{try{require('fs').statSync(p);return true}catch{return false}});if(!src)throw new Error('theme dir not found');mkdirSync('pkg/dist/modes/interactive/theme',{recursive:true});cpSync(src,'pkg/dist/modes/interactive/theme',{recursive:true})\"",
     "test": "node --import ./src/resources/extensions/kata/tests/resolve-ts.mjs --experimental-strip-types --test 'src/resources/extensions/kata/tests/*.test.ts' 'src/resources/extensions/kata/tests/*.test.mjs' 'src/tests/*.test.ts'",
     "dev": "tsc --watch",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/pkg/CHANGELOG.md
+++ b/apps/cli/pkg/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/apps/cli/pkg/CHANGELOG.md
+++ b/apps/cli/pkg/CHANGELOG.md
@@ -1,1 +1,0 @@
-../CHANGELOG.md

--- a/docs/plans/MIGRATION_PLAN.md
+++ b/docs/plans/MIGRATION_PLAN.md
@@ -79,19 +79,57 @@
 - [x] Releasing skill updated to cover both targets
 - [x] `.gitignore` updated (`.superpowers/`)
 
-### Phase 3: Import Kata Orchestrator — NOT STARTED
+### Phase 3: Adopt Turborepo — UP NEXT
+
+Adopt Turborepo for build orchestration, caching, and task parallelization. Switching costs increase as more packages, scripts, and CI patterns accumulate around the current manual orchestration.
+
+**Why now:**
+- 4 apps + 4 packages is the right size to adopt — complex enough to benefit, small enough that migration is low-risk
+- Root `package.json` already has ~50 scripts with manual `cd` chains and sequential `&&` orchestration
+- `typecheck:all`, `electron:build`, `validate:ci` all encode implicit dependency ordering by hand
+- Every new package/app added without Turbo copies the manual pattern, increasing future migration surface
+- No code changes required — only build config and script simplification
+
+**Scope:**
+- [ ] Install `turbo` as a root dev dependency
+- [ ] Create `turbo.json` with pipeline definitions for: `build`, `test`, `typecheck`, `lint`
+- [ ] Define task dependencies (e.g., `build` in `apps/electron` depends on `build` in `packages/*`)
+- [ ] Handle mixed runtimes: CLI uses `npm test` (Node), everything else uses `bun`
+- [ ] Simplify root scripts: `validate:ci` → `turbo build test typecheck lint`
+- [ ] Simplify `electron:build` chain (5 sequential sub-builds → Turbo pipeline with deps)
+- [ ] Simplify `typecheck:all` (4 sequential `cd && tsc` → `turbo typecheck`)
+- [ ] Update CI workflows (`desktop-release.yml`, `cli-release.yml`) to use `turbo`
+- [ ] Verify local caching works (`.turbo/` in `.gitignore`)
+- [ ] Optional: enable remote caching for CI ↔ local cache sharing
+
+**Scripts to migrate (current → target):**
+
+| Current script | Current command | Turbo equivalent |
+|---|---|---|
+| `typecheck:all` | `cd packages/core && tsc && cd ../shared && tsc && ...` | `turbo typecheck` |
+| `validate:ci` | `typecheck:all && lint:electron && test && ...` | `turbo build test typecheck lint` |
+| `electron:build` | 5 sequential `&&`-chained sub-builds | `turbo build --filter=@kata-sh/desktop` |
+| `test` | `test:packages && test:desktop` | `turbo test` |
+| `test:all` | `test && test:cli` | `turbo test` |
+
+**Not in scope:**
+- No package restructuring or code changes
+- No changes to individual package build commands (those stay as-is)
+- Remote caching is optional / can be added later
+
+### Phase 4: Import Kata Orchestrator — NOT STARTED
 
 - [ ] Wait for Orchestrator 2.0 release (cursor, plugin support, etc.) for cleaner import
 - [ ] Integrate orchestrator release workflows in CI (migrate from orchestrator repo and adapt)
 - [ ] Archive `kata-orchestrator`
 
-### Phase 4: Import Symphony — NOT STARTED
+### Phase 5: Import Symphony — NOT STARTED
 
 - [ ] Create `packages/symphony-core/` + `apps/symphony/`
 - [ ] Adapt from pnpm/vitest to bun workspace
 - [ ] Archive `kata-symphony`
 
-### Phase 5: Swap Agent Engine — NOT STARTED (Future)
+### Phase 6: Swap Agent Engine — NOT STARTED (Future)
 
 - [ ] Replace `@anthropic-ai/claude-agent-sdk` with `@mariozechner/pi-ai` + `@mariozechner/pi-agent-core`
 - [ ] Multi-provider support across all apps
@@ -141,8 +179,8 @@ Independent repos:
 | `kata-cloud-agents` | Renamed → `kata`                                   | ✅ Done  |
 | `kata-agents`       | Deleted                                            | ✅ Done  |
 | `kata-cloud`        | Deleted                                            | ✅ Done  |
-| `kata-orchestrator` | Import → archive                                   | Phase 3 |
-| `kata-symphony`     | Import → archive                                   | Phase 4 |
+| `kata-orchestrator` | Import → archive                                   | Phase 4 |
+| `kata-symphony`     | Import → archive                                   | Phase 5 |
 | `kata-marketplace`  | Keep independent (dist repo, builds from monorepo) | Ongoing |
 | `kata-skills`       | Keep independent (dist repo, builds from monorepo) | Ongoing |
 | `kata-site`         | Keep independent (Vercel deploy)                   | Ongoing |
@@ -164,7 +202,8 @@ Independent repos:
 | Distribution repos      | kata-marketplace and kata-skills stay independent | They're dist targets for different ecosystems (Claude Code, skills.sh) |
 | Site migration          | Deferred (keep independent)                       | Vercel deploy pipeline; no code sharing benefit                        |
 | Old repo handling       | Delete obsolete, archive after extraction         | Stars/forks preserved on archive; clean break for obsolete             |
-| Agent engine swap       | Deferred to Phase 5                               | Get monorepo structure right first; engine swap is high-risk           |
+| Build orchestration     | Turborepo (Phase 3, up next)                       | Switching costs compound — more scripts/packages = harder migration    |
+| Agent engine swap       | Deferred to Phase 6                               | Get monorepo structure right first; engine swap is high-risk           |
 | Git history for imports | Clean copy, not subtree                           | Simpler; low-star repos don't need preserved history                   |
 | Versioning              | Independent per app                               | Desktop `desktop-v*`, CLI `cli-v*`; root version unused                |
 | `@craft-agent/*` rename | Deferred                                          | Broad impact across electron app; not blocking                         |

--- a/docs/plans/MIGRATION_PLAN.md
+++ b/docs/plans/MIGRATION_PLAN.md
@@ -79,11 +79,10 @@
 - [x] Releasing skill updated to cover both targets
 - [x] `.gitignore` updated (`.superpowers/`)
 
-### Phase 3: Import Skills from Kata Orchestrator — NOT STARTED
+### Phase 3: Import Kata Orchestrator — NOT STARTED
 
-- [ ] Create `packages/skills/` from `kata-orchestrator/skills/`
-- [ ] Wire skills into CLI via `resource-loader.ts`
-- [ ] Update `kata-marketplace` and `kata-skills` dist repos
+- [ ] Wait for Orchestrator 2.0 release (cursor, plugin support, etc.) for cleaner import
+- [ ] Integrate orchestrator release workflows in CI (migrate from orchestrator repo and adapt)
 - [ ] Archive `kata-orchestrator`
 
 ### Phase 4: Import Symphony — NOT STARTED
@@ -128,6 +127,7 @@ kata/
 ```
 
 Independent repos:
+
 - `kata-marketplace` — Claude Code plugin distribution
 - `kata-skills` — skills.sh package distribution
 - `kata-site` — Marketing site (Vercel)
@@ -141,7 +141,7 @@ Independent repos:
 | `kata-cloud-agents` | Renamed → `kata`                                   | ✅ Done  |
 | `kata-agents`       | Deleted                                            | ✅ Done  |
 | `kata-cloud`        | Deleted                                            | ✅ Done  |
-| `kata-orchestrator` | Extract skills → archive                           | Phase 3 |
+| `kata-orchestrator` | Import → archive                                   | Phase 3 |
 | `kata-symphony`     | Import → archive                                   | Phase 4 |
 | `kata-marketplace`  | Keep independent (dist repo, builds from monorepo) | Ongoing |
 | `kata-skills`       | Keep independent (dist repo, builds from monorepo) | Ongoing |

--- a/docs/plans/MIGRATION_PLAN.md
+++ b/docs/plans/MIGRATION_PLAN.md
@@ -84,6 +84,7 @@
 Adopt Turborepo for build orchestration, caching, and task parallelization. Switching costs increase as more packages, scripts, and CI patterns accumulate around the current manual orchestration.
 
 **Why now:**
+
 - 4 apps + 4 packages is the right size to adopt — complex enough to benefit, small enough that migration is low-risk
 - Root `package.json` already has ~50 scripts with manual `cd` chains and sequential `&&` orchestration
 - `typecheck:all`, `electron:build`, `validate:ci` all encode implicit dependency ordering by hand
@@ -91,6 +92,7 @@ Adopt Turborepo for build orchestration, caching, and task parallelization. Swit
 - No code changes required — only build config and script simplification
 
 **Scope:**
+
 - [ ] Install `turbo` as a root dev dependency
 - [ ] Create `turbo.json` with pipeline definitions for: `build`, `test`, `typecheck`, `lint`
 - [ ] Define task dependencies (e.g., `build` in `apps/electron` depends on `build` in `packages/*`)
@@ -104,15 +106,16 @@ Adopt Turborepo for build orchestration, caching, and task parallelization. Swit
 
 **Scripts to migrate (current → target):**
 
-| Current script | Current command | Turbo equivalent |
-|---|---|---|
-| `typecheck:all` | `cd packages/core && tsc && cd ../shared && tsc && ...` | `turbo typecheck` |
-| `validate:ci` | `typecheck:all && lint:electron && test && ...` | `turbo build test typecheck lint` |
-| `electron:build` | 5 sequential `&&`-chained sub-builds | `turbo build --filter=@kata-sh/desktop` |
-| `test` | `test:packages && test:desktop` | `turbo test` |
-| `test:all` | `test && test:cli` | `turbo test` |
+| Current script   | Current command                                         | Turbo equivalent                        |
+| ---------------- | ------------------------------------------------------- | --------------------------------------- |
+| `typecheck:all`  | `cd packages/core && tsc && cd ../shared && tsc && ...` | `turbo typecheck`                       |
+| `validate:ci`    | `typecheck:all && lint:electron && test && ...`         | `turbo build test typecheck lint`       |
+| `electron:build` | 5 sequential `&&`-chained sub-builds                    | `turbo build --filter=@kata-sh/desktop` |
+| `test`           | `test:packages && test:desktop`                         | `turbo test`                            |
+| `test:all`       | `test && test:cli`                                      | `turbo test`                            |
 
 **Not in scope:**
+
 - No package restructuring or code changes
 - No changes to individual package build commands (those stay as-is)
 - Remote caching is optional / can be added later
@@ -129,7 +132,7 @@ Adopt Turborepo for build orchestration, caching, and task parallelization. Swit
 - [ ] Adapt from pnpm/vitest to bun workspace
 - [ ] Archive `kata-symphony`
 
-### Phase 6: Swap Agent Engine — NOT STARTED (Future)
+### Phase 6: Kata Desktop - Swap Agent Engine — NOT STARTED (Future)
 
 - [ ] Replace `@anthropic-ai/claude-agent-sdk` with `@mariozechner/pi-ai` + `@mariozechner/pi-agent-core`
 - [ ] Multi-provider support across all apps
@@ -202,7 +205,7 @@ Independent repos:
 | Distribution repos      | kata-marketplace and kata-skills stay independent | They're dist targets for different ecosystems (Claude Code, skills.sh) |
 | Site migration          | Deferred (keep independent)                       | Vercel deploy pipeline; no code sharing benefit                        |
 | Old repo handling       | Delete obsolete, archive after extraction         | Stars/forks preserved on archive; clean break for obsolete             |
-| Build orchestration     | Turborepo (Phase 3, up next)                       | Switching costs compound — more scripts/packages = harder migration    |
+| Build orchestration     | Turborepo (Phase 3, up next)                      | Switching costs compound — more scripts/packages = harder migration    |
 | Agent engine swap       | Deferred to Phase 6                               | Get monorepo structure right first; engine swap is high-risk           |
 | Git history for imports | Clean copy, not subtree                           | Simpler; low-star repos don't need preserved history                   |
 | Versioning              | Independent per app                               | Desktop `desktop-v*`, CLI `cli-v*`; root version unused                |


### PR DESCRIPTION
## CLI Release v0.2.1

### Changes
- Fix `/changelog` command — symlink `pkg/CHANGELOG.md` so Kata can find it
- Rewrite README for consumers: quick start with `npx`, getting started flow, how it works, mode comparison, full command reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Patch version bumped to 0.2.1.
  * Build process updated to include copying the changelog into the package output.
  * Repository ignore rules clarified to explicitly exclude generated build artifacts and tooling state files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->