### PR TITLE
CLI v0.4.0

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.4.0
+
+### Features
+
+- **Namespaced slice branches** (`kata/<scope>/<M>/<S>`) for monorepo/worktree safety — branches are scoped by project path, preventing silent collision across projects. Legacy `kata/<M>/<S>` format remains compatible during transition.
+- **Git service** (`git-service.ts`) ported from gsd-pi — typed API for branch management, smart staging (excludes `.kata-cli/` runtime files), auto-commit with conventional commit messages, and squash-merge. Replaces ad-hoc shell git execution.
+- **`linear_add_comment` tool** — post comments on Linear issues from agent workflows (UAT verdicts, status updates).
+- **Model preferences in `/kata step`** — `models.*` preferences now apply to `/kata step` in addition to `/kata auto`. The statusline badge shows the active model (e.g. `auto · claude-opus-4-6`).
+- **Auto-push before PR creation** — `runCreatePr` now checks if the branch exists on the remote and pushes it automatically if not. Returns a structured `push-failed` error instead of the cryptic GitHub GraphQL "Head sha can't be blank" message.
+- **PR titles prefixed with branch name** — PRs are titled `[kata/apps-cli/M001/S01] Slice title`, making them easy to identify per-project in a monorepo.
+- **`promptSnippet` for all custom tools** — upgraded to pi-coding-agent 0.60.0 which made `promptSnippet` opt-in; added snippets to all 109 custom tools so they appear in the agent's "Available tools" list.
+
+### Fixes
+
+- **PR error message** — auto-mode failure message now shows the actual branch name instead of hardcoding legacy `kata/<M>/<S>` format.
+- **`resolveModelForUnit`** — added missing `complete-milestone` and `reassess-roadmap` unit types; added warning when configured model ID is not found in registry.
+- **Provenance guard** — legacy branch fast-path in `ensureSliceBranch` now runs conflict detection even when already checked out on the legacy branch.
+- **Merge hint** — `kata_merge_pr` error hint no longer references `milestoneId`/`sliceId` params that don't exist on that tool.
+- **`promptSnippet` grammar** — fixed truncated and grammatically broken snippets in mac-tools, linear-tools, and pr-lifecycle.
+
+### Dependency
+
+- Upgrade `@mariozechner/pi-coding-agent` from `^0.57.1` to `^0.60.0`
+
 ## 0.3.0
 
 ### Built-in Linear Integration

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -91,7 +91,7 @@ Each slice flows through phases automatically:
 - **Complete** writes the summary, UAT script, marks the roadmap, and commits
 - **Reassess** checks if the roadmap still makes sense given what was learned
 
-All planning state lives in `.kata/` at the project root — human-readable markdown files that track milestones, slices, tasks, decisions, and progress.
+In file workflow mode, planning state lives in `.kata/` at the project root — human-readable markdown files that track milestones, slices, tasks, decisions, and progress. In Linear workflow mode, those same artifacts are stored in Linear issues/documents instead.
 
 ## Commands
 
@@ -141,7 +141,7 @@ All planning state lives in `.kata/` at the project root — human-readable mark
 
 ## Preferences
 
-Kata preferences live in `~/.kata-cli/preferences.md` (global) or `.kata-cli/preferences.md` (project-local). Manage with `/kata prefs`.
+Kata preferences live in `~/.kata-cli/preferences.md` (global) or `.kata/preferences.md` (project-local). Manage with `/kata prefs`. Legacy `.kata/PREFERENCES.md` is still read for backward compatibility.
 
 ```yaml
 ---
@@ -189,6 +189,8 @@ pr:
   review_on_create: false # run parallel code review after PR creation
   linear_link: false      # add Linear issue refs to PR body (requires linear mode)
 ```
+
+Slice branches use the canonical namespaced format `kata/<scope>/<M>/<S>` (for example `kata/apps-cli/M003/S05`). Legacy `kata/<M>/<S>` branches are still accepted during transition.
 
 ### How it works with auto-mode
 

--- a/apps/cli/docs/visual-explainers/kata-step-auto-journeys.html
+++ b/apps/cli/docs/visual-explainers/kata-step-auto-journeys.html
@@ -1593,7 +1593,7 @@ flowchart TD
   PR_PREF -->|skip-notify| NOTIFY["Pause + notify user"]
   NOTIFY --> USER_MANUAL["User handles merge manually"]
   USER_MANUAL --> RESUME
-  PR_PREF -->|legacy-squash-merge| SQUASH["Squash-merge slice branch"]
+  PR_PREF -->|direct-squash-merge| SQUASH["Squash-merge slice branch"]
   SQUASH --> NEXT["Continue to next slice"]
   PR_PREF -->|continue-auto| NEXT
   RESUME --> NEXT

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/resources/extensions/kata/auto-helpers.ts
+++ b/apps/cli/src/resources/extensions/kata/auto-helpers.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure helper functions extracted from auto.ts for testability.
+ * These have no side effects and no heavy imports.
+ */
+
+import { resolveModelForUnit } from "./preferences.js";
+
+// ─── Model switching ──────────────────────────────────────────────────────────
+
+export interface ModelSwitchResult {
+  /** What to do: "switch" = found in registry, "not-found" = preferred but missing, "none" = no preference */
+  action: "switch" | "not-found" | "none";
+  /** The model ID from preferences (if any) */
+  preferredModelId?: string;
+  /** Available model IDs (for "not-found" messages) */
+  availableModels: string[];
+  /** Status bar label to set */
+  statusLabel?: string;
+}
+
+/**
+ * Pure function: given a unit type, the available model IDs, and the current
+ * model ID, compute what model-switch action to take.
+ */
+export function resolveModelSwitch(
+  unitType: string,
+  availableModelIds: string[],
+  currentModelId: string | undefined,
+): ModelSwitchResult {
+  const preferredModelId = resolveModelForUnit(unitType);
+  if (!preferredModelId) {
+    return { action: "none", availableModels: availableModelIds };
+  }
+  const found = availableModelIds.includes(preferredModelId);
+  const statusLabel =
+    preferredModelId === currentModelId
+      ? `auto · ${preferredModelId}`
+      : "auto";
+
+  if (found) {
+    return {
+      action: "switch",
+      preferredModelId,
+      availableModels: availableModelIds,
+      statusLabel,
+    };
+  }
+  return {
+    action: "not-found",
+    preferredModelId,
+    availableModels: availableModelIds,
+    statusLabel,
+  };
+}
+
+// ─── Supervisor timeouts ──────────────────────────────────────────────────────
+
+/**
+ * Pure function: compute timeout milliseconds from supervisor config.
+ */
+export function computeSupervisorTimeouts(config: {
+  soft_timeout_minutes: number;
+  idle_timeout_minutes: number;
+  hard_timeout_minutes: number;
+}): { softMs: number; idleMs: number; hardMs: number } {
+  return {
+    softMs: config.soft_timeout_minutes * 60 * 1000,
+    idleMs: config.idle_timeout_minutes * 60 * 1000,
+    hardMs: config.hard_timeout_minutes * 60 * 1000,
+  };
+}

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -43,6 +43,7 @@ import {
   decidePostCompleteSliceAction,
   formatPrAutoCreateFailure,
 } from "./pr-auto.js";
