### PR TITLE
feat: rewrite sync-worktrees.sh to handle feature branches and validate

### DIFF
--- a/scripts/sync-worktrees.sh
+++ b/scripts/sync-worktrees.sh
@@ -1,130 +1,298 @@
 #!/usr/bin/env bash
+# sync-worktrees.sh — Sync all worktrees after a PR merge on GitHub.
+#
+# For worktrees on their standby branch: hard-reset to origin/main.
+# For worktrees on a feature branch: rebase onto origin/main.
+#
+# Usage:
+#   ./scripts/sync-worktrees.sh            # sync all worktrees
+#   ./scripts/sync-worktrees.sh --dry-run  # show what would happen without changing anything
+#
+# Safety:
+#   - Refuses to reset standby worktrees with uncommitted changes
+#   - Refuses to rebase feature branches with uncommitted changes
+#   - Aborts rebase automatically on conflict (leaves worktree unchanged)
+#   - Validates every worktree after sync
+#   - Dry-run mode previews all actions without side effects
+
 set -euo pipefail
 
+# ─── Globals ───────────────────────────────────────────────────────────────────
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-die() { echo "FATAL: $*" >&2; exit 1; }
 REPO_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)" || true
-[ -n "$REPO_DIR" ] || die "could not detect git repo root from $SCRIPT_DIR"
+DRY_RUN=false
+errors=0
+warnings=0
 
-# Discover main and standby worktrees from git metadata.
-MAIN_DIR="${MAIN_DIR:-}"
-STANDBY_PATHS=()
-STANDBY_BRANCHES=()
-record_worktree=""
-record_branch=""
+# Colors (disabled if not a terminal)
+if [ -t 1 ]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'
+  BLUE='\033[0;34m'; BOLD='\033[1m'; DIM='\033[2m'; RESET='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; BOLD=''; DIM=''; RESET=''
+fi
 
-flush_record() {
-  if [ -n "$record_worktree" ]; then
-    if [ -z "$MAIN_DIR" ]; then
-      MAIN_DIR="$record_worktree"
-    fi
-    case "$record_branch" in
-      wt-*-standby)
-        STANDBY_PATHS+=("$record_worktree")
-        STANDBY_BRANCHES+=("$record_branch")
-        ;;
-    esac
-  fi
-  record_worktree=""
-  record_branch=""
+# ─── Helpers ───────────────────────────────────────────────────────────────────
+
+die()  { echo -e "${RED}FATAL:${RESET} $*" >&2; exit 1; }
+err()  { echo -e "  ${RED}✗${RESET} $*" >&2; errors=$((errors + 1)); }
+warn() { echo -e "  ${YELLOW}⚠${RESET} $*" >&2; warnings=$((warnings + 1)); }
+ok()   { echo -e "  ${GREEN}✓${RESET} $*"; }
+info() { echo -e "  ${DIM}$*${RESET}"; }
+step() { echo -e "\n${BOLD}$*${RESET}"; }
+
+is_dirty() {
+  [ -n "$(git -C "$1" status --porcelain --untracked-files=normal 2>/dev/null)" ]
 }
+
+short_sha() {
+  git -C "$1" rev-parse --short HEAD 2>/dev/null
+}
+
+# ─── Parse args ────────────────────────────────────────────────────────────────
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run|-n) DRY_RUN=true ;;
+    --help|-h)
+      echo "Usage: sync-worktrees.sh [--dry-run]"
+      echo "Sync all worktrees after a PR merge on GitHub."
+      exit 0
+      ;;
+    *) die "Unknown argument: $arg" ;;
+  esac
+done
+
+# ─── Preflight ─────────────────────────────────────────────────────────────────
+
+[ -n "$REPO_DIR" ] || die "Could not detect git repo root from $SCRIPT_DIR"
+
+if $DRY_RUN; then
+  echo -e "${YELLOW}DRY RUN — no changes will be made${RESET}"
+fi
+
+step "Fetching origin..."
+if $DRY_RUN; then
+  info "Would run: git fetch origin"
+else
+  git -C "$REPO_DIR" fetch origin --quiet || die "git fetch origin failed"
+fi
+
+TARGET_SHA=$(git -C "$REPO_DIR" rev-parse origin/main)
+TARGET_SHORT="${TARGET_SHA:0:7}"
+step "Target: origin/main @ ${TARGET_SHORT}"
+
+# ─── Discover worktrees ───────────────────────────────────────────────────────
+
+declare -a WT_PATHS=()
+declare -a WT_BRANCHES=()
+declare -a WT_NAMES=()
+
+current_path=""
+current_branch=""
 
 while IFS= read -r line; do
   if [ -z "$line" ]; then
