### PR TITLE
CLI M005/S02 Namespace slice branches for monorepo safety

### DIFF
--- a/apps/cli/docs/plans/linear-mode-eval-playbook.md
+++ b/apps/cli/docs/plans/linear-mode-eval-playbook.md
@@ -16,7 +16,7 @@
 
 In **file mode**, `/kata` on a fresh project triggers a full onboarding flow:
 - Creates `.kata/` scaffold
-- Dispatches `buildDiscussPrompt` which asks "What's the vision?"
+- Dispatches `buildDiscussPrompt` which asks "What would you like to build?"
 - Captures decisions → writes `context.md` → kicks off planning
 
 In **Linear mode**, `/kata` calls `showLinearSmartEntry()` which:
@@ -83,7 +83,7 @@ I want to build a CLI tool that converts markdown to HTML
 - Begins the discuss/plan flow
 
 **What PROBABLY happens (current state):**
-- Kata runs file-mode flow (creates `.kata/`, asks "What's the vision?" via file-mode wizard)
+- Kata runs file-mode flow (creates `.kata/`, asks "What would you like to build?" via file-mode wizard)
 - Linear mode is never offered
 
 **Record:** Does the onboarding flow mention Linear mode? Is there a way to choose it without knowing about `/kata prefs`?
@@ -147,7 +147,7 @@ It should use `secure_env_collect`. If not, export directly.
 
 ---
 
-## Phase 2: Milestone Bootstrap — "What's the vision?"
+## Phase 2: Milestone Bootstrap — "What would you like to build?"
 
 ### 2.1 Start the workflow
 
@@ -155,7 +155,7 @@ It should use `secure_env_collect`. If not, export directly.
 /kata
 ```
 
-**What SHOULD happen:** Linear-mode smart entry. Since there are no milestones in the Linear project, Kata should guide the user through creating one — similar to the file-mode discuss flow that asks "What's the vision?"
+**What SHOULD happen:** Linear-mode smart entry. Since there are no milestones in the Linear project, Kata should guide the user through creating one — similar to the file-mode discuss flow that asks "What would you like to build?"
 
 **What PROBABLY happens:** `kata_derive_state` returns a state with no active milestone. `selectLinearPrompt` may return null (no matching phase). The user gets a notification like "No Linear prompt available for phase: ..." or "Linear mode is blocked."
 
@@ -361,7 +361,7 @@ Check at **every** `/kata` dispatch:
 
 Based on code review before the eval:
 
-1. **No Linear onboarding wizard.** File mode has "What's the vision?" via `buildDiscussPrompt`. Linear mode has nothing — `showLinearSmartEntry()` goes straight to `selectLinearPrompt()` which has no handler for "no milestones."
+1. **No Linear onboarding wizard.** File mode has "What would you like to build?" via `buildDiscussPrompt`. Linear mode has nothing — `showLinearSmartEntry()` goes straight to `selectLinearPrompt()` which has no handler for "no milestones."
 
 2. **No `/kata prefs` guided setup.** A new user can't discover Linear mode without knowing the preference key names.
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mariozechner/pi-coding-agent": "^0.57.1",
+    "@mariozechner/pi-coding-agent": "^0.60.0",
     "playwright": "^1.58.2"
   },
   "devDependencies": {

--- a/apps/cli/src/resources/AGENTS.md
+++ b/apps/cli/src/resources/AGENTS.md
@@ -532,6 +532,9 @@ Set `LINEAR_API_KEY` in your environment (a Linear personal API key). That's it 
 **Workflow:**
 `linear_list_workflow_states`, `linear_create_label`, `linear_list_labels`, `linear_delete_label`, `linear_ensure_label`
 
+**Comments:**
+`linear_add_comment`
+
 **Documents:**
 `linear_create_document`, `linear_get_document`, `linear_list_documents`, `linear_update_document`, `linear_delete_document`
 
@@ -566,5 +569,5 @@ The built-in extension is separate from the Linear MCP server. You do **not** ne
 - Config directory is `.kata-cli` (the `-cli` suffix avoids collision)
 - Extensions are synced from `src/resources/extensions/` to `~/.kata-cli/agent/extensions/` on every launch
 - The `shared/` extension directory is a library, not an entry point — it's imported by other extensions
-- Branch naming for workflow: `kata/M001/S01` (milestone/slice)
+- Branch naming for workflow: `kata/<scope>/M001/S01` (namespaced; legacy `kata/M001/S01` remains compatible)
 - MCP config lives at `~/.kata-cli/agent/mcp.json` (not `~/.pi/agent/mcp.json`)

--- a/apps/cli/src/resources/extensions/ask-user-questions.ts
+++ b/apps/cli/src/resources/extensions/ask-user-questions.ts
@@ -96,6 +96,7 @@ export default function AskUserQuestions(pi: ExtensionAPI) {
 		label: "Request User Input",
 		description:
 			"Request user input for one to three short questions and wait for the response. Single-select questions have 2-3 mutually exclusive options with a free-form 'None of the above' added automatically. Multi-select questions (allowMultiple: true) let the user toggle multiple options with SPACE and confirm with ENTER.",
+		promptSnippet: "Request user input for one to three short questions and wait for the response.",
 		promptGuidelines: [
 			"Use ask_user_questions when you need the user to choose between concrete alternatives before proceeding.",
 			"Keep questions to 1 when possible; never exceed 3.",

--- a/apps/cli/src/resources/extensions/bg-shell/index.ts
+++ b/apps/cli/src/resources/extensions/bg-shell/index.ts
@@ -1126,6 +1126,7 @@ export default function (pi: ExtensionAPI) {
 			"send (write stdin), send_and_wait (expect-style: send + wait for output pattern), " +
 			"signal (send OS signal), list (all processes with status), kill (terminate), restart (kill + relaunch), " +
 			"group_status (health of a process group), highlights (significant output lines only).",
+		promptSnippet: "Run shell commands in the background without blocking. Manages persistent background processes with intelligent lifecycle tracking.",
 
 		promptGuidelines: [
 			"Use bg_shell to start long-running processes (servers, watchers, builds) that should not block the agent.",

--- a/apps/cli/src/resources/extensions/browser-tools/index.ts
+++ b/apps/cli/src/resources/extensions/browser-tools/index.ts
@@ -1561,6 +1561,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Navigate",
 		description:
 			"Open the browser (if not already open) and navigate to a URL. Waits for network idle. Returns page title and current URL. Use ONLY for visually verifying locally-running web apps (e.g. http://localhost:3000). Do NOT use for documentation sites, GitHub, search results, or any external URL — use web_search instead.",
+		promptSnippet: "Open the browser (if not already open) and navigate to a URL.",
 		parameters: Type.Object({
 			url: Type.String({ description: "URL to navigate to, e.g. http://localhost:3000" }),
 		}),
@@ -1635,6 +1636,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_go_back",
 		label: "Browser Go Back",
 		description: "Navigate back in browser history. Returns a compact page summary after navigation.",
+		promptSnippet: "Navigate back in browser history.",
 		parameters: Type.Object({}),
 
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
@@ -1679,6 +1681,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_go_forward",
 		label: "Browser Go Forward",
 		description: "Navigate forward in browser history. Returns a compact page summary after navigation.",
+		promptSnippet: "Navigate forward in browser history.",
 		parameters: Type.Object({}),
 
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
@@ -1723,6 +1726,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_reload",
 		label: "Browser Reload",
 		description: "Reload the current page. Returns a screenshot, compact page summary, and page metadata (same shape as browser_navigate).", 
+		promptSnippet: "Reload the current page.",
 		parameters: Type.Object({}),
 
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
@@ -1778,6 +1782,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Screenshot",
 		description:
 			"Take a screenshot of the current browser page and return it as an inline image. Uses JPEG for viewport/fullpage (smaller, configurable quality) and PNG for element crops (preserves transparency). Optionally crop to a specific element by CSS selector.",
+		promptSnippet: "Take a screenshot of the current browser page and return it as an inline image.",
 		parameters: Type.Object({
 			fullPage: Type.Optional(
 				Type.Boolean({ description: "Capture the full scrollable page (default: false)" })
@@ -1858,6 +1863,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Click",
 		description:
 			"Click an element on the page by CSS selector or by x,y coordinates. Returns a compact page summary plus lightweight verification details after clicking. Provide either selector or both x and y. Prefer selector over coordinates — selectors are more reliable because they handle shadow DOM via getByRole fallbacks. Use coordinates only when you have no other option.", 
+		promptSnippet: "Click an element on the page by CSS selector or by x,y coordinates.",
 		parameters: Type.Object({
 			selector: Type.Optional(
 				Type.String({ description: "CSS selector of the element to click. The tool will try getByRole fallbacks if the CSS selector fails (handles shadow DOM)." })
@@ -1998,6 +2004,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Drag",
 		description:
 			"Drag an element and drop it onto another element. Use for sortable lists, kanban boards, sliders, and any drag-and-drop UI.",
+		promptSnippet: "Drag an element and drop it onto another element.",
 		parameters: Type.Object({
 			sourceSelector: Type.String({
 				description: "CSS selector of the element to drag",
@@ -2043,6 +2050,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Type",
 		description:
 			"Type text into an input element. By default uses atomic fill (clears and sets value instantly). Use 'slowly' for character-by-character typing when you need to trigger key handlers (e.g. search autocomplete). Use 'submit' to press Enter after typing. Returns a compact page summary plus lightweight verification details. IMPORTANT: Always provide a selector — do NOT rely on coordinate clicks to focus an input before calling this. CSS attribute selectors like combobox[aria-label='X'] work for most inputs; for shadow DOM inputs (e.g. Google Search), the tool automatically tries getByRole fallbacks.",
+		promptSnippet: "Type text into an input element.",
 		parameters: Type.Object({
 			text: Type.String({ description: "Text to type" }),
 			selector: Type.Optional(
@@ -2238,6 +2246,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Upload File",
 		description:
 			"Set files on a file input element. The selector must target an <input type=\"file\"> element. Accepts one or more absolute file paths.",
+		promptSnippet: "Set files on a file input element.",
 		parameters: Type.Object({
 			selector: Type.String({
 				description: 'CSS selector targeting the <input type="file"> element',
@@ -2284,6 +2293,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_scroll",
 		label: "Browser Scroll",
 		description: "Scroll the page up or down by a given number of pixels. Returns scroll position (px and percentage) and an accessibility snapshot of the visible content.",
+		promptSnippet: "Scroll the page up or down by a given number of pixels.",
 		parameters: Type.Object({
 			direction: StringEnum(["up", "down"] as const),
 			amount: Type.Optional(
@@ -2341,6 +2351,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Console Logs",
 		description:
 			"Get all buffered browser console logs and JavaScript errors captured since the last clear. Each entry includes timestamp and page URL. Note: JS errors are also auto-surfaced in interaction tool responses — use this for the full log.",
+		promptSnippet: "Get all buffered browser console logs and JavaScript errors captured since the last clear.",
 		parameters: Type.Object({
 			clear: Type.Optional(
 				Type.Boolean({
@@ -2393,6 +2404,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Network Logs",
 		description:
 			"Get buffered network requests and responses. Shows method, URL, status code, and resource type for all requests. Includes response body for failed requests (4xx/5xx). Use to debug API failures, CORS issues, missing resources, and auth problems.",
+		promptSnippet: "Get buffered network requests and responses.",
 		parameters: Type.Object({
 			clear: Type.Optional(
 				Type.Boolean({
@@ -2462,6 +2474,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Dialog Logs",
 		description:
 			"Get buffered JavaScript dialog events (alert, confirm, prompt, beforeunload). Dialogs are auto-accepted to prevent page freezes. Use this to see what dialogs appeared and their messages.",
+		promptSnippet: "Get buffered JavaScript dialog events (alert, confirm, prompt, beforeunload).",
 		parameters: Type.Object({
 			clear: Type.Optional(
 				Type.Boolean({
@@ -2519,6 +2532,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Evaluate",
 		description:
 			"Execute a JavaScript expression in the browser context and return the result. Useful for reading DOM state, checking values, etc.",
+		promptSnippet: "Execute a JavaScript expression in the browser context and return the result.",
 		parameters: Type.Object({
 			expression: Type.String({
 				description: "JavaScript expression to evaluate in the page context",
@@ -2571,6 +2585,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_close",
 		label: "Browser Close",
 		description: "Close the browser and clean up all resources.",
+		promptSnippet: "Close the browser and clean up all resources.",
 		parameters: Type.Object({}),
 
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
@@ -2597,6 +2612,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_trace_start",
 		label: "Browser Trace Start",
 		description: "Start a Playwright trace for the current browser session and persist trace metadata under the session artifact directory.",
+		promptSnippet: "Start a Playwright trace for the current browser session and persist trace metadata under the session artifact direct...",
 		parameters: Type.Object({
 			name: Type.Optional(Type.String({ description: "Optional short trace session name for artifact filenames." })),
 			title: Type.Optional(Type.String({ description: "Optional trace title recorded in metadata." })),
@@ -2636,6 +2652,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_trace_stop",
 		label: "Browser Trace Stop",
 		description: "Stop the active Playwright trace and write the trace zip to disk under the session artifact directory.",
+		promptSnippet: "Stop the active Playwright trace and write the trace zip to disk under the session artifact directory.",
 		parameters: Type.Object({
 			name: Type.Optional(Type.String({ description: "Optional artifact basename override for the trace zip." })),
 		}),
@@ -2682,6 +2699,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_export_har",
 		label: "Browser Export HAR",
 		description: "Export the truthfully recorded session HAR from disk to a stable artifact path and return compact metadata.",
+		promptSnippet: "Export the truthfully recorded session HAR from disk to a stable artifact path and return compact metadata.",
 		parameters: Type.Object({
 			filename: Type.Optional(Type.String({ description: "Optional destination filename within the session artifact directory." })),
 		}),
@@ -2728,6 +2746,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_timeline",
 		label: "Browser Timeline",
 		description: "Return a compact structured summary of the tracked browser action timeline and optional on-disk export path.",
+		promptSnippet: "Return a compact structured summary of the tracked browser action timeline and optional on-disk export path.",
 		parameters: Type.Object({
 			writeToDisk: Type.Optional(Type.Boolean({ description: "Write the timeline JSON to disk under the session artifact directory." })),
 			filename: Type.Optional(Type.String({ description: "Optional JSON filename when writeToDisk is true." })),
@@ -2765,6 +2784,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_session_summary",
 		label: "Browser Session Summary",
 		description: "Return a compact structured summary of the current browser session, including pages, actions, waits/assertions, bounded-history caveats, and trace/HAR state.",
+		promptSnippet: "Return a compact structured summary of the current browser session, including pages, actions, waits/assertions, bound...",
 		parameters: Type.Object({}),
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
 			try {
@@ -2829,6 +2849,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_debug_bundle",
 		label: "Browser Debug Bundle",
 		description: "Write a timestamped debug bundle to disk with screenshot, logs, timeline, pages, session summary, and accessibility output, then return compact paths and counts.",
+		promptSnippet: "Write a timestamped debug bundle to disk with screenshot, logs, timeline, pages, session summary, and accessibility o...",
 		parameters: Type.Object({
 			selector: Type.Optional(Type.String({ description: "Optional CSS selector to scope the accessibility snapshot before fallback behavior applies." })),
 			name: Type.Optional(Type.String({ description: "Optional short bundle name suffix for the output directory." })),
@@ -2924,6 +2945,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Assert",
 		description:
 			"Run one or more explicit browser assertions and return structured PASS/FAIL results. Prefer this for verification instead of inferring success from prose summaries.",
+		promptSnippet: "Run one or more explicit browser assertions and return structured PASS/FAIL results.",
 		promptGuidelines: [
 			"Prefer browser_assert for browser verification instead of inferring success from summaries.",
 			"When finishing UI work, explicit browser assertions should usually be the final verification step.",
@@ -2970,6 +2992,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Diff",
 		description:
 			"Report meaningful browser-state changes. By default compares the current page to the most recent tracked action state. Use this to understand what changed after a click, submit, or navigation.",
+		promptSnippet: "Report meaningful browser-state changes.",
 		promptGuidelines: [
 			"Use browser_diff after ambiguous or high-impact actions when you need to know what changed.",
 			"Prefer browser_diff over requesting a broad new page inspection when the question is change detection.",
@@ -3020,6 +3043,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Batch",
 		description:
 			"Execute multiple explicit browser steps in one call. Prefer this for obvious action sequences like click → type → wait → assert to reduce round trips and token usage.",
+		promptSnippet: "Execute multiple explicit browser steps in one call.",
 		promptGuidelines: [
 			"If the next 2-5 browser actions are obvious and low-risk, prefer browser_batch over multiple tiny browser calls.",
 			"Use browser_batch for explicit sequences like click → type → submit → wait → assert.",
@@ -3243,6 +3267,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Accessibility Tree",
 		description:
 			"Get the accessibility tree of the current page as structured text. Shows roles, names, labels, values, and states of all interactive elements. Use this to understand page structure before clicking — it reveals buttons, inputs, links, and their labels without needing to guess CSS selectors or coordinates. Much more reliable than inspecting the DOM directly.",
+		promptSnippet: "Get the accessibility tree of the current page as structured text.",
 		parameters: Type.Object({
 			selector: Type.Optional(
 				Type.String({
@@ -3303,6 +3328,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Find",
 		description:
 			"Find elements on the page by text content, ARIA role, or CSS selector. Returns only the matched nodes as a compact accessibility snapshot — far cheaper than browser_get_accessibility_tree. Use this after any action to locate a specific button, input, heading, or link before clicking it.",
+		promptSnippet: "Find elements on the page by text content, ARIA role, or CSS selector.",
 		promptGuidelines: [
 			"Use browser_find for cheap targeted discovery before requesting the full accessibility tree.",
 			"Prefer browser_find when you need one button, input, heading, dialog, or alert rather than a full-page structure dump.",
@@ -3441,6 +3467,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Snapshot Refs",
 		description:
 			"Capture a compact inventory of interactive elements and assign deterministic versioned refs (@vN:e1, @vN:e2, ...). Use these refs with browser_click_ref, browser_fill_ref, and browser_hover_ref.",
+		promptSnippet: "Capture a compact inventory of interactive elements and assign deterministic versioned refs (@vN:e1, @vN:e2, ...).",
 		parameters: Type.Object({
 			selector: Type.Optional(
 				Type.String({
@@ -3576,6 +3603,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_get_ref",
 		label: "Browser Get Ref",
 		description: "Inspect stored metadata for one deterministic element ref (prefer versioned format, e.g. @v3:e1).",
+		promptSnippet: "Inspect stored metadata for one deterministic element ref (prefer versioned format, e.g.",
 		parameters: Type.Object({
 			ref: Type.String({ description: "Reference id, preferably versioned (e.g. '@v3:e1')." }),
 		}),
@@ -3617,6 +3645,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_click_ref",
 		label: "Browser Click Ref",
 		description: "Click a previously snapshotted element by deterministic versioned ref (e.g. @v3:e2).",
+		promptSnippet: "Click a previously snapshotted element by deterministic versioned ref (e.g.",
 		parameters: Type.Object({
 			ref: Type.String({ description: "Reference id in versioned format, e.g. '@v3:e2'." }),
 		}),
@@ -3731,6 +3760,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_hover_ref",
 		label: "Browser Hover Ref",
 		description: "Hover a previously snapshotted element by deterministic versioned ref (e.g. @v3:e4).",
+		promptSnippet: "Hover a previously snapshotted element by deterministic versioned ref (e.g.",
 		parameters: Type.Object({
 			ref: Type.String({ description: "Reference id in versioned format, e.g. '@v3:e4'." }),
 		}),
@@ -3821,6 +3851,7 @@ export default function (pi: ExtensionAPI) {
 		name: "browser_fill_ref",
 		label: "Browser Fill Ref",
 		description: "Fill/type text into an input-like element by deterministic versioned ref (e.g. @v3:e1).",
+		promptSnippet: "Fill/type text into an input-like element by deterministic versioned ref (e.g.",
 		parameters: Type.Object({
 			ref: Type.String({ description: "Reference id in versioned format, e.g. '@v3:e1'." }),
 			text: Type.String({ description: "Text to enter." }),
@@ -3950,6 +3981,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Wait For",
 		description:
 			"Wait for a condition before continuing. Use after actions that trigger async updates — data fetches, route changes, animations, loading spinners. Choose the appropriate condition: 'selector_visible' waits for an element to appear, 'selector_hidden' waits for it to disappear, 'url_contains' waits for the URL to match, 'network_idle' waits for all network requests to finish, 'delay' waits a fixed number of milliseconds, 'text_visible' waits for text to appear in the page body, 'text_hidden' waits for text to disappear from the page body, 'request_completed' waits for a network response whose URL contains the given substring, 'console_message' waits for a console log message containing the given substring, 'element_count' waits for the number of elements matching the CSS selector in 'value' to satisfy the 'threshold' expression (e.g. '>=3', '==0', '<5'), 'region_stable' waits for the DOM region matching the CSS selector in 'value' to stop changing.",
+		promptSnippet: "Wait for a condition before continuing.",
 		parameters: Type.Object({
 			condition: StringEnum([
 				"selector_visible",
@@ -4188,6 +4220,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Hover",
 		description:
 			"Move the mouse over an element to trigger hover states — reveals tooltips, dropdown menus, CSS :hover effects, and other hover-dependent UI. Returns a compact page summary showing the resulting hover state.", 
+		promptSnippet: "Move the mouse over an element to trigger hover states — reveals tooltips, dropdown menus, CSS :hover effects, and ot...",
 		parameters: Type.Object({
 			selector: Type.String({
 				description: "CSS selector of the element to hover over",
@@ -4231,6 +4264,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Key Press",
 		description:
 			"Press a keyboard key or key combination. Returns a compact page summary plus lightweight verification details after the key press. Use for: submitting forms (Enter), closing modals (Escape), navigating focusable elements (Tab / Shift+Tab), operating dropdowns and menus (ArrowDown, ArrowUp, Space), copying/pasting (Meta+C, Meta+V). Key names follow the DOM KeyboardEvent key convention.", 
+		promptSnippet: "Press a keyboard key or key combination.",
 		parameters: Type.Object({
 			key: Type.String({
 				description:
@@ -4312,6 +4346,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Select Option",
 		description:
 			"Select an option from a <select> dropdown element by its visible label or value. Returns a compact page summary plus lightweight verification details. For custom-built dropdowns use browser_click to open them then browser_click to pick the option.", 
+		promptSnippet: "Select an option from a <select> dropdown element by its visible label or value.",
 		parameters: Type.Object({
 			selector: Type.String({
 				description: "CSS selector targeting the <select> element",
@@ -4411,6 +4446,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Set Checked",
 		description:
 			"Check or uncheck a checkbox or radio button. More reliable than clicking for form elements where you need a specific state.",
+		promptSnippet: "Check or uncheck a checkbox or radio button.",
 		parameters: Type.Object({
 			selector: Type.String({
 				description: "CSS selector targeting the checkbox or radio input",
@@ -4486,6 +4522,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Set Viewport",
 		description:
 			"Resize the browser viewport to test responsive layouts at different screen sizes. Use presets for common breakpoints or specify exact pixel dimensions. Essential for verifying mobile/tablet/desktop layouts.",
+		promptSnippet: "Resize the browser viewport to test responsive layouts at different screen sizes.",
 		parameters: Type.Object({
 			preset: Type.Optional(
 				StringEnum(["mobile", "tablet", "desktop", "wide"] as const)
@@ -4571,6 +4608,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Page Source",
 		description:
 			"Get the current HTML source of the page (or a specific element). Use when you need to inspect the actual DOM structure — verify semantic HTML, check that elements rendered correctly, debug why a selector isn't matching, or audit accessibility markup. Output is truncated for large pages.",
+		promptSnippet: "Get the current HTML source of the page (or a specific element).",
 		parameters: Type.Object({
 			selector: Type.Optional(
 				Type.String({
@@ -4627,6 +4665,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser List Pages",
 		description:
 			"List all open browser pages/tabs with their IDs, titles, URLs, and active status. Use to see what pages are available before switching.",
+		promptSnippet: "List all open browser pages/tabs with their IDs, titles, URLs, and active status.",
 		parameters: Type.Object({}),
 
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
@@ -4675,6 +4714,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Switch Page",
 		description:
 			"Switch the active browser page/tab by page ID. Use browser_list_pages to see available IDs. Clears any active frame selection.",
+		promptSnippet: "Switch the active browser page/tab by page ID.",
 		parameters: Type.Object({
 			id: Type.Number({ description: "Page ID to switch to (from browser_list_pages)" }),
 		}),
@@ -4713,6 +4753,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Close Page",
 		description:
 			"Close a specific browser page/tab by ID. Cannot close the last remaining page. The page's close event triggers automatic registry cleanup and active-page fallback.",
+		promptSnippet: "Close a specific browser page/tab by ID.",
 		parameters: Type.Object({
 			id: Type.Number({ description: "Page ID to close (from browser_list_pages)" }),
 		}),
@@ -4775,6 +4816,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser List Frames",
 		description:
 			"List all frames in the active page, including the main frame and any iframes. Shows frame name, URL, and parent frame name. Use before browser_select_frame to identify available frames.",
+		promptSnippet: "List all frames in the active page, including the main frame and any iframes.",
 		parameters: Type.Object({}),
 
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
@@ -4824,6 +4866,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Select Frame",
 		description:
 			"Select a frame within the active page to operate on. Find frames by name, URL pattern, or index. Pass null or \"main\" to reset back to the main page frame. Once a frame is selected, tools like browser_evaluate, browser_find, and browser_click will operate within that frame (after T03 migration).",
+		promptSnippet: "Select a frame within the active page to operate on.",
 		parameters: Type.Object({
 			name: Type.Optional(Type.String({ description: "Frame name to select. Use 'main' or 'null' to reset to main frame." })),
 			urlPattern: Type.Optional(Type.String({ description: "URL substring to match against frame URLs." })),

--- a/apps/cli/src/resources/extensions/github/index.ts
+++ b/apps/cli/src/resources/extensions/github/index.ts
@@ -614,7 +614,6 @@ export default function (pi: ExtensionAPI) {
 
 	pi.registerCommand("gh", {
 		description: "GitHub helper: /gh issues|prs|view|create|labels|milestones|status",
-
 		getArgumentCompletions: (prefix: string) => {
 			const subcommands = ["issues", "prs", "view", "create", "labels", "milestones", "status"];
 			const parts = prefix.trim().split(/\s+/);

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -984,7 +984,7 @@ async function dispatchNextUnit(
           });
           pi.sendMessage({
             content: [
-              `PR auto-create failed for slice ${completedSid}. The code is committed on branch \`kata/${completedMid}/${completedSid}\` — no work was lost.`,
+              `PR auto-create failed for slice ${completedSid}. The code is committed on branch \`${prCtx.branch}\` — no work was lost.`,
               ``,
               `**Error:** ${prResult.error}`,
               ``,

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -1075,7 +1075,8 @@ async function dispatchNextUnit(
   });
 
   // 13. Status + progress widget
