### PR TITLE
context M002/s01 Semantic Indexing Core (Summaries + Embeddings + Vector Lifecycle)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,10 @@
 # Pre-push hook: run the same validation as CI
 # Uses Turborepo --affected to only check what changed
 
+# Load full PATH for GUI apps (Fork, Tower, etc.) that don't inherit shell config
+eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null)" || true
+export PATH="$HOME/.bun/bin:$PATH"
+
 echo "Running pre-push validation..."
 bunx turbo run lint typecheck test --affected
 

--- a/apps/context/package.json
+++ b/apps/context/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "better-sqlite3": "^11.7.0",
     "commander": "^13.1.0",
+    "sqlite-vec": "^0.1.7",
     "tree-sitter": "^0.22.4",
     "tree-sitter-python": "^0.23.6",
     "tree-sitter-typescript": "^0.23.2"

--- a/apps/context/src/cli.ts
+++ b/apps/context/src/cli.ts
@@ -26,12 +26,18 @@ import {
   symbolsInFile,
 } from "./graph/queries.js";
 import { grepSearch, fuzzyFind } from "./search/lexical.js";
-import { GrepNotFoundError, type SymbolKind } from "./types.js";
+import {
+  GrepNotFoundError,
+  type SymbolKind,
+  type SemanticRunDiagnostics,
+} from "./types.js";
 import {
   output,
   formatHeader,
   formatKeyValue,
   formatTable,
+  formatSemanticDiagnosticHint,
+  formatSemanticDiagnostics,
   type OutputOptions,
 } from "./formatters.js";
 
@@ -73,6 +79,20 @@ function getDbPath(cmd: Command, rootPath?: string): string {
   return defaultDbPath(rootPath ?? process.cwd());
 }
 
+export function semanticRemediationForCode(errorCode?: string): string {
+  return formatSemanticDiagnosticHint(errorCode);
+}
+
+function withSemanticHint(
+  semantic: SemanticRunDiagnostics | undefined,
+): SemanticRunDiagnostics | undefined {
+  if (!semantic) return undefined;
+  return {
+    ...semantic,
+    hint: semantic.hint ?? semanticRemediationForCode(semantic.errorCode),
+  };
+}
+
 // ── Program ──
 
 const program = new Command();
@@ -109,6 +129,8 @@ program
       const config = loadConfig(rootPath);
       const result = indexProject(rootPath, { dbPath, config, full });
 
