### PR TITLE
feat(symphony): wire dispatch to spawn worker tasks via tokio (KAT-808)

### DIFF
--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -182,8 +182,7 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
         let (workflow_def, _) = context.workflow_store.effective_config();
         let prompt_template = workflow_def.prompt_template.clone();
 
-        let mut orchestrator =
-            Orchestrator::new(context.effective_config.clone(), prompt_template);
+        let mut orchestrator = Orchestrator::new(context.effective_config.clone(), prompt_template);
 
         let snapshot_handle = orchestrator.create_snapshot_handle();
         let refresh_sender = orchestrator.create_refresh_channel();

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -177,7 +177,13 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
         let tracker_client = LinearClient::new(context.effective_config.tracker.clone());
         let tracker_adapter = LinearAdapter::new(tracker_client);
         let mut tracker_port = LinearOrchestratorPort::new(tracker_adapter);
-        let mut orchestrator = Orchestrator::new(context.effective_config.clone());
+
+        // Get the prompt template from the workflow store.
+        let (workflow_def, _) = context.workflow_store.effective_config();
+        let prompt_template = workflow_def.prompt_template.clone();
+
+        let mut orchestrator =
+            Orchestrator::new(context.effective_config.clone(), prompt_template);
 
         let snapshot_handle = orchestrator.create_snapshot_handle();
         let refresh_sender = orchestrator.create_refresh_channel();

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -9,13 +9,190 @@ use std::time::Duration;
 use crate::codex::app_server;
 use crate::config;
 use crate::domain::{
-    AgentEvent, CodexTotals, Issue, OrchestratorSnapshot, OrchestratorState, PollingSnapshot,
-    RateLimitInfo, RefreshRequestOutcome, RetryEntry, RetrySnapshotEntry, RunAttempt,
-    ServiceConfig,
+    AgentEvent, CodexConfig, CodexTotals, HooksConfig, Issue, OrchestratorSnapshot,
+    OrchestratorState, PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetryEntry,
+    RetrySnapshotEntry, RunAttempt, ServiceConfig, WorkspaceConfig,
 };
 use crate::error::Result;
 use crate::ssh::{self, WorkerHostSelection};
 use crate::{path_safety, prompt_builder, workspace};
