### PR TITLE
feat(symphony): configurable workspace repository bootstrap

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -88,9 +88,12 @@ Everything outside the front-matter is ignored by Symphony.
 
 #### `workspace` section
 
-| Field            | Type   | Default                       | Description                                                                  |
-| ---------------- | ------ | ----------------------------- | ---------------------------------------------------------------------------- |
-| `workspace.root` | string | `$TMPDIR/symphony_workspaces` | Root directory for per-issue agent workspaces. Supports `~` tilde expansion. |
+| Field                     | Type   | Default                       | Description                                                                                                      |
+| ------------------------- | ------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `workspace.root`          | string | `$TMPDIR/symphony_workspaces` | Root directory for per-issue agent workspaces. Supports `~` tilde expansion.                                     |
+| `workspace.repo`          | string | _(none)_                      | Repository URL or local path to bootstrap into each newly-created workspace.                                     |
+| `workspace.strategy`      | string | `"clone"`                     | Bootstrap strategy: `"clone"` (default) or `"worktree"`. `worktree` requires `workspace.repo` to be local path. |
+| `workspace.branch_prefix` | string | `"symphony"`                  | Branch prefix used for auto-created issue branches (`<prefix>/<issue-identifier>`).                             |
 
 #### `agent` section
 
@@ -123,6 +126,10 @@ Everything outside the front-matter is ignored by Symphony.
 | `hooks.before_remove` | string | _(none)_ | Shell command run before the workspace is removed.                   |
 | `hooks.timeout_ms`    | u64    | `60000`  | Timeout for each hook invocation (ms).                               |
 
+All hooks receive these environment variables:
+`SYMPHONY_ISSUE_ID`, `SYMPHONY_ISSUE_IDENTIFIER`, `SYMPHONY_ISSUE_TITLE`,
+`SYMPHONY_WORKSPACE_PATH`.
+
 #### `worker` section (SSH)
 
 | Field                                   | Type     | Default  | Description                                                                                                               |
@@ -148,6 +155,9 @@ tracker:
 
 workspace:
   root: ~/symphony_workspaces
+  repo: https://github.com/example/project.git
+  strategy: clone
+  branch_prefix: symphony
 
 codex:
   command: codex app-server
@@ -179,6 +189,9 @@ polling:
 
 workspace:
   root: ~/workspaces/symphony
+  repo: /Users/alice/code/kata
+  strategy: worktree
+  branch_prefix: symphony
 
 agent:
   max_concurrent_agents: 5
@@ -194,7 +207,7 @@ codex:
   stall_timeout_ms: 600000
 
 hooks:
-  before_run: echo "Starting session for $ISSUE_ID"
+  before_run: echo "Starting session for $SYMPHONY_ISSUE_IDENTIFIER"
   after_run: notify-send "Session complete"
   timeout_ms: 30000
 
@@ -223,6 +236,17 @@ server:
 | `RUST_LOG`            | Log filter directives for `tracing_subscriber`. Examples: `info`, `debug`, `symphony=trace`. Default: `info`.                                                        |
 | `HOME`                | Used for tilde (`~`) expansion in `workspace.root`.                                                                                                                  |
 | `SYMPHONY_SSH_CONFIG` | Path to a custom SSH config file. When set, Symphony passes `-F <path>` to every `ssh` invocation. Useful for custom host keys, ProxyJump, or IdentityFile settings. |
+
+### Hook Environment Variables
+
+The following variables are injected for every lifecycle hook invocation:
+
+| Variable                      | Description                                   |
+| ----------------------------- | --------------------------------------------- |
+| `SYMPHONY_ISSUE_ID`           | Linear issue UUID.                            |
+| `SYMPHONY_ISSUE_IDENTIFIER`   | Human-readable issue identifier (for example, `KAT-800`). |
+| `SYMPHONY_ISSUE_TITLE`        | Linear issue title.                           |
+| `SYMPHONY_WORKSPACE_PATH`     | Absolute path to the workspace directory.     |
 
 ### `$VAR` Indirection Pattern
 

--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -94,6 +94,7 @@ Everything outside the front-matter is ignored by Symphony.
 | `workspace.repo`          | string | _(none)_                      | Repository URL or local path to bootstrap into each newly-created workspace.                                     |
 | `workspace.strategy`      | string | `"clone"`                     | Bootstrap strategy: `"clone"` (default) or `"worktree"`. `worktree` requires `workspace.repo` to be local path. |
 | `workspace.branch_prefix` | string | `"symphony"`                  | Branch prefix used for auto-created issue branches (`<prefix>/<issue-identifier>`).                             |
+| `workspace.clone_branch`  | string | _(none)_                      | Optional branch name to clone for `workspace.strategy: clone`. When set, Symphony runs clone bootstrap with `--branch <clone_branch>`. |
 
 #### `agent` section
 
@@ -158,6 +159,7 @@ workspace:
   repo: https://github.com/example/project.git
   strategy: clone
   branch_prefix: symphony
+  clone_branch: elixir-feature-parity
 
 codex:
   command: codex app-server

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -18,10 +18,10 @@ polling:
   interval_ms: 30000
 workspace:
   root: ~/symphony-workspaces
+  repo: https://github.com/gannonh/kata.git
+  strategy: clone
+  branch_prefix: symphony
 hooks:
-  after_create: |
-    git clone https://github.com/gannonh/kata.git . --single-branch --branch elixir-feature-parity
-    git checkout -b symphony/$(basename $PWD)
   timeout_ms: 120000
 agent:
   max_concurrent_agents: 1

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -21,6 +21,7 @@ workspace:
   repo: https://github.com/gannonh/kata.git
   strategy: clone
   branch_prefix: symphony
+  clone_branch: elixir-feature-parity
 hooks:
   timeout_ms: 120000
 agent:

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -12,7 +12,7 @@ use serde_yaml::{Mapping, Value};
 
 use crate::domain::{
     AgentConfig, ApiKey, CodexConfig, HooksConfig, PollingConfig, ServerConfig, ServiceConfig,
-    TrackerConfig, WorkerConfig, WorkspaceConfig,
+    TrackerConfig, WorkerConfig, WorkspaceConfig, WorkspaceRepoStrategy,
 };
 use crate::error::{Result, SymphonyError};
 
@@ -177,6 +177,9 @@ struct RawPollingConfig {
 #[serde(default)]
 struct RawWorkspaceConfig {
     root: Option<String>,
+    repo: Option<String>,
+    strategy: Option<String>,
+    branch_prefix: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -391,8 +394,27 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let raw_root = raw_workspace
         .root
         .unwrap_or_else(|| defaults.workspace.root.clone());
+    let strategy = match raw_workspace.strategy.as_deref().unwrap_or("clone") {
+        "clone" => WorkspaceRepoStrategy::Clone,
+        "worktree" => WorkspaceRepoStrategy::Worktree,
+        other => {
+            return Err(SymphonyError::InvalidWorkflowConfig(format!(
+                "workspace.strategy must be 'clone' or 'worktree' (got '{other}')"
+            )));
+        }
+    };
+    let repo = raw_workspace
+        .repo
+        .map(|value| expand_tilde(&value))
+        .filter(|value| !value.trim().is_empty());
+    let branch_prefix = raw_workspace
+        .branch_prefix
+        .unwrap_or_else(|| defaults.workspace.branch_prefix.clone());
     let workspace = WorkspaceConfig {
         root: expand_tilde(&raw_root),
+        repo,
+        strategy,
+        branch_prefix,
     };
 
     // ── WorkerConfig ──────────────────────────────────────────────────────
@@ -537,7 +559,33 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
         ));
     }
 