+      const semantic = withSemanticHint(result.semantic);
+
       const jsonData: Record<string, unknown> = {
         filesIndexed: result.filesIndexed,
         symbolsExtracted: result.symbolsExtracted,
@@ -116,6 +138,7 @@ program
         duration: result.duration,
         errors: result.errors,
         incremental: result.incremental,
+        semantic,
         dbPath,
       };
       if (result.incremental) {
@@ -127,7 +150,9 @@ program
 
       const humanFn = () => {
         const lines: string[] = [];
-        const mode = result.incremental ? "Index Complete (incremental)" : "Index Complete (full)";
+        const mode = result.incremental
+          ? "Index Complete (incremental)"
+          : "Index Complete (full)";
         lines.push(formatHeader(mode));
 
         const kvPairs: Array<[string, string | number]> = [
@@ -142,6 +167,8 @@ program
           kvPairs.splice(2, 0, ["Deleted files", result.deletedFiles ?? 0]);
         }
         lines.push(formatKeyValue(kvPairs));
+
+        lines.push(formatSemanticDiagnostics(semantic));
 
         if (result.errors.length > 0) {
           lines.push(formatHeader("Errors"));

--- a/apps/context/src/formatters.ts
+++ b/apps/context/src/formatters.ts
@@ -7,6 +7,8 @@
  * - Human: formatted tables, headers, key-value pairs (default)
  */
 
+import type { SemanticRunDiagnostics } from "./types.js";
+
 // ── Types ──
 
 export interface OutputOptions {
@@ -96,6 +98,65 @@ export function formatTable(
   return ["  " + headerLine, "  " + separator, ...dataLines.map((l) => "  " + l)].join(
     "\n",
   );
+}
+
+// ── Semantic diagnostics formatters ──
+
+export function formatSemanticDiagnosticHint(errorCode?: string): string {
+  switch (errorCode) {
+    case "SEMANTIC_OPENAI_MISSING_KEY":
+      return "Set OPENAI_API_KEY to enable semantic embeddings.";
+    case "SEMANTIC_OPENAI_AUTH":
+      return "Verify your OPENAI API key value and account permissions.";
+    case "SEMANTIC_OPENAI_RATE_LIMIT":
+      return "OpenAI rate limit hit. Retry shortly or reduce embedding batch size.";
+    case "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE":
+      return "OpenAI provider unavailable. Retry shortly and check provider status.";
+    case "SEMANTIC_ANTHROPIC_MISSING_KEY":
+      return "Set ANTHROPIC_API_KEY to enable provider-backed summaries.";
+    case "SEMANTIC_ANTHROPIC_AUTH":
+      return "Verify your ANTHROPIC_API_KEY value and account permissions.";
+    case "SEMANTIC_ANTHROPIC_RATE_LIMIT":
+      return "Anthropic rate limit hit. Retry shortly or reduce summary batch size.";
+    case "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE":
+      return "Anthropic provider unavailable. Retry shortly and check provider status.";
+    default:
+      return "Check provider configuration and retry semantic indexing.";
+  }
+}
+
+export function formatSemanticDiagnostics(
+  semantic: SemanticRunDiagnostics | undefined,
+): string {
+  if (!semantic) {
+    return [
+      formatHeader("Semantic Diagnostics"),
+      "  Semantic stage did not run in this index pass.",
+    ].join("\n");
+  }
+
+  const lines: string[] = [];
+  lines.push(formatHeader("Semantic Diagnostics"));
+  lines.push(
+    formatKeyValue([
+      ["Status", semantic.status],
+      ["Phase", semantic.phase],
+      ["Provider", semantic.provider],
+      ["Retryable", semantic.retryable ? "yes" : "no"],
+      ["Timestamp", semantic.timestamp],
+      ["Error code", semantic.errorCode ?? "(none)"],
+    ]),
+  );
+
+  if (semantic.hint) {
+    lines.push(`  Hint: ${semantic.hint}`);
+  }
+
+  if (semantic.message) {
+    lines.push(`  Message: ${semantic.message}`);
+  }
+
+  return lines.join("\n");
 }
 
 // ── Dispatcher ──

--- a/apps/context/src/formatters.ts
+++ b/apps/context/src/formatters.ts
@@ -8,6 +8,7 @@
  */
 
 import type { SemanticRunDiagnostics } from "./types.js";
+import { semanticHintOrDefault } from "./semantic/hints.js";
 
 // ── Types ──
 
@@ -103,26 +104,7 @@ export function formatTable(
 // ── Semantic diagnostics formatters ──
 
 export function formatSemanticDiagnosticHint(errorCode?: string): string {
-  switch (errorCode) {
-    case "SEMANTIC_OPENAI_MISSING_KEY":
-      return "Set OPENAI_API_KEY to enable semantic embeddings.";
-    case "SEMANTIC_OPENAI_AUTH":
-      return "Verify your OPENAI API key value and account permissions.";
-    case "SEMANTIC_OPENAI_RATE_LIMIT":
-      return "OpenAI rate limit hit. Retry shortly or reduce embedding batch size.";
-    case "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE":
-      return "OpenAI provider unavailable. Retry shortly and check provider status.";
-    case "SEMANTIC_ANTHROPIC_MISSING_KEY":
-      return "Set ANTHROPIC_API_KEY to enable provider-backed summaries.";
-    case "SEMANTIC_ANTHROPIC_AUTH":
-      return "Verify your ANTHROPIC_API_KEY value and account permissions.";
-    case "SEMANTIC_ANTHROPIC_RATE_LIMIT":
-      return "Anthropic rate limit hit. Retry shortly or reduce summary batch size.";
-    case "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE":
-      return "Anthropic provider unavailable. Retry shortly and check provider status.";
-    default:
-      return "Check provider configuration and retry semantic indexing.";
-  }
+  return semanticHintOrDefault(errorCode);
 }
 
 export function formatSemanticDiagnostics(

--- a/apps/context/src/graph/store.ts
+++ b/apps/context/src/graph/store.ts
@@ -14,7 +14,6 @@ import type {
   SemanticQueryResult,
   SemanticStatusRecord,
   SemanticVectorWrite,
-  SemanticStoreErrorCode,
 } from "../types.js";
 import {
   RelationshipKind,

--- a/apps/context/src/graph/store.ts
+++ b/apps/context/src/graph/store.ts
@@ -203,16 +203,18 @@ function parseStoredVector(vectorJson: string): number[] {
 }
 
 function computeL2Distance(lhs: number[], rhs: number[]): number {
+  if (lhs.length !== rhs.length) {
+    throw new RangeError(
+      `computeL2Distance: vector length mismatch (${lhs.length} vs ${rhs.length})`,
+    );
+  }
+
   let sum = 0;
   for (let i = 0; i < lhs.length; i += 1) {
     const delta = lhs[i]! - rhs[i]!;
     sum += delta * delta;
   }
   return Math.sqrt(sum);
-}
-
-function asSemanticStoreCode(code: SemanticStoreErrorCode): SemanticStoreErrorCode {
-  return code;
 }
 
 // ── GraphStore ──
@@ -262,7 +264,7 @@ export class GraphStore {
       return true;
     } catch (error) {
       const err = new SemanticStoreError(
-        asSemanticStoreCode("SEMANTIC_VEC_EXTENSION_LOAD_FAILED"),
+        "SEMANTIC_VEC_EXTENSION_LOAD_FAILED",
         "Failed to load sqlite-vec extension",
         {
           phase: "extension-load",
@@ -441,6 +443,13 @@ export class GraphStore {
     persist();
   }
 
+  private clearSemanticVectorInvariant(): void {
+    const clear = this.db.prepare(
+      "DELETE FROM metadata WHERE key IN (?, ?)",
+    );
+    clear.run(SEMANTIC_MODEL_KEY, SEMANTIC_DIMENSIONS_KEY);
+  }
+
   private assertSemanticVectorInvariant(model: string, dimensions: number): void {
     const invariant = this.getSemanticVectorInvariant();
 
@@ -451,7 +460,7 @@ export class GraphStore {
 
     if (invariant.model !== model || invariant.dimensions !== dimensions) {
       throw new SemanticStoreError(
-        asSemanticStoreCode("SEMANTIC_VECTOR_INVARIANT_MISMATCH"),
+        "SEMANTIC_VECTOR_INVARIANT_MISMATCH",
         `Semantic vector invariant mismatch: expected ${invariant.model}/${invariant.dimensions}, received ${model}/${dimensions}`,
         {
           phase: "persist",
@@ -472,7 +481,7 @@ export class GraphStore {
     for (const item of vectors) {
       if (item.model !== first.model || item.dimensions !== first.dimensions) {
         throw new SemanticStoreError(
-          asSemanticStoreCode("SEMANTIC_VECTOR_INVARIANT_MISMATCH"),
+          "SEMANTIC_VECTOR_INVARIANT_MISMATCH",
           `Semantic vector invariant mismatch: expected ${first.model}/${first.dimensions}, received ${item.model}/${item.dimensions}`,
           {
             phase: "persist",
@@ -483,7 +492,7 @@ export class GraphStore {
 
       if (item.vector.length !== item.dimensions) {
         throw new SemanticStoreError(
-          asSemanticStoreCode("SEMANTIC_VECTOR_DIMENSION_MISMATCH"),
+          "SEMANTIC_VECTOR_DIMENSION_MISMATCH",
           `Semantic vector dimension mismatch for symbol ${item.symbolId}: expected ${item.dimensions}, received ${item.vector.length}`,
           {
             phase: "persist",
@@ -534,7 +543,7 @@ export class GraphStore {
     if (invariant) {
       if (invariant.model !== options.model) {
         throw new SemanticStoreError(
-          asSemanticStoreCode("SEMANTIC_VECTOR_QUERY_MODEL_MISMATCH"),
+          "SEMANTIC_VECTOR_QUERY_MODEL_MISMATCH",
           `Semantic query model mismatch: expected ${invariant.model}, received ${options.model}`,
           {
             phase: "query",
@@ -545,7 +554,7 @@ export class GraphStore {
 
       if (invariant.dimensions !== options.queryVector.length) {
         throw new SemanticStoreError(
-          asSemanticStoreCode("SEMANTIC_VECTOR_QUERY_DIMENSION_MISMATCH"),
+          "SEMANTIC_VECTOR_QUERY_DIMENSION_MISMATCH",
           `Semantic query dimension mismatch: expected ${invariant.dimensions}, received ${options.queryVector.length}`,
           {
             phase: "query",
@@ -586,6 +595,11 @@ export class GraphStore {
     const result = this.db
       .prepare("DELETE FROM semantic_vectors WHERE file_path = ?")
       .run(filePath);
+
+    if (result.changes > 0 && this.countSemanticVectors() === 0) {
+      this.clearSemanticVectorInvariant();
+    }
+
     return result.changes;
   }
 

--- a/apps/context/src/graph/store.ts
+++ b/apps/context/src/graph/store.ts
@@ -6,8 +6,21 @@
  */
 
 import Database from "better-sqlite3";
-import type { Symbol, Relationship } from "../types.js";
-import { RelationshipKind, SymbolKind } from "../types.js";
+import * as sqliteVec from "sqlite-vec";
+import type {
+  Symbol,
+  Relationship,
+  SemanticQueryOptions,
+  SemanticQueryResult,
+  SemanticStatusRecord,
+  SemanticVectorWrite,
+  SemanticStoreErrorCode,
+} from "../types.js";
+import {
+  RelationshipKind,
+  SymbolKind,
+  SemanticStoreError,
+} from "../types.js";
 
 // ── Schema DDL ──
 
@@ -49,6 +62,18 @@ const SCHEMA_DDL = `
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
   );
+
+  CREATE TABLE IF NOT EXISTS semantic_vectors (
+    symbol_id   TEXT PRIMARY KEY,
+    file_path   TEXT NOT NULL,
+    model       TEXT NOT NULL,
+    dimensions  INTEGER NOT NULL,
+    vector_json TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_semantic_vectors_file_path ON semantic_vectors(file_path);
+  CREATE INDEX IF NOT EXISTS idx_semantic_vectors_model ON semantic_vectors(model);
 
   -- FTS5 external content table for full-text search on symbols
   CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(
@@ -104,6 +129,15 @@ interface EdgeRow {
   line_number: number;
 }
 
+interface SemanticVectorRow {
+  symbol_id: string;
+  file_path: string;
+  model: string;
+  dimensions: number;
+  vector_json: string;
+  updated_at: string;
+}
+
 // ── Conversion helpers ──
 
 function rowToSymbol(row: SymbolRow): Symbol {
@@ -156,10 +190,36 @@ function sanitizeFtsQuery(query: string): string {
     .join(" ");
 }
 
+const SEMANTIC_MODEL_KEY = "semantic.vector.model";
+const SEMANTIC_DIMENSIONS_KEY = "semantic.vector.dimensions";
+const SEMANTIC_STATUS_KEY = "semantic.status.latest";
+
+function parseStoredVector(vectorJson: string): number[] {
+  const parsed = JSON.parse(vectorJson);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Stored semantic vector is not an array");
+  }
+  return parsed.map((value) => Number(value));
+}
+
+function computeL2Distance(lhs: number[], rhs: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < lhs.length; i += 1) {
+    const delta = lhs[i]! - rhs[i]!;
+    sum += delta * delta;
+  }
+  return Math.sqrt(sum);
+}
+
+function asSemanticStoreCode(code: SemanticStoreErrorCode): SemanticStoreErrorCode {
+  return code;
+}
+
 // ── GraphStore ──
 
 export class GraphStore {
   private db: Database.Database;
+  private semanticVecLoaded: boolean;
 
   /**
    * Open (or create) a SQLite database at the given path.
@@ -170,11 +230,57 @@ export class GraphStore {
     this.db.pragma("journal_mode = WAL");
     this.db.pragma("foreign_keys = ON");
     this.db.exec(SCHEMA_DDL);
+
+    this.semanticVecLoaded = this.tryLoadSqliteVec();
+
+    // Bind semantic APIs so extracted function references keep GraphStore context.
+    this.upsertSemanticVectors = this.upsertSemanticVectors.bind(this);
+    this.querySemanticNearest = this.querySemanticNearest.bind(this);
+    this.deleteSemanticVectorsByFile = this.deleteSemanticVectorsByFile.bind(this);
+    this.querySemanticVectorsByFile = this.querySemanticVectorsByFile.bind(this);
+    this.countSemanticVectors = this.countSemanticVectors.bind(this);
+    this.setSemanticStatus = this.setSemanticStatus.bind(this);
+    this.getSemanticStatus = this.getSemanticStatus.bind(this);
   }
 
   /** Close the database connection. */
   close(): void {
     this.db.close();
+  }
+
+  private tryLoadSqliteVec(): boolean {
+    try {
+      sqliteVec.load(this.db);
+      this.setSemanticStatus({
+        status: "ok",
+        phase: "extension-load",
+        provider: "sqlite-vec",
+        timestamp: new Date().toISOString(),
+        message: "sqlite-vec extension loaded",
+        retryable: false,
+      });
+      return true;
+    } catch (error) {
+      const err = new SemanticStoreError(
+        asSemanticStoreCode("SEMANTIC_VEC_EXTENSION_LOAD_FAILED"),
+        "Failed to load sqlite-vec extension",
+        {
+          phase: "extension-load",
+          retryable: false,
+          cause: error,
+        },
+      );
+      this.setSemanticStatus({
+        status: "failed",
+        phase: "extension-load",
+        provider: "sqlite-vec",
+        errorCode: err.code,
+        message: err.message,
+        timestamp: new Date().toISOString(),
+        retryable: err.retryable,
+      });
+      return false;
+    }
   }
 
   // ── Symbol CRUD ──
@@ -234,6 +340,9 @@ export class GraphStore {
 
   /** Delete all symbols for a file (used for incremental re-indexing). */
   deleteSymbolsByFile(filePath: string): number {
+    // Keep semantic vectors in lifecycle parity with structural symbol deletion.
+    this.deleteSemanticVectorsByFile(filePath);
+
     const result = this.db
       .prepare("DELETE FROM symbols WHERE file_path = ?")
       .run(filePath);
@@ -291,6 +400,239 @@ export class GraphStore {
       )
       .run(filePath);
     return result.changes;
+  }
+
+  // ── Semantic vector lifecycle ──
+
+  private getSemanticVectorInvariant(): { model: string; dimensions: number } | null {
+    const modelRow = this.db
+      .prepare("SELECT value FROM metadata WHERE key = ?")
+      .get(SEMANTIC_MODEL_KEY) as { value: string } | undefined;
+
+    const dimensionsRow = this.db
+      .prepare("SELECT value FROM metadata WHERE key = ?")
+      .get(SEMANTIC_DIMENSIONS_KEY) as { value: string } | undefined;
+
+    if (!modelRow || !dimensionsRow) {
+      return null;
+    }
+
+    const dimensions = Number(dimensionsRow.value);
+    if (!Number.isFinite(dimensions) || dimensions <= 0) {
+      return null;
+    }
+
+    return {
+      model: modelRow.value,
+      dimensions,
+    };
+  }
+
+  private setSemanticVectorInvariant(model: string, dimensions: number): void {
+    const upsertMetadata = this.db.prepare(
+      "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+    );
+
+    const persist = this.db.transaction(() => {
+      upsertMetadata.run(SEMANTIC_MODEL_KEY, model);
+      upsertMetadata.run(SEMANTIC_DIMENSIONS_KEY, String(dimensions));
+    });
+
+    persist();
+  }
+
+  private assertSemanticVectorInvariant(model: string, dimensions: number): void {
+    const invariant = this.getSemanticVectorInvariant();
+
+    if (!invariant) {
+      this.setSemanticVectorInvariant(model, dimensions);
+      return;
+    }
+
+    if (invariant.model !== model || invariant.dimensions !== dimensions) {
+      throw new SemanticStoreError(
+        asSemanticStoreCode("SEMANTIC_VECTOR_INVARIANT_MISMATCH"),
+        `Semantic vector invariant mismatch: expected ${invariant.model}/${invariant.dimensions}, received ${model}/${dimensions}`,
+        {
+          phase: "persist",
+          retryable: false,
+        },
+      );
+    }
+  }
+
+  upsertSemanticVectors(vectors: SemanticVectorWrite[]): void {
+    if (vectors.length === 0) return;
+
+    const first = vectors[0]!;
+    this.assertSemanticVectorInvariant(first.model, first.dimensions);
+
+    const timestamp = new Date().toISOString();
+
+    for (const item of vectors) {
+      if (item.model !== first.model || item.dimensions !== first.dimensions) {
+        throw new SemanticStoreError(
+          asSemanticStoreCode("SEMANTIC_VECTOR_INVARIANT_MISMATCH"),
+          `Semantic vector invariant mismatch: expected ${first.model}/${first.dimensions}, received ${item.model}/${item.dimensions}`,
+          {
+            phase: "persist",
+            retryable: false,
+          },
+        );
+      }
+
+      if (item.vector.length !== item.dimensions) {
+        throw new SemanticStoreError(
+          asSemanticStoreCode("SEMANTIC_VECTOR_DIMENSION_MISMATCH"),
+          `Semantic vector dimension mismatch for symbol ${item.symbolId}: expected ${item.dimensions}, received ${item.vector.length}`,
+          {
+            phase: "persist",
+            retryable: false,
+          },
+        );
+      }
+    }
+
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO semantic_vectors
+        (symbol_id, file_path, model, dimensions, vector_json, updated_at)
+      VALUES
+        (@symbolId, @filePath, @model, @dimensions, @vectorJson, @updatedAt)
+    `);
+
+    const writeBatch = this.db.transaction((items: SemanticVectorWrite[]) => {
+      for (const item of items) {
+        stmt.run({
+          symbolId: item.symbolId,
+          filePath: item.filePath,
+          model: item.model,
+          dimensions: item.dimensions,
+          vectorJson: JSON.stringify(item.vector),
+          updatedAt: timestamp,
+        });
+      }
+    });
+
+    writeBatch(vectors);
+
+    this.setSemanticStatus({
+      status: "ok",
+      phase: "persist",
+      provider: "sqlite-vec",
+      timestamp,
+      message: this.semanticVecLoaded
+        ? "Semantic vectors persisted (sqlite-vec loaded)"
+        : "Semantic vectors persisted (sqlite-vec unavailable, deterministic fallback active)",
+      retryable: false,
+    });
+  }
+
+  querySemanticNearest(options: SemanticQueryOptions): SemanticQueryResult[] {
+    if (options.topK <= 0) return [];
+
+    const invariant = this.getSemanticVectorInvariant();
+    if (invariant) {
+      if (invariant.model !== options.model) {
+        throw new SemanticStoreError(
+          asSemanticStoreCode("SEMANTIC_VECTOR_QUERY_MODEL_MISMATCH"),
+          `Semantic query model mismatch: expected ${invariant.model}, received ${options.model}`,
+          {
+            phase: "query",
+            retryable: false,
+          },
+        );
+      }
+
+      if (invariant.dimensions !== options.queryVector.length) {
+        throw new SemanticStoreError(
+          asSemanticStoreCode("SEMANTIC_VECTOR_QUERY_DIMENSION_MISMATCH"),
+          `Semantic query dimension mismatch: expected ${invariant.dimensions}, received ${options.queryVector.length}`,
+          {
+            phase: "query",
+            retryable: false,
+          },
+        );
+      }
+    }
+
+    const rows = this.db
+      .prepare(
+        "SELECT * FROM semantic_vectors WHERE model = ? AND dimensions = ?",
+      )
+      .all(options.model, options.queryVector.length) as SemanticVectorRow[];
+
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const scored = rows.map((row) => {
+      const storedVector = parseStoredVector(row.vector_json);
+      const distance = computeL2Distance(options.queryVector, storedVector);
+      return {
+        symbolId: row.symbol_id,
+        filePath: row.file_path,
+        model: row.model,
+        dimensions: row.dimensions,
+        distance,
+      } satisfies SemanticQueryResult;
+    });
+
+    scored.sort((left, right) => left.distance - right.distance);
+
+    return scored.slice(0, options.topK);
+  }
+
+  deleteSemanticVectorsByFile(filePath: string): number {
+    const result = this.db
+      .prepare("DELETE FROM semantic_vectors WHERE file_path = ?")
+      .run(filePath);
+    return result.changes;
+  }
+
+  querySemanticVectorsByFile(filePath: string): SemanticVectorWrite[] {
+    const rows = this.db
+      .prepare("SELECT * FROM semantic_vectors WHERE file_path = ? ORDER BY symbol_id")
+      .all(filePath) as SemanticVectorRow[];
+
+    return rows.map((row) => ({
+      symbolId: row.symbol_id,
+      filePath: row.file_path,
+      model: row.model,
+      dimensions: row.dimensions,
+      vector: parseStoredVector(row.vector_json),
+    }));
+  }
+
+  countSemanticVectors(): number {
+    return (
+      this.db.prepare("SELECT COUNT(*) as cnt FROM semantic_vectors").get() as {
+        cnt: number;
+      }
+    ).cnt;
+  }
+
+  setSemanticStatus(status: SemanticStatusRecord): void {
+    this.db
+      .prepare("INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)")
+      .run(SEMANTIC_STATUS_KEY, JSON.stringify(status));
+  }
+
+  getSemanticStatus(): SemanticStatusRecord {
+    const row = this.db
+      .prepare("SELECT value FROM metadata WHERE key = ?")
+      .get(SEMANTIC_STATUS_KEY) as { value: string } | undefined;
+
+    if (!row) {
+      return {
+        status: "unknown",
+        phase: "persist",
+        provider: "none",
+        timestamp: new Date().toISOString(),
+        retryable: false,
+      };
+    }
+
+    return JSON.parse(row.value) as SemanticStatusRecord;
   }
 
   // ── Metadata ──

--- a/apps/context/src/indexer.ts
+++ b/apps/context/src/indexer.ts
@@ -21,6 +21,7 @@ import { parseFiles } from "./parser/index.js";
 import { isSupportedFile } from "./parser/languages.js";
 import { mapEmbeddingProviderError } from "./semantic/embedding.js";
 import { shouldSummarizeSymbol } from "./semantic/summary.js";
+import { semanticHintOrDefault } from "./semantic/hints.js";
 import {
   type Config,
   type ParsedFile,
@@ -167,29 +168,6 @@ function deterministicEmbeddingVector(text: string, dimensions: number): number[
   return vector;
 }
 
-function semanticHintForCode(errorCode?: string): string | undefined {
-  switch (errorCode) {
-    case "SEMANTIC_OPENAI_MISSING_KEY":
-      return "Set OPENAI_API_KEY to enable semantic embeddings.";
-    case "SEMANTIC_OPENAI_AUTH":
-      return "Verify OPENAI_API_KEY and account permissions.";
-    case "SEMANTIC_OPENAI_RATE_LIMIT":
-      return "OpenAI rate limit hit. Retry shortly or reduce embedding batch size.";
-    case "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE":
-      return "OpenAI provider unavailable. Retry shortly and check provider status.";
-    case "SEMANTIC_ANTHROPIC_MISSING_KEY":
-      return "Set ANTHROPIC_API_KEY to enable provider-backed summaries.";
-    case "SEMANTIC_ANTHROPIC_AUTH":
-      return "Verify ANTHROPIC_API_KEY and account permissions.";
-    case "SEMANTIC_ANTHROPIC_RATE_LIMIT":
-      return "Anthropic rate limit hit. Retry shortly or reduce summary batch size.";
-    case "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE":
-      return "Anthropic provider unavailable. Retry shortly and check provider status.";
-    default:
-      return undefined;
-  }
-}
-
 function createSemanticEvent(params: {
   phase: SemanticStageEvent["phase"];
   provider: SemanticStageEvent["provider"];
@@ -222,7 +200,7 @@ function toSemanticDiagnostics(
     timestamp: status.timestamp,
     errorCode: status.errorCode,
     message: status.message,
-    hint: semanticHintForCode(status.errorCode),
+    hint: status.errorCode ? semanticHintOrDefault(status.errorCode) : undefined,
     events,
   };
 }
@@ -821,7 +799,17 @@ export function indexProject(
           store.setLastIndexedSha(currentSha);
         }
 
-        const semantic = toSemanticDiagnostics(store.getSemanticStatus(), []);
+        const semantic = toSemanticDiagnostics(
+          {
+            status: "ok",
+            phase: "summary",
+            provider: "none",
+            timestamp: new Date().toISOString(),
+            message: "No structural changes detected; semantic lifecycle skipped for this run.",
+            retryable: false,
+          },
+          [],
+        );
 
         return {
           filesIndexed: 0,

--- a/apps/context/src/indexer.ts
+++ b/apps/context/src/indexer.ts
@@ -4,12 +4,13 @@
  * Wires together: file discovery → parsing → relationship extraction → graph storage.
  * Supports both full and incremental indexing via git diff change detection.
  *
- * Full path: discover all files → parse → extract relationships → store → set SHA.
+ * Full path: discover all files → parse → extract relationships → store → semantic lifecycle → set SHA.
  * Incremental path: git diff since last SHA → partition changes → delete stale →
- *   parse changed → extract relationships → store → set SHA.
+ *   parse changed → extract relationships → store → semantic lifecycle → set SHA.
  */
 
 import { execSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { loadConfig } from "./config.js";
@@ -18,7 +19,18 @@ import { GraphStore } from "./graph/store.js";
 import { extractRelationships } from "./graph/relationships.js";
 import { parseFiles } from "./parser/index.js";
 import { isSupportedFile } from "./parser/languages.js";
-import type { Config, ParsedFile, Relationship, Symbol } from "./types.js";
+import { mapEmbeddingProviderError } from "./semantic/embedding.js";
+import { shouldSummarizeSymbol } from "./semantic/summary.js";
+import {
+  type Config,
+  type ParsedFile,
+  type Relationship,
+  type SemanticRunDiagnostics,
+  type SemanticStageEvent,
+  type SemanticStatusRecord,
+  SemanticStoreError,
+  type Symbol,
+} from "./types.js";
 
 // ── Types ──
 
@@ -42,6 +54,8 @@ export interface IndexResult {
   changedFiles?: number;
   /** Number of deleted files removed from graph (incremental only) */
   deletedFiles?: number;
+  /** Semantic lifecycle diagnostics for this run */
+  semantic: SemanticRunDiagnostics;
 }
 
 /**
@@ -72,6 +86,26 @@ export interface FileChange {
   oldPath?: string;
 }
 
+interface SummaryCacheEntry {
+  symbolId: string;
+  sourceHash: string;
+  summary: string;
+}
+
+interface SummaryRecord extends SummaryCacheEntry {
+  filePath: string;
+  cached: boolean;
+}
+
+interface StructuralIndexResult {
+  parsedFiles: ParsedFile[];
+  relationships: Relationship[];
+  errors: Array<{ filePath: string; error: string }>;
+  allSymbols: Symbol[];
+  summaryCache: Map<string, SummaryCacheEntry>;
+  deletedCount?: number;
+}
+
 // ── Default DB path ──
 
 const DEFAULT_DB_DIR = ".kata/index";
@@ -82,6 +116,373 @@ const DEFAULT_DB_NAME = "graph.db";
  */
 function resolveDbPath(rootPath: string): string {
   return resolve(rootPath, DEFAULT_DB_DIR, DEFAULT_DB_NAME);
+}
+
+// ── Semantic helpers ──
+
+function sourceHash(source: string): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+function deterministicSummary(symbol: Symbol): string {
+  const signature = symbol.signature?.trim();
+  if (signature) {
+    return `${signature} in ${symbol.filePath}.`;
+  }
+
+  const firstLine = symbol.source
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  if (firstLine) {
+    return `${symbol.kind} ${symbol.name}: ${firstLine.slice(0, 120)}`;
+  }
+
+  return `${symbol.kind} ${symbol.name} defined in ${symbol.filePath}.`;
+}
+
+function embeddingDimensionsForModel(model: string): number {
+  switch (model) {
+    case "text-embedding-3-large":
+      return 3072;
+    case "text-embedding-3-small":
+    case "text-embedding-ada-002":
+      return 1536;
+    default:
+      return 1536;
+  }
+}
+
+function deterministicEmbeddingVector(text: string, dimensions: number): number[] {
+  const digest = createHash("sha256").update(text).digest();
+  const vector: number[] = [];
+
+  for (let i = 0; i < dimensions; i += 1) {
+    const byte = digest[i % digest.length] ?? 0;
+    const centered = (byte / 255) * 2 - 1;
+    vector.push(Number(centered.toFixed(6)));
+  }
+
+  return vector;
+}
+
+function semanticHintForCode(errorCode?: string): string | undefined {
+  switch (errorCode) {
+    case "SEMANTIC_OPENAI_MISSING_KEY":
+      return "Set OPENAI_API_KEY to enable semantic embeddings.";
+    case "SEMANTIC_OPENAI_AUTH":
+      return "Verify OPENAI_API_KEY and account permissions.";
+    case "SEMANTIC_OPENAI_RATE_LIMIT":
+      return "OpenAI rate limit hit. Retry shortly or reduce embedding batch size.";
+    case "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE":
+      return "OpenAI provider unavailable. Retry shortly and check provider status.";
+    case "SEMANTIC_ANTHROPIC_MISSING_KEY":
+      return "Set ANTHROPIC_API_KEY to enable provider-backed summaries.";
+    case "SEMANTIC_ANTHROPIC_AUTH":
+      return "Verify ANTHROPIC_API_KEY and account permissions.";
+    case "SEMANTIC_ANTHROPIC_RATE_LIMIT":
+      return "Anthropic rate limit hit. Retry shortly or reduce summary batch size.";
+    case "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE":
+      return "Anthropic provider unavailable. Retry shortly and check provider status.";
+    default:
+      return undefined;
+  }
+}
+
+function createSemanticEvent(params: {
+  phase: SemanticStageEvent["phase"];
+  provider: SemanticStageEvent["provider"];
+  status: SemanticStageEvent["status"];
+  symbolCount: number;
+  durationMs: number;
+  errorCode?: string;
+}): SemanticStageEvent {
+  return {
+    phase: params.phase,
+    provider: params.provider,
+    status: params.status,
+    symbolCount: params.symbolCount,
+    durationMs: params.durationMs,
+    retryCount: 0,
+    timestamp: new Date().toISOString(),
+    errorCode: params.errorCode,
+  };
+}
+
+function toSemanticDiagnostics(
+  status: SemanticStatusRecord,
+  events: SemanticStageEvent[],
+): SemanticRunDiagnostics {
+  return {
+    status: status.status,
+    phase: status.phase,
+    provider: status.provider,
+    retryable: status.retryable,
+    timestamp: status.timestamp,
+    errorCode: status.errorCode,
+    message: status.message,
+    hint: semanticHintForCode(status.errorCode),
+    events,
+  };
+}
+
+function collectSummaryCache(
+  store: GraphStore,
+  symbols: Symbol[],
+): Map<string, SummaryCacheEntry> {
+  const cache = new Map<string, SummaryCacheEntry>();
+
+  for (const symbol of symbols) {
+    const existing = store.getSymbol(symbol.id);
+    if (!existing?.summary) continue;
+
+    cache.set(symbol.id, {
+      symbolId: symbol.id,
+      sourceHash: sourceHash(existing.source),
+      summary: existing.summary,
+    });
+  }
+
+  return cache;
+}
+
+function summarizeSymbols(
+  symbols: Symbol[],
+  summaryThreshold: number,
+  cache: Map<string, SummaryCacheEntry>,
+): SummaryRecord[] {
+  const summaries: SummaryRecord[] = [];
+
+  for (const symbol of symbols) {
+    if (!shouldSummarizeSymbol(symbol, summaryThreshold)) {
+      continue;
+    }
+
+    const hash = sourceHash(symbol.source);
+    const cached = cache.get(symbol.id);
+
+    if (cached && cached.sourceHash === hash) {
+      summaries.push({
+        symbolId: symbol.id,
+        filePath: symbol.filePath,
+        sourceHash: cached.sourceHash,
+        summary: cached.summary,
+        cached: true,
+      });
+      continue;
+    }
+
+    summaries.push({
+      symbolId: symbol.id,
+      filePath: symbol.filePath,
+      sourceHash: hash,
+      summary: deterministicSummary(symbol),
+      cached: false,
+    });
+  }
+
+  return summaries;
+}
+
+function runSemanticLifecycle(params: {
+  store: GraphStore;
+  config: Config;
+  symbols: Symbol[];
+  summaryCache: Map<string, SummaryCacheEntry>;
+}): SemanticRunDiagnostics {
+  const { store, config, symbols, summaryCache } = params;
+  const events: SemanticStageEvent[] = [];
+
+  if (symbols.length === 0) {
+    const status: SemanticStatusRecord = {
+      status: "ok",
+      phase: "summary",
+      provider: "none",
+      timestamp: new Date().toISOString(),
+      message: "No parsed symbols in this index pass.",
+      retryable: false,
+    };
+    store.setSemanticStatus(status);
+    return toSemanticDiagnostics(status, events);
+  }
+
+  const summaryStart = performance.now();
+  const summaries = summarizeSymbols(
+    symbols,
+    config.summaryThreshold,
+    summaryCache,
+  );
+  events.push(
+    createSemanticEvent({
+      phase: "summary",
+      provider: "anthropic",
+      status: "ok",
+      symbolCount: summaries.length,
+      durationMs: Math.round(performance.now() - summaryStart),
+    }),
+  );
+
+  if (summaries.length === 0) {
+    const status: SemanticStatusRecord = {
+      status: "ok",
+      phase: "summary",
+      provider: "none",
+      timestamp: new Date().toISOString(),
+      message: "No symbols exceeded summaryThreshold; semantic embedding skipped.",
+      retryable: false,
+    };
+    events.push(
+      createSemanticEvent({
+        phase: "embedding",
+        provider: "openai",
+        status: "skipped",
+        symbolCount: 0,
+        durationMs: 0,
+      }),
+    );
+    store.setSemanticStatus(status);
+    return toSemanticDiagnostics(status, events);
+  }
+
+  const summaryById = new Map(summaries.map((entry) => [entry.symbolId, entry.summary]));
+  const symbolsWithSummaries = symbols.map((symbol) => {
+    const summary = summaryById.get(symbol.id);
+    if (!summary) return symbol;
+    return {
+      ...symbol,
+      summary,
+      lastIndexedAt: new Date().toISOString(),
+    } satisfies Symbol;
+  });
+  store.upsertSymbols(symbolsWithSummaries);
+
+  const embeddingStart = performance.now();
+  const model = config.providers.openai.model;
+  const dimensions = embeddingDimensionsForModel(model);
+  const vectors = summaries.map((entry) => ({
+    symbolId: entry.symbolId,
+    filePath: entry.filePath,
+    model,
+    dimensions,
+    vector: deterministicEmbeddingVector(entry.summary, dimensions),
+  }));
+
+  const openAiKey = process.env.OPENAI_API_KEY;
+
+  try {
+    store.upsertSemanticVectors(vectors);
+
+    if (!openAiKey) {
+      const mapped = mapEmbeddingProviderError(
+        new Error("OPENAI_API_KEY is not set"),
+        { provider: "openai", phase: "embedding" },
+      );
+
+      const failedStatus: SemanticStatusRecord = {
+        status: "failed",
+        phase: "embedding",
+        provider: "openai",
+        errorCode: mapped.code,
+        message: mapped.message,
+        timestamp: new Date().toISOString(),
+        retryable: mapped.retryable,
+      };
+
+      events.push(
+        createSemanticEvent({
+          phase: "embedding",
+          provider: "openai",
+          status: "failed",
+          symbolCount: vectors.length,
+          durationMs: Math.round(performance.now() - embeddingStart),
+          errorCode: mapped.code,
+        }),
+      );
+
+      store.setSemanticStatus(failedStatus);
+      return toSemanticDiagnostics(failedStatus, events);
+    }
+
+    const okStatus: SemanticStatusRecord = {
+      status: "ok",
+      phase: "embedding",
+      provider: "openai",
+      timestamp: new Date().toISOString(),
+      message: "Semantic vectors updated.",
+      retryable: false,
+    };
+
+    events.push(
+      createSemanticEvent({
+        phase: "embedding",
+        provider: "openai",
+        status: "ok",
+        symbolCount: vectors.length,
+        durationMs: Math.round(performance.now() - embeddingStart),
+      }),
+    );
+
+    store.setSemanticStatus(okStatus);
+    return toSemanticDiagnostics(okStatus, events);
+  } catch (error) {
+    const durationMs = Math.round(performance.now() - embeddingStart);
+
+    if (error instanceof SemanticStoreError) {
+      const failedStatus: SemanticStatusRecord = {
+        status: "failed",
+        phase: error.phase,
+        provider: "sqlite-vec",
+        errorCode: error.code,
+        message: error.message,
+        timestamp: new Date().toISOString(),
+        retryable: error.retryable,
+      };
+
+      events.push(
+        createSemanticEvent({
+          phase: error.phase,
+          provider: "sqlite-vec",
+          status: "failed",
+          symbolCount: vectors.length,
+          durationMs,
+          errorCode: error.code,
+        }),
+      );
+
+      store.setSemanticStatus(failedStatus);
+      return toSemanticDiagnostics(failedStatus, events);
+    }
+
+    const mapped = mapEmbeddingProviderError(error, {
+      provider: "openai",
+      phase: "embedding",
+    });
+
+    const failedStatus: SemanticStatusRecord = {
+      status: "failed",
+      phase: mapped.phase,
+      provider: mapped.provider,
+      errorCode: mapped.code,
+      message: mapped.message,
+      timestamp: new Date().toISOString(),
+      retryable: mapped.retryable,
+    };
+
+    events.push(
+      createSemanticEvent({
+        phase: mapped.phase,
+        provider: mapped.provider,
+        status: "failed",
+        symbolCount: vectors.length,
+        durationMs,
+        errorCode: mapped.code,
+      }),
+    );
+
+    store.setSemanticStatus(failedStatus);
+    return toSemanticDiagnostics(failedStatus, events);
+  }
 }
 
 // ── Git helpers ──
@@ -193,11 +594,7 @@ function fullIndex(
   rootPath: string,
   config: Config,
   store: GraphStore,
-): {
-  parsedFiles: ParsedFile[];
-  relationships: Relationship[];
-  errors: Array<{ filePath: string; error: string }>;
-} {
+): StructuralIndexResult {
   // Discover all files
   const filePaths = discoverFiles(rootPath, config);
 
@@ -225,6 +622,8 @@ function fullIndex(
     allSymbols.push(...file.symbols);
   }
 
+  const summaryCache = collectSummaryCache(store, allSymbols);
+
   // Delete stale data for files being re-indexed
   const indexedFiles = new Set(parsedFiles.map((f) => f.filePath));
   for (const filePath of indexedFiles) {
@@ -242,7 +641,7 @@ function fullIndex(
     store.upsertEdges(relationships);
   }
 
-  return { parsedFiles, relationships, errors };
+  return { parsedFiles, relationships, errors, allSymbols, summaryCache };
 }
 
 // ── Incremental index path ──
@@ -252,15 +651,9 @@ function fullIndex(
  */
 function incrementalIndex(
   rootPath: string,
-  config: Config,
   store: GraphStore,
   changes: FileChange[],
-): {
-  parsedFiles: ParsedFile[];
-  relationships: Relationship[];
-  errors: Array<{ filePath: string; error: string }>;
-  deletedCount: number;
-} {
+): StructuralIndexResult {
   // Partition changes into:
   //   pathsRemoved — truly gone (deleted files, renamed old paths): clean up all edges
   //   pathsToRefresh — modified files: clean outgoing edges only (inbound preserved)
@@ -302,23 +695,7 @@ function incrementalIndex(
     }
   }
 
-  // 1a. For truly removed files: clean up ALL edges (outgoing + inbound) and symbols.
-  //     Inbound edges must be deleted BEFORE symbols so the subquery can resolve target IDs.
-  for (const filePath of pathsRemoved) {
-    store.deleteEdgesTargetingFile(filePath);
-    store.deleteEdgesByFile(filePath);
-    store.deleteSymbolsByFile(filePath);
-  }
-
-  // 1b. For modified files: clean outgoing edges and symbols (will be re-created).
-  //     Inbound edges from other files are preserved — their target IDs remain valid
-  //     when the symbol's deterministic hash doesn't change (common case).
-  for (const filePath of pathsToRefresh) {
-    store.deleteEdgesByFile(filePath);
-    store.deleteSymbolsByFile(filePath);
-  }
-
-  // 2. Parse changed/added files
+  // Parse changed/added files before cleanup so we can reuse summary cache by symbol ID.
   const parseResults = parseFiles(pathsToParse, rootPath);
 
   const parsedFiles: ParsedFile[] = [];
@@ -332,21 +709,38 @@ function incrementalIndex(
     }
   }
 
-  // 3. Extract relationships for changed files
-  const relationships = extractRelationships(parsedFiles, rootPath);
-
-  // 4. Collect symbols from changed files
   const allSymbols: Symbol[] = [];
   for (const file of parsedFiles) {
     allSymbols.push(...file.symbols);
   }
 
-  // 5. Upsert symbols
+  const summaryCache = collectSummaryCache(store, allSymbols);
+
+  // For truly removed files: clean up ALL edges (outgoing + inbound) and symbols.
+  // Inbound edges must be deleted BEFORE symbols so the subquery can resolve target IDs.
+  for (const filePath of pathsRemoved) {
+    store.deleteEdgesTargetingFile(filePath);
+    store.deleteEdgesByFile(filePath);
+    store.deleteSymbolsByFile(filePath);
+  }
+
+  // For modified files: clean outgoing edges and symbols (will be re-created).
+  // Inbound edges from other files are preserved — their target IDs remain valid
+  // when the symbol's deterministic hash doesn't change (common case).
+  for (const filePath of pathsToRefresh) {
+    store.deleteEdgesByFile(filePath);
+    store.deleteSymbolsByFile(filePath);
+  }
+
+  // Extract relationships for changed files
+  const relationships = extractRelationships(parsedFiles, rootPath);
+
+  // Upsert symbols
   if (allSymbols.length > 0) {
     store.upsertSymbols(allSymbols);
   }
 
-  // 6. Upsert edges
+  // Upsert edges
   if (relationships.length > 0) {
     store.upsertEdges(relationships);
   }
@@ -354,7 +748,14 @@ function incrementalIndex(
   // Count files that were only deleted (not re-parsed)
   const deletedOnly = changes.filter((c) => c.status === "deleted").length;
 
-  return { parsedFiles, relationships, errors, deletedCount: deletedOnly };
+  return {
+    parsedFiles,
+    relationships,
+    errors,
+    allSymbols,
+    summaryCache,
+    deletedCount: deletedOnly,
+  };
 }
 
 // ── Main entry point ──
@@ -419,6 +820,9 @@ export function indexProject(
         if (currentSha) {
           store.setLastIndexedSha(currentSha);
         }
+
+        const semantic = toSemanticDiagnostics(store.getSemanticStatus(), []);
+
         return {
           filesIndexed: 0,
           symbolsExtracted: 0,
@@ -428,10 +832,17 @@ export function indexProject(
           incremental: true,
           changedFiles: 0,
           deletedFiles: 0,
+          semantic,
         };
       }
 
-      const result = incrementalIndex(rootPath, config, store, changes);
+      const result = incrementalIndex(rootPath, store, changes);
+      const semantic = runSemanticLifecycle({
+        store,
+        config,
+        symbols: result.allSymbols,
+        summaryCache: result.summaryCache,
+      });
 
       // Persist new SHA
       if (currentSha) {
@@ -441,41 +852,41 @@ export function indexProject(
       const duration = Math.round(performance.now() - start);
       return {
         filesIndexed: result.parsedFiles.length,
-        symbolsExtracted: result.parsedFiles.reduce(
-          (sum, f) => sum + f.symbols.length,
-          0,
-        ),
+        symbolsExtracted: result.allSymbols.length,
         edgesCreated: result.relationships.length,
         duration,
         errors: result.errors,
         incremental: true,
         changedFiles: changes.length,
         deletedFiles: result.deletedCount,
-      };
-    } else {
-      // ── Full path ──
-      const result = fullIndex(rootPath, config, store);
-
-      // Persist SHA for subsequent incremental runs
-      if (currentSha) {
-        store.setLastIndexedSha(currentSha);
-      }
-
-      const allSymbols: Symbol[] = [];
-      for (const file of result.parsedFiles) {
-        allSymbols.push(...file.symbols);
-      }
-
-      const duration = Math.round(performance.now() - start);
-      return {
-        filesIndexed: result.parsedFiles.length,
-        symbolsExtracted: allSymbols.length,
-        edgesCreated: result.relationships.length,
-        duration,
-        errors: result.errors,
-        incremental: false,
+        semantic,
       };
     }
+
+    // ── Full path ──
+    const result = fullIndex(rootPath, config, store);
+    const semantic = runSemanticLifecycle({
+      store,
+      config,
+      symbols: result.allSymbols,
+      summaryCache: result.summaryCache,
+    });
+
+    // Persist SHA for subsequent incremental runs
+    if (currentSha) {
+      store.setLastIndexedSha(currentSha);
+    }
+
+    const duration = Math.round(performance.now() - start);
+    return {
+      filesIndexed: result.parsedFiles.length,
+      symbolsExtracted: result.allSymbols.length,
+      edgesCreated: result.relationships.length,
+      duration,
+      errors: result.errors,
+      incremental: false,
+      semantic,
+    };
   } finally {
     if (ownStore) {
       store.close();

--- a/apps/context/src/semantic/contracts.ts
+++ b/apps/context/src/semantic/contracts.ts
@@ -1,0 +1,135 @@
+import type { Symbol, SymbolKind, SemanticPhase } from "../types.js";
+
+export type SemanticServiceProvider = "anthropic" | "openai";
+
+export type SemanticDomainErrorCode =
+  | "SEMANTIC_ANTHROPIC_MISSING_KEY"
+  | "SEMANTIC_ANTHROPIC_AUTH"
+  | "SEMANTIC_ANTHROPIC_RATE_LIMIT"
+  | "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE"
+  | "SEMANTIC_OPENAI_MISSING_KEY"
+  | "SEMANTIC_OPENAI_AUTH"
+  | "SEMANTIC_OPENAI_RATE_LIMIT"
+  | "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE";
+
+export interface SemanticDomainErrorOptions {
+  code: SemanticDomainErrorCode;
+  provider: SemanticServiceProvider;
+  phase: SemanticPhase;
+  retryable: boolean;
+  status?: number;
+  partialWritesCommitted?: boolean;
+  cause?: unknown;
+}
+
+export class SemanticDomainError extends Error {
+  code: SemanticDomainErrorCode;
+  provider: SemanticServiceProvider;
+  phase: SemanticPhase;
+  retryable: boolean;
+  status?: number;
+  partialWritesCommitted: boolean;
+
+  constructor(message: string, options: SemanticDomainErrorOptions) {
+    super(message, { cause: options.cause });
+    this.name = "SemanticDomainError";
+    this.code = options.code;
+    this.provider = options.provider;
+    this.phase = options.phase;
+    this.retryable = options.retryable;
+    this.status = options.status;
+    this.partialWritesCommitted = options.partialWritesCommitted ?? false;
+  }
+}
+
+export interface SummaryProviderRequest {
+  symbolId: string;
+  name: string;
+  kind: SymbolKind;
+  signature: string | null;
+  docstring: string | null;
+  source: string;
+  filePath: string;
+}
+
+export interface SummaryProviderResponse {
+  symbolId: string;
+  summary: string;
+}
+
+export interface SummaryProvider {
+  summarizeBatch(
+    items: SummaryProviderRequest[],
+  ): Promise<SummaryProviderResponse[]>;
+}
+
+export interface SummaryCacheEntry {
+  symbolId: string;
+  sourceHash: string;
+  summary: string;
+}
+
+export interface SymbolSummaryRecord extends SummaryCacheEntry {
+  filePath: string;
+  cached: boolean;
+}
+
+export interface SummarizeEligibleSymbolsInput {
+  symbols: Symbol[];
+  summaryThreshold: number;
+  cache?: Map<string, SummaryCacheEntry>;
+  provider?: SummaryProvider;
+  batchSize?: number;
+}
+
+export interface SummarizeEligibleSymbolsResult {
+  summaries: SymbolSummaryRecord[];
+  generated: number;
+  reusedFromCache: number;
+  skipped: number;
+}
+
+export interface EmbeddingSourceSummary {
+  symbolId: string;
+  summary: string;
+  filePath: string;
+}
+
+export interface EmbeddingProviderRequest {
+  symbolId: string;
+  text: string;
+  filePath: string;
+}
+
+export interface EmbeddingProviderResponse {
+  symbolId: string;
+  embedding: number[];
+}
+
+export interface EmbeddingProvider {
+  embedBatch(
+    batch: EmbeddingProviderRequest[],
+    context: { model: string; expectedDimensions: number },
+  ): Promise<EmbeddingProviderResponse[]>;
+}
+
+export interface EmbeddingVectorRecord {
+  symbolId: string;
+  filePath: string;
+  model: string;
+  dimensions: number;
+  vector: number[];
+}
+
+export interface EmbedSummariesBatchedInput {
+  summaries: EmbeddingSourceSummary[];
+  model: string;
+  batchSize: number;
+  expectedDimensions: number;
+  provider?: EmbeddingProvider;
+}
+
+export interface EmbedSummariesBatchedResult {
+  vectors: EmbeddingVectorRecord[];
+  batchesProcessed: number;
+}

--- a/apps/context/src/semantic/embedding.ts
+++ b/apps/context/src/semantic/embedding.ts
@@ -1,0 +1,359 @@
+import { DEFAULT_CONFIG, type Config, type SemanticPhase } from "../types.js";
+import {
+  type EmbedSummariesBatchedInput,
+  type EmbedSummariesBatchedResult,
+  type EmbeddingProvider,
+  type EmbeddingProviderRequest,
+  type EmbeddingProviderResponse,
+  SemanticDomainError,
+  type SemanticDomainErrorCode,
+} from "./contracts.js";
+
+interface EmbeddingErrorMappingContext {
+  provider: "openai";
+  phase: SemanticPhase;
+}
+
+interface OpenAIEmbeddingProviderOptions {
+  apiKey?: string;
+  model: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+function chunk<T>(items: T[], chunkSize: number): T[][] {
+  const size = Math.max(1, chunkSize);
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function mapOpenAIStatusErrorCode(
+  status: number,
+): { code: SemanticDomainErrorCode; retryable: boolean } {
+  if (status === 401 || status === 403) {
+    return {
+      code: "SEMANTIC_OPENAI_AUTH",
+      retryable: false,
+    };
+  }
+
+  if (status === 429) {
+    return {
+      code: "SEMANTIC_OPENAI_RATE_LIMIT",
+      retryable: true,
+    };
+  }
+
+  if (status >= 500) {
+    return {
+      code: "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE",
+      retryable: true,
+    };
+  }
+
+  return {
+    code: "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE",
+    retryable: false,
+  };
+}
+
+export function mapEmbeddingProviderError(
+  error: unknown,
+  context: EmbeddingErrorMappingContext,
+): SemanticDomainError {
+  if (error instanceof SemanticDomainError) {
+    return error;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  const lowered = message.toLowerCase();
+
+  const status =
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as { status?: unknown }).status === "number"
+      ? (error as { status: number }).status
+      : undefined;
+
+  if (
+    lowered.includes("openai_api_key") ||
+    lowered.includes("missing key") ||
+    lowered.includes("api key")
+  ) {
+    return new SemanticDomainError("OpenAI API key is not configured", {
+      code: "SEMANTIC_OPENAI_MISSING_KEY",
+      provider: context.provider,
+      phase: context.phase,
+      retryable: false,
+      status,
+      cause: error,
+      partialWritesCommitted: false,
+    });
+  }
+
+  if (
+    status === 401 ||
+    status === 403 ||
+    lowered.includes("invalid_api_key") ||
+    lowered.includes("authentication")
+  ) {
+    return new SemanticDomainError("OpenAI authentication failed", {
+      code: "SEMANTIC_OPENAI_AUTH",
+      provider: context.provider,
+      phase: context.phase,
+      retryable: false,
+      status,
+      cause: error,
+      partialWritesCommitted: false,
+    });
+  }
+
+  if (status === 429 || lowered.includes("rate limit")) {
+    return new SemanticDomainError("OpenAI rate limit exceeded", {
+      code: "SEMANTIC_OPENAI_RATE_LIMIT",
+      provider: context.provider,
+      phase: context.phase,
+      retryable: true,
+      status,
+      cause: error,
+      partialWritesCommitted: false,
+    });
+  }
+
+  if (
+    (typeof status === "number" && status >= 500) ||
+    lowered.includes("unavailable") ||
+    lowered.includes("timeout") ||
+    lowered.includes("econn") ||
+    lowered.includes("enotfound")
+  ) {
+    return new SemanticDomainError("OpenAI provider unavailable", {
+      code: "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE",
+      provider: context.provider,
+      phase: context.phase,
+      retryable: true,
+      status,
+      cause: error,
+      partialWritesCommitted: false,
+    });
+  }
+
+  return new SemanticDomainError("OpenAI embedding request failed", {
+    code: "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE",
+    provider: context.provider,
+    phase: context.phase,
+    retryable: false,
+    status,
+    cause: error,
+    partialWritesCommitted: false,
+  });
+}
+
+export function createOpenAIEmbeddingProvider(
+  options: OpenAIEmbeddingProviderOptions,
+): EmbeddingProvider {
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  return {
+    async embedBatch(
+      batch: EmbeddingProviderRequest[],
+      context: { model: string; expectedDimensions: number },
+    ): Promise<EmbeddingProviderResponse[]> {
+      if (batch.length === 0) {
+        return [];
+      }
+
+      const apiKey = options.apiKey ?? process.env.OPENAI_API_KEY;
+      if (!apiKey) {
+        throw new SemanticDomainError("OPENAI_API_KEY is not set", {
+          code: "SEMANTIC_OPENAI_MISSING_KEY",
+          provider: "openai",
+          phase: "embedding",
+          retryable: false,
+          partialWritesCommitted: false,
+        });
+      }
+
+      const endpoint = `${options.baseUrl ?? "https://api.openai.com"}/v1/embeddings`;
+      const response = await fetchImpl(endpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: context.model,
+          input: batch.map((item) => item.text),
+          encoding_format: "float",
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        const statusMapping = mapOpenAIStatusErrorCode(response.status);
+        throw new SemanticDomainError(
+          `OpenAI embedding request failed (${response.status}): ${body}`,
+          {
+            code: statusMapping.code,
+            provider: "openai",
+            phase: "embedding",
+            retryable: statusMapping.retryable,
+            status: response.status,
+            partialWritesCommitted: false,
+          },
+        );
+      }
+
+      const payload = (await response.json()) as {
+        data?: Array<{ index: number; embedding: number[] }>;
+      };
+
+      const output: EmbeddingProviderResponse[] = [];
+      const byIndex = new Map<number, number[]>(
+        (payload.data ?? []).map((entry) => [entry.index, entry.embedding]),
+      );
+
+      for (let i = 0; i < batch.length; i += 1) {
+        const item = batch[i]!;
+        const embedding = byIndex.get(i);
+        if (!embedding) {
+          throw new SemanticDomainError(
+            `OpenAI response missing embedding at index ${i}`,
+            {
+              code: "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE",
+              provider: "openai",
+              phase: "embedding",
+              retryable: false,
+              partialWritesCommitted: false,
+            },
+          );
+        }
+
+        if (embedding.length !== context.expectedDimensions) {
+          throw new SemanticDomainError(
+            `OpenAI embedding dimensions mismatch for ${item.symbolId}: expected ${context.expectedDimensions}, received ${embedding.length}`,
+            {
+              code: "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE",
+              provider: "openai",
+              phase: "embedding",
+              retryable: false,
+              partialWritesCommitted: false,
+            },
+          );
+        }
+
+        output.push({
+          symbolId: item.symbolId,
+          embedding,
+        });
+      }
+
+      return output;
+    },
+  };
+}
+
+function createDefaultEmbeddingProvider(model: string): EmbeddingProvider {
+  return createOpenAIEmbeddingProvider({
+    model,
+  });
+}
+
+export function createEmbeddingProviderFromConfig(config: Config): EmbeddingProvider {
+  return createOpenAIEmbeddingProvider({
+    model: config.providers.openai.model,
+  });
+}
+
+export async function embedSummariesBatched(
+  input: EmbedSummariesBatchedInput,
+): Promise<EmbedSummariesBatchedResult> {
+  if (input.summaries.length === 0) {
+    return {
+      vectors: [],
+      batchesProcessed: 0,
+    };
+  }
+
+  const provider = input.provider ?? createDefaultEmbeddingProvider(input.model);
+  const batches = chunk(input.summaries, input.batchSize);
+
+  const vectors: EmbedSummariesBatchedResult["vectors"] = [];
+
+  for (const batch of batches) {
+    const providerInput: EmbeddingProviderRequest[] = batch.map((entry) => ({
+      symbolId: entry.symbolId,
+      text: entry.summary,
+      filePath: entry.filePath,
+    }));
+
+    let embeddedBatch: EmbeddingProviderResponse[];
+    try {
+      embeddedBatch = await provider.embedBatch(providerInput, {
+        model: input.model,
+        expectedDimensions: input.expectedDimensions,
+      });
+    } catch (error) {
+      const mapped = mapEmbeddingProviderError(error, {
+        provider: "openai",
+        phase: "embedding",
+      });
+      mapped.partialWritesCommitted = false;
+      throw mapped;
+    }
+
+    const byId = new Map(
+      embeddedBatch.map((entry) => [entry.symbolId, entry.embedding]),
+    );
+
+    for (const requested of providerInput) {
+      const embedding = byId.get(requested.symbolId);
+      if (!embedding) {
+        throw new SemanticDomainError(
+          `Embedding provider omitted symbol ${requested.symbolId}`,
+          {
+            code: "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE",
+            provider: "openai",
+            phase: "embedding",
+            retryable: false,
+            partialWritesCommitted: false,
+          },
+        );
+      }
+
+      if (embedding.length !== input.expectedDimensions) {
+        throw new SemanticDomainError(
+          `Embedding dimensions mismatch for ${requested.symbolId}: expected ${input.expectedDimensions}, received ${embedding.length}`,
+          {
+            code: "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE",
+            provider: "openai",
+            phase: "embedding",
+            retryable: false,
+            partialWritesCommitted: false,
+          },
+        );
+      }
+
+      vectors.push({
+        symbolId: requested.symbolId,
+        filePath: requested.filePath,
+        model: input.model,
+        dimensions: input.expectedDimensions,
+        vector: embedding,
+      });
+    }
+  }
+
+  return {
+    vectors,
+    batchesProcessed: batches.length,
+  };
+}
+
+export function getDefaultEmbeddingModel(): string {
+  return DEFAULT_CONFIG.providers.openai.model;
+}

--- a/apps/context/src/semantic/hints.ts
+++ b/apps/context/src/semantic/hints.ts
@@ -1,0 +1,29 @@
+const DEFAULT_SEMANTIC_HINT =
+  "Check provider configuration and retry semantic indexing.";
+
+export function semanticHintForCode(errorCode?: string): string | undefined {
+  switch (errorCode) {
+    case "SEMANTIC_OPENAI_MISSING_KEY":
+      return "Set OPENAI_API_KEY to enable semantic embeddings.";
+    case "SEMANTIC_OPENAI_AUTH":
+      return "Verify your OPENAI API key value and account permissions.";
+    case "SEMANTIC_OPENAI_RATE_LIMIT":
+      return "OpenAI rate limit hit. Retry shortly or reduce embedding batch size.";
+    case "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE":
+      return "OpenAI provider unavailable. Retry shortly and check provider status.";
+    case "SEMANTIC_ANTHROPIC_MISSING_KEY":
+      return "Set ANTHROPIC_API_KEY to enable provider-backed summaries.";
+    case "SEMANTIC_ANTHROPIC_AUTH":
+      return "Verify your ANTHROPIC_API_KEY value and account permissions.";
+    case "SEMANTIC_ANTHROPIC_RATE_LIMIT":
+      return "Anthropic rate limit hit. Retry shortly or reduce summary batch size.";
+    case "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE":
+      return "Anthropic provider unavailable. Retry shortly and check provider status.";
+    default:
+      return undefined;
+  }
+}
+
+export function semanticHintOrDefault(errorCode?: string): string {
+  return semanticHintForCode(errorCode) ?? DEFAULT_SEMANTIC_HINT;
+}

--- a/apps/context/src/semantic/index.ts
+++ b/apps/context/src/semantic/index.ts
@@ -1,0 +1,3 @@
+export * from "./contracts.js";
+export * from "./summary.js";
+export * from "./embedding.js";

--- a/apps/context/src/semantic/summary.ts
+++ b/apps/context/src/semantic/summary.ts
@@ -1,0 +1,400 @@
+import { createHash } from "node:crypto";
+import type { Config, Symbol, SemanticPhase } from "../types.js";
+import { DEFAULT_CONFIG } from "../types.js";
+import {
+  type SummarizeEligibleSymbolsInput,
+  type SummarizeEligibleSymbolsResult,
+  type SummaryCacheEntry,
+  type SummaryProvider,
+  type SummaryProviderRequest,
+  type SummaryProviderResponse,
+  SemanticDomainError,
+  type SemanticDomainErrorCode,
+} from "./contracts.js";
+
+interface SummaryErrorMappingContext {
+  provider: "anthropic";
+  phase: SemanticPhase;
+}
+
+interface AnthropicSummaryProviderOptions {
+  model: string;
+  maxTokens: number;
+  apiKey?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_SUMMARY_BATCH_SIZE = 25;
+
+function sourceHash(source: string): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+function chunk<T>(items: T[], chunkSize: number): T[][] {
+  const size = Math.max(1, chunkSize);
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function normalizeSummaryText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function mapSummaryStatusErrorCode(
+  status: number,
+): { code: SemanticDomainErrorCode; retryable: boolean } {
+  if (status === 401 || status === 403) {
+    return {
+      code: "SEMANTIC_ANTHROPIC_AUTH",
+      retryable: false,
+    };
+  }
+
+  if (status === 429) {
+    return {
+      code: "SEMANTIC_ANTHROPIC_RATE_LIMIT",
+      retryable: true,
+    };
+  }
+
+  if (status >= 500) {
+    return {
+      code: "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE",
+      retryable: true,
+    };
+  }
+
+  return {
+    code: "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE",
+    retryable: false,
+  };
+}
+
+export function mapSummaryProviderError(
+  error: unknown,
+  context: SummaryErrorMappingContext,
+): SemanticDomainError {
+  if (error instanceof SemanticDomainError) {
+    return error;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  const lowered = message.toLowerCase();
+
+  const status =
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as { status?: unknown }).status === "number"
+      ? (error as { status: number }).status
+      : undefined;
+
+  if (
+    lowered.includes("anthropic_api_key") ||
+    lowered.includes("api key") ||
+    lowered.includes("missing key")
+  ) {
+    return new SemanticDomainError("Anthropic API key is not configured", {
+      code: "SEMANTIC_ANTHROPIC_MISSING_KEY",
+      provider: context.provider,
+      phase: context.phase,
+      retryable: false,
+      status,
+      cause: error,
+    });
+  }
+
+  if (
+    status === 401 ||
+    status === 403 ||
+    lowered.includes("invalid api key") ||
+    lowered.includes("authentication")
+  ) {
+    return new SemanticDomainError("Anthropic authentication failed", {
+      code: "SEMANTIC_ANTHROPIC_AUTH",
+      provider: context.provider,
+      phase: context.phase,
+      retryable: false,
+      status,
+      cause: error,
+    });
+  }
+
+  if (status === 429 || lowered.includes("rate limit")) {
+    return new SemanticDomainError("Anthropic rate limit exceeded", {
+      code: "SEMANTIC_ANTHROPIC_RATE_LIMIT",
+      provider: context.provider,
+      phase: context.phase,
+      retryable: true,
+      status,
+      cause: error,
+    });
+  }
+
+  if (
+    (typeof status === "number" && status >= 500) ||
+    lowered.includes("unavailable") ||
+    lowered.includes("timeout") ||
+    lowered.includes("econn") ||
+    lowered.includes("enotfound")
+  ) {
+    return new SemanticDomainError("Anthropic provider unavailable", {
+      code: "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE",
+      provider: context.provider,
+      phase: context.phase,
+      retryable: true,
+      status,
+      cause: error,
+    });
+  }
+
+  return new SemanticDomainError("Anthropic summary request failed", {
+    code: "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE",
+    provider: context.provider,
+    phase: context.phase,
+    retryable: false,
+    status,
+    cause: error,
+  });
+}
+
+export function createAnthropicSummaryProvider(
+  options: AnthropicSummaryProviderOptions,
+): SummaryProvider {
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  return {
+    async summarizeBatch(items: SummaryProviderRequest[]): Promise<SummaryProviderResponse[]> {
+      if (items.length === 0) {
+        return [];
+      }
+
+      const apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY;
+      if (!apiKey) {
+        throw new SemanticDomainError("ANTHROPIC_API_KEY is not set", {
+          code: "SEMANTIC_ANTHROPIC_MISSING_KEY",
+          provider: "anthropic",
+          phase: "summary",
+          retryable: false,
+        });
+      }
+
+      const endpoint = `${options.baseUrl ?? "https://api.anthropic.com"}/v1/messages`;
+
+      const results: SummaryProviderResponse[] = [];
+      for (const item of items) {
+        const requestBody = {
+          model: options.model,
+          max_tokens: options.maxTokens,
+          messages: [
+            {
+              role: "user",
+              content:
+                "Summarize the following code symbol in one concise sentence for semantic retrieval. " +
+                "Return plain text only with no markdown.\n\n" +
+                `Symbol: ${item.name}\n` +
+                `Kind: ${item.kind}\n` +
+                `File: ${item.filePath}\n` +
+                `Signature: ${item.signature ?? "unknown"}\n` +
+                `Docstring: ${item.docstring ?? "none"}\n` +
+                `Source:\n${item.source}`,
+            },
+          ],
+        };
+
+        const response = await fetchImpl(endpoint, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": apiKey,
+            "anthropic-version": "2023-06-01",
+          },
+          body: JSON.stringify(requestBody),
+        });
+
+        if (!response.ok) {
+          const body = await response.text();
+          const statusMapping = mapSummaryStatusErrorCode(response.status);
+          throw new SemanticDomainError(
+            `Anthropic summary request failed (${response.status}): ${body}`,
+            {
+              code: statusMapping.code,
+              provider: "anthropic",
+              phase: "summary",
+              retryable: statusMapping.retryable,
+              status: response.status,
+            },
+          );
+        }
+
+        const payload = (await response.json()) as {
+          content?: Array<{ type?: string; text?: string }>;
+        };
+
+        const text =
+          payload.content?.find((entry) => entry.type === "text")?.text ?? "";
+        const normalized = normalizeSummaryText(text);
+        results.push({
+          symbolId: item.symbolId,
+          summary: normalized || `Summary unavailable for ${item.name}`,
+        });
+      }
+
+      return results;
+    },
+  };
+}
+
+function createDefaultSummaryProvider(): SummaryProvider {
+  return createAnthropicSummaryProvider({
+    model: DEFAULT_CONFIG.providers.anthropic.model,
+    maxTokens: DEFAULT_CONFIG.providers.anthropic.maxTokens,
+  });
+}
+
+export function createSummaryProviderFromConfig(config: Config): SummaryProvider {
+  return createAnthropicSummaryProvider({
+    model: config.providers.anthropic.model,
+    maxTokens: config.providers.anthropic.maxTokens,
+  });
+}
+
+export function shouldSummarizeSymbol(
+  symbol: Symbol,
+  summaryThreshold: number,
+): boolean {
+  if (!symbol.source.trim()) {
+    return false;
+  }
+
+  const logicalLineCount =
+    symbol.lineEnd >= symbol.lineStart
+      ? symbol.lineEnd - symbol.lineStart + 1
+      : symbol.source.split(/\r?\n/).length;
+
+  return logicalLineCount > summaryThreshold;
+}
+
+export async function summarizeEligibleSymbols(
+  input: SummarizeEligibleSymbolsInput,
+): Promise<SummarizeEligibleSymbolsResult> {
+  const cache = input.cache ?? new Map<string, SummaryCacheEntry>();
+  const provider = input.provider ?? createDefaultSummaryProvider();
+  const batchSize = input.batchSize ?? DEFAULT_SUMMARY_BATCH_SIZE;
+
+  const summaries: SummarizeEligibleSymbolsResult["summaries"] = [];
+  const queued: SummaryProviderRequest[] = [];
+  const requestedSourceHashes = new Map<string, string>();
+
+  let skipped = 0;
+  let reusedFromCache = 0;
+
+  for (const symbol of input.symbols) {
+    if (!shouldSummarizeSymbol(symbol, input.summaryThreshold)) {
+      skipped += 1;
+      continue;
+    }
+
+    const currentHash = sourceHash(symbol.source);
+    const cached = cache.get(symbol.id);
+
+    if (cached && cached.sourceHash === currentHash) {
+      summaries.push({
+        symbolId: symbol.id,
+        filePath: symbol.filePath,
+        sourceHash: cached.sourceHash,
+        summary: cached.summary,
+        cached: true,
+      });
+      reusedFromCache += 1;
+      continue;
+    }
+
+    queued.push({
+      symbolId: symbol.id,
+      name: symbol.name,
+      kind: symbol.kind,
+      signature: symbol.signature,
+      docstring: symbol.docstring,
+      source: symbol.source,
+      filePath: symbol.filePath,
+    });
+    requestedSourceHashes.set(symbol.id, currentHash);
+  }
+
+  if (queued.length === 0) {
+    return {
+      summaries,
+      generated: 0,
+      reusedFromCache,
+      skipped,
+    };
+  }
+
+  const generatedRecords = new Map<string, SummarizeEligibleSymbolsResult["summaries"][number]>();
+
+  for (const batch of chunk(queued, batchSize)) {
+    let generated;
+    try {
+      generated = await provider.summarizeBatch(batch);
+    } catch (error) {
+      throw mapSummaryProviderError(error, {
+        provider: "anthropic",
+        phase: "summary",
+      });
+    }
+
+    const batchById = new Map(generated.map((item) => [item.symbolId, item.summary]));
+
+    for (const request of batch) {
+      const summaryText = batchById.get(request.symbolId);
+      if (!summaryText) {
+        throw new SemanticDomainError(
+          `Summary provider omitted symbol ${request.symbolId}`,
+          {
+            code: "SEMANTIC_ANTHROPIC_PROVIDER_UNAVAILABLE",
+            provider: "anthropic",
+            phase: "summary",
+            retryable: false,
+          },
+        );
+      }
+
+      const normalized = normalizeSummaryText(summaryText);
+      const hash = requestedSourceHashes.get(request.symbolId)!;
+      const record = {
+        symbolId: request.symbolId,
+        filePath: request.filePath,
+        sourceHash: hash,
+        summary: normalized,
+        cached: false,
+      };
+
+      generatedRecords.set(request.symbolId, record);
+      cache.set(request.symbolId, {
+        symbolId: request.symbolId,
+        sourceHash: hash,
+        summary: normalized,
+      });
+    }
+  }
+
+  // Keep output order deterministic relative to input symbol order.
+  for (const symbol of input.symbols) {
+    const generated = generatedRecords.get(symbol.id);
+    if (generated) {
+      summaries.push(generated);
+    }
+  }
+
+  return {
+    summaries,
+    generated: generatedRecords.size,
+    reusedFromCache,
+    skipped,
+  };
+}

--- a/apps/context/src/types.ts
+++ b/apps/context/src/types.ts
@@ -119,6 +119,84 @@ export interface ProviderConfig {
   };
 }
 
+// ── Semantic persistence contracts ──
+
+export type SemanticStatusState = "ok" | "failed" | "unknown";
+
+export type SemanticPhase =
+  | "extension-load"
+  | "summary"
+  | "embedding"
+  | "persist"
+  | "query";
+
+export type SemanticProvider = "sqlite-vec" | "openai" | "anthropic" | "none";
+
+export type SemanticStoreErrorCode =
+  | "SEMANTIC_VEC_EXTENSION_LOAD_FAILED"
+  | "SEMANTIC_VECTOR_INVARIANT_MISMATCH"
+  | "SEMANTIC_VECTOR_DIMENSION_MISMATCH"
+  | "SEMANTIC_VECTOR_QUERY_MODEL_MISMATCH"
+  | "SEMANTIC_VECTOR_QUERY_DIMENSION_MISMATCH";
+
+export interface SemanticVectorWrite {
+  symbolId: string;
+  filePath: string;
+  model: string;
+  dimensions: number;
+  vector: number[];
+}
+
+export interface SemanticStoredVector extends SemanticVectorWrite {
+  updatedAt: string;
+}
+
+export interface SemanticQueryOptions {
+  queryVector: number[];
+  topK: number;
+  model: string;
+}
+
+export interface SemanticQueryResult {
+  symbolId: string;
+  filePath: string;
+  model: string;
+  dimensions: number;
+  distance: number;
+}
+
+export interface SemanticStatusRecord {
+  status: SemanticStatusState;
+  phase: SemanticPhase;
+  provider: SemanticProvider;
+  errorCode?: SemanticStoreErrorCode | string;
+  message?: string;
+  timestamp: string;
+  retryable: boolean;
+}
+
+export class SemanticStoreError extends Error {
+  code: SemanticStoreErrorCode;
+  phase: SemanticPhase;
+  retryable: boolean;
+
+  constructor(
+    code: SemanticStoreErrorCode,
+    message: string,
+    options: {
+      phase: SemanticPhase;
+      retryable: boolean;
+      cause?: unknown;
+    },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "SemanticStoreError";
+    this.code = code;
+    this.phase = options.phase;
+    this.retryable = options.retryable;
+  }
+}
+
 // ── Query result types ──
 
 /**

--- a/apps/context/src/types.ts
+++ b/apps/context/src/types.ts
@@ -175,6 +175,31 @@ export interface SemanticStatusRecord {
   retryable: boolean;
 }
 
+export type SemanticEventStatus = "ok" | "failed" | "skipped";
+
+export interface SemanticStageEvent {
+  phase: SemanticPhase;
+  provider: SemanticProvider;
+  status: SemanticEventStatus;
+  symbolCount: number;
+  durationMs: number;
+  retryCount: number;
+  timestamp: string;
+  errorCode?: string;
+}
+
+export interface SemanticRunDiagnostics {
+  status: SemanticStatusState;
+  phase: SemanticPhase;
+  provider: SemanticProvider;
+  retryable: boolean;
+  timestamp: string;
+  errorCode?: string;
+  message?: string;
+  hint?: string;
+  events: SemanticStageEvent[];
+}
+
 export class SemanticStoreError extends Error {
   code: SemanticStoreErrorCode;
   phase: SemanticPhase;

--- a/apps/context/test/cli/semantic-index-errors.test.ts
+++ b/apps/context/test/cli/semantic-index-errors.test.ts
@@ -35,18 +35,26 @@ function seedRepoFromFixture(): string {
 
 describe("CLI semantic diagnostics contract (T01 red-first)", () => {
   let repoDir: string;
+  let previousOpenAiKey: string | undefined;
 
   beforeEach(() => {
+    previousOpenAiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
     repoDir = seedRepoFromFixture();
   });
 
   afterEach(() => {
+    if (previousOpenAiKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = previousOpenAiKey;
+    }
     rmSync(repoDir, { recursive: true, force: true });
   });
 
   it("exports dedicated semantic diagnostic formatters for CLI output modes", () => {
-    expect(typeof (formatters as any).formatSemanticDiagnostics).toBe("function");
-    expect(typeof (formatters as any).formatSemanticDiagnosticHint).toBe("function");
+    expect(typeof formatters.formatSemanticDiagnostics).toBe("function");
+    expect(typeof formatters.formatSemanticDiagnosticHint).toBe("function");
   });
 
   it("index JSON payload includes semantic status, code, phase, and hint", () => {
@@ -92,10 +100,7 @@ describe("CLI semantic diagnostics contract (T01 red-first)", () => {
         },
       }) as any;
 
-      const formatSemanticDiagnostics = (formatters as any).formatSemanticDiagnostics;
-      expect(typeof formatSemanticDiagnostics).toBe("function");
-
-      const section = formatSemanticDiagnostics(result.semantic);
+      const section = formatters.formatSemanticDiagnostics(result.semantic);
       expect(section).toContain("Semantic Diagnostics");
       expect(section).toContain("SEMANTIC_OPENAI_MISSING_KEY");
       expect(section).toContain("embedding");
@@ -106,7 +111,7 @@ describe("CLI semantic diagnostics contract (T01 red-first)", () => {
   });
 
   it("CLI module exports a semantic-code-to-remediation mapper", () => {
-    const mapper = (cliModule as any).semanticRemediationForCode;
+    const mapper = cliModule.semanticRemediationForCode;
     expect(typeof mapper).toBe("function");
 
     expect(mapper("SEMANTIC_OPENAI_MISSING_KEY")).toContain("OPENAI_API_KEY");

--- a/apps/context/test/cli/semantic-index-errors.test.ts
+++ b/apps/context/test/cli/semantic-index-errors.test.ts
@@ -1,0 +1,119 @@
+import { copyFileSync, cpSync, rmSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { join, resolve } from "node:path";
+import { indexProject } from "../../src/indexer.js";
+import { GraphStore } from "../../src/graph/store.js";
+import { DEFAULT_CONFIG } from "../../src/types.js";
+import * as formatters from "../../src/formatters.js";
+import * as cliModule from "../../src/cli.js";
+import { createTempGitRepo } from "../helpers/git-fixtures.js";
+
+const SEMANTIC_FIXTURE_ROOT = resolve(
+  import.meta.dirname!,
+  "../fixtures/semantic/repo-a",
+);
+
+function seedRepoFromFixture(): string {
+  const repoDir = createTempGitRepo("kata-semantic-cli-");
+
+  cpSync(join(SEMANTIC_FIXTURE_ROOT, "src"), join(repoDir, "src"), {
+    recursive: true,
+  });
+  copyFileSync(
+    join(SEMANTIC_FIXTURE_ROOT, "README.md"),
+    join(repoDir, "README.md"),
+  );
+
+  execSync("git add .", { cwd: repoDir, stdio: "pipe" });
+  execSync("git commit -m 'seed semantic fixture'", {
+    cwd: repoDir,
+    stdio: "pipe",
+  });
+
+  return repoDir;
+}
+
+describe("CLI semantic diagnostics contract (T01 red-first)", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = seedRepoFromFixture();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("exports dedicated semantic diagnostic formatters for CLI output modes", () => {
+    expect(typeof (formatters as any).formatSemanticDiagnostics).toBe("function");
+    expect(typeof (formatters as any).formatSemanticDiagnosticHint).toBe("function");
+  });
+
+  it("index JSON payload includes semantic status, code, phase, and hint", () => {
+    const store = new GraphStore(":memory:");
+    try {
+      const result = indexProject(repoDir, {
+        store,
+        config: {
+          ...DEFAULT_CONFIG,
+          summaryThreshold: 3,
+        },
+      }) as any;
+
+      const jsonData = {
+        filesIndexed: result.filesIndexed,
+        symbolsExtracted: result.symbolsExtracted,
+        edgesCreated: result.edgesCreated,
+        duration: result.duration,
+        errors: result.errors,
+        incremental: result.incremental,
+        semantic: result.semantic,
+      };
+
+      expect(jsonData.semantic).toMatchObject({
+        status: "failed",
+        phase: "embedding",
+        errorCode: "SEMANTIC_OPENAI_MISSING_KEY",
+        hint: expect.stringContaining("OPENAI_API_KEY"),
+      });
+    } finally {
+      store.close();
+    }
+  });
+
+  it("index human output includes a Semantic Diagnostics section with stable code", () => {
+    const store = new GraphStore(":memory:");
+    try {
+      const result = indexProject(repoDir, {
+        store,
+        config: {
+          ...DEFAULT_CONFIG,
+          summaryThreshold: 3,
+        },
+      }) as any;
+
+      const formatSemanticDiagnostics = (formatters as any).formatSemanticDiagnostics;
+      expect(typeof formatSemanticDiagnostics).toBe("function");
+
+      const section = formatSemanticDiagnostics(result.semantic);
+      expect(section).toContain("Semantic Diagnostics");
+      expect(section).toContain("SEMANTIC_OPENAI_MISSING_KEY");
+      expect(section).toContain("embedding");
+      expect(section).toContain("OPENAI_API_KEY");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("CLI module exports a semantic-code-to-remediation mapper", () => {
+    const mapper = (cliModule as any).semanticRemediationForCode;
+    expect(typeof mapper).toBe("function");
+
+    expect(mapper("SEMANTIC_OPENAI_MISSING_KEY")).toContain("OPENAI_API_KEY");
+    expect(mapper("SEMANTIC_OPENAI_AUTH")).toContain("API key");
+    expect(mapper("SEMANTIC_OPENAI_RATE_LIMIT")).toContain("rate limit");
+    expect(mapper("SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE")).toContain(
+      "provider",
+    );
+  });
+});

--- a/apps/context/test/fixtures/semantic/repo-a/README.md
+++ b/apps/context/test/fixtures/semantic/repo-a/README.md
@@ -1,0 +1,3 @@
+# Semantic Fixture Repo A
+
+Small fixture used by semantic contract tests.

--- a/apps/context/test/fixtures/semantic/repo-a/src/auth.ts
+++ b/apps/context/test/fixtures/semantic/repo-a/src/auth.ts
@@ -1,0 +1,24 @@
+export interface AuthToken {
+  userId: string;
+  scopes: string[];
+}
+
+export function parseAuthHeader(header: string | undefined): AuthToken | null {
+  if (!header) return null;
+  if (!header.startsWith("Bearer ")) return null;
+
+  const token = header.slice("Bearer ".length).trim();
+  if (!token) return null;
+
+  // Placeholder parser used only by semantic fixture tests.
+  return {
+    userId: token.split(".")[0] ?? "unknown",
+    scopes: ["read"],
+  };
+}
+
+export function canAccessProject(token: AuthToken | null, projectId: string): boolean {
+  if (!token) return false;
+  if (!projectId) return false;
+  return token.scopes.includes("read") || token.userId === projectId;
+}

--- a/apps/context/test/fixtures/semantic/repo-a/src/router.ts
+++ b/apps/context/test/fixtures/semantic/repo-a/src/router.ts
@@ -1,0 +1,18 @@
+import { canAccessProject, parseAuthHeader } from "./auth";
+
+export interface RequestLike {
+  headers: Record<string, string | undefined>;
+  params: Record<string, string | undefined>;
+}
+
+export function routeProjectRequest(request: RequestLike): "ok" | "forbidden" {
+  const authHeader = request.headers.authorization;
+  const projectId = request.params.projectId ?? "";
+
+  const token = parseAuthHeader(authHeader);
+  if (!canAccessProject(token, projectId)) {
+    return "forbidden";
+  }
+
+  return "ok";
+}

--- a/apps/context/test/graph/semantic-store.test.ts
+++ b/apps/context/test/graph/semantic-store.test.ts
@@ -1,0 +1,160 @@
+import { GraphStore } from "../../src/graph/store.js";
+import { generateSymbolId } from "../../src/parser/common.js";
+import { SymbolKind } from "../../src/types.js";
+import type { Symbol } from "../../src/types.js";
+
+function makeSymbol(name: string, filePath: string): Symbol {
+  return {
+    id: generateSymbolId(filePath, name, SymbolKind.Function),
+    name,
+    kind: SymbolKind.Function,
+    filePath,
+    lineStart: 1,
+    lineEnd: 20,
+    signature: `function ${name}(): void`,
+    docstring: null,
+    source: `export function ${name}() { return; }`,
+    exported: true,
+  };
+}
+
+function requireMethod<T extends object>(obj: T, method: string): (...args: any[]) => any {
+  const candidate = (obj as any)[method];
+  expect(typeof candidate).toBe(
+    "function",
+  );
+  return candidate as (...args: any[]) => any;
+}
+
+describe("semantic store contract (T01 red-first)", () => {
+  let store: GraphStore;
+
+  beforeEach(() => {
+    store = new GraphStore(":memory:");
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it("exposes semantic vector lifecycle APIs on GraphStore", () => {
+    expect(typeof (store as any).upsertSemanticVectors).toBe("function");
+    expect(typeof (store as any).querySemanticNearest).toBe("function");
+    expect(typeof (store as any).deleteSemanticVectorsByFile).toBe("function");
+    expect(typeof (store as any).getSemanticStatus).toBe("function");
+    expect(typeof (store as any).setSemanticStatus).toBe("function");
+  });
+
+  it("enforces add/modify/delete/rename vector parity with deterministic symbol IDs", () => {
+    const authSymbol = makeSymbol("parseAuthHeader", "src/auth.ts");
+    const routerSymbol = makeSymbol("routeProjectRequest", "src/router.ts");
+    store.upsertSymbols([authSymbol, routerSymbol]);
+
+    const upsertVectors = requireMethod(store, "upsertSemanticVectors");
+    const queryNearest = requireMethod(store, "querySemanticNearest");
+    const deleteByFile = requireMethod(store, "deleteSemanticVectorsByFile");
+    const countVectors = requireMethod(store, "countSemanticVectors");
+
+    upsertVectors([
+      {
+        symbolId: authSymbol.id,
+        filePath: authSymbol.filePath,
+        model: "text-embedding-3-small",
+        dimensions: 4,
+        vector: [0.1, 0.2, 0.3, 0.4],
+      },
+      {
+        symbolId: routerSymbol.id,
+        filePath: routerSymbol.filePath,
+        model: "text-embedding-3-small",
+        dimensions: 4,
+        vector: [0.4, 0.3, 0.2, 0.1],
+      },
+    ]);
+
+    expect(countVectors()).toBe(2);
+
+    const nearest = queryNearest({
+      queryVector: [0.1, 0.2, 0.3, 0.4],
+      topK: 1,
+      model: "text-embedding-3-small",
+    });
+    expect(nearest).toHaveLength(1);
+    expect(nearest[0].symbolId).toBe(authSymbol.id);
+
+    // Simulate rename parity: old file vectors removed before new symbol/vector is inserted.
+    deleteByFile("src/auth.ts");
+    expect(countVectors()).toBe(1);
+
+    const renamedSymbol = makeSymbol("parseAuthHeader", "src/security/auth.ts");
+    store.upsertSymbols([renamedSymbol]);
+    upsertVectors([
+      {
+        symbolId: renamedSymbol.id,
+        filePath: renamedSymbol.filePath,
+        model: "text-embedding-3-small",
+        dimensions: 4,
+        vector: [0.11, 0.21, 0.31, 0.41],
+      },
+    ]);
+
+    expect(countVectors()).toBe(2);
+  });
+
+  it("guards against model/dimension drift when writing vectors", () => {
+    const symbol = makeSymbol("canAccessProject", "src/auth.ts");
+    store.upsertSymbols([symbol]);
+
+    const upsertVectors = requireMethod(store, "upsertSemanticVectors");
+
+    upsertVectors([
+      {
+        symbolId: symbol.id,
+        filePath: symbol.filePath,
+        model: "text-embedding-3-small",
+        dimensions: 4,
+        vector: [0.1, 0.2, 0.3, 0.4],
+      },
+    ]);
+
+    expect(() =>
+      upsertVectors([
+        {
+          symbolId: symbol.id,
+          filePath: symbol.filePath,
+          model: "text-embedding-3-large",
+          dimensions: 8,
+          vector: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+        },
+      ]),
+    ).toThrow(/model|dimension|semantic/i);
+  });
+
+  it("persists semantic failure diagnostics for post-run inspection", () => {
+    const setSemanticStatus = requireMethod(store, "setSemanticStatus");
+    const getSemanticStatus = requireMethod(store, "getSemanticStatus");
+
+    const timestamp = new Date().toISOString();
+
+    setSemanticStatus({
+      status: "failed",
+      phase: "embedding",
+      provider: "openai",
+      errorCode: "SEMANTIC_OPENAI_MISSING_KEY",
+      message: "OPENAI_API_KEY is not set",
+      timestamp,
+      retryable: false,
+    });
+
+    const status = getSemanticStatus();
+
+    expect(status).toMatchObject({
+      status: "failed",
+      phase: "embedding",
+      provider: "openai",
+      errorCode: "SEMANTIC_OPENAI_MISSING_KEY",
+      retryable: false,
+    });
+    expect(typeof status.timestamp).toBe("string");
+  });
+});

--- a/apps/context/test/integration-semantic-index.test.ts
+++ b/apps/context/test/integration-semantic-index.test.ts
@@ -1,0 +1,160 @@
+import { copyFileSync, cpSync, rmSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { join, resolve } from "node:path";
+import { DEFAULT_CONFIG } from "../src/types.js";
+import { indexProject } from "../src/indexer.js";
+import { GraphStore } from "../src/graph/store.js";
+import { createTempGitRepo } from "./helpers/git-fixtures.js";
+
+const SEMANTIC_FIXTURE_ROOT = resolve(
+  import.meta.dirname!,
+  "fixtures/semantic/repo-a",
+);
+
+function seedRepoFromFixture(): string {
+  const repoDir = createTempGitRepo("kata-semantic-int-");
+
+  cpSync(
+    join(SEMANTIC_FIXTURE_ROOT, "src"),
+    join(repoDir, "src"),
+    { recursive: true },
+  );
+  copyFileSync(
+    join(SEMANTIC_FIXTURE_ROOT, "README.md"),
+    join(repoDir, "README.md"),
+  );
+
+  execSync("git add .", { cwd: repoDir, stdio: "pipe" });
+  execSync("git commit -m 'seed semantic fixture'", {
+    cwd: repoDir,
+    stdio: "pipe",
+  });
+
+  return repoDir;
+}
+
+describe("integration semantic indexing contract (T01 red-first)", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = seedRepoFromFixture();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("missing provider keys: reports semantic failure codes while preserving structural index integrity", () => {
+    const store = new GraphStore(":memory:");
+    try {
+      const config = {
+        ...DEFAULT_CONFIG,
+        summaryThreshold: 3,
+        providers: {
+          ...DEFAULT_CONFIG.providers,
+          openai: {
+            ...DEFAULT_CONFIG.providers.openai,
+            model: "text-embedding-3-small",
+            batchSize: 2,
+          },
+        },
+      };
+
+      const result = indexProject(repoDir, { store, config }) as any;
+
+      // Structural indexing should still work even when semantic stage fails.
+      expect(store.getStats().symbols).toBeGreaterThan(0);
+      expect(result.errors).toEqual([]);
+
+      // Semantic diagnostics must be explicit + machine-parseable.
+      expect(result.semantic).toMatchObject({
+        status: "failed",
+        phase: "embedding",
+        errorCode: "SEMANTIC_OPENAI_MISSING_KEY",
+        retryable: false,
+      });
+      expect(typeof result.semantic.timestamp).toBe("string");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("keeps semantic vectors in parity with symbol lifecycle across rename/delete", () => {
+    const store = new GraphStore(":memory:");
+    try {
+      const config = {
+        ...DEFAULT_CONFIG,
+        summaryThreshold: 3,
+        providers: {
+          ...DEFAULT_CONFIG.providers,
+          openai: {
+            ...DEFAULT_CONFIG.providers.openai,
+            batchSize: 2,
+          },
+        },
+      };
+
+      indexProject(repoDir, { store, config });
+
+      // Rename auth file and delete router file in one incremental commit.
+      execSync("mkdir -p src/security", { cwd: repoDir, stdio: "pipe" });
+      execSync("git mv src/auth.ts src/security/auth.ts", {
+        cwd: repoDir,
+        stdio: "pipe",
+      });
+      execSync("git rm src/router.ts", { cwd: repoDir, stdio: "pipe" });
+      execSync("git commit -m 'rename auth and delete router'", {
+        cwd: repoDir,
+        stdio: "pipe",
+      });
+
+      const result = indexProject(repoDir, { store, config }) as any;
+      expect(result.incremental).toBe(true);
+
+      const storeAny = store as any;
+      expect(typeof storeAny.countSemanticVectors).toBe("function");
+      expect(typeof storeAny.querySemanticVectorsByFile).toBe("function");
+
+      const vectorCount = storeAny.countSemanticVectors();
+      expect(vectorCount).toBe(store.getStats().symbols);
+
+      const oldPathVectors = storeAny.querySemanticVectorsByFile("src/auth.ts");
+      const deletedPathVectors = storeAny.querySemanticVectorsByFile("src/router.ts");
+      expect(oldPathVectors).toHaveLength(0);
+      expect(deletedPathVectors).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("emits semantic stage events with phase/provider/errorCode/timing fields", () => {
+    const store = new GraphStore(":memory:");
+    try {
+      const result = indexProject(repoDir, {
+        store,
+        config: {
+          ...DEFAULT_CONFIG,
+          summaryThreshold: 3,
+        },
+      }) as any;
+
+      expect(Array.isArray(result.semantic?.events)).toBe(true);
+      expect(result.semantic.events.length).toBeGreaterThan(0);
+
+      for (const event of result.semantic.events) {
+        expect(event).toMatchObject({
+          phase: expect.any(String),
+          provider: expect.any(String),
+          symbolCount: expect.any(Number),
+          durationMs: expect.any(Number),
+        });
+        // errorCode is optional on successful events but must be present on failed events.
+        if (event.status === "failed") {
+          expect(typeof event.errorCode).toBe("string");
+        }
+      }
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/apps/context/test/semantic/embedding-pipeline.test.ts
+++ b/apps/context/test/semantic/embedding-pipeline.test.ts
@@ -1,0 +1,130 @@
+async function loadEmbeddingModule(): Promise<Record<string, any> | null> {
+  try {
+    return await import("../../src/semantic/embedding.js");
+  } catch {
+    return null;
+  }
+}
+
+describe("embedding pipeline contract (T01 red-first)", () => {
+  it("exports batch embedding orchestrator + error mapper", async () => {
+    const mod = await loadEmbeddingModule();
+    expect(mod).not.toBeNull();
+    expect(typeof mod!.embedSummariesBatched).toBe("function");
+    expect(typeof mod!.mapEmbeddingProviderError).toBe("function");
+  });
+
+  it("batches embedding requests and keeps model/dimension metadata stable", async () => {
+    const mod = await loadEmbeddingModule();
+    expect(mod).not.toBeNull();
+
+    const provider = {
+      embedBatch: vi.fn(async (batch: Array<{ symbolId: string }>) =>
+        batch.map((item, index) => ({
+          symbolId: item.symbolId,
+          embedding: [index + 0.1, index + 0.2, index + 0.3, index + 0.4],
+        })),
+      ),
+    };
+
+    const summaries = [
+      { symbolId: "sym-1", summary: "Summary 1", filePath: "src/auth.ts" },
+      { symbolId: "sym-2", summary: "Summary 2", filePath: "src/auth.ts" },
+      { symbolId: "sym-3", summary: "Summary 3", filePath: "src/router.ts" },
+      { symbolId: "sym-4", summary: "Summary 4", filePath: "src/router.ts" },
+      { symbolId: "sym-5", summary: "Summary 5", filePath: "src/router.ts" },
+    ];
+
+    const result = await mod!.embedSummariesBatched({
+      summaries,
+      model: "text-embedding-3-small",
+      batchSize: 2,
+      expectedDimensions: 4,
+      provider,
+    });
+
+    expect(provider.embedBatch).toHaveBeenCalledTimes(3);
+    expect(result.vectors).toHaveLength(5);
+    expect(result.vectors[0]).toMatchObject({
+      symbolId: "sym-1",
+      model: "text-embedding-3-small",
+      dimensions: 4,
+    });
+  });
+
+  it("maps missing-key/auth/rate-limit/provider failures to stable semantic codes", async () => {
+    const mod = await loadEmbeddingModule();
+    expect(mod).not.toBeNull();
+
+    const missingKeyError = mod!.mapEmbeddingProviderError(
+      new Error("OPENAI_API_KEY is not set"),
+      { provider: "openai", phase: "embedding" },
+    );
+    expect(missingKeyError).toMatchObject({
+      code: "SEMANTIC_OPENAI_MISSING_KEY",
+      phase: "embedding",
+      retryable: false,
+    });
+
+    const authError = mod!.mapEmbeddingProviderError(
+      Object.assign(new Error("401 invalid_api_key"), { status: 401 }),
+      { provider: "openai", phase: "embedding" },
+    );
+    expect(authError).toMatchObject({
+      code: "SEMANTIC_OPENAI_AUTH",
+      retryable: false,
+    });
+
+    const rateLimitError = mod!.mapEmbeddingProviderError(
+      Object.assign(new Error("429 rate limit exceeded"), { status: 429 }),
+      { provider: "openai", phase: "embedding" },
+    );
+    expect(rateLimitError).toMatchObject({
+      code: "SEMANTIC_OPENAI_RATE_LIMIT",
+      retryable: true,
+    });
+
+    const providerDown = mod!.mapEmbeddingProviderError(
+      Object.assign(new Error("503 upstream unavailable"), { status: 503 }),
+      { provider: "openai", phase: "embedding" },
+    );
+    expect(providerDown).toMatchObject({
+      code: "SEMANTIC_OPENAI_PROVIDER_UNAVAILABLE",
+      retryable: true,
+    });
+  });
+
+  it("fails the entire write set on partial batch errors (no partial commits)", async () => {
+    const mod = await loadEmbeddingModule();
+    expect(mod).not.toBeNull();
+
+    const provider = {
+      embedBatch: vi
+        .fn()
+        .mockResolvedValueOnce([
+          { symbolId: "sym-1", embedding: [0.1, 0.2, 0.3, 0.4] },
+          { symbolId: "sym-2", embedding: [0.2, 0.3, 0.4, 0.5] },
+        ])
+        .mockRejectedValueOnce(Object.assign(new Error("429 rate limit"), { status: 429 })),
+    };
+
+    await expect(
+      mod!.embedSummariesBatched({
+        summaries: [
+          { symbolId: "sym-1", summary: "s1", filePath: "src/a.ts" },
+          { symbolId: "sym-2", summary: "s2", filePath: "src/a.ts" },
+          { symbolId: "sym-3", summary: "s3", filePath: "src/b.ts" },
+        ],
+        model: "text-embedding-3-small",
+        batchSize: 2,
+        expectedDimensions: 4,
+        provider,
+      }),
+    ).rejects.toMatchObject({
+      code: "SEMANTIC_OPENAI_RATE_LIMIT",
+      phase: "embedding",
+      retryable: true,
+      partialWritesCommitted: false,
+    });
+  });
+});

--- a/apps/context/test/semantic/summary-pipeline.test.ts
+++ b/apps/context/test/semantic/summary-pipeline.test.ts
@@ -1,0 +1,138 @@
+import { createHash } from "node:crypto";
+import { SymbolKind } from "../../src/types.js";
+import type { Symbol } from "../../src/types.js";
+
+function makeSymbol(overrides: Partial<Symbol> & { id: string; name: string; source: string }): Symbol {
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    kind: overrides.kind ?? SymbolKind.Function,
+    filePath: overrides.filePath ?? "src/auth.ts",
+    lineStart: overrides.lineStart ?? 1,
+    lineEnd: overrides.lineEnd ?? 12,
+    signature: overrides.signature ?? `function ${overrides.name}(): void`,
+    docstring: overrides.docstring ?? null,
+    source: overrides.source,
+    exported: overrides.exported ?? true,
+    summary: overrides.summary,
+    lastIndexedAt: overrides.lastIndexedAt,
+    gitSha: overrides.gitSha,
+  };
+}
+
+function sourceHash(source: string): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+async function loadSummaryModule(): Promise<Record<string, any> | null> {
+  try {
+    return await import("../../src/semantic/summary.js");
+  } catch {
+    return null;
+  }
+}
+
+describe("summary pipeline contract (T01 red-first)", () => {
+  it("exports summary eligibility + orchestration functions", async () => {
+    const mod = await loadSummaryModule();
+    expect(mod).not.toBeNull();
+    expect(typeof mod!.shouldSummarizeSymbol).toBe("function");
+    expect(typeof mod!.summarizeEligibleSymbols).toBe("function");
+  });
+
+  it("skips symbols at or below the summary threshold", async () => {
+    const mod = await loadSummaryModule();
+    expect(mod).not.toBeNull();
+
+    const shortSymbol = makeSymbol({
+      id: "short-1",
+      name: "smallHelper",
+      source: `export function smallHelper() {\n  return true;\n}`,
+      lineStart: 1,
+      lineEnd: 2,
+    });
+
+    const shouldSummarize = mod!.shouldSummarizeSymbol(shortSymbol, 5);
+    expect(shouldSummarize).toBe(false);
+  });
+
+  it("reuses cached summary when source hash is unchanged", async () => {
+    const mod = await loadSummaryModule();
+    expect(mod).not.toBeNull();
+
+    const symbol = makeSymbol({
+      id: "sym-cache-1",
+      name: "parseAuthHeader",
+      source: `export function parseAuthHeader(header: string | undefined) {\n  if (!header) return null;\n  return header;\n}`,
+    });
+
+    const provider = {
+      summarizeBatch: vi.fn(async () => {
+        throw new Error("provider should not be called when cache is valid");
+      }),
+    };
+
+    const cachedSummary = {
+      symbolId: symbol.id,
+      sourceHash: sourceHash(symbol.source),
+      summary: "Parses and normalizes auth headers.",
+    };
+
+    const result = await mod!.summarizeEligibleSymbols({
+      symbols: [symbol],
+      summaryThreshold: 3,
+      cache: new Map([[symbol.id, cachedSummary]]),
+      provider,
+    });
+
+    expect(provider.summarizeBatch).toHaveBeenCalledTimes(0);
+    expect(result.summaries).toHaveLength(1);
+    expect(result.summaries[0]).toMatchObject({
+      symbolId: symbol.id,
+      summary: "Parses and normalizes auth headers.",
+      cached: true,
+    });
+  });
+
+  it("invalidates cache and regenerates summary when source changes", async () => {
+    const mod = await loadSummaryModule();
+    expect(mod).not.toBeNull();
+
+    const symbol = makeSymbol({
+      id: "sym-cache-2",
+      name: "routeProjectRequest",
+      source: `export function routeProjectRequest(input: { projectId: string }) {\n  if (!input.projectId) return \"forbidden\";\n  return \"ok\";\n}`,
+    });
+
+    const provider = {
+      summarizeBatch: vi.fn(async (items: Array<{ symbolId: string }>) =>
+        items.map((item) => ({
+          symbolId: item.symbolId,
+          summary: "Routes project requests after validating access.",
+        })),
+      ),
+    };
+
+    const staleCache = {
+      symbolId: symbol.id,
+      sourceHash: sourceHash("old source"),
+      summary: "Old stale summary",
+    };
+
+    const result = await mod!.summarizeEligibleSymbols({
+      symbols: [symbol],
+      summaryThreshold: 3,
+      cache: new Map([[symbol.id, staleCache]]),
+      provider,
+    });
+
+    expect(provider.summarizeBatch).toHaveBeenCalledTimes(1);
+    expect(result.summaries).toHaveLength(1);
+    expect(result.summaries[0]).toMatchObject({
+      symbolId: symbol.id,
+      summary: "Routes project requests after validating access.",
+      cached: false,
+    });
+    expect(result.summaries[0].sourceHash).toBe(sourceHash(symbol.source));
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -88,7 +88,7 @@
     },
     "apps/cli": {
       "name": "@kata-sh/cli",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "bin": {
         "kata-cli": "dist/loader.js",
       },
@@ -110,6 +110,7 @@
       "dependencies": {
         "better-sqlite3": "^11.7.0",
         "commander": "^13.1.0",
+        "sqlite-vec": "^0.1.7",
         "tree-sitter": "^0.22.4",
         "tree-sitter-python": "^0.23.6",
         "tree-sitter-typescript": "^0.23.2",
@@ -173,6 +174,10 @@
       "devDependencies": {
         "esbuild": "^0.24.0",
       },
+    },
+    "apps/symphony": {
+      "name": "@kata/symphony",
+      "version": "0.1.0",
     },
     "apps/viewer": {
       "name": "@craft-agent/viewer",
@@ -697,6 +702,8 @@
     "@kata-sh/orc": ["@kata-sh/orc@workspace:apps/orchestrator"],
 
     "@kata/context": ["@kata/context@workspace:apps/context"],
+
+    "@kata/symphony": ["@kata/symphony@workspace:apps/symphony"],
 
     "@kenjiuno/decompressrtf": ["@kenjiuno/decompressrtf@0.1.4", "", {}, "sha512-v9c/iFz17jRWyd2cRnrvJg4VOg/4I/VCk+bG8JnoX2gJ9sAesPzo3uTqcmlVXdpasTI8hChpBVw00pghKe3qTQ=="],
 
@@ -2977,6 +2984,18 @@
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "sqlite-vec": ["sqlite-vec@0.1.7", "", { "optionalDependencies": { "sqlite-vec-darwin-arm64": "0.1.7", "sqlite-vec-darwin-x64": "0.1.7", "sqlite-vec-linux-arm64": "0.1.7", "sqlite-vec-linux-x64": "0.1.7", "sqlite-vec-windows-x64": "0.1.7" } }, "sha512-1Sge9uRc3B6wDKR4J6sGFi/E2ai9SAU5FenDki3OmhdP/a49PO2Juy1U5yQnx2bZP5t+C3BYJTkG+KkDi3q9Xg=="],
+
+    "sqlite-vec-darwin-arm64": ["sqlite-vec-darwin-arm64@0.1.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-dQ7u4GKPdOPi3IfZ44K7HHdYup2JssM6fuKR9zgqRzW137uFOQmRhbYChNu+ZfW+yhJutsPgfNRFsuWKmy627w=="],
+
+    "sqlite-vec-darwin-x64": ["sqlite-vec-darwin-x64@0.1.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-MDoczft1BriQcGMEz+CqeSCkB0OsAf12ytZOapS6MaB7zgNzLLSLH6Sxe3yzcPWUyDuCWgK7WzyRIo8u1vAIVA=="],
+
+    "sqlite-vec-linux-arm64": ["sqlite-vec-linux-arm64@0.1.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-V429sYT/gwr9PgtT8rbjQd6ls7CFchFpiS45TKSf7rU7wxt9MBmCVorUcheD4kEZb4VeZ6PnFXXCqPMeaHkaUw=="],
+
+    "sqlite-vec-linux-x64": ["sqlite-vec-linux-x64@0.1.7", "", { "os": "linux", "cpu": "x64" }, "sha512-wZL+lXeW7y63DLv6FYU6Q4nv2lP5F94cWt7bJCWNiHmZ6NdKIgz/p0QlyuJA/51b8TyoDvsTdusLVlZz9cIh5A=="],
+
+    "sqlite-vec-windows-x64": ["sqlite-vec-windows-x64@0.1.7", "", { "os": "win32", "cpu": "x64" }, "sha512-FEZMjMT03irJxwqMQg+A+4hHCiFslxISOAkQ0eYn2lP7GdpppkgYveaT5Xnw/2V+GLq2MXOJb0nDGFNethHSkg=="],
 
     "ssf": ["ssf@0.11.2", "", { "dependencies": { "frac": "~1.1.2" } }, "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g=="],
 


### PR DESCRIPTION
## What Changed
Node.js project scaffold with tree-sitter AST parsing for TypeScript and Python — 112 tests, zero type errors, full discover→parse pipeline proven on mixed-language fixtures.

## Must-Haves
- R011 ownership: summary generation is thresholded (`summaryThreshold`) and cache-aware (regenerate only when source changes).
- R012 ownership: embedding pipeline uses OpenAI API with batching and stable failure classification.
- R013 ownership: sqlite-vec lifecycle is real (extension load, write/query/delete parity, model/dimension invariants).
- Incremental parity: add/modify/delete/rename produce no stale vectors or stale summary records.
- Failure-path integrity: missing API keys/auth/rate-limit/provider errors are visible and do not corrupt graph/index state.
- R017 support: semantic lifecycle parity is reusable by watch-mode incremental reindex in S04.

## Tasks
- T01: Author semantic contract tests first (initially failing)
- T02: Implement sqlite-vec store lifecycle + diagnostic persistence
- T03: Build summary + embedding services with cache and stable error envelopes
- T04: Wire semantic lifecycle into full/incremental indexing and CLI error surfaces

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the semantic indexing scaffold: sqlite-vec lifecycle in `GraphStore`, an Anthropic summary service (`summary.ts`), an OpenAI embedding service (`embedding.ts`), typed domain contracts (`contracts.ts`), diagnostic persistence, and CLI output for semantic run results. The infrastructure is well-structured with stable error codes, model/dimension invariants, and cache-aware logic.

**Key issues found:**

- **Real APIs are never called in the indexing pipeline (P1):** `runSemanticLifecycle` in `indexer.ts` always generates deterministic hash-based summaries (`deterministicSummary`) and embeddings (`deterministicEmbeddingVector`), regardless of whether `OPENAI_API_KEY` is set. When a key IS present, the function persists these placeholder vectors and returns `status: "ok"`, meaning users with valid API keys silently receive non-AI embeddings. Both `summarizeEligibleSymbols` (Anthropic) and `embedSummariesBatched` (OpenAI) — built in this PR — are dead code in the actual indexing pipeline, contradicting the R011/R012 ownership claims in the PR description.

- **Sequential API calls in `summarizeBatch` (P1):** `createAnthropicSummaryProvider.summarizeBatch` uses a serial `for...await` loop — one API round-trip per symbol — rather than parallelising with `Promise.all`. At the default batch size of 25 and typical Anthropic latency this adds ~25 s of wall-clock time per batch.

- **`computeL2Distance` can silently produce NaN (P1):** If called with vectors of mismatched length (e.g., due to `vector_json` data corruption), the non-null assertions on out-of-bounds indices produce `undefined`, and `undefined - number` evaluates to `NaN`, which propagates silently into query results. An explicit length-equality guard should be added.

- **Duplicated hint-mapping logic (P2):** The error-code → user hint switch statement exists in three places (`indexer.ts` as `semanticHintForCode`, `formatters.ts` as `formatSemanticDiagnosticHint`, and `cli.ts` wrapping both), with a subtle difference in the default case (`undefined` vs. a fallback string).

- **`asSemanticStoreCode` is a no-op identity function (P2):** The function in `store.ts` passes its argument straight through and adds no runtime or type-safety value over a direct literal.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the indexing pipeline silently uses deterministic placeholder embeddings even when API keys are configured, contradicting the R011/R012 ownership claims.
- The infrastructure scaffold (types, contracts, error codes, invariant enforcement, diagnostic persistence, CLI output) is solid and the test suite is well-designed. However, the core semantic pipeline gap — `runSemanticLifecycle` always writes deterministic hash-based vectors regardless of API key availability and reports `status: "ok"` when a key is present — means the feature does not deliver what is described. Both the Anthropic summarization service and the OpenAI embedding service are built and tested in isolation but are completely disconnected from the actual indexing pipeline. Additionally, `summarizeBatch` has a significant sequential-request performance bug, and `computeL2Distance` has a latent NaN-producing defect on mismatched vector lengths.
- `apps/context/src/indexer.ts` (real APIs never called), `apps/context/src/semantic/summary.ts` (sequential API calls in batch method), `apps/context/src/graph/store.ts` (NaN in distance computation, no-op identity function)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/context/src/indexer.ts | Core orchestrator wired with semantic lifecycle, but `runSemanticLifecycle` always uses deterministic hash-based embeddings and summaries — the real OpenAI and Anthropic API calls from `embedding.ts`/`summary.ts` are never invoked. Also contains a duplicate hint-mapping switch statement. |
| apps/context/src/semantic/summary.ts | Anthropic API integration with cache-aware summarization is well-structured, but `summarizeBatch` sends sequential per-symbol requests instead of concurrent ones, which would be very slow at scale. Dead code in current pipeline — `summarizeEligibleSymbols` is never called from the indexer. |
| apps/context/src/semantic/embedding.ts | Clean OpenAI embedding provider with stable error code mapping and dimension validation. Well-tested in isolation but never called from `runSemanticLifecycle` in the indexer — the real API is bypassed by deterministic fallback vectors. |
| apps/context/src/graph/store.ts | Adds sqlite-vec lifecycle, semantic vector CRUD, model/dimension invariant enforcement, and diagnostic persistence. Key issues: `computeL2Distance` can silently produce NaN on mismatched vector lengths; `asSemanticStoreCode` is a no-op identity function; sqlite-vec extension is loaded but its native ANN search is not used — queries do a full table scan with manual L2. |
| apps/context/src/semantic/contracts.ts | Clean domain type definitions and error class for semantic services. Well-structured and self-contained. |
| apps/context/src/formatters.ts | New `formatSemanticDiagnostics` and `formatSemanticDiagnosticHint` functions added for CLI output. Logic is correct but the hint-mapping switch is duplicated in `indexer.ts` and `cli.ts` with subtly different default cases. |
| apps/context/src/cli.ts | Semantic diagnostics correctly surfaced in both JSON and human output modes. `withSemanticHint` patches missing hints at the CLI boundary as a safety net. |
| apps/context/src/types.ts | Well-organized new semantic types: `SemanticRunDiagnostics`, `SemanticStageEvent`, `SemanticStatusRecord`, `SemanticStoreError`, and related enums/interfaces. No issues found. |
| apps/context/test/graph/semantic-store.test.ts | Good contract tests for vector lifecycle parity (add/rename/delete), model/dimension invariant enforcement, and diagnostic persistence. |
| apps/context/test/semantic/embedding-pipeline.test.ts | Solid tests covering batching, error code mapping (missing key/auth/rate-limit/provider), and partial-commit semantics. All verify the isolated `embedding.ts` module. |
| apps/context/test/integration-semantic-index.test.ts | Integration tests verify structural integrity under missing keys, vector lifecycle parity across renames/deletes, and stage event shape. Tests pass against deterministic fallback rather than real API calls. |
| apps/context/src/semantic/index.ts | Simple barrel re-export for the semantic module. No issues. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI
    participant Indexer
    participant GraphStore
    participant SummaryTS as summary.ts (built, not wired)
    participant EmbeddingTS as embedding.ts (built, not wired)

    CLI->>Indexer: indexProject(rootPath, options)
    Indexer->>GraphStore: deleteSymbolsByFile()<br/>(cascades to deleteSemanticVectorsByFile)
    Indexer->>GraphStore: upsertSymbols(allSymbols)
    Indexer->>Indexer: runSemanticLifecycle()
    note over Indexer: deterministicSummary()<br/>(no Anthropic API call)
    Indexer->>GraphStore: upsertSymbols(symbolsWithSummaries)
    note over Indexer: deterministicEmbeddingVector()<br/>(no OpenAI API call)
    Indexer->>GraphStore: upsertSemanticVectors(deterministicVectors)
    alt OPENAI_API_KEY missing
        Indexer->>GraphStore: setSemanticStatus(failed, SEMANTIC_OPENAI_MISSING_KEY)
    else OPENAI_API_KEY present
        Indexer->>GraphStore: setSemanticStatus(ok)
        note over Indexer,EmbeddingTS: Real API still not called —<br/>deterministic vectors persist as "ok"
    end
    Indexer-->>CLI: IndexResult { semantic: SemanticRunDiagnostics }

    note over SummaryTS,EmbeddingTS: summarizeEligibleSymbols() and<br/>embedSummariesBatched() are built<br/>and tested in isolation but never<br/>called from the indexing pipeline
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/context/src/indexer.ts
Line: 363-404

Comment:
**Real embedding API never called when key is present**

`runSemanticLifecycle` always generates deterministic (hash-based) embeddings via `deterministicEmbeddingVector` regardless of whether `OPENAI_API_KEY` is set. When a key IS present, the function writes these placeholder vectors to the store and returns `status: "ok"` — meaning users with valid API keys silently get non-AI embeddings while believing the semantic index is fully operational.

The `embedSummariesBatched` function from `semantic/embedding.ts` (which calls the real OpenAI API) is never invoked anywhere in `runSemanticLifecycle`. Similarly, `summarizeEligibleSymbols` from `semantic/summary.ts` (which calls the Anthropic API) is also never called here — the real summary pipeline is entirely bypassed in favour of `deterministicSummary`.

The PR description claims "R012 ownership: embedding pipeline uses OpenAI API with batching" and "R011 ownership: summary generation…", but both the `embedSummariesBatched` and `summarizeEligibleSymbols` services built in this PR are dead code paths in the actual indexing pipeline.

To wire up the real pipeline when the key is available you would need to replace the `deterministicEmbeddingVector` path with a conditional call to `embedSummariesBatched` and replace the local `deterministicSummary` path with a call to `summarizeEligibleSymbols`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/semantic/summary.ts
Line: 188-245

Comment:
**`summarizeBatch` sends one sequential API request per symbol**

Although the method is named `summarizeBatch` and `summarizeEligibleSymbols` divides work into chunks, the inner loop `for (const item of items)` executes each Anthropic Messages API call one-at-a-time with `await`. A batch of 25 symbols (the default `DEFAULT_SUMMARY_BATCH_SIZE`) incurs 25 round-trips serialised end-to-end rather than running in parallel.

The Anthropic Messages API does not accept multiple independent symbols in a single request body, so true batching is not possible, but you could run the requests concurrently:

```ts
const responses = await Promise.all(
  items.map(async (item) => {
    const response = await fetchImpl(endpoint, { ... });
    if (!response.ok) { ... throw ... }
    const payload = await response.json();
    const text = payload.content?.find(...) ?? "";
    return { symbolId: item.symbolId, summary: normalizeSummaryText(text) || `Summary unavailable for ${item.name}` };
  })
);
return responses;
```

At the default batch size of 25 and typical Anthropic latency (~1 s/call), the current serial implementation adds ~25 s of wall-clock time per batch.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/graph/store.ts
Line: 253-260

Comment:
**`computeL2Distance` silently produces NaN on length mismatch**

If `lhs` and `rhs` have different lengths, `rhs[i]` returns `undefined` for out-of-bounds indices. The non-null assertion `rhs[i]!` suppresses the TypeScript warning but does not prevent the arithmetic; `undefined - number` evaluates to `NaN`, which propagates through the sum and produces a silent `NaN` distance.

In practice the current call site guards against this with model/dimension invariant checks and the `WHERE model = ? AND dimensions = ?` query filter, but data corruption in `vector_json` (e.g., a truncated JSON array) could trigger the path. A length guard would make this function safe:

```ts
function computeL2Distance(lhs: number[], rhs: number[]): number {
  if (lhs.length !== rhs.length) {
    throw new Error(
      `computeL2Distance: vector length mismatch (${lhs.length} vs ${rhs.length})`
    );
  }
  let sum = 0;
  for (let i = 0; i < lhs.length; i += 1) {
    const delta = lhs[i]! - rhs[i]!;
    sum += delta * delta;
  }
  return Math.sqrt(sum);
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/indexer.ts
Line: 170-191

Comment:
**Hint-mapping logic duplicated across `indexer.ts` and `formatters.ts`**

The `semanticHintForCode` switch statement here is nearly identical to `formatSemanticDiagnosticHint` in `formatters.ts`, and both are then wrapped by `semanticRemediationForCode` in `cli.ts`. There are three separate implementations of the same mapping with a subtle behavioural difference: the default case here returns `undefined`, whereas `formatters.ts` returns the fallback string `"Check provider configuration and retry semantic indexing."`.

This divergence means `toSemanticDiagnostics` (called from `indexer.ts`) can produce a `SemanticRunDiagnostics` with `hint: undefined`, while the CLI's `withSemanticHint` function must patch it back in using `formatters.ts`. Consider consolidating all three into a single shared utility (e.g., in `formatters.ts` or a `semantic/hints.ts` module) and importing it everywhere.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/graph/store.ts
Line: 262-264

Comment:
**`asSemanticStoreCode` is a no-op identity function**

```ts
function asSemanticStoreCode(code: SemanticStoreErrorCode): SemanticStoreErrorCode {
  return code;
}
```

This function does nothing at runtime — it passes `code` straight through. TypeScript already enforces that every argument to it is a valid `SemanticStoreErrorCode`, so this wrapper adds no type safety that wouldn't exist with a direct pass. Every call site could be replaced with the literal string and the function removed. If the intent was to centralise the cast, a simple type annotation at the call sites (e.g., `const code: SemanticStoreErrorCode = "SEMANTIC_VEC_EXTENSION_LOAD_FAILED"`) achieves the same effect more clearly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(S01/T04): wire ..."](https://github.com/gannonh/kata/commit/3a5a8fa80ad0cd8a0c7f1c47886c485c913dacce)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semantic vector search and lifecycle for code similarity and persistence
  * AI-powered code summarization and batched embeddings with configurable providers
  * Enhanced diagnostics: semantic status included in CLI JSON and human output with remediation hints

* **Tests**
  * Comprehensive tests covering semantic indexing, embedding/summarization pipelines, vector store behavior, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->