### PR TITLE
[kata/apps-cli/M005/S04] Fix step mode statusline badge

### DIFF
--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -111,6 +111,7 @@ export type { ModelSwitchResult } from "./auto-helpers.js";
 
 let active = false;
 let paused = false;
+let stepActive = false;
 let verbose = false;
 let cmdCtx: ExtensionCommandContext | null = null;
 let basePath = "";
@@ -192,6 +193,14 @@ export function isAutoActive(): boolean {
 
 export function isAutoPaused(): boolean {
   return paused;
+}
+
+export function isStepActive(): boolean {
+  return stepActive;
+}
+
+export function setStepActive(v: boolean): void {
+  stepActive = v;
 }
 
 function clearUnitTimeout(): void {
@@ -301,6 +310,7 @@ export async function startAuto(
   if (paused) {
     paused = false;
     active = true;
+    stepActive = false;
     verbose = verboseMode;
     cmdCtx = ctx;
     basePath = base;
@@ -379,6 +389,7 @@ export async function startAuto(
   }
 
   active = true;
+  stepActive = false;
   verbose = verboseMode;
   cmdCtx = ctx;
   basePath = base;

--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -15,7 +15,7 @@ import { deriveState } from "./state.js";
 import type { KataState } from "./types.js";
 import { KataDashboardOverlay } from "./dashboard-overlay.js";
 import { showSmartEntry, showQueue, showDiscuss } from "./guided-flow.js";
-import { startAuto, stopAuto, isAutoActive, isAutoPaused } from "./auto.js";
+import { startAuto, stopAuto, isAutoActive, isAutoPaused, setStepActive } from "./auto.js";
 import type { KataBackend } from "./backend.js";
 import { createBackend } from "./backend-factory.js";
 import {
@@ -406,6 +406,8 @@ export function registerKataCommand(pi: ExtensionAPI): void {
         }
 
         ctx.ui.notify(`/kata step: ${state.phase} — ${unitId}`, "info");
+        ctx.ui.setStatus("kata-auto", "step");
+        setStepActive(true);
         pi.sendMessage({ customType: "kata-step", content: prompt, display: false }, { triggerTurn: true });
         return;
       }

--- a/apps/cli/src/resources/extensions/kata/index.ts
+++ b/apps/cli/src/resources/extensions/kata/index.ts
@@ -36,6 +36,8 @@ import { deriveState } from "./state.js";
 import {
   isAutoActive,
   isAutoPaused,
+  isStepActive,
+  setStepActive,
   handleAgentEnd,
   handleProviderError,
   pauseAuto,
@@ -226,6 +228,13 @@ export default function (pi: ExtensionAPI) {
   pi.on("agent_end", async (event, ctx: ExtensionContext) => {
     // If discuss phase just finished, ask user whether to start auto-mode
     if (await checkAutoStartAfterDiscuss()) return;
+
+    // If a step turn just finished, clear the step badge and return
+    if (isStepActive()) {
+      setStepActive(false);
+      ctx.ui.setStatus("kata-auto", undefined);
+      return;
+    }
 
     // If auto-mode is already running, advance to next unit
     if (!isAutoActive()) return;


### PR DESCRIPTION
## What Changed
See slice plan: S04: Fix step mode statusline badge

## Must-Haves
- R004 (owned): `(step)` badge shown during `/kata step` execution
- R004 (owned): Badge clears on agent_end when step turn completes
- R004 (owned): `/kata auto` still shows `(auto)`, not `(step)`
- `npx tsc --noEmit` passes after changes

## Tasks
- T01: Add stepActive flag, set step badge on dispatch, clear on agent_end

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `stepActive` boolean flag in `auto.ts` to track when a `/kata step` turn is in flight, and uses it to show a `(step)` status badge during execution and clear it on `agent_end` — keeping `/kata auto`'s `(auto)` badge unaffected.

**Key changes:**
- `auto.ts`: Adds `stepActive` module-level flag with `isStepActive()` / `setStepActive()` accessors; both `startAuto()` code paths (resume + fresh start) explicitly reset the flag to `false`, preventing auto-mode from inheriting a stale step state.
- `commands.ts`: After resolving the step prompt, sets `ctx.ui.setStatus("kata-auto", "step")` and `setStepActive(true)` immediately before `pi.sendMessage()` — no guard against calling this while `isAutoActive()` is already `true`, which could stall the auto-mode loop.
- `index.ts`: Inserts a `isStepActive()` check early in the `agent_end` handler; clears the flag and badge then returns before the auto-mode advancement path, satisfying the "badge clears on turn end" requirement.

**One concern flagged:** The `/kata step` handler in `commands.ts` does not guard against being called while auto-mode is active. If a user issues `/kata step` between two auto-driven turns, `stepActive` will be set to `true` and the subsequent `agent_end` will return early, skipping `handleAgentEnd()` and stalling that auto-mode cycle. Adding an `isAutoActive()` guard (consistent with the pattern used by `/kata stop`) would close this gap.

<h3>Confidence Score: 4/5</h3>

- Safe to merge for the targeted step-badge use case; one edge-case regression risk if `/kata step` is called during active auto-mode.
- The core implementation is correct and well-scoped: the flag is set, cleared, and reset in all the right places for the described requirements. The deduction is for the missing `isAutoActive()` guard in the step handler — without it, a user who accidentally runs `/kata step` while auto-mode is running can silently stall the auto-mode loop for that cycle.
- `apps/cli/src/resources/extensions/kata/commands.ts` — the step handler needs an `isAutoActive()` guard before setting `stepActive`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/auto.ts | Adds `stepActive` boolean flag with `isStepActive()` / `setStepActive()` accessors; correctly resets the flag to `false` in both resume and fresh-start paths of `startAuto()`, ensuring auto-mode never inherits a lingering step state. |
| apps/cli/src/resources/extensions/kata/commands.ts | Sets the `(step)` status badge and `stepActive = true` just before dispatching the step message turn, but lacks a guard to prevent this from running while `isAutoActive()` is true — which can stall the auto-mode advancement loop if both run concurrently. |
| apps/cli/src/resources/extensions/kata/index.ts | Correctly inserts the step-active check in the `agent_end` handler before the auto-mode advancement path; clears badge and flag atomically then returns early so auto-mode is not triggered after a step turn. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant commands.ts
    participant auto.ts
    participant index.ts
    participant UI

    User->>commands.ts: /kata step
    commands.ts->>auto.ts: setStepActive(true)
    commands.ts->>UI: setStatus("kata-auto", "step")
    commands.ts->>index.ts: sendMessage (kata-step turn)
    Note over index.ts: agent turn runs...
    index.ts->>index.ts: agent_end fires
    index.ts->>auto.ts: isStepActive() → true
    index.ts->>auto.ts: setStepActive(false)
    index.ts->>UI: setStatus("kata-auto", undefined)
    Note over index.ts: return early — no auto advancement

    User->>commands.ts: /kata auto
    commands.ts->>auto.ts: startAuto()
    auto.ts->>auto.ts: stepActive = false (reset)
    auto.ts->>UI: setStatus("kata-auto", "auto")
    Note over auto.ts: auto-mode loop begins
    auto.ts->>index.ts: agent_end fires
    index.ts->>auto.ts: isStepActive() → false
    index.ts->>auto.ts: isAutoActive() → true
    index.ts->>auto.ts: handleAgentEnd() → advance
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/commands.ts
Line: 406-411

Comment:
**`/kata step` can corrupt auto-mode state**

If `/kata step` is invoked while auto-mode is actively running (e.g. between auto-driven turns), `setStepActive(true)` will be set while `isAutoActive()` is also `true`. When the step turn's `agent_end` fires, `index.ts` will detect `isStepActive() === true` and **return early**, skipping `handleAgentEnd()` — permanently stalling the auto-mode loop for that cycle.

Before this PR, calling `/kata step` during auto-mode had no effect on the `agent_end` handler because `stepActive` didn't exist. Now the introduction of `stepActive` without a guard makes this a new regression path.

A simple guard would prevent the inconsistency:

```suggestion
        ctx.ui.notify(`/kata step: ${state.phase} — ${unitId}`, "info");
        if (!isAutoActive()) {
          ctx.ui.setStatus("kata-auto", "step");
          setStepActive(true);
        }
        pi.sendMessage({ customType: "kata-step", content: prompt, display: false }, { triggerTurn: true });
        return;
```

Alternatively, the handler could notify and bail early if `isAutoActive()` is true (matching the pattern used by `/kata stop`).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(S04/T01): add s..."](https://github.com/gannonh/kata/commit/3da428499568e994f1948393371d2dc06ae6a254)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved step mode state management in the kata extension with better tracking and coordination mechanisms.
  * Enhanced step command execution flow with improved UI status synchronization.
  * Refined event handling to ensure proper step state cleanup and lifecycle management.
  * Optimized control flow for more consistent and reliable step operation behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->