+    // workspace.branch_prefix must be present and non-empty
+    if config.workspace.branch_prefix.trim().is_empty() {
+        return Err(SymphonyError::InvalidWorkflowConfig(
+            "workspace.branch_prefix must be non-empty".to_string(),
+        ));
+    }
+
+    // workspace.strategy=worktree requires a local workspace.repo path
+    if config.workspace.strategy == WorkspaceRepoStrategy::Worktree {
+        let repo = config.workspace.repo.as_deref().ok_or_else(|| {
+            SymphonyError::InvalidWorkflowConfig(
+                "workspace.repo is required when workspace.strategy is 'worktree'".to_string(),
+            )
+        })?;
+        if repo_is_remote(repo) {
+            return Err(SymphonyError::InvalidWorkflowConfig(
+                "workspace.strategy 'worktree' requires workspace.repo to be a local path"
+                    .to_string(),
+            ));
+        }
+    }
+
     Ok(ValidatedServiceConfig(config.clone()))
+}
+
+fn repo_is_remote(repo: &str) -> bool {
+    repo.contains("://") || repo.starts_with("git@")
 }
 
 // ── Unit tests ────────────────────────────────────────────────────────────────

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -15,6 +15,7 @@ use crate::domain::{
     TrackerConfig, WorkerConfig, WorkspaceConfig, WorkspaceRepoStrategy,
 };
 use crate::error::{Result, SymphonyError};
+use crate::repo_url::repo_is_remote;
 
 // ── Key normalization and null-dropping ───────────────────────────────────────
 
@@ -180,6 +181,7 @@ struct RawWorkspaceConfig {
     repo: Option<String>,
     strategy: Option<String>,
     branch_prefix: Option<String>,
+    clone_branch: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -410,11 +412,20 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let branch_prefix = raw_workspace
         .branch_prefix
         .unwrap_or_else(|| defaults.workspace.branch_prefix.clone());
+    let clone_branch = raw_workspace.clone_branch.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
     let workspace = WorkspaceConfig {
         root: expand_tilde(&raw_root),
         repo,
         strategy,
-        branch_prefix,
+        branch_prefix: branch_prefix.trim().to_string(),
+        clone_branch,
     };
 
     // ── WorkerConfig ──────────────────────────────────────────────────────
@@ -583,11 +594,6 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
 
     Ok(ValidatedServiceConfig(config.clone()))
 }
-
-fn repo_is_remote(repo: &str) -> bool {
-    repo.contains("://") || repo.starts_with("git@")
-}
-
 // ── Unit tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -183,6 +183,7 @@ pub struct WorkspaceConfig {
     pub repo: Option<String>,
     pub strategy: WorkspaceRepoStrategy,
     pub branch_prefix: String,
+    pub clone_branch: Option<String>,
 }
 
 /// Workspace repository bootstrap strategy.
@@ -199,6 +200,7 @@ impl Default for WorkspaceConfig {
             repo: None,
             strategy: WorkspaceRepoStrategy::Clone,
             branch_prefix: "symphony".to_string(),
+            clone_branch: None,
         }
     }
 }

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -180,12 +180,25 @@ impl Default for PollingConfig {
 #[derive(Debug, Clone)]
 pub struct WorkspaceConfig {
     pub root: String,
+    pub repo: Option<String>,
+    pub strategy: WorkspaceRepoStrategy,
+    pub branch_prefix: String,
+}
+
+/// Workspace repository bootstrap strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceRepoStrategy {
+    Clone,
+    Worktree,
 }
 
 impl Default for WorkspaceConfig {
     fn default() -> Self {
         Self {
             root: default_workspace_root(),
+            repo: None,
+            strategy: WorkspaceRepoStrategy::Clone,
+            branch_prefix: "symphony".to_string(),
         }
     }
 }

--- a/apps/symphony/src/lib.rs
+++ b/apps/symphony/src/lib.rs
@@ -8,6 +8,7 @@ pub mod linear;
 
 pub mod path_safety;
 pub mod prompt_builder;
