### PR TITLE
Fix worktree sync docs: use git pull instead of update-ref

### DIFF
--- a/.agents/skills/managing-kata-worktrees/SKILL.md
+++ b/.agents/skills/managing-kata-worktrees/SKILL.md
@@ -22,19 +22,20 @@ kata-mono uses a multi-worktree layout where each worktree maps to a monorepo ap
 
 ## Standby branch tracking
 
-Each standby branch must track `origin/main` so `git pull` works, and its pointer must be at `origin/main`:
+Each standby branch must track `origin/main` so `git pull` works:
 
 ```bash
-# Set tracking (tells git what to compare against)
 git branch --set-upstream-to=origin/main wt-cli-standby
-
-# Move the branch pointer to origin/main (actually syncs the commit)
-git update-ref refs/heads/wt-cli-standby refs/remotes/origin/main
 ```
 
-`--set-upstream-to` only sets the tracking reference. It does not move the branch pointer. A newly created standby branch can track `origin/main` but still point at whatever commit it was created from. Always run both commands when setting up a new standby branch.
+If `git pull` reports "no tracking information," re-run that command. Tracking can be lost if a branch is recreated.
 
-If `git pull` reports "no tracking information," re-run the `--set-upstream-to` command. Tracking can be lost if a branch is recreated.
+For initial setup of a new standby branch, set tracking and then pull from within the worktree to sync both the ref and working tree:
+
+```bash
+git branch --set-upstream-to=origin/main wt-<name>-standby
+git -C /Volumes/EVO/kata/kata-mono.worktrees/wt-<name> pull
+```
 
 ## Starting work on a ticket
 