-  ctx.ui.setStatus("kata-auto", "auto");
+  const statusModelId = resolveModelForUnit(unitType);
+  ctx.ui.setStatus("kata-auto", statusModelId ? `auto · ${statusModelId}` : "auto");
   if (mid) {
     // Try file-based cache first (works for FileBackend), fall back to state.progress
     updateSliceProgressCache(basePath, mid, state.activeSlice?.id);
@@ -1124,6 +1125,11 @@ async function dispatchNextUnit(
     if (model) {
       const ok = await pi.setModel(model);
       if (ok) ctx.ui.notify(`Model: ${preferredModelId}`, "info");
+    } else {
+      ctx.ui.notify(
+        `Model preference '${preferredModelId}' not found in registry — using current model. Available: ${allModels.map((m) => m.id).slice(0, 5).join(", ")}...`,
+        "warning",
+      );
     }
   }
 

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -1075,8 +1075,7 @@ async function dispatchNextUnit(
   });
 
   // 13. Status + progress widget
-  const statusModelId = resolveModelForUnit(unitType);
-  ctx.ui.setStatus("kata-auto", statusModelId ? `auto · ${statusModelId}` : "auto");
+  ctx.ui.setStatus("kata-auto", "auto");
   if (mid) {
     // Try file-based cache first (works for FileBackend), fall back to state.progress
     updateSliceProgressCache(basePath, mid, state.activeSlice?.id);
@@ -1130,6 +1129,11 @@ async function dispatchNextUnit(
         `Model preference '${preferredModelId}' not found in registry — using current model. Available: ${allModels.map((m) => m.id).slice(0, 5).join(", ")}...`,
         "warning",
       );
+    }
+    if (preferredModelId && preferredModelId === ctx.state.selectedModel?.id) {
+      ctx.ui.setStatus("kata-auto", `auto · ${preferredModelId}`);
+    } else {
+      ctx.ui.setStatus("kata-auto", "auto");
     }
   }
 

