### PR TITLE
docs(readme): enhance branding and product overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
+<div align="center">
+
 # Kata
 
-Kata is a monorepo for three AI agent products:
+**型** · /ˈkɑːtɑː/ · *noun* - a choreographed pattern practiced repeatedly until perfected
+
+![alt text](assets/brand/logo-circle-dark.png)
+<br>
+[kata.sh](https://kata.sh)
+
+</div>
+
+---
+
+## Kata Monorepo
+
+This is the Kata monorepo for three AI agent products:
 
 - Kata CLI in `apps/cli`
 - Kata Desktop in `apps/electron`
@@ -10,11 +24,11 @@ The repo also contains shared packages that support the product apps.
 
 ## Products
 
-| Product | Path | Use it for | Quick start |
-| --- | --- | --- | --- |
-| [Kata CLI](apps/cli/README.md) | `apps/cli` | Terminal-based coding work with guided and autonomous execution modes | `npx @kata-sh/cli` |
-| [Kata Desktop](apps/electron/README.md) | `apps/electron` | Desktop-based agent work with workspaces, session management, sources, and approval controls | [GitHub Releases](https://github.com/gannonh/kata/releases) |
-| [Kata Orchestrator](apps/orchestrator/README.md) | `apps/orchestrator` | Spec-driven workflows for Claude Code, OpenCode, Gemini CLI, and Codex | `npx @kata-sh/orc@latest` |
+| Product                                          | Path                | Use it for                                                                                   | Quick start                                                 |
+| ------------------------------------------------ | ------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| [Kata CLI](apps/cli/README.md)                   | `apps/cli`          | Terminal-based coding work with guided and autonomous execution modes                        | `npx @kata-sh/cli`                                          |
+| [Kata Desktop](apps/electron/README.md)          | `apps/electron`     | Desktop-based agent work with workspaces, session management, sources, and approval controls | [GitHub Releases](https://github.com/gannonh/kata/releases) |
+| [Kata Orchestrator](apps/orchestrator/README.md) | `apps/orchestrator` | Spec-driven workflows for Claude Code, OpenCode, Gemini CLI, and Codex                       | `npx @kata-sh/orc@latest`                                   |
 
 ## Kata CLI
 
@@ -86,17 +100,17 @@ Use Kata Orchestrator when you want:
 
 Read more in [apps/orchestrator/README.md](apps/orchestrator/README.md).
 
-| Path | Purpose |
-| --- | --- |
-| `apps/cli` | Kata CLI |
-| `apps/electron` | Kata Desktop |
-| `apps/orchestrator` | Kata Orchestrator |
-| `apps/online-docs` | Online documentation site |
-| `apps/viewer` | Viewer app |
-| `packages/core` | Shared types |
-| `packages/shared` | Shared agent, auth, config, git, session, and source logic |
-| `packages/ui` | Shared UI code |
-| `packages/mermaid` | Shared Mermaid package |
+| Path                | Purpose                                                    |
+| ------------------- | ---------------------------------------------------------- |
+| `apps/cli`          | Kata CLI                                                   |
+| `apps/electron`     | Kata Desktop                                               |
+| `apps/orchestrator` | Kata Orchestrator                                          |
+| `apps/online-docs`  | Online documentation site                                  |
+| `apps/viewer`       | Viewer app                                                 |
+| `packages/core`     | Shared types                                               |
+| `packages/shared`   | Shared agent, auth, config, git, session, and source logic |
+| `packages/ui`       | Shared UI code                                             |
+| `packages/mermaid`  | Shared Mermaid package                                     |
 
 ## Local Development
 
@@ -114,21 +128,21 @@ bun run githooks:install
 
 Common commands:
 
-| Command | Purpose |
-| --- | --- |
-| `bun run electron:dev` | Start Kata Desktop in development mode |
-| `cd apps/cli && npm run build` | Build Kata CLI |
-| `cd apps/orchestrator && npm test` | Run Kata Orchestrator tests |
-| `bun run typecheck:all` | Run TypeScript checks across shared packages |
+| Command                            | Purpose                                      |
+| ---------------------------------- | -------------------------------------------- |
+| `bun run electron:dev`             | Start Kata Desktop in development mode       |
+| `cd apps/cli && npm run build`     | Build Kata CLI                               |
+| `cd apps/orchestrator && npm test` | Run Kata Orchestrator tests                  |
+| `bun run typecheck:all`            | Run TypeScript checks across shared packages |
 
 ## Testing
 
-| Command | Runs |
-| --- | --- |
-| `bun run test` | Shared package and desktop unit tests |
-| `bun run test:cli` | Kata CLI tests |
+| Command            | Runs                                   |
+| ------------------ | -------------------------------------- |
+| `bun run test`     | Shared package and desktop unit tests  |
+| `bun run test:cli` | Kata CLI tests                         |
 | `bun run test:all` | Shared package, desktop, and CLI tests |
-| `bun run test:e2e` | Desktop Playwright tests |
+| `bun run test:e2e` | Desktop Playwright tests               |
 
 The CLI uses Node's built-in test runner. The shared packages and desktop tests use Bun.
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the README with branding improvements — adding a centered header section with the Kata logo, Japanese character (型), IPA pronunciation, tagline, and a link to `kata.sh` — and reformats all markdown tables to use aligned column padding for better readability in raw form.

**Key changes:**
- Adds a centered branding block at the top of the README with logo, tagline, and website link
- Reformats the `## Kata Monorepo` section header (previously inline prose)
- Reformats all existing markdown tables with consistent column-width padding

**Issues found:**
- The image alt text on line 7 is a literal placeholder (`"alt text"`) rather than a descriptive string, which should be corrected for accessibility
- The logo asset used (`logo-circle-dark.png`) is designed for dark backgrounds; a light-mode variant (`logo-circle-light.svg`) exists in the repo and could be served via a `<picture>` element to support both GitHub themes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only modifies documentation with no impact on code or functionality.
- The change is documentation-only (README.md). There are no code changes, no logic to break, and the referenced logo asset exists in the repository. The two style suggestions (alt text and dark-mode logo) are minor polish items that do not block merging.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Documentation-only change adding branding (logo, tagline, website link) at the top of the README and reformatting all markdown tables with aligned column padding. Minor accessibility issue with placeholder alt text on the logo image; dark-only logo asset may render poorly on light-mode GitHub themes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[Centered Branding Header]
    B --> B1[Kata title]
    B --> B2[Japanese character 型 + tagline]
    B --> B3[Logo: logo-circle-dark.png]
    B --> B4[Link: kata.sh]
    A --> C[## Kata Monorepo Section]
    C --> C1[Products table]
    C --> C2[Kata CLI section]
    C --> C3[Kata Desktop section]
    C --> C4[Kata Orchestrator section]
    C --> C5[Repository structure table]
    A --> D[## Local Development]
    D --> D1[Common commands table]
    A --> E[## Testing]
    E --> E1[Test commands table]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: README.md
Line: 7

Comment:
**Non-descriptive image alt text**

The alt text `"alt text"` is a placeholder and doesn't describe the image. This hurts accessibility (screen readers will read it literally) and is poor practice. It should be replaced with something meaningful.

```suggestion
![Kata logo](assets/brand/logo-circle-dark.png)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: README.md
Line: 7

Comment:
**Dark logo may not render well on light-mode GitHub themes**

The image `logo-circle-dark.png` is specifically a dark-background variant (as indicated by the filename). On GitHub with a light theme, this may display poorly — e.g., a dark logo on a white background.

The repository also contains `assets/brand/logo-circle-light.svg` for light contexts. GitHub supports the `<picture>` element with `prefers-color-scheme` to serve the correct variant per theme:

```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="assets/brand/logo-circle-dark.png">
  <img alt="Kata logo" src="assets/brand/logo-circle-light.svg" height="120">
</picture>
```

This ensures the logo looks correct regardless of the viewer's GitHub theme setting.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 11dc4ea</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->