### PR TITLE
ci: fix orc release workflow + add publish dry-run gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,37 @@ jobs:
       - name: Run CLI tests
         run: cd apps/cli && npm test
 
+  # Orchestrator dry-run: only on release PRs (version bump in apps/orchestrator/package.json)
+  orc-publish-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Check if orchestrator version bumped
+        id: version-check
+        run: |
+          CURRENT_VERSION=$(node -p "require('./apps/orchestrator/package.json').version")
+          if git ls-remote --tags origin | grep -q "refs/tags/orc-v$CURRENT_VERSION"; then
+            echo "Version $CURRENT_VERSION already tagged, skipping dry-run"
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          else
+            echo "New orchestrator version $CURRENT_VERSION detected, running publish dry-run"
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node.js
+        if: steps.version-check.outputs.should_run == 'true'
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '22'
+
+      - name: Publish dry-run
+        if: steps.version-check.outputs.should_run == 'true'
+        run: cd apps/orchestrator && npm publish --dry-run --access public
+
   # Desktop E2E: only on release PRs (version bump in apps/electron/package.json)
   e2e-mocked:
     needs: validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Check if orchestrator version bumped
         id: version-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         id: version-check
         run: |
           CURRENT_VERSION=$(node -p "require('./apps/orchestrator/package.json').version")
-          if git ls-remote --tags origin | grep -q "refs/tags/orc-v$CURRENT_VERSION"; then
+          if git ls-remote --tags origin "refs/tags/orc-v$CURRENT_VERSION" | grep -q .; then
             echo "Version $CURRENT_VERSION already tagged, skipping dry-run"
             echo "should_run=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run CLI tests
         run: cd apps/cli && npm test
 
-  # Orchestrator dry-run: only on release PRs (version bump in apps/orchestrator/package.json)
+  # Orchestrator dry-run: runs when the current orchestrator version has not yet been tagged/released
   orc-publish-dry-run:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/orc-release.yml
+++ b/.github/workflows/orc-release.yml
@@ -50,12 +50,6 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
-
-      - name: Install dependencies
-        run: bun install
-
       - name: Run tests
         run: cd apps/orchestrator && npm test
 
@@ -74,12 +68,6 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
-
-      - name: Install dependencies
-        run: bun install
 
       - name: Publish to npm
         run: cd apps/orchestrator && npm publish --access public


### PR DESCRIPTION
## What

Two CI fixes in one commit:

### 1. Drop install step from `orc-release.yml`

The orchestrator has no external dependencies — tests are pure `node --test` and `build-hooks.js` is plain file copying. Installing dependencies (whether via `npm` or `bun`) was the source of two consecutive release failures:
- v2.0.0: `npm install` failed with `EUNSUPPORTEDPROTOCOL` (workspace:\* deps in other monorepo packages)
- v2.0.1: `bun install` from root failed with `playwright@^1.58.2` not yet published

Fix: remove the install step entirely from both `test` and `publish` jobs.

### 2. Add `orc-publish-dry-run` gate to `ci.yml`

Runs `npm publish --dry-run` on PRs that bump the orchestrator version. Exercises `prepublishOnly` (build-hooks) and npm packaging before anything reaches main. Skips on non-release PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline with version validation and a gated dry-run publish to reduce accidental releases.
  * Simplified CI workflows by removing the Bun setup and install steps from relevant jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two targeted CI fixes for the orchestrator release pipeline: it removes the unnecessary `bun install` step from `orc-release.yml` (which was causing back-to-back release failures due to workspace protocol and missing-package errors), and adds a pre-merge `orc-publish-dry-run` gate to `ci.yml` that validates `prepublishOnly` and npm packaging before changes reach `main`.

