### PR TITLE
feat(M001/S05): Incremental indexing via git diff + CLI --full flag + integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,10 @@ target/
 vendor/
 *.log
 tmp/
+
+# ── Kata baseline (auto-generated) ──
+.idea/
+node_modules/
+dist/
+coverage/
+.cache/

--- a/apps/context/.kata/preferences.md
+++ b/apps/context/.kata/preferences.md
@@ -16,7 +16,11 @@ prefer_skills: []
 avoid_skills: []
 skill_rules: []
 custom_instructions: []
-models: {}
+models:
+  research: claude-sonnet-4-6
+  planning: claude-opus-4-6     # Opus for architectural decisions
+  execution: claude-sonnet-4-6
+  completion: claude-sonnet-4-6
 skill_discovery:
 auto_supervisor: {}
 ---

--- a/apps/context/AGENTS.md
+++ b/apps/context/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+## Hard Rules
+
+- **Never use `git push --no-verify` or `git commit --no-verify`.** Pre-push and pre-commit hooks are quality gates. If a gate fails, fix the underlying problem. Bypassing hooks is never acceptable — not to unblock a push, not to save time, not for any reason short of an explicit instruction from the user.
+
+## Git Workflow: Worktrees and Standby Branches
+
+This repo uses git worktrees. Each worktree has a **standby branch** (e.g. `wt-cli-standby`) that tracks `main`. Because git does not allow the same branch to be checked out in multiple worktrees simultaneously, the standby branch acts as a `main` proxy for the worktree.
+
+**Standby branches are not working branches.** Treat `wt-cli-standby` (and any `*-standby` branch) exactly like `main`:
+
+- Never commit to a standby branch.
+- At the start of any session, if `git branch --show-current` returns a standby branch, you are effectively on main. Create (or check out) the correct feature branch — `kata/M00X/S0X` — before doing any work.

--- a/apps/context/skill/SKILL.md
+++ b/apps/context/skill/SKILL.md
@@ -62,10 +62,13 @@ When neither `--json` nor `--quiet` is set, output is human-readable with format
 
 Index a project directory into the knowledge graph. Parses all TypeScript and Python files, extracts symbols and cross-file relationships (imports, calls, inheritance), and stores them in SQLite.
 
+Supports **incremental indexing**: after the first full index, subsequent runs only process files changed since the last indexed git commit. Use `--full` to force a complete re-index.
+
 ```bash
 kata-context index .
 kata-context index /path/to/project
 kata-context index . --json
+kata-context index . --full          # Force full re-index
 ```
 
 **Output (human):**

--- a/apps/context/src/cli.ts
+++ b/apps/context/src/cli.ts
@@ -92,11 +92,13 @@ program
 program
   .command("index")
   .argument("[path]", "Project root to index", ".")
+  .option("--full", "Force full re-index (ignore incremental cache)")
   .description("Index a project into the knowledge graph")