-    flush_record
+    if [ -n "$current_path" ] && [ -n "$current_branch" ]; then
+      WT_PATHS+=("$current_path")
+      WT_BRANCHES+=("$current_branch")
+      WT_NAMES+=("$(basename "$current_path")")
+    fi
+    current_path=""
+    current_branch=""
     continue
   fi
   case "$line" in
-    worktree\ *) record_worktree="${line#worktree }" ;;
-    branch\ refs/heads/*) record_branch="${line#branch refs/heads/}" ;;
+    worktree\ *)          current_path="${line#worktree }" ;;
+    branch\ refs/heads/*) current_branch="${line#branch refs/heads/}" ;;
   esac
-done < <(git -C "$REPO_DIR" worktree list --porcelain)
-flush_record  # flush final record (porcelain output may not end with blank line)
+done < <(git -C "$REPO_DIR" worktree list --porcelain; echo "")
 
-[ -n "$MAIN_DIR" ] || die "could not detect worktree path for branch 'main'"
-[ "${#STANDBY_PATHS[@]}" -gt 0 ] || die "no standby worktrees found (expected branches named wt-*-standby)"
+[ "${#WT_PATHS[@]}" -gt 0 ] || die "No worktrees found"
 
-errors=0
-warn() { echo "ERROR: $*" >&2; errors=$((errors + 1)); }
-is_dirty() {
-  [ -n "$(git -C "$1" status --porcelain --untracked-files=normal)" ]
-}
+# ─── Classify and sync each worktree ──────────────────────────────────────────
 
-# -- Step 1: Move main checkout to exactly origin/main --------------------
-echo "==> Switching $MAIN_DIR to main"
-if ! git -C "$MAIN_DIR" switch main 2>&1; then
-  die "switch to main failed"
-fi
+synced=0
+skipped=0
+rebased=0
 
-if is_dirty "$MAIN_DIR"; then
-  die "main worktree has local changes/untracked files; clean it before sync"
-fi
+for i in "${!WT_PATHS[@]}"; do
+  wt_path="${WT_PATHS[$i]}"
+  branch="${WT_BRANCHES[$i]}"
+  name="${WT_NAMES[$i]}"
+  wt_sha=$(git -C "$wt_path" rev-parse HEAD 2>/dev/null || echo "unknown")
 
-echo "==> Fetching origin/main"
-if ! git -C "$MAIN_DIR" fetch origin main 2>&1; then
-  die "fetch failed"
-fi
+  # ── Case 1: main branch (root worktree) ──────────────────────────────────
+  if [ "$branch" = "main" ]; then
+    step "[$name] main branch"
 
-target_sha=$(git -C "$MAIN_DIR" rev-parse origin/main)
-echo "==> Resetting main checkout to ${target_sha:0:7}"
-if ! git -C "$MAIN_DIR" reset --hard "$target_sha" 2>&1; then
-  die "main reset failed"
-fi
+    if [ "$wt_sha" = "$TARGET_SHA" ]; then
+      ok "Already at $TARGET_SHORT"
+      synced=$((synced + 1))
+      continue
+    fi
 
-main_sha=$(git -C "$MAIN_DIR" rev-parse HEAD)
-if [ "$main_sha" != "$target_sha" ]; then
-  die "main expected ${target_sha:0:7} but got ${main_sha:0:7}"
-fi
-echo "    main is at ${target_sha:0:7}"
+    if is_dirty "$wt_path"; then
+      err "$name: main has uncommitted changes — skipping"
+      skipped=$((skipped + 1))
+      continue
+    fi
 
-# -- Step 2: Move each standby worktree to exactly target_sha -------------
-for i in "${!STANDBY_PATHS[@]}"; do
-  wt_path="${STANDBY_PATHS[$i]}"
-  branch="${STANDBY_BRANCHES[$i]}"
-  wt="$(basename "$wt_path")"
-
-  if [ ! -d "$wt_path" ]; then
-    warn "$wt: directory not found"
+    if $DRY_RUN; then
+      info "Would reset main to $TARGET_SHORT"
+    else
+      git -C "$wt_path" reset --hard "$TARGET_SHA" --quiet
+      ok "Reset to $TARGET_SHORT"
+    fi
+    synced=$((synced + 1))
     continue
   fi
+
+  # ── Case 2: standby branch (*-standby) ───────────────────────────────────
+  if [[ "$branch" == *-standby ]]; then
+    step "[$name] standby: $branch"
+
+    if [ "$wt_sha" = "$TARGET_SHA" ]; then
+      ok "Already at $TARGET_SHORT"
+      synced=$((synced + 1))
+      continue
+    fi
+
+    if is_dirty "$wt_path"; then
+      err "$name: has uncommitted changes on standby — skipping"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if $DRY_RUN; then
+      info "Would hard-reset $branch to $TARGET_SHORT"
+      info "Would set upstream to origin/main"
+    else
+      git -C "$wt_path" reset --hard "$TARGET_SHA" --quiet
+      git -C "$wt_path" branch --set-upstream-to=origin/main "$branch" >/dev/null 2>&1 || true
+      ok "Reset to $TARGET_SHORT"
+    fi
+    synced=$((synced + 1))
+    continue
+  fi
+
+  # ── Case 3: feature branch (active work) ─────────────────────────────────
+  step "[$name] feature: $branch"
+
+  # Check if already up to date (branch contains origin/main)
+  if git -C "$wt_path" merge-base --is-ancestor "$TARGET_SHA" HEAD 2>/dev/null; then
+    ok "Already contains $TARGET_SHORT — no rebase needed"
+    synced=$((synced + 1))
+    continue
+  fi
+
+  # Count how many commits are ahead/behind
+  behind=$(git -C "$wt_path" rev-list --count HEAD.."$TARGET_SHA" 2>/dev/null || echo "?")
+  ahead=$(git -C "$wt_path" rev-list --count "$TARGET_SHA"..HEAD 2>/dev/null || echo "?")
+  info "$ahead commits ahead, $behind behind origin/main"
 
   if is_dirty "$wt_path"; then
-    warn "$wt: has local changes/untracked files - skipping"
+    err "$name: has uncommitted changes — skipping rebase"
+    skipped=$((skipped + 1))
     continue
   fi
 
-  current=$(git -C "$wt_path" branch --show-current)
-  if [ "$current" != "$branch" ]; then
-    echo "==> Switching $wt to $branch"
-    if ! git -C "$wt_path" switch "$branch" 2>&1; then
-      warn "$wt: switch failed"
+  if $DRY_RUN; then
+    info "Would rebase $branch onto origin/main"
+  else
+    # Attempt rebase — abort on any conflict
+    if git -C "$wt_path" rebase origin/main --quiet 2>/dev/null; then
+      new_sha=$(short_sha "$wt_path")
+      ok "Rebased onto $TARGET_SHORT (now at $new_sha)"
+      rebased=$((rebased + 1))
+    else
+      # Conflict — abort the rebase, leave worktree unchanged
+      git -C "$wt_path" rebase --abort 2>/dev/null || true
+      err "$name: rebase conflict — aborted, worktree unchanged"
+      warn "$name: resolve manually: cd $wt_path && git rebase origin/main"
+      skipped=$((skipped + 1))
       continue
     fi
   fi
+  synced=$((synced + 1))
+done
 
-  echo "==> Resetting $wt to ${target_sha:0:7}"
-  if ! git -C "$wt_path" reset --hard "$target_sha" 2>&1; then
-    warn "$wt: reset failed"
-    continue
-  fi
+# ─── Validation ────────────────────────────────────────────────────────────────
 
-  if ! git -C "$wt_path" branch --set-upstream-to=origin/main "$branch" >/dev/null 2>&1; then
-    warn "$wt: failed to set upstream to origin/main"
-  fi
+step "Validating..."
 
-  wt_sha=$(git -C "$wt_path" rev-parse HEAD)
-  if [ "$wt_sha" != "$target_sha" ]; then
-    warn "$wt: expected ${target_sha:0:7} but got ${wt_sha:0:7}"
+validation_ok=true
+
+for i in "${!WT_PATHS[@]}"; do
+  wt_path="${WT_PATHS[$i]}"
+  branch="${WT_BRANCHES[$i]}"
+  name="${WT_NAMES[$i]}"
+  wt_sha=$(git -C "$wt_path" rev-parse HEAD 2>/dev/null || echo "unknown")
+
+  # Standby and main should be exactly at target
+  if [ "$branch" = "main" ] || [[ "$branch" == *-standby ]]; then
+    if $DRY_RUN; then
+      info "$name: would verify SHA matches $TARGET_SHORT"
+    elif [ "$wt_sha" != "$TARGET_SHA" ]; then
+      err "$name: expected $TARGET_SHORT but at ${wt_sha:0:7}"
+      validation_ok=false
+    else
+      ok "$name: $branch @ $TARGET_SHORT"
+    fi
   else
-    echo "    $wt now at ${target_sha:0:7}"
+    # Feature branch should contain origin/main
+    if $DRY_RUN; then
+      info "$name: would verify $branch contains $TARGET_SHORT"
+    elif git -C "$wt_path" merge-base --is-ancestor "$TARGET_SHA" HEAD 2>/dev/null; then
+      ok "$name: $branch contains $TARGET_SHORT (at ${wt_sha:0:7})"
+    else
+      err "$name: $branch does NOT contain $TARGET_SHORT"
+      validation_ok=false
+    fi
+  fi
+
+  # Check for dirty state (should be clean after sync)
+  if ! $DRY_RUN && is_dirty "$wt_path"; then
+    err "$name: working tree is dirty after sync"
+    validation_ok=false
+  fi
+
+  # Check for detached HEAD
+  current_branch=$(git -C "$wt_path" branch --show-current 2>/dev/null)
+  if ! $DRY_RUN && [ -z "$current_branch" ]; then
+    err "$name: detached HEAD"
+    validation_ok=false
+  fi
+
+  # Check for in-progress rebase
+  if ! $DRY_RUN && [ -d "$wt_path/.git/rebase-merge" ] || [ -d "$wt_path/.git/rebase-apply" ]; then
+    err "$name: rebase in progress"
+    validation_ok=false
   fi
 done
 
-# -- Summary --------------------------------------------------------------
-echo ""
+# ─── Summary ───────────────────────────────────────────────────────────────────
+
+step "Summary"
+total=${#WT_PATHS[@]}
+echo -e "  Worktrees: $total total, ${GREEN}$synced synced${RESET}, ${BLUE}$rebased rebased${RESET}, ${YELLOW}$skipped skipped${RESET}"
+
 if [ "$errors" -gt 0 ]; then
-  echo "FAILED: $errors error(s) above. Fix them before starting work."
-  exit 1
-else
-  echo "All worktrees switched to standby and synced to main (${target_sha:0:7})."
+  echo -e "  ${RED}$errors error(s)${RESET}"
 fi
+if [ "$warnings" -gt 0 ]; then
+  echo -e "  ${YELLOW}$warnings warning(s)${RESET}"
+fi
+
+if $DRY_RUN; then
+  echo -e "\n${YELLOW}Dry run complete — no changes were made.${RESET}"
+  exit 0
+fi
+
+if [ "$errors" -gt 0 ] || [ "$validation_ok" = false ]; then
+  echo -e "\n${RED}Sync completed with errors. Review above.${RESET}"
+  exit 1
+fi
+
+echo -e "\n${GREEN}All worktrees synced to origin/main ($TARGET_SHORT).${RESET}"


### PR DESCRIPTION
## What

Rewrites `scripts/sync-worktrees.sh` to handle all three worktree states after a PR merge:

| Worktree state | Action |
|---|---|
| **Standby branch** (`*-standby`) | Hard-reset to `origin/main` |
| **Feature branch** (active work) | Rebase onto `origin/main`, abort on conflict |
| **Main** (root worktree) | Reset to `origin/main` |

## Why

The previous script only handled standby branches. Feature branches (e.g. `kata/apps-symphony/M001/S07`) were ignored, leaving them behind main after merges. The user had to manually rebase or use terminal commands that Fork doesn't expose well.

## Safety checks

- Refuses to touch worktrees with uncommitted changes (skips with error)
- Aborts rebase automatically on conflict, leaving worktree unchanged
- Post-sync validation verifies:
  - Standby/main SHAs match `origin/main` exactly
  - Feature branches contain `origin/main` (ancestor check)
  - No dirty working trees after sync
  - No detached HEADs
  - No in-progress rebases

## Usage

```bash
./scripts/sync-worktrees.sh            # sync all worktrees
./scripts/sync-worktrees.sh --dry-run  # preview without changes
```

## Example output

```
[wt-cli] standby: wt-cli-standby
  ✓ Reset to 93a8306

[wt-symphony] feature: kata/apps-symphony/M001/S07
  ✓ Already contains 93a8306 — no rebase needed

Validating...
  ✓ wt-cli: wt-cli-standby @ 93a8306
  ✓ wt-symphony: kata/apps-symphony/M001/S07 contains 93a8306 (at c79c4ec)

All worktrees synced to origin/main (93a8306).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` flag to preview operations without applying changes.
  * Added `--help` flag for command usage information.
  * Enhanced error and warning reporting with colored output.
  * Improved validation with detailed status reporting of synced, rebased, and skipped worktrees.

* **Chores**
  * Restructured worktree synchronization logic for improved reliability and error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites `scripts/sync-worktrees.sh` from a simple standby-only reset script into a full three-path sync tool that handles the main branch, standby branches, and active feature branches, adding dry-run mode, colored output, and a post-sync validation pass.

The overall design is solid, but there are **three logic bugs** and one usability issue:

- **Critical — rebase-in-progress detection always fails for linked worktrees (line 269):** Linked worktrees have a `.git` *file*, not a directory, so `[ -d "$wt_path/.git/rebase-merge" ]` is always false. The git dir must be resolved with `git rev-parse --git-dir` first.
- **Critical — operator-precedence bypasses dry-run guard (line 269):** `! $DRY_RUN && [rebase-merge] || [rebase-apply]` is parsed as `(! $DRY_RUN && [rebase-merge]) || [rebase-apply]`; the `rebase-apply` check runs even in dry-run mode and can generate false errors.
- **Silent exclusion of detached-HEAD worktrees (lines 97–101):** Worktrees in detached HEAD state are dropped from discovery with no warning printed to the user.
- **Stale `TARGET_SHA` in dry-run (line 82):** Fetch is intentionally skipped in dry-run, but no notice is printed to inform the user that the preview is based on a potentially stale local ref.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the rebase-detection validation is broken for all linked worktrees and the dry-run guard has an operator-precedence hole.
- Two of the bugs directly undermine the stated safety guarantees: in-progress rebase detection silently does nothing for every non-root worktree (the very case the feature is meant to protect), and the operator-precedence bug can fire false errors or let the dry-run guard be bypassed. The detached-HEAD silent skip is also a correctness gap for the "validates every worktree" guarantee.
- scripts/sync-worktrees.sh — specifically lines 269 (rebase detection), 97-101 (worktree discovery), and 82 (stale SHA in dry-run)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/sync-worktrees.sh | Complete rewrite adding feature-branch rebase support, dry-run mode, colored output, and post-sync validation — but has a critical rebase-detection bug (wrong `.git` path for linked worktrees), an operator-precedence bug that bypasses dry-run guard, silent exclusion of detached-HEAD worktrees, and a stale SHA issue in dry-run mode. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Start]) --> B[Parse args --dry-run / --help]
    B --> C{DRY_RUN?}
    C -- No --> D[git fetch origin]
    C -- Yes --> E[Skip fetch\n⚠ TARGET_SHA may be stale]
    D --> F[Resolve TARGET_SHA from origin/main]
    E --> F
    F --> G[Discover worktrees via\ngit worktree list --porcelain]
    G --> H{Has branch ref?}
    H -- No branch = detached HEAD --> I[⚠ Silently skipped]
    H -- Yes --> J[Add to WT_PATHS arrays]
    J --> K{Classify branch}

    K -- branch = main --> L{Already at TARGET_SHA?}
    L -- Yes --> M[ok: Already at SHA]
    L -- No --> N{is_dirty?}
    N -- Yes --> O[err: skip]
    N -- No --> P[reset --hard TARGET_SHA]

    K -- branch = *-standby --> Q{Already at TARGET_SHA?}
    Q -- Yes --> R[ok: Already at SHA]
    Q -- No --> S{is_dirty?}
    S -- Yes --> T[err: skip]
    S -- No --> U[reset --hard TARGET_SHA\nbranch --set-upstream-to origin/main]

    K -- feature branch --> V{merge-base --is-ancestor TARGET_SHA HEAD?}
    V -- Yes --> W[ok: no rebase needed]
    V -- No --> X{is_dirty?}
    X -- Yes --> Y[err: skip]
    X -- No --> Z{DRY_RUN?}
    Z -- Yes --> AA[info: Would rebase]
    Z -- No --> AB[git rebase origin/main]
    AB -- success --> AC[ok: Rebased]
    AB -- conflict --> AD[git rebase --abort\nerr: conflict]

    P & U & AC & AA --> VAL[Validation Loop]

    VAL --> VAL1{main or *-standby?}
    VAL1 -- Yes --> VAL2{wt_sha == TARGET_SHA?}
    VAL2 -- No --> ERR1[err: SHA mismatch]
    VAL2 -- Yes --> OK1[ok]
    VAL1 -- No = feature --> VAL3{merge-base --is-ancestor?}
    VAL3 -- No --> ERR2[err: does not contain target]
    VAL3 -- Yes --> OK2[ok]
    VAL --> VAL4[is_dirty? → err]
    VAL --> VAL5[detached HEAD? → err]
    VAL --> VAL6["[ -d wt_path/.git/rebase-merge ] ⚠ Bug:\nalways false for linked worktrees\n+ || not guarded by !DRY_RUN"]

    VAL6 --> DONE([Summary & Exit])
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/sync-worktrees.sh
Line: 269

Comment:
**Two bugs on this line: operator precedence and wrong `.git` path for linked worktrees**

**Bug 1 — Operator precedence:** In bash, `&&` binds tighter than `||`, so the expression is parsed as:

```bash
(! $DRY_RUN && [ -d "$wt_path/.git/rebase-merge" ]) || [ -d "$wt_path/.git/rebase-apply" ]
```

The `rebase-apply` check is **not guarded by `! $DRY_RUN`** and will always run, even during a dry-run. If any worktree happens to have a `.git/rebase-apply` directory, it will falsely report an error in dry-run mode.

**Bug 2 — Wrong `.git` path for linked worktrees:** `git worktree add` creates a `.git` **file** (not a directory) in the linked worktree pointing to `.git/worktrees/<name>/`. This means `[ -d "$wt_path/.git/rebase-merge" ]` will always be `false` for every non-root linked worktree, silently missing in-progress rebases. The rebase state for a linked worktree lives inside the git dir returned by `git rev-parse --git-dir`.

The fix combines both corrections:

```bash
  git_dir=$(git -C "$wt_path" rev-parse --git-dir 2>/dev/null || true)
  if ! $DRY_RUN && [ -n "$git_dir" ] && { [ -d "$git_dir/rebase-merge" ] || [ -d "$git_dir/rebase-apply" ]; }; then
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/sync-worktrees.sh
Line: 97-101

Comment:
**Detached-HEAD worktrees silently excluded**

The worktree discovery block only records a worktree when both `current_path` and `current_branch` are non-empty. A worktree in detached HEAD state emits `HEAD <sha>` from `git worktree list --porcelain` instead of `branch refs/heads/<name>`, so `current_branch` is never set and the worktree is silently dropped from the arrays.

This means detached-HEAD worktrees are completely invisible to the sync and validation passes. No error or warning is printed, so the user has no indication that a worktree was skipped. Consider logging a warning for each worktree that has a path but no branch so the user knows to inspect it manually.

```bash
    if [ -n "$current_path" ] && [ -n "$current_branch" ]; then
      WT_PATHS+=("$current_path")
      WT_BRANCHES+=("$current_branch")
      WT_NAMES+=("$(basename "$current_path")")
    elif [ -n "$current_path" ]; then
      warn "$(basename "$current_path"): detached HEAD — skipping"
    fi
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/sync-worktrees.sh
Line: 82

Comment:
**`TARGET_SHA` resolved from potentially stale local ref in dry-run mode**

In dry-run mode, `git fetch origin` is skipped (line 76–80), but `TARGET_SHA` is still resolved from `origin/main` on line 82. If the local remote-tracking ref is stale, the entire dry-run preview will be based on an outdated SHA, and the user will see "no rebase needed" for branches that actually lag behind the real remote tip.

Consider printing a note in dry-run mode to make this explicit:

```bash
TARGET_SHA=$(git -C "$REPO_DIR" rev-parse origin/main)
TARGET_SHORT="${TARGET_SHA:0:7}"
if $DRY_RUN; then
  info "(Using cached origin/main — run without --dry-run to fetch latest)"
fi
step "Target: origin/main @ ${TARGET_SHORT}"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/sync-worktrees.sh
Line: 201-218

Comment:
**Dry-run summary misreports feature branch as `synced` instead of `rebased`**

When `--dry-run` is used on a feature branch that needs rebasing, the code falls through to `synced=$((synced + 1))` (line 218) without incrementing `rebased`. The summary therefore reports the branch as synced rather than as a pending rebase, which is misleading.

```suggestion
  if $DRY_RUN; then
    info "Would rebase $branch onto origin/main"
    rebased=$((rebased + 1))
  else
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat: rewrite sync-w..."](https://github.com/gannonh/kata/commit/a21b20e6a2256244efcd609be64d120d27597809)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->