### PR TITLE
cli m005/s01 Port git-service extension from gsd-pi

### DIFF
--- a/apps/cli/src/resources/extensions/kata/git-service.ts
+++ b/apps/cli/src/resources/extensions/kata/git-service.ts
@@ -243,39 +243,244 @@ export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
   return subject;
 }
 
-// ─── Git I/O Stubs (implemented in T03) ──────────────────────────────────────
-// Exported here so the module satisfies all named imports in the test file.
-// T03 replaces these with real implementations.
+// ─── Module-level session state ───────────────────────────────────────────────
 
-/** Get the current branch name. Implemented in T03. */
-export function getCurrentBranch(_basePath: string): string {
-  throw new Error("getCurrentBranch not yet implemented — see T03");
-}
+/**
+ * Tracks repos where the one-time runtime-file index cleanup has already run.
+ * Keyed by basePath. Persists for the process lifetime — this is correct
+ * semantics: the cleanup fires at most once per repo per process.
+ */
+const _runtimeFilesCleanedUp = new Set<string>();
 
-/** Detect the integration (main) branch for the repo. Implemented in T03. */
-export function getMainBranch(_basePath: string): string {
-  throw new Error("getMainBranch not yet implemented — see T03");
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Check whether a local branch exists.
+ *
+ * Uses try/catch instead of { allowFailure: true } because `--quiet` produces
+ * no stdout on either success or failure — the output can't distinguish the
+ * two cases. try/catch on exit code is reliable.
+ */
+function branchExists(basePath: string, branch: string): boolean {
+  try {
+    runGit(basePath, ["show-ref", "--verify", `refs/heads/${branch}`]);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
- * Smart-stage and auto-commit dirty working tree, excluding runtime paths.
- * Implemented in T03.
+ * Stage all changes, then unstage each runtime exclusion path.
+ *
+ * On the first call for a given basePath, also removes tracked runtime files
+ * from the git index (one-time cleanup for files that were historically
+ * committed before .kata-cli/ was added to .gitignore).
+ *
+ * Ordering matters:
+ *   1. `git add -A` stages everything (including tracked runtime file modifications)
+ *   2. `git reset HEAD -- <path>` unstages each exclusion path
+ *   3. `git rm --cached -r --force -- <path>` removes tracked runtime files from
+ *      the index entirely (creates a "deleted" staging entry → committed in the
+ *      first autoCommit as "untrack these files"). Guarded by _runtimeFilesCleanedUp.
+ *
+ * allowFailure is set on reset and rm because paths that are not staged or not
+ * tracked simply produce a non-zero exit — not an error condition.
+ */
+function smartStage(basePath: string, extraExclusions: readonly string[] = []): void {
+  const allExclusions = [...RUNTIME_EXCLUSION_PATHS, ...extraExclusions];
+
+  // Stage everything first
+  runGit(basePath, ["add", "-A"]);
+
+  // Unstage each runtime/extra exclusion path
+  for (const path of allExclusions) {
+    runGit(basePath, ["reset", "HEAD", "--", path], { allowFailure: true });
+  }
+
+  // One-time cleanup: remove previously-tracked runtime files from the index.
+  // Runs at most once per basePath per process lifetime.
+  if (!_runtimeFilesCleanedUp.has(basePath)) {
+    for (const path of allExclusions) {
+      runGit(basePath, ["rm", "--cached", "-r", "--force", "--", path], {
+        allowFailure: true,
+      });
+    }
+    _runtimeFilesCleanedUp.add(basePath);
+  }
+}
+
+// ─── Git I/O Functions ────────────────────────────────────────────────────────
+
+/**
+ * Get the current branch name.
+ * Returns the branch name trimmed of whitespace.
+ */
+export function getCurrentBranch(basePath: string): string {
+  return runGit(basePath, ["branch", "--show-current"]);
+}
+
+/**
+ * Detect the integration (main) branch for the repo.
+ *
+ * Resolution order:
+ *   1. Explicit `prefs.main_branch` override (if branch exists locally)
+ *   2. `origin/HEAD` symbolic-ref (the remote's default branch)
+ *   3. `refs/heads/main` — most common default name
+ *   4. `refs/heads/master` — legacy default name
+ *   5. Current branch (last resort / detached HEAD fallback)
+ *
+ * Observability: when no remote is configured (common in test repos), steps 2
+ * and 3/4 fall through naturally and the current branch is returned — which
+ * is correct for single-branch repos and test environments.
+ */
+export function getMainBranch(basePath: string, prefs?: GitPreferences): string {
+  // Step 1: explicit preference override
+  if (prefs?.main_branch && branchExists(basePath, prefs.main_branch)) {
+    return prefs.main_branch;
+  }
+
+  // Step 2: origin/HEAD symbolic ref (remote's default branch)
+  const originHead = runGit(
+    basePath,
+    ["symbolic-ref", "refs/remotes/origin/HEAD"],
+    { allowFailure: true },
+  );
+  if (originHead) {
+    const prefix = "refs/remotes/origin/";
+    if (originHead.startsWith(prefix)) {
+      const branch = originHead.slice(prefix.length).trim();
+      if (branch && branchExists(basePath, branch)) return branch;
+    }
+  }
+
+  // Step 3: check refs/heads/main
+  if (runGit(basePath, ["show-ref", "--verify", "refs/heads/main"], { allowFailure: true })) {
+    return "main";
+  }
+
+  // Step 4: check refs/heads/master
+  if (runGit(basePath, ["show-ref", "--verify", "refs/heads/master"], { allowFailure: true })) {
+    return "master";
+  }
+
+  // Step 5: fall back to current branch (detached HEAD / single-branch repo)
+  return runGit(basePath, ["branch", "--show-current"]);
+}
+
+/**
+ * Commit the current staging area with the given message.
+ *
+ * Returns opts.message on success (the caller can use this as the "what was committed"
+ * signal), or null when nothing is staged and allowEmpty is not set.
+ *
+ * Uses `git commit -F -` (read message from stdin) for multi-line and special-character
+ * safety — avoids shell quoting issues with `-m` and message contents.
+ *
+ * Observability: null return is the explicit "nothing to commit after exclusions"
+ * signal — callers should treat null as a no-op, not an error.
+ */
+export function commit(basePath: string, opts: CommitOptions): string | null {
+  const staged = runGit(basePath, ["diff", "--cached", "--name-only"], {
+    allowFailure: true,
+  });
+  if (!staged && !opts.allowEmpty) return null;
+
+  const args = ["commit", "-F", "-"];
+  if (opts.allowEmpty) args.push("--allow-empty");
+  runGit(basePath, args, { input: opts.message });
+  return opts.message;
+}
+
+/**
+ * Smart-stage all dirty files (excluding RUNTIME_EXCLUSION_PATHS and any
+ * extra exclusions) and auto-commit.
+ *
+ * Returns the commit message string on success, null when nothing to commit
+ * after exclusions (i.e. only runtime files were dirty).
+ *
+ * Commit message:
+ *   - With taskContext: delegates to buildTaskCommitMessage for a meaningful
+ *     conventional commit line derived from the task execution results.
+ *   - Without taskContext: generic `chore(${unitId}): auto-commit after ${unitType}`
+ *
+ * Observability: null return signals the "only runtime files were dirty" condition
+ * — callers can use this to skip logging a commit that didn't happen.
  */
 export function autoCommitCurrentBranch(
-  _basePath: string,
-  _unitType: string,
-  _unitId: string,
-  _taskContext?: TaskCommitContext,
-  _extraExclusions?: readonly string[],
+  basePath: string,
+  unitType: string,
+  unitId: string,
+  taskContext?: TaskCommitContext,
+  extraExclusions?: readonly string[],
 ): string | null {
-  throw new Error("autoCommitCurrentBranch not yet implemented — see T03");
+  smartStage(basePath, extraExclusions ?? []);
+
+  // After exclusion-aware staging, check if anything is actually staged
+  const staged = runGit(basePath, ["diff", "--cached", "--name-only"], {
+    allowFailure: true,
+  });
+  if (!staged) return null;
+
+  const message = taskContext
+    ? buildTaskCommitMessage(taskContext)
+    : `chore(${unitId}): auto-commit after ${unitType}`;
+
+  return commit(basePath, { message });
 }
 
 /**
- * Stage (smart) and commit with the given options.
- * Returns commit message on success, null when nothing to commit.
- * Implemented in T03.
+ * Squash-merge the current slice branch into the main/integration branch.
+ *
+ * Workflow:
+ *   1. Capture current (slice) branch name
+ *   2. Detect main branch
+ *   3. Switch to main
+ *   4. `git merge --squash <sliceBranch>` — stages all slice commits as one
+ *   5. Commit with a conventional feat() message
+ *
+ * Throws MergeConflictError (not a generic Error) when the squash merge
+ * encounters conflicts. The working tree is left in conflicted state so
+ * the caller can dispatch a fix session.
+ *
+ * Observability: MergeConflictError exposes conflictedFiles[], branch, mainBranch,
+ * and strategy — a future agent can inspect this without running git manually.
  */
-export function commit(_basePath: string, _opts: CommitOptions): string | null {
-  throw new Error("commit not yet implemented — see T03");
+export function mergeSliceToMain(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+  sliceTitle: string,
+  prefs?: GitPreferences,
+): MergeSliceResult {
+  const sliceBranch = getCurrentBranch(basePath);
+  const mainBranch = getMainBranch(basePath, prefs);
+
+  runGit(basePath, ["switch", mainBranch]);
+
+  try {
+    runGit(basePath, ["merge", "--squash", sliceBranch]);
+  } catch {
+    // Collect conflicted files for the caller to act on
+    const conflictedFiles = runGit(
+      basePath,
+      ["diff", "--name-only", "--diff-filter=U"],
+      { allowFailure: true },
+    )
+      .split("\n")
+      .filter(Boolean);
+
+    throw new MergeConflictError({
+      message: `Merge conflict while squashing ${sliceBranch} into ${mainBranch}`,
+      conflictedFiles,
+      strategy: prefs?.merge_strategy ?? "squash",
+      branch: sliceBranch,
+      mainBranch,
+    });
+  }
+
+  const squashMsg = `feat(${milestoneId}/${sliceId}): ${sliceTitle}`;
+  commit(basePath, { message: squashMsg });
+
+  return { branch: sliceBranch, mergedCommitMessage: squashMsg, deletedBranch: false };
 }

--- a/apps/cli/src/resources/extensions/kata/git-service.ts
+++ b/apps/cli/src/resources/extensions/kata/git-service.ts
@@ -1,0 +1,281 @@
+/**
+ * Kata Git Service
+ *
+ * Core git operations for Kata: types, constants, and pure helpers.
+ * Higher-level operations (commit, staging, branching) build on these in T03.
+ *
+ * This module centralizes the GitPreferences interface, runtime exclusion
+ * paths, commit type inference, and the runGit shell helper.
+ */
+
+import { execFileSync } from "node:child_process";
+
+// ─── Environment ──────────────────────────────────────────────────────────────
+
+/**
+ * Environment variables that suppress interactive git prompts.
+ * Spread with process.env in runGit so PATH and other vars are preserved.
+ */
+const GIT_NO_PROMPT_ENV = {
+  GIT_TERMINAL_PROMPT: "0",
+  GIT_SSH_COMMAND: "ssh -o BatchMode=yes",
+};
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface GitPreferences {
+  auto_push?: boolean;
+  remote?: string;
+  merge_strategy?: "squash" | "merge";
+  main_branch?: string;
+}
+
+export interface CommitOptions {
+  message: string;
+  allowEmpty?: boolean;
+}
+
+/** Context for generating a meaningful commit message from task execution results. */
+export interface TaskCommitContext {
+  taskId: string;
+  taskTitle: string;
+  /** The one-liner from the task summary (e.g. "Added retry-aware worker status logging") */
+  oneLiner?: string;
+  /** Files modified by this task (from task summary frontmatter) */
+  keyFiles?: string[];
+}
+
+/**
+ * Thrown when a slice merge hits code conflicts.
+ * The working tree is left in a conflicted state so the caller can dispatch
+ * a fix-merge session to resolve it.
+ */
+export class MergeConflictError extends Error {
+  readonly conflictedFiles: string[];
+  readonly strategy: string;
+  readonly branch: string;
+  readonly mainBranch: string;
+
+  constructor(props: {
+    message: string;
+    conflictedFiles: string[];
+    strategy: string;
+    branch: string;
+    mainBranch: string;
+  }) {
+    super(props.message);
+    this.name = "MergeConflictError";
+    this.conflictedFiles = props.conflictedFiles;
+    this.strategy = props.strategy;
+    this.branch = props.branch;
+    this.mainBranch = props.mainBranch;
+  }
+}
+
+export interface MergeSliceResult {
+  branch: string;
+  mergedCommitMessage: string;
+  deletedBranch: boolean;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Validates branch names against a safe character set.
+ * Prevents shell injection via branch name arguments.
+ * Accepts: letters, digits, dots, underscores, hyphens, slashes.
+ */
+export const VALID_BRANCH_NAME = /^[a-zA-Z0-9._\-\/]+$/;
+
+/**
+ * Kata runtime paths that should be excluded from smart staging.
+ * These are transient/generated artifacts that should never be committed.
+ * All entries use the .kata-cli/ prefix (not .gsd/).
+ */
+export const RUNTIME_EXCLUSION_PATHS: readonly string[] = [
+  ".kata-cli/activity/",
+  ".kata-cli/runtime/",
+  ".kata-cli/worktrees/",
+  ".kata-cli/auto.lock",
+  ".kata-cli/metrics.json",
+  ".kata-cli/completed-units.json",
+  ".kata-cli/STATE.md",
+];
+
+// ─── Git Helper ───────────────────────────────────────────────────────────────
+
+/**
+ * Strip git-svn noise from error messages.
+ * Some systems (notably Arch Linux) have a buggy git-svn Perl module that
+ * emits warnings on every git invocation, confusing users.
+ */
+function filterGitSvnNoise(message: string): string {
+  return message
+    .replace(/Pseudo-merge base [^\n]*\n?/g, "")
+    .replace(/Duplicate specification "[^"]*" for option "[^"]*"\n?/g, "")
+    .replace(/Unable to determine upstream SVN information from .*\n?/g, "")
+    .replace(/Perhaps the repository is empty\. at .*git-svn.*\n?/g, "")
+    .trim();
+}
+
+/**
+ * Run a git command in the given directory.
+ * Returns trimmed stdout. Throws on non-zero exit unless allowFailure is set.
+ * When `input` is provided, it is piped to stdin.
+ *
+ * Observability: on failure, the thrown Error.message includes both the git
+ * command args and the filtered stderr — enabling a future agent to read the
+ * exact git failure without re-running the command.
+ */
+export function runGit(
+  basePath: string,
+  args: string[],
+  options: { allowFailure?: boolean; input?: string } = {},
+): string {
+  try {
+    return execFileSync("git", args, {
+      cwd: basePath,
+      encoding: "utf-8",
+      env: { ...process.env, ...GIT_NO_PROMPT_ENV },
+      stdio: options.input != null ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+      ...(options.input != null ? { input: options.input } : {}),
+    }).trim();
+  } catch (error) {
+    if (options.allowFailure) return "";
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `git ${args.join(" ")} failed in ${basePath}: ${filterGitSvnNoise(message)}`,
+    );
+  }
+}
+
+// ─── Commit Type Inference ────────────────────────────────────────────────────
+
+/**
+ * Keyword-to-commit-type mapping. Order matters — first match wins.
+ * Each entry: [keywords[], commitType].
+ * Word-boundary matching prevents partial matches (e.g. "fix" ≠ "prefix").
+ * Multi-word keywords (e.g. "clean up") use substring matching.
+ */
+const COMMIT_TYPE_RULES: [string[], string][] = [
+  [["fix", "fixed", "fixes", "bug", "patch", "hotfix", "repair", "correct"], "fix"],
+  [["refactor", "restructure", "reorganize"], "refactor"],
+  [["doc", "docs", "documentation", "readme", "changelog"], "docs"],
+  [["test", "tests", "testing", "spec", "coverage"], "test"],
+  [["perf", "performance", "optimize", "speed", "cache"], "perf"],
+  [
+    [
+      "chore",
+      "cleanup",
+      "clean up",
+      "dependencies",
+      "deps",
+      "bump",
+      "config",
+      "ci",
+      "archive",
+      "remove",
+      "delete",
+    ],
+    "chore",
+  ],
+];
+
+/**
+ * Infer a conventional commit type from a title (and optional one-liner).
+ * Uses case-insensitive word-boundary matching against known keywords.
+ * Returns "feat" when no keywords match.
+ *
+ * Used for both slice squash-merge titles and task commit messages.
+ */
+export function inferCommitType(title: string, oneLiner?: string): string {
+  const lower = `${title} ${oneLiner ?? ""}`.toLowerCase();
+
+  for (const [keywords, commitType] of COMMIT_TYPE_RULES) {
+    for (const keyword of keywords) {
+      if (keyword.includes(" ")) {
+        // Multi-word keyword: use substring match (word boundaries don't apply)
+        if (lower.includes(keyword)) return commitType;
+      } else {
+        // Single word: use word-boundary regex to prevent partial matches
+        const re = new RegExp(`\\b${keyword}\\b`, "i");
+        if (re.test(lower)) return commitType;
+      }
+    }
+  }
+
+  return "feat";
+}
+
+// ─── Commit Message Builder ───────────────────────────────────────────────────
+
+/**
+ * Build a meaningful conventional commit message from task execution context.
+ * Format: `{type}({taskId}): {description}`
+ *
+ * The description is the task summary one-liner if available (it describes
+ * what was actually built), falling back to the task title (what was planned).
+ * The commit type is inferred from the title and one-liner keywords.
+ */
+export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
+  const scope = ctx.taskId;
+  const description = ctx.oneLiner ?? ctx.taskTitle;
+  const type = inferCommitType(ctx.taskTitle, ctx.oneLiner);
+
+  // Truncate description to keep subject line under ~72 chars
+  const maxDescLen = 68 - type.length - scope.length;
+  const truncated =
+    description.length > maxDescLen
+      ? description.slice(0, maxDescLen - 1).trimEnd() + "…"
+      : description;
+
+  const subject = `${type}(${scope}): ${truncated}`;
+
+  // Build body with key files if available (capped at 8 to keep commit concise)
+  if (ctx.keyFiles && ctx.keyFiles.length > 0) {
+    const fileLines = ctx.keyFiles
+      .slice(0, 8)
+      .map((f) => `- ${f}`)
+      .join("\n");
+    return `${subject}\n\n${fileLines}`;
+  }
+
+  return subject;
+}
+
+// ─── Git I/O Stubs (implemented in T03) ──────────────────────────────────────
+// Exported here so the module satisfies all named imports in the test file.
+// T03 replaces these with real implementations.
+
+/** Get the current branch name. Implemented in T03. */
+export function getCurrentBranch(_basePath: string): string {
+  throw new Error("getCurrentBranch not yet implemented — see T03");
+}
+
+/** Detect the integration (main) branch for the repo. Implemented in T03. */
+export function getMainBranch(_basePath: string): string {
+  throw new Error("getMainBranch not yet implemented — see T03");
+}
+
+/**
+ * Smart-stage and auto-commit dirty working tree, excluding runtime paths.
+ * Implemented in T03.
+ */
+export function autoCommitCurrentBranch(
+  _basePath: string,
+  _unitType: string,
+  _unitId: string,
+  _taskContext?: TaskCommitContext,
+  _extraExclusions?: readonly string[],
+): string | null {
+  throw new Error("autoCommitCurrentBranch not yet implemented — see T03");
+}
+
+/**
+ * Stage (smart) and commit with the given options.
+ * Returns commit message on success, null when nothing to commit.
+ * Implemented in T03.
+ */
+export function commit(_basePath: string, _opts: CommitOptions): string | null {
+  throw new Error("commit not yet implemented — see T03");
+}

--- a/apps/cli/src/resources/extensions/kata/git-service.ts
+++ b/apps/cli/src/resources/extensions/kata/git-service.ts
@@ -223,7 +223,9 @@ export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
   const type = inferCommitType(ctx.taskTitle, ctx.oneLiner);
 
   // Truncate description to keep subject line under ~72 chars
-  const maxDescLen = 68 - type.length - scope.length;
+  // Math.max(1, ...) guards against negative values when taskId is unusually long,
+  // which would cause slice(0, negative) to strip from the end instead of truncating.
+  const maxDescLen = Math.max(1, 68 - type.length - scope.length);
   const truncated =
     description.length > maxDescLen
       ? description.slice(0, maxDescLen - 1).trimEnd() + "…"
@@ -458,9 +460,10 @@ export function mergeSliceToMain(
 
   runGit(basePath, ["switch", mainBranch]);
 
+  // Only squash-merge is implemented; non-squash strategy is a future TODO.
   try {
     runGit(basePath, ["merge", "--squash", sliceBranch]);
-  } catch {
+  } catch (mergeErr) {
     // Collect conflicted files for the caller to act on
     const conflictedFiles = runGit(
       basePath,
@@ -470,17 +473,28 @@ export function mergeSliceToMain(
       .split("\n")
       .filter(Boolean);
 
+    // Non-conflict failure (missing branch, dirty index, invalid ref, etc.)
+    // — rethrow the original git error rather than misclassifying it as a conflict.
+    if (conflictedFiles.length === 0) {
+      throw mergeErr;
+    }
+
     throw new MergeConflictError({
       message: `Merge conflict while squashing ${sliceBranch} into ${mainBranch}`,
       conflictedFiles,
-      strategy: prefs?.merge_strategy ?? "squash",
+      strategy: "squash", // always squash — non-squash merge path not yet implemented
       branch: sliceBranch,
       mainBranch,
     });
   }
 
   const squashMsg = `feat(${milestoneId}/${sliceId}): ${sliceTitle}`;
-  commit(basePath, { message: squashMsg });
+  const committed = commit(basePath, { message: squashMsg });
+  if (!committed) {
+    throw new Error(
+      `Squash of ${sliceBranch} into ${mainBranch} staged nothing — slice may be empty or already merged`,
+    );
+  }
 
   return { branch: sliceBranch, mergedCommitMessage: squashMsg, deletedBranch: false };
 }

--- a/apps/cli/src/resources/extensions/kata/tests/git-service.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/git-service.test.ts
@@ -12,6 +12,8 @@ import {
   getMainBranch,
   autoCommitCurrentBranch,
   commit,
+  mergeSliceToMain,
+  MergeConflictError,
   RUNTIME_EXCLUSION_PATHS,
   VALID_BRANCH_NAME,
   type GitPreferences,
@@ -691,6 +693,108 @@ describe("getMainBranch", () => {
       // No 'main' or 'master' branch — should fall back
       const branch = getMainBranch(repo);
       assert.equal(branch, "trunk");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── mergeSliceToMain ─────────────────────────────────────────────────────────
+
+describe("mergeSliceToMain", () => {
+  it("happy path: squash-merges slice commits onto main and returns result", () => {
+    const repo = initRepo("main");
+    try {
+      // Create a slice branch with one new commit
+      execFileSync("git", ["checkout", "-b", "kata/M001/S01"], { cwd: repo });
+      createFile(repo, "src/feature.ts", "export const feature = 1;");
+      execFileSync("git", ["add", "-A"], { cwd: repo });
+      execFileSync("git", ["commit", "-m", "feat: add feature"], { cwd: repo });
+
+      const result = mergeSliceToMain(repo, "M001", "S01", "Feature slice");
+
+      assert.equal(result.branch, "kata/M001/S01", "returns slice branch name");
+      assert.equal(
+        result.mergedCommitMessage,
+        "feat(M001/S01): Feature slice",
+        "returns conventional squash commit message",
+      );
+      assert.equal(result.deletedBranch, false);
+
+      // Should now be on main
+      assert.equal(getCurrentBranch(repo), "main");
+
+      // The squash commit must appear in main's log
+      const log = gitRaw(["log", "--oneline", "-1"], repo);
+      assert.ok(
+        log.includes("feat(M001/S01): Feature slice"),
+        `squash commit is in main log: "${log}"`,
+      );
+
+      // The feature file must be present on main
+      const showStat = gitRaw(["show", "--stat", "--format=", "HEAD"], repo);
+      assert.ok(showStat.includes("src/feature.ts"), "feature file is in the squash commit");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when slice has no new commits (empty squash stages nothing)", () => {
+    const repo = initRepo("main");
+    try {
+      // Create slice branch with NO additional commits — identical to main
+      execFileSync("git", ["checkout", "-b", "kata/M001/S01"], { cwd: repo });
+
+      assert.throws(
+        () => mergeSliceToMain(repo, "M001", "S01", "Empty slice"),
+        (err: unknown) => {
+          assert.ok(err instanceof Error, "throws an Error");
+          assert.ok(
+            (err as Error).message.includes("staged nothing"),
+            `error mentions 'staged nothing': "${(err as Error).message}"`,
+          );
+          return true;
+        },
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("throws MergeConflictError with populated conflictedFiles on conflict", () => {
+    const repo = initRepo("main");
+    try {
+      // Create a conflicting edit on the slice branch
+      execFileSync("git", ["checkout", "-b", "kata/M001/S01"], { cwd: repo });
+      createFile(repo, "conflict.txt", "slice version\n");
+      execFileSync("git", ["add", "-A"], { cwd: repo });
+      execFileSync("git", ["commit", "-m", "feat: slice edit"], { cwd: repo });
+
+      // Create a conflicting edit on main
+      execFileSync("git", ["checkout", "main"], { cwd: repo });
+      createFile(repo, "conflict.txt", "main version\n");
+      execFileSync("git", ["add", "-A"], { cwd: repo });
+      execFileSync("git", ["commit", "-m", "chore: main edit"], { cwd: repo });
+
+      // Switch back to slice so mergeSliceToMain captures the right current branch
+      execFileSync("git", ["checkout", "kata/M001/S01"], { cwd: repo });
+
+      assert.throws(
+        () => mergeSliceToMain(repo, "M001", "S01", "Conflicting slice"),
+        (err: unknown) => {
+          assert.ok(err instanceof MergeConflictError, "throws MergeConflictError");
+          const mce = err as MergeConflictError;
+          assert.ok(mce.conflictedFiles.length > 0, "conflictedFiles is non-empty");
+          assert.ok(
+            mce.conflictedFiles.includes("conflict.txt"),
+            `conflictedFiles includes conflict.txt: ${JSON.stringify(mce.conflictedFiles)}`,
+          );
+          assert.equal(mce.strategy, "squash", "strategy is always 'squash'");
+          assert.equal(mce.branch, "kata/M001/S01", "records the slice branch");
+          assert.equal(mce.mainBranch, "main", "records the main branch");
+          return true;
+        },
+      );
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }

--- a/apps/cli/src/resources/extensions/kata/tests/git-service.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/git-service.test.ts
@@ -1,0 +1,698 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import {
+  inferCommitType,
+  buildTaskCommitMessage,
+  runGit,
+  getCurrentBranch,
+  getMainBranch,
+  autoCommitCurrentBranch,
+  commit,
+  RUNTIME_EXCLUSION_PATHS,
+  VALID_BRANCH_NAME,
+  type GitPreferences,
+  type CommitOptions,
+  type TaskCommitContext,
+} from "../git-service.js";
+
+// ─── Test Helpers ─────────────────────────────────────────────────────────────
+
+function createFile(base: string, relativePath: string, content = "x"): void {
+  const full = join(base, relativePath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+}
+
+/**
+ * Create a temp repo with an initial commit so HEAD exists.
+ * All git I/O tests that need a working repo use this.
+ */
+function initRepo(branch = "main"): string {
+  const dir = mkdtempSync(join(tmpdir(), "kata-git-service-test-"));
+  execFileSync("git", ["init", "-b", branch], { cwd: dir });
+  execFileSync("git", ["config", "user.name", "Pi Test"], { cwd: dir });
+  execFileSync("git", ["config", "user.email", "pi@example.com"], { cwd: dir });
+  createFile(dir, ".gitkeep", "");
+  execFileSync("git", ["add", "-A"], { cwd: dir });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: dir });
+  return dir;
+}
+
+/**
+ * Create an empty repo (no commits) — used by runGit tests that need
+ * commands to fail (e.g. `git log --oneline` on a repo with no history).
+ */
+function initEmptyRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kata-git-service-test-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: dir });
+  execFileSync("git", ["config", "user.name", "Pi Test"], { cwd: dir });
+  execFileSync("git", ["config", "user.email", "pi@example.com"], { cwd: dir });
+  return dir;
+}
+
+/** Run a raw git command for test setup/verification (bypasses git-service.js). */
+function gitRaw(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+// ─── inferCommitType ──────────────────────────────────────────────────────────
+
+describe("inferCommitType", () => {
+  it("generic feature title → feat", () => {
+    assert.equal(inferCommitType("Implement user authentication"), "feat");
+  });
+
+  it("add-style title → feat", () => {
+    assert.equal(inferCommitType("Add dashboard page"), "feat");
+  });
+
+  it("title with 'fix' → fix", () => {
+    assert.equal(inferCommitType("Fix login redirect bug"), "fix");
+  });
+
+  it("title with 'bug' → fix", () => {
+    assert.equal(inferCommitType("Bug in session handling"), "fix");
+  });
+
+  it("title with 'hotfix' → fix", () => {
+    assert.equal(inferCommitType("Hotfix for production crash"), "fix");
+  });
+
+  it("title with 'patch' → fix", () => {
+    assert.equal(inferCommitType("Patch memory leak"), "fix");
+  });
+
+  it("title with 'refactor' → refactor", () => {
+    assert.equal(inferCommitType("Refactor state management"), "refactor");
+  });
+
+  it("title with 'restructure' → refactor", () => {
+    assert.equal(inferCommitType("Restructure project layout"), "refactor");
+  });
+
+  it("title with 'reorganize' → refactor", () => {
+    assert.equal(inferCommitType("Reorganize module imports"), "refactor");
+  });
+
+  it("title with 'documentation' → docs", () => {
+    assert.equal(inferCommitType("Update API documentation"), "docs");
+  });
+
+  it("title with 'doc' → docs", () => {
+    assert.equal(inferCommitType("Add doc for setup guide"), "docs");
+  });
+
+  it("title with 'tests' → test", () => {
+    assert.equal(inferCommitType("Add unit tests for auth"), "test");
+  });
+
+  it("title with 'testing' → test", () => {
+    assert.equal(inferCommitType("Testing infrastructure setup"), "test");
+  });
+
+  it("title with 'chore' → chore", () => {
+    assert.equal(inferCommitType("Chore: update dependencies"), "chore");
+  });
+
+  it("title with 'cleanup' → chore", () => {
+    assert.equal(inferCommitType("Cleanup unused imports"), "chore");
+  });
+
+  it("title with 'clean up' → chore", () => {
+    assert.equal(inferCommitType("Clean up stale branches"), "chore");
+  });
+
+  it("title with 'archive' → chore", () => {
+    assert.equal(inferCommitType("Archive old milestones"), "chore");
+  });
+
+  it("title with 'remove' → chore", () => {
+    assert.equal(inferCommitType("Remove deprecated endpoints"), "chore");
+  });
+
+  it("title with 'delete' → chore", () => {
+    assert.equal(inferCommitType("Delete temp files"), "chore");
+  });
+
+  it("title with 'optimize' → perf", () => {
+    assert.equal(inferCommitType("Optimize database queries"), "perf");
+  });
+
+  it("title with 'performance' → perf", () => {
+    assert.equal(inferCommitType("Improve rendering performance"), "perf");
+  });
+
+  it("mixed keywords → first match wins (fix before refactor)", () => {
+    assert.equal(inferCommitType("Fix and refactor the login module"), "fix");
+  });
+
+  it("mixed keywords → first match wins (refactor before test)", () => {
+    assert.equal(inferCommitType("Refactor test utilities"), "refactor");
+  });
+
+  it("unrecognized title → feat", () => {
+    assert.equal(inferCommitType("Build the new pipeline"), "feat");
+  });
+
+  it("empty title → feat", () => {
+    assert.equal(inferCommitType(""), "feat");
+  });
+
+  it("'testify' does not match 'test' — word boundary prevents partial match", () => {
+    assert.equal(inferCommitType("Testify integration"), "feat");
+  });
+
+  it("'documentary' does not match 'doc' — word boundary prevents partial match", () => {
+    assert.equal(inferCommitType("Documentary style UI"), "feat");
+  });
+
+  it("'prefix' does not match 'fix' — word boundary prevents partial match", () => {
+    assert.equal(inferCommitType("Add prefix to all IDs"), "feat");
+  });
+});
+
+// ─── inferCommitType with oneLiner ───────────────────────────────────────────
+
+describe("inferCommitType with oneLiner", () => {
+  it("one-liner with 'fixed' overrides generic title → fix", () => {
+    assert.equal(
+      inferCommitType("implement dashboard", "Fixed rendering bug in sidebar"),
+      "fix",
+    );
+  });
+
+  it("one-liner with 'performance' and 'caching' → perf", () => {
+    assert.equal(
+      inferCommitType("add search", "Optimized query performance with caching"),
+      "perf",
+    );
+  });
+});
+
+// ─── buildTaskCommitMessage ───────────────────────────────────────────────────
+
+describe("buildTaskCommitMessage", () => {
+  it("builds full message with one-liner and key files", () => {
+    const msg = buildTaskCommitMessage({
+      taskId: "S01/T02",
+      taskTitle: "implement user authentication",
+      oneLiner: "Added JWT-based auth with refresh token rotation",
+      keyFiles: ["src/auth.ts", "src/middleware/jwt.ts"],
+    });
+    assert.ok(msg.startsWith("feat(S01/T02):"), "message starts with type(scope)");
+    assert.ok(msg.includes("JWT-based auth"), "message includes one-liner content");
+    assert.ok(msg.includes("- src/auth.ts"), "message body includes first key file");
+    assert.ok(msg.includes("- src/middleware/jwt.ts"), "message body includes second key file");
+  });
+
+  it("infers commit type from title when no one-liner provided", () => {
+    const msg = buildTaskCommitMessage({
+      taskId: "S02/T01",
+      taskTitle: "fix login redirect bug",
+    });
+    assert.ok(msg.startsWith("fix(S02/T01):"), "infers fix type from title");
+    assert.ok(msg.includes("fix login redirect bug"), "uses task title when no one-liner");
+    assert.ok(!msg.includes("\n"), "no body section when no key files");
+  });
+
+  it("infers test type from title", () => {
+    const msg = buildTaskCommitMessage({
+      taskId: "S01/T03",
+      taskTitle: "add tests",
+      oneLiner: "Unit tests for auth module with coverage",
+    });
+    assert.ok(msg.startsWith("test(S01/T03):"), "infers test type from title");
+  });
+});
+
+// ─── RUNTIME_EXCLUSION_PATHS ──────────────────────────────────────────────────
+
+describe("RUNTIME_EXCLUSION_PATHS", () => {
+  it("is an array with entries", () => {
+    assert.ok(Array.isArray(RUNTIME_EXCLUSION_PATHS), "is an array");
+    assert.ok(RUNTIME_EXCLUSION_PATHS.length > 0, "has at least one entry");
+  });
+
+  it("all entries start with .kata-cli/ prefix", () => {
+    for (const p of RUNTIME_EXCLUSION_PATHS) {
+      assert.ok(p.startsWith(".kata-cli/"), `path starts with .kata-cli/: "${p}"`);
+    }
+  });
+
+  it("includes .kata-cli/activity/", () => {
+    assert.ok(
+      RUNTIME_EXCLUSION_PATHS.includes(".kata-cli/activity/"),
+      "includes .kata-cli/activity/",
+    );
+  });
+
+  it("includes .kata-cli/auto.lock", () => {
+    assert.ok(
+      RUNTIME_EXCLUSION_PATHS.includes(".kata-cli/auto.lock"),
+      "includes .kata-cli/auto.lock",
+    );
+  });
+
+  it("includes .kata-cli/STATE.md", () => {
+    assert.ok(
+      RUNTIME_EXCLUSION_PATHS.includes(".kata-cli/STATE.md"),
+      "includes .kata-cli/STATE.md",
+    );
+  });
+
+  it("includes .kata-cli/metrics.json", () => {
+    assert.ok(
+      RUNTIME_EXCLUSION_PATHS.includes(".kata-cli/metrics.json"),
+      "includes .kata-cli/metrics.json",
+    );
+  });
+
+  it("includes .kata-cli/completed-units.json", () => {
+    assert.ok(
+      RUNTIME_EXCLUSION_PATHS.includes(".kata-cli/completed-units.json"),
+      "includes .kata-cli/completed-units.json",
+    );
+  });
+
+  it("includes .kata-cli/worktrees/", () => {
+    assert.ok(
+      RUNTIME_EXCLUSION_PATHS.includes(".kata-cli/worktrees/"),
+      "includes .kata-cli/worktrees/",
+    );
+  });
+
+  it("does not contain any .gsd/ paths", () => {
+    for (const p of RUNTIME_EXCLUSION_PATHS) {
+      assert.ok(!p.startsWith(".gsd/"), `no .gsd/ paths — found: "${p}"`);
+    }
+  });
+});
+
+// ─── VALID_BRANCH_NAME ────────────────────────────────────────────────────────
+
+describe("VALID_BRANCH_NAME", () => {
+  it("accepts 'main'", () => assert.ok(VALID_BRANCH_NAME.test("main")));
+  it("accepts 'master'", () => assert.ok(VALID_BRANCH_NAME.test("master")));
+  it("accepts 'develop'", () => assert.ok(VALID_BRANCH_NAME.test("develop")));
+  it("accepts 'feature/foo'", () => assert.ok(VALID_BRANCH_NAME.test("feature/foo")));
+  it("accepts 'release-1.0'", () => assert.ok(VALID_BRANCH_NAME.test("release-1.0")));
+  it("accepts 'my_branch'", () => assert.ok(VALID_BRANCH_NAME.test("my_branch")));
+  it("accepts 'v2.0.1'", () => assert.ok(VALID_BRANCH_NAME.test("v2.0.1")));
+  it("accepts 'kata/M001/S01'", () => assert.ok(VALID_BRANCH_NAME.test("kata/M001/S01")));
+
+  it("rejects shell injection 'main; rm -rf /'", () => {
+    assert.ok(!VALID_BRANCH_NAME.test("main; rm -rf /"));
+  });
+
+  it("rejects '&& injection'", () => {
+    assert.ok(!VALID_BRANCH_NAME.test("main && echo pwned"));
+  });
+
+  it("rejects empty string", () => {
+    assert.ok(!VALID_BRANCH_NAME.test(""));
+  });
+
+  it("rejects spaces in branch name", () => {
+    assert.ok(!VALID_BRANCH_NAME.test("branch name"));
+  });
+
+  it("rejects backtick injection", () => {
+    assert.ok(!VALID_BRANCH_NAME.test("branch`cmd`"));
+  });
+
+  it("rejects $() subshell injection", () => {
+    assert.ok(!VALID_BRANCH_NAME.test("branch$(cmd)"));
+  });
+});
+
+// ─── runGit ───────────────────────────────────────────────────────────────────
+
+describe("runGit", () => {
+  // Use an empty repo (no commits) so `git log` will fail — tests both
+  // success and failure paths without needing an initial commit.
+  let repo: string;
+
+  beforeAll(() => {
+    repo = initEmptyRepo();
+  });
+
+  afterAll(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("returns git command output on success", () => {
+    const branch = runGit(repo, ["branch", "--show-current"]);
+    assert.equal(branch, "main");
+  });
+
+  it("allowFailure: true returns empty string on error", () => {
+    const result = runGit(repo, ["log", "--oneline"], { allowFailure: true });
+    assert.equal(result, "");
+  });
+
+  it("throws an Error on failure when allowFailure is not set", () => {
+    assert.throws(
+      () => runGit(repo, ["log", "--oneline"]),
+      (err: unknown) => {
+        assert.ok(err instanceof Error, "throws an Error instance");
+        // Error message should identify the failed git command
+        const msg = (err as Error).message;
+        assert.ok(
+          msg.includes("log") || msg.includes("failed") || msg.length > 0,
+          `error message is descriptive: "${msg}"`,
+        );
+        return true;
+      },
+    );
+  });
+});
+
+// ─── type exports compile checks ─────────────────────────────────────────────
+
+describe("type exports", () => {
+  it("GitPreferences is usable as a type", () => {
+    // Compile-time check: if we reach here the type imported correctly
+    const _prefs: GitPreferences = { auto_push: true, remote: "origin" };
+    assert.ok(true);
+  });
+
+  it("CommitOptions is usable as a type", () => {
+    const _opts: CommitOptions = { message: "test" };
+    assert.ok(true);
+  });
+
+  it("TaskCommitContext is usable as a type", () => {
+    const _ctx: TaskCommitContext = {
+      taskId: "S01/T01",
+      taskTitle: "test task",
+    };
+    assert.ok(true);
+  });
+});
+
+// ─── smart staging — runtime file exclusions ──────────────────────────────────
+
+describe("smart staging — runtime file exclusions", () => {
+  it("excludes .kata-cli/ runtime files from commit; commits real source files", () => {
+    const repo = initRepo();
+    try {
+      // Create runtime files (should be excluded from staging)
+      createFile(repo, ".kata-cli/activity/log.jsonl", "log data");
+      createFile(repo, ".kata-cli/runtime/state.json", '{"state":true}');
+      createFile(repo, ".kata-cli/STATE.md", "# State");
+      createFile(repo, ".kata-cli/auto.lock", "lock");
+      createFile(repo, ".kata-cli/metrics.json", "{}");
+      createFile(repo, ".kata-cli/worktrees/wt/file.txt", "wt data");
+
+      // Create a real source file (should be staged and committed)
+      createFile(repo, "src/code.ts", 'console.log("hello");');
+
+      const msg = autoCommitCurrentBranch(repo, "task", "T01");
+      assert.ok(msg !== null, "autoCommit succeeds when real source file is present");
+
+      // Only the real source file should be in the commit
+      const showStat = gitRaw(["show", "--stat", "--format=", "HEAD"], repo);
+      assert.ok(showStat.includes("src/code.ts"), "src/code.ts is in the commit");
+      assert.ok(
+        !showStat.includes(".kata-cli/activity"),
+        ".kata-cli/activity/ excluded from commit",
+      );
+      assert.ok(
+        !showStat.includes(".kata-cli/runtime"),
+        ".kata-cli/runtime/ excluded from commit",
+      );
+      assert.ok(!showStat.includes("STATE.md"), ".kata-cli/STATE.md excluded from commit");
+      assert.ok(!showStat.includes("auto.lock"), ".kata-cli/auto.lock excluded from commit");
+      assert.ok(!showStat.includes("metrics.json"), ".kata-cli/metrics.json excluded from commit");
+      assert.ok(
+        !showStat.includes(".kata-cli/worktrees"),
+        ".kata-cli/worktrees/ excluded from commit",
+      );
+
+      // Runtime files should still be untracked after commit
+      const statusOut = gitRaw(["status", "--short", "--untracked-files=all"], repo);
+      assert.ok(
+        statusOut.includes(".kata-cli/activity/"),
+        ".kata-cli/activity/ still untracked after commit",
+      );
+      assert.ok(
+        statusOut.includes(".kata-cli/runtime/"),
+        ".kata-cli/runtime/ still untracked after commit",
+      );
+      assert.ok(
+        statusOut.includes(".kata-cli/STATE.md"),
+        ".kata-cli/STATE.md still untracked after commit",
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── smart staging — tracked runtime file cleanup (_runtimeFilesCleanedUp) ───
+
+describe("smart staging — tracked runtime file cleanup", () => {
+  it(
+    "removes previously-tracked .kata-cli/ files from index before committing real files",
+    () => {
+      const repo = initRepo();
+      try {
+        // Simulate: .kata-cli/ runtime files were previously force-added to git
+        // (mirrors the historical bug where files were accidentally tracked)
+        createFile(repo, ".kata-cli/metrics.json", '{"version":1}');
+        createFile(repo, ".kata-cli/completed-units.json", '["unit1"]');
+        createFile(repo, ".kata-cli/activity/log.jsonl", '{"ts":1}');
+        createFile(repo, "src/real.ts", "real code");
+
+        execFileSync(
+          "git",
+          [
+            "add",
+            "-f",
+            ".kata-cli/metrics.json",
+            ".kata-cli/completed-units.json",
+            ".kata-cli/activity/log.jsonl",
+            "src/real.ts",
+          ],
+          { cwd: repo },
+        );
+        execFileSync("git", ["commit", "-m", "init with tracked runtime files"], { cwd: repo });
+
+        // Add .gitignore to exclude .kata-cli/ (mirrors real-world setup)
+        createFile(repo, ".gitignore", ".kata-cli/\n");
+        execFileSync("git", ["add", ".gitignore"], { cwd: repo });
+        execFileSync("git", ["commit", "-m", "add gitignore"], { cwd: repo });
+
+        // Precondition: runtime files are tracked in the git index
+        const tracked = gitRaw(["ls-files", ".kata-cli/"], repo);
+        assert.ok(tracked.includes("metrics.json"), "precondition: metrics.json is tracked");
+        assert.ok(
+          tracked.includes("completed-units.json"),
+          "precondition: completed-units.json is tracked",
+        );
+        assert.ok(
+          tracked.includes("activity/log.jsonl"),
+          "precondition: activity log is tracked",
+        );
+
+        // Modify both runtime files and a real source file
+        createFile(repo, ".kata-cli/metrics.json", '{"version":2}');
+        createFile(repo, ".kata-cli/completed-units.json", '["unit1","unit2"]');
+        createFile(repo, ".kata-cli/activity/log.jsonl", '{"ts":2}');
+        createFile(repo, "src/real.ts", "updated code");
+
+        // First autoCommit: commits real.ts; auto-cleanup removes runtime files from index
+        const msg = autoCommitCurrentBranch(repo, "execute-task", "M001/S01/T01");
+        assert.ok(msg !== null, "first autoCommit produces a commit");
+
+        const show = gitRaw(["show", "--stat", "HEAD"], repo);
+        assert.ok(show.includes("src/real.ts"), "real files are in the commit");
+
+        // Runtime files must be removed from the git index after cleanup
+        const trackedAfter = gitRaw(["ls-files", ".kata-cli/"], repo);
+        assert.equal(trackedAfter, "", "no .kata-cli/ runtime files remain in the git index");
+
+        // Second autoCommit: runtime files still excluded (even after first cleanup)
+        createFile(repo, ".kata-cli/metrics.json", '{"version":3}');
+        createFile(repo, ".kata-cli/completed-units.json", '["unit1","unit2","unit3"]');
+        createFile(repo, "src/real.ts", "third version");
+
+        const msg2 = autoCommitCurrentBranch(repo, "execute-task", "M001/S01/T02");
+        assert.ok(msg2 !== null, "second autoCommit produces a commit");
+
+        const show2 = gitRaw(["show", "--stat", "HEAD"], repo);
+        assert.ok(show2.includes("src/real.ts"), "real files committed in second commit");
+        assert.ok(!show2.includes("metrics"), "metrics.json not in second commit");
+        assert.ok(!show2.includes("completed-units"), "completed-units.json not in second commit");
+        assert.ok(!show2.includes("activity"), "activity log not in second commit");
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+// ─── autoCommitCurrentBranch ──────────────────────────────────────────────────
+
+describe("autoCommitCurrentBranch — clean repo", () => {
+  it("returns null when repo is clean (nothing to commit)", () => {
+    const repo = initRepo();
+    try {
+      const result = autoCommitCurrentBranch(repo, "task", "T01");
+      assert.equal(result, null);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("autoCommitCurrentBranch — dirty repo without taskContext", () => {
+  it("returns generic commit message format", () => {
+    const repo = initRepo();
+    try {
+      createFile(repo, "src/new-feature.ts", "export const x = 1;");
+
+      const msg = autoCommitCurrentBranch(repo, "task", "T01");
+      assert.equal(msg, "chore(T01): auto-commit after task");
+
+      const log = gitRaw(["log", "--oneline", "-1"], repo);
+      assert.ok(
+        log.includes("chore(T01): auto-commit after task"),
+        "generic message appears in git log",
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("autoCommitCurrentBranch — dirty repo with taskContext", () => {
+  it("returns meaningful commit message using taskContext", () => {
+    const repo = initRepo();
+    try {
+      createFile(repo, "src/auth.ts", "export function login() {}");
+
+      const ctx: TaskCommitContext = {
+        taskId: "S01/T02",
+        taskTitle: "implement user authentication endpoint",
+        oneLiner: "Added JWT-based auth with refresh token rotation",
+        keyFiles: ["src/auth.ts"],
+      };
+
+      const msg = autoCommitCurrentBranch(repo, "task", "S01/T02", ctx);
+      assert.ok(msg !== null, "returns a non-null message with task context");
+      assert.ok(msg!.startsWith("feat(S01/T02):"), "uses feat type and task scope");
+      assert.ok(msg!.includes("JWT-based auth"), "includes one-liner content");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("autoCommitCurrentBranch — empty-after-staging guard", () => {
+  it("returns null when only runtime files are dirty", () => {
+    const repo = initRepo();
+    try {
+      // Create only runtime files — no real source changes
+      createFile(repo, ".kata-cli/activity/x.jsonl", "data");
+
+      const result = autoCommitCurrentBranch(repo, "task", "T02");
+      assert.equal(result, null, "returns null when only runtime files are dirty");
+
+      // No new commit should have been created (still at the init commit)
+      const logCount = gitRaw(["rev-list", "--count", "HEAD"], repo);
+      assert.equal(logCount, "1", "no new commit created when only runtime files changed");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── commit ───────────────────────────────────────────────────────────────────
+
+describe("commit", () => {
+  it("returns null when nothing is staged", () => {
+    const repo = initRepo();
+    try {
+      // Clean repo: no changes staged — commit should be a no-op
+      const result = commit(repo, { message: "should not commit" });
+      assert.equal(result, null);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── getCurrentBranch ─────────────────────────────────────────────────────────
+
+describe("getCurrentBranch", () => {
+  it("returns 'main' on main branch", () => {
+    const repo = initRepo("main");
+    try {
+      assert.equal(getCurrentBranch(repo), "main");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("returns slice branch name kata/M001/S01", () => {
+    const repo = initRepo("main");
+    try {
+      execFileSync("git", ["checkout", "-b", "kata/M001/S01"], { cwd: repo });
+      assert.equal(getCurrentBranch(repo), "kata/M001/S01");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("returns feature branch name", () => {
+    const repo = initRepo("main");
+    try {
+      execFileSync("git", ["checkout", "-b", "feature/foo"], { cwd: repo });
+      assert.equal(getCurrentBranch(repo), "feature/foo");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── getMainBranch ────────────────────────────────────────────────────────────
+
+describe("getMainBranch", () => {
+  it("returns 'main' when repo has a main branch", () => {
+    const repo = initRepo("main");
+    try {
+      assert.equal(getMainBranch(repo), "main");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 'master' when repo only has a master branch", () => {
+    const repo = initRepo("master");
+    try {
+      assert.equal(getMainBranch(repo), "master");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to current branch when neither main nor master exists", () => {
+    const repo = initRepo("trunk");
+    try {
+      // No 'main' or 'master' branch — should fall back
+      const branch = getMainBranch(repo);
+      assert.equal(branch, "trunk");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What Changed
See slice plan: S01: (no slice plan found)

## Must-Haves
- See slice plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Git Service for the Kata CLI with branch management, conventional commit message generation, staging, merge operations, and conflict error handling.

* **Tests**
  * Added comprehensive test suite covering branch operations, commit message inference, staging, merge scenarios, and conflict detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the `git-service` extension from `gsd-pi` into the Kata CLI, introducing core git primitives — `runGit`, `smartStage`, `commit`, `autoCommitCurrentBranch`, `mergeSliceToMain` — along with supporting types, constants, and a comprehensive integration test suite that exercises these against real temporary git repositories.

The foundational pieces (`runGit`, `inferCommitType`, `buildTaskCommitMessage`, smart staging, branch detection) are well-implemented and well-tested. The top-level merge workflow in `mergeSliceToMain`, however, has two logic bugs and no test coverage:

- **Silent false-success on empty squash** (`git-service.ts` line 483): the return value of `commit()` is discarded. When a squash produces nothing staged (empty or already-merged slice), `commit()` returns `null` but `mergeSliceToMain` still returns a successful `MergeSliceResult` with a `mergedCommitMessage`, misleading callers into thinking a real commit was created.
- **`merge_strategy: "merge"` silently ignored** (`git-service.ts` line 462): `mergeSliceToMain` always executes `git merge --squash` regardless of `prefs.merge_strategy`. The `MergeConflictError` propagates the pref value as `strategy`, creating a contradictory message if the user configured `"merge"`.
- **Negative `maxDescLen`** (`git-service.ts` line 226): if `taskId` is long enough that `68 - type.length - scope.length < 0`, `description.slice(0, maxDescLen - 1)` truncates from the *end* of the string rather than the beginning, producing an over-long subject line.
- **`mergeSliceToMain` and `MergeConflictError` have zero test coverage** in the test file, which is notable given the bugs found above.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge without fixing the silent false-success in mergeSliceToMain and the ignored merge_strategy preference.
- The pure-helper and staging layers are solid and well-tested, but mergeSliceToMain — the most consequential function in the module — has two correctness bugs and no test coverage. The discarded commit() return value means callers can receive a success signal for a merge that produced no commit, which is a silent data-loss risk. Score of 3 reflects solid foundations marred by untested, buggy top-level merge logic.
- apps/cli/src/resources/extensions/kata/git-service.ts (mergeSliceToMain, buildTaskCommitMessage) and apps/cli/src/resources/extensions/kata/tests/git-service.test.ts (missing mergeSliceToMain coverage)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/git-service.ts | New git service module with solid foundations (runGit, smartStage, inferCommitType) but mergeSliceToMain has two logic bugs: the commit() return value is discarded (silent no-commit on empty squash), and merge_strategy: "merge" preference is silently ignored while MergeConflictError still reports it, creating a misleading mismatch. buildTaskCommitMessage also has an edge case with negative maxDescLen for long taskId scopes. |
| apps/cli/src/resources/extensions/kata/tests/git-service.test.ts | Comprehensive integration tests for pure helpers and staging logic using real temp git repos; however, the most complex exported function (mergeSliceToMain) and the MergeConflictError class have zero test coverage. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant mergeSliceToMain
    participant runGit
    participant commit

    Caller->>mergeSliceToMain: mergeSliceToMain(basePath, milestoneId, sliceId, sliceTitle, prefs)
    mergeSliceToMain->>runGit: getCurrentBranch → sliceBranch
    mergeSliceToMain->>runGit: getMainBranch → mainBranch
    mergeSliceToMain->>runGit: git switch mainBranch
    mergeSliceToMain->>runGit: git merge --squash sliceBranch
    alt Merge conflict
        runGit-->>mergeSliceToMain: throws
        mergeSliceToMain->>runGit: git diff --name-only --diff-filter=U
        runGit-->>mergeSliceToMain: conflictedFiles[]
        mergeSliceToMain-->>Caller: throws MergeConflictError
    else Squash OK
        runGit-->>mergeSliceToMain: success
        mergeSliceToMain->>commit: commit(basePath, squashMsg)
        commit->>runGit: git diff --cached --name-only
        alt Nothing staged (empty slice) ⚠️
            commit-->>mergeSliceToMain: null (return value discarded!)
            mergeSliceToMain-->>Caller: MergeSliceResult (false success)
        else Files staged
            commit->>runGit: git commit -F - (stdin)
            runGit-->>commit: success
            commit-->>mergeSliceToMain: squashMsg
            mergeSliceToMain-->>Caller: MergeSliceResult{branch, mergedCommitMessage, deletedBranch:false}
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/git-service.ts
Line: 483-485

Comment:
**Silent no-commit on empty squash**

`commit()` returns `null` when nothing is staged (e.g. the slice branch has no net diff against `mainBranch`). Here the return value is discarded, so `mergeSliceToMain` reports a successful merge and returns a `mergedCommitMessage` even though **no commit was ever created**. Callers that trust the non-null result to indicate a real commit will have incorrect state.

```suggestion
  const squashMsg = `feat(${milestoneId}/${sliceId}): ${sliceTitle}`;
  const committed = commit(basePath, { message: squashMsg });
  if (!committed) {
    throw new Error(
      `Squash of ${sliceBranch} into ${mainBranch} staged nothing — slice may be empty or already merged`,
    );
  }

  return { branch: sliceBranch, mergedCommitMessage: squashMsg, deletedBranch: false };
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/git-service.ts
Line: 462

Comment:
**`merge_strategy: "merge"` silently ignored**

`GitPreferences.merge_strategy` accepts both `"squash"` and `"merge"`, but `mergeSliceToMain` always calls `git merge --squash` regardless of the preference value. The `MergeConflictError` below even propagates `prefs?.merge_strategy ?? "squash"` in its `strategy` field — so if a user has `merge_strategy: "merge"`, the error would claim the strategy was `"merge"` while the code actually performed a squash. Either the non-squash path should be implemented, or the `merge_strategy` type should be narrowed to only `"squash"` until the regular-merge path is added.

```
// Current — merge_strategy preference is never consulted:
runGit(basePath, ["merge", "--squash", sliceBranch]);

// Should branch on prefs?.merge_strategy:
if ((prefs?.merge_strategy ?? "squash") === "squash") {
  runGit(basePath, ["merge", "--squash", sliceBranch]);
} else {
  runGit(basePath, ["merge", "--no-ff", sliceBranch]);
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/git-service.ts
Line: 226

Comment:
**Negative `maxDescLen` for long `taskId` + type combinations**

`maxDescLen` is computed as `68 - type.length - scope.length`. `type` can be up to 8 chars (`"refactor"`), and there is no cap on `taskId`/`scope` length. If `scope.length > 60`, `maxDescLen` goes negative, and `description.slice(0, maxDescLen - 1)` becomes something like `description.slice(0, -10)` — which strips 10 chars from the **end** of the string rather than trimming to the desired length, leaving an over-long subject line.

Adding a guard prevents the subject from exceeding the 72-char budget:

```suggestion
  const maxDescLen = Math.max(1, 68 - type.length - scope.length);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/tests/git-service.test.ts
Line: 1-20

Comment:
**No tests for `mergeSliceToMain` or `MergeConflictError`**

`mergeSliceToMain` is the most complex exported function in `git-service.ts` — it orchestrates a branch switch, squash-merge, conflict detection, and commit — but the test file imports neither it nor `MergeConflictError`. Given the logic bug identified above (discarded `commit()` return value), and the untested `merge_strategy` branching, this function has zero test coverage. At minimum, the following cases should be covered:

- Happy path: slice branch with commits → squash merged and committed onto `mainBranch`
- Empty/already-merged slice → function should not silently succeed
- Conflict scenario → `MergeConflictError` thrown with correct `conflictedFiles` populated

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(S01/T03): imple..."](https://github.com/gannonh/kata/commit/cc7c8846d9d02bb67c197876b58aec054ae1a194)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->