--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -26,6 +26,7 @@ import {
   loadProjectKataPreferences,
   loadEffectiveKataPreferences,
   resolveAllSkillReferences,
+  resolveModelForUnit,
   type LoadedKataPreferences,
 } from "./preferences.js";
 import {
@@ -387,6 +388,23 @@ export function registerKataCommand(pi: ExtensionAPI): void {
             ? `${state.activeMilestone.id}/${state.activeSlice.id}`
             : state.activeMilestone.id;
 
+        // Apply model preference for this phase (mirrors auto.ts step 18)
+        const stepUnitType = phaseToUnitType(state.phase);
+        const preferredModelId = resolveModelForUnit(stepUnitType);
+        if (preferredModelId) {
+          const allModels = ctx.modelRegistry.getAll();
+          const model = allModels.find((m) => m.id === preferredModelId);
+          if (model) {
+            const ok = await pi.setModel(model);
+            if (ok) ctx.ui.notify(`Model: ${preferredModelId}`, "info");
+          } else {
+            ctx.ui.notify(
+              `Model preference '${preferredModelId}' not found in registry — using current model.`,
+              "warning",
+            );
+          }
+        }
+
         ctx.ui.notify(`/kata step: ${state.phase} — ${unitId}`, "info");
         pi.sendMessage({ customType: "kata-step", content: prompt, display: false }, { triggerTurn: true });
         return;
@@ -680,4 +698,29 @@ async function ensurePreferencesFile(
     `Edit ${path} to update ${scope} Kata skill preferences.`,
     "info",
   );
+}
+
+/**
+ * Map a Kata state phase to the auto-mode unit type string used by
+ * resolveModelForUnit(). Mirrors the default branch of deriveUnitType()
+ * in auto.ts without requiring PromptOptions.
+ */
+function phaseToUnitType(phase: string): string {
+  switch (phase) {
+    case "pre-planning":
+      return "plan-milestone";
+    case "planning":
+      return "plan-slice";
+    case "executing":
+    case "verifying":
+      return "execute-task";
+    case "summarizing":
+      return "complete-slice";
+    case "completing-milestone":
+      return "complete-milestone";
+    case "replanning-slice":
+      return "replan-slice";
+    default:
+      return `unknown-${phase}`;
+  }
 }

--- a/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
+++ b/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
@@ -45,7 +45,7 @@ Full documentation for `~/.kata-cli/preferences.md` (global) and `.kata/preferen
 
 - `custom_instructions`: extra durable instructions related to skill use.
 
-- `models`: per-stage model selection for auto-mode and PR review. Keys: `research`, `planning`, `execution`, `completion`, `review`. Values: model IDs (for example `claude-sonnet-4-6`, `claude-opus-4-6`). The `review` key controls which model PR reviewer subagents use (via `/kata pr review`). Omit a key to use whatever model is currently active.
+- `models`: per-stage model selection for auto-mode, step mode, and PR review. Keys: `research`, `planning`, `execution`, `completion`, `review`. Values: model IDs (for example `claude-sonnet-4-6`, `claude-opus-4-6`). The `review` key controls which model PR reviewer subagents use (via `/kata pr review`). Applied in both `/kata auto` and `/kata step`. Omit a key to use whatever model is currently active.
 
 - `skill_discovery`: controls how Kata discovers and applies skills during auto-mode. Valid values:
   - `auto` — skills are found and applied automatically without prompting.
@@ -130,7 +130,7 @@ models:
 ---
 ```
 
-Opus for planning (where architectural decisions matter most), Sonnet for everything else (faster, cheaper). The `review` key sets the model for PR reviewer subagents — Sonnet is recommended (faster, parallel-friendly). Omit any key to use the currently selected model.
+Opus for planning (where architectural decisions matter most), Sonnet for everything else (faster, cheaper). The `review` key sets the model for PR reviewer subagents — Sonnet is recommended (faster, parallel-friendly). Model preferences apply to both `/kata auto` and `/kata step`. Omit any key to use the currently selected model.
 
 ---
 

--- a/apps/cli/src/resources/extensions/kata/file-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/file-backend.ts
@@ -382,10 +382,13 @@ export class FileBackend implements KataBackend {
   }
 
   async preparePrContext(milestoneId: string, sliceId: string): Promise<PrContext> {
-    const { ensureSliceBranch } = await import("./worktree.js");
+    const { ensureSliceBranch, getCurrentBranch, getSliceBranchName } = await import("./worktree.js");
     ensureSliceBranch(this.basePath, milestoneId, sliceId);
 
-    const branch = `kata/${milestoneId}/${sliceId}`;
+    const currentBranch = getCurrentBranch(this.basePath);
+    const branch = currentBranch.startsWith("kata/")
+      ? currentBranch
+      : getSliceBranchName(this.basePath, milestoneId, sliceId);
     const documents: Record<string, string> = {};
 
     // Use explicit path resolution instead of readDocument to avoid stale active-state lookups

--- a/apps/cli/src/resources/extensions/kata/file-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/file-backend.ts
@@ -386,9 +386,7 @@ export class FileBackend implements KataBackend {
     ensureSliceBranch(this.basePath, milestoneId, sliceId);
 
     const currentBranch = getCurrentBranch(this.basePath);
-    const branch = currentBranch.startsWith("kata/")
-      ? currentBranch
-      : getSliceBranchName(this.basePath, milestoneId, sliceId);
+    const branch = currentBranch;
     const documents: Record<string, string> = {};
 
     // Use explicit path resolution instead of readDocument to avoid stale active-state lookups
@@ -1448,4 +1446,3 @@ function buildResumeSection(
 
   return lines.join("\n");
 }
-

--- a/apps/cli/src/resources/extensions/kata/linear-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-backend.ts
@@ -234,14 +234,15 @@ export class LinearBackend implements KataBackend {
   }
 
   async preparePrContext(milestoneId: string, sliceId: string): Promise<PrContext> {
-    const branch = `kata/${milestoneId}/${sliceId}`;
     const cwd = this.gitRoot;
-    // Check if already on the target branch
-    const current = execSync("git branch --show-current", { cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-    if (current !== branch) {
-      execSync(`git branch -f ${branch} HEAD`, { cwd, stdio: "pipe" });
-      execSync(`git checkout ${branch}`, { cwd, stdio: "pipe" });
-    }
+    const { ensureSliceBranch, getCurrentBranch, getSliceBranchName } = await import("./worktree.js");
+    ensureSliceBranch(cwd, milestoneId, sliceId);
+
+    const currentBranch = getCurrentBranch(cwd);
+    const branch = currentBranch.startsWith("kata/")
+      ? currentBranch
+      : getSliceBranchName(cwd, milestoneId, sliceId);
+
     execSync(`git push -u origin ${branch}`, { cwd, stdio: "pipe" });
 
     const documents: Record<string, string> = {};

--- a/apps/cli/src/resources/extensions/kata/linear-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-backend.ts
@@ -234,14 +234,12 @@ export class LinearBackend implements KataBackend {
   }
 
   async preparePrContext(milestoneId: string, sliceId: string): Promise<PrContext> {
-    const cwd = this.gitRoot;
+    const cwd = this.basePath;
     const { ensureSliceBranch, getCurrentBranch, getSliceBranchName } = await import("./worktree.js");
     ensureSliceBranch(cwd, milestoneId, sliceId);
 
     const currentBranch = getCurrentBranch(cwd);
-    const branch = currentBranch.startsWith("kata/")
-      ? currentBranch
-      : getSliceBranchName(cwd, milestoneId, sliceId);
+    const branch = currentBranch;
 
     execSync(`git push -u origin ${branch}`, { cwd, stdio: "pipe" });
 

--- a/apps/cli/src/resources/extensions/kata/linear-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-backend.ts
@@ -5,7 +5,7 @@
  * the linear-documents module, and git operations to local exec.
  */
 
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
@@ -241,7 +241,12 @@ export class LinearBackend implements KataBackend {
     const currentBranch = getCurrentBranch(cwd);
     const branch = currentBranch;
 
-    execSync(`git push -u origin ${branch}`, { cwd, stdio: "pipe" });
+    // Best-effort push — runCreatePr has its own push guard as a safety net
+    try {
+      execFileSync("git", ["push", "-u", "origin", branch], { cwd, stdio: "pipe" });
+    } catch {
+      // Non-fatal: runCreatePr will retry the push if needed
+    }
 
     const documents: Record<string, string> = {};
     const plan = await this.readDocument(`${sliceId}-PLAN`);

--- a/apps/cli/src/resources/extensions/kata/preferences.ts
+++ b/apps/cli/src/resources/extensions/kata/preferences.ts
@@ -650,10 +650,12 @@ export function resolveModelForUnit(unitType: string): string | undefined {
     case "plan-milestone":
     case "plan-slice":
     case "replan-slice":
+    case "reassess-roadmap":
       return m.planning;
     case "execute-task":
       return m.execution;
     case "complete-slice":
+    case "complete-milestone":
     case "run-uat":
       return m.completion;
     default:

--- a/apps/cli/src/resources/extensions/kata/prompts/discuss.md
+++ b/apps/cli/src/resources/extensions/kata/prompts/discuss.md
@@ -1,6 +1,6 @@
 {{preamble}}
 
-Say exactly: "What's the vision?" — nothing else. Wait for the user's answer.
+Say exactly: "What would you like to build?" — nothing else. Wait for the user's answer.
 
 ## Discussion Phase
 

--- a/apps/cli/src/resources/extensions/kata/prompts/system.md
+++ b/apps/cli/src/resources/extensions/kata/prompts/system.md
@@ -76,7 +76,7 @@ Titles live inside file content (headings, frontmatter), not in file or director
 - **Slices** are demoable vertical increments (S01, S02, ...) ordered by risk. After each slice completes, the roadmap is reassessed before the next slice begins.
 - **Tasks** are single-context-window units of work (T01, T02, ...)
 - Checkboxes in roadmap and plan files track completion (`[ ]` → `[x]`)
-- Each slice gets its own git branch: `kata/M001/S01`
+- Each slice gets its own git branch: `kata/<scope>/M001/S01` (legacy `kata/M001/S01` remains compatible during transition)
 - Slices are squash-merged to main when complete
 - Summaries compress prior work — read them instead of re-reading all task details
 - `STATE.md` is the quick-glance status file — keep it updated after changes

--- a/apps/cli/src/resources/extensions/kata/tests/file-backend.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/file-backend.test.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -34,6 +35,15 @@ function createTmpBase(): string {
   const base = mkdtempSync(join(tmpdir(), "kata-fb-test-"));
   mkdirSync(join(base, ".kata", "milestones"), { recursive: true });
   return base;
+}
+
+function initGitRepo(base: string): void {
+  execSync("git init -b main", { cwd: base, stdio: "pipe" });
+  execSync("git config user.email kata-test@example.com", { cwd: base, stdio: "pipe" });
+  execSync("git config user.name Kata Test", { cwd: base, stdio: "pipe" });
+  writeFileSync(join(base, "README.md"), "# test\n");
+  execSync("git add README.md", { cwd: base, stdio: "pipe" });
+  execSync('git commit -m "init"', { cwd: base, stdio: "pipe" });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -177,6 +187,30 @@ console.log("\n=== FileBackend: listDocuments ===");
   const backend = new FileBackend(base);
   const docs = await backend.listDocuments();
   assertEq(docs.length, 0, "no documents for empty project");
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// (j) preparePrContext emits namespaced branch and loads slice docs
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log("\n=== FileBackend: preparePrContext branch format ===");
+{
+  const base = createTmpBase();
+  initGitRepo(base);
+
+  const sliceDir = join(base, ".kata", "milestones", "M001", "slices", "S02");
+  mkdirSync(sliceDir, { recursive: true });
+  writeFileSync(join(sliceDir, "S02-PLAN.md"), "# S02 Plan\n");
+  writeFileSync(join(sliceDir, "S02-SUMMARY.md"), "# S02 Summary\n");
+
+  const backend = new FileBackend(base);
+  const ctx = await backend.preparePrContext("M001", "S02");
+
+  assertEq(ctx.branch, "kata/root/M001/S02", "preparePrContext emits namespaced branch in repo root scope");
+  assert("PLAN" in ctx.documents, "preparePrContext includes PLAN document content when present");
+  assert("SUMMARY" in ctx.documents, "preparePrContext includes SUMMARY document content when present");
+
   rmSync(base, { recursive: true, force: true });
 }
 

--- a/apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts
@@ -1,4 +1,8 @@
 import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LinearBackend, type LinearBackendConfig } from "../linear-backend.ts";
 import type { KataBackend } from "../backend.ts";
 import type { KataState } from "../types.ts";
@@ -12,6 +16,23 @@ const TEST_CONFIG: LinearBackendConfig = {
 
 function makeBackend(): LinearBackend {
   return new LinearBackend("/tmp/test-project", TEST_CONFIG);
+}
+
+function initGitRepo(base: string): void {
+  execSync("git init -b main", { cwd: base, stdio: "pipe" });
+  execSync("git config user.email kata-test@example.com", { cwd: base, stdio: "pipe" });
+  execSync("git config user.name Kata Test", { cwd: base, stdio: "pipe" });
+  writeFileSync(join(base, "README.md"), "# test\n");
+  execSync("git add README.md", { cwd: base, stdio: "pipe" });
+  execSync('git commit -m "init"', { cwd: base, stdio: "pipe" });
+}
+
+function initBareRemote(base: string): string {
+  const remote = mkdtempSync(join(tmpdir(), "kata-linear-remote-"));
+  execSync("git init --bare", { cwd: remote, stdio: "pipe" });
+  execSync(`git remote add origin ${remote}`, { cwd: base, stdio: "pipe" });
+  execSync("git push -u origin main", { cwd: base, stdio: "pipe" });
+  return remote;
 }
 
 function makeState(overrides?: Partial<KataState>): KataState {
@@ -40,6 +61,36 @@ describe("LinearBackend interface", () => {
   it("sets basePath from constructor", () => {
     const backend = new LinearBackend("/tmp/test-project", TEST_CONFIG);
     assert.equal(backend.basePath, "/tmp/test-project");
+  });
+});
+
+// ─── preparePrContext ───────────────────────────────────────────────────────
+
+describe("LinearBackend.preparePrContext", () => {
+  it("checks out and returns namespaced slice branch context", async () => {
+    const base = mkdtempSync(join(tmpdir(), "kata-linear-prctx-"));
+    initGitRepo(base);
+    const remote = initBareRemote(base);
+
+    try {
+      const backend = new LinearBackend(base, TEST_CONFIG);
+      backend.readDocument = async (name: string) => {
+        if (name === "S02-PLAN") return "# S02 Plan\n";
+        if (name === "S02-SUMMARY") return "# S02 Summary\n";
+        return null;
+      };
+
+      const ctx = await backend.preparePrContext("M001", "S02");
+      assert.equal(ctx.branch, "kata/root/M001/S02");
+      assert.equal(
+        execSync("git branch --show-current", { cwd: base, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim(),
+        "kata/root/M001/S02",
+      );
+      assert.deepEqual(Object.keys(ctx.documents).sort(), ["PLAN", "SUMMARY"]);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+      rmSync(remote, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/cli/src/resources/extensions/kata/tests/pr-auto.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/pr-auto.test.ts
@@ -1,12 +1,6 @@
 /**
  * Contract tests for auto-mode post-complete-slice decision matrix.
  *
- * These tests FAIL until T03 creates `pr-auto.ts` and exports:
- *   - decidePostCompleteSliceAction(prPrefs)
- *   - formatPrAutoCreateFailure(failure)
- *
- * Expected failure: MODULE_NOT_FOUND for ../pr-auto.js
- *
  * Pins D049: auto-mode creates a PR and pauses when pr.enabled && pr.auto_create;
  * legacy squash-merge remains only for PR-disabled projects.
  */
@@ -150,8 +144,9 @@ test("formatPrAutoCreateFailure includes actionable hint", () => {
 test("formatPrAutoCreateFailure produces diagnostic output inspectable by a future agent", () => {
   const failure: PrAutoCreateFailure = {
     phase: "branch-parse-failed",
-    error: "could not detect slice ID from branch kata/M003/S05",
-    hint: "Ensure the branch follows kata/MXXX/SYY naming convention",
+    error: "could not detect slice ID from branch kata/apps-cli/M003/S05",
+    hint:
+      "Ensure the branch follows kata/<scope>/MXXX/SYY (or legacy kata/MXXX/SYY during transition)",
   };
   const text = formatPrAutoCreateFailure(failure);
 
@@ -160,5 +155,7 @@ test("formatPrAutoCreateFailure produces diagnostic output inspectable by a futu
   // 2. Read the error (what went wrong)
   // 3. Follow the hint (what to do next)
   assert.match(text, /branch-parse-failed|branch/, "must include failure phase");
-  assert.match(text, /kata\/M003\/S05|branch/, "must reference the failing context");
+  assert.match(text, /kata\/apps-cli\/M003\/S05|branch/, "must reference the failing context");
+  assert.match(text, /kata\/<scope>\/MXXX\/SYY/, "must include namespaced branch format guidance");
+  assert.match(text, /legacy kata\/MXXX\/SYY/, "must include legacy branch compatibility guidance");
 });

--- a/apps/cli/src/resources/extensions/kata/tests/pr-command.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/pr-command.test.ts
@@ -64,7 +64,7 @@ function makePrStatusDeps(
   overrides: Partial<PrStatusDependencies> = {},
 ): PrStatusDependencies {
   return {
-    getCurrentBranch: () => "kata/M003/S05",
+    getCurrentBranch: () => "kata/apps-cli/M003/S05",
     getOpenPrNumber: async () => null,
     getPrEnabled: () => false,
     getPrAutoCreate: () => false,
@@ -76,7 +76,7 @@ function makePrStatusDeps(
 test("buildPrStatusReport includes branch and PR state in message", async () => {
   const report = await buildPrStatusReport(
     makePrStatusDeps({
-      getCurrentBranch: () => "kata/M003/S05",
+      getCurrentBranch: () => "kata/apps-cli/M003/S05",
       getOpenPrNumber: async () => 42,
       getPrEnabled: () => true,
     }),
@@ -84,8 +84,20 @@ test("buildPrStatusReport includes branch and PR state in message", async () => 
 
   assert.ok(typeof report.level === "string", "report must have level");
   assert.ok(typeof report.message === "string", "report must have message");
-  assert.match(report.message, /kata\/M003\/S05/, "message must include branch name");
+  assert.match(report.message, /kata\/apps-cli\/M003\/S05/, "message must include namespaced branch name");
   assert.match(report.message, /42/, "message must include PR number");
+});
+
+test("buildPrStatusReport preserves legacy branch display during transition", async () => {
+  const report = await buildPrStatusReport(
+    makePrStatusDeps({
+      getCurrentBranch: () => "kata/M003/S05",
+      getOpenPrNumber: async () => null,
+      getPrEnabled: () => true,
+    }),
+  );
+
+  assert.match(report.message, /kata\/M003\/S05/, "message must still surface legacy branch names");
 });
 
 test("buildPrStatusReport shows 'no open PR' when none exists", async () => {

--- a/apps/cli/src/resources/extensions/kata/tests/worktree.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/worktree.test.ts
@@ -252,6 +252,52 @@ async function main(): Promise<void> {
   );
   switchToMain(base);
 
+  console.log("\n=== legacy+namespaced coexistence contract ===");
+  run("git branch kata/M001/S06 main", base);
+  run("git branch kata/other-scope/M001/S06 main", base);
+  let coexistenceError: unknown = null;
+  try {
+    ensureSliceBranch(base, "M001", "S06");
+  } catch (error) {
+    coexistenceError = error;
+  }
+  assert(
+    coexistenceError instanceof Error,
+    "legacy branch is rejected when conflicting namespaced branch exists",
+  );
+  const coexistenceMessage = coexistenceError instanceof Error ? coexistenceError.message : "";
+  assert(
+    coexistenceMessage.includes("kata/root/M001/S06"),
+    "legacy rejection reports expected namespaced target scope",
+  );
+  assert(
+    coexistenceMessage.includes("kata/other-scope/M001/S06"),
+    "legacy rejection reports conflicting namespaced branch",
+  );
+
+  console.log("\n=== mergeSliceToMain rejects legacy with conflicting namespaced branch ===");
+  run("git branch kata/M001/S07 main", base);
+  run("git branch kata/other-scope/M001/S07 main", base);
+  let mergeConflictError: unknown = null;
+  try {
+    mergeSliceToMain(base, "M001", "S07", "Slice Seven");
+  } catch (error) {
+    mergeConflictError = error;
+  }
+  assert(
+    mergeConflictError instanceof Error,
+    "mergeSliceToMain refuses legacy branch when conflicting namespaced branch exists",
+  );
+  const mergeConflictMessage = mergeConflictError instanceof Error ? mergeConflictError.message : "";
+  assert(
+    mergeConflictMessage.includes("kata/other-scope/M001/S07"),
+    "merge conflict error identifies conflicting namespaced branch",
+  );
+  assert(
+    mergeConflictMessage.includes("root"),
+    "merge conflict error reports expected project scope",
+  );
+
   console.log("\n=== getSliceBranchName namespaced contract ===");
   assertEq(
     getSliceBranchName(base, "M001", "S01"),

--- a/apps/cli/src/resources/extensions/kata/tests/worktree.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/worktree.test.ts
@@ -254,7 +254,7 @@ async function main(): Promise<void> {
 
   console.log("\n=== getSliceBranchName namespaced contract ===");
   assertEq(
-    getSliceBranchName("M001", "S01"),
+    getSliceBranchName(base, "M001", "S01"),
     "kata/root/M001/S01",
     "branch name format includes project scope",
   );

--- a/apps/cli/src/resources/extensions/kata/tests/worktree.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/worktree.test.ts
@@ -75,28 +75,28 @@ async function main(): Promise<void> {
   console.log("\n=== ensureSliceBranch ===");
   const created = ensureSliceBranch(base, "M001", "S01");
   assert(created, "branch created on first ensure");
-  assertEq(getCurrentBranch(base), "kata/M001/S01", "switched to slice branch");
+  assertEq(getCurrentBranch(base), "kata/root/M001/S01", "switched to namespaced slice branch");
 
   console.log("\n=== idempotent ensure ===");
   const secondCreate = ensureSliceBranch(base, "M001", "S01");
   assertEq(secondCreate, false, "branch not recreated on second ensure");
-  assertEq(getCurrentBranch(base), "kata/M001/S01", "still on slice branch");
+  assertEq(getCurrentBranch(base), "kata/root/M001/S01", "still on namespaced slice branch");
 
   console.log("\n=== getActiveSliceBranch ===");
   assertEq(
     getActiveSliceBranch(base),
-    "kata/M001/S01",
-    "getActiveSliceBranch returns current slice branch",
+    "kata/root/M001/S01",
+    "getActiveSliceBranch returns current namespaced slice branch",
   );
 
   console.log("\n=== state surfaces active branch ===");
   const state = await deriveState(base);
-  assertEq(state.activeBranch, "kata/M001/S01", "state exposes active branch");
+  assertEq(state.activeBranch, "kata/root/M001/S01", "state exposes namespaced active branch");
 
   console.log("\n=== workspace index surfaces branch ===");
   const index = await indexWorkspace(base);
   const slice = index.milestones[0]?.slices[0];
-  assertEq(slice?.branch, "kata/M001/S01", "workspace index exposes branch");
+  assertEq(slice?.branch, "kata/root/M001/S01", "workspace index exposes namespaced branch");
 
   console.log("\n=== autoCommitCurrentBranch ===");
   // Clean — should return null
@@ -143,7 +143,7 @@ async function main(): Promise<void> {
   switchToMain(base);
 
   const merge = mergeSliceToMain(base, "M001", "S01", "Slice One");
-  assertEq(merge.branch, "kata/M001/S01", "merge reports branch");
+  assertEq(merge.branch, "kata/root/M001/S01", "merge reports namespaced branch");
   assertEq(getCurrentBranch(base), "main", "still on main after merge");
   assert(
     readFileSync(join(base, "README.md"), "utf-8").includes("slice"),
@@ -153,7 +153,7 @@ async function main(): Promise<void> {
 
   // Verify branch is actually gone
   const branches = run("git branch", base);
-  assert(!branches.includes("kata/M001/S01"), "slice branch no longer exists");
+  assert(!branches.includes("kata/root/M001/S01"), "namespaced slice branch no longer exists");
 
   console.log("\n=== switchToMain auto-commits dirty files ===");
   // Set up S02
@@ -178,6 +178,11 @@ async function main(): Promise<void> {
   run("git commit -m 'chore: add S02'", base);
 
   ensureSliceBranch(base, "M001", "S02");
+  assertEq(
+    getCurrentBranch(base),
+    "kata/root/M001/S02",
+    "S02 uses namespaced branch format",
+  );
   writeFileSync(join(base, "feature.txt"), "new feature\n", "utf-8");
   // Don't commit — switchToMain should auto-commit
   switchToMain(base);
@@ -189,6 +194,11 @@ async function main(): Promise<void> {
 
   // Verify the commit happened on the slice branch
   ensureSliceBranch(base, "M001", "S02");
+  assertEq(
+    getCurrentBranch(base),
+    "kata/root/M001/S02",
+    "auto-commit verification re-enters namespaced S02 branch",
+  );
   assert(
     readFileSync(join(base, "feature.txt"), "utf-8").includes("new feature"),
     "dirty file was committed on slice branch",
@@ -203,11 +213,50 @@ async function main(): Promise<void> {
   );
   assertEq(mergeS02.deletedBranch, true, "S02 branch deleted");
 
-  console.log("\n=== getSliceBranchName ===");
+  console.log("\n=== legacy branch continuity contract ===");
+  run("git branch kata/M001/S03 main", base);
+  const legacyCreated = ensureSliceBranch(base, "M001", "S03");
+  assertEq(
+    legacyCreated,
+    false,
+    "existing legacy branch remains checkout-compatible during transition",
+  );
+  assertEq(
+    getCurrentBranch(base),
+    "kata/M001/S03",
+    "legacy branch format can still be activated",
+  );
+  switchToMain(base);
+
+  console.log("\n=== provenance mismatch diagnostics contract ===");
+  run("git branch kata/other-scope/M001/S05 main", base);
+  let provenanceError: unknown = null;
+  try {
+    ensureSliceBranch(base, "M001", "S05");
+  } catch (error) {
+    provenanceError = error;
+  }
+  assert(
+    provenanceError instanceof Error,
+    "cross-scope namespaced branch reuse is rejected",
+  );
+  const provenanceMessage =
+    provenanceError instanceof Error ? provenanceError.message : "";
+  assert(
+    provenanceMessage.includes("kata/other-scope/M001/S05"),
+    "provenance rejection includes conflicting branch value",
+  );
+  assert(
+    provenanceMessage.includes("root"),
+    "provenance rejection includes expected project scope",
+  );
+  switchToMain(base);
+
+  console.log("\n=== getSliceBranchName namespaced contract ===");
   assertEq(
     getSliceBranchName("M001", "S01"),
-    "kata/M001/S01",
-    "branch name format correct",
+    "kata/root/M001/S01",
+    "branch name format includes project scope",
   );
 
   rmSync(base, { recursive: true, force: true });

--- a/apps/cli/src/resources/extensions/kata/workspace-index.ts
+++ b/apps/cli/src/resources/extensions/kata/workspace-index.ts
@@ -112,7 +112,7 @@ async function indexSlice(basePath: string, milestoneId: string, sliceId: string
     summaryPath,
     uatPath,
     tasksDir,
-    branch: getSliceBranchName(milestoneId, sliceId),
+    branch: getSliceBranchName(basePath, milestoneId, sliceId),
     tasks,
   };
 }

--- a/apps/cli/src/resources/extensions/kata/worktree.ts
+++ b/apps/cli/src/resources/extensions/kata/worktree.ts
@@ -11,8 +11,18 @@
  *   3. mergeSliceToMain() — checkout main, squash-merge, delete branch
  */
 
-import { existsSync } from "node:fs";
-import { execSync } from "node:child_process";
+import path from "node:path";
+
+import {
+  autoCommitCurrentBranch as autoCommitCurrentBranchFromGitService,
+  getCurrentBranch as getCurrentBranchFromGitService,
+  getMainBranch as getMainBranchFromGitService,
+  runGit,
+} from "./git-service.ts";
+import { resolveGitRoot } from "./git-utils.ts";
+
+const LEGACY_SLICE_BRANCH_RE = /^kata\/([A-Z]\d+)\/([A-Z]\d+)$/;
+const NAMESPACED_SLICE_BRANCH_RE = /^kata\/([^/]+)\/([A-Z]\d+)\/([A-Z]\d+)$/;
 
 export interface MergeSliceResult {
   branch: string;
@@ -20,51 +30,138 @@ export interface MergeSliceResult {
   deletedBranch: boolean;
 }
 
-function runGit(basePath: string, args: string[], options: { allowFailure?: boolean } = {}): string {
-  try {
-    return execSync(`git ${args.join(" ")}`, {
-      cwd: basePath,
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-    }).trim();
-  } catch (error) {
-    if (options.allowFailure) return "";
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`git ${args.join(" ")} failed in ${basePath}: ${message}`);
-  }
+function normalizeScopeSegment(scope: string): string {
+  const sanitized = scope
+    .replace(/[^a-zA-Z0-9._-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized || "root";
 }
 
-export function getSliceBranchName(milestoneId: string, sliceId: string): string {
+export function getProjectScope(basePath: string): string {
+  const gitRoot = resolveGitRoot(basePath);
+  const relative = path.relative(gitRoot, basePath);
+
+  // If basePath is not inside gitRoot (e.g. a polluted GIT_DIR env),
+  // avoid leaking absolute path structure into branch names.
+  if (
+    !relative
+    || relative === "."
+    || relative.startsWith(`..${path.sep}`)
+    || relative === ".."
+    || path.isAbsolute(relative)
+  ) {
+    return "root";
+  }
+
+  const normalized = relative
+    .split(path.sep)
+    .filter(Boolean)
+    .join("-");
+
+  return normalizeScopeSegment(normalized);
+}
+
+function getLegacySliceBranchName(milestoneId: string, sliceId: string): string {
   return `kata/${milestoneId}/${sliceId}`;
 }
 
+export function getSliceBranchName(basePath: string, milestoneId: string, sliceId: string): string {
+  return `kata/${getProjectScope(basePath)}/${milestoneId}/${sliceId}`;
+}
+
 export function getMainBranch(basePath: string): string {
-  const symbolic = runGit(basePath, ["symbolic-ref", "refs/remotes/origin/HEAD"], { allowFailure: true });
-  if (symbolic) {
-    const match = symbolic.match(/refs\/remotes\/origin\/(.+)$/);
-    if (match) return match[1]!;
-  }
-
-  const mainExists = runGit(basePath, ["show-ref", "--verify", "refs/heads/main"], { allowFailure: true });
-  if (mainExists) return "main";
-
-  const masterExists = runGit(basePath, ["show-ref", "--verify", "refs/heads/master"], { allowFailure: true });
-  if (masterExists) return "master";
-
-  return runGit(basePath, ["branch", "--show-current"]);
+  return getMainBranchFromGitService(basePath);
 }
 
 export function getCurrentBranch(basePath: string): string {
-  return runGit(basePath, ["branch", "--show-current"]);
+  return getCurrentBranchFromGitService(basePath);
 }
 
 function branchExists(basePath: string, branch: string): boolean {
   try {
-    runGit(basePath, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
+    runGit(basePath, ["show-ref", "--verify", `refs/heads/${branch}`]);
     return true;
   } catch {
     return false;
   }
+}
+
+function parseNamespacedSliceBranch(branch: string): {
+  scope: string;
+  milestoneId: string;
+  sliceId: string;
+} | null {
+  const match = branch.match(NAMESPACED_SLICE_BRANCH_RE);
+  if (!match) return null;
+  const [, scope, milestoneId, sliceId] = match;
+  return {
+    scope: scope!,
+    milestoneId: milestoneId!,
+    sliceId: sliceId!,
+  };
+}
+
+function parseLegacySliceBranch(branch: string): {
+  milestoneId: string;
+  sliceId: string;
+} | null {
+  const match = branch.match(LEGACY_SLICE_BRANCH_RE);
+  if (!match) return null;
+  const [, milestoneId, sliceId] = match;
+  return {
+    milestoneId: milestoneId!,
+    sliceId: sliceId!,
+  };
+}
+
+function listKataBranches(basePath: string): string[] {
+  const refs = runGit(
+    basePath,
+    ["for-each-ref", "--format=%(refname:short)", "refs/heads/kata"],
+    { allowFailure: true },
+  );
+  if (!refs) return [];
+  return refs
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean);
+}
+
+function findConflictingNamespacedBranch(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+  expectedScope: string,
+): string | null {
+  for (const branch of listKataBranches(basePath)) {
+    const parsed = parseNamespacedSliceBranch(branch);
+    if (!parsed) continue;
+    if (parsed.milestoneId !== milestoneId) continue;
+    if (parsed.sliceId !== sliceId) continue;
+    if (parsed.scope === expectedScope) continue;
+    return branch;
+  }
+
+  return null;
+}
+
+function resolvePreferredSliceBranch(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+): string | null {
+  const namespacedBranch = getSliceBranchName(basePath, milestoneId, sliceId);
+  if (branchExists(basePath, namespacedBranch)) {
+    return namespacedBranch;
+  }
+
+  const legacyBranch = getLegacySliceBranchName(milestoneId, sliceId);
+  if (branchExists(basePath, legacyBranch)) {
+    return legacyBranch;
+  }
+
+  return null;
 }
 
 /**
@@ -73,21 +170,35 @@ function branchExists(basePath: string, branch: string): boolean {
  * Returns true if the branch was newly created.
  */
 export function ensureSliceBranch(basePath: string, milestoneId: string, sliceId: string): boolean {
-  const branch = getSliceBranchName(milestoneId, sliceId);
+  const namespacedBranch = getSliceBranchName(basePath, milestoneId, sliceId);
+  const legacyBranch = getLegacySliceBranchName(milestoneId, sliceId);
   const current = getCurrentBranch(basePath);
 
-  if (current === branch) return false;
+  if (current === namespacedBranch || current === legacyBranch) return false;
 
-  const mainBranch = getMainBranch(basePath);
-  let created = false;
-
-  if (!branchExists(basePath, branch)) {
-    runGit(basePath, ["branch", branch, mainBranch]);
-    created = true;
+  const preferredExisting = resolvePreferredSliceBranch(basePath, milestoneId, sliceId);
+  if (preferredExisting) {
+    runGit(basePath, ["checkout", preferredExisting]);
+    return false;
   }
 
-  runGit(basePath, ["checkout", branch]);
-  return created;
+  const expectedScope = getProjectScope(basePath);
+  const conflictingBranch = findConflictingNamespacedBranch(
+    basePath,
+    milestoneId,
+    sliceId,
+    expectedScope,
+  );
+  if (conflictingBranch) {
+    throw new Error(
+      `Refusing to reuse slice branch from a different project scope: found ${conflictingBranch}; expected scope ${expectedScope} for M/S ${milestoneId}/${sliceId}`,
+    );
+  }
+
+  const mainBranch = getMainBranch(basePath);
+  runGit(basePath, ["branch", namespacedBranch, mainBranch]);
+  runGit(basePath, ["checkout", namespacedBranch]);
+  return true;
 }
 
 /**
@@ -97,17 +208,7 @@ export function ensureSliceBranch(basePath: string, milestoneId: string, sliceId
 export function autoCommitCurrentBranch(
   basePath: string, unitType: string, unitId: string,
 ): string | null {
-  const status = runGit(basePath, ["status", "--short"]);
-  if (!status.trim()) return null;
-
-  runGit(basePath, ["add", "-A"]);
-
-  const staged = runGit(basePath, ["diff", "--cached", "--stat"]);
-  if (!staged.trim()) return null;
-
-  const message = `chore(${unitId}): auto-commit after ${unitType}`;
-  runGit(basePath, ["commit", "-m", JSON.stringify(message)]);
-  return message;
+  return autoCommitCurrentBranchFromGitService(basePath, unitType, unitId);
 }
 
 /**
@@ -132,7 +233,12 @@ export function switchToMain(basePath: string): void {
 export function mergeSliceToMain(
   basePath: string, milestoneId: string, sliceId: string, sliceTitle: string,
 ): MergeSliceResult {
-  const branch = getSliceBranchName(milestoneId, sliceId);
+  const namespacedBranch = getSliceBranchName(basePath, milestoneId, sliceId);
+  const legacyBranch = getLegacySliceBranchName(milestoneId, sliceId);
+  const branch = branchExists(basePath, namespacedBranch)
+    ? namespacedBranch
+    : legacyBranch;
+
   const mainBranch = getMainBranch(basePath);
 
   const current = getCurrentBranch(basePath);
@@ -179,4 +285,32 @@ export function getActiveSliceBranch(basePath: string): string | null {
   } catch {
     return null;
   }
+}
+
+export function parseSliceBranchName(branch: string): {
+  scope?: string;
+  milestoneId: string;
+  sliceId: string;
+  namespaced: boolean;
+} | null {
+  const namespaced = parseNamespacedSliceBranch(branch);
+  if (namespaced) {
+    return {
+      scope: namespaced.scope,
+      milestoneId: namespaced.milestoneId,
+      sliceId: namespaced.sliceId,
+      namespaced: true,
+    };
+  }
+
+  const legacy = parseLegacySliceBranch(branch);
+  if (legacy) {
+    return {
+      milestoneId: legacy.milestoneId,
+      sliceId: legacy.sliceId,
+      namespaced: false,
+    };
+  }
+
+  return null;
 }

--- a/apps/cli/src/resources/extensions/kata/worktree.ts
+++ b/apps/cli/src/resources/extensions/kata/worktree.ts
@@ -202,7 +202,7 @@ export function ensureSliceBranch(basePath: string, milestoneId: string, sliceId
   );
   if (conflictingBranch) {
     throw new Error(
-      `Refusing to use legacy branch ${legacyBranch} for ${milestoneId}/${sliceId} due conflicting scope namespace: found ${conflictingBranch}; expected scope ${expectedScope}`,
+      `Refusing to use legacy branch ${legacyBranch} for ${milestoneId}/${sliceId} due conflicting scope namespace: found ${conflictingBranch}; expected ${namespacedBranch} (scope ${expectedScope})`,
     );
   }
 
@@ -257,7 +257,7 @@ export function mergeSliceToMain(
     );
     if (conflictingBranch) {
       throw new Error(
-        `Refusing to merge legacy branch ${legacyBranch} for ${milestoneId}/${sliceId} due conflicting scope namespace: found ${conflictingBranch}; expected scope ${expectedScope}`,
+        `Refusing to merge legacy branch ${legacyBranch} for ${milestoneId}/${sliceId} due conflicting scope namespace: found ${conflictingBranch}; expected ${namespacedBranch} (scope ${expectedScope})`,
       );
     }
     branch = legacyBranch;

--- a/apps/cli/src/resources/extensions/kata/worktree.ts
+++ b/apps/cli/src/resources/extensions/kata/worktree.ts
@@ -185,7 +185,7 @@ export function ensureSliceBranch(basePath: string, milestoneId: string, sliceId
   const legacyBranch = getLegacySliceBranchName(milestoneId, sliceId);
   const current = getCurrentBranch(basePath);
 
-  if (current === namespacedBranch || current === legacyBranch) return false;
+  if (current === namespacedBranch) return false;
 
   const preferredExisting = resolvePreferredSliceBranch(basePath, milestoneId, sliceId);
   if (preferredExisting) {

--- a/apps/cli/src/resources/extensions/kata/worktree.ts
+++ b/apps/cli/src/resources/extensions/kata/worktree.ts
@@ -157,11 +157,22 @@ function resolvePreferredSliceBranch(
   }
 
   const legacyBranch = getLegacySliceBranchName(milestoneId, sliceId);
-  if (branchExists(basePath, legacyBranch)) {
-    return legacyBranch;
+  if (!branchExists(basePath, legacyBranch)) {
+    return null;
   }
 
-  return null;
+  const expectedScope = getProjectScope(basePath);
+  const conflictingBranch = findConflictingNamespacedBranch(
+    basePath,
+    milestoneId,
+    sliceId,
+    expectedScope,
+  );
+  if (conflictingBranch) {
+    return null;
+  }
+
+  return legacyBranch;
 }
 
 /**
@@ -191,7 +202,7 @@ export function ensureSliceBranch(basePath: string, milestoneId: string, sliceId
   );
   if (conflictingBranch) {
     throw new Error(
-      `Refusing to reuse slice branch from a different project scope: found ${conflictingBranch}; expected scope ${expectedScope} for M/S ${milestoneId}/${sliceId}`,
+      `Refusing to use legacy branch ${legacyBranch} for ${milestoneId}/${sliceId} due conflicting scope namespace: found ${conflictingBranch}; expected scope ${expectedScope}`,
     );
   }
 
@@ -235,9 +246,22 @@ export function mergeSliceToMain(
 ): MergeSliceResult {
   const namespacedBranch = getSliceBranchName(basePath, milestoneId, sliceId);
   const legacyBranch = getLegacySliceBranchName(milestoneId, sliceId);
-  const branch = branchExists(basePath, namespacedBranch)
-    ? namespacedBranch
-    : legacyBranch;
+  let branch = namespacedBranch;
+  if (!branchExists(basePath, namespacedBranch)) {
+    const expectedScope = getProjectScope(basePath);
+    const conflictingBranch = findConflictingNamespacedBranch(
+      basePath,
+      milestoneId,
+      sliceId,
+      expectedScope,
+    );
+    if (conflictingBranch) {
+      throw new Error(
+        `Refusing to merge legacy branch ${legacyBranch} for ${milestoneId}/${sliceId} due conflicting scope namespace: found ${conflictingBranch}; expected scope ${expectedScope}`,
+      );
+    }
+    branch = legacyBranch;
+  }
 
   const mainBranch = getMainBranch(basePath);
 

--- a/apps/cli/src/resources/extensions/linear/linear-client.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-client.ts
@@ -876,4 +876,26 @@ export class LinearClient {
     this.assertSuccess("documentUpdate", data.documentUpdate.success);
     return data.documentUpdate.document;
   }
+
+  // ── Comments ────────────────────────────────────────────────────────────
+
+  async createComment(issueId: string, body: string): Promise<{ id: string; body: string; createdAt: string; url: string }> {
+    const data = await this.graphql<{
+      commentCreate: { success: boolean; comment: { id: string; body: string; createdAt: string; url: string } };
+    }>(`
+      mutation CreateComment($input: CommentCreateInput!) {
+        commentCreate(input: $input) {
+          success
+          comment {
+            id
+            body
+            createdAt
+            url
+          }
+        }
+      }
+    `, { input: { issueId, body } });
+    this.assertSuccess("commentCreate", data.commentCreate.success);
+    return data.commentCreate.comment;
+  }
 }

--- a/apps/cli/src/resources/extensions/linear/linear-tools.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-tools.ts
@@ -99,7 +99,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_get_team",
     label: "Linear: Get Team",
     description: "Get a team by key (e.g. 'KAT') or UUID.",
-    promptSnippet: "Get a team by key (e.g.",
+    promptSnippet: "Get a team by key or UUID.",
     parameters: Type.Object({
       idOrKey: Type.String({ description: "Team key (e.g. 'KAT') or UUID" }),
     }),
@@ -281,7 +281,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_get_issue",
     label: "Linear: Get Issue",
     description: "Get an issue by UUID or identifier (e.g. 'KAT-42'). Returns full details including parent, children, labels, and state.",
-    promptSnippet: "Get an issue by UUID or identifier (e.g.",
+    promptSnippet: "Get an issue by UUID or identifier.",
     parameters: Type.Object({
       id: Type.String({ description: "Issue UUID or identifier (e.g. 'KAT-42')" }),
     }),

--- a/apps/cli/src/resources/extensions/linear/linear-tools.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-tools.ts
@@ -397,6 +397,20 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     async execute(_id, params) { return run(() => client.deleteLabel(params.id)); },
   });
 
+  // ── Comments ──────────────────────────────────────────────────────────
+
+  pi.registerTool({
+    name: "linear_add_comment",
+    label: "Linear: Add Comment",
+    description: "Post a comment on a Linear issue. Returns the created comment with id, body, createdAt, and url.",
+    promptSnippet: "Post a comment on a Linear issue.",
+    parameters: Type.Object({
+      issueId: Type.String({ description: "Issue UUID to comment on" }),
+      body: Type.String({ description: "Comment body (markdown supported)" }),
+    }),
+    async execute(_id, params) { return run(() => client.createComment(params.issueId, params.body)); },
+  });
+
   pi.registerTool({
     name: "linear_ensure_label",
     label: "Linear: Ensure Label",

--- a/apps/cli/src/resources/extensions/linear/linear-tools.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-tools.ts
@@ -90,6 +90,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_list_teams",
     label: "Linear: List Teams",
     description: "List all teams in the Linear workspace.",
+    promptSnippet: "List all teams in the Linear workspace.",
     parameters: Type.Object({}),
     async execute() { return run(() => client.listTeams()); },
   });
@@ -98,6 +99,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_get_team",
     label: "Linear: Get Team",
     description: "Get a team by key (e.g. 'KAT') or UUID.",
+    promptSnippet: "Get a team by key (e.g.",
     parameters: Type.Object({
       idOrKey: Type.String({ description: "Team key (e.g. 'KAT') or UUID" }),
     }),
@@ -112,6 +114,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_create_project",
     label: "Linear: Create Project",
     description: "Create a new Linear project.",
+    promptSnippet: "Create a new Linear project.",
     parameters: Type.Object({
       name: Type.String({ description: "Project name" }),
       teamIds: Type.Array(Type.String(), { description: "Team UUIDs to associate with the project" }),
@@ -127,6 +130,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_get_project",
     label: "Linear: Get Project",
     description: "Get a project by UUID or slug ID.",
+    promptSnippet: "Get a project by UUID or slug ID.",
     parameters: Type.Object({
       id: Type.String({ description: "Project UUID or slug ID" }),
     }),
@@ -137,6 +141,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_list_projects",
     label: "Linear: List Projects",
     description: "List projects in the workspace, optionally filtered by team.",
+    promptSnippet: "List projects in the workspace, optionally filtered by team.",
     parameters: Type.Object({
       teamId: Type.Optional(Type.String({ description: "Filter by team UUID" })),
       first: Type.Optional(Type.Number({ description: "Max results per page (default: 50)" })),
@@ -151,6 +156,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_update_project",
     label: "Linear: Update Project",
     description: "Update a project's name, description, state, or dates.",
+    promptSnippet: "Update a projects name, description, state, or dates.",
     parameters: Type.Object({
       id: Type.String({ description: "Project UUID" }),
       name: Type.Optional(Type.String({ description: "New name" })),
@@ -169,6 +175,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_delete_project",
     label: "Linear: Delete Project",
     description: "Delete a project by UUID.",
+    promptSnippet: "Delete a project by UUID.",
     parameters: Type.Object({
       id: Type.String({ description: "Project UUID" }),
     }),
@@ -183,6 +190,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_create_milestone",
     label: "Linear: Create Milestone",
     description: "Create a milestone under a project. Milestones belong to projects, not teams.",
+    promptSnippet: "Create a milestone under a project.",
     parameters: Type.Object({
       name: Type.String({ description: "Milestone name" }),
       projectId: Type.String({ description: "Project UUID (required — milestones belong to projects)" }),
@@ -197,6 +205,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_get_milestone",
     label: "Linear: Get Milestone",
     description: "Get a milestone by UUID.",
+    promptSnippet: "Get a milestone by UUID.",
     parameters: Type.Object({
       id: Type.String({ description: "Milestone UUID" }),
     }),
@@ -207,6 +216,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_list_milestones",
     label: "Linear: List Milestones",
     description: "List milestones under a project.",
+    promptSnippet: "List milestones under a project.",
     parameters: Type.Object({
       projectId: Type.String({ description: "Project UUID" }),
     }),
@@ -217,6 +227,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_update_milestone",
     label: "Linear: Update Milestone",
     description: "Update a milestone's name, description, target date, or sort order.",
+    promptSnippet: "Update a milestones name, description, target date, or sort order.",
     parameters: Type.Object({
       id: Type.String({ description: "Milestone UUID" }),
       name: Type.Optional(Type.String({ description: "New name" })),
@@ -234,6 +245,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_delete_milestone",
     label: "Linear: Delete Milestone",
     description: "Delete a milestone by UUID.",
+    promptSnippet: "Delete a milestone by UUID.",
     parameters: Type.Object({
       id: Type.String({ description: "Milestone UUID" }),
     }),
@@ -248,6 +260,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_create_issue",
     label: "Linear: Create Issue",
     description: "Create an issue. Use parentId (UUID) to create a sub-issue. Supports project, milestone, labels, and state assignment.",
+    promptSnippet: "Create an issue.",
     parameters: Type.Object({
       title: Type.String({ description: "Issue title" }),
       teamId: Type.String({ description: "Team UUID" }),
@@ -268,6 +281,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_get_issue",
     label: "Linear: Get Issue",
     description: "Get an issue by UUID or identifier (e.g. 'KAT-42'). Returns full details including parent, children, labels, and state.",
+    promptSnippet: "Get an issue by UUID or identifier (e.g.",
     parameters: Type.Object({
       id: Type.String({ description: "Issue UUID or identifier (e.g. 'KAT-42')" }),
     }),
@@ -278,6 +292,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_list_issues",
     label: "Linear: List Issues",
     description: "List issues with optional filters: team, project, parent (for sub-issues), state, labels, assignee.",
+    promptSnippet: "List issues with optional filters: team, project, parent (for sub-issues), state, labels, assignee.",
     parameters: Type.Object({
       teamId: Type.Optional(Type.String({ description: "Filter by team UUID" })),
       projectId: Type.Optional(Type.String({ description: "Filter by project UUID" })),
@@ -294,6 +309,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_update_issue",
     label: "Linear: Update Issue",
     description: "Update an issue's title, description, state, labels, priority, assignee, parent, project, or milestone.",
+    promptSnippet: "Update an issues title, description, state, labels, priority, assignee, parent, project, or milestone.",
     parameters: Type.Object({
       id: Type.String({ description: "Issue UUID" }),
       title: Type.Optional(Type.String({ description: "New title" })),
@@ -317,6 +333,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_delete_issue",
     label: "Linear: Delete Issue",
     description: "Delete an issue by UUID.",
+    promptSnippet: "Delete an issue by UUID.",
     parameters: Type.Object({
       id: Type.String({ description: "Issue UUID" }),
     }),
@@ -331,6 +348,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_list_workflow_states",
     label: "Linear: List Workflow States",
     description: "List all workflow states for a team. States have types: backlog, unstarted, started, completed, canceled.",
+    promptSnippet: "List all workflow states for a team.",
     parameters: Type.Object({
       teamId: Type.String({ description: "Team UUID" }),
     }),
@@ -345,6 +363,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_create_label",
     label: "Linear: Create Label",
     description: "Create an issue label. Omit teamId for a workspace-level label.",
+    promptSnippet: "Create an issue label.",
     parameters: Type.Object({
       name: Type.String({ description: "Label name" }),
       color: Type.Optional(Type.String({ description: "Label color hex (e.g. '#FF0000')" })),
@@ -358,6 +377,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_list_labels",
     label: "Linear: List Labels",
     description: "List labels, optionally filtered by team.",
+    promptSnippet: "List labels, optionally filtered by team.",
     parameters: Type.Object({
       teamId: Type.Optional(Type.String({ description: "Filter by team UUID" })),
     }),
@@ -370,6 +390,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_delete_label",
     label: "Linear: Delete Label",
     description: "Delete a label by UUID.",
+    promptSnippet: "Delete a label by UUID.",
     parameters: Type.Object({
       id: Type.String({ description: "Label UUID" }),
     }),
@@ -380,6 +401,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_ensure_label",
     label: "Linear: Ensure Label",
     description: "Get or create a label by name. Idempotent — returns existing label if name matches, creates new one otherwise.",
+    promptSnippet: "Get or create a label by name.",
     parameters: Type.Object({
       name: Type.String({ description: "Label name" }),
       color: Type.Optional(Type.String({ description: "Label color hex (used only when creating)" })),
@@ -400,6 +422,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_create_document",
     label: "Linear: Create Document",
     description: "Create a document. Attach to a project and/or issue via their UUIDs.",
+    promptSnippet: "Create a document.",
     parameters: Type.Object({
       title: Type.String({ description: "Document title" }),
       content: Type.Optional(Type.String({ description: "Document content (markdown)" })),
@@ -415,6 +438,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_get_document",
     label: "Linear: Get Document",
     description: "Get a document by UUID. Returns full markdown content.",
+    promptSnippet: "Get a document by UUID.",
     parameters: Type.Object({
       id: Type.String({ description: "Document UUID" }),
     }),
@@ -425,6 +449,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_list_documents",
     label: "Linear: List Documents",
     description: "List documents, optionally filtered by project.",
+    promptSnippet: "List documents, optionally filtered by project.",
     parameters: Type.Object({
       projectId: Type.Optional(Type.String({ description: "Filter by project UUID" })),
       first: Type.Optional(Type.Number({ description: "Max results per page (default: 50)" })),
@@ -439,6 +464,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_delete_document",
     label: "Linear: Delete Document",
     description: "Delete a document by UUID.",
+    promptSnippet: "Delete a document by UUID.",
     parameters: Type.Object({
       id: Type.String({ description: "Document UUID" }),
     }),
@@ -449,6 +475,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_update_document",
     label: "Linear: Update Document",
     description: "Update a document's title, content, icon, or color.",
+    promptSnippet: "Update a documents title, content, icon, or color.",
     parameters: Type.Object({
       id: Type.String({ description: "Document UUID" }),
       title: Type.Optional(Type.String({ description: "New title" })),
@@ -470,6 +497,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     name: "linear_get_viewer",
     label: "Linear: Get Viewer",
     description: "Get the authenticated user's profile. Useful for verifying API key and getting user ID.",
+    promptSnippet: "Get the authenticated users profile.",
     parameters: Type.Object({}),
     async execute() { return run(() => client.getViewer()); },
   });
@@ -485,6 +513,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       "Idempotently provision the three Kata labels (kata:milestone, kata:slice, kata:task) " +
       "in the given team. Returns the full KataLabelSet with label IDs. " +
       "Call this once per session; pass the returned label IDs to the kata_create_* tools.",
+    promptSnippet: "Idempotently provision the three Kata labels (kata:milestone, kata:slice, kata:task) in the given team.",
     parameters: Type.Object({
       teamId: Type.String({ description: "Team UUID in which to provision the Kata labels" }),
     }),
@@ -499,6 +528,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     description:
       "Create a Linear ProjectMilestone representing a Kata milestone. " +
       "The name is formatted as '[M001] Title' for round-trip parsing.",
+    promptSnippet: "Create a Linear ProjectMilestone representing a Kata milestone.",
     parameters: Type.Object({
       projectId: Type.String({ description: "Project UUID to attach the milestone to" }),
       kataId: Type.String({ description: "Kata milestone ID, e.g. 'M001'" }),
@@ -529,6 +559,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       "Create a Linear issue representing a Kata slice. " +
       "The title is formatted as '[S01] Title'. Applies the kata:slice label. " +
       "Call kata_ensure_labels first to obtain sliceLabelId and taskLabelId.",
+    promptSnippet: "Create a Linear issue representing a Kata slice.",
     parameters: Type.Object({
       teamId: Type.String({ description: "Team UUID" }),
       projectId: Type.String({ description: "Project UUID" }),
@@ -586,6 +617,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       "The title is formatted as '[T01] Title'. Applies the kata:task label. " +
       "The task is attached as a child of the given slice issue. " +
       "Call kata_ensure_labels first to obtain sliceLabelId and taskLabelId.",
+    promptSnippet: "Create a Linear sub-issue representing a Kata task.",
     parameters: Type.Object({
       teamId: Type.String({ description: "Team UUID" }),
       projectId: Type.String({ description: "Project UUID" }),
@@ -641,6 +673,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     description:
       "List all Linear issues representing Kata slices in a project. " +
       "Resolves the kata:slice label automatically from the team.",
+    promptSnippet: "List all Linear issues representing Kata slices in a project.",
     parameters: Type.Object({
       projectId: Type.String({ description: "Project UUID to scope the query" }),
       teamId: Type.String({ description: "Team UUID (from kata_derive_state or preferences)" }),
@@ -659,6 +692,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     description:
       "List all Linear sub-issues representing Kata tasks for a given slice issue. " +
       "Queries by parentId — returns all direct children of the slice issue.",
+    promptSnippet: "List all Linear sub-issues representing Kata tasks for a given slice issue.",
     parameters: Type.Object({
       sliceIssueId: Type.String({ description: "Linear issue UUID of the parent slice issue" }),
     }),
@@ -680,6 +714,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       "If no matching document exists, a new one is created. " +
       "Exactly one of projectId or issueId must be provided. " +
       "Returns the full LinearDocument including id, title, content, createdAt, updatedAt.",
+    promptSnippet: "Write a Kata artifact as a Linear Document (upsert by title).",
     parameters: Type.Object({
       title: Type.String({ description: "Document title, e.g. 'M001-ROADMAP' or 'DECISIONS'" }),
       content: Type.String({ description: "Markdown content to write" }),
@@ -707,6 +742,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       "Returns the document (with full markdown content) if found, or null if not yet written. " +
       "null is the canonical signal for 'document does not exist yet'. " +
       "Exactly one of projectId or issueId must be provided.",
+    promptSnippet: "Read a Kata artifact document by title from the attachment target.",
     parameters: Type.Object({
       title: Type.String({ description: "Document title to look up, e.g. 'M001-ROADMAP'" }),
       projectId: Type.Optional(Type.String({ description: "Project UUID — scope the lookup to this project" })),
@@ -733,6 +769,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       "Zero-side-effect inspection surface — does not modify any state. " +
       "Returns an array of LinearDocument objects; empty array means no documents exist. " +
       "Exactly one of projectId or issueId must be provided.",
+    promptSnippet: "List all Kata documents attached to a given project or issue.",
     parameters: Type.Object({
       projectId: Type.Optional(Type.String({ description: "Project UUID — list documents attached to this project" })),
       issueId: Type.Optional(Type.String({ description: "Issue UUID — list documents attached to this issue" })),
@@ -760,6 +797,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
     description:
       "List all Linear project milestones for a Kata project, sorted by sortOrder. " +
       "Zero-side-effect inspection surface — does not modify any state.",
+    promptSnippet: "List all Linear project milestones for a Kata project, sorted by sortOrder.",
     parameters: Type.Object({
       projectId: Type.String({ description: "Linear project UUID" }),
     }),
@@ -778,6 +816,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       "Returns a KataState JSON with activeMilestone, activeSlice, activeTask, phase, progress, blockers, " +
       "plus projectId and teamId (use these for kata_read_document / kata_list_documents calls). " +
       "Returns phase 'blocked' (not an error) when LINEAR_API_KEY or project config is missing.",
+    promptSnippet: "Derive a full KataState from the Linear API.",
     parameters: Type.Object({}),
     async execute() {
       const apiKey = process.env.LINEAR_API_KEY;
@@ -846,6 +885,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       "Advance a Linear issue to the workflow state corresponding to a given Kata phase. " +
       "Resolves the correct Linear stateId from the team's workflow states, then updates the issue. " +
       "Returns the updated issue with its new state.",
+    promptSnippet: "Advance a Linear issue to the workflow state corresponding to a given Kata phase.",
     parameters: Type.Object({
       issueId: Type.String({ description: "Linear issue UUID to update" }),
       phase: Type.Union(

--- a/apps/cli/src/resources/extensions/mac-tools/index.ts
+++ b/apps/cli/src/resources/extensions/mac-tools/index.ts
@@ -397,7 +397,7 @@ export default function (pi: ExtensionAPI) {
 			"- 'tree': Dump the full accessibility subtree as an indented tree. Use maxDepth/maxCount to bound output.\n" +
 			"- 'focused': Get the currently focused element in the app. No criteria needed.\n" +
 			"The 'app' param accepts an app name (e.g. 'Finder') or bundle ID (e.g. 'com.apple.Finder').",
-		promptSnippet: "Find UI elements in a macOS applications accessibility tree.",
+		promptSnippet: "Find UI elements in a macOS application's accessibility tree.",
 		promptGuidelines: [
 			"Prefer for targeted element search — use role/title/value criteria to narrow results.",
 			"Use mode:focused to check the current focus target without search criteria.",
@@ -530,7 +530,7 @@ export default function (pi: ExtensionAPI) {
 			"Tighter defaults than mac_find's tree mode — designed for quick structure inspection. " +
 			"Each line: `role \"title\" [value]` with 2-space indent per depth level. " +
 			"Omits title/value when nil or empty.",
-		promptSnippet: "Get a compact accessibility tree of a macOS applications UI structure.",
+		promptSnippet: "Get a compact accessibility tree of a macOS application's UI structure.",
 		promptGuidelines: [
 			"Use for understanding app UI structure — start with low limits and increase if needed.",
 			"Prefer mac_find search mode when you know what you're looking for.",

--- a/apps/cli/src/resources/extensions/mac-tools/index.ts
+++ b/apps/cli/src/resources/extensions/mac-tools/index.ts
@@ -166,6 +166,7 @@ export default function (pi: ExtensionAPI) {
 			"Check whether macOS Accessibility and Screen Recording permissions are enabled for the current terminal. " +
 			"Returns { accessibilityEnabled, screenRecordingEnabled }. Accessibility is required for UI automation; " +
 			"Screen Recording is required for mac_screenshot. Both are granted in System Settings > Privacy & Security.",
+		promptSnippet: "Check whether macOS Accessibility and Screen Recording permissions are enabled for the current terminal.",
 		promptGuidelines: [
 			"Run this first if any mac tool returns a permission error.",
 		],
@@ -204,6 +205,7 @@ export default function (pi: ExtensionAPI) {
 			"List all running macOS applications. Returns an array of { name, bundleId, pid, isActive } " +
 			"for user-facing apps (regular activation policy). Set includeBackground to true to also " +
 			"include accessory/background apps.",
+		promptSnippet: "List all running macOS applications.",
 		promptGuidelines: [
 			"Use to discover what apps are running before interacting with them.",
 		],
@@ -235,6 +237,7 @@ export default function (pi: ExtensionAPI) {
 			"Launch a macOS application by name or bundle ID. " +
 			"Returns { launched, name, bundleId, pid } on success. " +
 			"Provide either 'name' (e.g. 'TextEdit') or 'bundleId' (e.g. 'com.apple.TextEdit').",
+		promptSnippet: "Launch a macOS application by name or bundle ID.",
 		promptGuidelines: [
 			"Use app name for well-known apps; use bundleId when the name is ambiguous.",
 		],
@@ -273,6 +276,7 @@ export default function (pi: ExtensionAPI) {
 			"Bring a running macOS application to the front. " +
 			"Returns { activated, name } on success. Errors if the app is not running. " +
 			"Provide either 'name' or 'bundleId'.",
+		promptSnippet: "Bring a running macOS application to the front.",
 		promptGuidelines: [
 			"Activate an app before interacting with its UI to ensure it is frontmost.",
 		],
@@ -310,6 +314,7 @@ export default function (pi: ExtensionAPI) {
 			"Quit a running macOS application. " +
 			"Returns { quit, name } on success. Errors if the app is not running. " +
 			"Provide either 'name' or 'bundleId'.",
+		promptSnippet: "Quit a running macOS application.",
 		promptGuidelines: [
 			"Use to clean up apps launched during automation — don't leave apps running unnecessarily.",
 		],
@@ -349,6 +354,7 @@ export default function (pi: ExtensionAPI) {
 			"The windowId can be used with getWindowInfo for detailed inspection or with screenshotWindow for capture. " +
 			"Returns an empty array (not error) if the app is running but has no visible windows. " +
 			"Errors if the app is not running.",
+		promptSnippet: "List all on-screen windows for a macOS application.",
 		promptGuidelines: [
 			"Use to get windowId values needed by mac_screenshot.",
 		],
@@ -391,6 +397,7 @@ export default function (pi: ExtensionAPI) {
 			"- 'tree': Dump the full accessibility subtree as an indented tree. Use maxDepth/maxCount to bound output.\n" +
 			"- 'focused': Get the currently focused element in the app. No criteria needed.\n" +
 			"The 'app' param accepts an app name (e.g. 'Finder') or bundle ID (e.g. 'com.apple.Finder').",
+		promptSnippet: "Find UI elements in a macOS applications accessibility tree.",
 		promptGuidelines: [
 			"Prefer for targeted element search — use role/title/value criteria to narrow results.",
 			"Use mode:focused to check the current focus target without search criteria.",
@@ -523,6 +530,7 @@ export default function (pi: ExtensionAPI) {
 			"Tighter defaults than mac_find's tree mode — designed for quick structure inspection. " +
 			"Each line: `role \"title\" [value]` with 2-space indent per depth level. " +
 			"Omits title/value when nil or empty.",
+		promptSnippet: "Get a compact accessibility tree of a macOS applications UI structure.",
 		promptGuidelines: [
 			"Use for understanding app UI structure — start with low limits and increase if needed.",
 			"Prefer mac_find search mode when you know what you're looking for.",
@@ -580,6 +588,7 @@ export default function (pi: ExtensionAPI) {
 			"Click a UI element in a macOS application by performing AXPress. " +
 			"Finds the first element matching the given criteria (role, title, value, identifier) and clicks it. " +
 			"At least one criterion is required. Returns the clicked element's attributes.",
+		promptSnippet: "Click a UI element in a macOS application by performing AXPress.",
 		promptGuidelines: [
 			"Verify the click worked by reading the resulting state with mac_find or mac_read.",
 			"Use mac_find first to discover the right role/title/value criteria before clicking.",
@@ -637,6 +646,7 @@ export default function (pi: ExtensionAPI) {
 			"Finds the first element matching the given criteria and sets its value. " +
 			"Returns the actual value after setting (read-back verification). " +
 			"At least one criterion is required.",
+		promptSnippet: "Type text into a UI element in a macOS application by setting its AXValue attribute.",
 		promptGuidelines: [
 			"Read back the value after typing to verify — the return value includes actual content.",
 			"Target text fields/areas by role (AXTextArea, AXTextField) for reliability.",
@@ -696,6 +706,7 @@ export default function (pi: ExtensionAPI) {
 			"Take a screenshot of a macOS application window by its window ID (from mac_list_windows). " +
 			"Returns the screenshot as an image content block for visual analysis, alongside text metadata " +
 			"(dimensions and format). Requires Screen Recording permission — use mac_check_permissions to verify.",
+		promptSnippet: "Take a screenshot of a macOS application window by its window ID (from mac_list_windows).",
 		promptGuidelines: [
 			"Use for visual verification when accessibility attributes aren't sufficient.",
 			"Prefer nominal resolution unless retina detail is needed — retina doubles payload size.",
@@ -747,6 +758,7 @@ export default function (pi: ExtensionAPI) {
 			"Finds the first element matching the given criteria and reads the named attribute(s). " +
 			"AXValue subtypes (CGPoint, CGSize, CGRect, CFRange) are automatically unpacked to structured dicts. " +
 			"Use 'attribute' for a single attribute or 'attributes' for multiple. At least one search criterion is required.",
+		promptSnippet: "Read one or more accessibility attributes from a UI element in a macOS application.",
 		promptGuidelines: [
 			"Use to verify state after actions — read AXValue to confirm text was typed, AXEnabled to check if a button is active.",
 		],

--- a/apps/cli/src/resources/extensions/pr-lifecycle/gh-utils.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/gh-utils.ts
@@ -52,19 +52,30 @@ export function getCurrentBranch(cwd: string): string | null {
 }
 
 /**
- * Parses a Kata-convention branch name (`kata/<MilestoneId>/<SliceId>`) into
- * structured parts. Returns null when the branch does not match the pattern.
+ * Parses a Kata-convention slice branch into structured milestone/slice IDs.
+ *
+ * Accepted formats:
+ * - Namespaced: `kata/<scope>/<MilestoneId>/<SliceId>`
+ * - Legacy:     `kata/<MilestoneId>/<SliceId>`
+ *
+ * Returns null when the branch does not match either accepted pattern.
  *
  * @example
- * parseBranchToSlice("kata/M001/S01") // → { milestoneId: "M001", sliceId: "S01" }
- * parseBranchToSlice("main")           // → null
+ * parseBranchToSlice("kata/apps-cli/M001/S01") // → { milestoneId: "M001", sliceId: "S01" }
+ * parseBranchToSlice("kata/M001/S01")          // → { milestoneId: "M001", sliceId: "S01" }
+ * parseBranchToSlice("main")                   // → null
  */
 export function parseBranchToSlice(
   branch: string,
 ): { milestoneId: string; sliceId: string } | null {
-  const match = branch.match(/^kata\/([A-Z]\d+)\/([A-Z]\d+)$/);
-  if (!match) return null;
-  return { milestoneId: match[1], sliceId: match[2] };
+  const namespaced = branch.match(/^kata\/[^/]+\/([A-Z]\d+)\/([A-Z]\d+)$/);
+  if (namespaced) {
+    return { milestoneId: namespaced[1], sliceId: namespaced[2] };
+  }
+
+  const legacy = branch.match(/^kata\/([A-Z]\d+)\/([A-Z]\d+)$/);
+  if (!legacy) return null;
+  return { milestoneId: legacy[1], sliceId: legacy[2] };
 }
 
 /**

--- a/apps/cli/src/resources/extensions/pr-lifecycle/gh-utils.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/gh-utils.ts
@@ -6,6 +6,7 @@
  */
 
 import { execSync } from "node:child_process";
+import { parseSliceBranchName } from "../kata/worktree.js";
 
 const PIPE = { stdio: ["pipe", "pipe", "pipe"] as [string, string, string] };
 
@@ -68,14 +69,9 @@ export function getCurrentBranch(cwd: string): string | null {
 export function parseBranchToSlice(
   branch: string,
 ): { milestoneId: string; sliceId: string } | null {
-  const namespaced = branch.match(/^kata\/[^/]+\/([A-Z]\d+)\/([A-Z]\d+)$/);
-  if (namespaced) {
-    return { milestoneId: namespaced[1], sliceId: namespaced[2] };
-  }
-
-  const legacy = branch.match(/^kata\/([A-Z]\d+)\/([A-Z]\d+)$/);
-  if (!legacy) return null;
-  return { milestoneId: legacy[1], sliceId: legacy[2] };
+  const parsed = parseSliceBranchName(branch);
+  if (!parsed) return null;
+  return { milestoneId: parsed.milestoneId, sliceId: parsed.sliceId };
 }
 
 /**

--- a/apps/cli/src/resources/extensions/pr-lifecycle/index.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/index.ts
@@ -453,7 +453,7 @@ export default function (pi: ExtensionAPI): void {
       "or { ok: false, phase, error } on failure.",
       "Phase enum: gh-missing | gh-unauth | reply-failed.",
     ].join(" "),
-    promptSnippet: "Replies to an inline GitHub PR review thread via the",
+    promptSnippet: "Reply to an inline GitHub PR review thread.",
     parameters: {
       type: "object" as const,
       properties: {
@@ -592,7 +592,7 @@ export default function (pi: ExtensionAPI): void {
             `Current branch '${branch}' does not match supported Kata slice branch formats: `
             + "kata/<scope>/<MilestoneId>/<SliceId> or legacy kata/<MilestoneId>/<SliceId>",
           hint:
-            "Switch to a Kata slice branch (e.g. kata/apps-cli/M003/S04, or legacy kata/M003/S04 during transition) or pass milestoneId and sliceId explicitly.",
+            "Switch to a Kata slice branch (e.g. kata/apps-cli/M003/S04, or legacy kata/M003/S04 during transition) before running kata_merge_pr.",
         });
       }
 

--- a/apps/cli/src/resources/extensions/pr-lifecycle/index.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/index.ts
@@ -582,9 +582,11 @@ export default function (pi: ExtensionAPI): void {
         return toolFail({
           ok: false,
           phase: "branch-parse-failed",
-          error: `Current branch '${branch}' does not match kata/<MilestoneId>/<SliceId> pattern`,
+          error:
+            `Current branch '${branch}' does not match supported Kata slice branch formats: `
+            + "kata/<scope>/<MilestoneId>/<SliceId> or legacy kata/<MilestoneId>/<SliceId>",
           hint:
-            "Switch to a Kata slice branch (e.g. kata/M003/S04) or pass milestoneId and sliceId explicitly.",
+            "Switch to a Kata slice branch (e.g. kata/apps-cli/M003/S04, or legacy kata/M003/S04 during transition) or pass milestoneId and sliceId explicitly.",
         });
       }
 

--- a/apps/cli/src/resources/extensions/pr-lifecycle/index.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/index.ts
@@ -112,6 +112,7 @@ export default function (pi: ExtensionAPI): void {
       "Uses `milestoneId`/`sliceId` from params when provided; auto-detects from branch name otherwise.",
       "Returns { ok: true, url } on success; { ok: false, phase, error, hint } on any failure.",
     ].join(" "),
+    promptSnippet: "Create a GitHub PR for the current Kata slice branch.",
     parameters: {
       type: "object" as const,
       properties: {
@@ -195,6 +196,7 @@ export default function (pi: ExtensionAPI): void {
       "Returns { ok: true, prNumber, selectedReviewers, findings } on success.",
       "Returns { ok: false, phase, error, hint } for: gh-missing, gh-unauth, not-in-pr, diff-empty.",
     ].join(" "),
+    promptSnippet: "Runs a parallel PR review for the open GitHub PR on the current branch.",
     parameters: {
       type: "object" as const,
       properties: {
@@ -339,6 +341,7 @@ export default function (pi: ExtensionAPI): void {
       "Returns { ok: true, pull_request, conversation_comments, reviews, review_threads } on success.",
       "Returns { ok: false, phase, error, hint } on any failure.",
     ].join(" "),
+    promptSnippet: "Fetches all PR comments for the open PR on the current branch.",
     parameters: {
       type: "object" as const,
       properties: {
@@ -395,6 +398,7 @@ export default function (pi: ExtensionAPI): void {
       "Phase enum: gh-missing | gh-unauth | resolve-failed.",
       "Note: check isResolved before calling — GitHub returns an error if the thread is already resolved.",
     ].join(" "),
+    promptSnippet: "Resolves an inline GitHub PR review thread via the `resolveReviewThread` GraphQL mutation.",
     parameters: {
       type: "object" as const,
       properties: {
@@ -449,6 +453,7 @@ export default function (pi: ExtensionAPI): void {
       "or { ok: false, phase, error } on failure.",
       "Phase enum: gh-missing | gh-unauth | reply-failed.",
     ].join(" "),
+    promptSnippet: "Replies to an inline GitHub PR review thread via the",
     parameters: {
       type: "object" as const,
       properties: {
@@ -510,6 +515,7 @@ export default function (pi: ExtensionAPI): void {
       "Phase enum: gh-missing | gh-unauth | branch-parse-failed | pr-detect-failed |",
       "ci-failing | ci-pending | merge-failed.",
     ].join(" "),
+    promptSnippet: "Merge the open GitHub PR for the current Kata slice branch.",
     parameters: {
       type: "object" as const,
       properties: {

--- a/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner.ts
@@ -124,9 +124,11 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
       return {
         ok: false,
         phase: "branch-parse-failed",
-        error: `Current branch '${branch}' does not match kata/<MilestoneId>/<SliceId> pattern`,
+        error:
+          `Current branch '${branch}' does not match supported Kata slice branch formats: `
+          + "kata/<scope>/<MilestoneId>/<SliceId> or legacy kata/<MilestoneId>/<SliceId>",
         hint:
-          "Switch to a Kata slice branch (e.g. kata/M003/S01) or pass milestoneId and sliceId explicitly.",
+          "Switch to a Kata slice branch (e.g. kata/apps-cli/M003/S01, or legacy kata/M003/S01 during transition) or pass milestoneId and sliceId explicitly.",
       };
     }
     milestoneId = parsed.milestoneId;

--- a/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner.ts
@@ -191,8 +191,38 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
     const PIPE = { stdio: ["pipe", "pipe", "pipe"] as ["pipe", "pipe", "pipe"] };
     const ghEnv = { ...process.env, GH_PAGER: "" };
 
-    // Create the PR
+    // Resolve branch and ensure it's pushed to the remote
     const head = getCurrentBranch(cwd) ?? "";
+
+    if (head) {
+      // Check if branch exists on remote; push if not
+      try {
+        const remoteRef = execSync(
+          `git ls-remote --heads origin ${head}`,
+          { encoding: "utf8", cwd, ...PIPE },
+        ).trim();
+        if (!remoteRef) {
+          // Branch not on remote — push with upstream tracking
+          try {
+            execSync(
+              `git push -u origin ${head}`,
+              { encoding: "utf8", cwd, ...PIPE },
+            );
+          } catch (pushErr) {
+            const pe = pushErr as { stderr?: string; message?: string };
+            return {
+              ok: false,
+              phase: "push-failed",
+              error: `Branch '${head}' is not on the remote and push failed: ${pe.stderr ?? pe.message ?? String(pushErr)}`,
+              hint: "Check git remote configuration and network connectivity. Run: git remote -v",
+            };
+          }
+        }
+      } catch {
+        // ls-remote failed (no remote configured, network error, etc.)
+        // Proceed anyway — gh pr create will surface the real error
+      }
+    }
 
     // Prefix title with branch name for monorepo identification
     // e.g. "[kata/apps-context/M002/S02] Slice title here"

--- a/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner.ts
@@ -193,11 +193,18 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
 
     // Create the PR
     const head = getCurrentBranch(cwd) ?? "";
+
+    // Prefix title with branch name for monorepo identification
+    // e.g. "[kata/apps-context/M002/S02] Slice title here"
+    const normalizedTitle = head && !title.includes(head)
+      ? `[${head}] ${title}`
+      : title;
+
     try {
       execSync(
         [
           "gh", "pr", "create",
-          "--title", shellEscape(title),
+          "--title", shellEscape(normalizedTitle),
           "--base", shellEscape(baseBranch),
           "--head", shellEscape(head),
           "--body-file", shellEscape(tmpPath),

--- a/apps/cli/src/resources/extensions/pr-lifecycle/tests/gh-utils.test.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/tests/gh-utils.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+
+import { parseBranchToSlice } from "../gh-utils.js";
+
+describe("parseBranchToSlice", () => {
+  test("parses legacy kata/<M>/<S> branch format", () => {
+    assert.deepEqual(parseBranchToSlice("kata/M005/S02"), {
+      milestoneId: "M005",
+      sliceId: "S02",
+    });
+  });
+
+  test("parses namespaced kata/<scope>/<M>/<S> branch format", () => {
+    assert.deepEqual(parseBranchToSlice("kata/apps-cli/M005/S02"), {
+      milestoneId: "M005",
+      sliceId: "S02",
+    });
+  });
+
+  test("returns null for non-kata branches", () => {
+    assert.equal(parseBranchToSlice("main"), null);
+    assert.equal(parseBranchToSlice("feature/M005/S02"), null);
+  });
+
+  test("returns null for malformed kata branch values", () => {
+    assert.equal(parseBranchToSlice("kata/M005"), null);
+    assert.equal(parseBranchToSlice("kata/apps-cli/M005"), null);
+    assert.equal(parseBranchToSlice("kata/apps-cli/m005/S02"), null);
+    assert.equal(parseBranchToSlice("kata/apps-cli/M005/s02"), null);
+  });
+});

--- a/apps/cli/src/resources/extensions/subagent/index.ts
+++ b/apps/cli/src/resources/extensions/subagent/index.ts
@@ -529,6 +529,7 @@ export default function (pi: ExtensionAPI) {
       "Use the /subagent command to list available agents and their descriptions.",
       "Use chain mode to pipeline: scout finds context, planner designs, worker implements.",
     ].join(" "),
+    promptSnippet: "Delegate tasks to specialized subagents with isolated context windows.",
     promptGuidelines: [
       "Use subagent to delegate self-contained tasks that benefit from an isolated context window.",
       "Use scout agent first when you need codebase context before implementing.",

--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
         "kata-cli": "dist/loader.js",
       },
       "dependencies": {
-        "@mariozechner/pi-coding-agent": "^0.57.1",
+        "@mariozechner/pi-coding-agent": "^0.60.0",
         "playwright": "^1.58.2",
       },
       "devDependencies": {
@@ -745,13 +745,13 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.57.1", "", { "dependencies": { "@mariozechner/pi-ai": "^0.57.1" } }, "sha512-WXsBbkNWOObFGHkhixaT8GXJpHDd3+fn8QntYF+4R8Sa9WB90ENXWidO6b7vcKX+JX0jjO5dIsQxmzosARJKlg=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.60.0", "", { "dependencies": { "@mariozechner/pi-ai": "^0.60.0" } }, "sha512-1zQcfFp8r0iwZCxCBQ9/ccFJoagns68cndLPTJJXl1ZqkYirzSld1zBOPxLAgeAKWIz3OX8dB2WQwTJFhmEojQ=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.57.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Bd/J4a3YpdzJVyHLih0vDSdB0QPL4ti0XsAwtHOK/8eVhB0fHM1CpcgIrcBFJ23TMcKXMi0qamz18ERfp8tmgg=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.60.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-OiMuXQturnEDPmA+ho7eLe4G8plO2z21yjNMs9niQREauoblWOz7Glv58I66KPzczLED4aZTlQLTRdU6t1rz8A=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.57.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.57.1", "@mariozechner/pi-ai": "^0.57.1", "@mariozechner/pi-tui": "^0.57.1", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-u5MQEduj68rwVIsRsqrWkJYiJCyPph/a6bMoJAQKo1sb+Pc17Y/ojwa+wGssnUMjEB38AQKofWTVe8NFEpSWNw=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.60.0", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.60.0", "@mariozechner/pi-ai": "^0.60.0", "@mariozechner/pi-tui": "^0.60.0", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-IOv7cTU4nbznFNUE5ofi13k2dmSG39coBoGWIBQTVw3iVyl0HxuHbg0NiTx3ktrPIDNtkii+y7tWXzWqwoo4lw=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.57.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-cjoRghLbeAHV0tTJeHgZXaryUi5zzBZofeZ7uJun1gztnckLLRjoVeaPTujNlc5BIfyKvFqhh1QWCZng/MXlpg=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.60.0", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-ZAK5gxYhGmfJqMjfWcRBjB8glITltDbTrYJXvcDtfengbKTZN0p39p5uO5pvUB8/PiAWKTRS06yaNMhf/LG26g=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
 


### PR DESCRIPTION
## What Changed
See slice plan: S02: Namespace slice branches for monorepo safety

## Must-Haves
- R002 (owned): New slice branches are namespaced by project scope and cannot silently reuse stale branches from unrelated projects.
- R002 (owned): Legacy `kata/<M>/<S>` branches remain compatible during transition (parse + checkout continuity).
- R001 (supporting): `worktree.ts` provenance checks consume `runGit()`/`getCurrentBranch()` from `git-service.ts` rather than ad-hoc git shell execution in touched paths.
- Boundary contract closure: `parseBranchToSlice()` + PR context builders operate correctly with namespaced branches and still parse legacy branches.

## Tasks
- T01: Add failing regression tests for namespaced/legacy branch contracts
- T02: Implement namespaced branch generation and provenance guard in worktree layer
- T03: Propagate dual-format parsing and namespaced branch wiring through PR/backends
- T04: Close remaining branch-format drift and prove slice-level integration

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR namespaces Kata slice branches from the legacy `kata/<M>/<S>` format to `kata/<scope>/<M>/<S>`, where scope is derived from the project's path relative to the git root. This prevents silent branch reuse across unrelated projects in a monorepo. Legacy branches remain checkout-compatible during transition, and a provenance guard in `ensureSliceBranch` rejects cross-scope branch reuse.

Key changes:
- `worktree.ts`: `getSliceBranchName` gains a `basePath` argument; `getProjectScope` derives the scope segment from the relative path; `ensureSliceBranch` gains a provenance check (`findConflictingNamespacedBranch`) that throws when a different-scope branch exists for the same milestone/slice; `parseSliceBranchName` is exported as a dual-format parser.
- `file-backend.ts` / `linear-backend.ts`: Both `preparePrContext` implementations replace the hardcoded `kata/<M>/<S>` string with a dynamic resolution via `getCurrentBranch` after `ensureSliceBranch`, preserving the legacy branch name during transition.
- `gh-utils.ts`: `parseBranchToSlice` updated to accept both branch formats (namespaced first, then legacy fallback).
- Tests: New regression tests for namespaced branch contracts in all four test files; new `gh-utils.test.ts` covers `parseBranchToSlice` format coverage.

**Issues found:**
- The provenance guard in `ensureSliceBranch` has a bypass path: when a legacy branch (`kata/M001/S05`) coexists alongside a conflicting namespaced branch (`kata/other-scope/M001/S05`), `resolvePreferredSliceBranch` returns the legacy branch before `findConflictingNamespacedBranch` is ever called. The conflict is silently ignored. This case is not covered by any test.
- `mergeSliceToMain` falls back to the legacy branch without a scope check, so callers invoking it directly (without `ensureSliceBranch`) skip provenance validation.
- `parseBranchToSlice` in `gh-utils.ts` and `parseSliceBranchName` in `worktree.ts` are duplicate implementations of the same dual-format parsing logic.

<h3>Confidence Score: 3/5</h3>

- Merge with caution — the core namespacing logic is sound but the provenance guard has an unverified bypass in the legacy-branch coexistence scenario.
- The branch naming, scope derivation, and dual-format parsing are well-implemented and thoroughly tested for the happy path. The provenance check correctly blocks cross-scope reuse when starting from scratch. However, the guard is silently bypassed when both a legacy branch and a conflicting namespaced branch exist simultaneously, which is exactly the monorepo transition scenario the PR aims to protect against. Additionally, `mergeSliceToMain` has no scope validation of its own. These gaps reduce confidence that R002 is fully closed.
- `apps/cli/src/resources/extensions/kata/worktree.ts` — specifically the `ensureSliceBranch` provenance logic (lines 149–202) and `mergeSliceToMain` legacy fallback (lines 236–240).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/worktree.ts | Core branch management rewritten to support namespaced `kata/<scope>/<M>/<S>` format alongside legacy `kata/<M>/<S>`; introduces provenance guard that has a bypass path when a legacy branch coexists with a conflicting namespaced branch, and `mergeSliceToMain` falls back to legacy branch without a scope check. |
| apps/cli/src/resources/extensions/kata/file-backend.ts | Replaces hardcoded `kata/<M>/<S>` branch string with dynamic resolution via `getCurrentBranch`; the `startsWith("kata/")` guard is over-broad but functionally harmless post-`ensureSliceBranch`. |
| apps/cli/src/resources/extensions/kata/linear-backend.ts | Migrates `preparePrContext` from ad-hoc `execSync` git calls to `ensureSliceBranch`/`getCurrentBranch` from `worktree.ts`; same over-broad `startsWith("kata/")` pattern as file-backend. |
| apps/cli/src/resources/extensions/pr-lifecycle/gh-utils.ts | `parseBranchToSlice` updated to accept both namespaced and legacy formats; duplicate parsing logic mirrors `parseSliceBranchName` in `worktree.ts`, creating a two-implementation maintenance risk. |
| apps/cli/src/resources/extensions/kata/tests/worktree.test.ts | Good coverage of namespaced branch creation, idempotency, legacy continuity, and provenance rejection; missing the edge case where both a legacy and a conflicting namespaced branch coexist simultaneously. |
| apps/cli/src/resources/extensions/pr-lifecycle/tests/gh-utils.test.ts | New test file with solid coverage of `parseBranchToSlice` for namespaced, legacy, null, and malformed inputs. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ensureSliceBranch called] --> B{Already on namespaced\nor legacy branch?}
    B -- Yes --> C[return false\nno-op]
    B -- No --> D[resolvePreferredSliceBranch]
    D --> E{Namespaced branch\nkata/scope/M/S exists?}
    E -- Yes --> F[checkout namespaced branch\nreturn false]
    E -- No --> G{Legacy branch\nkata/M/S exists?}
    G -- Yes --> H[checkout legacy branch\nreturn false]
    G -- No --> I[findConflictingNamespacedBranch]
    I --> J{Other-scope branch\nfor same M/S found?}
    J -- Yes --> K[throw Error\nprovenance mismatch]
    J -- No --> L[create kata/scope/M/S\nfrom main]
    L --> M[checkout new namespaced branch\nreturn true]

    style H fill:#ffdd99,stroke:#cc8800
    style K fill:#ffcccc,stroke:#cc0000
    style F fill:#ccffcc,stroke:#006600
    style M fill:#ccffcc,stroke:#006600

    N[⚠️ Bypass gap: if both G and J\nare true simultaneously,\nconflicting branch is silently ignored]
    H -.-> N
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/worktree.ts
Line: 149-183

Comment:
**Provenance guard bypassed when legacy and conflicting branches coexist**

`resolvePreferredSliceBranch` returns the legacy branch (`kata/M001/S05`) whenever it exists, which means `findConflictingNamespacedBranch` is never reached in that code path. Consider this scenario in a monorepo:

- `kata/project-b/M001/S05` exists (committed by another project)
- `kata/M001/S05` also exists (a legacy branch)

When `ensureSliceBranch` is called for project-a (scope = `project-a`):
1. `resolvePreferredSliceBranch` checks `kata/project-a/M001/S05` → not found
2. Checks `kata/M001/S05` → found → returns it immediately
3. Checks out the legacy branch, returns `false`
4. `findConflictingNamespacedBranch` is **never called** — `kata/project-b/M001/S05` conflict is silently ignored

The R002 requirement ("cannot silently reuse stale branches from unrelated projects") is only enforced when no legacy branch exists alongside a conflicting namespaced branch. The provenance check should run before falling back to the legacy branch, or at least emit a warning when a conflicting namespaced branch coexists with the chosen legacy branch.

The test coverage in `worktree.test.ts` only covers the case where there is no legacy branch (`kata/M001/S05` is absent), leaving this bypass path untested.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/file-backend.ts
Line: 384-391

Comment:
**Overly broad branch detection after `ensureSliceBranch`**

The `startsWith("kata/")` check accepts any kata branch as `branch`, not specifically the one that `ensureSliceBranch` just established. The function is documented to ensure the correct branch, so using the return value of `getCurrentBranch` unconditionally would be both simpler and more accurate. The fallback to `getSliceBranchName` can only be reached if the caller was on a non-kata branch and `ensureSliceBranch` somehow did not switch — which would indicate a bug that this code would then mask.

The same pattern appears in `linear-backend.ts` at the equivalent `preparePrContext` method (diff lines ~55–58).

```suggestion
    const currentBranch = getCurrentBranch(this.basePath);
    const branch = currentBranch;
```

If the fallback is intentional for detached-HEAD scenarios, a comment explaining the rationale would help readers understand why `startsWith("kata/")` is used instead of the branch name returned by `ensureSliceBranch`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/worktree.ts
Line: 290-316

Comment:
**Duplicate branch-parsing logic between `worktree.ts` and `gh-utils.ts`**

`parseSliceBranchName` (exported here) and `parseBranchToSlice` in `pr-lifecycle/gh-utils.ts` both parse the same two branch formats (`kata/<scope>/<M>/<S>` and `kata/<M>/<S>`) with near-identical regex patterns. Having two implementations means any future format change must be updated in two places and both test suites must be kept in sync.

`gh-utils.ts` is in a different package (`pr-lifecycle`), but since it already has a known cross-extension dependency path, it could import `parseSliceBranchName` from `worktree.js` and derive `{ milestoneId, sliceId }` from the result, keeping the parsing logic in a single source of truth.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/worktree.ts
Line: 236-240

Comment:
**`mergeSliceToMain` silently falls back to legacy branch without provenance check**

When neither the namespaced branch nor the legacy branch exists, the function sets `branch = legacyBranch` and then throws at the `!branchExists` guard below — that's fine. But if the namespaced branch doesn't exist while the legacy branch does, the code merges the legacy branch without verifying it belongs to this project scope. In a shared monorepo, `kata/M001/S01` might have been created by a different project, and its history would be merged into this project's main branch without any warning.

The `ensureSliceBranch` provenance guard is not called before `mergeSliceToMain`, so callers that call `mergeSliceToMain` directly (without going through `ensureSliceBranch` first) bypass scope validation entirely. A scope check here, or at minimum a comment noting that the caller is responsible for provenance validation, would improve safety.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(S02/T04): align..."](https://github.com/gannonh/kata/commit/193396277f9ac0e0179a43b9f5d4efa86f36a90e)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support namespaced slice branches (kata/<scope>/Mxxx/Syy) alongside legacy format; PR title normalization and per-step model preference added.
  * Added short prompt snippets to many tool descriptors and a new Linear "add comment" action.

* **Behavior Changes**
  * PR creation may push the current branch if missing and provides clearer branch-format errors/hints; auto-mode status shows model info and warns if preferred model is unavailable.

* **Tests**
  * Added/updated tests covering namespaced vs legacy branch parsing and Git-backed workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->