### PR TITLE
ci: add workflow_dispatch trigger to orc-release

### DIFF
--- a/.github/workflows/orc-release.yml
+++ b/.github/workflows/orc-release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'apps/orchestrator/**'
+  workflow_dispatch:
 
 concurrency:
   group: orc-release-${{ github.sha }}


### PR DESCRIPTION
The orc-v2.0.1 release failed on main because the release workflow had a root-level `bun install` step that choked on `playwright@^1.58.2` from the CLI workspace. PR #66 already fixed this by removing the install step, but the release was never re-triggered because that PR only touched `.github/workflows/` — not `apps/orchestrator/**`.

This adds `workflow_dispatch` to `orc-release.yml` so we can manually trigger the release with `gh workflow run` after merge, without needing a dummy commit under `apps/orchestrator/`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `workflow_dispatch` trigger to `orc-release.yml`, enabling the orchestrator release workflow to be manually re-triggered via `gh workflow run` without requiring a new commit under `apps/orchestrator/`. This is a targeted fix for the situation described in the PR description, where the `orc-v2.0.1` release failed and could not be re-triggered after the upstream fix in PR #66.

Key points:
- The change is minimal and surgical — one line added to the `on:` block.
- The existing `check-version` job already guards against duplicate releases by checking if the tag exists remotely before proceeding, so manual dispatch is safe to run idempotently.
- No new permissions, secrets, or inputs are required; the workflow functions identically whether triggered by a push or manually dispatched.
- No issues were identified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds only a `workflow_dispatch` trigger with no other changes to workflow logic, permissions, or secrets.
- The change is a single-line, well-understood GitHub Actions configuration addition. The workflow already has a built-in idempotency guard (tag-existence check) that prevents duplicate releases, making manual dispatch safe. There are no new security surface areas introduced.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/orc-release.yml | Adds `workflow_dispatch` trigger so the release workflow can be manually re-triggered without a dummy commit; the rest of the workflow (version/tag-existence check, test, publish, tagging) is unchanged. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant ORC as check-version job
    participant NPM as npm registry
    participant Repo as GitHub Repo

    Dev->>GH: gh workflow run orc-release.yml (workflow_dispatch)
    GH->>ORC: Start check-version job
    ORC->>Repo: git ls-remote --tags (check if orc-vX.Y.Z exists)
    alt Tag already exists
        ORC-->>GH: should_release=false → skip test & publish
    else Tag does not exist
        ORC-->>GH: should_release=true
        GH->>GH: Run test job (npm test)
        GH->>NPM: npm publish --access public
        GH->>Repo: git tag orc-vX.Y.Z && git push
        GH->>Repo: Create GitHub Release
    end
```

<sub>Last reviewed commit: 7adb2df</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the release workflow configuration to enable manual triggering of orchestrator application deployments. Teams can now dispatch the release workflow on demand, providing greater flexibility for scheduled releases and rapid response to critical updates. This allows deployments to occur according to business needs rather than relying solely on automated triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->