+
+// ── Standalone Worker Task ──────────────────────────────────────────────
+
+/// Run the full worker lifecycle for a single issue. This function is
+/// designed to run in a spawned tokio task — it takes owned/cloned data
+/// and does not require `&mut Orchestrator`.
+///
+/// Steps: ensure workspace → before_run hook → render prompt → start
+/// Codex session → stream turn → stop session → after_run hook.
+async fn run_worker_task(
+    issue: &Issue,
+    prompt_template: &str,
+    attempt: Option<u32>,
+    worker_host: Option<&str>,
+    workspace_config: &WorkspaceConfig,
+    hooks_config: &HooksConfig,
+    codex_config: &CodexConfig,
+) -> WorkerResult {
+    let issue_id = issue.id.clone();
+
+    // 1. Ensure workspace (create dir + after_create hook)
+    let workspace_info = match workspace::ensure_workspace(
+        &issue.identifier,
+        workspace_config,
+        hooks_config,
+    ) {
+        Ok(info) => info,
+        Err(err) => {
+            tracing::error!(
+                event = "worker_workspace_failed",
+                issue_id = %issue_id,
+                issue_identifier = %issue.identifier,
+                error = %err,
+                "workspace creation failed"
+            );
+            return WorkerResult {
+                issue_id,
+                completion: WorkerCompletion::Failed {
+                    error: format!("workspace creation failed: {err}"),
+                },
+                events: vec![],
+                metrics: None,
+            };
+        }
+    };
+
+    let workspace_path = Path::new(&workspace_info.path);
+
+    // 2. Before-run hook
+    if let Err(err) = workspace::run_before_run_hook(workspace_path, hooks_config) {
+        tracing::error!(
+            event = "worker_before_run_failed",
+            issue_id = %issue_id,
+            error = %err,
+            "before_run hook failed"
+        );
+        return WorkerResult {
+            issue_id,
+            completion: WorkerCompletion::Failed {
+                error: format!("before_run hook failed: {err}"),
+            },
+            events: vec![],
+            metrics: None,
+        };
+    }
+
+    // 3. Render prompt
+    let prompt = match prompt_builder::render_prompt(prompt_template, issue, attempt) {
+        Ok(prompt) => prompt,
+        Err(err) => {
+            tracing::error!(
+                event = "worker_prompt_failed",
+                issue_id = %issue_id,
+                error = %err,
+                "prompt rendering failed"
+            );
+            return WorkerResult {
+                issue_id,
+                completion: WorkerCompletion::Failed {
+                    error: format!("prompt rendering failed: {err}"),
+                },
+                events: vec![],
+                metrics: None,
+            };
+        }
+    };
+
+    // 4. Start Codex session
+    let workspace_root = Path::new(&workspace_config.root);
+    let mut session = match app_server::start_session(
+        codex_config,
+        issue,
+        workspace_path,
+        workspace_root,
+        worker_host,
+    )
+    .await
+    {
+        Ok(session) => session,
+        Err(err) => {
+            tracing::error!(
+                event = "worker_session_start_failed",
+                issue_id = %issue_id,
+                issue_identifier = %issue.identifier,
+                error = %err,
+                "codex session start failed"
+            );
+            return WorkerResult {
+                issue_id,
+                completion: WorkerCompletion::Failed {
+                    error: format!("codex session start failed: {err}"),
+                },
+                events: vec![],
+                metrics: None,
+            };
+        }
+    };
+
+    tracing::info!(
+        event = "worker_started",
+        issue_id = %issue_id,
+        issue_identifier = %issue.identifier,
+        session_id = %session.session_id,
+        workspace_path = %workspace_info.path,
+        "worker attempt started"
+    );
+
+    // 5. Run turn — use a no-op graphql executor (linear_graphql tool
+    //    requires a real LinearClient; wired up separately when needed)
+    let mut observed_events: Vec<AgentEvent> = Vec::new();
+    let graphql_executor = |_query: String, _vars: serde_json::Value| async move {
+        Err(crate::error::SymphonyError::InvalidWorkflowConfig(
+            "linear_graphql not configured in worker task".to_string(),
+        ))
+    };
+
+    let run_result: Result<_> =
+        app_server::run_turn(&mut session, &prompt, graphql_executor, |event| {
+            observed_events.push(event);
+        })
+        .await;
+
+    // 6. Stop session
+    if let Err(err) = app_server::stop_session(session).await {
+        tracing::warn!(
+            issue_id = %issue_id,
+            error = %err,
+            "failed to stop codex session cleanly"
+        );
+    }
+
+    // 7. After-run hook
+    let _ = workspace::run_after_run_hook(workspace_path, hooks_config);
+
+    // 8. Build result
+    match run_result {
+        Ok(turn_result) => WorkerResult {
+            issue_id,
+            completion: WorkerCompletion::Completed,
+            events: observed_events,
+            metrics: Some(TurnMetrics {
+                input_tokens: turn_result.input_tokens,
+                output_tokens: turn_result.output_tokens,
+                total_tokens: turn_result.total_tokens,
+                rate_limits: turn_result.rate_limits,
+            }),
+        },
+        Err(err) => WorkerResult {
+            issue_id,
+            completion: WorkerCompletion::Failed {
+                error: err.to_string(),
+            },
+            events: observed_events,
+            metrics: None,
+        },
+    }
+}
 
 // ── Snapshot Handle (S07 read seam) ─────────────────────────────────────
 
@@ -179,9 +356,26 @@ pub enum RuntimeEvent {
 }
 
 #[derive(Debug, Clone)]
