### PR TITLE
Orchestrator v2.0.1

### DIFF
--- a/.github/workflows/orc-release.yml
+++ b/.github/workflows/orc-release.yml
@@ -50,8 +50,11 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+
       - name: Install dependencies
-        run: cd apps/orchestrator && npm install
+        run: bun install
 
       - name: Run tests
         run: cd apps/orchestrator && npm test
@@ -72,8 +75,11 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+
       - name: Install dependencies
-        run: cd apps/orchestrator && npm install
+        run: bun install
 
       - name: Publish to npm
         run: cd apps/orchestrator && npm publish --access public

--- a/apps/orchestrator/CHANGELOG.md
+++ b/apps/orchestrator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.1] - 2026-03-13
+
+### Fixed
+
+- CI workflow now uses `bun install` from monorepo root instead of `npm install` in the app directory, fixing `EUNSUPPORTEDPROTOCOL` error caused by `workspace:*` dependencies in other monorepo packages
+
 ## [2.0.0] - 2026-03-13
 
 ### Changed

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/orc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini and Codex.",
   "bin": {
     "kata": "bin/install.js"


### PR DESCRIPTION
## Orchestrator v2.0.1

### Fixed

- CI workflow now uses `bun install` from monorepo root instead of `npm install` in the app directory, fixing `EUNSUPPORTEDPROTOCOL` error caused by `workspace:*` dependencies in other monorepo packages

---

This is a patch release to fix the failed 2.0.0 publish. No functional changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a patch release (v2.0.1) that fixes the failed v2.0.0 publish by correcting the CI workflow to use `bun install` from the monorepo root instead of `npm install` inside `apps/orchestrator`, resolving the `EUNSUPPORTEDPROTOCOL` error caused by `workspace:*` references in sibling packages.

- Adds `oven-sh/setup-bun@v2.0.1` (pinned by SHA) to both the `test` and `publish` jobs in `.github/workflows/orc-release.yml`
- Replaces `cd apps/orchestrator && npm install` with `bun install` at the repo root in both jobs
- Keeps `npm test` and `npm publish` unchanged, which is correct since Node.js is still set up and npm authentication (via `NODE_AUTH_TOKEN`) is required for publishing
- Bumps `package.json` version to `2.0.1` and adds a corresponding `CHANGELOG.md` entry
- Minor: both `bun install` calls omit `--frozen-lockfile`, which is recommended in CI to ensure reproducible builds

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it is a targeted CI fix with no functional code changes.
- The change is minimal and clearly correct: switching to `bun install` from the monorepo root is the right fix for the `workspace:*` protocol error. The only non-critical gap is the missing `--frozen-lockfile` flag on `bun install` in CI.
- `.github/workflows/orc-release.yml` — consider adding `--frozen-lockfile` to both `bun install` steps.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/orc-release.yml | Adds `oven-sh/setup-bun` step to both `test` and `publish` jobs and switches `npm install` to `bun install` from the monorepo root; `npm test` and `npm publish` are intentionally kept. Minor: `bun install` should use `--frozen-lockfile` in CI for reproducible builds. |
| apps/orchestrator/CHANGELOG.md | Adds `[2.0.1]` entry documenting the CI workflow fix. No issues. |
| apps/orchestrator/package.json | Version bumped from `2.0.0` to `2.0.1`. No other changes; no issues. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Push (main)
    participant CV as check-version job
    participant T as test job
    participant P as publish job

    GH->>CV: Trigger on apps/orchestrator/** change
    CV->>CV: Read package.json version
    CV->>CV: Check if orc-vX.Y.Z tag exists on remote
    CV-->>T: should_release=true / version=2.0.1

    T->>T: actions/checkout
    T->>T: setup-node (v22)
    T->>T: setup-bun (v2.0.1) [NEW]
    T->>T: bun install (monorepo root) [CHANGED]
    T->>T: cd apps/orchestrator && npm test

    T-->>P: tests passed

    P->>P: actions/checkout
    P->>P: setup-node (v22, registry=npmjs)
    P->>P: setup-bun (v2.0.1) [NEW]
    P->>P: bun install (monorepo root) [CHANGED]
    P->>P: cd apps/orchestrator && npm publish
    P->>P: git tag orc-v2.0.1 + push
    P->>P: Create GitHub Release
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/orc-release.yml
Line: 57

Comment:
**Use `--frozen-lockfile` in CI**

Running `bun install` without `--frozen-lockfile` in CI allows the lockfile to be silently updated if it's out of sync, which can cause non-reproducible builds. It's best practice to enforce the lockfile in CI environments.

```suggestion
        run: bun install --frozen-lockfile
```

This same suggestion applies to the `install` step in the `publish` job at line 82.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: f443476</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->