+pub mod repo_url;
 pub mod ssh;
 pub mod workspace;
 

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -45,7 +45,7 @@ async fn run_worker_task(
 
     // 1. Ensure workspace (create dir + after_create hook)
     let workspace_info =
-        match workspace::ensure_workspace(&issue.identifier, &config.workspace, &config.hooks) {
+        match workspace::ensure_workspace_for_issue(issue, &config.workspace, &config.hooks) {
             Ok(info) => info,
             Err(err) => {
                 tracing::error!(
@@ -69,7 +69,8 @@ async fn run_worker_task(
     let workspace_path = Path::new(&workspace_info.path);
 
     // 2. Before-run hook
-    if let Err(err) = workspace::run_before_run_hook(workspace_path, &config.hooks) {
+    if let Err(err) = workspace::run_before_run_hook_for_issue(workspace_path, &config.hooks, issue)
+    {
         tracing::error!(
             event = "worker_before_run_failed",
             issue_id = %issue_id,
@@ -171,7 +172,7 @@ async fn run_worker_task(
     }
 
     // 7. After-run hook
-    let _ = workspace::run_after_run_hook(workspace_path, &config.hooks);
+    let _ = workspace::run_after_run_hook_for_issue(workspace_path, &config.hooks, issue);
 
     // 8. Build result
     match run_result {
@@ -999,8 +1000,8 @@ impl Orchestrator {
         E: Fn(String, serde_json::Value) -> EFut + Clone + Send,
         EFut: Future<Output = Result<serde_json::Value>> + Send,
     {
-        let workspace_info = workspace::ensure_workspace(
-            &issue.identifier,
+        let workspace_info = workspace::ensure_workspace_for_issue(
+            issue,
             &self.config.workspace,
             &self.config.hooks,
         )?;
@@ -1032,7 +1033,9 @@ impl Orchestrator {
         self.state.retry_attempts.remove(&issue.id);
 
         let workspace_path = Path::new(&workspace_info.path);
-        if let Err(err) = workspace::run_before_run_hook(workspace_path, &self.config.hooks) {
+        if let Err(err) =
+            workspace::run_before_run_hook_for_issue(workspace_path, &self.config.hooks, issue)
+        {
             self.handle_worker_completion(
                 &issue.id,
                 WorkerCompletion::Failed {
@@ -1107,7 +1110,7 @@ impl Orchestrator {
             );
         }
 
-        let _ = workspace::run_after_run_hook(workspace_path, &self.config.hooks);
+        let _ = workspace::run_after_run_hook_for_issue(workspace_path, &self.config.hooks, issue);
 
         match run_result {
             Ok(turn_result) => {

--- a/apps/symphony/src/repo_url.rs
+++ b/apps/symphony/src/repo_url.rs
@@ -1,0 +1,39 @@
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Returns true when a repo reference looks like a remote URL.
+pub fn repo_is_remote(repo: &str) -> bool {
+    repo.contains("://") || repo.starts_with("git@")
+}
+
+/// Redacts URL user-info segments (`scheme://user[:pass]@host`) in command output.
+pub fn redact_url_credentials(input: &str) -> String {
+    static URL_USERINFO_RE: OnceLock<Regex> = OnceLock::new();
+    let re = URL_USERINFO_RE.get_or_init(|| {
+        Regex::new(r"([A-Za-z][A-Za-z0-9+.\-]*://)([^/@\s]+)@")
+            .expect("repo URL redaction regex must compile")
+    });
+    re.replace_all(input, "$1[REDACTED]@").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_repo_is_remote() {
+        assert!(repo_is_remote("https://github.com/org/repo.git"));
+        assert!(repo_is_remote("git@github.com:org/repo.git"));
+        assert!(!repo_is_remote("/tmp/local-repo"));
+    }
+
+    #[test]
+    fn test_redact_url_credentials() {
+        let output = "fatal: could not read from https://user:token@example.com/repo";
+        let redacted = redact_url_credentials(output);
+        assert!(
+            redacted.contains("https://[REDACTED]@example.com/repo"),
+            "expected URL credentials to be redacted, got: {redacted}"
+        );
+    }
+}

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -199,6 +199,12 @@ fn bootstrap_repository(
                 ));
             }
 
+            // Older git versions require a non-existent target path for
+            // `git worktree add`. remove the pre-created empty directory first.
+            if workspace.exists() {
+                std::fs::remove_dir(workspace)?;
+            }
+
             let mut worktree_cmd = Command::new("git");
             worktree_cmd
                 .arg("-C")

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -3,10 +3,42 @@
 //! Full implementation in S04/T03. This is the public API skeleton so tests compile.
 
 use std::path::Path;
+use std::process::Command;
 
-use crate::domain::{HooksConfig, Workspace, WorkspaceConfig};
+use crate::domain::{HooksConfig, Issue, Workspace, WorkspaceConfig, WorkspaceRepoStrategy};
 use crate::error::{Result, SymphonyError};
 use crate::path_safety;
+
+#[derive(Debug, Clone)]
+struct HookIssueContext {
+    issue_id: String,
+    issue_identifier: String,
+    issue_title: String,
+}
+
+impl HookIssueContext {
+    fn from_identifier(identifier: &str) -> Self {
+        Self {
+            issue_id: String::new(),
+            issue_identifier: identifier.to_string(),
+            issue_title: String::new(),
+        }
+    }
+
+    fn from_issue(issue: &Issue) -> Self {
+        Self {
+            issue_id: issue.id.clone(),
+            issue_identifier: issue.identifier.clone(),
+            issue_title: issue.title.clone(),
+        }
+    }
+
+    fn from_issue_or_identifier(issue: Option<&Issue>, identifier: &str) -> Self {
+        issue
+            .map(Self::from_issue)
+            .unwrap_or_else(|| Self::from_identifier(identifier))
+    }
+}
 
 /// Create or reuse a workspace directory for the given identifier.
 ///
@@ -14,13 +46,34 @@ use crate::path_safety;
 /// - Computes the workspace path under `config.root`
 /// - Validates that the workspace stays within the root (no symlink escapes)
 /// - Creates the directory if missing, reuses if present, replaces non-dirs
+/// - Runs repository bootstrap (when configured) before `after_create`
 /// - Runs the `after_create` hook if the directory was newly created
 pub fn ensure_workspace(
     identifier: &str,
     config: &WorkspaceConfig,
     hooks: &HooksConfig,
 ) -> Result<Workspace> {
+    ensure_workspace_internal(identifier, None, config, hooks)
+}
+
+/// Issue-aware variant that injects full issue metadata into hook env vars.
+pub fn ensure_workspace_for_issue(
+    issue: &Issue,
+    config: &WorkspaceConfig,
+    hooks: &HooksConfig,
+) -> Result<Workspace> {
+    ensure_workspace_internal(&issue.identifier, Some(issue), config, hooks)
+}
+
+fn ensure_workspace_internal(
+    identifier: &str,
+    issue: Option<&Issue>,
+    config: &WorkspaceConfig,
+    hooks: &HooksConfig,
+) -> Result<Workspace> {
     let safe_id = path_safety::sanitize_identifier(identifier);
+    let hook_issue = HookIssueContext::from_issue_or_identifier(issue, identifier);
+
     let root_path = Path::new(&config.root);
     let canonical_root = path_safety::canonicalize(root_path)?;
     let workspace_path = canonical_root.join(&safe_id);
@@ -45,10 +98,21 @@ pub fn ensure_workspace(
         (canonical_workspace.clone(), true)
     };
 
-    // Run after_create hook if newly created — clean up on failure
+    // Run bootstrap + after_create hook if newly created — clean up on failure
     if created_now {
+        if let Err(err) = bootstrap_repository(&final_path, config, &hook_issue.issue_identifier) {
+            let _ = std::fs::remove_dir_all(&final_path);
+            return Err(err);
+        }
+
         if let Some(ref command) = hooks.after_create {
-            if let Err(err) = run_hook("after_create", command, &final_path, hooks.timeout_ms) {
+            if let Err(err) = run_hook(
+                "after_create",
+                command,
+                &final_path,
+                hooks.timeout_ms,
+                &hook_issue,
+            ) {
                 // Remove the partially-initialized workspace so the next call
                 // doesn't silently reuse it with created_now=false
                 let _ = std::fs::remove_dir_all(&final_path);
@@ -90,9 +154,112 @@ pub fn validate_workspace_path(workspace: &Path, root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Run repository bootstrap (clone/worktree + branch creation) when configured.
+fn bootstrap_repository(
+    workspace: &Path,
+    config: &WorkspaceConfig,
+    issue_identifier: &str,
+) -> Result<()> {
+    let Some(repo) = config.repo.as_deref() else {
+        return Ok(());
+    };
+
+    let branch_name = format!("{}/{}", config.branch_prefix, issue_identifier);
+    let workspace_str = workspace.to_string_lossy().to_string();
+
+    match config.strategy {
+        WorkspaceRepoStrategy::Clone => {
+            // Keep CLI parity with the proposal: git clone <repo> . --single-branch
+            let mut clone_cmd = Command::new("git");
+            clone_cmd
+                .arg("clone")
+                .arg(repo)
+                .arg(".")
+                .arg("--single-branch")
+                .current_dir(workspace);
+            run_git_command(clone_cmd, "workspace clone bootstrap")?;
+
+            let mut checkout_cmd = Command::new("git");
+            checkout_cmd
+                .arg("checkout")
+                .arg("-b")
+                .arg(&branch_name)
+                .current_dir(workspace);
+            run_git_command(checkout_cmd, "workspace branch bootstrap")
+        }
+        WorkspaceRepoStrategy::Worktree => {
+            if repo_is_remote(repo) {
+                return Err(SymphonyError::InvalidWorkflowConfig(
+                    "workspace.strategy 'worktree' requires workspace.repo to be a local path"
+                        .to_string(),
+                ));
+            }
+
+            let mut worktree_cmd = Command::new("git");
+            worktree_cmd
+                .arg("-C")
+                .arg(repo)
+                .arg("worktree")
+                .arg("add")
+                .arg(&workspace_str)
+                .arg("-b")
+                .arg(&branch_name);
+            run_git_command(worktree_cmd, "workspace worktree bootstrap")
+        }
+    }
+}
+
+/// Remove a worktree checkout from the source repository.
+fn cleanup_worktree_checkout(workspace: &Path, config: &WorkspaceConfig) -> Result<()> {
+    if config.strategy != WorkspaceRepoStrategy::Worktree {
+        return Ok(());
+    }
+
+    let Some(repo) = config.repo.as_deref() else {
+        return Ok(());
+    };
+
+    let workspace_str = workspace.to_string_lossy().to_string();
+    let mut worktree_remove = Command::new("git");
+    worktree_remove
+        .arg("-C")
+        .arg(repo)
+        .arg("worktree")
+        .arg("remove")
+        .arg("--force")
+        .arg(&workspace_str);
+    run_git_command(worktree_remove, "workspace worktree cleanup")
+}
+
+fn repo_is_remote(repo: &str) -> bool {
+    repo.contains("://") || repo.starts_with("git@")
+}
+
+fn run_git_command(mut command: Command, context: &str) -> Result<()> {
+    let output = command.output().map_err(SymphonyError::Io)?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let status = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    let truncated = truncate_output(&combined, 2048);
+
+    Err(SymphonyError::Other(format!(
+        "{context} failed (status {status}): {truncated}"
+    )))
+}
+
 /// Run a hook command via `sh -lc` in the workspace directory with a timeout.
-fn run_hook(name: &str, command: &str, workspace: &Path, timeout_ms: u64) -> Result<()> {
-    use std::process::Command;
+fn run_hook(
+    name: &str,
+    command: &str,
+    workspace: &Path,
+    timeout_ms: u64,
+    issue: &HookIssueContext,
+) -> Result<()> {
     use std::time::Duration;
 
     tracing::info!(
@@ -104,9 +271,14 @@ fn run_hook(name: &str, command: &str, workspace: &Path, timeout_ms: u64) -> Res
     #[cfg(unix)]
     use std::os::unix::process::CommandExt;
 
+    let workspace_path = workspace.to_string_lossy().to_string();
     let mut cmd = Command::new("sh");
     cmd.args(["-lc", command])
         .current_dir(workspace)
+        .env("SYMPHONY_ISSUE_ID", &issue.issue_id)
+        .env("SYMPHONY_ISSUE_IDENTIFIER", &issue.issue_identifier)
+        .env("SYMPHONY_ISSUE_TITLE", &issue.issue_title)
+        .env("SYMPHONY_WORKSPACE_PATH", &workspace_path)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
@@ -196,8 +368,36 @@ unsafe fn libc_kill(pid: i32, sig: i32) -> i32 {
 
 /// Run the `before_run` hook — failure is fatal.
 pub fn run_before_run_hook(workspace: &Path, hooks: &HooksConfig) -> Result<()> {
+    run_before_run_hook_internal(workspace, hooks, None)
+}
+
+/// Issue-aware variant that injects full issue metadata into hook env vars.
+pub fn run_before_run_hook_for_issue(
+    workspace: &Path,
+    hooks: &HooksConfig,
+    issue: &Issue,
+) -> Result<()> {
+    run_before_run_hook_internal(workspace, hooks, Some(issue))
+}
+
+fn run_before_run_hook_internal(
+    workspace: &Path,
+    hooks: &HooksConfig,
+    issue: Option<&Issue>,
+) -> Result<()> {
     if let Some(ref command) = hooks.before_run {
-        run_hook("before_run", command, workspace, hooks.timeout_ms)
+        let fallback_identifier = workspace
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        let hook_issue = HookIssueContext::from_issue_or_identifier(issue, fallback_identifier);
+        run_hook(
+            "before_run",
+            command,
+            workspace,
+            hooks.timeout_ms,
+            &hook_issue,
+        )
     } else {
         Ok(())
     }
@@ -205,8 +405,36 @@ pub fn run_before_run_hook(workspace: &Path, hooks: &HooksConfig) -> Result<()> 
 
 /// Run the `after_run` hook — failure is logged and ignored.
 pub fn run_after_run_hook(workspace: &Path, hooks: &HooksConfig) -> Result<()> {
+    run_after_run_hook_internal(workspace, hooks, None)
+}
+
+/// Issue-aware variant that injects full issue metadata into hook env vars.
+pub fn run_after_run_hook_for_issue(
+    workspace: &Path,
+    hooks: &HooksConfig,
+    issue: &Issue,
+) -> Result<()> {
+    run_after_run_hook_internal(workspace, hooks, Some(issue))
+}
+
+fn run_after_run_hook_internal(
+    workspace: &Path,
+    hooks: &HooksConfig,
+    issue: Option<&Issue>,
+) -> Result<()> {
     if let Some(ref command) = hooks.after_run {
-        match run_hook("after_run", command, workspace, hooks.timeout_ms) {
+        let fallback_identifier = workspace
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        let hook_issue = HookIssueContext::from_issue_or_identifier(issue, fallback_identifier);
+        match run_hook(
+            "after_run",
+            command,
+            workspace,
+            hooks.timeout_ms,
+            &hook_issue,
+        ) {
             Ok(()) => Ok(()),
             Err(e) => {
                 tracing::warn!(error = %e, "after_run hook failure ignored");
@@ -224,15 +452,47 @@ pub fn remove_workspace(
     config: &WorkspaceConfig,
     hooks: &HooksConfig,
 ) -> Result<()> {
+    remove_workspace_internal(workspace, config, hooks, None)
+}
+
+/// Issue-aware variant that injects full issue metadata into hook env vars.
+pub fn remove_workspace_for_issue(
+    workspace: &Path,
+    config: &WorkspaceConfig,
+    hooks: &HooksConfig,
+    issue: &Issue,
+) -> Result<()> {
+    remove_workspace_internal(workspace, config, hooks, Some(issue))
+}
+
+fn remove_workspace_internal(
+    workspace: &Path,
+    config: &WorkspaceConfig,
+    hooks: &HooksConfig,
+    issue: Option<&Issue>,
+) -> Result<()> {
     let canonical_root = path_safety::canonicalize(Path::new(&config.root))?;
 
     if workspace.exists() {
         validate_workspace_path(workspace, &canonical_root)?;
+        let canonical_workspace = path_safety::canonicalize(workspace)?;
 
         // Run before_remove hook (failure ignored)
         if let Some(ref command) = hooks.before_remove {
-            if workspace.is_dir() {
-                match run_hook("before_remove", command, workspace, hooks.timeout_ms) {
+            if canonical_workspace.is_dir() {
+                let fallback_identifier = canonical_workspace
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("");
+                let hook_issue =
+                    HookIssueContext::from_issue_or_identifier(issue, fallback_identifier);
+                match run_hook(
+                    "before_remove",
+                    command,
+                    &canonical_workspace,
+                    hooks.timeout_ms,
+                    &hook_issue,
+                ) {
                     Ok(()) => {}
                     Err(e) => {
                         tracing::warn!(error = %e, "before_remove hook failure ignored");
@@ -241,7 +501,11 @@ pub fn remove_workspace(
             }
         }
 
-        std::fs::remove_dir_all(workspace)?;
+        cleanup_worktree_checkout(&canonical_workspace, config)?;
+
+        if canonical_workspace.exists() {
+            std::fs::remove_dir_all(&canonical_workspace)?;
+        }
     }
 
     Ok(())

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 use crate::domain::{HooksConfig, Issue, Workspace, WorkspaceConfig, WorkspaceRepoStrategy};
 use crate::error::{Result, SymphonyError};
 use crate::path_safety;
+use crate::repo_url::{redact_url_credentials, repo_is_remote};
 
 #[derive(Debug, Clone)]
 struct HookIssueContext {
@@ -175,8 +176,11 @@ fn bootstrap_repository(
                 .arg("clone")
                 .arg(repo)
                 .arg(".")
-                .arg("--single-branch")
-                .current_dir(workspace);
+                .arg("--single-branch");
+            if let Some(clone_branch) = config.clone_branch.as_deref() {
+                clone_cmd.arg("--branch").arg(clone_branch);
+            }
+            clone_cmd.current_dir(workspace);
             run_git_command(clone_cmd, "workspace clone bootstrap")?;
 
             let mut checkout_cmd = Command::new("git");
@@ -231,10 +235,6 @@ fn cleanup_worktree_checkout(workspace: &Path, config: &WorkspaceConfig) -> Resu
     run_git_command(worktree_remove, "workspace worktree cleanup")
 }
 
-fn repo_is_remote(repo: &str) -> bool {
-    repo.contains("://") || repo.starts_with("git@")
-}
-
 fn run_git_command(mut command: Command, context: &str) -> Result<()> {
     let output = command.output().map_err(SymphonyError::Io)?;
     if output.status.success() {
@@ -245,7 +245,8 @@ fn run_git_command(mut command: Command, context: &str) -> Result<()> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let combined = format!("{stdout}{stderr}");
-    let truncated = truncate_output(&combined, 2048);
+    let redacted = redact_url_credentials(&combined);
+    let truncated = truncate_output(&redacted, 2048);
 
     Err(SymphonyError::Other(format!(
         "{context} failed (status {status}): {truncated}"
@@ -501,7 +502,13 @@ fn remove_workspace_internal(
             }
         }
 
-        cleanup_worktree_checkout(&canonical_workspace, config)?;
+        if let Err(err) = cleanup_worktree_checkout(&canonical_workspace, config) {
+            tracing::warn!(
+                error = %err,
+                workspace = %canonical_workspace.display(),
+                "worktree cleanup failed; continuing workspace directory removal"
+            );
+        }
 
         if canonical_workspace.exists() {
             std::fs::remove_dir_all(&canonical_workspace)?;

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -9,7 +9,9 @@ use std::io::Write;
 use tempfile::NamedTempFile;
 
 use symphony::config::{from_workflow, validate};
-use symphony::domain::{CodexConfig, ServiceConfig, TrackerConfig};
+use symphony::domain::{
+    CodexConfig, ServiceConfig, TrackerConfig, WorkspaceConfig, WorkspaceRepoStrategy,
+};
 use symphony::error::SymphonyError;
 use symphony::workflow::parse_workflow;
 use symphony::workflow_store::WorkflowStore;
@@ -132,6 +134,9 @@ fn test_config_defaults() {
     assert_eq!(config.polling.interval_ms, 30_000);
     assert_eq!(config.agent.max_concurrent_agents, 10);
     assert_eq!(config.agent.max_turns, 20);
+    assert_eq!(config.workspace.repo, None);
+    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
+    assert_eq!(config.workspace.branch_prefix, "symphony");
 }
 
 #[test]
@@ -193,6 +198,93 @@ fn test_config_tilde_expansion() {
         Some(home) => std::env::set_var("HOME", home),
         None => std::env::remove_var("HOME"),
     }
+}
+
+#[test]
+fn test_workspace_repo_strategy_and_branch_prefix_parse() {
+    let yaml_str = r#"
+workspace:
+  root: ~/workspaces
+  repo: https://github.com/gannonh/kata.git
+  strategy: clone
+  branch_prefix: symphony
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace bootstrap config should parse");
+
+    assert_eq!(
+        config.workspace.repo.as_deref(),
+        Some("https://github.com/gannonh/kata.git")
+    );
+    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
+    assert_eq!(config.workspace.branch_prefix, "symphony");
+}
+
+#[test]
+fn test_workspace_strategy_invalid_value_errors() {
+    let yaml_str = r#"
+workspace:
+  repo: /tmp/local-repo
+  strategy: invalid
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let result = from_workflow(&raw);
+
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.strategy")),
+        "invalid workspace.strategy should return InvalidWorkflowConfig, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_config_validation_rejects_worktree_without_repo() {
+    let config = ServiceConfig {
+        tracker: TrackerConfig {
+            kind: Some("linear".to_string()),
+            api_key: Some("test-key".into()),
+            project_slug: Some("my-project".to_string()),
+            ..TrackerConfig::default()
+        },
+        workspace: WorkspaceConfig {
+            strategy: WorkspaceRepoStrategy::Worktree,
+            repo: None,
+            ..WorkspaceConfig::default()
+        },
+        ..ServiceConfig::default()
+    };
+
+    let result = validate(&config);
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.repo")),
+        "worktree strategy without repo should fail validation, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_config_validation_rejects_worktree_with_remote_repo() {
+    let config = ServiceConfig {
+        tracker: TrackerConfig {
+            kind: Some("linear".to_string()),
+            api_key: Some("test-key".into()),
+            project_slug: Some("my-project".to_string()),
+            ..TrackerConfig::default()
+        },
+        workspace: WorkspaceConfig {
+            strategy: WorkspaceRepoStrategy::Worktree,
+            repo: Some("https://github.com/gannonh/kata.git".to_string()),
+            ..WorkspaceConfig::default()
+        },
+        ..ServiceConfig::default()
+    };
+
+    let result = validate(&config);
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.strategy") && msg.contains("local")),
+        "worktree strategy with remote repo should fail validation, got: {:?}",
+        result
+    );
 }
 
 #[test]

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -137,6 +137,7 @@ fn test_config_defaults() {
     assert_eq!(config.workspace.repo, None);
     assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
     assert_eq!(config.workspace.branch_prefix, "symphony");
+    assert_eq!(config.workspace.clone_branch, None);
 }
 
 #[test]
@@ -207,7 +208,8 @@ workspace:
   root: ~/workspaces
   repo: https://github.com/gannonh/kata.git
   strategy: clone
-  branch_prefix: symphony
+  branch_prefix: " symphony "
+  clone_branch: elixir-feature-parity
 "#;
     let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
     let config = from_workflow(&raw).expect("workspace bootstrap config should parse");
@@ -218,6 +220,21 @@ workspace:
     );
     assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
     assert_eq!(config.workspace.branch_prefix, "symphony");
+    assert_eq!(
+        config.workspace.clone_branch.as_deref(),
+        Some("elixir-feature-parity")
+    );
+}
+
+#[test]
+fn test_workspace_clone_branch_blank_is_ignored() {
+    let yaml_str = r#"
+workspace:
+  clone_branch: "   "
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace clone branch should parse");
+    assert_eq!(config.workspace.clone_branch, None);
 }
 
 #[test]

--- a/apps/symphony/tests/workspace_prompt_tests.rs
+++ b/apps/symphony/tests/workspace_prompt_tests.rs
@@ -110,6 +110,7 @@ fn workspace_config(root: &Path) -> WorkspaceConfig {
         repo: None,
         strategy: WorkspaceRepoStrategy::Clone,
         branch_prefix: "symphony".to_string(),
+        clone_branch: None,
     }
 }
 
@@ -188,6 +189,24 @@ fn init_git_repo(path: &Path) {
         .current_dir(path)
         .args(["commit", "-m", "initial commit"]);
     command_success(commit, "git commit source repo files");
+}
+
+fn create_branch_with_commit(path: &Path, branch: &str, file: &str, contents: &str) {
+    let mut checkout = Command::new("git");
+    checkout.current_dir(path).args(["checkout", "-b", branch]);
+    command_success(checkout, "git checkout new source branch");
+
+    fs::write(path.join(file), contents).unwrap();
+
+    let mut add = Command::new("git");
+    add.current_dir(path).args(["add", file]);
+    command_success(add, "git add branch-specific file");
+
+    let mut commit = Command::new("git");
+    commit
+        .current_dir(path)
+        .args(["commit", "-m", "branch-specific commit"]);
+    command_success(commit, "git commit branch-specific file");
 }
 
 fn shell_quote(path: &Path) -> String {
@@ -433,12 +452,19 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
     let source_repo = tmp.path().join("source-repo");
     fs::create_dir_all(&root).unwrap();
     init_git_repo(&source_repo);
+    create_branch_with_commit(
+        &source_repo,
+        "elixir-feature-parity",
+        "BASE_BRANCH.txt",
+        "elixir-feature-parity\n",
+    );
 
     let config = WorkspaceConfig {
         root: root.to_string_lossy().to_string(),
         repo: Some(source_repo.to_string_lossy().to_string()),
         strategy: WorkspaceRepoStrategy::Clone,
         branch_prefix: "symphony".to_string(),
+        clone_branch: Some("elixir-feature-parity".to_string()),
     };
     let hooks = HooksConfig {
         after_create: Some("git rev-parse --abbrev-ref HEAD > hook_branch.txt".to_string()),
@@ -459,6 +485,10 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
     assert!(
         ws_path.join("README.md").exists(),
         "cloned workspace should contain source repo files"
+    );
+    assert!(
+        ws_path.join("BASE_BRANCH.txt").exists(),
+        "clone bootstrap should clone the configured source branch"
     );
 
     let mut branch_cmd = Command::new("git");
@@ -490,6 +520,7 @@ fn test_workspace_worktree_bootstrap_and_cleanup() {
         repo: Some(source_repo.to_string_lossy().to_string()),
         strategy: WorkspaceRepoStrategy::Worktree,
         branch_prefix: "symphony".to_string(),
+        clone_branch: None,
     };
     let hooks = hooks_config_none();
     let issue = make_test_issue("KAT-801");
@@ -612,6 +643,41 @@ fn test_workspace_remove_runs_before_remove_hook() {
     assert!(
         !ws_path.exists(),
         "workspace should be removed even if hook fails"
+    );
+}
+
+#[test]
+fn test_workspace_remove_continues_when_worktree_cleanup_fails() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(source_repo.to_string_lossy().to_string()),
+        strategy: WorkspaceRepoStrategy::Worktree,
+        branch_prefix: "symphony".to_string(),
+        clone_branch: None,
+    };
+    let hooks = hooks_config_none();
+    let issue = make_test_issue("KAT-803");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+    let ws_path = PathBuf::from(&ws.path);
+
+    // Break worktree cleanup by moving the source repo path away.
+    fs::rename(&source_repo, tmp.path().join("moved-source-repo")).unwrap();
+
+    let result = symphony::workspace::remove_workspace_for_issue(&ws_path, &config, &hooks, &issue);
+    assert!(
+        result.is_ok(),
+        "workspace removal should continue after cleanup failure"
+    );
+    assert!(
+        !ws_path.exists(),
+        "workspace directory should still be deleted if worktree cleanup fails"
     );
 }
 

--- a/apps/symphony/tests/workspace_prompt_tests.rs
+++ b/apps/symphony/tests/workspace_prompt_tests.rs
@@ -5,11 +5,12 @@
 use std::fs;
 use std::os::unix::fs as unix_fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use chrono::{DateTime, Utc};
 use tempfile::TempDir;
 
-use symphony::domain::{BlockerRef, HooksConfig, Issue, WorkspaceConfig};
+use symphony::domain::{BlockerRef, HooksConfig, Issue, WorkspaceConfig, WorkspaceRepoStrategy};
 use symphony::error::SymphonyError;
 use symphony::path_safety;
 
@@ -106,6 +107,9 @@ fn test_canonicalize_nested_symlink() {
 fn workspace_config(root: &Path) -> WorkspaceConfig {
     WorkspaceConfig {
         root: root.to_string_lossy().to_string(),
+        repo: None,
+        strategy: WorkspaceRepoStrategy::Clone,
+        branch_prefix: "symphony".to_string(),
     }
 }
 
@@ -137,6 +141,58 @@ fn make_test_issue(identifier: &str) -> Issue {
         created_at: None,
         updated_at: None,
     }
+}
+
+fn command_success(mut cmd: Command, context: &str) -> String {
+    let output = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("{context}: failed to spawn command: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "{context}: command failed\nstatus: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        stdout,
+        stderr
+    );
+    stdout.trim().to_string()
+}
+
+fn init_git_repo(path: &Path) {
+    fs::create_dir_all(path).unwrap();
+    fs::write(path.join("README.md"), "hello from source repo\n").unwrap();
+
+    let mut init = Command::new("git");
+    init.current_dir(path).arg("init");
+    command_success(init, "git init source repo");
+
+    let mut set_name = Command::new("git");
+    set_name
+        .current_dir(path)
+        .args(["config", "user.name", "Symphony Test"]);
+    command_success(set_name, "git config user.name");
+
+    let mut set_email = Command::new("git");
+    set_email
+        .current_dir(path)
+        .args(["config", "user.email", "symphony-tests@example.com"]);
+    command_success(set_email, "git config user.email");
+
+    let mut add = Command::new("git");
+    add.current_dir(path).args(["add", "."]);
+    command_success(add, "git add source repo files");
+
+    let mut commit = Command::new("git");
+    commit
+        .current_dir(path)
+        .args(["commit", "-m", "initial commit"]);
+    command_success(commit, "git commit source repo files");
+}
+
+fn shell_quote(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    format!("'{}'", raw.replace('\'', "'\"'\"'"))
 }
 
 #[test]
@@ -368,6 +424,145 @@ fn test_workspace_after_create_hook_timeout() {
         }
         other => panic!("Expected WorkspaceHookTimeout, got: {:?}", other),
     }
+}
+
+#[test]
+fn test_workspace_clone_bootstrap_and_branch_creation() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(source_repo.to_string_lossy().to_string()),
+        strategy: WorkspaceRepoStrategy::Clone,
+        branch_prefix: "symphony".to_string(),
+    };
+    let hooks = HooksConfig {
+        after_create: Some("git rev-parse --abbrev-ref HEAD > hook_branch.txt".to_string()),
+        before_run: None,
+        after_run: None,
+        before_remove: None,
+        timeout_ms: 5_000,
+    };
+    let issue = make_test_issue("KAT-800");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+    let ws_path = PathBuf::from(&ws.path);
+
+    assert!(
+        ws.created_now,
+        "new clone workspace should be newly created"
+    );
+    assert!(
+        ws_path.join("README.md").exists(),
+        "cloned workspace should contain source repo files"
+    );
+
+    let mut branch_cmd = Command::new("git");
+    branch_cmd.args(["-C", &ws.path, "rev-parse", "--abbrev-ref", "HEAD"]);
+    let branch = command_success(branch_cmd, "read clone workspace branch");
+    assert_eq!(
+        branch, "symphony/KAT-800",
+        "clone bootstrap should create and checkout issue branch"
+    );
+
+    let hook_branch = fs::read_to_string(ws_path.join("hook_branch.txt")).unwrap();
+    assert_eq!(
+        hook_branch.trim(),
+        "symphony/KAT-800",
+        "after_create hook should run after bootstrap and see the created branch"
+    );
+}
+
+#[test]
+fn test_workspace_worktree_bootstrap_and_cleanup() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(source_repo.to_string_lossy().to_string()),
+        strategy: WorkspaceRepoStrategy::Worktree,
+        branch_prefix: "symphony".to_string(),
+    };
+    let hooks = hooks_config_none();
+    let issue = make_test_issue("KAT-801");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+    let ws_path = PathBuf::from(&ws.path);
+    assert!(
+        ws_path.join("README.md").exists(),
+        "worktree workspace should expose source repo files"
+    );
+
+    let source_repo_str = source_repo.to_string_lossy().to_string();
+    let mut list_before_cmd = Command::new("git");
+    list_before_cmd.args(["-C", &source_repo_str, "worktree", "list", "--porcelain"]);
+    let list_before = command_success(list_before_cmd, "list worktrees before cleanup");
+    assert!(
+        list_before.contains(&ws.path),
+        "source repo should track new worktree path"
+    );
+
+    symphony::workspace::remove_workspace_for_issue(&ws_path, &config, &hooks, &issue).unwrap();
+    assert!(!ws_path.exists(), "workspace directory should be removed");
+
+    let mut list_after_cmd = Command::new("git");
+    list_after_cmd.args(["-C", &source_repo_str, "worktree", "list", "--porcelain"]);
+    let list_after = command_success(list_after_cmd, "list worktrees after cleanup");
+    assert!(
+        !list_after.contains(&ws.path),
+        "source repo should no longer track removed worktree"
+    );
+}
+
+#[test]
+fn test_workspace_hooks_receive_issue_metadata_env() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    fs::create_dir_all(&root).unwrap();
+    let before_remove_log = tmp.path().join("before_remove_env.txt");
+    let before_remove_log_quoted = shell_quote(&before_remove_log);
+    let env_dump =
+        "printf '%s|%s|%s|%s' \"$SYMPHONY_ISSUE_ID\" \"$SYMPHONY_ISSUE_IDENTIFIER\" \"$SYMPHONY_ISSUE_TITLE\" \"$SYMPHONY_WORKSPACE_PATH\"";
+
+    let hooks = HooksConfig {
+        after_create: Some(format!("{env_dump} > after_create_env.txt")),
+        before_run: Some(format!("{env_dump} > before_run_env.txt")),
+        after_run: Some(format!("{env_dump} > after_run_env.txt")),
+        before_remove: Some(format!("{env_dump} > {before_remove_log_quoted}")),
+        timeout_ms: 5_000,
+    };
+    let config = workspace_config(&root);
+    let issue = make_test_issue("KAT-802");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+    let ws_path = PathBuf::from(&ws.path);
+    let expected = format!(
+        "{}|{}|{}|{}",
+        issue.id, issue.identifier, issue.title, ws.path
+    );
+
+    let after_create_env = fs::read_to_string(ws_path.join("after_create_env.txt")).unwrap();
+    assert_eq!(after_create_env, expected);
+
+    symphony::workspace::run_before_run_hook_for_issue(&ws_path, &hooks, &issue).unwrap();
+    let before_run_env = fs::read_to_string(ws_path.join("before_run_env.txt")).unwrap();
+    assert_eq!(before_run_env, expected);
+
+    symphony::workspace::run_after_run_hook_for_issue(&ws_path, &hooks, &issue).unwrap();
+    let after_run_env = fs::read_to_string(ws_path.join("after_run_env.txt")).unwrap();
+    assert_eq!(after_run_env, expected);
+
+    symphony::workspace::remove_workspace_for_issue(&ws_path, &config, &hooks, &issue).unwrap();
+    let before_remove_env = fs::read_to_string(before_remove_log).unwrap();
+    assert_eq!(before_remove_env, expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add first-class workspace bootstrap config in `WORKFLOW.md` front matter:
  - `workspace.repo` (URL or local path)
  - `workspace.strategy` (`clone` default, or `worktree`)
  - `workspace.branch_prefix` (default `symphony`)
- implement repository bootstrap in workspace lifecycle:
  - `clone`: `git clone <repo> . --single-branch`, then checkout `<prefix>/<issue-identifier>`
  - `worktree`: `git -C <repo> worktree add <workspace> -b <prefix>/<issue-identifier>`
  - worktree cleanup on removal: `git worktree remove --force`
- inject issue metadata env vars into all lifecycle hooks:
  - `SYMPHONY_ISSUE_ID`
  - `SYMPHONY_ISSUE_IDENTIFIER`
  - `SYMPHONY_ISSUE_TITLE`
  - `SYMPHONY_WORKSPACE_PATH`
- wire orchestrator to use issue-aware workspace/hook APIs
- add tests for config parsing/validation, clone/worktree bootstrap, hook env propagation, and after_create ordering
- update Symphony docs/workflow examples to describe and use the new config

## Testing
- `cd apps/symphony && cargo fmt -- --check`
- `cd apps/symphony && cargo test --test workflow_config_tests --test workspace_prompt_tests`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `cd apps/symphony && cargo test`

## Linear
- KAT-800

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes workspace repository bootstrapping from a manual `after_create` shell hook to a first-class `WorkspaceConfig` concept, adding `workspace.repo`, `workspace.strategy` (`clone`/`worktree`), and `workspace.branch_prefix` fields. It also wires issue metadata (`SYMPHONY_ISSUE_ID`, `SYMPHONY_ISSUE_IDENTIFIER`, `SYMPHONY_ISSUE_TITLE`, `SYMPHONY_WORKSPACE_PATH`) into all lifecycle hooks. The domain, config parsing, validation, orchestrator wiring, and tests are well-structured.

Key concerns found during review:

- **Missing `base_branch` option for clone strategy** — the previous `WORKFLOW.md` `after_create` hook explicitly passed `--branch elixir-feature-parity` to `git clone`. The new bootstrap config provides no equivalent field, so the migrated `WORKFLOW.md` silently switches from `elixir-feature-parity` to the repo's default branch. Agents will operate on the wrong base without any error.
- **Worktree strategy pre-creates the workspace directory before `git worktree add`** — `ensure_workspace_internal` calls `create_dir_all` for *all* strategies before invoking `bootstrap_repository`. `git worktree add` only accepts a pre-existing empty directory as of Git 2.36 (April 2022); on older systems the command rejects the path and bootstrap fails with an opaque error.
- **Git clone failure output may expose embedded credentials** — `run_git_command` captures stderr verbatim and inserts it into a `SymphonyError::Other` message. If `workspace.repo` contains credentials in the URL, those credentials will appear in error logs.
- **`HookIssueContext::from_identifier` is likely dead code** — now that all orchestrator call sites use the `_for_issue` variants, the legacy path (and its `from_identifier` constructor) is only exercised by the public shims, which could be removed or annotated to avoid a future `clippy` warning.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the WORKFLOW.md migration silently changes the cloned base branch, and the worktree strategy will fail on Git < 2.36.
- The PR introduces two correctness issues that can produce silent wrong-branch operation and/or runtime bootstrap failures, plus a credential-exposure risk in error messages.
- apps/symphony/src/workspace.rs (bootstrap_repository clone branch selection, worktree pre-creation, run_git_command error output), apps/symphony/WORKFLOW.md (base branch regression)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/workspace.rs | Core of the PR: adds bootstrap_repository (clone/worktree), cleanup_worktree_checkout, and issue-aware hook variants. Three issues identified: the clone strategy loses the ability to specify a base branch (functional regression from WORKFLOW.md), the worktree strategy creates the workspace directory before calling git worktree add (compatibility breakage on Git < 2.36), and git output is captured verbatim which can leak credentials in error messages. |
| apps/symphony/src/config.rs | Parses and validates the new workspace.repo, workspace.strategy, and workspace.branch_prefix fields. Parsing and validation logic is correct. The repo_is_remote helper duplication (noted in previous thread) is the only structural concern. |
| apps/symphony/src/orchestrator.rs | Migrates all three call sites (ensure_workspace, run_before_run_hook, run_after_run_hook) to the issue-aware variants in both run_worker_task and the Orchestrator impl. No remove_workspace calls found that would need updating. |
| apps/symphony/tests/workflow_config_tests.rs | Adds tests for strategy/prefix parsing, invalid strategy rejection, worktree-without-repo validation, and worktree-with-remote-repo validation. Coverage for the new validation paths looks complete. |
| apps/symphony/tests/workspace_prompt_tests.rs | Integration tests for clone bootstrap, worktree bootstrap+cleanup, and hook env-var propagation. Tests are well structured and use a real git repo. The clone test would pass on the default branch, so the missing base_branch issue won't be caught here. |
| apps/symphony/WORKFLOW.md | Migrates the example WORKFLOW.md from a manual after_create clone hook to first-class workspace bootstrap config. The migration silently drops --branch elixir-feature-parity, changing which base branch agents operate on. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant W as workspace.rs
    participant FS as Filesystem
    participant G as git

    O->>W: ensure_workspace_for_issue(issue, config, hooks)
    W->>FS: canonicalize(root)
    W->>FS: create_dir_all(workspace)
    W->>W: bootstrap_repository(workspace, config, identifier)

    alt strategy == Clone
        W->>G: git clone repo . --single-branch
        G-->>W: ok
        W->>G: git checkout -b prefix/identifier
        G-->>W: ok
    else strategy == Worktree
        W->>G: git -C repo worktree add workspace -b prefix/identifier
        note over W,G: ⚠️ Fails on Git < 2.36 if workspace dir already exists
        G-->>W: ok
    end

    W->>W: run_hook("after_create", command, workspace, issue)
    W-->>O: Workspace { path, created_now: true }

    O->>W: run_before_run_hook_for_issue(workspace, hooks, issue)
    W->>W: run_hook("before_run", ...)

    Note over W: Hook env vars injected:<br/>SYMPHONY_ISSUE_ID<br/>SYMPHONY_ISSUE_IDENTIFIER<br/>SYMPHONY_ISSUE_TITLE<br/>SYMPHONY_WORKSPACE_PATH

    O->>W: run_after_run_hook_for_issue(workspace, hooks, issue)
    W->>W: run_hook("after_run", ...) [failure ignored]

    O->>W: remove_workspace_for_issue(workspace, config, hooks, issue)
    W->>W: run_hook("before_remove", ...) [failure ignored]

    alt strategy == Worktree
        W->>G: git -C repo worktree remove --force workspace
        note over W,G: ⚠️ Failure propagates, blocks remove_dir_all
        G-->>W: ok
    end

    W->>FS: remove_dir_all(workspace)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/src/workspace.rs`, line 96-106 ([link](https://github.com/gannonh/kata/blob/585146503936150780495de91b12a2dfc162ee99/apps/symphony/src/workspace.rs#L96-L106)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Workspace directory created before `git worktree add` is called**

   For the `Worktree` strategy, `create_dir_all` creates the workspace directory on lines 97–98, and then `bootstrap_repository` calls `git worktree add <workspace> -b <branch>` on that already-existing path.

   `git worktree add` only accepts a pre-existing directory as of Git 2.36 (April 2022). On systems with an older Git, the command fails with:
   ```
   fatal: '<path>' already exists
   ```
   This causes `bootstrap_repository` to return an error, which then triggers cleanup (`remove_dir_all`) and a propagated error — a confusing failure mode for users on slightly older systems.

   A safer approach is to remove the pre-created directory before calling `git worktree add` (and let git create it), then only re-create it on failure for consistent cleanup:

   ```rust
   // Don't pre-create for worktree strategy; git creates the directory
   WorkspaceRepoStrategy::Worktree => {
       // remove the empty dir created by ensure_workspace_internal
       let _ = std::fs::remove_dir(&workspace);
       // git worktree add will create it
       run_git_command(worktree_cmd, "workspace worktree bootstrap")
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/workspace.rs
   Line: 96-106

   Comment:
   **Workspace directory created before `git worktree add` is called**

   For the `Worktree` strategy, `create_dir_all` creates the workspace directory on lines 97–98, and then `bootstrap_repository` calls `git worktree add <workspace> -b <branch>` on that already-existing path.

   `git worktree add` only accepts a pre-existing directory as of Git 2.36 (April 2022). On systems with an older Git, the command fails with:
   ```
   fatal: '<path>' already exists
   ```
   This causes `bootstrap_repository` to return an error, which then triggers cleanup (`remove_dir_all`) and a propagated error — a confusing failure mode for users on slightly older systems.

   A safer approach is to remove the pre-created directory before calling `git worktree add` (and let git create it), then only re-create it on failure for consistent cleanup:

   ```rust
   // Don't pre-create for worktree strategy; git creates the directory
   WorkspaceRepoStrategy::Worktree => {
       // remove the empty dir created by ensure_workspace_internal
       let _ = std::fs::remove_dir(&workspace);
       // git worktree add will create it
       run_git_command(worktree_cmd, "workspace worktree bootstrap")
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/workspace.rs
Line: 170-188

Comment:
**Missing `base_branch` config for clone strategy**

The clone bootstrap runs `git clone <repo> . --single-branch` without a `--branch` flag, so it always clones the repository's default branch. The old `WORKFLOW.md` `after_create` hook explicitly specified `--branch elixir-feature-parity`, but the new first-class config provides no equivalent `base_branch` field. The updated `WORKFLOW.md` silently changes which branch the workspace is cloned from (default branch instead of `elixir-feature-parity`), which means agents will operate on the wrong base.

Adding a `base_branch: <name>` field to `WorkspaceConfig` (defaulting to `None` → clone default branch) and threading it through to `git clone ... --branch <base_branch>` would restore this capability. Until then, users who need a non-default base branch are forced back to a manual `after_create` hook that duplicates the bootstrap logic.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/workspace.rs
Line: 96-106

Comment:
**Workspace directory created before `git worktree add` is called**

For the `Worktree` strategy, `create_dir_all` creates the workspace directory on lines 97–98, and then `bootstrap_repository` calls `git worktree add <workspace> -b <branch>` on that already-existing path.

`git worktree add` only accepts a pre-existing directory as of Git 2.36 (April 2022). On systems with an older Git, the command fails with:
```
fatal: '<path>' already exists
```
This causes `bootstrap_repository` to return an error, which then triggers cleanup (`remove_dir_all`) and a propagated error — a confusing failure mode for users on slightly older systems.

A safer approach is to remove the pre-created directory before calling `git worktree add` (and let git create it), then only re-create it on failure for consistent cleanup:

```rust
// Don't pre-create for worktree strategy; git creates the directory
WorkspaceRepoStrategy::Worktree => {
    // remove the empty dir created by ensure_workspace_internal
    let _ = std::fs::remove_dir(&workspace);
    // git worktree add will create it
    run_git_command(worktree_cmd, "workspace worktree bootstrap")
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/workspace.rs
Line: 299-321

Comment:
**`HookIssueContext::from_identifier` is now dead code**

`from_identifier` constructs a context with an empty `issue_id` and `issue_title`. The only non-test call path that reaches `from_issue_or_identifier(None, ...)` is via the legacy `ensure_workspace`, `run_before_run_hook`, `run_after_run_hook`, and `remove_workspace` public functions.

These legacy wrappers were retained for backward compatibility, but the orchestrator now exclusively calls the `_for_issue` variants. If the legacy functions will eventually be removed, `from_identifier` will become truly dead. Marking it `#[allow(dead_code)]` (or removing it and migrating callers) would prevent a latent `cargo clippy` warning from surfacing later.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/workspace.rs
Line: 469-484

Comment:
**Git error output may expose credentials from repo URLs**

When `git clone` fails, Git sometimes echoes the full remote URL — including any embedded credentials — in stderr. The `run_git_command` helper captures stdout+stderr verbatim and inserts them into a `SymphonyError::Other` message that is subsequently logged:

```rust
let combined = format!("{stdout}{stderr}");
let truncated = truncate_output(&combined, 2048);
Err(SymphonyError::Other(format!("{context} failed (status {status}): {truncated}")))
```

If a user configures `workspace.repo` with credentials embedded in the URL (a common pattern for CI tokens), those credentials will appear in error messages and log output. Consider stripping the user-info component from any URL before passing it into the `Command`, or redacting it from the error string before surfacing it to callers.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(symphony): add ..."](https://github.com/gannonh/kata/commit/585146503936150780495de91b12a2dfc162ee99)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->