- **`orc-release.yml`**: Drops `Setup Bun` + `Install dependencies` from both `test` and `publish` jobs. This is safe because `npm test` (`node scripts/run-tests.cjs`) and the `prepublishOnly` hook (`build-hooks.js`) rely exclusively on Node.js built-in modules (`fs`, `path`) — no external packages are required.
- **`ci.yml`**: Adds `orc-publish-dry-run` job using the same tag-existence pattern as the existing `e2e-mocked` gate. Runs `npm publish --dry-run --access public` when the current orchestrator version is not yet tagged on origin.
- Minor: `fetch-depth: 0` in the new job's checkout fetches full repo history, but `git ls-remote --tags origin` is a direct network call that never consults local refs — `fetch-depth: 1` would be sufficient.
- Minor: The job comment says "only on release PRs (version bump in apps/orchestrator/package.json)" but the gate actually fires on any PR where the current version is not yet tagged, not just PRs that specifically bump the version.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the fixes are well-reasoned, consistent with existing patterns, and address real release failures.
- The root cause of both release failures is correctly identified and fixed. The `build-hooks.js` script's use of only built-in modules confirms no install step is needed. The new dry-run gate mirrors the established `e2e-mocked` pattern. Only minor style observations exist (unnecessary `fetch-depth: 0` and a slightly inaccurate comment).
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds `orc-publish-dry-run` job that exercises `prepublishOnly` (build-hooks) + npm packaging via `npm publish --dry-run` on PRs where the orchestrator version is not yet tagged. Pattern mirrors the existing `e2e-mocked` gate. Minor: `fetch-depth: 0` is unnecessary since `git ls-remote` doesn't need local history, and the job comment overstates the gate precision. |
| .github/workflows/orc-release.yml | Removes `Setup Bun` and `Install dependencies` steps from both `test` and `publish` jobs. Safe because `npm test` runs pure Node.js (`node scripts/run-tests.cjs`) and `npm publish` triggers `prepublishOnly` → `build-hooks.js` which uses only built-in `fs`/`path` modules — no external packages are needed. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant CI as ci.yml
    participant VC as version-check step
    participant OR as origin (git tags)
    participant DRY as npm publish --dry-run
    participant REL as orc-release.yml (on merge)

    PR->>CI: opened / updated
    CI->>VC: read apps/orchestrator/package.json version
    VC->>OR: git ls-remote --tags origin
    OR-->>VC: tag list
    alt orc-vX.Y.Z tag already exists
        VC-->>CI: should_run=false → skip
    else version not yet tagged
        VC-->>CI: should_run=true
        CI->>DRY: cd apps/orchestrator && npm publish --dry-run
        DRY-->>CI: triggers prepublishOnly → build-hooks.js (fs copy only)
        DRY-->>CI: packaging validated ✓
    end

    PR->>REL: merged to main (orchestrator path changed)
    REL->>REL: check-version → orc-vX.Y.Z not tagged
    REL->>REL: test job (node --test, no install)
    REL->>REL: publish job (npm publish, no install)
    REL->>OR: git tag orc-vX.Y.Z + GitHub Release
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 69-72

Comment:
**`fetch-depth: 0` unnecessary for this checkout**

The only git operation in this job that uses the checkout is `git ls-remote --tags origin`, which is a pure network call to the remote — it never reads local history. Fetching the full history (`fetch-depth: 0`) is unnecessary overhead; `fetch-depth: 1` (the default) is sufficient and will be faster on a large repo.

```suggestion
      - name: Checkout
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
        with:
          fetch-depth: 1
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 65

Comment:
**Misleading job comment — runs on all PRs with an unreleased version**

The comment says _"only on release PRs (version bump in apps/orchestrator/package.json)"_, but the implementation doesn't check whether _this PR_ bumped the version. It checks whether the current version in `package.json` already has a tag on origin. This means the dry-run will fire on **every PR** opened during the window between a version bump landing and the actual release (e.g. a docs or unrelated fix PR would still trigger it). This is consistent with how `e2e-mocked` works, but the comment overstates the precision of the gate. Consider updating the comment to reflect the actual behavior:

```suggestion
  # Orchestrator dry-run: runs when the current orchestrator version has not yet been tagged/released
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 30c8c69</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->