@@ -88,6 +89,23 @@ git log --oneline wt-<name>-standby..main
 # See what the standby has that main doesn't (should be empty)
 git log --oneline main..wt-<name>-standby
 ```
+
+## Sync all worktrees after a merge
+
+After merging a PR, pull main from the root repo. Worktrees share the same git object store, so they see the updated refs automatically. Then pull from within each worktree to fast-forward its standby branch:
+
+```bash
+# From the main repo root
+git checkout main && git pull
+
+# Then from each worktree (or using -C)
+for wt in wt-cli wt-context wt-desktop wt-orc wt-symphony; do
+  git -C /Volumes/EVO/kata/kata-mono.worktrees/$wt pull
+  echo "$wt: $(git -C /Volumes/EVO/kata/kata-mono.worktrees/$wt log --oneline -1)"
+done
+```
+
+Do not use `git update-ref` or `git reset --hard` to sync worktrees. These operate on refs or working trees in isolation and cause dirty state. Use `git pull` from within the worktree, which updates both the branch pointer and working tree together.
 
 ## Health check (all worktrees)
 


### PR DESCRIPTION
## Summary

- Replace `git update-ref` with `git pull` in worktree sync instructions
- Add "sync all worktrees" section with correct pull-based workflow
- Add warning against `update-ref` and `reset --hard` for worktree sync

## Test plan

- [x] Skill file reviewed for correctness

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `managing-kata-worktrees` skill to replace the previously recommended `git update-ref` approach for syncing standby branches with `git pull`, and adds a dedicated "Sync all worktrees after a merge" section. The intent is correct — `git pull` is the safer and more idiomatic way to keep standby branches current — but two issues need attention before merging:

- The new blanket warning against `git reset --hard` directly contradicts the existing conflict-recovery guidance in "Returning to standby after a PR merge," which explicitly recommends `git reset --hard origin/main` as a valid fallback when `git pull` fails. The warning needs to be scoped (e.g., "not as the primary method") to avoid confusing readers or causing them to skip a legitimate recovery step.
- The bulk-pull loop in the new section runs `git pull` in every worktree directory without first checking whether that worktree is on its standby branch. If a worktree is on an active feature branch, the pull will silently update the wrong branch. A guard or prose note about this prerequisite would prevent errors.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the contradictory `git reset --hard` warning and adding a standby-branch prerequisite to the bulk-pull loop.
- The core change (replacing `git update-ref` with `git pull`) is correct and an improvement. However, the new blanket warning against `git reset --hard` directly conflicts with valid guidance already present in the document, and the new loop script can silently pull the wrong branch if a worktree is not on standby. These issues reduce confidence to 3/5 — the PR is directionally right but needs targeted fixes before it is fully safe to rely on as authoritative skill documentation.
- .agents/skills/managing-kata-worktrees/SKILL.md — the new warning (line 108) and the bulk-pull loop (lines 101–105) both need attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .agents/skills/managing-kata-worktrees/SKILL.md | Documentation updated to replace `git update-ref` with `git pull` for worktree sync; new "Sync all worktrees" section added, but the blanket warning against `git reset --hard` contradicts the existing conflict-recovery guidance already in the file, and the bulk-pull loop has no guard against non-standby branches. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Root as Root Repo (kata-mono/)
    participant Remote as origin/main
    participant WT as Each Worktree (wt-*/standby)

    Dev->>Root: git checkout main && git pull
    Root->>Remote: fetch + fast-forward main
    Remote-->>Root: updated refs (shared object store)
    Note over WT: Worktrees see new refs automatically<br/>(shared git object store)
    Dev->>WT: git -C .../wt-<name> pull
    WT->>Remote: fetch + fast-forward wt-<name>-standby
    Remote-->>WT: branch pointer + working tree updated
    Note over WT: ⚠ Must be on standby branch first<br/>or pull targets wrong branch
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .agents/skills/managing-kata-worktrees/SKILL.md
Line: 108

Comment:
**Warning contradicts existing `git reset --hard` guidance**

The new warning states "Do not use `git update-ref` or `git reset --hard` to sync worktrees," but the existing "Returning to standby after a PR merge" section (lines 65–73) explicitly recommends `git reset --hard origin/main` as the correct recovery path when `git pull` fails due to conflicts:

```bash
git checkout wt-<name>-standby
git fetch origin
git reset --hard origin/main
```

A reader following this guide may conclude that `git reset --hard` is never acceptable and skip the documented recovery step in a legitimate conflict scenario. Consider scoping the warning to be more precise, e.g.:

```suggestion
Do not use `git update-ref` or `git reset --hard` as the primary method to sync worktrees. These operate on refs or working trees in isolation and can cause dirty state. Use `git pull` from within the worktree, which updates both the branch pointer and working tree together. (`git reset --hard origin/main` is acceptable as a recovery fallback only when `git pull` fails with conflicts and you have confirmed the PR captured all work — see "Returning to standby after a PR merge.")

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .agents/skills/managing-kata-worktrees/SKILL.md
Line: 101-105

Comment:
**Loop lacks prerequisite check for standby branch**

The loop runs `git pull` in each worktree without first verifying it is on its standby branch. If a worktree is on an active feature branch (e.g., `feat/my-feature`), the pull will fast-forward or attempt to merge that feature branch instead of the standby branch — silently doing the wrong thing.

Consider adding a note or a guard to the loop:

```bash
for wt in wt-cli wt-context wt-desktop wt-orc wt-symphony; do
  current_branch=$(git -C /Volumes/EVO/kata/kata-mono.worktrees/$wt branch --show-current)
  if [[ "$current_branch" != "${wt}-standby" ]]; then
    echo "$wt: SKIPPED (on branch $current_branch, not standby)"
    continue
  fi
  git -C /Volumes/EVO/kata/kata-mono.worktrees/$wt pull
  echo "$wt: $(git -C /Volumes/EVO/kata/kata-mono.worktrees/$wt log --oneline -1)"
done
```

At minimum, a prose note like "Ensure each worktree is on its standby branch before running this loop" would prevent silent errors.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["docs: fix worktree s..."](https://github.com/gannonh/kata/commit/f47b9a4866d24c64f43d2c7f42cb8dc20ce4a19f)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->