+import { initDebugLog, closeDebugLog, dlog } from "./debug-log.js";
 import { runCreatePr } from "../pr-lifecycle/pr-runner.js";
 import {
   validatePlanBoundary,
@@ -115,6 +116,10 @@ let backend: KataBackend | null = null;
 let lastUnit: { type: string; id: string } | null = null;
 let retryCount = 0;
 const MAX_RETRIES = 1;
+
+/** Provider error retry state */
+const MAX_PROVIDER_RETRIES = 10;
+let providerErrorStreak = 0;
 
 /** Crash recovery prompt — set by startAuto, consumed by first dispatchNextUnit */
 let pendingCrashRecovery: string | null = null;
@@ -208,6 +213,10 @@ export async function stopAuto(
   clearUnitTimeout();
   if (basePath) clearLock(basePath);
   clearSkillSnapshot();
+
+  providerErrorStreak = 0;
+  dlog("stop", { reason: "explicit" });
+  closeDebugLog();
 
   // Show final cost summary before resetting
   const ledger = getLedger();
@@ -385,6 +394,17 @@ export async function startAuto(
     snapshotSkills();
   }
 
+  providerErrorStreak = 0;
+  initDebugLog(base);
+  dlog("init", {
+    basePath: base,
+    phase: state.phase,
+    milestone: state.activeMilestone?.id ?? null,
+    slice: state.activeSlice?.id ?? null,
+    task: state.activeTask?.id ?? null,
+    model: ctx.model?.id ?? null,
+  });
+
   ctx.ui.setStatus("kata-auto", "auto");
   const pendingCount = state.registry.filter(
     (m) => m.status !== "complete",
@@ -401,11 +421,77 @@ export async function startAuto(
 
 // ─── Agent End Handler ────────────────────────────────────────────────────────
 
+/** Backoff delay in ms: 5s, 10s, 20s, 40s, 60s, 60s, ... */
+function providerBackoffMs(attempt: number): number {
+  return Math.min(5000 * Math.pow(2, attempt), 60_000);
+}
+
+/**
+ * Handle a provider/network error during auto-mode.
+ * Retries with exponential backoff up to MAX_PROVIDER_RETRIES before pausing.
+ */
+export async function handleProviderError(
+  ctx: ExtensionContext,
+  pi: ExtensionAPI,
+  errorMsg: string,
+): Promise<void> {
+  if (!active || !cmdCtx) return;
+
+  providerErrorStreak++;
+  const delayMs = providerBackoffMs(providerErrorStreak - 1);
+  const delaySec = Math.round(delayMs / 1000);
+
+  dlog("provider-error", {
+    error: errorMsg,
+    streak: providerErrorStreak,
+    backoffSec: delaySec,
+  });
+
+  if (providerErrorStreak >= MAX_PROVIDER_RETRIES) {
+    dlog("pause", { reason: "provider-error-exhausted", streak: providerErrorStreak });
+    ctx.ui.notify(
+      `Auto-mode paused: ${providerErrorStreak} consecutive provider errors (${errorMsg}). Run /kata auto to retry.`,
+      "warning",
+    );
+    providerErrorStreak = 0;
+    await pauseAuto(ctx, pi);
+    return;
+  }
+
+  ctx.ui.notify(
+    `Provider error (${errorMsg}). Retrying in ${delaySec}s (${providerErrorStreak}/${MAX_PROVIDER_RETRIES})...`,
+    "warning",
+  );
+
+  await new Promise((r) => setTimeout(r, delayMs));
+
+  if (!active) return; // user stopped during backoff
+
+  dlog("provider-retry", { streak: providerErrorStreak });
+
+  try {
+    await handleAgentEnd(ctx, pi);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    dlog("provider-retry-error", { error: message });
+    ctx.ui.notify(`Auto-mode error during retry: ${message}`, "error");
+    await stopAuto(ctx, pi);
+  }
+}
+
 export async function handleAgentEnd(
   ctx: ExtensionContext,
   pi: ExtensionAPI,
 ): Promise<void> {
   if (!active || !cmdCtx) return;
+
+  // Successful agent completion — reset provider error streak
+  providerErrorStreak = 0;
+
+  dlog("agent-end", {
+    unit: currentUnit?.type ?? "none",
+    id: currentUnit?.id ?? "none",
+  });
 
   // Unit completed — clear its timeout
   clearUnitTimeout();
@@ -422,9 +508,13 @@ export async function handleAgentEnd(
         currentUnit.id,
       );
       if (commitMsg) {
+        dlog("autocommit", { unit: currentUnit.type, id: currentUnit.id });
         ctx.ui.notify(`Auto-committed uncommitted changes.`, "info");
       }
-    } catch {
+    } catch (err) {
+      dlog("autocommit-error", {
+        error: err instanceof Error ? err.message : String(err),
+      });
       // Non-fatal
     }
   }
@@ -433,6 +523,7 @@ export async function handleAgentEnd(
     await dispatchNextUnit(ctx, pi);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    dlog("dispatch-error", { error: message });
     ctx.ui.notify(`Auto-mode error: ${message}`, "error");
     await stopAuto(ctx, pi);
   }
@@ -795,6 +886,13 @@ async function dispatchNextUnit(
   const mid = state.activeMilestone?.id;
   const midTitle = state.activeMilestone?.title;
 
+  dlog("derive-state", {
+    phase: state.phase,
+    milestone: mid ?? null,
+    slice: state.activeSlice?.id ?? null,
+    task: state.activeTask?.id ?? null,
+  });
+
   // 2. Milestone transition detection
   if (mid && currentMilestoneId && mid !== currentMilestoneId) {
     ctx.ui.notify(
@@ -872,6 +970,13 @@ async function dispatchNextUnit(
   const unitType = deriveUnitType(state, dispatchOptions);
   const unitId = deriveUnitId(state, dispatchOptions);
 
+  dlog("dispatch", {
+    unit: unitType,
+    id: unitId,
+    phase: state.phase,
+    promptLen: prompt.length,
+  });
+
   ctx.ui.notify(`Auto-mode: ${unitType} — ${unitId}`, "info");
 
   await emitObservabilityWarnings(ctx, unitType, unitId);
@@ -879,6 +984,7 @@ async function dispatchNextUnit(
   // 7. Stuck detection
   if (lastUnit && lastUnit.type === unitType && lastUnit.id === unitId) {
     retryCount++;
+    dlog("retry", { unit: unitType, id: unitId, retryCount });
     if (retryCount > MAX_RETRIES) {
       if (currentUnit) {
         const modelId = ctx.model?.id ?? "unknown";

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -1236,7 +1236,7 @@ async function dispatchNextUnit(
         "warning",
       );
     }
-    if (preferredModelId && preferredModelId === ctx.state.selectedModel?.id) {
+    if (preferredModelId && preferredModelId === ctx.getModel()?.id) {
       ctx.ui.setStatus("kata-auto", `auto · ${preferredModelId}`);
     } else {
       ctx.ui.setStatus("kata-auto", "auto");

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -103,6 +103,10 @@ import {
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { makeUI, GLYPH, INDENT } from "../shared/ui.js";
 
+import { resolveModelSwitch, computeSupervisorTimeouts } from "./auto-helpers.js";
+export { resolveModelSwitch, computeSupervisorTimeouts } from "./auto-helpers.js";
+export type { ModelSwitchResult } from "./auto-helpers.js";
+
 // ─── State ────────────────────────────────────────────────────────────────────
 
 let active = false;
@@ -1223,32 +1227,32 @@ async function dispatchNextUnit(
   }
 
   // 18. Model switching
-  const preferredModelId = resolveModelForUnit(unitType);
-  if (preferredModelId) {
-    const allModels = ctx.modelRegistry.getAll();
-    const model = allModels.find((m) => m.id === preferredModelId);
+  const switchResult = resolveModelSwitch(
+    unitType,
+    ctx.modelRegistry.getAll().map((m) => m.id),
+    ctx.model?.id,
+  );
+  if (switchResult.action === "switch") {
+    const model = ctx.modelRegistry.getAll().find((m) => m.id === switchResult.preferredModelId);
     if (model) {
       const ok = await pi.setModel(model);
-      if (ok) ctx.ui.notify(`Model: ${preferredModelId}`, "info");
-    } else {
-      ctx.ui.notify(
-        `Model preference '${preferredModelId}' not found in registry — using current model. Available: ${allModels.map((m) => m.id).slice(0, 5).join(", ")}...`,
-        "warning",
-      );
+      if (ok) ctx.ui.notify(`Model: ${switchResult.preferredModelId}`, "info");
     }
-    if (preferredModelId && preferredModelId === ctx.model?.id) {
-      ctx.ui.setStatus("kata-auto", `auto · ${preferredModelId}`);
-    } else {
-      ctx.ui.setStatus("kata-auto", "auto");
-    }
+  } else if (switchResult.action === "not-found") {
+    ctx.ui.notify(
+      `Model preference '${switchResult.preferredModelId}' not found in registry — using current model. Available: ${switchResult.availableModels.slice(0, 5).join(", ")}...`,
+      "warning",
+    );
+  }
+  if (switchResult.statusLabel) {
+    ctx.ui.setStatus("kata-auto", switchResult.statusLabel);
   }
 
   // 19. Timeout supervision
   clearUnitTimeout();
   const supervisor = resolveAutoSupervisorConfig();
-  const softTimeoutMs = supervisor.soft_timeout_minutes * 60 * 1000;
-  const idleTimeoutMs = supervisor.idle_timeout_minutes * 60 * 1000;
-  const hardTimeoutMs = supervisor.hard_timeout_minutes * 60 * 1000;
+  const { softMs: softTimeoutMs, idleMs: idleTimeoutMs, hardMs: hardTimeoutMs } =
+    computeSupervisorTimeouts(supervisor);
 
   wrapupWarningHandle = setTimeout(() => {
     wrapupWarningHandle = null;

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -474,7 +474,7 @@ export async function handleProviderError(
   dlog("provider-retry", { streak: providerErrorStreak });
 
   try {
-    await handleAgentEnd(ctx, pi);
+    await handleAgentEnd(ctx, pi, /* resetStreak */ false);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     dlog("provider-retry-error", { error: message });
@@ -486,11 +486,12 @@ export async function handleProviderError(
 export async function handleAgentEnd(
   ctx: ExtensionContext,
   pi: ExtensionAPI,
+  resetStreak = true,
 ): Promise<void> {
   if (!active || !cmdCtx) return;
 
-  // Successful agent completion — reset provider error streak
-  providerErrorStreak = 0;
+  // Reset provider error streak only on normal completion, not during retries
+  if (resetStreak) providerErrorStreak = 0;
 
   dlog("agent-end", {
     unit: currentUnit?.type ?? "none",

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -1236,7 +1236,7 @@ async function dispatchNextUnit(
         "warning",
       );
     }
-    if (preferredModelId && preferredModelId === ctx.getModel()?.id) {
+    if (preferredModelId && preferredModelId === ctx.model?.id) {
       ctx.ui.setStatus("kata-auto", `auto · ${preferredModelId}`);
     } else {
       ctx.ui.setStatus("kata-auto", "auto");

--- a/apps/cli/src/resources/extensions/kata/debug-log.ts
+++ b/apps/cli/src/resources/extensions/kata/debug-log.ts
@@ -1,0 +1,108 @@
+/**
+ * Kata Debug Logger
+ *
+ * Structured append-only debug log for auto-mode orchestration.
+ * Activated by KATA_DEBUG=1 (or any truthy value).
+ * Writes to .kata/debug.log in the project directory.
+ *
+ * All orchestration events — dispatch decisions, state transitions,
+ * agent_end signals, model switches, errors — are captured here.
+ * The activity JSONL captures what the LLM said; this captures
+ * what the dispatch layer did.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+let logPath: string | null = null;
+let enabled = false;
+
+/**
+ * Initialize the debug logger for a project directory.
+ * Call once at auto-mode start. No-op if KATA_DEBUG is not set.
+ */
+export function initDebugLog(basePath: string): void {
+  const envVal = process.env.KATA_DEBUG;
+  enabled = !!envVal && envVal !== "0" && envVal !== "false";
+  if (!enabled) {
+    logPath = null;
+    return;
+  }
+
+  const kataDir = join(basePath, ".kata");
+  mkdirSync(kataDir, { recursive: true });
+  logPath = join(kataDir, "debug.log");
+
+  // Session separator
+  const sep = `\n${"─".repeat(60)}\n`;
+  const header = `${sep}[auto-start] ${iso()} pid=${process.pid}\n`;
+  try {
+    appendFileSync(logPath, header, "utf-8");
+  } catch {
+    // If we can't write, disable silently
+    enabled = false;
+    logPath = null;
+  }
+}
+
+/**
+ * Tear down the debug logger. Called on auto-mode stop.
+ */
+export function closeDebugLog(): void {
+  if (enabled && logPath) {
+    write("auto-stop", {});
+  }
+  logPath = null;
+  // Don't reset `enabled` — let initDebugLog control that
+}
+
+/**
+ * Log a structured event. No-op if debug logging is disabled.
+ *
+ * @param event - Short event name (e.g. "dispatch", "agent-end", "error")
+ * @param data  - Key-value pairs to log
+ */
+export function dlog(
+  event: string,
+  data: Record<string, string | number | boolean | null | undefined>,
+): void {
+  if (!enabled || !logPath) return;
+  write(event, data);
+}
+
+/**
+ * Check if debug logging is currently active.
+ */
+export function isDebugLogEnabled(): boolean {
+  return enabled;
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────
+
+function iso(): string {
+  return new Date().toISOString();
+}
+
+function write(
+  event: string,
+  data: Record<string, string | number | boolean | null | undefined>,
+): void {
+  if (!logPath) return;
+
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(data)) {
+    if (v === undefined || v === null) continue;
+    if (typeof v === "string" && v.includes(" ")) {
+      parts.push(`${k}="${v}"`);
+    } else {
+      parts.push(`${k}=${v}`);
+    }
+  }
+
+  const line = `${iso()} [${event}] ${parts.join(" ")}\n`;
+  try {
+    appendFileSync(logPath, line, "utf-8");
+  } catch {
+    // Never let logging break auto-mode
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
+++ b/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
@@ -89,19 +89,21 @@ If Linear mode is configured but not ready, the status output stays redacted and
 
 Run `/kata pr status` to inspect the PR lifecycle configuration:
 
+Canonical slice branches use the namespaced format `kata/<scope>/<milestone>/<slice>` (for example `kata/apps-cli/M003/S05`). Legacy `kata/<milestone>/<slice>` branches remain supported during transition.
+
 ```text
 PR lifecycle: enabled
-branch: kata/M003/S05
+branch: kata/apps-cli/M003/S05
 base_branch: main
 auto_create: true
-open PR: #70 — kata/M003/S05
+open PR: #70 — kata/apps-cli/M003/S05
 ```
 
 When PR lifecycle is disabled or not configured:
 
 ```text
 PR lifecycle: pr.enabled is false (disabled)
-branch: kata/M003/S05
+branch: kata/apps-cli/M003/S05
 Set pr.enabled: true in .kata/preferences.md to activate the PR workflow.
 ```
 

--- a/apps/cli/src/resources/extensions/kata/gitignore.ts
+++ b/apps/cli/src/resources/extensions/kata/gitignore.ts
@@ -19,6 +19,7 @@ const BASELINE_PATTERNS = [
   ".kata/activity/",
   ".kata/runtime/",
   ".kata/auto.lock",
+  ".kata/debug.log",
   ".kata/metrics.json",
   ".kata/STATE.md",
 

--- a/apps/cli/src/resources/extensions/kata/index.ts
+++ b/apps/cli/src/resources/extensions/kata/index.ts
@@ -37,9 +37,11 @@ import {
   isAutoActive,
   isAutoPaused,
   handleAgentEnd,
+  handleProviderError,
   pauseAuto,
   getAutoDashboardData,
 } from "./auto.js";
+import { dlog } from "./debug-log.js";
 import { saveActivityLog } from "./activity-log.js";
 import { checkAutoStartAfterDiscuss } from "./guided-flow.js";
 import { KataDashboardOverlay } from "./dashboard-overlay.js";
@@ -86,6 +88,8 @@ const KATA_LOGO_LINES = [
   "  ██║  ██╗██║  ██║   ██║   ██║  ██║",
   "  ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝",
 ];
+
+// Provider error retry is handled in auto.ts — see handleProviderError()
 
 export default function (pi: ExtensionAPI) {
   registerKataCommand(pi);
@@ -230,12 +234,29 @@ export default function (pi: ExtensionAPI) {
     // instead of advancing. This preserves the conversation so the user
     // can inspect what happened, interact with the agent, or resume.
     const lastMsg = event.messages[event.messages.length - 1];
-    if (
-      lastMsg &&
-      "stopReason" in lastMsg &&
-      lastMsg.stopReason === "aborted"
-    ) {
+    const stopReason =
+      lastMsg && "stopReason" in lastMsg ? lastMsg.stopReason : undefined;
+
+    dlog("agent-end-event", {
+      stopReason: stopReason ?? "end_turn",
+      messages: event.messages.length,
+    });
+
+    if (stopReason === "aborted") {
+      dlog("pause", { reason: "user-abort" });
       await pauseAuto(ctx, pi);
+      return;
+    }
+
+    // If the agent session ended with a provider/network error, retry
+    // with exponential backoff instead of advancing (which would burn
+    // through the stuck-detection budget on transient failures).
+    if (stopReason === "error") {
+      const errorMsg =
+        lastMsg && "errorMessage" in lastMsg
+          ? (lastMsg as Record<string, unknown>).errorMessage
+          : "unknown";
+      await handleProviderError(ctx, pi, String(errorMsg));
       return;
     }
 

--- a/apps/cli/src/resources/extensions/kata/preferences.ts
+++ b/apps/cli/src/resources/extensions/kata/preferences.ts
@@ -42,6 +42,14 @@ export interface AutoSupervisorConfig {
   hard_timeout_minutes?: number;
 }
 
+/** AutoSupervisorConfig with defaults applied — timeouts are always numbers. */
+export interface ResolvedAutoSupervisorConfig {
+  model?: string;
+  soft_timeout_minutes: number;
+  idle_timeout_minutes: number;
+  hard_timeout_minutes: number;
+}
+
 export type WorkflowMode = "file" | "linear";
 
 export interface KataWorkflowPreferences {
@@ -693,7 +701,7 @@ export function resolveModelForUnit(unitType: string): string | undefined {
   }
 }
 
-export function resolveAutoSupervisorConfig(): AutoSupervisorConfig {
+export function resolveAutoSupervisorConfig(): ResolvedAutoSupervisorConfig {
   const prefs = loadEffectiveKataPreferences();
   const configured = prefs?.preferences.auto_supervisor ?? {};
 

--- a/apps/cli/src/resources/extensions/kata/preferences.ts
+++ b/apps/cli/src/resources/extensions/kata/preferences.ts
@@ -575,12 +575,42 @@ function parseFrontmatterBlock(frontmatter: string): KataPreferences {
 function parseScalar(
   value: string,
 ): string | number | boolean | unknown[] | Record<string, never> {
-  if (value === "true") return true;
-  if (value === "false") return false;
-  if (value === "[]") return [];
-  if (value === "{}") return {};
-  if (/^-?\d+$/.test(value)) return Number(value);
-  return value.replace(/^['\"]|['\"]$/g, "");
+  const normalizedValue = stripInlineYamlComment(value).trim();
+
+  if (normalizedValue === "true") return true;
+  if (normalizedValue === "false") return false;
+  if (normalizedValue === "[]") return [];
+  if (normalizedValue === "{}") return {};
+  if (/^-?\d+$/.test(normalizedValue)) return Number(normalizedValue);
+
+  return normalizedValue.replace(/^['\"]|['\"]$/g, "");
+}
+
+function stripInlineYamlComment(value: string): string {
+  let inSingle = false;
+  let inDouble = false;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+
+    if (char === "'" && !inDouble) {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (char === '"' && !inSingle) {
+      inDouble = !inDouble;
+      continue;
+    }
+
+    if (!inSingle && !inDouble && char === "#") {
+      const prev = i > 0 ? value[i - 1] : "";
+      if (i === 0 || /\s/.test(prev)) {
+        return value.slice(0, i).trimEnd();
+      }
+    }
+  }
+
+  return value;
 }
 
 /**
@@ -777,6 +807,24 @@ function validatePreferences(preferences: KataPreferences): {
     validated.pr = normalizedPr.value;
   }
 
+  const normalizedModels = normalizeModelPreferences(preferences.models);
+  if (normalizedModels.errors.length > 0) {
+    errors.push(...normalizedModels.errors);
+  }
+  if (normalizedModels.value) {
+    validated.models = normalizedModels.value;
+  }
+
+  const normalizedAutoSupervisor = normalizeAutoSupervisorConfig(
+    preferences.auto_supervisor,
+  );
+  if (normalizedAutoSupervisor.errors.length > 0) {
+    errors.push(...normalizedAutoSupervisor.errors);
+  }
+  if (normalizedAutoSupervisor.value) {
+    validated.auto_supervisor = normalizedAutoSupervisor.value;
+  }
+
   validated.always_use_skills = normalizeStringList(
     preferences.always_use_skills,
   );
@@ -942,6 +990,103 @@ function normalizePrPreferences(value: unknown): {
         normalized.base_branch = trimmed;
       }
     }
+  }
+
+  return {
+    value: Object.keys(normalized).length > 0 ? normalized : undefined,
+    errors,
+  };
+}
+
+function normalizeModelPreferences(value: unknown): {
+  value?: KataModelConfig;
+  errors: string[];
+} {
+  if (value === undefined) return { errors: [] };
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { errors: ["models must be an object"] };
+  }
+
+  const normalized: KataModelConfig = {};
+  const errors: string[] = [];
+
+  for (const key of [
+    "research",
+    "planning",
+    "execution",
+    "completion",
+    "review",
+  ] as const) {
+    const raw = (value as Record<string, unknown>)[key];
+    if (raw === undefined) continue;
+
+    if (typeof raw !== "string") {
+      errors.push(`models.${key} must be a string`);
+      continue;
+    }
+
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      errors.push(`models.${key} must not be empty`);
+      continue;
+    }
+
+    normalized[key] = trimmed;
+  }
+
+  return {
+    value: Object.keys(normalized).length > 0 ? normalized : undefined,
+    errors,
+  };
+}
+
+function normalizeAutoSupervisorConfig(value: unknown): {
+  value?: AutoSupervisorConfig;
+  errors: string[];
+} {
+  if (value === undefined) return { errors: [] };
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { errors: ["auto_supervisor must be an object"] };
+  }
+
+  const normalized: AutoSupervisorConfig = {};
+  const errors: string[] = [];
+
+  const rawModel = (value as Record<string, unknown>).model;
+  if (rawModel !== undefined) {
+    if (typeof rawModel !== "string") {
+      errors.push("auto_supervisor.model must be a string");
+    } else {
+      const trimmed = rawModel.trim();
+      if (!trimmed) {
+        errors.push("auto_supervisor.model must not be empty");
+      } else {
+        normalized.model = trimmed;
+      }
+    }
+  }
+
+  for (const key of [
+    "soft_timeout_minutes",
+    "idle_timeout_minutes",
+    "hard_timeout_minutes",
+  ] as const) {
+    const raw = (value as Record<string, unknown>)[key];
+    if (raw === undefined) continue;
+
+    const numeric =
+      typeof raw === "number"
+        ? raw
+        : typeof raw === "string"
+          ? Number(raw)
+          : NaN;
+
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+      errors.push(`auto_supervisor.${key} must be a positive number`);
+      continue;
+    }
+
+    normalized[key] = numeric;
   }
 
   return {

--- a/apps/cli/src/resources/extensions/kata/templates/preferences.md
+++ b/apps/cli/src/resources/extensions/kata/templates/preferences.md
@@ -15,7 +15,7 @@ avoid_skills: []
 skill_rules: []
 custom_instructions: []
 models: {}
-skill_discovery:
+skill_discovery: suggest
 auto_supervisor: {}
 ---
 

--- a/apps/cli/src/resources/extensions/kata/tests/auto-model-switch.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/auto-model-switch.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { test, describe } from "node:test";
+import { resolveModelSwitch, computeSupervisorTimeouts } from "../auto-helpers.ts";
+import { resolveAutoSupervisorConfig, resolveModelForUnit } from "../preferences.ts";
+
+// ─── resolveModelSwitch ───────────────────────────────────────────────────────
+
+describe("resolveModelSwitch", () => {
+  const registry = ["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-3-5"];
+
+  test("returns 'none' when no preference exists for unit type", () => {
+    // resolveModelForUnit returns undefined for unknown types, which means
+    // resolveModelSwitch should return action: "none" when preferences have no
+    // models configured (default state — no preferences file in cwd).
+    const result = resolveModelSwitch("unknown-unit-type", registry, "claude-sonnet-4-6");
+    assert.equal(result.action, "none");
+    assert.equal(result.preferredModelId, undefined);
+    assert.equal(result.statusLabel, undefined);
+  });
+
+  test("returns 'none' for unknown unit types (no model mapping)", () => {
+    const result = resolveModelSwitch("__unknown_unit__", registry, "claude-haiku-3-5");
+    assert.equal(result.action, "none");
+    assert.equal(result.preferredModelId, undefined);
+    assert.equal(result.statusLabel, undefined);
+    assert.deepEqual(result.availableModels, registry);
+  });
+
+  test("returns action based on resolveModelForUnit for known unit types", () => {
+    // resolveModelForUnit reads preferences from cwd — if a preferences file
+    // exists with models configured, this returns "switch" or "not-found".
+    // If no preferences exist, it returns "none".
+    const result = resolveModelSwitch("execute-task", registry, "claude-sonnet-4-6");
+    // The action depends on whether a preferences file exists in cwd.
+    // Either way, it must be one of the valid actions and not throw.
+    assert.ok(["switch", "not-found", "none"].includes(result.action));
+    assert.ok(Array.isArray(result.availableModels));
+  });
+});
+
+// Since resolveModelSwitch calls resolveModelForUnit internally (impure),
+// we also test the decision logic directly with known inputs.
+
+describe("resolveModelSwitch decision logic", () => {
+  // We test the three code paths by simulating what resolveModelSwitch does
+  // when given different inputs. The extracted function is pure in its
+  // registry/currentModel inputs — the impurity is resolveModelForUnit.
+  // These tests validate the contract that auto.ts relies on.
+
+  test("preferred model found in registry → action: switch, statusLabel set", () => {
+    // Simulate: resolveModelForUnit returned "claude-opus-4-6"
+    // Registry has it, current model is different.
+    const preferred = "claude-opus-4-6";
+    const registry = ["claude-sonnet-4-6", "claude-opus-4-6"];
+    const current = "claude-sonnet-4-6";
+
+    const found = registry.includes(preferred);
+    const statusLabel = preferred === current ? `auto · ${preferred}` : "auto";
+
+    assert.equal(found, true);
+    assert.equal(statusLabel, "auto");
+  });
+
+  test("preferred model matches current → statusLabel includes model name", () => {
+    const preferred = "claude-opus-4-6";
+    const current = "claude-opus-4-6";
+    const statusLabel = preferred === current ? `auto · ${preferred}` : "auto";
+    assert.equal(statusLabel, "auto · claude-opus-4-6");
+  });
+
+  test("preferred model NOT in registry → action: not-found", () => {
+    const preferred = "claude-ultra-99";
+    const registry = ["claude-sonnet-4-6", "claude-opus-4-6"];
+    const found = registry.includes(preferred);
+    assert.equal(found, false);
+  });
+
+  test("no preferred model → action: none, no status change", () => {
+    const preferred = undefined;
+    assert.equal(preferred, undefined);
+  });
+});
+
+// ─── resolveModelForUnit mapping ──────────────────────────────────────────────
+
+describe("resolveModelForUnit unit-type mapping", () => {
+  // These test the mapping logic without needing preferences files.
+  // Without preferences, all return undefined. This validates the
+  // switch-case doesn't throw for any unit type.
+
+  const unitTypes = [
+    "research-milestone",
+    "research-slice",
+    "plan-milestone",
+    "plan-slice",
+    "replan-slice",
+    "reassess-roadmap",
+    "execute-task",
+    "complete-slice",
+    "complete-milestone",
+    "run-uat",
+  ];
+
+  for (const unitType of unitTypes) {
+    test(`resolveModelForUnit('${unitType}') does not throw`, () => {
+      // Should return undefined (no preferences) — but must not crash
+      const result = resolveModelForUnit(unitType);
+      assert.equal(typeof result === "string" || result === undefined, true);
+    });
+  }
+
+  test("unknown unit type returns undefined", () => {
+    assert.equal(resolveModelForUnit("nonexistent"), undefined);
+  });
+});
+
+// ─── computeSupervisorTimeouts ────────────────────────────────────────────────
+
+describe("computeSupervisorTimeouts", () => {
+  test("converts minutes to milliseconds", () => {
+    const result = computeSupervisorTimeouts({
+      soft_timeout_minutes: 15,
+      idle_timeout_minutes: 8,
+      hard_timeout_minutes: 25,
+    });
+    assert.equal(result.softMs, 15 * 60 * 1000);
+    assert.equal(result.idleMs, 8 * 60 * 1000);
+    assert.equal(result.hardMs, 25 * 60 * 1000);
+  });
+
+  test("handles default values (20/10/30)", () => {
+    const result = computeSupervisorTimeouts({
+      soft_timeout_minutes: 20,
+      idle_timeout_minutes: 10,
+      hard_timeout_minutes: 30,
+    });
+    assert.equal(result.softMs, 1_200_000);
+    assert.equal(result.idleMs, 600_000);
+    assert.equal(result.hardMs, 1_800_000);
+  });
+
+  test("handles zero values", () => {
+    const result = computeSupervisorTimeouts({
+      soft_timeout_minutes: 0,
+      idle_timeout_minutes: 0,
+      hard_timeout_minutes: 0,
+    });
+    assert.equal(result.softMs, 0);
+    assert.equal(result.idleMs, 0);
+    assert.equal(result.hardMs, 0);
+  });
+
+  test("handles fractional minutes", () => {
+    const result = computeSupervisorTimeouts({
+      soft_timeout_minutes: 1.5,
+      idle_timeout_minutes: 0.5,
+      hard_timeout_minutes: 2.5,
+    });
+    assert.equal(result.softMs, 90_000);
+    assert.equal(result.idleMs, 30_000);
+    assert.equal(result.hardMs, 150_000);
+  });
+});
+
+// ─── resolveAutoSupervisorConfig defaults ─────────────────────────────────────
+
+describe("resolveAutoSupervisorConfig", () => {
+  test("provides safe defaults when no preferences exist", () => {
+    const config = resolveAutoSupervisorConfig();
+    assert.equal(config.soft_timeout_minutes, 20);
+    assert.equal(config.idle_timeout_minutes, 10);
+    assert.equal(config.hard_timeout_minutes, 30);
+    assert.equal(config.model, undefined);
+  });
+
+  test("return type has required timeout fields (not optional)", () => {
+    const config = resolveAutoSupervisorConfig();
+    // These should be numbers, not undefined — the resolved type guarantees it
+    assert.equal(typeof config.soft_timeout_minutes, "number");
+    assert.equal(typeof config.idle_timeout_minutes, "number");
+    assert.equal(typeof config.hard_timeout_minutes, "number");
+  });
+
+  test("resolved config is directly usable by computeSupervisorTimeouts", () => {
+    const config = resolveAutoSupervisorConfig();
+    // This should compile and not throw — the resolved type matches the input type
+    const timeouts = computeSupervisorTimeouts(config);
+    assert.equal(typeof timeouts.softMs, "number");
+    assert.equal(typeof timeouts.idleMs, "number");
+    assert.equal(typeof timeouts.hardMs, "number");
+    assert.ok(timeouts.softMs > 0);
+    assert.ok(timeouts.idleMs > 0);
+    assert.ok(timeouts.hardMs > 0);
+  });
+});
+
+// ─── ctx.model contract ───────────────────────────────────────────────────────
+
+describe("ctx.model access pattern", () => {
+  // These tests validate the optional-chaining pattern that auto.ts uses.
+  // The bug was ctx.state.selectedModel (doesn't exist) and ctx.getModel()
+  // (not a function). The correct pattern is ctx.model?.id.
+
+  test("optional chaining on undefined model returns undefined", () => {
+    const ctx = { model: undefined as { id: string } | undefined };
+    assert.equal(ctx.model?.id, undefined);
+  });
+
+  test("optional chaining on defined model returns id", () => {
+    const ctx = { model: { id: "claude-sonnet-4-6" } as { id: string } | undefined };
+    assert.equal(ctx.model?.id, "claude-sonnet-4-6");
+  });
+
+  test("comparison with preferred model works correctly", () => {
+    const preferred = "claude-opus-4-6";
+    const ctxWithMatch = { model: { id: "claude-opus-4-6" } };
+    const ctxWithMismatch = { model: { id: "claude-sonnet-4-6" } };
+    const ctxWithNoModel = { model: undefined as { id: string } | undefined };
+
+    assert.equal(preferred === ctxWithMatch.model?.id, true);
+    assert.equal(preferred === ctxWithMismatch.model?.id, false);
+    assert.equal(preferred === ctxWithNoModel.model?.id, false);
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/debug-log.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/debug-log.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  initDebugLog,
+  closeDebugLog,
+  dlog,
+  isDebugLogEnabled,
+} from '../debug-log.ts';
+
+test('debug log is disabled when KATA_DEBUG is not set', () => {
+  const saved = process.env.KATA_DEBUG;
+  delete process.env.KATA_DEBUG;
+  try {
+    const tmp = mkdtempSync(join(tmpdir(), 'kata-debug-'));
+    initDebugLog(tmp);
+    assert.equal(isDebugLogEnabled(), false);
+    dlog('test-event', { key: 'value' });
+    assert.equal(existsSync(join(tmp, '.kata', 'debug.log')), false);
+    closeDebugLog();
+  } finally {
+    if (saved !== undefined) process.env.KATA_DEBUG = saved;
+    else delete process.env.KATA_DEBUG;
+  }
+});
+
+test('debug log writes events when KATA_DEBUG=1', () => {
+  const saved = process.env.KATA_DEBUG;
+  process.env.KATA_DEBUG = '1';
+  try {
+    const tmp = mkdtempSync(join(tmpdir(), 'kata-debug-'));
+    initDebugLog(tmp);
+    assert.equal(isDebugLogEnabled(), true);
+
+    dlog('dispatch', { unit: 'research-slice', id: 'M001/S07', phase: 'planning' });
+    dlog('agent-end', { unit: 'research-slice', id: 'M001/S07' });
+    closeDebugLog();
+
+    const logPath = join(tmp, '.kata', 'debug.log');
+    assert.equal(existsSync(logPath), true);
+
+    const content = readFileSync(logPath, 'utf-8');
+    assert.ok(content.includes('[auto-start]'), 'should have session header');
+    assert.ok(content.includes('[dispatch]'), 'should have dispatch event');
+    assert.ok(content.includes('unit=research-slice'), 'should have unit field');
+    assert.ok(content.includes('id=M001/S07'), 'should have id field');
+    assert.ok(content.includes('[agent-end]'), 'should have agent-end event');
+    assert.ok(content.includes('[auto-stop]'), 'should have close event');
+  } finally {
+    if (saved !== undefined) process.env.KATA_DEBUG = saved;
+    else delete process.env.KATA_DEBUG;
+  }
+});
+
+test('debug log handles values with spaces using quotes', () => {
+  const saved = process.env.KATA_DEBUG;
+  process.env.KATA_DEBUG = '1';
+  try {
+    const tmp = mkdtempSync(join(tmpdir(), 'kata-debug-'));
+    initDebugLog(tmp);
+
+    dlog('provider-error', { error: 'fetch failed', streak: 3 });
+    closeDebugLog();
+
+    const content = readFileSync(join(tmp, '.kata', 'debug.log'), 'utf-8');
+    assert.ok(content.includes('error="fetch failed"'), 'should quote values with spaces');
+    assert.ok(content.includes('streak=3'), 'should not quote numeric values');
+  } finally {
+    if (saved !== undefined) process.env.KATA_DEBUG = saved;
+    else delete process.env.KATA_DEBUG;
+  }
+});
+
+test('debug log is disabled when KATA_DEBUG=0', () => {
+  const saved = process.env.KATA_DEBUG;
+  process.env.KATA_DEBUG = '0';
+  try {
+    const tmp = mkdtempSync(join(tmpdir(), 'kata-debug-'));
+    initDebugLog(tmp);
+    assert.equal(isDebugLogEnabled(), false);
+    closeDebugLog();
+  } finally {
+    if (saved !== undefined) process.env.KATA_DEBUG = saved;
+    else delete process.env.KATA_DEBUG;
+  }
+});

--- a/apps/cli/src/resources/extensions/kata/tests/preferences-frontmatter.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/preferences-frontmatter.test.ts
@@ -126,6 +126,70 @@ linear:
   });
 });
 
+test('loadEffectiveKataPreferences preserves models and auto_supervisor settings', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'kata-preferences-frontmatter-'));
+  const kataDir = join(tmp, '.kata');
+  mkdirSync(kataDir, { recursive: true });
+  writeFileSync(
+    join(kataDir, 'preferences.md'),
+    `---
+version: 1
+models:
+  research: claude-sonnet-4-6
+  planning: claude-opus-4-6     # Opus for architecture
+  execution: claude-opus-4-6
+  completion: claude-sonnet-4-6
+  review: claude-sonnet-4-6
+auto_supervisor:
+  model: claude-sonnet-4-6
+  soft_timeout_minutes: "25"
+  idle_timeout_minutes: 12
+  hard_timeout_minutes: 40
+---
+`,
+  );
+
+  const script = `
+    import {
+      loadEffectiveKataPreferences,
+      resolveModelForUnit,
+      resolveAutoSupervisorConfig,
+    } from ${JSON.stringify(preferencesPath)};
+
+    const prefs = loadEffectiveKataPreferences();
+    console.log(JSON.stringify({
+      models: prefs?.preferences.models ?? null,
+      researchModel: resolveModelForUnit('research-slice') ?? null,
+      planningModel: resolveModelForUnit('plan-slice') ?? null,
+      executionModel: resolveModelForUnit('execute-task') ?? null,
+      completionModel: resolveModelForUnit('complete-slice') ?? null,
+      supervisor: resolveAutoSupervisorConfig(),
+    }));
+  `;
+
+  const output = runPreferencesScript(tmp, script);
+
+  assert.deepEqual(JSON.parse(output), {
+    models: {
+      research: 'claude-sonnet-4-6',
+      planning: 'claude-opus-4-6',
+      execution: 'claude-opus-4-6',
+      completion: 'claude-sonnet-4-6',
+      review: 'claude-sonnet-4-6',
+    },
+    researchModel: 'claude-sonnet-4-6',
+    planningModel: 'claude-opus-4-6',
+    executionModel: 'claude-opus-4-6',
+    completionModel: 'claude-sonnet-4-6',
+    supervisor: {
+      model: 'claude-sonnet-4-6',
+      soft_timeout_minutes: 25,
+      idle_timeout_minutes: 12,
+      hard_timeout_minutes: 40,
+    },
+  });
+});
+
 test('loadProjectKataPreferences prefers canonical lowercase filename over legacy uppercase filename', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'kata-preferences-frontmatter-'));
   mkdirSync(join(tmp, '.kata'), { recursive: true });


### PR DESCRIPTION
## CLI v0.4.0

### Features
- **Namespaced slice branches** (`kata/<scope>/<M>/<S>`) for monorepo/worktree safety — scoped by project path, legacy `kata/<M>/<S>` compatible during transition
- **Git service** (`git-service.ts`) — typed API for branch management, smart staging, auto-commit, squash-merge
- **`linear_add_comment` tool** — post comments on Linear issues from agent workflows
- **Model preferences in `/kata step`** — `models.*` prefs now apply to step mode; statusline shows active model
- **Auto-push before PR creation** — structured `push-failed` error instead of cryptic GitHub GraphQL failure
- **PR titles prefixed with branch name** — `[kata/apps-cli/M001/S01] Slice title`
- **`promptSnippet` for all 109 custom tools** — pi-coding-agent 0.60.0 made this opt-in

### Fixes
- PR error message shows actual branch name (not hardcoded legacy format)
- `resolveModelForUnit` covers `complete-milestone` and `reassess-roadmap`; warns on missing model ID
- Provenance guard runs even when already on legacy branch
- `kata_merge_pr` hint no longer references non-existent params
- Various truncated/broken `promptSnippet` strings in mac-tools, linear-tools, pr-lifecycle

### Dependency
- Upgrade `@mariozechner/pi-coding-agent` `^0.57.1` → `^0.60.0`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a release-preparation PR for `@kata-sh/cli` v0.4.0. The diff is intentionally minimal — it bumps the `version` field in `package.json` from `0.3.0` to `0.4.0` and appends the corresponding changelog section in `CHANGELOG.md`. The underlying feature work (namespaced slice branches, `git-service.ts`, `linear_add_comment`, model preference routing, auto-push before PR creation, etc.) was implemented in prior commits already present in the repository.

Key observations:
- The changelog entry is well-structured and consistent with the PR description.
- The `@mariozechner/pi-coding-agent` dependency is already at `^0.60.0` in the current `package.json`; the upgrade itself does not appear in this diff. The PR description lists it as part of this release, but technically it was committed separately — worth confirming the dependency bump and any associated lockfile (`bun.lockb` / `package-lock.json`) updates landed on `main` before this PR merges, to keep the changelog claim accurate.
- The semver choice (minor bump 0.3 → 0.4) is appropriate for a release that adds multiple new features without breaking the public API.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only updates a version field and changelog text with no functional code changes.
- Both changed files are documentation/metadata: a version string bump and a human-readable changelog entry. There is no executable code, no dependency resolution change visible in the diff, and no risk of runtime regression. The sole area to watch is ensuring the dependency upgrade (mentioned in the changelog) and any accompanying lockfile changes are already committed to the base branch before merging.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/CHANGELOG.md | Adds well-structured 0.4.0 changelog section documenting 7 features, 5 fixes, and 1 dependency upgrade; content matches PR description accurately. |
| apps/cli/package.json | Version field bumped from 0.3.0 to 0.4.0; dependency @mariozechner/pi-coding-agent is already at ^0.60.0 (the upgrade itself does not appear in this diff, indicating it was committed earlier on this branch or in a prior PR). |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Feature PRs merged to main]) --> B["git-service.ts, namespaced branches,\nlinear_add_comment, auto-push,\nmodel prefs in step mode"]
    A --> C["pi-coding-agent 0.57.1 to 0.60.0\ndependency bump"]
    B --> D{"This PR — v0.4.0 release"}
    C --> D
    D --> E["apps/cli/package.json\nversion: 0.3.0 to 0.4.0"]
    D --> F["apps/cli/CHANGELOG.md\nAdd 0.4.0 section\n7 features · 5 fixes · 1 dep"]
    E --> G([Publish kata-sh/cli 0.4.0])
```

<sub>Last reviewed commit: ["chore(release): bump..."](https://github.com/gannonh/kata/commit/088d7265ff5c416b51d66dd2ef348966997dc463)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust preference parsing that preserves model and auto-supervisor settings; auto-mode adds provider-error retry/backoff, pause-on-failure, model-switching improvements, and structured debug logging.

* **Documentation**
  * Updated PR lifecycle diagram label.

* **Tests**
  * Added tests for preference preservation/config resolution, auto model-switching, supervisor timeout handling, and debug-logging behavior.

* **Chores**
  * Package version bumped to 0.4.0; gitignore updated to exclude debug logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->