+pub struct DispatchedIssue {
+    pub issue: Issue,
+    pub attempt: Option<u32>,
+    pub worker_host: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct TickResult {
     pub dispatched_issue_ids: Vec<String>,
+    pub dispatched_issues: Vec<DispatchedIssue>,
     pub dispatch_skipped: bool,
+}
+
+/// Result sent back from a spawned worker task to the orchestrator loop.
+#[derive(Debug)]
+pub struct WorkerResult {
+    pub issue_id: String,
+    pub completion: WorkerCompletion,
+    pub events: Vec<AgentEvent>,
+    pub metrics: Option<TurnMetrics>,
 }
 
 #[derive(Debug, Clone)]
@@ -236,12 +430,19 @@ pub struct Orchestrator {
     snapshot_handle: Option<SnapshotHandle>,
     /// Optional refresh receiver for HTTP control access.
     refresh_receiver: Option<RefreshReceiver>,
+    /// Channel for receiving results from spawned worker tasks.
+    worker_result_rx: tokio::sync::mpsc::UnboundedReceiver<WorkerResult>,
+    /// Sender half cloned into each spawned worker task.
+    worker_result_tx: tokio::sync::mpsc::UnboundedSender<WorkerResult>,
+    /// The prompt template from the WORKFLOW.md body, used to render per-issue prompts.
+    prompt_template: String,
 }
 
 impl Orchestrator {
-    pub fn new(config: ServiceConfig) -> Self {
+    pub fn new(config: ServiceConfig, prompt_template: String) -> Self {
         let poll_interval_ms = config.polling.interval_ms;
         let max_concurrent_agents = config.agent.max_concurrent_agents;
+        let (worker_result_tx, worker_result_rx) = tokio::sync::mpsc::unbounded_channel();
 
         Self {
             config,
@@ -263,6 +464,9 @@ impl Orchestrator {
             next_retry_token: 0,
             snapshot_handle: None,
             refresh_receiver: None,
+            worker_result_rx,
+            worker_result_tx,
+            prompt_template,
         }
     }
 
@@ -276,40 +480,118 @@ impl Orchestrator {
 
             self.detect_stalled_workers(now_ms, stall_timeout_ms);
 
-            if let Err(err) = self.tick(port) {
-                tracing::warn!(
-                    phase = "tick",
-                    error = %err,
-                    "orchestrator tick failed; continuing"
-                );
+            match self.tick(port) {
+                Ok(tick_result) => {
+                    self.spawn_workers_for_dispatched(&tick_result.dispatched_issues);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        phase = "tick",
+                        error = %err,
+                        "orchestrator tick failed; continuing"
+                    );
+                }
             }
 
-            self.process_due_retries(port, Utc::now().timestamp_millis());
+            let retry_dispatched = self.process_due_retries(port, Utc::now().timestamp_millis());
+            self.spawn_workers_for_dispatched(&retry_dispatched);
             self.publish_snapshot();
 
-            // Sleep until next poll interval, but wake early on refresh request.
+            // Sleep until next poll interval, but wake early on refresh request
+            // or worker result.
             let sleep_duration = Duration::from_millis(self.state.poll_interval_ms);
             let refresh_notify = self.refresh_receiver.as_ref().map(|r| r.notify.clone());
 
-            if let Some(notify) = refresh_notify {
-                tokio::select! {
-                    _ = tokio::time::sleep(sleep_duration) => {},
-                    _ = notify.notified() => {
-                        if let Some(receiver) = &self.refresh_receiver {
-                            if receiver.take_pending() {
-                                tracing::info!(
-                                    event = "refresh_requested",
-                                    "HTTP refresh request woke orchestrator loop; triggering immediate tick"
-                                );
-                                self.events.push(RuntimeEvent::RefreshRequested);
-                            }
+            tokio::select! {
+                _ = tokio::time::sleep(sleep_duration) => {},
+                result = self.worker_result_rx.recv() => {
+                    if let Some(result) = result {
+                        self.handle_worker_result(result);
+                        self.publish_snapshot();
+                    }
+                    // Drain any additional ready results.
+                    while let Ok(result) = self.worker_result_rx.try_recv() {
+                        self.handle_worker_result(result);
+                        self.publish_snapshot();
+                    }
+                },
+                _ = async {
+                    if let Some(notify) = &refresh_notify {
+                        notify.notified().await;
+                    } else {
+                        std::future::pending::<()>().await;
+                    }
+                } => {
+                    if let Some(receiver) = &self.refresh_receiver {
+                        if receiver.take_pending() {
+                            tracing::info!(
+                                event = "refresh_requested",
+                                "HTTP refresh request woke orchestrator loop; triggering immediate tick"
+                            );
+                            self.events.push(RuntimeEvent::RefreshRequested);
                         }
-                    },
-                }
-            } else {
-                tokio::time::sleep(sleep_duration).await;
+                    }
+                },
             }
         }
+    }
+
+    /// Spawn a tokio task for each newly dispatched issue.
+    fn spawn_workers_for_dispatched(&mut self, dispatched: &[DispatchedIssue]) {
+        for d in dispatched {
+            // Update status from "scheduled" to "running"
+            if let Some(attempt) = self.state.running.get_mut(&d.issue.id) {
+                attempt.status = "running".to_string();
+            }
+            let issue = d.issue.clone();
+            let attempt = d.attempt;
+            let worker_host = d.worker_host.clone();
+            let tx = self.worker_result_tx.clone();
+            let prompt_template = self.prompt_template.clone();
+            let workspace_config = self.config.workspace.clone();
+            let hooks_config = self.config.hooks.clone();
+            let codex_config = self.config.codex.clone();
+
+            tokio::spawn(async move {
+                let result = run_worker_task(
+                    &issue,
+                    &prompt_template,
+                    attempt,
+                    worker_host.as_deref(),
+                    &workspace_config,
+                    &hooks_config,
+                    &codex_config,
+                )
+                .await;
+
+                if let Err(err) = tx.send(result) {
+                    tracing::error!(
+                        error = %err,
+                        "failed to send worker result back to orchestrator"
+                    );
+                }
+            });
+        }
+    }
+
+    /// Process a worker result received from a spawned worker task.
+    fn handle_worker_result(&mut self, result: WorkerResult) {
+        // Ingest agent events (for activity tracking, token accounting, etc.)
+        for event in &result.events {
+            self.ingest_agent_event(&result.issue_id, event);
+        }
+
+        // Apply token metrics if present
+        if let Some(metrics) = &result.metrics {
+            self.apply_turn_metrics(metrics);
+        }
+
+        // Handle completion (schedules retry on failure, marks complete on success)
+        self.handle_worker_completion(
+            &result.issue_id,
+            result.completion,
+            Utc::now().timestamp_millis(),
+        );
     }
 
     pub fn startup_cleanup(&mut self, port: &mut dyn OrchestratorPort) -> Result<()> {
@@ -346,6 +628,7 @@ impl Orchestrator {
             self.events.push(RuntimeEvent::ValidationSkippedDispatch);
             return Ok(TickResult {
                 dispatched_issue_ids: vec![],
+                dispatched_issues: vec![],
                 dispatch_skipped: true,
             });
         }
@@ -360,6 +643,7 @@ impl Orchestrator {
             self.events.push(RuntimeEvent::ValidationSkippedDispatch);
             return Ok(TickResult {
                 dispatched_issue_ids: vec![],
+                dispatched_issues: vec![],
                 dispatch_skipped: true,
             });
         }
@@ -369,6 +653,7 @@ impl Orchestrator {
 
         let candidates = port.fetch_candidate_issues()?;
         let mut dispatched_issue_ids = vec![];
+        let mut dispatched_issues = vec![];
 
         for candidate in self.sort_issues_for_dispatch(candidates) {
             if self.available_slots() == 0 {
@@ -441,12 +726,18 @@ impl Orchestrator {
                 WorkerHostSelection::Remote(ref host) => Some(host.clone()),
                 _ => None,
             };
-            self.dispatch_issue(&refreshed_issue, None, None, worker_host);
-            dispatched_issue_ids.push(refreshed_issue.id);
+            self.dispatch_issue(&refreshed_issue, None, None, worker_host.clone());
+            dispatched_issue_ids.push(refreshed_issue.id.clone());
+            dispatched_issues.push(DispatchedIssue {
+                issue: refreshed_issue,
+                attempt: None,
+                worker_host,
+            });
         }
 
         Ok(TickResult {
             dispatched_issue_ids,
+            dispatched_issues,
             dispatch_skipped: false,
         })
     }
@@ -1215,7 +1506,12 @@ impl Orchestrator {
             .insert(issue.id.clone(), normalize_issue_state(&issue.state));
     }
 
-    fn process_due_retries(&mut self, port: &mut dyn OrchestratorPort, now_ms: i64) {
+    fn process_due_retries(
+        &mut self,
+        port: &mut dyn OrchestratorPort,
+        now_ms: i64,
+    ) -> Vec<DispatchedIssue> {
+        let mut dispatched = Vec::new();
         let due_retries: Vec<RetryEntry> = self
             .state
             .retry_attempts
@@ -1316,8 +1612,13 @@ impl Orchestrator {
                     &issue,
                     Some(retry.attempt),
                     retry.workspace_path.clone(),
-                    worker_host,
+                    worker_host.clone(),
                 );
+                dispatched.push(DispatchedIssue {
+                    issue,
+                    attempt: Some(retry.attempt),
+                    worker_host,
+                });
                 continue;
             }
 
@@ -1350,6 +1651,8 @@ impl Orchestrator {
                 retry_context,
             );
         }
+
+        dispatched
     }
 
     fn default_workspace_path_for_issue(&self, issue: &Issue) -> String {

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -37,30 +37,27 @@ async fn run_worker_task(
     let issue_id = issue.id.clone();
 
     // 1. Ensure workspace (create dir + after_create hook)
-    let workspace_info = match workspace::ensure_workspace(
-        &issue.identifier,
-        workspace_config,
-        hooks_config,
-    ) {
-        Ok(info) => info,
-        Err(err) => {
-            tracing::error!(
-                event = "worker_workspace_failed",
-                issue_id = %issue_id,
-                issue_identifier = %issue.identifier,
-                error = %err,
-                "workspace creation failed"
-            );
-            return WorkerResult {
-                issue_id,
-                completion: WorkerCompletion::Failed {
-                    error: format!("workspace creation failed: {err}"),
-                },
-                events: vec![],
-                metrics: None,
-            };
-        }
-    };
+    let workspace_info =
+        match workspace::ensure_workspace(&issue.identifier, workspace_config, hooks_config) {
+            Ok(info) => info,
+            Err(err) => {
+                tracing::error!(
+                    event = "worker_workspace_failed",
+                    issue_id = %issue_id,
+                    issue_identifier = %issue.identifier,
+                    error = %err,
+                    "workspace creation failed"
+                );
+                return WorkerResult {
+                    issue_id,
+                    completion: WorkerCompletion::Failed {
+                        error: format!("workspace creation failed: {err}"),
+                    },
+                    events: vec![],
+                    metrics: None,
+                };
+            }
+        };
 
     let workspace_path = Path::new(&workspace_info.path);
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -119,7 +119,7 @@ fn issue(
 
 #[test]
 fn test_reconcile_startup_terminal_cleanup_marks_terminal_issues_completed() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let mut port = FakePort {
         terminal_issues: vec![issue("issue-closed", "SIM-10", "Done", Some(1), 0)],
         ..FakePort::default()
@@ -140,7 +140,7 @@ fn test_reconcile_startup_terminal_cleanup_marks_terminal_issues_completed() {
 
 #[test]
 fn test_reconcile_tick_reconcile_before_validate_before_dispatch() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let mut port = FakePort {
         candidate_issues: vec![issue("issue-1", "SIM-1", "Todo", Some(2), 0)],
         ..FakePort::default()
@@ -163,7 +163,7 @@ fn test_reconcile_tick_reconcile_before_validate_before_dispatch() {
 
 #[test]
 fn test_reconcile_refresh_failure_is_non_fatal_and_dispatch_continues() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let mut port = FakePort {
         reconcile_should_fail: true,
         candidate_issues: vec![issue("issue-1", "SIM-1", "Todo", Some(2), 0)],
@@ -190,7 +190,7 @@ fn test_reconcile_refresh_failure_is_non_fatal_and_dispatch_continues() {
 
 #[test]
 fn test_completed_is_bookkeeping_and_does_not_block_dispatch() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let candidate = issue("issue-1", "SIM-1", "Todo", Some(1), 0);
     orchestrator
         .state_mut()
@@ -212,7 +212,7 @@ fn test_completed_is_bookkeeping_and_does_not_block_dispatch() {
 
 #[test]
 fn test_preflight_validation_failure_skips_dispatch_but_reconcile_continues() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let mut port = FakePort {
         validate_should_fail: true,
         candidate_issues: vec![issue("issue-2", "SIM-2", "Todo", Some(1), 0)],
@@ -252,7 +252,7 @@ fn test_preflight_validation_failure_skips_dispatch_but_reconcile_continues() {
 
 #[test]
 fn test_dispatch_candidate_sorting_and_gating_rules() {
-    let mut orchestrator = Orchestrator::new(test_config(1));
+    let mut orchestrator = Orchestrator::new(test_config(1), String::new());
 
     let mut blocked = issue("issue-blocked", "SIM-20", "Todo", Some(0), 0);
     blocked.blocked_by.push(BlockerRef {
@@ -286,7 +286,7 @@ fn test_dispatch_candidate_sorting_and_gating_rules() {
 
 #[test]
 fn test_dispatch_enforces_per_state_concurrency_caps() {
-    let mut orchestrator = Orchestrator::new(test_config(3));
+    let mut orchestrator = Orchestrator::new(test_config(3), String::new());
 
     let seeded_todo = issue("issue-seeded", "SIM-23", "Todo", Some(1), -30);
     let mut seed_port = FakePort {
@@ -325,7 +325,7 @@ fn test_dispatch_enforces_per_state_concurrency_caps() {
 
 #[test]
 fn test_dispatch_predispatch_refresh_rejects_stale_state() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let stale_candidate = issue("issue-stale", "SIM-30", "In Progress", Some(1), 0);
     let refreshed_terminal = issue("issue-stale", "SIM-30", "Done", Some(1), 0);
 
@@ -356,7 +356,7 @@ fn test_dispatch_predispatch_refresh_rejects_stale_state() {
 
 #[test]
 fn test_retry_scheduling_continuation_and_failure_backoff_rules() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let now_ms = 10_000;
 
     let continuation_token = orchestrator.schedule_retry(
@@ -409,7 +409,7 @@ fn test_retry_scheduling_continuation_and_failure_backoff_rules() {
 
 #[test]
 fn test_stale_retry_timer_is_ignored() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let now_ms = 20_000;
 
     let current_token = orchestrator.schedule_retry(
@@ -466,7 +466,7 @@ fn test_stale_retry_timer_is_ignored() {
 
 #[test]
 fn test_stall_detection_schedules_forced_retry() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
 
     orchestrator.state_mut().running.insert(
         "issue-stalled".to_string(),
@@ -514,7 +514,7 @@ fn test_stall_detection_schedules_forced_retry() {
 
 #[test]
 fn test_token_totals_and_rate_limits_accumulate_into_snapshot() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
 
     orchestrator.apply_turn_metrics(&TurnMetrics {
         input_tokens: 10,
@@ -560,7 +560,7 @@ fn test_token_totals_and_rate_limits_accumulate_into_snapshot() {
 
 #[test]
 fn test_snapshot_exposes_running_and_retry_diagnostics() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
 
     orchestrator.state_mut().running.insert(
         "issue-running".to_string(),
@@ -625,7 +625,7 @@ fn test_snapshot_exposes_running_and_retry_diagnostics() {
 
 #[test]
 fn test_worker_completion_schedules_continuation_retry_with_session_context() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
 
     orchestrator.state_mut().running.insert(
         "issue-complete".to_string(),
@@ -690,7 +690,7 @@ fn test_worker_completion_schedules_continuation_retry_with_session_context() {
 
 #[test]
 fn test_worker_failure_preserves_attempt_and_backoff_cap() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
 
     orchestrator.state_mut().running.insert(
         "issue-fail".to_string(),
@@ -753,7 +753,7 @@ fn test_worker_failure_preserves_attempt_and_backoff_cap() {
 
 #[test]
 fn test_snapshot_handle_read_returns_published_state() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
 
     // Dispatch an issue so the snapshot has running state
     let candidate = issue("issue-snap", "SIM-90", "Todo", Some(1), 0);
@@ -780,7 +780,7 @@ fn test_snapshot_handle_read_returns_published_state() {
 
 #[test]
 fn test_snapshot_handle_updates_after_publish() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let handle = orchestrator.create_snapshot_handle();
 
     // Initially empty running state
@@ -816,7 +816,7 @@ fn test_snapshot_handle_updates_after_publish() {
 
 #[test]
 fn test_snapshot_handle_is_clone_cheap_and_shares_state() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let handle1 = orchestrator.create_snapshot_handle();
     let handle2 = handle1.clone();
 
@@ -842,7 +842,7 @@ fn test_snapshot_handle_is_clone_cheap_and_shares_state() {
 
 #[test]
 fn test_snapshot_handle_preserves_codex_totals_and_rate_limits() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let handle = orchestrator.create_snapshot_handle();
 
     orchestrator.apply_turn_metrics(&TurnMetrics {
@@ -1004,7 +1004,7 @@ async fn test_refresh_channel_notified_wakes_on_request() {
 
 #[test]
 fn test_orchestrator_create_refresh_channel_returns_functional_sender() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let sender = orchestrator.create_refresh_channel();
 
     let outcome = sender.request_refresh();
@@ -1016,7 +1016,7 @@ fn test_orchestrator_create_refresh_channel_returns_functional_sender() {
 
 #[test]
 fn test_orchestrator_create_snapshot_handle_and_refresh_channel_independently() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let handle = orchestrator.create_snapshot_handle();
     let sender = orchestrator.create_refresh_channel();
 
@@ -1030,7 +1030,7 @@ fn test_orchestrator_create_snapshot_handle_and_refresh_channel_independently() 
 
 #[test]
 fn test_snapshot_handle_reflects_retry_queue_for_api_use() {
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let handle = orchestrator.create_snapshot_handle();
 
     orchestrator.schedule_retry(
@@ -1063,7 +1063,7 @@ fn test_reconcile_non_active_state_stops_run_without_cleanup() {
     // in terminal_states ["Done", "Canceled"]).
     // Expected: release_issue path fires → running entry is removed, but the issue is
     // NOT added to `completed` (no terminal cleanup).
-    let mut orchestrator = Orchestrator::new(test_config(2));
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
 
     // Manually seed the running map as if the orchestrator already dispatched this issue.
     let attempt = symphony::domain::RunAttempt {


### PR DESCRIPTION
## Problem

`dispatch_issue()` recorded intent in the running map with status `"scheduled"`, but nothing spawned a tokio task to call `execute_worker_attempt()`. The orchestrator polled Linear, picked candidates, marked them scheduled — but no workspace was created, no hooks ran, and no Codex session launched. Symphony was a brain without hands.

## Fix

After `tick()` returns dispatched issues, the orchestrator now spawns a `tokio::spawn` task per issue that runs the full worker lifecycle:

1. `ensure_workspace()` — create directory + `after_create` hook
2. `run_before_run_hook()` — pre-session hook
3. `render_prompt()` — Liquid template with issue data
4. `start_session()` — launch Codex app-server subprocess
5. `run_turn()` — stream the agent session
6. `stop_session()` — clean shutdown
7. `run_after_run_hook()` — post-session hook

Results flow back via `tokio::sync::mpsc::UnboundedChannel<WorkerResult>`. The `run()` loop `select!`s on worker results alongside the poll timer and refresh channel.

## Changes

- **`src/orchestrator.rs`**: Added `run_worker_task()` standalone async function, `WorkerResult` + `DispatchedIssue` types, worker result channel, `spawn_workers_for_dispatched()`, `handle_worker_result()`. Updated `TickResult` to carry full `Issue` objects. Updated `process_due_retries()` to also return dispatched issues for spawning.
- **`src/main.rs`**: Passes prompt template from `WorkflowStore` into `Orchestrator::new()`.
- **`tests/orchestrator_tests.rs`**: Updated all 23 `Orchestrator::new()` calls for new signature.

## Verification

- `cargo test` — 211 tests, 0 failures
- `cargo clippy -- -D warnings` — exits zero
- `cargo fmt --check` — clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the "Symphony brain gets hands" milestone by wiring the orchestrator's dispatch loop to actually spawn tokio tasks that run the full worker lifecycle (workspace setup → hooks → prompt rendering → Codex session → result reporting). Previously, `dispatch_issue()` recorded intent but no task ever executed.

**Key changes:**
- `run_worker_task`: new standalone async function encapsulating the 7-step worker lifecycle, designed to run inside `tokio::spawn` without borrowing `&mut Orchestrator`
- `WorkerResult` / `DispatchedIssue`: new types to carry dispatched issue context into spawned tasks and results back via an `UnboundedChannel`
- `spawn_workers_for_dispatched` / `handle_worker_result`: orchestrator methods that bridge the channel on both ends
- `TickResult` and `process_due_retries` updated to carry full `Issue` objects so retry workers can also be spawned
- `select!` updated to wake on worker results in addition to the poll timer and refresh channel

**Issues found:**
- The `graphql_executor` passed to `run_turn` inside `run_worker_task` is a no-op closure that always returns `InvalidWorkflowConfig`. Any agent session that invokes the `linear_graphql` tool will receive an immediate error. The prior `execute_worker_attempt` path accepted a generic executor; this PR removes that flexibility without replacement, making `linear_graphql` tool calls silently regress in production.
- When the `worker_result_rx` arm of the `select!` fires, the loop immediately re-enters `tick()` (Linear API calls) without sleeping. Worker completion thus bypasses the configured `poll_interval_ms`, which can cause unbounded re-polling under concurrent worker load.
- `execute_worker_attempt` is now unreachable from the production `run()` path. Its presence alongside `run_worker_task` creates two diverging implementations of the same lifecycle (the graphql executor signatures are already different); it should either be removed or clearly documented as a testing seam.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge until the no-op graphql executor regression is resolved; any workflow using the `linear_graphql` tool will silently fail at runtime.
- The overall architecture is sound — the channel-based worker result pattern is clean and correct. However, two logic issues lower the score significantly: (1) the no-op `graphql_executor` is a silent regression that will cause runtime failures for agents using `linear_graphql`, and (2) worker completion bypasses the configured poll interval, risking API rate-limit exhaustion under load. The first issue in particular is a functional correctness problem that should be addressed before merging.
- apps/symphony/src/orchestrator.rs — specifically the `run_worker_task` graphql_executor closure (lines 143–155) and the `select!` worker-result arm re-ticking without sleep (lines 499–534).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Core change: adds `run_worker_task`, `WorkerResult`, `DispatchedIssue`, and wires the dispatch loop to spawn real tokio tasks. Two logic issues: the `graphql_executor` is a no-op that silently breaks agents using `linear_graphql`, and worker completion triggers an immediate re-tick that bypasses the configured poll interval. |
| apps/symphony/src/main.rs | Minor bootstrapping change: reads `prompt_template` from `WorkflowStore` and passes it to `Orchestrator::new()`. Straightforward and correct. |
| apps/symphony/tests/orchestrator_tests.rs | Mechanical update: all 23 `Orchestrator::new()` calls updated to pass `String::new()` as the prompt template. No logic changes; tests continue to exercise the same scenarios. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OrcLoop as Orchestrator run()
    participant Tick as tick() / process_due_retries()
    participant Spawn as spawn_workers_for_dispatched()
    participant Task as tokio spawn run_worker_task
    participant Chan as UnboundedChannel WorkerResult
    participant Handle as handle_worker_result()

    OrcLoop->>Tick: tick(port)
    Tick-->>OrcLoop: TickResult dispatched_issues
    OrcLoop->>Spawn: spawn_workers_for_dispatched(dispatched_issues)
    Spawn->>Spawn: set status running
    Spawn->>Task: tokio::spawn(run_worker_task)

    OrcLoop->>Tick: process_due_retries(port)
    Tick-->>OrcLoop: Vec DispatchedIssue retries
    OrcLoop->>Spawn: spawn_workers_for_dispatched(retries)
    Spawn->>Task: tokio::spawn(run_worker_task)

    Note over Task: ensure_workspace, before_run_hook, render_prompt, start_session, run_turn, stop_session, after_run_hook
    Task->>Chan: tx.send(WorkerResult)

    OrcLoop->>OrcLoop: select! sleep / worker_result_rx / refresh
    Chan-->>OrcLoop: WorkerResult received
    OrcLoop->>Handle: handle_worker_result(result)
    Handle->>Handle: ingest_agent_events, apply_turn_metrics
    Handle->>Handle: handle_worker_completion
    OrcLoop->>OrcLoop: publish_snapshot()
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/src/orchestrator.rs`, line 972-981 ([link](https://github.com/gannonh/kata/blob/7b065f2534fd57036fd9b632578507d8e76fdf75/apps/symphony/src/orchestrator.rs#L972-L981)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`execute_worker_attempt` is now a dead production code path**

   After this PR the `run()` loop no longer calls `execute_worker_attempt`; all dispatch goes through `spawn_workers_for_dispatched` → `run_worker_task`. `execute_worker_attempt` is still `pub` (so the dead-code lint stays quiet), but it will diverge from `run_worker_task` over time — for example, `run_worker_task` omits the `self.state.running` update that `execute_worker_attempt` performs (that update was moved to `spawn_workers_for_dispatched`), and the graphql executor signatures are already different.

   If this method is retained for integration tests or a future call site, a doc comment explaining that fact would prevent confusion. If it is truly superseded, removing or deprecating it now avoids silent divergence.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/orchestrator.rs
   Line: 972-981

   Comment:
   **`execute_worker_attempt` is now a dead production code path**

   After this PR the `run()` loop no longer calls `execute_worker_attempt`; all dispatch goes through `spawn_workers_for_dispatched` → `run_worker_task`. `execute_worker_attempt` is still `pub` (so the dead-code lint stays quiet), but it will diverge from `run_worker_task` over time — for example, `run_worker_task` omits the `self.state.running` update that `execute_worker_attempt` performs (that update was moved to `spawn_workers_for_dispatched`), and the graphql executor signatures are already different.

   If this method is retained for integration tests or a future call site, a doc comment explaining that fact would prevent confusion. If it is truly superseded, removing or deprecating it now avoids silent divergence.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 143-155

Comment:
**No-op `graphql_executor` silently breaks `linear_graphql` tool**

The `run_worker_task` function wires a closure that always returns an `InvalidWorkflowConfig` error as the `graphql_executor`. Any agent session that invokes the `linear_graphql` tool during its turn will receive an immediate error and likely fail. The existing `execute_worker_attempt` method accepted a generic `graphql_executor: E` parameter so a real `LinearClient`-backed executor could be passed in; the replacement path removes that capability entirely.

The PR description says "wired up separately when needed," but no mechanism to actually thread a real executor into the spawned tasks is provided here. Until that follow-up lands, all workflows that use the `linear_graphql` tool will silently regress.

Consider plumbing a `LinearClient` (or a `Arc<dyn Fn(...) -> ...>` wrapper) into `DispatchedIssue` or as a new `Orchestrator` field so `spawn_workers_for_dispatched` can clone it into each task:

```rust
// Option: add a LinearClient to the spawned closure
let graphql_executor = {
    let client = self.linear_client.clone();
    move |query: String, vars: serde_json::Value| {
        let client = client.clone();
        async move { client.execute_graphql(query, vars).await }
    }
};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 499-534

Comment:
**Worker completion bypasses poll-interval, causing unbounded re-polling**

When the `worker_result_rx` arm fires, the `select!` exits and the loop immediately calls `tick()` (→ `reconcile_running` + `fetch_candidate_issues`) and `process_due_retries` without sleeping. In a steady-state scenario with `N` concurrently running workers each finishing faster than the configured poll interval, the orchestrator will make Linear API calls at the rate workers complete rather than at the configured interval. Under load this can exhaust rate limits and defeat the purpose of `polling.interval_ms`.

The timer arm correctly sleeps for the full interval before re-entering the loop, but the worker-result arm skips it entirely. Consider either:
- returning to the top of the sleep *only* after all results are drained — i.e., do not re-tick until the timer fires after a batch of worker completions, or
- introducing a minimum "last ticked" guard so re-ticking via this arm is rate-limited to at most once per interval.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 972-981

Comment:
**`execute_worker_attempt` is now a dead production code path**

After this PR the `run()` loop no longer calls `execute_worker_attempt`; all dispatch goes through `spawn_workers_for_dispatched` → `run_worker_task`. `execute_worker_attempt` is still `pub` (so the dead-code lint stays quiet), but it will diverge from `run_worker_task` over time — for example, `run_worker_task` omits the `self.state.running` update that `execute_worker_attempt` performs (that update was moved to `spawn_workers_for_dispatched`), and the graphql executor signatures are already different.

If this method is retained for integration tests or a future call site, a doc comment explaining that fact would prevent confusion. If it is truly superseded, removing or deprecating it now avoids silent divergence.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["style: cargo fmt"](https://github.com/gannonh/kata/commit/7b065f2534fd57036fd9b632578507d8e76fdf75)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->