-  .action(async (pathArg: string, _opts: unknown, cmd: Command) => {
+  .action(async (pathArg: string, opts: { full?: boolean }, cmd: Command) => {
     const rootPath = resolve(pathArg);
     const outputOpts = getOutputOptions(cmd);
     const dbPath = getDbPath(cmd, rootPath);
+    const full = opts.full ?? false;
 
     try {
       if (!existsSync(rootPath)) {
@@ -105,31 +107,41 @@ program
       }
 
       const config = loadConfig(rootPath);
-      const result = indexProject(rootPath, { dbPath, config });
+      const result = indexProject(rootPath, { dbPath, config, full });
 
-      const jsonData = {
+      const jsonData: Record<string, unknown> = {
         filesIndexed: result.filesIndexed,
         symbolsExtracted: result.symbolsExtracted,
         edgesCreated: result.edgesCreated,
         duration: result.duration,
         errors: result.errors,
+        incremental: result.incremental,
         dbPath,
       };
+      if (result.incremental) {
+        jsonData.changedFiles = result.changedFiles;
+        jsonData.deletedFiles = result.deletedFiles;
+      }
 
       const quietLines = [String(result.filesIndexed)];
 
       const humanFn = () => {
         const lines: string[] = [];
-        lines.push(formatHeader("Index Complete"));
-        lines.push(
-          formatKeyValue([
-            ["Files indexed", result.filesIndexed],
-            ["Symbols extracted", result.symbolsExtracted],
-            ["Edges created", result.edgesCreated],
-            ["Duration", `${result.duration}ms`],
-            ["Database", dbPath],
-          ]),
-        );
+        const mode = result.incremental ? "Index Complete (incremental)" : "Index Complete (full)";
+        lines.push(formatHeader(mode));
+
+        const kvPairs: Array<[string, string | number]> = [
+          ["Files indexed", result.filesIndexed],
+          ["Symbols extracted", result.symbolsExtracted],
+          ["Edges created", result.edgesCreated],
+          ["Duration", `${result.duration}ms`],
+          ["Database", dbPath],
+        ];
+        if (result.incremental) {
+          kvPairs.splice(1, 0, ["Changed files", result.changedFiles ?? 0]);
+          kvPairs.splice(2, 0, ["Deleted files", result.deletedFiles ?? 0]);
+        }
+        lines.push(formatKeyValue(kvPairs));
 
         if (result.errors.length > 0) {
           lines.push(formatHeader("Errors"));

--- a/apps/context/src/graph/store.ts
+++ b/apps/context/src/graph/store.ts
@@ -279,6 +279,20 @@ export class GraphStore {
     return result.changes;
   }
 
+  /**
+   * Delete all edges targeting symbols in a file (inbound edges).
+   * Must be called BEFORE deleteSymbolsByFile to resolve target IDs.
+   * Prevents orphan edges when a file is deleted or renamed.
+   */
+  deleteEdgesTargetingFile(filePath: string): number {
+    const result = this.db
+      .prepare(
+        "DELETE FROM edges WHERE target_id IN (SELECT id FROM symbols WHERE file_path = ?)",
+      )
+      .run(filePath);
+    return result.changes;
+  }
+
   // ── Metadata ──
 
   /** Get the last indexed git SHA. Returns null if never indexed. */

--- a/apps/context/src/indexer.ts
+++ b/apps/context/src/indexer.ts
@@ -2,9 +2,14 @@
  * Indexing pipeline orchestrator.
  *
  * Wires together: file discovery → parsing → relationship extraction → graph storage.
- * This is the main entry point for indexing a project into the knowledge graph.
+ * Supports both full and incremental indexing via git diff change detection.
+ *
+ * Full path: discover all files → parse → extract relationships → store → set SHA.
+ * Incremental path: git diff since last SHA → partition changes → delete stale →
+ *   parse changed → extract relationships → store → set SHA.
  */
 
+import { execSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { loadConfig } from "./config.js";
@@ -12,6 +17,7 @@ import { discoverFiles } from "./discovery.js";
 import { GraphStore } from "./graph/store.js";
 import { extractRelationships } from "./graph/relationships.js";
 import { parseFiles, type ParseResult } from "./parser/index.js";
+import { isSupportedFile } from "./parser/languages.js";
 import type { Config, ParsedFile, Relationship, Symbol } from "./types.js";
 
 // ── Types ──
@@ -30,6 +36,12 @@ export interface IndexResult {
   duration: number;
   /** Files that failed to parse (path + error) */
   errors: Array<{ filePath: string; error: string }>;
+  /** Whether incremental indexing was used */
+  incremental: boolean;
+  /** Number of changed files processed (incremental only) */
+  changedFiles?: number;
+  /** Number of deleted files removed from graph (incremental only) */
+  deletedFiles?: number;
 }
 
 /**
@@ -42,6 +54,22 @@ export interface IndexOptions {
   config?: Config;
   /** An existing open GraphStore to use (for testing with :memory: databases). */
   store?: GraphStore;
+  /** Force full re-index even if a last-indexed SHA exists. */
+  full?: boolean;
+}
+
+// ── Change detection types ──
+
+/** Status of a file change detected by git diff. */
+export type FileChangeStatus = "added" | "modified" | "deleted" | "renamed";
+
+/** A single file change from git diff. */
+export interface FileChange {
+  status: FileChangeStatus;
+  /** File path (for added/modified/deleted) or new path (for renamed). */
+  filePath: string;
+  /** Old path (for renamed files only). */
+  oldPath?: string;
 }
 
 // ── Default DB path ──
@@ -56,27 +84,124 @@ function resolveDbPath(rootPath: string): string {
   return resolve(rootPath, DEFAULT_DB_DIR, DEFAULT_DB_NAME);
 }
 
+// ── Git helpers ──
+
 /**
- * Index a project: discover files, parse them, extract relationships,
- * and store everything in the knowledge graph.
+ * Get the current HEAD SHA of the git repository.
  *
  * @param rootPath - Absolute path to the project root
- * @param options - Optional: dbPath, config overrides, or pre-opened store
- * @returns Summary of what was indexed
+ * @returns Current HEAD SHA, or null if not a git repo or git is unavailable
  */
-export function indexProject(
+export function getCurrentSha(rootPath: string): string | null {
+  try {
+    const sha = execSync("git rev-parse HEAD", {
+      cwd: rootPath,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get changed files between a base SHA and HEAD using `git diff`.
+ *
+ * Parses `git diff --name-status --diff-filter=ACDMR` output to detect
+ * added, copied, deleted, modified, and renamed files.
+ *
+ * @param rootPath - Absolute path to the project root
+ * @param baseSha - The SHA to diff against (last indexed SHA)
+ * @returns Array of file changes, or null if git command fails
+ */
+export function getChangedFiles(
   rootPath: string,
-  options?: IndexOptions,
-): IndexResult {
-  const start = performance.now();
+  baseSha: string,
+): FileChange[] | null {
+  try {
+    const output = execSync(
+      `git diff --name-status --diff-filter=ACDMR ${baseSha} HEAD`,
+      {
+        cwd: rootPath,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    ).trim();
 
-  // 1. Load config
-  const config = options?.config ?? loadConfig(rootPath);
+    if (!output) return [];
 
-  // 2. Discover files
+    const changes: FileChange[] = [];
+    const lines = output.split("\n");
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      // Tab-separated: STATUS\tPATH or STATUS\tOLD_PATH\tNEW_PATH (for renames)
+      const parts = line.split("\t");
+      const statusCode = parts[0];
+
+      if (!statusCode) continue;
+
+      // Rename lines start with R followed by similarity percentage (e.g. R100, R095)
+      if (statusCode.startsWith("R")) {
+        const oldPath = parts[1];
+        const newPath = parts[2];
+        if (oldPath && newPath) {
+          changes.push({
+            status: "renamed",
+            filePath: newPath,
+            oldPath: oldPath,
+          });
+        }
+      } else if (statusCode.startsWith("C")) {
+        // Copied files — treat as added (the copy target is new)
+        const newPath = parts[2];
+        if (newPath) {
+          changes.push({ status: "added", filePath: newPath });
+        }
+      } else {
+        const filePath = parts[1];
+        if (!filePath) continue;
+
+        switch (statusCode) {
+          case "A":
+            changes.push({ status: "added", filePath });
+            break;
+          case "D":
+            changes.push({ status: "deleted", filePath });
+            break;
+          case "M":
+            changes.push({ status: "modified", filePath });
+            break;
+        }
+      }
+    }
+
+    return changes;
+  } catch {
+    return null;
+  }
+}
+
+// ── Full index path ──
+
+/**
+ * Execute the full indexing path: discover all files, parse, extract, store.
+ */
+function fullIndex(
+  rootPath: string,
+  config: Config,
+  store: GraphStore,
+): {
+  parsedFiles: ParsedFile[];
+  relationships: Relationship[];
+  errors: Array<{ filePath: string; error: string }>;
+} {
+  // Discover all files
   const filePaths = discoverFiles(rootPath, config);
 
-  // 3. Parse all files
+  // Parse all files
   const parseResults = parseFiles(filePaths, rootPath);
 
   // Separate successes and errors
@@ -91,16 +216,157 @@ export function indexProject(
     }
   }
 
-  // 4. Extract cross-file relationships
+  // Extract cross-file relationships
   const relationships = extractRelationships(parsedFiles, rootPath);
 
-  // 5. Collect all symbols
+  // Collect all symbols
   const allSymbols: Symbol[] = [];
   for (const file of parsedFiles) {
     allSymbols.push(...file.symbols);
   }
 
-  // 6. Open or use provided store
+  // Delete stale data for files being re-indexed
+  const indexedFiles = new Set(parsedFiles.map((f) => f.filePath));
+  for (const filePath of indexedFiles) {
+    store.deleteEdgesByFile(filePath);
+    store.deleteSymbolsByFile(filePath);
+  }
+
+  // Upsert symbols
+  if (allSymbols.length > 0) {
+    store.upsertSymbols(allSymbols);
+  }
+
+  // Upsert edges
+  if (relationships.length > 0) {
+    store.upsertEdges(relationships);
+  }
+
+  return { parsedFiles, relationships, errors };
+}
+
+// ── Incremental index path ──
+
+/**
+ * Execute the incremental indexing path: process only changed files.
+ */
+function incrementalIndex(
+  rootPath: string,
+  config: Config,
+  store: GraphStore,
+  changes: FileChange[],
+): {
+  parsedFiles: ParsedFile[];
+  relationships: Relationship[];
+  errors: Array<{ filePath: string; error: string }>;
+  deletedCount: number;
+} {
+  // Partition changes into delete-targets and parse-targets
+  const pathsToDelete: string[] = [];
+  const pathsToParse: string[] = [];
+
+  for (const change of changes) {
+    switch (change.status) {
+      case "deleted":
+        pathsToDelete.push(change.filePath);
+        break;
+
+      case "renamed":
+        // Delete old path data
+        if (change.oldPath) {
+          pathsToDelete.push(change.oldPath);
+        }
+        // Parse new path (if supported)
+        if (isSupportedFile(change.filePath)) {
+          pathsToParse.push(change.filePath);
+        }
+        break;
+
+      case "added":
+        if (isSupportedFile(change.filePath)) {
+          pathsToParse.push(change.filePath);
+        }
+        break;
+
+      case "modified":
+        // Delete old data then re-parse
+        pathsToDelete.push(change.filePath);
+        if (isSupportedFile(change.filePath)) {
+          pathsToParse.push(change.filePath);
+        }
+        break;
+    }
+  }
+
+  // 1. Delete graph data for removed/modified files
+  for (const filePath of pathsToDelete) {
+    store.deleteEdgesByFile(filePath);
+    store.deleteSymbolsByFile(filePath);
+  }
+
+  // 2. Parse changed/added files
+  const parseResults = parseFiles(pathsToParse, rootPath);
+
+  const parsedFiles: ParsedFile[] = [];
+  const errors: Array<{ filePath: string; error: string }> = [];
+
+  for (const result of parseResults) {
+    if (result.parsed) {
+      parsedFiles.push(result.parsed);
+    } else if (result.error) {
+      errors.push({ filePath: result.filePath, error: result.error });
+    }
+  }
+
+  // 3. Extract relationships for changed files
+  const relationships = extractRelationships(parsedFiles, rootPath);
+
+  // 4. Collect symbols from changed files
+  const allSymbols: Symbol[] = [];
+  for (const file of parsedFiles) {
+    allSymbols.push(...file.symbols);
+  }
+
+  // 5. Upsert symbols
+  if (allSymbols.length > 0) {
+    store.upsertSymbols(allSymbols);
+  }
+
+  // 6. Upsert edges
+  if (relationships.length > 0) {
+    store.upsertEdges(relationships);
+  }
+
+  // Count files that were only deleted (not re-parsed)
+  const deletedOnly = changes.filter((c) => c.status === "deleted").length;
+
+  return { parsedFiles, relationships, errors, deletedCount: deletedOnly };
+}
+
+// ── Main entry point ──
+
+/**
+ * Index a project: discover files, parse them, extract relationships,
+ * and store everything in the knowledge graph.
+ *
+ * Supports incremental indexing: when a last-indexed SHA exists and `full`
+ * is not set, only files changed since that SHA are processed. Falls back
+ * to full indexing when git metadata is unavailable or the SHA is missing.
+ *
+ * @param rootPath - Absolute path to the project root
+ * @param options - Optional: dbPath, config overrides, store, or full flag
+ * @returns Summary of what was indexed
+ */
+export function indexProject(
+  rootPath: string,
+  options?: IndexOptions,
+): IndexResult {
+  const start = performance.now();
+
+  // 1. Load config
+  const config = options?.config ?? loadConfig(rootPath);
+
+  // 2. Open or use provided store
   const ownStore = !options?.store;
   const dbPath = options?.dbPath ?? resolveDbPath(rootPath);
   let store: GraphStore;
@@ -108,42 +374,97 @@ export function indexProject(
   if (options?.store) {
     store = options.store;
   } else {
-    // Ensure the directory exists
     mkdirSync(dirname(dbPath), { recursive: true });
     store = new GraphStore(dbPath);
   }
 
   try {
-    // 7. Delete stale data for files being re-indexed
-    const indexedFiles = new Set(parsedFiles.map((f) => f.filePath));
-    for (const filePath of indexedFiles) {
-      store.deleteEdgesByFile(filePath);
-      store.deleteSymbolsByFile(filePath);
+    // 3. Decide: incremental or full?
+    const forceFull = options?.full === true;
+    const lastSha = store.getLastIndexedSha();
+    const currentSha = getCurrentSha(rootPath);
+
+    let useIncremental = false;
+    let changes: FileChange[] | null = null;
+
+    if (!forceFull && lastSha && currentSha) {
+      // Try incremental: get changed files
+      changes = getChangedFiles(rootPath, lastSha);
+      if (changes !== null) {
+        useIncremental = true;
+      }
     }
 
-    // 8. Upsert symbols into the graph
-    if (allSymbols.length > 0) {
-      store.upsertSymbols(allSymbols);
-    }
+    if (useIncremental && changes !== null) {
+      // ── Incremental path ──
 
-    // 9. Upsert edges into the graph
-    if (relationships.length > 0) {
-      store.upsertEdges(relationships);
+      // No changes since last index
+      if (changes.length === 0) {
+        const duration = Math.round(performance.now() - start);
+        // Update SHA even if no changes (HEAD may have advanced via non-code commits)
+        if (currentSha) {
+          store.setLastIndexedSha(currentSha);
+        }
+        return {
+          filesIndexed: 0,
+          symbolsExtracted: 0,
+          edgesCreated: 0,
+          duration,
+          errors: [],
+          incremental: true,
+          changedFiles: 0,
+          deletedFiles: 0,
+        };
+      }
+
+      const result = incrementalIndex(rootPath, config, store, changes);
+
+      // Persist new SHA
+      if (currentSha) {
+        store.setLastIndexedSha(currentSha);
+      }
+
+      const duration = Math.round(performance.now() - start);
+      return {
+        filesIndexed: result.parsedFiles.length,
+        symbolsExtracted: result.parsedFiles.reduce(
+          (sum, f) => sum + f.symbols.length,
+          0,
+        ),
+        edgesCreated: result.relationships.length,
+        duration,
+        errors: result.errors,
+        incremental: true,
+        changedFiles: changes.length,
+        deletedFiles: result.deletedCount,
+      };
+    } else {
+      // ── Full path ──
+      const result = fullIndex(rootPath, config, store);
+
+      // Persist SHA for subsequent incremental runs
+      if (currentSha) {
+        store.setLastIndexedSha(currentSha);
+      }
+
+      const allSymbols: Symbol[] = [];
+      for (const file of result.parsedFiles) {
+        allSymbols.push(...file.symbols);
+      }
+
+      const duration = Math.round(performance.now() - start);
+      return {
+        filesIndexed: result.parsedFiles.length,
+        symbolsExtracted: allSymbols.length,
+        edgesCreated: result.relationships.length,
+        duration,
+        errors: result.errors,
+        incremental: false,
+      };
     }
   } finally {
-    // Only close if we opened it
     if (ownStore) {
       store.close();
     }
   }
-
-  const duration = Math.round(performance.now() - start);
-
-  return {
-    filesIndexed: parsedFiles.length,
-    symbolsExtracted: allSymbols.length,
-    edgesCreated: relationships.length,
-    duration,
-    errors,
-  };
 }

--- a/apps/context/src/indexer.ts
+++ b/apps/context/src/indexer.ts
@@ -9,7 +9,7 @@
  *   parse changed → extract relationships → store → set SHA.
  */
 
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { loadConfig } from "./config.js";
@@ -120,14 +120,14 @@ export function getChangedFiles(
   baseSha: string,
 ): FileChange[] | null {
   try {
-    const output = execSync(
-      `git diff --name-status --diff-filter=ACDMR ${baseSha} HEAD`,
-      {
-        cwd: rootPath,
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "pipe"],
-      },
-    ).trim();
+    // Use spawnSync with argument array to avoid shell injection via baseSha
+    const result = spawnSync(
+      "git",
+      ["diff", "--name-status", "--diff-filter=ACDMR", baseSha, "HEAD"],
+      { cwd: rootPath, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    if (result.status !== 0 || result.error) return null;
+    const output = (result.stdout as string).trim();
 
     if (!output) return [];
 
@@ -261,20 +261,24 @@ function incrementalIndex(
   errors: Array<{ filePath: string; error: string }>;
   deletedCount: number;
 } {
-  // Partition changes into delete-targets and parse-targets
-  const pathsToDelete: string[] = [];
+  // Partition changes into:
+  //   pathsRemoved — truly gone (deleted files, renamed old paths): clean up all edges
+  //   pathsToRefresh — modified files: clean outgoing edges only (inbound preserved)
+  //   pathsToParse — files to re-parse
+  const pathsRemoved: string[] = [];
+  const pathsToRefresh: string[] = [];
   const pathsToParse: string[] = [];
 
   for (const change of changes) {
     switch (change.status) {
       case "deleted":
-        pathsToDelete.push(change.filePath);
+        pathsRemoved.push(change.filePath);
         break;
 
       case "renamed":
-        // Delete old path data
+        // Old path is truly removed
         if (change.oldPath) {
-          pathsToDelete.push(change.oldPath);
+          pathsRemoved.push(change.oldPath);
         }
         // Parse new path (if supported)
         if (isSupportedFile(change.filePath)) {
@@ -289,8 +293,8 @@ function incrementalIndex(
         break;
 
       case "modified":
-        // Delete old data then re-parse
-        pathsToDelete.push(change.filePath);
+        // Modified: refresh outgoing edges but preserve inbound
+        pathsToRefresh.push(change.filePath);
         if (isSupportedFile(change.filePath)) {
           pathsToParse.push(change.filePath);
         }
@@ -298,8 +302,18 @@ function incrementalIndex(
     }
   }
 
-  // 1. Delete graph data for removed/modified files
-  for (const filePath of pathsToDelete) {
+  // 1a. For truly removed files: clean up ALL edges (outgoing + inbound) and symbols.
+  //     Inbound edges must be deleted BEFORE symbols so the subquery can resolve target IDs.
+  for (const filePath of pathsRemoved) {
+    store.deleteEdgesTargetingFile(filePath);
+    store.deleteEdgesByFile(filePath);
+    store.deleteSymbolsByFile(filePath);
+  }
+
+  // 1b. For modified files: clean outgoing edges and symbols (will be re-created).
+  //     Inbound edges from other files are preserved — their target IDs remain valid
+  //     when the symbol's deterministic hash doesn't change (common case).
+  for (const filePath of pathsToRefresh) {
     store.deleteEdgesByFile(filePath);
     store.deleteSymbolsByFile(filePath);
   }

--- a/apps/context/test/helpers/git-fixtures.ts
+++ b/apps/context/test/helpers/git-fixtures.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared git test helpers for creating temporary repos and committing files.
+ *
+ * Used by both incremental.test.ts and integration-e2e.test.ts.
+ */
+
+import { mkdtempSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+
+/** Create a temporary git repo with initial commit and return its path. */
+export function createTempGitRepo(prefix = "kata-test-"): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync("git config user.email 'test@test.com'", {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  execSync("git config user.name 'Test'", { cwd: dir, stdio: "pipe" });
+
+  // Initial empty commit so we have a HEAD
+  execSync("git commit --allow-empty -m 'init'", {
+    cwd: dir,
+    stdio: "pipe",
+  });
+
+  return dir;
+}
+
+/** Write a file, git add, and commit. */
+export function commitFile(
+  repoDir: string,
+  relPath: string,
+  content: string,
+  message: string,
+): void {
+  const fullPath = join(repoDir, relPath);
+  const dir = dirname(fullPath);
+  if (dir !== repoDir) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(fullPath, content, "utf-8");
+  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
+}
+
+/** Delete a file, git add, and commit. */
+export function deleteAndCommit(
+  repoDir: string,
+  relPath: string,
+  message: string,
+): void {
+  const fullPath = join(repoDir, relPath);
+  unlinkSync(fullPath);
+  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
+}
+
+/** Rename a file, git add, and commit. */
+export function renameAndCommit(
+  repoDir: string,
+  oldPath: string,
+  newPath: string,
+  message: string,
+): void {
+  execSync(`git mv "${oldPath}" "${newPath}"`, {
+    cwd: repoDir,
+    stdio: "pipe",
+  });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
+}
+
+/** Get HEAD SHA of a repo. */
+export function headSha(repoDir: string): string {
+  return execSync("git rev-parse HEAD", {
+    cwd: repoDir,
+    encoding: "utf-8",
+  }).trim();
+}

--- a/apps/context/test/incremental.test.ts
+++ b/apps/context/test/incremental.test.ts
@@ -4,8 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, unlinkSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -16,57 +15,13 @@ import {
   type IndexResult,
 } from "../src/indexer.js";
 import { GraphStore } from "../src/graph/store.js";
-
-// ── Helpers ──
-
-/** Create a temporary git repo with initial commit and return its path. */
-function createTempGitRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), "kata-inc-test-"));
-  execSync("git init", { cwd: dir, stdio: "pipe" });
-  execSync("git config user.email 'test@test.com'", { cwd: dir, stdio: "pipe" });
-  execSync("git config user.name 'Test'", { cwd: dir, stdio: "pipe" });
-
-  // Initial empty commit so we have a HEAD
-  execSync("git commit --allow-empty -m 'init'", { cwd: dir, stdio: "pipe" });
-
-  return dir;
-}
-
-/** Write a file, git add, and commit. */
-function commitFile(repoDir: string, relPath: string, content: string, message: string): void {
-  const fullPath = join(repoDir, relPath);
-  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
-  if (dir !== repoDir) {
-    mkdirSync(dir, { recursive: true });
-  }
-  writeFileSync(fullPath, content, "utf-8");
-  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
-  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
-}
-
-/** Delete a file, git add, and commit. */
-function deleteAndCommit(repoDir: string, relPath: string, message: string): void {
-  const fullPath = join(repoDir, relPath);
-  unlinkSync(fullPath);
-  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
-  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
-}
-
-/** Rename a file, git add, and commit. */
-function renameAndCommit(
-  repoDir: string,
-  oldPath: string,
-  newPath: string,
-  message: string,
-): void {
-  execSync(`git mv "${oldPath}" "${newPath}"`, { cwd: repoDir, stdio: "pipe" });
-  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
-}
-
-/** Get HEAD SHA of a repo. */
-function headSha(repoDir: string): string {
-  return execSync("git rev-parse HEAD", { cwd: repoDir, encoding: "utf-8" }).trim();
-}
+import {
+  createTempGitRepo,
+  commitFile,
+  deleteAndCommit,
+  renameAndCommit,
+  headSha,
+} from "./helpers/git-fixtures.js";
 
 // ── Sample TypeScript source files ──
 
@@ -370,7 +325,6 @@ describe("indexProject — incremental change handling", () => {
     try {
       indexProject(repoDir, { store });
 
-      const statsBefore = store.getStats();
       const symbolsBefore = store.getSymbolsByFile("utils.ts");
       const hasMultiply = symbolsBefore.some((s) => s.name === "multiply");
       expect(hasMultiply).toBe(false);
@@ -399,8 +353,6 @@ describe("indexProject — incremental change handling", () => {
     const store = new GraphStore(":memory:");
     try {
       indexProject(repoDir, { store });
-
-      const statsBefore = store.getStats();
 
       // Add a Python file
       commitFile(repoDir, "helper.py", PY_HELPER, "add helper");

--- a/apps/context/test/incremental.test.ts
+++ b/apps/context/test/incremental.test.ts
@@ -1,0 +1,662 @@
+/**
+ * Tests for incremental indexing: git diff integration, path selection,
+ * delete-then-insert, SHA behavior, and edge cases.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, unlinkSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  indexProject,
+  getCurrentSha,
+  getChangedFiles,
+  type FileChange,
+  type IndexResult,
+} from "../src/indexer.js";
+import { GraphStore } from "../src/graph/store.js";
+
+// ── Helpers ──
+
+/** Create a temporary git repo with initial commit and return its path. */
+function createTempGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kata-inc-test-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync("git config user.email 'test@test.com'", { cwd: dir, stdio: "pipe" });
+  execSync("git config user.name 'Test'", { cwd: dir, stdio: "pipe" });
+
+  // Initial empty commit so we have a HEAD
+  execSync("git commit --allow-empty -m 'init'", { cwd: dir, stdio: "pipe" });
+
+  return dir;
+}
+
+/** Write a file, git add, and commit. */
+function commitFile(repoDir: string, relPath: string, content: string, message: string): void {
+  const fullPath = join(repoDir, relPath);
+  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+  if (dir !== repoDir) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(fullPath, content, "utf-8");
+  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
+}
+
+/** Delete a file, git add, and commit. */
+function deleteAndCommit(repoDir: string, relPath: string, message: string): void {
+  const fullPath = join(repoDir, relPath);
+  unlinkSync(fullPath);
+  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
+}
+
+/** Rename a file, git add, and commit. */
+function renameAndCommit(
+  repoDir: string,
+  oldPath: string,
+  newPath: string,
+  message: string,
+): void {
+  execSync(`git mv "${oldPath}" "${newPath}"`, { cwd: repoDir, stdio: "pipe" });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
+}
+
+/** Get HEAD SHA of a repo. */
+function headSha(repoDir: string): string {
+  return execSync("git rev-parse HEAD", { cwd: repoDir, encoding: "utf-8" }).trim();
+}
+
+// ── Sample TypeScript source files ──
+
+const TS_UTILS = `
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+export function subtract(a: number, b: number): number {
+  return a - b;
+}
+`;
+
+const TS_UTILS_V2 = `
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+export function subtract(a: number, b: number): number {
+  return a - b;
+}
+
+export function multiply(a: number, b: number): number {
+  return a * b;
+}
+`;
+
+const TS_SERVICE = `
+import { add } from './utils';
+
+export class Calculator {
+  compute(a: number, b: number): number {
+    return add(a, b);
+  }
+}
+`;
+
+const PY_HELPER = `
+def greet(name: str) -> str:
+    """Greet someone by name."""
+    return f"Hello, {name}!"
+
+class Greeter:
+    def __init__(self, prefix: str):
+        self.prefix = prefix
+
+    def greet(self, name: str) -> str:
+        return f"{self.prefix} {name}!"
+`;
+
+// ── Tests: getCurrentSha ──
+
+describe("getCurrentSha", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("returns the current HEAD SHA for a git repo", () => {
+    const sha = getCurrentSha(repoDir);
+    expect(sha).toBeTruthy();
+    expect(sha!.length).toBe(40); // full SHA
+    expect(/^[0-9a-f]{40}$/.test(sha!)).toBe(true);
+  });
+
+  it("returns null for a non-git directory", () => {
+    const nonGitDir = mkdtempSync(join(tmpdir(), "kata-nongit-"));
+    try {
+      const sha = getCurrentSha(nonGitDir);
+      expect(sha).toBeNull();
+    } finally {
+      rmSync(nonGitDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Tests: getChangedFiles ──
+
+describe("getChangedFiles", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("detects added files", () => {
+    const baseSha = headSha(repoDir);
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const changes = getChangedFiles(repoDir, baseSha);
+    expect(changes).not.toBeNull();
+    expect(changes!.length).toBe(1);
+    expect(changes![0]).toEqual({ status: "added", filePath: "utils.ts" });
+  });
+
+  it("detects modified files", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+    const baseSha = headSha(repoDir);
+    commitFile(repoDir, "utils.ts", TS_UTILS_V2, "modify utils");
+
+    const changes = getChangedFiles(repoDir, baseSha);
+    expect(changes).not.toBeNull();
+    expect(changes!.length).toBe(1);
+    expect(changes![0]).toEqual({ status: "modified", filePath: "utils.ts" });
+  });
+
+  it("detects deleted files", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+    const baseSha = headSha(repoDir);
+    deleteAndCommit(repoDir, "utils.ts", "delete utils");
+
+    const changes = getChangedFiles(repoDir, baseSha);
+    expect(changes).not.toBeNull();
+    expect(changes!.length).toBe(1);
+    expect(changes![0]).toEqual({ status: "deleted", filePath: "utils.ts" });
+  });
+
+  it("detects renamed files", () => {
+    commitFile(repoDir, "old-name.ts", TS_UTILS, "add old-name");
+    const baseSha = headSha(repoDir);
+    renameAndCommit(repoDir, "old-name.ts", "new-name.ts", "rename");
+
+    const changes = getChangedFiles(repoDir, baseSha);
+    expect(changes).not.toBeNull();
+    expect(changes!.length).toBe(1);
+    expect(changes![0].status).toBe("renamed");
+    expect(changes![0].filePath).toBe("new-name.ts");
+    expect(changes![0].oldPath).toBe("old-name.ts");
+  });
+
+  it("detects multiple changes", () => {
+    commitFile(repoDir, "a.ts", TS_UTILS, "add a");
+    commitFile(repoDir, "b.ts", TS_SERVICE, "add b");
+    const baseSha = headSha(repoDir);
+
+    commitFile(repoDir, "a.ts", TS_UTILS_V2, "modify a");
+    commitFile(repoDir, "c.py", PY_HELPER, "add c");
+    deleteAndCommit(repoDir, "b.ts", "delete b");
+
+    const changes = getChangedFiles(repoDir, baseSha);
+    expect(changes).not.toBeNull();
+    expect(changes!.length).toBe(3);
+
+    const statuses = new Set(changes!.map((c) => `${c.status}:${c.filePath}`));
+    expect(statuses.has("modified:a.ts")).toBe(true);
+    expect(statuses.has("added:c.py")).toBe(true);
+    expect(statuses.has("deleted:b.ts")).toBe(true);
+  });
+
+  it("returns empty array when no changes", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+    const sha = headSha(repoDir);
+
+    const changes = getChangedFiles(repoDir, sha);
+    expect(changes).not.toBeNull();
+    expect(changes!.length).toBe(0);
+  });
+
+  it("returns null for invalid SHA", () => {
+    const changes = getChangedFiles(repoDir, "0000000000000000000000000000000000000000");
+    expect(changes).toBeNull();
+  });
+});
+
+// ── Tests: indexProject incremental path selection ──
+
+describe("indexProject — path selection", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("first index is always full and stores SHA", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      const result = indexProject(repoDir, { store });
+
+      expect(result.incremental).toBe(false);
+      expect(result.filesIndexed).toBe(1);
+      expect(result.symbolsExtracted).toBeGreaterThan(0);
+
+      // SHA should be stored
+      const storedSha = store.getLastIndexedSha();
+      expect(storedSha).toBeTruthy();
+      expect(storedSha).toBe(headSha(repoDir));
+    } finally {
+      store.close();
+    }
+  });
+
+  it("second index with changes uses incremental path", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      // First: full index
+      const result1 = indexProject(repoDir, { store });
+      expect(result1.incremental).toBe(false);
+
+      // Add a new file
+      commitFile(repoDir, "service.ts", TS_SERVICE, "add service");
+
+      // Second: incremental
+      const result2 = indexProject(repoDir, { store });
+      expect(result2.incremental).toBe(true);
+      expect(result2.changedFiles).toBe(1);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("second index with no changes returns immediately", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      // No changes
+      const result2 = indexProject(repoDir, { store });
+      expect(result2.incremental).toBe(true);
+      expect(result2.changedFiles).toBe(0);
+      expect(result2.filesIndexed).toBe(0);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("full option forces full index even with existing SHA", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      // First: full index
+      indexProject(repoDir, { store });
+
+      // Second: force full
+      const result2 = indexProject(repoDir, { store, full: true });
+      expect(result2.incremental).toBe(false);
+      expect(result2.filesIndexed).toBe(1);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("non-git directory always does full index", () => {
+    const nonGitDir = mkdtempSync(join(tmpdir(), "kata-nongit-"));
+    try {
+      writeFileSync(join(nonGitDir, "utils.ts"), TS_UTILS, "utf-8");
+
+      const store = new GraphStore(":memory:");
+      try {
+        const result = indexProject(nonGitDir, { store });
+        expect(result.incremental).toBe(false);
+        expect(result.filesIndexed).toBe(1);
+
+        // SHA should NOT be stored (no git)
+        expect(store.getLastIndexedSha()).toBeNull();
+      } finally {
+        store.close();
+      }
+    } finally {
+      rmSync(nonGitDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Tests: incremental change handling ──
+
+describe("indexProject — incremental change handling", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("modified file: old symbols replaced, new symbols present", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      const statsBefore = store.getStats();
+      const symbolsBefore = store.getSymbolsByFile("utils.ts");
+      const hasMultiply = symbolsBefore.some((s) => s.name === "multiply");
+      expect(hasMultiply).toBe(false);
+
+      // Modify: add multiply function
+      commitFile(repoDir, "utils.ts", TS_UTILS_V2, "add multiply");
+
+      const result = indexProject(repoDir, { store });
+      expect(result.incremental).toBe(true);
+
+      const symbolsAfter = store.getSymbolsByFile("utils.ts");
+      const hasMultiplyAfter = symbolsAfter.some((s) => s.name === "multiply");
+      expect(hasMultiplyAfter).toBe(true);
+
+      // add and subtract should still be there
+      expect(symbolsAfter.some((s) => s.name === "add")).toBe(true);
+      expect(symbolsAfter.some((s) => s.name === "subtract")).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("added file: new symbols appear in graph", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      const statsBefore = store.getStats();
+
+      // Add a Python file
+      commitFile(repoDir, "helper.py", PY_HELPER, "add helper");
+
+      const result = indexProject(repoDir, { store });
+      expect(result.incremental).toBe(true);
+      expect(result.changedFiles).toBe(1);
+
+      const pySymbols = store.getSymbolsByFile("helper.py");
+      expect(pySymbols.length).toBeGreaterThan(0);
+      expect(pySymbols.some((s) => s.name === "greet")).toBe(true);
+
+      // Original TS symbols still present
+      const tsSymbols = store.getSymbolsByFile("utils.ts");
+      expect(tsSymbols.some((s) => s.name === "add")).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("deleted file: symbols and edges removed from graph", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+    commitFile(repoDir, "service.ts", TS_SERVICE, "add service");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      // Verify service.ts symbols exist
+      const serviceSymbols = store.getSymbolsByFile("service.ts");
+      expect(serviceSymbols.length).toBeGreaterThan(0);
+
+      // Delete service.ts
+      deleteAndCommit(repoDir, "service.ts", "delete service");
+
+      const result = indexProject(repoDir, { store });
+      expect(result.incremental).toBe(true);
+      expect(result.deletedFiles).toBe(1);
+
+      // Service symbols gone
+      const serviceSymbolsAfter = store.getSymbolsByFile("service.ts");
+      expect(serviceSymbolsAfter.length).toBe(0);
+
+      // Utils symbols still present
+      const utilsSymbols = store.getSymbolsByFile("utils.ts");
+      expect(utilsSymbols.some((s) => s.name === "add")).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("renamed file: old path gone, new path has symbols", () => {
+    commitFile(repoDir, "old-utils.ts", TS_UTILS, "add old-utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      const oldSymbols = store.getSymbolsByFile("old-utils.ts");
+      expect(oldSymbols.length).toBeGreaterThan(0);
+
+      // Rename
+      renameAndCommit(repoDir, "old-utils.ts", "new-utils.ts", "rename");
+
+      const result = indexProject(repoDir, { store });
+      expect(result.incremental).toBe(true);
+
+      // Old path should be empty
+      const oldSymbolsAfter = store.getSymbolsByFile("old-utils.ts");
+      expect(oldSymbolsAfter.length).toBe(0);
+
+      // New path should have symbols
+      const newSymbols = store.getSymbolsByFile("new-utils.ts");
+      expect(newSymbols.length).toBeGreaterThan(0);
+      expect(newSymbols.some((s) => s.name === "add")).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ── Tests: SHA persistence ──
+
+describe("indexProject — SHA persistence", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("full index stores SHA", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      expect(store.getLastIndexedSha()).toBeNull();
+
+      indexProject(repoDir, { store });
+
+      const storedSha = store.getLastIndexedSha();
+      expect(storedSha).toBe(headSha(repoDir));
+    } finally {
+      store.close();
+    }
+  });
+
+  it("incremental index updates SHA to current HEAD", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+      const sha1 = store.getLastIndexedSha();
+
+      commitFile(repoDir, "service.ts", TS_SERVICE, "add service");
+      const expectedSha2 = headSha(repoDir);
+
+      indexProject(repoDir, { store });
+      const sha2 = store.getLastIndexedSha();
+
+      expect(sha2).toBe(expectedSha2);
+      expect(sha2).not.toBe(sha1);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("force-full index updates SHA", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+      const sha1 = store.getLastIndexedSha();
+
+      commitFile(repoDir, "service.ts", TS_SERVICE, "add service");
+
+      indexProject(repoDir, { store, full: true });
+      const sha2 = store.getLastIndexedSha();
+
+      expect(sha2).toBe(headSha(repoDir));
+      expect(sha2).not.toBe(sha1);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("no-change incremental run still advances SHA if HEAD moved", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      // Non-code commit (e.g. README change)
+      commitFile(repoDir, "README.md", "# Hello", "docs update");
+      const newHead = headSha(repoDir);
+
+      const result = indexProject(repoDir, { store });
+      expect(result.incremental).toBe(true);
+      expect(result.changedFiles).toBe(1); // README.md appears as added
+      expect(store.getLastIndexedSha()).toBe(newHead);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ── Tests: unsupported file filtering ──
+
+describe("indexProject — unsupported file filtering", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("incremental mode skips unsupported added files", () => {
+    commitFile(repoDir, "utils.ts", TS_UTILS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      // Add a markdown file — should not be parsed
+      commitFile(repoDir, "docs.md", "# Documentation", "add docs");
+
+      const result = indexProject(repoDir, { store });
+      expect(result.incremental).toBe(true);
+      // changedFiles counts all git changes, but filesIndexed counts only parsed files
+      expect(result.changedFiles).toBe(1);
+      expect(result.filesIndexed).toBe(0); // .md is not supported
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ── Tests: edge cases ──
+
+describe("indexProject — incremental edge cases", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("handles multiple file changes in one incremental pass", () => {
+    commitFile(repoDir, "a.ts", TS_UTILS, "add a");
+    commitFile(repoDir, "b.ts", TS_SERVICE, "add b");
+    commitFile(repoDir, "c.py", PY_HELPER, "add c");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      const statsBefore = store.getStats();
+      expect(statsBefore.symbols).toBeGreaterThan(0);
+
+      // Modify a, delete b, add d
+      commitFile(repoDir, "a.ts", TS_UTILS_V2, "modify a");
+      deleteAndCommit(repoDir, "b.ts", "delete b");
+      commitFile(repoDir, "d.ts", 'export function double(n: number): number { return n * 2; }', "add d");
+
+      const result = indexProject(repoDir, { store });
+      expect(result.incremental).toBe(true);
+      expect(result.changedFiles).toBe(3);
+
+      // b.ts symbols gone
+      expect(store.getSymbolsByFile("b.ts").length).toBe(0);
+
+      // a.ts has multiply now
+      const aSymbols = store.getSymbolsByFile("a.ts");
+      expect(aSymbols.some((s) => s.name === "multiply")).toBe(true);
+
+      // d.ts exists
+      const dSymbols = store.getSymbolsByFile("d.ts");
+      expect(dSymbols.length).toBeGreaterThan(0);
+
+      // c.py untouched
+      const cSymbols = store.getSymbolsByFile("c.py");
+      expect(cSymbols.length).toBeGreaterThan(0);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/apps/context/test/integration-e2e.test.ts
+++ b/apps/context/test/integration-e2e.test.ts
@@ -1,0 +1,748 @@
+/**
+ * End-to-end integration tests for S05: Incremental Indexing.
+ *
+ * Creates real temporary git repos, runs full and incremental indexing,
+ * and validates:
+ *   1. CLI --full flag forces full re-index
+ *   2. Incremental graph correctness equals full re-index on same state
+ *   3. Add/modify/delete/rename handling is correct end-to-end
+ *   4. Single-file incremental performance < 2s
+ *   5. SHA persistence across both paths
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  unlinkSync,
+} from "node:fs";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { indexProject, type IndexResult } from "../src/indexer.js";
+import { GraphStore } from "../src/graph/store.js";
+
+// ── Git helpers ──
+
+function createTempGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kata-e2e-int-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync("git config user.email 'test@test.com'", {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  execSync("git config user.name 'Test'", { cwd: dir, stdio: "pipe" });
+  execSync("git commit --allow-empty -m 'init'", {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  return dir;
+}
+
+function commitFile(
+  repoDir: string,
+  relPath: string,
+  content: string,
+  message: string,
+): void {
+  const fullPath = join(repoDir, relPath);
+  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+  if (dir !== repoDir) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(fullPath, content, "utf-8");
+  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
+}
+
+function deleteAndCommit(
+  repoDir: string,
+  relPath: string,
+  message: string,
+): void {
+  unlinkSync(join(repoDir, relPath));
+  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
+}
+
+function renameAndCommit(
+  repoDir: string,
+  oldPath: string,
+  newPath: string,
+  message: string,
+): void {
+  execSync(`git mv "${oldPath}" "${newPath}"`, {
+    cwd: repoDir,
+    stdio: "pipe",
+  });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
+}
+
+function headSha(repoDir: string): string {
+  return execSync("git rev-parse HEAD", {
+    cwd: repoDir,
+    encoding: "utf-8",
+  }).trim();
+}
+
+// ── Snapshot helpers ──
+
+/** Extract a sorted set of all symbol names from a GraphStore. */
+function allSymbolNames(store: GraphStore): string[] {
+  const stats = store.getStats();
+  // Use the FTS search with a wildcard to get all — or use raw SQL via the store
+  // We'll use the store's internal db if possible, but safer to rely on existing APIs
+  // symbolsInFile won't help (we need all files). Use findSymbols or direct query.
+  // GraphStore exposes db as a property — let's do a direct query.
+  const rows = (store as any).db
+    .prepare("SELECT name, kind, file_path, line_start FROM symbols ORDER BY name, file_path")
+    .all() as Array<{ name: string; kind: string; file_path: string; line_start: number }>;
+  return rows.map(
+    (r) => `${r.name}:${r.kind}:${r.file_path}:${r.line_start}`,
+  );
+}
+
+/** Extract a sorted set of all edges from a GraphStore. */
+function allEdges(store: GraphStore): string[] {
+  const rows = (store as any).db
+    .prepare(
+      `SELECT s.name as source_name, s.file_path as source_file,
+              t.name as target_name, t.file_path as target_file,
+              e.kind
+       FROM edges e
+       JOIN symbols s ON e.source_id = s.id
+       JOIN symbols t ON e.target_id = t.id
+       ORDER BY source_name, target_name, e.kind`,
+    )
+    .all() as Array<{
+    source_name: string;
+    source_file: string;
+    target_name: string;
+    target_file: string;
+    kind: string;
+  }>;
+  return rows.map(
+    (r) =>
+      `${r.source_name}(${r.source_file})-[${r.kind}]->${r.target_name}(${r.target_file})`,
+  );
+}
+
+// ── Fixture content ──
+
+const UTILS_TS = `
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+export function subtract(a: number, b: number): number {
+  return a - b;
+}
+`;
+
+const UTILS_V2_TS = `
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+export function subtract(a: number, b: number): number {
+  return a - b;
+}
+
+export function multiply(a: number, b: number): number {
+  return a * b;
+}
+`;
+
+const SERVICE_TS = `
+import { add } from './utils';
+
+export class Calculator {
+  compute(a: number, b: number): number {
+    return add(a, b);
+  }
+}
+`;
+
+const HELPER_PY = `
+def greet(name: str) -> str:
+    """Greet someone by name."""
+    return f"Hello, {name}!"
+
+class Greeter:
+    def __init__(self, prefix: str):
+        self.prefix = prefix
+
+    def greet(self, name: str) -> str:
+        return f"{self.prefix} {name}!"
+`;
+
+const EXTRA_TS = `
+export interface Config {
+  debug: boolean;
+  port: number;
+}
+
+export function createConfig(debug: boolean): Config {
+  return { debug, port: 3000 };
+}
+`;
+
+// ── Tests ──
+
+describe("E2E Integration: --full flag", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("--full forces full index even when previous SHA exists", () => {
+    // Setup: create a file, do initial full index
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      const first = indexProject(repoDir, { store });
+      expect(first.incremental).toBe(false);
+      expect(first.filesIndexed).toBeGreaterThan(0);
+
+      // SHA is now stored — without --full, next index would be incremental
+      // Modify a file and commit
+      commitFile(repoDir, "utils.ts", UTILS_V2_TS, "update utils");
+
+      // Without full: should be incremental
+      const incResult = indexProject(repoDir, { store });
+      expect(incResult.incremental).toBe(true);
+
+      // Now force full: should be full despite having stored SHA
+      commitFile(repoDir, "utils.ts", UTILS_TS, "revert utils");
+      const fullResult = indexProject(repoDir, { store, full: true });
+      expect(fullResult.incremental).toBe(false);
+      expect(fullResult.filesIndexed).toBeGreaterThan(0);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("--full re-indexes all files, not just changed ones", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+    commitFile(repoDir, "service.ts", SERVICE_TS, "add service");
+
+    const store = new GraphStore(":memory:");
+    try {
+      // Initial full index
+      const first = indexProject(repoDir, { store });
+      expect(first.incremental).toBe(false);
+      expect(first.filesIndexed).toBe(2);
+
+      // Only modify one file
+      commitFile(repoDir, "utils.ts", UTILS_V2_TS, "update utils");
+
+      // Incremental would only process the changed file
+      // But with --full, both files should be re-indexed
+      const fullResult = indexProject(repoDir, { store, full: true });
+      expect(fullResult.incremental).toBe(false);
+      expect(fullResult.filesIndexed).toBe(2); // both files, not just changed one
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("E2E Integration: incremental graph correctness", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("incremental result graph equals full re-index graph after modify", () => {
+    // Build up a repo with multiple files
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+    commitFile(repoDir, "service.ts", SERVICE_TS, "add service");
+
+    // --- Incremental path ---
+    const incStore = new GraphStore(":memory:");
+    try {
+      // Full baseline
+      indexProject(repoDir, { store: incStore });
+
+      // Modify one file
+      commitFile(repoDir, "utils.ts", UTILS_V2_TS, "update utils");
+
+      // Incremental update
+      const incResult = indexProject(repoDir, { store: incStore });
+      expect(incResult.incremental).toBe(true);
+
+      const incSymbols = allSymbolNames(incStore);
+      const incEdges = allEdges(incStore);
+
+      // --- Full re-index path (from scratch on the same final state) ---
+      const fullStore = new GraphStore(":memory:");
+      try {
+        const fullResult = indexProject(repoDir, {
+          store: fullStore,
+          full: true,
+        });
+        expect(fullResult.incremental).toBe(false);
+
+        const fullSymbols = allSymbolNames(fullStore);
+        const fullEdges = allEdges(fullStore);
+
+        // Compare symbol sets
+        expect(incSymbols).toEqual(fullSymbols);
+        // Compare edge sets
+        expect(incEdges).toEqual(fullEdges);
+      } finally {
+        fullStore.close();
+      }
+    } finally {
+      incStore.close();
+    }
+  });
+
+  it("incremental result graph equals full re-index after add", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+
+    const incStore = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store: incStore });
+
+      // Add a new file
+      commitFile(repoDir, "extra.ts", EXTRA_TS, "add extra");
+
+      const incResult = indexProject(repoDir, { store: incStore });
+      expect(incResult.incremental).toBe(true);
+
+      const incSymbols = allSymbolNames(incStore);
+      const incEdges = allEdges(incStore);
+
+      const fullStore = new GraphStore(":memory:");
+      try {
+        indexProject(repoDir, { store: fullStore, full: true });
+        const fullSymbols = allSymbolNames(fullStore);
+        const fullEdges = allEdges(fullStore);
+
+        expect(incSymbols).toEqual(fullSymbols);
+        expect(incEdges).toEqual(fullEdges);
+      } finally {
+        fullStore.close();
+      }
+    } finally {
+      incStore.close();
+    }
+  });
+
+  it("incremental result graph equals full re-index after delete", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+    commitFile(repoDir, "extra.ts", EXTRA_TS, "add extra");
+
+    const incStore = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store: incStore });
+
+      // Delete one file
+      deleteAndCommit(repoDir, "extra.ts", "delete extra");
+
+      const incResult = indexProject(repoDir, { store: incStore });
+      expect(incResult.incremental).toBe(true);
+
+      const incSymbols = allSymbolNames(incStore);
+      const incEdges = allEdges(incStore);
+
+      const fullStore = new GraphStore(":memory:");
+      try {
+        indexProject(repoDir, { store: fullStore, full: true });
+        const fullSymbols = allSymbolNames(fullStore);
+        const fullEdges = allEdges(fullStore);
+
+        expect(incSymbols).toEqual(fullSymbols);
+        expect(incEdges).toEqual(fullEdges);
+      } finally {
+        fullStore.close();
+      }
+    } finally {
+      incStore.close();
+    }
+  });
+
+  it("incremental result graph equals full re-index after rename", () => {
+    commitFile(repoDir, "old-utils.ts", UTILS_TS, "add old-utils");
+    commitFile(repoDir, "service.ts", SERVICE_TS, "add service");
+
+    const incStore = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store: incStore });
+
+      // Rename
+      renameAndCommit(repoDir, "old-utils.ts", "utils.ts", "rename utils");
+
+      const incResult = indexProject(repoDir, { store: incStore });
+      expect(incResult.incremental).toBe(true);
+
+      const incSymbols = allSymbolNames(incStore);
+
+      // Verify old path symbols are gone
+      const oldPathSymbols = incSymbols.filter((s) =>
+        s.includes("old-utils.ts"),
+      );
+      expect(oldPathSymbols).toHaveLength(0);
+
+      // Verify new path symbols exist
+      const newPathSymbols = incSymbols.filter((s) => s.includes("utils.ts"));
+      expect(newPathSymbols.length).toBeGreaterThan(0);
+
+      const fullStore = new GraphStore(":memory:");
+      try {
+        indexProject(repoDir, { store: fullStore, full: true });
+        const fullSymbols = allSymbolNames(fullStore);
+
+        expect(incSymbols).toEqual(fullSymbols);
+      } finally {
+        fullStore.close();
+      }
+    } finally {
+      incStore.close();
+    }
+  });
+
+  it("incremental result graph equals full re-index after multi-change", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+    commitFile(repoDir, "service.ts", SERVICE_TS, "add service");
+    commitFile(repoDir, "extra.ts", EXTRA_TS, "add extra");
+
+    const incStore = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store: incStore });
+
+      // Multiple changes: modify one, delete another, add a new one
+      commitFile(repoDir, "utils.ts", UTILS_V2_TS, "update utils");
+      deleteAndCommit(repoDir, "extra.ts", "delete extra");
+      commitFile(repoDir, "helper.py", HELPER_PY, "add helper");
+
+      const incResult = indexProject(repoDir, { store: incStore });
+      expect(incResult.incremental).toBe(true);
+
+      const incSymbols = allSymbolNames(incStore);
+      const incEdges = allEdges(incStore);
+
+      const fullStore = new GraphStore(":memory:");
+      try {
+        indexProject(repoDir, { store: fullStore, full: true });
+        const fullSymbols = allSymbolNames(fullStore);
+        const fullEdges = allEdges(fullStore);
+
+        expect(incSymbols).toEqual(fullSymbols);
+        expect(incEdges).toEqual(fullEdges);
+      } finally {
+        fullStore.close();
+      }
+    } finally {
+      incStore.close();
+    }
+  });
+});
+
+describe("E2E Integration: add/delete graph correctness", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("added file symbols appear in graph after incremental run", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      // Verify only utils symbols
+      const beforeSymbols = allSymbolNames(store);
+      expect(beforeSymbols.some((s) => s.startsWith("add:"))).toBe(true);
+      expect(beforeSymbols.some((s) => s.startsWith("Config:"))).toBe(false);
+
+      // Add a new file
+      commitFile(repoDir, "extra.ts", EXTRA_TS, "add extra");
+      const result = indexProject(repoDir, { store });
+      expect(result.incremental).toBe(true);
+
+      // Now Config and createConfig should be present
+      const afterSymbols = allSymbolNames(store);
+      expect(afterSymbols.some((s) => s.startsWith("Config:"))).toBe(true);
+      expect(
+        afterSymbols.some((s) => s.startsWith("createConfig:")),
+      ).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("deleted file symbols and edges are absent after incremental run", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+    commitFile(repoDir, "extra.ts", EXTRA_TS, "add extra");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      // Verify extra symbols exist
+      const beforeSymbols = allSymbolNames(store);
+      expect(beforeSymbols.some((s) => s.startsWith("Config:"))).toBe(true);
+
+      // Delete extra.ts
+      deleteAndCommit(repoDir, "extra.ts", "delete extra");
+      const result = indexProject(repoDir, { store });
+      expect(result.incremental).toBe(true);
+
+      // Config and createConfig should be gone
+      const afterSymbols = allSymbolNames(store);
+      expect(afterSymbols.some((s) => s.includes("extra.ts"))).toBe(false);
+      // utils symbols should still be there
+      expect(afterSymbols.some((s) => s.startsWith("add:"))).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("E2E Integration: SHA persistence", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("full index stores baseline SHA required for incremental", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      // No SHA before first index
+      expect(store.getLastIndexedSha()).toBeNull();
+
+      indexProject(repoDir, { store });
+
+      // SHA should be stored
+      const sha = store.getLastIndexedSha();
+      expect(sha).toBeTruthy();
+      expect(sha!.length).toBe(40);
+      expect(sha).toBe(headSha(repoDir));
+    } finally {
+      store.close();
+    }
+  });
+
+  it("incremental index updates SHA to current HEAD", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+      const firstSha = store.getLastIndexedSha();
+
+      commitFile(repoDir, "utils.ts", UTILS_V2_TS, "update utils");
+      indexProject(repoDir, { store });
+      const secondSha = store.getLastIndexedSha();
+
+      expect(secondSha).not.toBe(firstSha);
+      expect(secondSha).toBe(headSha(repoDir));
+    } finally {
+      store.close();
+    }
+  });
+
+  it("--full index also updates SHA", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+      const firstSha = store.getLastIndexedSha();
+
+      commitFile(repoDir, "utils.ts", UTILS_V2_TS, "update utils");
+      indexProject(repoDir, { store, full: true });
+      const secondSha = store.getLastIndexedSha();
+
+      expect(secondSha).not.toBe(firstSha);
+      expect(secondSha).toBe(headSha(repoDir));
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("E2E Integration: performance", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("single-file incremental completes within 2s", () => {
+    // Create a small project with multiple files for a realistic baseline
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+    commitFile(repoDir, "service.ts", SERVICE_TS, "add service");
+    commitFile(repoDir, "extra.ts", EXTRA_TS, "add extra");
+    commitFile(repoDir, "helper.py", HELPER_PY, "add helper");
+
+    const store = new GraphStore(":memory:");
+    try {
+      // Full baseline index
+      indexProject(repoDir, { store });
+
+      // Single file modification
+      commitFile(repoDir, "utils.ts", UTILS_V2_TS, "update utils");
+
+      // Measure incremental time
+      const start = performance.now();
+      const result = indexProject(repoDir, { store });
+      const elapsed = performance.now() - start;
+
+      expect(result.incremental).toBe(true);
+      expect(result.changedFiles).toBe(1);
+      expect(elapsed).toBeLessThan(2000); // < 2 seconds
+    } finally {
+      store.close();
+    }
+  });
+
+  it("no-change incremental is near-instant", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+    commitFile(repoDir, "service.ts", SERVICE_TS, "add service");
+
+    const store = new GraphStore(":memory:");
+    try {
+      indexProject(repoDir, { store });
+
+      // No changes — should return immediately
+      const start = performance.now();
+      const result = indexProject(repoDir, { store });
+      const elapsed = performance.now() - start;
+
+      expect(result.incremental).toBe(true);
+      expect(result.changedFiles).toBe(0);
+      expect(result.filesIndexed).toBe(0);
+      expect(elapsed).toBeLessThan(500); // Should be very fast
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("E2E Integration: CLI --full option wiring", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("indexProject full option propagates correctly", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+
+    const store = new GraphStore(":memory:");
+    try {
+      // First index (full, stores SHA)
+      const first = indexProject(repoDir, { store });
+      expect(first.incremental).toBe(false);
+      expect(store.getLastIndexedSha()).toBeTruthy();
+
+      // Default (no full option) — should be incremental since no changes
+      const second = indexProject(repoDir, { store });
+      expect(second.incremental).toBe(true);
+
+      // full: true — should force full even though SHA exists
+      const third = indexProject(repoDir, { store, full: true });
+      expect(third.incremental).toBe(false);
+
+      // full: false — should still be incremental
+      const fourth = indexProject(repoDir, { store, full: false });
+      expect(fourth.incremental).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("IndexResult metadata is correct for incremental runs", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+    commitFile(repoDir, "service.ts", SERVICE_TS, "add service");
+
+    const store = new GraphStore(":memory:");
+    try {
+      const first = indexProject(repoDir, { store });
+      expect(first.incremental).toBe(false);
+      expect(first.changedFiles).toBeUndefined();
+      expect(first.deletedFiles).toBeUndefined();
+
+      // Modify one file
+      commitFile(repoDir, "utils.ts", UTILS_V2_TS, "update utils");
+      const second = indexProject(repoDir, { store });
+      expect(second.incremental).toBe(true);
+      expect(second.changedFiles).toBe(1);
+      expect(second.deletedFiles).toBe(0);
+      expect(second.filesIndexed).toBe(1); // only the modified file
+    } finally {
+      store.close();
+    }
+  });
+
+  it("IndexResult metadata is correct for full runs", () => {
+    commitFile(repoDir, "utils.ts", UTILS_TS, "add utils");
+    commitFile(repoDir, "service.ts", SERVICE_TS, "add service");
+
+    const store = new GraphStore(":memory:");
+    try {
+      const result = indexProject(repoDir, { store, full: true });
+      expect(result.incremental).toBe(false);
+      expect(result.filesIndexed).toBe(2);
+      expect(result.symbolsExtracted).toBeGreaterThan(0);
+      expect(result.edgesCreated).toBeGreaterThanOrEqual(0);
+      expect(typeof result.duration).toBe("number");
+      expect(Array.isArray(result.errors)).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("E2E Integration: CLI Commander --full option", () => {
+  it("program has --full option on index command", async () => {
+    // Import the program and verify the option is registered
+    const { program } = await import("../src/cli.js");
+    const indexCmd = program.commands.find((c) => c.name() === "index");
+    expect(indexCmd).toBeDefined();
+
+    const options = indexCmd!.options;
+    const fullOpt = options.find(
+      (o) => o.long === "--full",
+    );
+    expect(fullOpt).toBeDefined();
+    expect(fullOpt!.description).toBeTruthy();
+  });
+});

--- a/apps/context/test/integration-e2e.test.ts
+++ b/apps/context/test/integration-e2e.test.ts
@@ -11,81 +11,16 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import {
-  mkdtempSync,
-  writeFileSync,
-  mkdirSync,
-  rmSync,
-  unlinkSync,
-} from "node:fs";
-import { execSync } from "node:child_process";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { rmSync } from "node:fs";
 import { indexProject, type IndexResult } from "../src/indexer.js";
 import { GraphStore } from "../src/graph/store.js";
-
-// ── Git helpers ──
-
-function createTempGitRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), "kata-e2e-int-"));
-  execSync("git init", { cwd: dir, stdio: "pipe" });
-  execSync("git config user.email 'test@test.com'", {
-    cwd: dir,
-    stdio: "pipe",
-  });
-  execSync("git config user.name 'Test'", { cwd: dir, stdio: "pipe" });
-  execSync("git commit --allow-empty -m 'init'", {
-    cwd: dir,
-    stdio: "pipe",
-  });
-  return dir;
-}
-
-function commitFile(
-  repoDir: string,
-  relPath: string,
-  content: string,
-  message: string,
-): void {
-  const fullPath = join(repoDir, relPath);
-  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
-  if (dir !== repoDir) {
-    mkdirSync(dir, { recursive: true });
-  }
-  writeFileSync(fullPath, content, "utf-8");
-  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
-  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
-}
-
-function deleteAndCommit(
-  repoDir: string,
-  relPath: string,
-  message: string,
-): void {
-  unlinkSync(join(repoDir, relPath));
-  execSync(`git add "${relPath}"`, { cwd: repoDir, stdio: "pipe" });
-  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
-}
-
-function renameAndCommit(
-  repoDir: string,
-  oldPath: string,
-  newPath: string,
-  message: string,
-): void {
-  execSync(`git mv "${oldPath}" "${newPath}"`, {
-    cwd: repoDir,
-    stdio: "pipe",
-  });
-  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: "pipe" });
-}
-
-function headSha(repoDir: string): string {
-  return execSync("git rev-parse HEAD", {
-    cwd: repoDir,
-    encoding: "utf-8",
-  }).trim();
-}
+import {
+  createTempGitRepo,
+  commitFile,
+  deleteAndCommit,
+  renameAndCommit,
+  headSha,
+} from "./helpers/git-fixtures.js";
 
 // ── Snapshot helpers ──
 


### PR DESCRIPTION
## What Changed
See slice plan: S05: (no slice plan found)

## Must-Haves
- See slice plan

## Linear Issues
- Closes KAT-453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--full` flag to the index command to force a complete re-index, bypassing incremental cache
  * Implemented incremental indexing for faster re-indexing when code changes are detected
  * Enhanced output to differentiate between incremental and full indexing modes
  * Added reporting of changed and deleted files when using incremental indexing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements incremental indexing for the `kata-context` CLI (KAT-453 / S05). After the first full index the tool now diffs the current HEAD against the stored baseline SHA using `git diff --name-status`, processes only added/modified/deleted/renamed files, and persists the new SHA — falling back to a full re-index whenever git metadata is unavailable. A `--full` CLI flag forces a complete re-index at any time. The feature is backed by two new test suites (662 + 748 lines) that cover unit-level git helpers, path selection logic, SHA persistence, and end-to-end graph correctness by comparing incremental vs. full re-index results.

Key findings from the review:

- **Shell injection via string interpolation** (`indexer.ts`): `baseSha` is interpolated directly into the `execSync` shell command string. In practice the SHA is always a 40-hex string, but the pattern is unsafe by design — `spawnSync` with an argument array should be used instead.
- **`deletedFiles` count underreports on renames** (`indexer.ts`): The `deletedCount` only tallies `status === "deleted"` changes. Renamed files' old-path records are also pruned from the graph but are not reflected in the counter, so the CLI can show "Deleted files: 0" after renaming files.
- **Unused `statsBefore` variables** (`incremental.test.ts`): Two tests declare this variable but never read it, causing linter warnings.
- **`(store as any).db` bypasses type safety** (`integration-e2e.test.ts`): Direct raw-SQL access via the private `db` field will break silently if `GraphStore` internals change.
- **Duplicated test helpers**: `createTempGitRepo`, `commitFile`, `deleteAndCommit`, `renameAndCommit`, and `headSha` are copy-pasted between `incremental.test.ts` and `integration-e2e.test.ts` and should be extracted to a shared fixture file.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the shell injection pattern and the `deletedFiles` count inaccuracy.
- The feature is well-designed and comprehensively tested (1,400+ lines of new tests covering unit, integration, and E2E scenarios). The fall-back-to-full-index safety net is correctly implemented. However, the shell command string interpolation of `baseSha` is a security smell that should be fixed before merging (even though the practical risk is low today), and the `deletedFiles` count misreports graph cleanup on renames — a user-visible accuracy bug in the CLI output.
- apps/context/src/indexer.ts — shell injection pattern in `getChangedFiles` and `deletedFiles` counting logic in `incrementalIndex`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/context/src/indexer.ts | Core change: adds incremental indexing via `getCurrentSha`, `getChangedFiles`, `fullIndex`, and `incrementalIndex` helpers. Key concerns: `baseSha` is string-interpolated into a shell command (should use `spawnSync` with arg array), and the `deletedFiles` count omits renamed files' old-path removals. |
| apps/context/src/cli.ts | Adds `--full` flag to the `index` command and surfaces `incremental`, `changedFiles`, and `deletedFiles` in both JSON and human-readable output. Clean, straightforward changes with correct TypeScript typing. |
| apps/context/test/incremental.test.ts | New 662-line unit test suite covering getCurrentSha, getChangedFiles, path selection, incremental change handling, SHA persistence, and edge cases. Well structured; minor issues: unused `statsBefore` variables in two tests, and helper functions are duplicated from `integration-e2e.test.ts`. |
| apps/context/test/integration-e2e.test.ts | New 748-line E2E integration test suite that validates full vs incremental graph correctness, SHA persistence, performance budgets, and CLI `--full` flag. Good coverage; `(store as any).db` raw SQL access bypasses type safety, and git helper functions are duplicated from `incremental.test.ts`. |
| apps/context/skill/SKILL.md | Documentation updated to describe incremental indexing and the new `--full` flag with usage examples. No issues. |
| apps/context/AGENTS.md | New agent guidance file covering hook bypass rules and git worktree/standby branch conventions. Documentation only, no code changes. |
| .gitignore | Adds standard build artifact patterns (`.idea/`, `node_modules/`, `dist/`, `coverage/`, `.cache/`) under a "Kata baseline" section. Routine housekeeping. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([indexProject called]) --> B{full flag set?}
    B -- yes --> F[fullIndex path]
    B -- no --> C{lastSha in store?}
    C -- no --> F
    C -- yes --> D[getCurrentSha]
    D --> E{currentSha available?}
    E -- no --> F
    E -- yes --> G[getChangedFiles: git diff lastSha HEAD]
    G --> H{git diff succeeded?}
    H -- null / error --> F
    H -- ok --> I{changes.length == 0?}
    I -- yes --> J[Return early: 0 files indexed\nUpdate SHA to currentSha]
    I -- no --> K[incrementalIndex]
    K --> K1[Partition: pathsToDelete / pathsToParse]
    K1 --> K2[deleteEdgesByFile + deleteSymbolsByFile\nfor deleted & modified & renamed old-path]
    K2 --> K3[parseFiles on changed/added files]
    K3 --> K4[extractRelationships for changed files]
    K4 --> K5[upsertSymbols + upsertEdges]
    K5 --> L[setLastIndexedSha to currentSha]
    F --> F1[discoverFiles all]
    F1 --> F2[parseFiles all]
    F2 --> F3[extractRelationships all]
    F3 --> F4[delete-then-upsert symbols + edges]
    F4 --> L
    L --> M([Return IndexResult])
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/context/src/indexer.ts
Line: 103-111

Comment:
**Shell injection risk via string interpolation**

`baseSha` is interpolated directly into a shell command string passed to `execSync`. Although in practice `baseSha` is always a 40-character hex string (set by `getCurrentSha` → `git rev-parse HEAD`), building commands via string interpolation is unsafe by design. If the stored SHA were ever corrupted or tampered with, shell metacharacters could be injected.

Use `spawnSync` with an argument array to avoid the shell entirely:

```
import { spawnSync } from "node:child_process";

const result = spawnSync(
  "git",
  ["diff", "--name-status", `--diff-filter=ACDMR`, baseSha, "HEAD"],
  { cwd: rootPath, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
);
if (result.status !== 0 || result.error) return null;
const output = (result.stdout as string).trim();
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/indexer.ts
Line: 296

Comment:
**`deletedFiles` count omits renames' old paths**

Only changes with `status === "deleted"` are counted, but for a renamed file the old path's data is also deleted from the graph (via `pathsToDelete.push(change.oldPath)`). The CLI then displays "Deleted files: 0" after a rename, even though old-path records were pruned from the graph — which is confusing.

Consider counting all paths removed from the store:

```suggestion
  const deletedOnly =
    changes.filter((c) => c.status === "deleted").length +
    changes.filter((c) => c.status === "renamed" && !!c.oldPath).length;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/test/incremental.test.ts
Line: 373-374

Comment:
**Unused `statsBefore` variables**

`statsBefore` is assigned but never read in two tests, which will trigger a TypeScript/linter warning. The same issue occurs at line 403 (the "added file" test).

```suggestion
      const symbolsBefore = store.getSymbolsByFile("utils.ts");
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/test/integration-e2e.test.ts
Line: 100-106

Comment:
**`(store as any).db` bypasses TypeScript type safety**

Both `allSymbolNames` and `allEdges` reach into `GraphStore`'s private `db` field via `(store as any).db`. This compiles today, but will break silently if `GraphStore`'s internals change and TypeScript won't catch it.

Consider exposing narrow query methods on `GraphStore` (e.g., `getAllSymbols()` and `getAllEdges()`) so the tests can rely on the public API, or at minimum add a comment explaining this is intentional test-only introspection.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/test/incremental.test.ts
Line: 1-10

Comment:
**Duplicated test helpers across two test files**

`createTempGitRepo`, `commitFile`, `deleteAndCommit`, `renameAndCommit`, and `headSha` are defined identically (or near-identically) in both `incremental.test.ts` and `integration-e2e.test.ts`. Duplicated helpers drift over time and make test maintenance harder.

Extract them into a shared fixture, e.g. `apps/context/test/helpers/git-fixtures.ts`, and import from both test files.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: cf38269</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->