### PR TITLE
CLI v0.3.0

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 0.3.0
+
+### Built-in Linear Integration
+
+- Add native Linear extension with GraphQL client — 22+ tools, no MCP server required
+- Linear workflow mode (`workflow.mode: linear`) stores all Kata artifacts as Linear documents
+- State derivation from Linear API (`kata_derive_state`) replaces file-based `state.md`
+- Entity mapping: milestones → ProjectMilestones, slices → Issues, tasks → Sub-issues
+- Document storage: plans, summaries, decisions stored as LinearDocuments via API
+- Rate limit resilience with automatic retry and error classification
+- `LINEAR_API_KEY` hydration in auth wizard
+
+### KataBackend Architecture
+
+- Unified `KataBackend` interface abstracts File and Linear backends behind a common API
+- Eliminate all `isLinearMode` forks — single codepath through unified dispatch loop
+- Unified prompt layer: all prompt templates migrated to backend ops vars
+- Phase recipes — shared declaration of what each workflow phase reads/writes
+- Merge `LINEAR-WORKFLOW.md` into unified `KATA-WORKFLOW.md`
+- Golden snapshot tests and structural prompt assertions for both backends
+
+### PR Lifecycle Management
+
+- Add `/kata pr` subcommands: `status`, `create`, `review`, `address`, `merge`
+- PR creation with body composition from `.kata/` slice artifacts
+- Bundled reviewer subagents with parallel dispatch for code review
+- Context-aware comment evaluation with triage-first workflow
+- PR address workflow: fetch comments, evaluate, fix, reply, resolve threads
+- Linear cross-linking: `Closes KAT-N` references and issue state advancement on merge
+- PR gating in auto-mode: slice completion gates on PR creation when `pr.enabled`
+- Replace Python PR scripts (`create_pr_safe.py`, `fetch_comments.py`) with native TypeScript
+
+### Other Features
+
+- Add `/kata step` as first-class subcommand for single-step execution
+- Patch Opus 4.6 context window to 1M at session start
+
+### Fixes
+
+- Monorepo support: add `gitRoot` to KataBackend for correct PR and merge operations
+- Abort step on branch failure, correct multi-milestone paths, replan fallback
+- PR failure pauses and helps user recover instead of terse error
+- Show PR notification after stop message so it's visible
+- Linear: improve teamKey → teamId resolution across all surfaces
+- Linear: sort milestones by sortOrder, scope task-level docs to slice issue
+- Linear: `ensureLabel` falls back to workspace-level labels before creating
+- Linear: deterministic active slice/task selection in state derivation
+- Harden error handling, caching, and edge cases across kata extensions
+- Truncate large diffs in reviewer prompts to prevent context overflow
+
+### Internal
+
+- Migrate tests from Node `--test` to Bun test runner
+- Extract shared utilities and fix duplicate code across backends
+- Add Turborepo `lint` and `typecheck` scripts
+
 ## 0.2.1
 
 - Fix `/changelog` command — symlink `pkg/CHANGELOG.md` so Kata can find it

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -100,6 +100,7 @@ All planning state lives in `.kata/` at the project root — human-readable mark
 | Command | Description |
 |---------|-------------|
 | `/kata` | Contextual wizard — suggests next step based on project state |
+| `/kata step` | Execute one step (research, plan, task, etc.) then stop |
 | `/kata auto` | Start autonomous mode |
 | `/kata stop` | Stop auto-mode after current task |
 | `/kata status` | Progress dashboard |

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/resources/AGENTS.md
+++ b/apps/cli/src/resources/AGENTS.md
@@ -63,6 +63,7 @@ Kata sets these env vars in `loader.ts` before importing `cli.ts`:
 The main extension registers the `/kata` slash command with subcommands:
 
 - `/kata` — Contextual wizard (smart entry point based on project state)
+- `/kata step` — Execute one step (research, plan, task, etc.) then stop
 - `/kata auto` — Start auto-mode (loops fresh sessions until milestone complete)
 - `/kata stop` — Stop auto-mode gracefully
 - `/kata status` — Progress dashboard


### PR DESCRIPTION
## CLI v0.3.0

### Built-in Linear Integration
- Native Linear extension with GraphQL client — 22+ tools, no MCP server required
- Linear workflow mode stores all Kata artifacts as Linear documents
- State derivation from Linear API replaces file-based `state.md`
- Entity mapping: milestones → ProjectMilestones, slices → Issues, tasks → Sub-issues
- Rate limit resilience with automatic retry and error classification

### KataBackend Architecture
- Unified `KataBackend` interface abstracts File and Linear backends behind a common API
- Eliminate all `isLinearMode` forks — single codepath through unified dispatch loop
- Unified prompt layer: all prompt templates migrated to backend ops vars
- Phase recipes — shared declaration of what each workflow phase reads/writes
- Merge `LINEAR-WORKFLOW.md` into unified `KATA-WORKFLOW.md`

### PR Lifecycle Management
- `/kata pr` subcommands: `status`, `create`, `review`, `address`, `merge`
- PR creation with body composition from `.kata/` slice artifacts
- Bundled reviewer subagents with parallel dispatch for code review
- Context-aware comment evaluation with triage-first workflow
- Linear cross-linking with `Closes KAT-N` references
- Replace Python PR scripts with native TypeScript

### Other
- `/kata step` as first-class subcommand
- Patch Opus 4.6 context window to 1M
- Migrate tests from Node `--test` to Bun test
- Many bug fixes (monorepo support, error recovery, Linear edge cases)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a version bump release commit for the `@kata-sh/cli` package, advancing it from `0.2.1` to `0.3.0`. The two changed files are `CHANGELOG.md` (new 0.3.0 section) and `package.json` (version field only). The actual feature implementation (Linear integration, KataBackend architecture, PR lifecycle management, etc.) was landed in prior commits and this PR simply captures the release artifact.

- `CHANGELOG.md` is well-structured with clear sections (Built-in Linear Integration, KataBackend Architecture, PR Lifecycle Management, Other Features, Fixes, Internal) that accurately match the PR description.
- `package.json` bumps `"version"` from `"0.2.1"` to `"0.3.0"` — correct for the scope of changes (new features, architectural changes) described.
- No logic, dependencies, scripts, or other fields in `package.json` were altered in this PR.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure version bump and changelog update with no behavioral changes.
- Only two files are changed: the changelog receives a new 0.3.0 section and package.json receives a single version field update. There is no code logic, no new dependencies, and no risk of runtime regression. The changelog content is accurate, well-formatted, and consistent with the existing style.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/CHANGELOG.md | Added well-structured 0.3.0 changelog section covering Linear integration, KataBackend architecture, PR lifecycle management, fixes, and internal changes. Consistent with existing format and PR description. |
| apps/cli/package.json | Single-field version bump from 0.2.1 to 0.3.0. No other fields changed. Version aligns with the changelog entry and the scope of features described. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[kata pr create] --> B[Compose PR body\nfrom .kata/ artifacts]
    B --> C{pr.enabled?}
    C -- yes --> D[Create GitHub PR\nwith Closes KAT-N ref]
    C -- no --> E[Skip PR gating]
    D --> F[Dispatch reviewer\nsubagents in parallel]
    F --> G[kata pr review\nfetch comments]
    G --> H[Triage comments]
    H --> I{Actionable?}
    I -- yes --> J[kata pr address\nfix + reply + resolve]
    I -- no --> K[Skip]
    J --> L[kata pr merge\nadvance Linear issue state]
    E --> M[Continue slice completion]
```

<sub>Last reviewed commit: ["chore(release): bump..."](https://github.com/gannonh/kata/commit/3e7b44463f7051b794cc5902181b394fd5c929a6)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.3.0 for the CLI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->