### PR TITLE
feat(symphony): Elixir feature parity — Phase 1 complete

### DIFF
--- a/.codex/skills/commit/SKILL.md
+++ b/.codex/skills/commit/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: commit
+description:
+  Create a well-formed git commit from current changes using session history for
+  rationale and summary; use when asked to commit, prepare a commit message, or
+  finalize staged work.
+---
+
+# Commit
+
+## Goals
+
+- Produce a commit that reflects the actual code changes and the session
+  context.
+- Follow common git conventions (type prefix, short subject, wrapped body).
+- Include both summary and rationale in the body.
+
+## Inputs
+
+- Codex session history for intent and rationale.
+- `git status`, `git diff`, and `git diff --staged` for actual changes.
+- Repo-specific commit conventions if documented.
+
+## Steps
+
+1. Read session history to identify scope, intent, and rationale.
+2. Inspect the working tree and staged changes (`git status`, `git diff`,
+   `git diff --staged`).
+3. Stage intended changes, including new files (`git add -A`) after confirming
+   scope.
+4. Sanity-check newly added files; if anything looks random or likely ignored
+   (build artifacts, logs, temp files), flag it to the user before committing.
+5. If staging is incomplete or includes unrelated files, fix the index or ask
+   for confirmation.
+6. Choose a conventional type and optional scope that match the change (e.g.,
+   `feat(scope): ...`, `fix(scope): ...`, `refactor(scope): ...`).
+7. Write a subject line in imperative mood, <= 72 characters, no trailing
+   period.
+8. Write a body that includes:
+   - Summary of key changes (what changed).
+   - Rationale and trade-offs (why it changed).
+   - Tests or validation run (or explicit note if not run).
+9. Append a `Co-authored-by` trailer for Codex using `Codex <codex@openai.com>`
+   unless the user explicitly requests a different identity.
+10. Wrap body lines at 72 characters.
+11. Create the commit message with a here-doc or temp file and use
+    `git commit -F <file>` so newlines are literal (avoid `-m` with `\n`).
+12. Commit only when the message matches the staged changes: if the staged diff
+    includes unrelated files or the message describes work that isn't staged,
+    fix the index or revise the message before committing.
+
+## Output
+
+- A single commit created with `git commit` whose message reflects the session.
+
+## Template
+
+Type and scope are examples only; adjust to fit the repo and changes.
+
+```
+<type>(<scope>): <short summary>
+
+Summary:
+- <what changed>
+- <what changed>
+
+Rationale:
+- <why>
+- <why>
+
+Tests:
+- <command or "not run (reason)">
+
+Co-authored-by: Codex <codex@openai.com>
+```

--- a/.codex/skills/land/SKILL.md
+++ b/.codex/skills/land/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: land
+description:
+  Land a PR by monitoring conflicts, resolving them, waiting for checks, and
+  squash-merging when green; use when asked to land, merge, or shepherd a PR to
+  completion.
+---
+
+# Land
+
+## Goals
+
+- Ensure the PR is conflict-free with main.
+- Keep CI green and fix failures when they occur.
+- Squash-merge the PR once checks pass.
+- Do not yield to the user until the PR is merged; keep the watcher loop running
+  unless blocked.
+- No need to delete remote branches after merge; the repo auto-deletes head
+  branches.
+
+## Preconditions
+
+- `gh` CLI is authenticated.
+- You are on the PR branch with a clean working tree.
+
+## Steps
+
+1. Locate the PR for the current branch.
+2. Confirm the full gauntlet is green locally before any push.
+3. If the working tree has uncommitted changes, commit with the `commit` skill
+   and push with the `push` skill before proceeding.
+4. Check mergeability and conflicts against main.
+5. If conflicts exist, use the `pull` skill to fetch/merge `origin/main` and
+   resolve conflicts, then use the `push` skill to publish the updated branch.
+6. Ensure Codex review comments (if present) are acknowledged and any required
+   fixes are handled before merging.
+7. Watch checks until complete.
+8. If checks fail, pull logs, fix the issue, commit with the `commit` skill,
+   push with the `push` skill, and re-run checks.
+9. When all checks are green and review feedback is addressed, squash-merge and
+   delete the branch using the PR title/body for the merge subject/body.
+10. **Context guard:** Before implementing review feedback, confirm it does not
+    conflict with the user’s stated intent or task context. If it conflicts,
+    respond inline with a justification and ask the user before changing code.
+11. **Pushback template:** When disagreeing, reply inline with: acknowledge +
+    rationale + offer alternative.
+12. **Ambiguity gate:** When ambiguity blocks progress, use the clarification
+    flow (assign PR to current GH user, mention them, wait for response). Do not
+    implement until ambiguity is resolved.
+    - If you are confident you know better than the reviewer, you may proceed
+      without asking the user, but reply inline with your rationale.
+13. **Per-comment mode:** For each review comment, choose one of: accept,
+    clarify, or push back. Reply inline (or in the issue thread for Codex
+    reviews) stating the mode before changing code.
+14. **Reply before change:** Always respond with intended action before pushing
+    code changes (inline for review comments, issue thread for Codex reviews).
+
+## Commands
+
+```
+# Ensure branch and PR context
+branch=$(git branch --show-current)
+pr_number=$(gh pr view --json number -q .number)
+pr_title=$(gh pr view --json title -q .title)
+pr_body=$(gh pr view --json body -q .body)
+
+# Check mergeability and conflicts
+mergeable=$(gh pr view --json mergeable -q .mergeable)
+
+if [ "$mergeable" = "CONFLICTING" ]; then
+  # Run the `pull` skill to handle fetch + merge + conflict resolution.
+  # Then run the `push` skill to publish the updated branch.
+fi
+
+# Preferred: use the Async Watch Helper below. The manual loop is a fallback
+# when Python cannot run or the helper script is unavailable.
+# Wait for review feedback: Codex reviews arrive as issue comments that start
+# with "## Codex Review — <persona>". Treat them like reviewer feedback: reply
+# with a `[codex]` issue comment acknowledging the findings and whether you're
+# addressing or deferring them.
+while true; do
+  gh api repos/{owner}/{repo}/issues/"$pr_number"/comments \
+    --jq '.[] | select(.body | startswith("## Codex Review")) | .id' | rg -q '.' \
+    && break
+  sleep 10
+done
+
+# Watch checks
+if ! gh pr checks --watch; then
+  gh pr checks
+  # Identify failing run and inspect logs
+  # gh run list --branch "$branch"
+  # gh run view <run-id> --log
+  exit 1
+fi
+
+# Squash-merge (remote branches auto-delete on merge in this repo)
+gh pr merge --squash --subject "$pr_title" --body "$pr_body"
+```
+
+## Async Watch Helper
+
+Preferred: use the asyncio watcher to monitor review comments, CI, and head
+updates in parallel:
+
+```
+python3 .codex/skills/land/land_watch.py
+```
+
+Exit codes:
+
+- 2: Review comments detected (address feedback)
+- 3: CI checks failed
+- 4: PR head updated (autofix commit detected)
+
+## Failure Handling
+
+- If checks fail, pull details with `gh pr checks` and `gh run view --log`, then
+  fix locally, commit with the `commit` skill, push with the `push` skill, and
+  re-run the watch.
+- Use judgment to identify flaky failures. If a failure is a flake (e.g., a
+  timeout on only one platform), you may proceed without fixing it.
+- If CI pushes an auto-fix commit (authored by GitHub Actions), it does not
+  trigger a fresh CI run. Detect the updated PR head, pull locally, merge
+  `origin/main` if needed, add a real author commit, and force-push to retrigger
+  CI, then restart the checks loop.
+- If all jobs fail with corrupted pnpm lockfile errors on the merge commit, the
+  remediation is to fetch latest `origin/main`, merge, force-push, and rerun CI.
+- If mergeability is `UNKNOWN`, wait and re-check.
+- Do not merge while review comments (human or Codex review) are outstanding.
+- Codex review jobs retry on failure and are non-blocking; use the presence of
+  `## Codex Review — <persona>` issue comments (not job status) as the signal
+  that review feedback is available.
+- Do not enable auto-merge; this repo has no required checks so auto-merge can
+  skip tests.
+- If the remote PR branch advanced due to your own prior force-push or merge,
+  avoid redundant merges; re-run the formatter locally if needed and
+  `git push --force-with-lease`.
+
+## Review Handling
+
+- Codex reviews now arrive as issue comments posted by GitHub Actions. They
+  start with `## Codex Review — <persona>` and include the reviewer’s
+  methodology + guardrails used. Treat these as feedback that must be
+  acknowledged before merge.
+- Human review comments are blocking and must be addressed (responded to and
+  resolved) before requesting a new review or merging.
+- If multiple reviewers comment in the same thread, respond to each comment
+  (batching is fine) before closing the thread.
+- Fetch review comments via `gh api` and reply with a prefixed comment.
+- Use review comment endpoints (not issue comments) to find inline feedback:
+  - List PR review comments:
+    ```
+    gh api repos/{owner}/{repo}/pulls/<pr_number>/comments
+    ```
+  - PR issue comments (top-level discussion):
+    ```
+    gh api repos/{owner}/{repo}/issues/<pr_number>/comments
+    ```
+  - Reply to a specific review comment:
+    ```
+    gh api -X POST /repos/{owner}/{repo}/pulls/<pr_number>/comments \
+      -f body='[codex] <response>' -F in_reply_to=<comment_id>
+    ```
+- `in_reply_to` must be the numeric review comment id (e.g., `2710521800`), not
+  the GraphQL node id (e.g., `PRRC_...`), and the endpoint must include the PR
+  number (`/pulls/<pr_number>/comments`).
+- If GraphQL review reply mutation is forbidden, use REST.
+- A 404 on reply typically means the wrong endpoint (missing PR number) or
+  insufficient scope; verify by listing comments first.
+- All GitHub comments generated by this agent must be prefixed with `[codex]`.
+- For Codex review issue comments, reply in the issue thread (not a review
+  thread) with `[codex]` and state whether you will address the feedback now or
+  defer it (include rationale).
+- If feedback requires changes:
+  - For inline review comments (human), reply with intended fixes
+    (`[codex] ...`) **as an inline reply to the original review comment** using
+    the review comment endpoint and `in_reply_to` (do not use issue comments for
+    this).
+  - Implement fixes, commit, push.
+  - Reply with the fix details and commit sha (`[codex] ...`) in the same place
+    you acknowledged the feedback (issue comment for Codex reviews, inline reply
+    for review comments).
+  - The land watcher treats Codex review issue comments as unresolved until a
+    newer `[codex]` issue comment is posted acknowledging the findings.
+- Only request a new Codex review when you need a rerun (e.g., after new
+  commits). Do not request one without changes since the last review.
+  - Before requesting a new Codex review, re-run the land watcher and ensure
+    there are zero outstanding review comments (all have `[codex]` inline
+    replies).
+  - After pushing new commits, the Codex review workflow will rerun on PR
+    synchronization (or you can re-run the workflow manually). Post a concise
+    root-level summary comment so reviewers have the latest delta:
+    ```
+    [codex] Changes since last review:
+    - <short bullets of deltas>
+    Commits: <sha>, <sha>
+    Tests: <commands run>
+    ```
+  - Only request a new review if there is at least one new commit since the
+    previous request.
+  - Wait for the next Codex review comment before merging.
+
+## Scope + PR Metadata
+
+- The PR title and description should reflect the full scope of the change, not
+  just the most recent fix.
+- If review feedback expands scope, decide whether to include it now or defer
+  it. You can accept, defer, or decline feedback. If deferring or declining,
+  call it out in the root-level `[codex]` update with a brief reason (e.g.,
+  out-of-scope, conflicts with intent, unnecessary).
+- Correctness issues raised in review comments should be addressed. If you plan
+  to defer or decline a correctness concern, validate first and explain why the
+  concern does not apply.
+- Classify each review comment as one of: correctness, design, style,
+  clarification, scope.
+- For correctness feedback, provide concrete validation (test, log, or
+  reasoning) before closing it.
+- When accepting feedback, include a one-line rationale in the root-level
+  update.
+- When declining feedback, offer a brief alternative or follow-up trigger.
+- Prefer a single consolidated "review addressed" root-level comment after a
+  batch of fixes instead of many small updates.
+- For doc feedback, confirm the doc change matches behavior (no doc-only edits
+  to appease review).

--- a/.codex/skills/linear/SKILL.md
+++ b/.codex/skills/linear/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: linear
+description: |
+  Use Symphony's `linear_graphql` client tool for raw Linear GraphQL
+  operations such as comment editing and upload flows.
+---
+
+# Linear GraphQL
+
+Use this skill for raw Linear GraphQL work during Symphony app-server sessions.
+
+## Primary tool
+
+Use the `linear_graphql` client tool exposed by Symphony's app-server session.
+It reuses Symphony's configured Linear auth for the session.
+
+Tool input:
+
+```json
+{
+  "query": "query or mutation document",
+  "variables": {
+    "optional": "graphql variables object"
+  }
+}
+```
+
+Tool behavior:
+
+- Send one GraphQL operation per tool call.
+- Treat a top-level `errors` array as a failed GraphQL operation even if the
+  tool call itself completed.
+- Keep queries/mutations narrowly scoped; ask only for the fields you need.
+
+## Discovering unfamiliar operations
+
+When you need an unfamiliar mutation, input type, or object field, use targeted
+introspection through `linear_graphql`.
+
+List mutation names:
+
+```graphql
+query ListMutations {
+  __type(name: "Mutation") {
+    fields {
+      name
+    }
+  }
+}
+```
+
+Inspect a specific input object:
+
+```graphql
+query CommentCreateInputShape {
+  __type(name: "CommentCreateInput") {
+    inputFields {
+      name
+      type {
+        kind
+        name
+        ofType {
+          kind
+          name
+        }
+      }
+    }
+  }
+}
+```
+
+## Common workflows
+
+### Query an issue by key, identifier, or id
+
+Use these progressively:
+
+- Start with `issue(id: $key)` when you have a ticket key such as `MT-686`.
+- Fall back to `issues(filter: ...)` when you need identifier search semantics.
+- Once you have the internal issue id, prefer `issue(id: $id)` for narrower reads.
+
+Lookup by issue key:
+
+```graphql
+query IssueByKey($key: String!) {
+  issue(id: $key) {
+    id
+    identifier
+    title
+    state {
+      id
+      name
+      type
+    }
+    project {
+      id
+      name
+    }
+    branchName
+    url
+    description
+    updatedAt
+    links {
+      nodes {
+        id
+        url
+        title
+      }
+    }
+  }
+}
+```
+
+Lookup by identifier filter:
+
+```graphql
+query IssueByIdentifier($identifier: String!) {
+  issues(filter: { identifier: { eq: $identifier } }, first: 1) {
+    nodes {
+      id
+      identifier
+      title
+      state {
+        id
+        name
+        type
+      }
+      project {
+        id
+        name
+      }
+      branchName
+      url
+      description
+      updatedAt
+    }
+  }
+}
+```
+
+Resolve a key to an internal id:
+
+```graphql
+query IssueByIdOrKey($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+  }
+}
+```
+
+Read the issue once the internal id is known:
+
+```graphql
+query IssueDetails($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+    url
+    description
+    state {
+      id
+      name
+      type
+    }
+    project {
+      id
+      name
+    }
+    attachments {
+      nodes {
+        id
+        title
+        url
+        sourceType
+      }
+    }
+  }
+}
+```
+
+### Query team workflow states for an issue
+
+Use this before changing issue state when you need the exact `stateId`:
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    id
+    team {
+      id
+      key
+      name
+      states {
+        nodes {
+          id
+          name
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+### Edit an existing comment
+
+Use `commentUpdate` through `linear_graphql`:
+
+```graphql
+mutation UpdateComment($id: String!, $body: String!) {
+  commentUpdate(id: $id, input: { body: $body }) {
+    success
+    comment {
+      id
+      body
+    }
+  }
+}
+```
+
+### Create a comment
+
+Use `commentCreate` through `linear_graphql`:
+
+```graphql
+mutation CreateComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment {
+      id
+      url
+    }
+  }
+}
+```
+
+### Move an issue to a different state
+
+Use `issueUpdate` with the destination `stateId`:
+
+```graphql
+mutation MoveIssueToState($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue {
+      id
+      identifier
+      state {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
+### Attach a GitHub PR to an issue
+
+Use the GitHub-specific attachment mutation when linking a PR:
+
+```graphql
+mutation AttachGitHubPR($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkGitHubPR(
+    issueId: $issueId
+    url: $url
+    title: $title
+    linkKind: links
+  ) {
+    success
+    attachment {
+      id
+      title
+      url
+    }
+  }
+}
+```
+
+If you only need a plain URL attachment and do not care about GitHub-specific
+link metadata, use:
+
+```graphql
+mutation AttachURL($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
+    success
+    attachment {
+      id
+      title
+      url
+    }
+  }
+}
+```
+
+### Introspection patterns used during schema discovery
+
+Use these when the exact field or mutation shape is unclear:
+
+```graphql
+query QueryFields {
+  __type(name: "Query") {
+    fields {
+      name
+    }
+  }
+}
+```
+
+```graphql
+query IssueFieldArgs {
+  __type(name: "Query") {
+    fields {
+      name
+      args {
+        name
+        type {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Upload a video to a comment
+
+Do this in three steps:
+
+1. Call `linear_graphql` with `fileUpload` to get `uploadUrl`, `assetUrl`, and
+   any required upload headers.
+2. Upload the local file bytes to `uploadUrl` with `curl -X PUT` and the exact
+   headers returned by `fileUpload`.
+3. Call `linear_graphql` again with `commentCreate` (or `commentUpdate`) and
+   include the resulting `assetUrl` in the comment body.
+
+Useful mutations:
+
+```graphql
+mutation FileUpload(
+  $filename: String!
+  $contentType: String!
+  $size: Int!
+  $makePublic: Boolean
+) {
+  fileUpload(
+    filename: $filename
+    contentType: $contentType
+    size: $size
+    makePublic: $makePublic
+  ) {
+    success
+    uploadFile {
+      uploadUrl
+      assetUrl
+      headers {
+        key
+        value
+      }
+    }
+  }
+}
+```
+
+## Usage rules
+
+- Use `linear_graphql` for comment edits, uploads, and ad-hoc Linear API
+  queries.
+- Prefer the narrowest issue lookup that matches what you already know:
+  key -> identifier search -> internal id.
+- For state transitions, fetch team states first and use the exact `stateId`
+  instead of hardcoding names inside mutations.
+- Prefer `attachmentLinkGitHubPR` over a generic URL attachment when linking a
+  GitHub PR to a Linear issue.
+- Do not introduce new raw-token shell helpers for GraphQL access.
+- If you need shell work for uploads, only use it for signed upload URLs
+  returned by `fileUpload`; those URLs already carry the needed authorization.

--- a/.codex/skills/pull/SKILL.md
+++ b/.codex/skills/pull/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: pull
+description:
+  Pull latest origin/main into the current local branch and resolve merge
+  conflicts (aka update-branch). Use when Codex needs to sync a feature branch
+  with origin, perform a merge-based update (not rebase), and guide conflict
+  resolution best practices.
+---
+
+# Pull
+
+## Workflow
+
+1. Verify git status is clean or commit/stash changes before merging.
+2. Ensure rerere is enabled locally:
+   - `git config rerere.enabled true`
+   - `git config rerere.autoupdate true`
+3. Confirm remotes and branches:
+   - Ensure the `origin` remote exists.
+   - Ensure the current branch is the one to receive the merge.
+4. Fetch latest refs:
+   - `git fetch origin`
+5. Sync the remote feature branch first:
+   - `git pull --ff-only origin $(git branch --show-current)`
+   - This pulls branch updates made remotely (for example, a GitHub auto-commit)
+     before merging `origin/main`.
+6. Merge in order:
+   - Prefer `git -c merge.conflictstyle=zdiff3 merge origin/main` for clearer
+     conflict context.
+7. If conflicts appear, resolve them (see conflict guidance below), then:
+   - `git add <files>`
+   - `git commit` (or `git merge --continue` if the merge is paused)
+8. Verify with project checks (follow repo policy in `AGENTS.md`).
+9. Summarize the merge:
+   - Call out the most challenging conflicts/files and how they were resolved.
+   - Note any assumptions or follow-ups.
+
+## Conflict Resolution Guidance (Best Practices)
+
+- Inspect context before editing:
+  - Use `git status` to list conflicted files.
+  - Use `git diff` or `git diff --merge` to see conflict hunks.
+  - Use `git diff :1:path/to/file :2:path/to/file` and
+    `git diff :1:path/to/file :3:path/to/file` to compare base vs ours/theirs
+    for a file-level view of intent.
+  - With `merge.conflictstyle=zdiff3`, conflict markers include:
+    - `<<<<<<<` ours, `|||||||` base, `=======` split, `>>>>>>>` theirs.
+    - Matching lines near the start/end are trimmed out of the conflict region,
+      so focus on the differing core.
+  - Summarize the intent of both changes, decide the semantically correct
+    outcome, then edit:
+    - State what each side is trying to achieve (bug fix, refactor, rename,
+      behavior change).
+    - Identify the shared goal, if any, and whether one side supersedes the
+      other.
+    - Decide the final behavior first; only then craft the code to match that
+      decision.
+    - Prefer preserving invariants, API contracts, and user-visible behavior
+      unless the conflict clearly indicates a deliberate change.
+  - Open files and understand intent on both sides before choosing a resolution.
+- Prefer minimal, intention-preserving edits:
+  - Keep behavior consistent with the branch’s purpose.
+  - Avoid accidental deletions or silent behavior changes.
+- Resolve one file at a time and rerun tests after each logical batch.
+- Use `ours/theirs` only when you are certain one side should win entirely.
+- For complex conflicts, search for related files or definitions to align with
+  the rest of the codebase.
+- For generated files, resolve non-generated conflicts first, then regenerate:
+  - Prefer resolving source files and handwritten logic before touching
+    generated artifacts.
+  - Run the CLI/tooling command that produced the generated file to recreate it
+    cleanly, then stage the regenerated output.
+- For import conflicts where intent is unclear, accept both sides first:
+  - Keep all candidate imports temporarily, finish the merge, then run lint/type
+    checks to remove unused or incorrect imports safely.
+- After resolving, ensure no conflict markers remain:
+  - `git diff --check`
+- When unsure, note assumptions and ask for confirmation before finalizing the
+  merge.
+
+## When To Ask The User (Keep To A Minimum)
+
+Do not ask for input unless there is no safe, reversible alternative. Prefer
+making a best-effort decision, documenting the rationale, and proceeding.
+
+Ask the user only when:
+
+- The correct resolution depends on product intent or behavior not inferable
+  from code, tests, or nearby documentation.
+- The conflict crosses a user-visible contract, API surface, or migration where
+  choosing incorrectly could break external consumers.
+- A conflict requires selecting between two mutually exclusive designs with
+  equivalent technical merit and no clear local signal.
+- The merge introduces data loss, schema changes, or irreversible side effects
+  without an obvious safe default.
+- The branch is not the intended target, or the remote/branch names do not exist
+  and cannot be determined locally.
+
+Otherwise, proceed with the merge, explain the decision briefly in notes, and
+leave a clear, reviewable commit history.

--- a/.codex/skills/push/SKILL.md
+++ b/.codex/skills/push/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: push
+description:
+  Push current branch changes to origin and create or update the corresponding
+  pull request; use when asked to push, publish updates, or create pull request.
+---
+
+# Push
+
+## Prerequisites
+
+- `gh` CLI is installed and available in `PATH`.
+- `gh auth status` succeeds for GitHub operations in this repo.
+
+## Goals
+
+- Push current branch changes to `origin` safely.
+- Create a PR if none exists for the branch, otherwise update the existing PR.
+- Keep branch history clean when remote has moved.
+
+## Related Skills
+
+- `pull`: use this when push is rejected or sync is not clean (non-fast-forward,
+  merge conflict risk, or stale branch).
+
+## Steps
+
+1. Identify current branch and confirm remote state.
+2. Run local validation (`cd apps/symphony && cargo test && cargo clippy -- -D warnings`) before pushing.
+3. Push branch to `origin` with upstream tracking if needed, using whatever
+   remote URL is already configured.
+4. If push is not clean/rejected:
+   - If the failure is a non-fast-forward or sync problem, run the `pull`
+     skill to merge `origin/main`, resolve conflicts, and rerun validation.
+   - Push again; use `--force-with-lease` only when history was rewritten.
+   - If the failure is due to auth, permissions, or workflow restrictions on
+     the configured remote, stop and surface the exact error instead of
+     rewriting remotes or switching protocols as a workaround.
+
+5. Ensure a PR exists for the branch:
+   - If no PR exists, create one.
+   - If a PR exists and is open, update it.
+   - If branch is tied to a closed/merged PR, create a new branch + PR.
+   - Write a proper PR title that clearly describes the change outcome
+   - For branch updates, explicitly reconsider whether current PR title still
+     matches the latest scope; update it if it no longer does.
+6. Write/update PR body explicitly using `.github/pull_request_template.md`:
+   - Fill every section with concrete content for this change.
+   - Replace all placeholder comments (`<!-- ... -->`).
+   - Keep bullets/checkboxes where template expects them.
+   - If PR already exists, refresh body content so it reflects the total PR
+     scope (all intended work on the branch), not just the newest commits,
+     including newly added work, removed work, or changed approach.
+   - Do not reuse stale description text from earlier iterations.
+8. Reply with the PR URL from `gh pr view`.
+
+## Commands
+
+```sh
+# Identify branch
+branch=$(git branch --show-current)
+
+# Minimal validation gate
+cd apps/symphony && cargo test && cargo clippy -- -D warnings
+
+# Initial push: respect the current origin remote.
+git push -u origin HEAD
+
+# If that failed because the remote moved, use the pull skill. After
+# pull-skill resolution and re-validation, retry the normal push:
+git push -u origin HEAD
+
+# If the configured remote rejects the push for auth, permissions, or workflow
+# restrictions, stop and surface the exact error.
+
+# Only if history was rewritten locally:
+git push --force-with-lease origin HEAD
+
+# Ensure a PR exists (create only if missing)
+pr_state=$(gh pr view --json state -q .state 2>/dev/null || true)
+if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
+  echo "Current branch is tied to a closed PR; create a new branch + PR." >&2
+  exit 1
+fi
+
+# Write a clear, human-friendly title that summarizes the shipped change.
+pr_title="<clear PR title written for this change>"
+if [ -z "$pr_state" ]; then
+  gh pr create --title "$pr_title"
+else
+  # Reconsider title on every branch update; edit if scope shifted.
+  gh pr edit --title "$pr_title"
+fi
+
+# Write/edit PR body to match .github/pull_request_template.md before validation.
+# Example workflow:
+# 1) open the template and draft body content for this PR
+# 2) gh pr edit --body-file /tmp/pr_body.md
+# 3) for branch updates, re-check that title/body still match current diff
+
+tmp_pr_body=$(mktemp)
+gh pr view --json body -q .body > "$tmp_pr_body"
+rm -f "$tmp_pr_body"
+
+# Show PR URL for the reply
+gh pr view --json url -q .url
+```
+
+## Notes
+
+- Do not use `--force`; only use `--force-with-lease` as the last resort.
+- Distinguish sync problems from remote auth/permission problems:
+  - Use the `pull` skill for non-fast-forward or stale-branch issues.
+  - Surface auth, permissions, or workflow restrictions directly instead of
+    changing remotes or protocols.

--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -88,9 +88,12 @@ Everything outside the front-matter is ignored by Symphony.
 
 #### `workspace` section
 
-| Field            | Type   | Default                       | Description                                                                  |
-| ---------------- | ------ | ----------------------------- | ---------------------------------------------------------------------------- |
-| `workspace.root` | string | `$TMPDIR/symphony_workspaces` | Root directory for per-issue agent workspaces. Supports `~` tilde expansion. |
+| Field                     | Type   | Default                       | Description                                                                                                      |
+| ------------------------- | ------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `workspace.root`          | string | `$TMPDIR/symphony_workspaces` | Root directory for per-issue agent workspaces. Supports `~` tilde expansion.                                     |
+| `workspace.repo`          | string | _(none)_                      | Repository URL or local path to bootstrap into each newly-created workspace.                                     |
+| `workspace.strategy`      | string | `"clone"`                     | Bootstrap strategy: `"clone"` (default) or `"worktree"`. `worktree` requires `workspace.repo` to be local path. |
+| `workspace.branch_prefix` | string | `"symphony"`                  | Branch prefix used for auto-created issue branches (`<prefix>/<issue-identifier>`).                             |
 
 #### `agent` section
 
@@ -123,6 +126,10 @@ Everything outside the front-matter is ignored by Symphony.
 | `hooks.before_remove` | string | _(none)_ | Shell command run before the workspace is removed.                   |
 | `hooks.timeout_ms`    | u64    | `60000`  | Timeout for each hook invocation (ms).                               |
 
+All hooks receive these environment variables:
+`SYMPHONY_ISSUE_ID`, `SYMPHONY_ISSUE_IDENTIFIER`, `SYMPHONY_ISSUE_TITLE`,
+`SYMPHONY_WORKSPACE_PATH`.
+
 #### `worker` section (SSH)
 
 | Field                                   | Type     | Default  | Description                                                                                                               |
@@ -148,6 +155,9 @@ tracker:
 
 workspace:
   root: ~/symphony_workspaces
+  repo: https://github.com/example/project.git
+  strategy: clone
+  branch_prefix: symphony
 
 codex:
   command: codex app-server
@@ -179,6 +189,9 @@ polling:
 
 workspace:
   root: ~/workspaces/symphony
+  repo: /Users/alice/code/kata
+  strategy: worktree
+  branch_prefix: symphony
 
 agent:
   max_concurrent_agents: 5
@@ -194,7 +207,7 @@ codex:
   stall_timeout_ms: 600000
 
 hooks:
-  before_run: echo "Starting session for $ISSUE_ID"
+  before_run: echo "Starting session for $SYMPHONY_ISSUE_IDENTIFIER"
   after_run: notify-send "Session complete"
   timeout_ms: 30000
 
@@ -223,6 +236,17 @@ server:
 | `RUST_LOG`            | Log filter directives for `tracing_subscriber`. Examples: `info`, `debug`, `symphony=trace`. Default: `info`.                                                        |
 | `HOME`                | Used for tilde (`~`) expansion in `workspace.root`.                                                                                                                  |
 | `SYMPHONY_SSH_CONFIG` | Path to a custom SSH config file. When set, Symphony passes `-F <path>` to every `ssh` invocation. Useful for custom host keys, ProxyJump, or IdentityFile settings. |
+
+### Hook Environment Variables
+
+The following variables are injected for every lifecycle hook invocation:
+
+| Variable                      | Description                                   |
+| ----------------------------- | --------------------------------------------- |
+| `SYMPHONY_ISSUE_ID`           | Linear issue UUID.                            |
+| `SYMPHONY_ISSUE_IDENTIFIER`   | Human-readable issue identifier (for example, `KAT-800`). |
+| `SYMPHONY_ISSUE_TITLE`        | Linear issue title.                           |
+| `SYMPHONY_WORKSPACE_PATH`     | Absolute path to the workspace directory.     |
 
 ### `$VAR` Indirection Pattern
 

--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -94,6 +94,7 @@ Everything outside the front-matter is ignored by Symphony.
 | `workspace.repo`          | string | _(none)_                      | Repository URL or local path to bootstrap into each newly-created workspace.                                     |
 | `workspace.strategy`      | string | `"clone"`                     | Bootstrap strategy: `"clone"` (default) or `"worktree"`. `worktree` requires `workspace.repo` to be local path. |
 | `workspace.branch_prefix` | string | `"symphony"`                  | Branch prefix used for auto-created issue branches (`<prefix>/<issue-identifier>`).                             |
+| `workspace.clone_branch`  | string | _(none)_                      | Optional branch name to clone for `workspace.strategy: clone`. When set, Symphony runs clone bootstrap with `--branch <clone_branch>`. |
 
 #### `agent` section
 
@@ -158,6 +159,7 @@ workspace:
   repo: https://github.com/example/project.git
   strategy: clone
   branch_prefix: symphony
+  clone_branch: elixir-feature-parity
 
 codex:
   command: codex app-server

--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -367,6 +367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1900,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "dotenvy",
  "liquid",
  "liquid-core",
  "mockito",

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -50,6 +50,7 @@ clap = { version = "4", features = ["derive"] }
 
 # Regex for sanitization
 regex = "1"
+dotenvy = "0.15.7"
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -28,6 +28,7 @@ agent:
   max_turns: 20
 codex:
   command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
+  stall_timeout_ms: 900000
   approval_policy: never
   thread_sandbox: danger-full-access
   turn_sandbox_policy:

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -2,86 +2,337 @@
 tracker:
   kind: linear
   api_key: $LINEAR_API_KEY
-  project_slug: 89d4761fddf0
+  project_slug: "89d4761fddf0"
   active_states:
-    - "In Progress"
-    - "Todo"
+    - Todo
+    - In Progress
+    - Merging
+    - Rework
   terminal_states:
-    - "Done"
-    - "Cancelled"
-    - "Canceled"
-    - "Duplicate"
-
+    - Closed
+    - Cancelled
+    - Canceled
+    - Duplicate
+    - Done
 polling:
   interval_ms: 30000
-
 workspace:
   root: ~/symphony-workspaces
-
+hooks:
+  after_create: |
+    git clone /Volumes/EVO/kata/kata-mono . --single-branch --branch elixir-feature-parity
+    git checkout -b symphony/$(basename $PWD)
+  timeout_ms: 120000
 agent:
   max_concurrent_agents: 1
-  max_turns: 25
-  max_retry_backoff_ms: 120000
-
+  max_turns: 20
 codex:
-  command: ["codex", "app-server"]
-  approval_policy: "never"
-  turn_timeout_ms: 3600000
-  stall_timeout_ms: 300000
-
-hooks:
-  after_create: "git clone /Volumes/EVO/kata/kata-mono . --single-branch --branch elixir-feature-parity && git checkout -b symphony/$(basename $PWD)"
-  timeout_ms: 120000
-
+  command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
 server:
   port: 8080
   host: "127.0.0.1"
 ---
 
-You are working on a Linear issue for the Symphony project (a Rust orchestrator in the kata-mono monorepo).
-
-**Issue:** {{ issue.identifier }} — {{ issue.title }}
-
-**Description:**
-{{ issue.description }}
-
-{% if issue.labels != empty %}
-**Labels:** {{ issue.labels | join: ", " }}
-{% endif %}
-
-{% if issue.blocked_by != empty %}
-**Blocked by:**
-{% for blocker in issue.blocked_by %}
-- {{ blocker.identifier }}: {{ blocker.title }}
-{% endfor %}
-{% endif %}
+You are working on a Linear ticket `{{ issue.identifier }}`
 
 {% if attempt %}
-{% if attempt.number > 1 %}
-**Retry attempt {{ attempt.number }}.**
-{% if attempt.prior_error %}
-Previous attempt failed with: {{ attempt.prior_error }}
-Take a different approach.
+Continuation context:
+
+- This is retry attempt #{{ attempt }} because the ticket is still in an active state.
+- Resume from the current workspace state instead of restarting from scratch.
+- Do not repeat already-completed investigation or validation unless needed for new code changes.
+- Do not end the turn while the issue remains in an active state unless you are blocked by missing required permissions/secrets.
+  {% endif %}
+
+Issue context:
+Identifier: {{ issue.identifier }}
+Title: {{ issue.title }}
+Current status: {{ issue.state }}
+Labels: {{ issue.labels }}
+URL: {{ issue.url }}
+
+Description:
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+No description provided.
 {% endif %}
-{% endif %}
-{% endif %}
 
----
+Instructions:
 
-## Your environment
+1. This is an unattended orchestration session. Never ask a human to perform follow-up actions.
+2. Only stop early for a true blocker (missing required auth/permissions/secrets). If blocked, record it in the workpad and move the issue according to workflow.
+3. Final message must report completed actions and blockers only. Do not include "next steps for user".
 
-You are in a git clone of the kata-mono monorepo. The Symphony crate is at `apps/symphony/`.
+Work only in the provided repository copy. Do not touch any other path.
 
-You are on branch `symphony/{{ issue.identifier }}`.
+## Repository context
 
-## Instructions
+This is the **kata-mono** monorepo. The Symphony crate lives at `apps/symphony/`.
 
-1. Read the issue description carefully.
-2. Work in `apps/symphony/` unless the issue requires changes elsewhere.
-3. Make your changes. Write tests where appropriate.
-4. Run `cargo test` from `apps/symphony/` to verify.
-5. Run `cargo clippy -- -D warnings` to check for lint issues.
-6. Commit your changes with a descriptive message: `feat(symphony): <what you did> ({{ issue.identifier }})`.
-7. Push your branch: `git push -u origin symphony/{{ issue.identifier }}`.
+- Build: `cd apps/symphony && cargo build`
+- Test: `cd apps/symphony && cargo test`
+- Lint: `cd apps/symphony && cargo clippy -- -D warnings`
+- Format: `cd apps/symphony && cargo fmt`
 
-When done, summarize what you changed and why.
+Read `apps/symphony/AGENTS.md` for full architecture reference.
+
+## Prerequisite: Linear MCP or `linear_graphql` tool is available
+
+The agent should be able to talk to Linear, either via a configured Linear MCP server or injected `linear_graphql` tool. If none are present, stop and ask the user to configure Linear.
+
+## Default posture
+
+- Start by determining the ticket's current status, then follow the matching flow for that status.
+- Start every task by opening the tracking workpad comment and bringing it up to date before doing new implementation work.
+- Spend extra effort up front on planning and verification design before implementation.
+- Reproduce first: always confirm the current behavior/issue signal before changing code so the fix target is explicit.
+- Keep ticket metadata current (state, checklist, acceptance criteria, links).
+- Treat a single persistent Linear comment as the source of truth for progress.
+- Use that single workpad comment for all progress and handoff notes; do not post separate "done"/summary comments.
+- Treat any ticket-authored `Validation`, `Test Plan`, or `Testing` section as non-negotiable acceptance input: mirror it in the workpad and execute it before considering the work complete.
+- When meaningful out-of-scope improvements are discovered during execution,
+  file a separate Linear issue instead of expanding scope. The follow-up issue
+  must include a clear title, description, and acceptance criteria, be placed in
+  `Backlog`, be assigned to the same project as the current issue, link the
+  current issue as `related`, and use `blockedBy` when the follow-up depends on
+  the current issue.
+- Move status only when the matching quality bar is met.
+- Operate autonomously end-to-end unless blocked by missing requirements, secrets, or permissions.
+- Use the blocked-access escape hatch only for true external blockers (missing required tools/auth) after exhausting documented fallbacks.
+
+## Related skills
+
+- `linear`: interact with Linear.
+- `commit`: produce clean, logical commits during implementation.
+- `push`: keep remote branch current and publish updates.
+- `pull`: keep branch updated with latest `origin/main` before handoff.
+- `land`: when ticket reaches `Merging`, explicitly open and follow `.codex/skills/land/SKILL.md`, which includes the `land` loop.
+
+## Status map
+
+- `Backlog` -> out of scope for this workflow; do not modify.
+- `Todo` -> queued; the orchestrator moves this to `In Progress` on dispatch. Verify state is `In Progress` before active work.
+  - Special case: if a PR is already attached, treat as feedback/rework loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `Human Review`).
+- `In Progress` -> implementation actively underway.
+- `Human Review` -> PR is attached and validated; waiting on human approval.
+- `Merging` -> approved by human; execute the `land` skill flow (do not call `gh pr merge` directly).
+- `Rework` -> reviewer requested changes; planning + implementation required.
+- `Done` -> terminal state; no further action required.
+
+## Step 0: Determine current ticket state and route
+
+1. Fetch the issue by explicit ticket ID.
+2. Read the current state.
+3. Route to the matching flow:
+   - `Backlog` -> do not modify issue content/state; stop and wait for human to move it to `Todo`.
+   - `Todo` -> orchestrator already moved to `In Progress`; verify state, then ensure bootstrap workpad comment exists (create if missing), then start execution flow.
+     - If PR is already attached, start by reviewing all open PR comments and deciding required changes vs explicit pushback responses.
+   - `In Progress` -> continue execution flow from current scratchpad comment.
+   - `Human Review` -> wait and poll for decision/review updates.
+   - `Merging` -> on entry, open and follow `.codex/skills/land/SKILL.md`; do not call `gh pr merge` directly.
+   - `Rework` -> run rework flow.
+   - `Done` -> do nothing and shut down.
+4. Check whether a PR already exists for the current branch and whether it is closed.
+   - If a branch PR exists and is `CLOSED` or `MERGED`, treat prior branch work as non-reusable for this run.
+   - Create a fresh branch from `origin/main` and restart execution flow as a new attempt.
+5. For `Todo` tickets, do startup sequencing in this exact order:
+   - verify issue is in `In Progress` (orchestrator handles this on dispatch)
+   - find/create `## Codex Workpad` bootstrap comment
+   - only then begin analysis/planning/implementation work.
+6. Add a short comment if state and issue content are inconsistent, then proceed with the safest flow.
+
+## Step 1: Start/continue execution (Todo or In Progress)
+
+1.  Find or create a single persistent scratchpad comment for the issue:
+    - Search existing comments for a marker header: `## Codex Workpad`.
+    - Ignore resolved comments while searching; only active/unresolved comments are eligible to be reused as the live workpad.
+    - If found, reuse that comment; do not create a new workpad comment.
+    - If not found, create one workpad comment and use it for all updates.
+    - Persist the workpad comment ID and only write progress updates to that ID.
+2.  If arriving from `Todo`, do not delay on additional status transitions: the issue should already be `In Progress` before this step begins.
+3.  Immediately reconcile the workpad before new edits:
+    - Check off items that are already done.
+    - Expand/fix the plan so it is comprehensive for current scope.
+    - Ensure `Acceptance Criteria` and `Validation` are current and still make sense for the task.
+4.  Start work by writing/updating a hierarchical plan in the workpad comment.
+5.  Ensure the workpad includes a compact environment stamp at the top as a code fence line:
+    - Format: `<host>:<abs-workdir>@<short-sha>`
+    - Example: `devbox-01:/home/dev-user/code/symphony-workspaces/MT-32@7bdde33bc`
+    - Do not include metadata already inferable from Linear issue fields (`issue ID`, `status`, `branch`, `PR link`).
+6.  Add explicit acceptance criteria and TODOs in checklist form in the same comment.
+    - If changes are user-facing, include a UI walkthrough acceptance criterion that describes the end-to-end user path to validate.
+    - If changes touch app files or app behavior, add explicit app-specific flow checks to `Acceptance Criteria` in the workpad (for example: launch path, changed interaction path, and expected result path).
+    - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
+7.  Run a principal-style self-review of the plan and refine it in the comment.
+8.  Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
+9.  Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
+    - Include a `pull skill evidence` note with:
+      - merge source(s),
+      - result (`clean` or `conflicts resolved`),
+      - resulting `HEAD` short SHA.
+10. Compact context and proceed to execution.
+
+## PR feedback sweep protocol (required)
+
+When a ticket has an attached PR, run this protocol before moving to `Human Review`:
+
+1. Identify the PR number from issue links/attachments.
+2. Gather feedback from all channels:
+   - Top-level PR comments (`gh pr view --comments`).
+   - Inline review comments (`gh api repos/<owner>/<repo>/pulls/<pr>/comments`).
+   - Review summaries/states (`gh pr view --json reviews`).
+3. Treat every actionable reviewer comment (human or bot), including inline review comments, as blocking until one of these is true:
+   - code/test/docs updated to address it, or
+   - explicit, justified pushback reply is posted on that thread.
+4. Update the workpad plan/checklist to include each feedback item and its resolution status.
+5. Re-run validation after feedback-driven changes and push updates.
+6. Repeat this sweep until there are no outstanding actionable comments.
+
+## Blocked-access escape hatch (required behavior)
+
+Use this only when completion is blocked by missing required tools or missing auth/permissions that cannot be resolved in-session.
+
+- GitHub is **not** a valid blocker by default. Always try fallback strategies first (alternate remote/auth mode, then continue publish/review flow).
+- Do not move to `Human Review` for GitHub access/auth until all fallback strategies have been attempted and documented in the workpad.
+- If a non-GitHub required tool is missing, or required non-GitHub auth is unavailable, move the ticket to `Human Review` with a short blocker brief in the workpad that includes:
+  - what is missing,
+  - why it blocks required acceptance/validation,
+  - exact human action needed to unblock.
+- Keep the brief concise and action-oriented; do not add extra top-level comments outside the workpad.
+
+## Step 2: Execution phase (Todo -> In Progress -> Human Review)
+
+1.  Determine current repo state (`branch`, `git status`, `HEAD`) and verify the kickoff `pull` sync result is already recorded in the workpad before implementation continues.
+2.  Verify current issue state is `In Progress` (orchestrator moves from `Todo` on dispatch).
+3.  Load the existing workpad comment and treat it as the active execution checklist.
+    - Edit it liberally whenever reality changes (scope, risks, validation approach, discovered tasks).
+4.  Implement against the hierarchical TODOs and keep the comment current:
+    - Check off completed items.
+    - Add newly discovered items in the appropriate section.
+    - Keep parent/child structure intact as scope evolves.
+    - Update the workpad immediately after each meaningful milestone (for example: reproduction complete, code change landed, validation run, review feedback addressed).
+    - Never leave completed work unchecked in the plan.
+    - For tickets that started as `Todo` with an attached PR, run the full PR feedback sweep protocol immediately after kickoff and before new feature work.
+5.  Run validation/tests required for the scope.
+    - Mandatory gate: execute all ticket-provided `Validation`/`Test Plan`/ `Testing` requirements when present; treat unmet items as incomplete work.
+    - Prefer a targeted proof that directly demonstrates the behavior you changed.
+    - You may make temporary local proof edits to validate assumptions (for example: tweak a local build input for `make`, or hardcode a UI account / response path) when this increases confidence.
+    - Revert every temporary proof edit before commit/push.
+    - Document these temporary proof steps and outcomes in the workpad `Validation`/`Notes` sections so reviewers can follow the evidence.
+    - If app-touching, run `launch-app` validation and capture/upload media via `github-pr-media` before handoff.
+6.  Re-check all acceptance criteria and close any gaps.
+7.  Before every `git push` attempt, run the required validation for your scope and confirm it passes; if it fails, address issues and rerun until green, then commit and push changes.
+8.  Attach PR URL to the issue (prefer attachment; use the workpad comment only if attachment is unavailable).
+    - Ensure the GitHub PR has label `symphony` (add it if missing).
+9.  Merge latest `origin/main` into branch, resolve conflicts, and rerun checks.
+10. Update the workpad comment with final checklist status and validation notes.
+    - Mark completed plan/acceptance/validation checklist items as checked.
+    - Add final handoff notes (commit + validation summary) in the same workpad comment.
+    - Do not include PR URL in the workpad comment; keep PR linkage on the issue via attachment/link fields.
+    - Add a short `### Confusions` section at the bottom when any part of task execution was unclear/confusing, with concise bullets.
+    - Do not post any additional completion summary comment.
+11. Before moving to `Human Review`, poll PR feedback and checks:
+    - Read the PR `Manual QA Plan` comment (when present) and use it to sharpen UI/runtime test coverage for the current change.
+    - Run the full PR feedback sweep protocol.
+    - Confirm PR checks are passing (green) after the latest changes.
+    - Confirm every required ticket-provided validation/test-plan item is explicitly marked complete in the workpad.
+    - Repeat this check-address-verify loop until no outstanding comments remain and checks are fully passing.
+    - Re-open and refresh the workpad before state transition so `Plan`, `Acceptance Criteria`, and `Validation` exactly match completed work.
+12. Only then move issue to `Human Review`.
+    - Exception: if blocked by missing required non-GitHub tools/auth per the blocked-access escape hatch, move to `Human Review` with the blocker brief and explicit unblock actions.
+13. For `Todo` tickets that already had a PR attached at kickoff:
+    - Ensure all existing PR feedback was reviewed and resolved, including inline review comments (code changes or explicit, justified pushback response).
+    - Ensure branch was pushed with any required updates.
+    - Then move to `Human Review`.
+
+## Step 3: Human Review and merge handling
+
+1. When the issue is in `Human Review`, do not code or change ticket content.
+2. Poll for updates as needed, including GitHub PR review comments from humans and bots.
+3. If review feedback requires changes, move the issue to `Rework` and follow the rework flow.
+4. If approved, human moves the issue to `Merging`.
+5. When the issue is in `Merging`, open and follow `.codex/skills/land/SKILL.md`, then run the `land` skill in a loop until the PR is merged. Do not call `gh pr merge` directly.
+6. After merge is complete, move the issue to `Done`.
+
+## Step 4: Rework handling
+
+1. Treat `Rework` as a full approach reset, not incremental patching.
+2. Re-read the full issue body and all human comments; explicitly identify what will be done differently this attempt.
+3. Close the existing PR tied to the issue.
+4. Remove the existing `## Codex Workpad` comment from the issue.
+5. Create a fresh branch from `origin/main`.
+6. Start over from the normal kickoff flow:
+   - If current issue state is `Todo`, move it to `In Progress`; otherwise keep the current state.
+   - Create a new bootstrap `## Codex Workpad` comment.
+   - Build a fresh plan/checklist and execute end-to-end.
+
+## Completion bar before Human Review
+
+- Step 1/2 checklist is fully complete and accurately reflected in the single workpad comment.
+- Acceptance criteria and required ticket-provided validation items are complete.
+- Validation/tests are green for the latest commit.
+- PR feedback sweep is complete and no actionable comments remain.
+- PR checks are green, branch is pushed, and PR is linked on the issue.
+- Required PR metadata is present (`symphony` label).
+- If app-touching, runtime validation/media requirements from `App runtime validation (required)` are complete.
+
+## Guardrails
+
+- If the branch PR is already closed/merged, do not reuse that branch or prior implementation state for continuation.
+- For closed/merged branch PRs, create a new branch from `origin/main` and restart from reproduction/planning as if starting fresh.
+- If issue state is `Backlog`, do not modify it; wait for human to move to `Todo`.
+- Do not edit the issue body/description for planning or progress tracking.
+- Use exactly one persistent workpad comment (`## Codex Workpad`) per issue.
+- If comment editing is unavailable in-session, use the update script. Only report blocked if both MCP editing and script-based editing are unavailable.
+- Temporary proof edits are allowed only for local verification and must be reverted before commit.
+- If out-of-scope improvements are found, create a separate Backlog issue rather
+  than expanding current scope, and include a clear
+  title/description/acceptance criteria, same-project assignment, a `related`
+  link to the current issue, and `blockedBy` when the follow-up depends on the
+  current issue.
+- Do not move to `Human Review` unless the `Completion bar before Human Review` is satisfied.
+- In `Human Review`, do not make changes; wait and poll.
+- If state is terminal (`Done`), do nothing and shut down.
+- Keep issue text concise, specific, and reviewer-oriented.
+- If blocked and no workpad exists yet, add one blocker comment describing blocker, impact, and next unblock action.
+
+## Workpad template
+
+Use this exact structure for the persistent workpad comment and keep it updated in place throughout execution:
+
+````md
+## Codex Workpad
+
+```text
+<hostname>:<abs-path>@<short-sha>
+```
+
+### Plan
+
+- [ ] 1\. Parent task
+  - [ ] 1.1 Child task
+  - [ ] 1.2 Child task
+- [ ] 2\. Parent task
+
+### Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+### Validation
+
+- [ ] targeted tests: `<command>`
+
+### Notes
+
+- <short progress note with timestamp>
+
+### Confusions
+
+- <only include when something was confusing during execution>
+````

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -111,7 +111,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 - `linear`: interact with Linear. **MANDATORY: read `.codex/skills/linear/SKILL.md` before ANY `linear_graphql` tool call.** It contains the exact correct query shapes, field names, and argument types. Do not guess Linear GraphQL schema — use the skill.
 - `commit`: produce clean, logical commits during implementation.
 - `push`: keep remote branch current and publish updates.
-- `pull`: keep branch updated with latest `origin/main` before handoff.
+- `pull`: **DO NOT merge origin/main.** Your branch `elixir-feature-parity` IS the latest. If you need to sync, use `git pull origin elixir-feature-parity`.
 - `land`: when ticket reaches `Merging`, explicitly open and follow `.codex/skills/land/SKILL.md`, which includes the `land` loop.
 
 ## Status map

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -150,29 +150,29 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 ## Step 1: Start/continue execution (Todo or In Progress)
 
-1.  Find or create a single persistent scratchpad comment for the issue:
+1. Find or create a single persistent scratchpad comment for the issue:
     - Search existing comments for a marker header: `## Codex Workpad`.
     - Ignore resolved comments while searching; only active/unresolved comments are eligible to be reused as the live workpad.
     - If found, reuse that comment; do not create a new workpad comment.
     - If not found, create one workpad comment and use it for all updates.
     - Persist the workpad comment ID and only write progress updates to that ID.
-2.  If arriving from `Todo`, do not delay on additional status transitions: the issue should already be `In Progress` before this step begins.
-3.  Immediately reconcile the workpad before new edits:
+2. If arriving from `Todo`, do not delay on additional status transitions: the issue should already be `In Progress` before this step begins.
+3. Immediately reconcile the workpad before new edits:
     - Check off items that are already done.
     - Expand/fix the plan so it is comprehensive for current scope.
     - Ensure `Acceptance Criteria` and `Validation` are current and still make sense for the task.
-4.  Start work by writing/updating a hierarchical plan in the workpad comment.
-5.  Ensure the workpad includes a compact environment stamp at the top as a code fence line:
+4. Start work by writing/updating a hierarchical plan in the workpad comment.
+5. Ensure the workpad includes a compact environment stamp at the top as a code fence line:
     - Format: `<host>:<abs-workdir>@<short-sha>`
     - Example: `devbox-01:/home/dev-user/code/symphony-workspaces/MT-32@7bdde33bc`
     - Do not include metadata already inferable from Linear issue fields (`issue ID`, `status`, `branch`, `PR link`).
-6.  Add explicit acceptance criteria and TODOs in checklist form in the same comment.
+6. Add explicit acceptance criteria and TODOs in checklist form in the same comment.
     - If changes are user-facing, include a UI walkthrough acceptance criterion that describes the end-to-end user path to validate.
     - If changes touch app files or app behavior, add explicit app-specific flow checks to `Acceptance Criteria` in the workpad (for example: launch path, changed interaction path, and expected result path).
     - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
-7.  Run a principal-style self-review of the plan and refine it in the comment.
-8.  Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
-9.  Run the `pull` skill to sync with latest `origin/elixir-feature-parity` before any code edits, then record the pull/sync result in the workpad `Notes`.
+7. Run a principal-style self-review of the plan and refine it in the comment.
+8. Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
+9. Run the `pull` skill to sync with latest `origin/elixir-feature-parity` before any code edits, then record the pull/sync result in the workpad `Notes`.
     - Include a `pull skill evidence` note with:
       - merge source(s),
       - result (`clean` or `conflicts resolved`),
@@ -209,29 +209,29 @@ Use this only when completion is blocked by missing required tools or missing au
 
 ## Step 2: Execution phase (Todo -> In Progress -> Human Review)
 
-1.  Determine current repo state (`branch`, `git status`, `HEAD`) and verify the kickoff `pull` sync result is already recorded in the workpad before implementation continues.
-2.  Verify current issue state is `In Progress` (orchestrator moves from `Todo` on dispatch).
-3.  Load the existing workpad comment and treat it as the active execution checklist.
+1. Determine current repo state (`branch`, `git status`, `HEAD`) and verify the kickoff `pull` sync result is already recorded in the workpad before implementation continues.
+2. Verify current issue state is `In Progress` (orchestrator moves from `Todo` on dispatch).
+3. Load the existing workpad comment and treat it as the active execution checklist.
     - Edit it liberally whenever reality changes (scope, risks, validation approach, discovered tasks).
-4.  Implement against the hierarchical TODOs and keep the comment current:
+4. Implement against the hierarchical TODOs and keep the comment current:
     - Check off completed items.
     - Add newly discovered items in the appropriate section.
     - Keep parent/child structure intact as scope evolves.
     - Update the workpad immediately after each meaningful milestone (for example: reproduction complete, code change landed, validation run, review feedback addressed).
     - Never leave completed work unchecked in the plan.
     - For tickets that started as `Todo` with an attached PR, run the full PR feedback sweep protocol immediately after kickoff and before new feature work.
-5.  Run validation/tests required for the scope.
+5. Run validation/tests required for the scope.
     - Mandatory gate: execute all ticket-provided `Validation`/`Test Plan`/ `Testing` requirements when present; treat unmet items as incomplete work.
     - Prefer a targeted proof that directly demonstrates the behavior you changed.
     - You may make temporary local proof edits to validate assumptions (for example: tweak a local build input for `make`, or hardcode a UI account / response path) when this increases confidence.
     - Revert every temporary proof edit before commit/push.
     - Document these temporary proof steps and outcomes in the workpad `Validation`/`Notes` sections so reviewers can follow the evidence.
     - If app-touching, run `launch-app` validation and capture/upload media via `github-pr-media` before handoff.
-6.  Re-check all acceptance criteria and close any gaps.
-7.  Before every `git push` attempt, run the required validation for your scope and confirm it passes; if it fails, address issues and rerun until green, then commit and push changes.
-8.  Attach PR URL to the issue (prefer attachment; use the workpad comment only if attachment is unavailable).
+6. Re-check all acceptance criteria and close any gaps.
+7. Before every `git push` attempt, run the required validation for your scope and confirm it passes; if it fails, address issues and rerun until green, then commit and push changes.
+8. Attach PR URL to the issue (prefer attachment; use the workpad comment only if attachment is unavailable).
     - Ensure the GitHub PR has label `symphony` (add it if missing).
-9.  Merge latest `origin/elixir-feature-parity` into branch, resolve conflicts, and rerun checks.
+9. Merge latest `origin/elixir-feature-parity` into branch, resolve conflicts, and rerun checks.
 10. Update the workpad comment with final checklist status and validation notes.
     - Mark completed plan/acceptance/validation checklist items as checked.
     - Add final handoff notes (commit + validation summary) in the same workpad comment.

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -20,7 +20,7 @@ workspace:
   root: ~/symphony-workspaces
 hooks:
   after_create: |
-    git clone /Volumes/EVO/kata/kata-mono . --single-branch --branch elixir-feature-parity
+    git clone https://github.com/gannonh/kata.git . --single-branch --branch elixir-feature-parity
     git checkout -b symphony/$(basename $PWD)
   timeout_ms: 120000
 agent:
@@ -29,9 +29,9 @@ agent:
 codex:
   command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
   approval_policy: never
-  thread_sandbox: workspace-write
+  thread_sandbox: danger-full-access
   turn_sandbox_policy:
-    type: workspaceWrite
+    type: dangerFullAccess
 server:
   port: 8080
   host: "127.0.0.1"

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -18,10 +18,10 @@ polling:
   interval_ms: 30000
 workspace:
   root: ~/symphony-workspaces
+  repo: https://github.com/gannonh/kata.git
+  strategy: clone
+  branch_prefix: symphony
 hooks:
-  after_create: |
-    git clone https://github.com/gannonh/kata.git . --single-branch --branch elixir-feature-parity
-    git checkout -b symphony/$(basename $PWD)
   timeout_ms: 120000
 agent:
   max_concurrent_agents: 1

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -25,11 +25,12 @@ agent:
 
 codex:
   command: ["codex", "app-server"]
+  approval_policy: "never"
   turn_timeout_ms: 3600000
   stall_timeout_ms: 300000
 
 hooks:
-  after_create: "git clone /Volumes/EVO/kata/kata-mono . --single-branch && git checkout -b symphony/$(basename $PWD)"
+  after_create: "git clone /Volumes/EVO/kata/kata-mono . --single-branch --branch elixir-feature-parity && git checkout -b symphony/$(basename $PWD)"
   timeout_ms: 120000
 
 server:
@@ -48,18 +49,20 @@ You are working on a Linear issue for the Symphony project (a Rust orchestrator 
 **Labels:** {{ issue.labels | join: ", " }}
 {% endif %}
 
-{% if issue.blockers != empty %}
+{% if issue.blocked_by != empty %}
 **Blocked by:**
-{% for blocker in issue.blockers %}
+{% for blocker in issue.blocked_by %}
 - {{ blocker.identifier }}: {{ blocker.title }}
 {% endfor %}
 {% endif %}
 
+{% if attempt %}
 {% if attempt.number > 1 %}
 **Retry attempt {{ attempt.number }}.**
-{% if attempt.prior_error != nil %}
+{% if attempt.prior_error %}
 Previous attempt failed with: {{ attempt.prior_error }}
 Take a different approach.
+{% endif %}
 {% endif %}
 {% endif %}
 

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -112,7 +112,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 - `linear`: interact with Linear. **MANDATORY: read `.codex/skills/linear/SKILL.md` before ANY `linear_graphql` tool call.** It contains the exact correct query shapes, field names, and argument types. Do not guess Linear GraphQL schema — use the skill.
 - `commit`: produce clean, logical commits during implementation.
 - `push`: keep remote branch current and publish updates.
-- `pull`: keep branch updated before handoff. Use `origin/elixir-feature-parity` as the upstream — NOT `origin/elixir-feature-parity`.
+- `pull`: keep branch updated before handoff. Use `origin/elixir-feature-parity` as the upstream — NOT `origin/main`.
 - `land`: when ticket reaches `Merging`, explicitly open and follow `.codex/skills/land/SKILL.md`, which includes the `land` loop.
 
 ## Status map

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -21,7 +21,7 @@ workspace:
   repo: https://github.com/gannonh/kata.git
   strategy: clone
   branch_prefix: symphony
-  clone_branch: elixir-feature-parity
+  clone_branch: main
 hooks:
   timeout_ms: 120000
 agent:
@@ -80,7 +80,7 @@ This is the **kata-mono** monorepo. The Symphony crate lives at `apps/symphony/`
 - Test: `cd apps/symphony && cargo test`
 - Lint: `cd apps/symphony && cargo clippy -- -D warnings`
 - Format: `cd apps/symphony && cargo fmt`
-- Base branch: `elixir-feature-parity` (NOT `main`). All merges, rebases, and PR base targets use this branch.
+- Base branch: `main`. All merges, rebases, and PR base targets use this branch.
 
 Read `apps/symphony/AGENTS.md` for full architecture reference.
 
@@ -113,7 +113,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 - `linear`: interact with Linear. **MANDATORY: read `.codex/skills/linear/SKILL.md` before ANY `linear_graphql` tool call.** It contains the exact correct query shapes, field names, and argument types. Do not guess Linear GraphQL schema — use the skill.
 - `commit`: produce clean, logical commits during implementation.
 - `push`: keep remote branch current and publish updates.
-- `pull`: keep branch updated before handoff. Use `origin/elixir-feature-parity` as the upstream — NOT `origin/main`.
+- `pull`: keep branch updated before handoff. Use `origin/main` as the upstream.
 - `land`: when ticket reaches `Merging`, explicitly open and follow `.codex/skills/land/SKILL.md`, which includes the `land` loop.
 
 ## Status map
@@ -142,7 +142,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
    - `Done` -> do nothing and shut down.
 4. Check whether a PR already exists for the current branch and whether it is closed.
    - If a branch PR exists and is `CLOSED` or `MERGED`, treat prior branch work as non-reusable for this run.
-   - Create a fresh branch from `origin/elixir-feature-parity` and restart execution flow as a new attempt.
+   - Create a fresh branch from `origin/main` and restart execution flow as a new attempt.
 5. For `Todo` tickets, do startup sequencing in this exact order:
    - verify issue is in `In Progress` (orchestrator handles this on dispatch)
    - find/create `## Codex Workpad` bootstrap comment
@@ -173,7 +173,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
     - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
 7. Run a principal-style self-review of the plan and refine it in the comment.
 8. Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
-9. Run the `pull` skill to sync with latest `origin/elixir-feature-parity` before any code edits, then record the pull/sync result in the workpad `Notes`.
+9. Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
     - Include a `pull skill evidence` note with:
       - merge source(s),
       - result (`clean` or `conflicts resolved`),
@@ -232,7 +232,7 @@ Use this only when completion is blocked by missing required tools or missing au
 7. Before every `git push` attempt, run the required validation for your scope and confirm it passes; if it fails, address issues and rerun until green, then commit and push changes.
 8. Attach PR URL to the issue (prefer attachment; use the workpad comment only if attachment is unavailable).
     - Ensure the GitHub PR has label `symphony` (add it if missing).
-9. Merge latest `origin/elixir-feature-parity` into branch, resolve conflicts, and rerun checks.
+9. Merge latest `origin/main` into branch, resolve conflicts, and rerun checks.
 10. Update the workpad comment with final checklist status and validation notes.
     - Mark completed plan/acceptance/validation checklist items as checked.
     - Add final handoff notes (commit + validation summary) in the same workpad comment.
@@ -268,7 +268,7 @@ Use this only when completion is blocked by missing required tools or missing au
 2. Re-read the full issue body and all human comments; explicitly identify what will be done differently this attempt.
 3. Close the existing PR tied to the issue.
 4. Remove the existing `## Codex Workpad` comment from the issue.
-5. Create a fresh branch from `origin/elixir-feature-parity`.
+5. Create a fresh branch from `origin/main`.
 6. Start over from the normal kickoff flow:
    - If current issue state is `Todo`, move it to `In Progress`; otherwise keep the current state.
    - Create a new bootstrap `## Codex Workpad` comment.
@@ -287,7 +287,7 @@ Use this only when completion is blocked by missing required tools or missing au
 ## Guardrails
 
 - If the branch PR is already closed/merged, do not reuse that branch or prior implementation state for continuation.
-- For closed/merged branch PRs, create a new branch from `origin/elixir-feature-parity` and restart from reproduction/planning as if starting fresh.
+- For closed/merged branch PRs, create a new branch from `origin/main` and restart from reproduction/planning as if starting fresh.
 - If issue state is `Backlog`, do not modify it; wait for human to move to `Todo`.
 - Do not edit the issue body/description for planning or progress tracking.
 - Use exactly one persistent workpad comment (`## Codex Workpad`) per issue.

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -21,6 +21,7 @@ workspace:
   repo: https://github.com/gannonh/kata.git
   strategy: clone
   branch_prefix: symphony
+  clone_branch: elixir-feature-parity
 hooks:
   timeout_ms: 120000
 agent:

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -108,7 +108,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 ## Related skills
 
-- `linear`: interact with Linear.
+- `linear`: interact with Linear. **MANDATORY: read `.codex/skills/linear/SKILL.md` before ANY `linear_graphql` tool call.** It contains the exact correct query shapes, field names, and argument types. Do not guess Linear GraphQL schema — use the skill.
 - `commit`: produce clean, logical commits during implementation.
 - `push`: keep remote branch current and publish updates.
 - `pull`: keep branch updated with latest `origin/main` before handoff.

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -79,6 +79,7 @@ This is the **kata-mono** monorepo. The Symphony crate lives at `apps/symphony/`
 - Test: `cd apps/symphony && cargo test`
 - Lint: `cd apps/symphony && cargo clippy -- -D warnings`
 - Format: `cd apps/symphony && cargo fmt`
+- Base branch: `elixir-feature-parity` (NOT `main`). All merges, rebases, and PR base targets use this branch.
 
 Read `apps/symphony/AGENTS.md` for full architecture reference.
 
@@ -111,7 +112,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 - `linear`: interact with Linear. **MANDATORY: read `.codex/skills/linear/SKILL.md` before ANY `linear_graphql` tool call.** It contains the exact correct query shapes, field names, and argument types. Do not guess Linear GraphQL schema — use the skill.
 - `commit`: produce clean, logical commits during implementation.
 - `push`: keep remote branch current and publish updates.
-- `pull`: **DO NOT merge origin/main.** Your branch `elixir-feature-parity` IS the latest. If you need to sync, use `git pull origin elixir-feature-parity`.
+- `pull`: keep branch updated before handoff. Use `origin/elixir-feature-parity` as the upstream — NOT `origin/elixir-feature-parity`.
 - `land`: when ticket reaches `Merging`, explicitly open and follow `.codex/skills/land/SKILL.md`, which includes the `land` loop.
 
 ## Status map
@@ -140,7 +141,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
    - `Done` -> do nothing and shut down.
 4. Check whether a PR already exists for the current branch and whether it is closed.
    - If a branch PR exists and is `CLOSED` or `MERGED`, treat prior branch work as non-reusable for this run.
-   - Create a fresh branch from `origin/main` and restart execution flow as a new attempt.
+   - Create a fresh branch from `origin/elixir-feature-parity` and restart execution flow as a new attempt.
 5. For `Todo` tickets, do startup sequencing in this exact order:
    - verify issue is in `In Progress` (orchestrator handles this on dispatch)
    - find/create `## Codex Workpad` bootstrap comment
@@ -171,7 +172,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
     - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
 7.  Run a principal-style self-review of the plan and refine it in the comment.
 8.  Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
-9.  Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
+9.  Run the `pull` skill to sync with latest `origin/elixir-feature-parity` before any code edits, then record the pull/sync result in the workpad `Notes`.
     - Include a `pull skill evidence` note with:
       - merge source(s),
       - result (`clean` or `conflicts resolved`),
@@ -230,7 +231,7 @@ Use this only when completion is blocked by missing required tools or missing au
 7.  Before every `git push` attempt, run the required validation for your scope and confirm it passes; if it fails, address issues and rerun until green, then commit and push changes.
 8.  Attach PR URL to the issue (prefer attachment; use the workpad comment only if attachment is unavailable).
     - Ensure the GitHub PR has label `symphony` (add it if missing).
-9.  Merge latest `origin/main` into branch, resolve conflicts, and rerun checks.
+9.  Merge latest `origin/elixir-feature-parity` into branch, resolve conflicts, and rerun checks.
 10. Update the workpad comment with final checklist status and validation notes.
     - Mark completed plan/acceptance/validation checklist items as checked.
     - Add final handoff notes (commit + validation summary) in the same workpad comment.
@@ -266,7 +267,7 @@ Use this only when completion is blocked by missing required tools or missing au
 2. Re-read the full issue body and all human comments; explicitly identify what will be done differently this attempt.
 3. Close the existing PR tied to the issue.
 4. Remove the existing `## Codex Workpad` comment from the issue.
-5. Create a fresh branch from `origin/main`.
+5. Create a fresh branch from `origin/elixir-feature-parity`.
 6. Start over from the normal kickoff flow:
    - If current issue state is `Todo`, move it to `In Progress`; otherwise keep the current state.
    - Create a new bootstrap `## Codex Workpad` comment.
@@ -285,7 +286,7 @@ Use this only when completion is blocked by missing required tools or missing au
 ## Guardrails
 
 - If the branch PR is already closed/merged, do not reuse that branch or prior implementation state for continuation.
-- For closed/merged branch PRs, create a new branch from `origin/main` and restart from reproduction/planning as if starting fresh.
+- For closed/merged branch PRs, create a new branch from `origin/elixir-feature-parity` and restart from reproduction/planning as if starting fresh.
 - If issue state is `Backlog`, do not modify it; wait for human to move to `Todo`.
 - Do not edit the issue body/description for planning or progress tracking.
 - Use exactly one persistent workpad comment (`## Codex Workpad`) per issue.

--- a/apps/symphony/docs/plans/2026-03-19-phase1-minimum-viable-loop.md
+++ b/apps/symphony/docs/plans/2026-03-19-phase1-minimum-viable-loop.md
@@ -1,0 +1,450 @@
+# Phase 1: Minimum Viable Loop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Get Symphony's autonomous work loop running end-to-end — orchestrator dispatches a ticket, agent does the work, opens PR, moves issue through Linear states, human approves, agent lands PR, next ticket dispatched.
+
+**Architecture:** Five independent changes: (1) wire real LinearClient into worker tasks for `linear_graphql` tool, (2) implement tracker writeback in LinearAdapter so orchestrator can move issues to In Progress, (3) port the Elixir WORKFLOW.md prompt, (4) port 5 Codex skills, (5) Linear states already configured by user.
+
+**Tech Stack:** Rust, Linear GraphQL API, Codex app-server, Liquid templates
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/orchestrator.rs` | Modify | Add TrackerConfig to worker task, add In Progress writeback call |
+| `src/linear/adapter.rs` | Modify | Implement `create_comment` and `update_issue_state` (currently stubs) |
+| `src/linear/client.rs` | Modify | Add `resolve_state_id` and `update_issue_state` GraphQL methods |
+| `src/main.rs` | Modify | Pass TrackerAdapter to orchestrator for writeback calls |
+| `WORKFLOW.md` | Rewrite | Port Elixir WORKFLOW.md with adaptations |
+| `.codex/skills/linear/SKILL.md` | Create | Copy from Elixir reference (no changes needed) |
+| `.codex/skills/commit/SKILL.md` | Create | Copy from Elixir reference (no changes needed) |
+| `.codex/skills/pull/SKILL.md` | Create | Copy from Elixir reference, remove Elixir-specific commands |
+| `.codex/skills/push/SKILL.md` | Create | Copy from Elixir reference, adapt validation commands |
+| `.codex/skills/land/SKILL.md` | Create | Copy from Elixir reference, remove Elixir-specific commands |
+| `tests/linear_client_tests.rs` | Modify | Add tests for resolve_state_id and update_issue_state |
+
+---
+
+### Task 1: Implement LinearClient GraphQL write methods
+
+**Files:**
+- Modify: `src/linear/client.rs`
+- Test: `tests/linear_client_tests.rs`
+
+- [ ] **Step 1: Write failing test for `resolve_state_id`**
+
+Add `test_resolve_state_id_returns_matching_state` to `tests/linear_client_tests.rs`. Mock the GraphQL response that returns team states for an issue. Assert the resolved state ID matches.
+
+```rust
+#[tokio::test]
+async fn test_resolve_state_id_returns_matching_state() {
+    let mut server = Server::new_async().await;
+    let mock = server.mock("POST", "/")
+        .with_body(json!({
+            "data": {
+                "issue": {
+                    "team": {
+                        "states": {
+                            "nodes": [{"id": "state-123"}]
+                        }
+                    }
+                }
+            }
+        }).to_string())
+        .create_async().await;
+
+    let client = test_client(&server);
+    let result = client.resolve_state_id("issue-1", "In Progress").await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "state-123");
+    mock.assert_async().await;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test linear_client_tests test_resolve_state_id -- --nocapture`
+Expected: FAIL — method does not exist
+
+- [ ] **Step 3: Implement `resolve_state_id` on LinearClient**
+
+Add to `src/linear/client.rs`:
+
+```rust
+const STATE_LOOKUP_QUERY: &str = r#"
+    query SymphonyResolveStateId($issueId: String!, $stateName: String!) {
+        issue(id: $issueId) {
+            team {
+                states(filter: {name: {eq: $stateName}}, first: 1) {
+                    nodes { id }
+                }
+            }
+        }
+    }
+"#;
+
+pub async fn resolve_state_id(&self, issue_id: &str, state_name: &str) -> Result<String> {
+    let variables = json!({"issueId": issue_id, "stateName": state_name});
+    let response = self.graphql(STATE_LOOKUP_QUERY, variables).await?;
+    response["data"]["issue"]["team"]["states"]["nodes"][0]["id"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| SymphonyError::Other(format!("state '{}' not found", state_name)))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --test linear_client_tests test_resolve_state_id -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Write failing test for `update_issue_state`**
+
+Add `test_update_issue_state_resolves_and_updates`. Two mock responses: first for state lookup, second for issue update mutation.
+
+- [ ] **Step 6: Implement `update_issue_state` on LinearClient**
+
+```rust
+const UPDATE_STATE_MUTATION: &str = r#"
+    mutation SymphonyUpdateIssueState($issueId: String!, $stateId: String!) {
+        issueUpdate(id: $issueId, input: {stateId: $stateId}) {
+            success
+        }
+    }
+"#;
+
+pub async fn update_issue_state(&self, issue_id: &str, state_name: &str) -> Result<()> {
+    let state_id = self.resolve_state_id(issue_id, state_name).await?;
+    let variables = json!({"issueId": issue_id, "stateId": state_id});
+    let response = self.graphql(UPDATE_STATE_MUTATION, variables).await?;
+    match response["data"]["issueUpdate"]["success"].as_bool() {
+        Some(true) => Ok(()),
+        _ => Err(SymphonyError::Other("issueUpdate failed".to_string())),
+    }
+}
+```
+
+- [ ] **Step 7: Run tests to verify both pass**
+
+Run: `cargo test --test linear_client_tests test_resolve_state_id test_update_issue_state -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 8: Write failing test for state not found**
+
+Test that `resolve_state_id` returns an error when the state name doesn't match any team states.
+
+- [ ] **Step 9: Implement and verify**
+
+Run: `cargo test --test linear_client_tests -- --nocapture`
+Expected: All new tests PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/linear/client.rs tests/linear_client_tests.rs
+git commit -m "feat(symphony): add resolve_state_id and update_issue_state to LinearClient"
+```
+
+---
+
+### Task 2: Wire LinearAdapter write methods
+
+**Files:**
+- Modify: `src/linear/adapter.rs`
+
+- [ ] **Step 1: Replace `create_comment` stub with real implementation**
+
+```rust
+async fn create_comment(&self, issue_id: &str, body: &str) -> Result<()> {
+    self.client.create_comment(issue_id, body).await
+}
+```
+
+(Also add `create_comment` to `LinearClient` in `client.rs` — same pattern as Elixir's `@create_comment_mutation`)
+
+- [ ] **Step 2: Replace `update_issue_state` stub with real implementation**
+
+```rust
+async fn update_issue_state(&self, issue_id: &str, state_name: &str) -> Result<()> {
+    self.client.update_issue_state(issue_id, state_name).await
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `cargo build`
+Expected: Compiles clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/linear/adapter.rs src/linear/client.rs
+git commit -m "feat(symphony): implement TrackerAdapter write methods (create_comment, update_issue_state)"
+```
+
+---
+
+### Task 3: Wire real `linear_graphql` executor into worker tasks
+
+**Files:**
+- Modify: `src/orchestrator.rs`
+
+- [ ] **Step 1: Add `TrackerConfig` parameter to `run_worker_task`**
+
+Add `tracker_config: &crate::domain::TrackerConfig` as the last parameter.
+
+- [ ] **Step 2: Replace dummy executor with real LinearClient**
+
+```rust
+let linear_client = crate::linear::client::LinearClient::new(tracker_config.clone());
+let graphql_executor = move |query: String, vars: serde_json::Value| {
+    let client = linear_client.clone();
+    async move { client.graphql_raw(&query, vars).await }
+};
+```
+
+- [ ] **Step 3: Pass `tracker_config` from `spawn_workers_for_dispatched`**
+
+Add `let tracker_config = self.config.tracker.clone();` and pass it to `run_worker_task`.
+
+- [ ] **Step 4: Verify build**
+
+Run: `cargo build`
+Expected: Compiles clean
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test`
+Expected: All 211 tests pass (existing tests don't call `run_worker_task` directly)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orchestrator.rs
+git commit -m "feat(symphony): wire real linear_graphql executor into worker tasks"
+```
+
+---
+
+### Task 4: Add "In Progress" writeback on dispatch
+
+**Files:**
+- Modify: `src/orchestrator.rs`
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Add `update_issue_state` to `OrchestratorPort` trait**
+
+```rust
+fn update_issue_state(&mut self, issue_id: &str, state_name: &str) -> Result<()>;
+```
+
+- [ ] **Step 2: Implement in `LinearOrchestratorPort` in `main.rs`**
+
+```rust
+fn update_issue_state(&mut self, issue_id: &str, state_name: &str) -> Result<()> {
+    self.block_on(self.adapter.update_issue_state(issue_id, state_name))
+}
+```
+
+- [ ] **Step 3: Update fake port in `tests/orchestrator_tests.rs`**
+
+Add a no-op implementation to the fake port used in tests:
+
+```rust
+fn update_issue_state(&mut self, _issue_id: &str, _state_name: &str) -> Result<()> {
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Call writeback in `spawn_workers_for_dispatched`**
+
+Before spawning each worker task, call the port. But `spawn_workers_for_dispatched` doesn't have access to `port`. We need to pass it in.
+
+Change `spawn_workers_for_dispatched` signature to accept `port: &mut dyn OrchestratorPort`:
+
+```rust
+fn spawn_workers_for_dispatched(&mut self, dispatched: &[DispatchedIssue], port: &mut dyn OrchestratorPort) {
+    for d in dispatched {
+        // Move to In Progress in Linear (best-effort, don't block dispatch on failure)
+        if let Err(err) = port.update_issue_state(&d.issue.id, "In Progress") {
+            tracing::warn!(
+                event = "writeback_failed",
+                issue_id = %d.issue.id,
+                issue_identifier = %d.issue.identifier,
+                error = %err,
+                "failed to move issue to In Progress; continuing with dispatch"
+            );
+        }
+        // ... rest of spawn logic
+    }
+}
+```
+
+Update call sites in `run()` to pass `port`.
+
+- [ ] **Step 5: Verify build and tests**
+
+Run: `cargo test`
+Expected: All tests pass
+
+- [ ] **Step 6: Run clippy**
+
+Run: `cargo clippy -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/orchestrator.rs src/main.rs tests/orchestrator_tests.rs
+git commit -m "feat(symphony): move issue to In Progress on dispatch (orchestrator writeback)"
+```
+
+---
+
+### Task 5: Port WORKFLOW.md from Elixir reference
+
+**Files:**
+- Rewrite: `apps/symphony/WORKFLOW.md`
+
+- [ ] **Step 1: Copy Elixir WORKFLOW.md**
+
+```bash
+cp /Volumes/EVO/kata/openai-symphony/elixir/WORKFLOW.md /Volumes/EVO/kata/kata-mono.worktrees/wt-symphony/apps/symphony/WORKFLOW.md
+```
+
+- [ ] **Step 2: Update front-matter**
+
+- `tracker.project_slug` → `89d4761fddf0`
+- `workspace.root` → `~/symphony-workspaces`
+- `hooks.after_create` → `git clone /Volumes/EVO/kata/kata-mono . --single-branch --branch elixir-feature-parity && git checkout -b symphony/$(basename $PWD)`
+- `hooks.before_remove` → remove (no Elixir cleanup needed)
+- `active_states` → `[Todo, In Progress, Merging, Rework]`
+- `codex.command` → keep as-is (includes `--model gpt-5.3-codex`)
+- `approval_policy` → `never`
+
+- [ ] **Step 3: Adapt prompt body**
+
+- Replace references to "this repository" with context about `apps/symphony/` in the kata-mono monorepo
+- Remove `mise` references (we use `cargo`)
+- Replace `make -C elixir all` validation with `cd apps/symphony && cargo test && cargo clippy -- -D warnings`
+- Replace `mix pr_body.check` with equivalent or remove
+- Update Step 0 to note that orchestrator already moved to In Progress (agent verifies rather than transitions)
+
+- [ ] **Step 4: Verify template renders**
+
+Run Symphony briefly and check logs for template errors:
+```bash
+RUST_LOG=info ./target/release/symphony WORKFLOW.md --port 8080 --i-understand-that-this-will-be-running-without-the-usual-guardrails
+```
+Kill after first dispatch. Confirm no Liquid template errors in logs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/symphony/WORKFLOW.md
+git commit -m "feat(symphony): port Elixir WORKFLOW.md with full agent state machine"
+```
+
+---
+
+### Task 6: Port Codex skills
+
+**Files:**
+- Create: `.codex/skills/linear/SKILL.md`
+- Create: `.codex/skills/commit/SKILL.md`
+- Create: `.codex/skills/pull/SKILL.md`
+- Create: `.codex/skills/push/SKILL.md`
+- Create: `.codex/skills/land/SKILL.md`
+
+- [ ] **Step 1: Copy `linear` skill (no changes needed)**
+
+```bash
+mkdir -p .codex/skills/linear
+cp /Volumes/EVO/kata/openai-symphony/.codex/skills/linear/SKILL.md .codex/skills/linear/SKILL.md
+```
+
+- [ ] **Step 2: Copy `commit` skill (no changes needed)**
+
+```bash
+mkdir -p .codex/skills/commit
+cp /Volumes/EVO/kata/openai-symphony/.codex/skills/commit/SKILL.md .codex/skills/commit/SKILL.md
+```
+
+- [ ] **Step 3: Copy `pull` skill (no changes needed)**
+
+```bash
+mkdir -p .codex/skills/pull
+cp /Volumes/EVO/kata/openai-symphony/.codex/skills/pull/SKILL.md .codex/skills/pull/SKILL.md
+```
+
+- [ ] **Step 4: Copy and adapt `push` skill**
+
+```bash
+mkdir -p .codex/skills/push
+cp /Volumes/EVO/kata/openai-symphony/.codex/skills/push/SKILL.md .codex/skills/push/SKILL.md
+```
+
+Then edit: replace `make -C elixir all` with `cd apps/symphony && cargo test && cargo clippy -- -D warnings`. Remove `mix pr_body.check` references.
+
+- [ ] **Step 5: Copy and adapt `land` skill**
+
+```bash
+mkdir -p .codex/skills/land
+cp /Volumes/EVO/kata/openai-symphony/.codex/skills/land/SKILL.md .codex/skills/land/SKILL.md
+```
+
+Read and remove any Elixir-specific references (`mix`, `mise`, `iex`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .codex/skills/
+git commit -m "feat(symphony): port Codex skills from Elixir reference (linear, commit, push, pull, land)"
+```
+
+---
+
+### Task 7: Final verification and push
+
+**Files:** None new
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cargo test`
+Expected: All tests pass (211 + new write method tests)
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 3: Run cargo fmt**
+
+Run: `cargo fmt`
+
+- [ ] **Step 4: Build release binary**
+
+Run: `cargo build --release`
+
+- [ ] **Step 5: Push branch**
+
+```bash
+git push origin elixir-feature-parity
+```
+
+- [ ] **Step 6: Clean stale workspace and test end-to-end**
+
+```bash
+rm -rf ~/symphony-workspaces/KAT-800
+RUST_LOG=info ./target/release/symphony WORKFLOW.md --port 8080 --i-understand-that-this-will-be-running-without-the-usual-guardrails
+```
+
+Verify in logs:
+- Issue moved to In Progress ✓
+- Workspace cloned ✓
+- Codex session started ✓
+- No template errors ✓
+- `linear_graphql` tool available (no dummy error) ✓

--- a/apps/symphony/docs/specs/2026-03-19-phase1-minimum-viable-loop.md
+++ b/apps/symphony/docs/specs/2026-03-19-phase1-minimum-viable-loop.md
@@ -1,0 +1,133 @@
+# Phase 1: Minimum Viable Loop
+
+**Date:** 2026-03-19
+**Status:** Approved
+**Branch:** `elixir-feature-parity`
+
+## Goal
+
+Get Symphony's autonomous work loop running end-to-end: orchestrator picks up a ticket from Linear → clones repo → agent does the work → agent opens PR → agent moves issue to Human Review → human approves by moving to Merging → agent lands PR → issue moves to Done → next ticket dispatched.
+
+## Linear State Machine
+
+```
+Todo → In Progress → Human Review → Merging → Done
+                   ↗
+       Rework ────┘
+```
+
+- **Todo** (unstarted) — queued for dispatch
+- **In Progress** (started) — orchestrator moved it here on dispatch; agent is working
+- **Human Review** (started) — agent finished, PR attached, waiting on human. NOT in active_states — Symphony stops working.
+- **Merging** (started) — human approved. Symphony re-dispatches. Agent runs `land` skill to merge PR.
+- **Rework** (started) — human rejected. Symphony re-dispatches. Agent starts fresh.
+- **Done** (completed) — terminal. Loop stops.
+
+`active_states` in WORKFLOW.md:
+```yaml
+active_states:
+  - Todo
+  - In Progress
+  - Merging
+  - Rework
+```
+
+## Change 1: Wire Real `linear_graphql` Executor
+
+**Problem:** `run_worker_task` in `orchestrator.rs` has a dummy GraphQL executor that always errors. The agent cannot talk to Linear.
+
+**Fix:**
+- Add `TrackerConfig` parameter to `run_worker_task`
+- Create a `LinearClient` from it inside the worker task
+- Pass `client.graphql_raw()` as the executor closure
+- `spawn_workers_for_dispatched` passes `self.config.tracker.clone()` to each spawned task
+
+**Files:** `src/orchestrator.rs`
+**Impact:** ~15 lines changed. No new modules or dependencies.
+
+## Change 2: Orchestrator "In Progress" Writeback
+
+**Problem:** The orchestrator only reads from Linear. When it dispatches an issue, the issue stays in "Todo" in Linear.
+
+**Fix:**
+- Add to `LinearAdapter` (in `src/linear/adapter.rs`):
+  - `resolve_state_id(issue_id, state_name) -> Result<String>` — GraphQL query to look up a workflow state ID by name via the issue's team
+  - `update_issue_state(issue_id, state_name) -> Result<()>` — resolves state ID then calls `issueUpdate` mutation
+  - These match the exact GraphQL queries from the Elixir adapter
+- Add `update_issue_state` to `OrchestratorPort` trait
+- In `spawn_workers_for_dispatched`, before spawning each worker task, call `port.update_issue_state(issue_id, "In Progress")`
+- Log and continue on failure — a failed state update must not block dispatch
+
+**Files:** `src/linear/adapter.rs`, `src/orchestrator.rs`, `src/main.rs`
+**Impact:** ~70 lines total.
+
+## Change 3: WORKFLOW.md Prompt Port
+
+**Start from:** Copy the Elixir WORKFLOW.md (`/Volumes/EVO/kata/openai-symphony/elixir/WORKFLOW.md`) verbatim.
+
+**Then make these changes:**
+
+1. `tracker.project_slug` → `89d4761fddf0` (Symphony project)
+2. `workspace.root` → `~/symphony-workspaces`
+3. `hooks.after_create` → clone from local repo on `elixir-feature-parity` branch (remove `mise` and Elixir dep setup)
+4. `hooks.before_remove` → remove `cd elixir && mise exec -- mix workspace.before_remove`
+5. `codex.command` → keep as-is from Elixir (`codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server`)
+6. `active_states` → `[Todo, In Progress, Merging, Rework]`
+7. In prompt body, replace repository context with `apps/symphony/` within kata-mono monorepo
+8. Remove `mise` references from prompt body (we use `cargo`, not `mix`)
+9. Skill path references stay the same (`.codex/skills/`)
+10. Since orchestrator moves to "In Progress" on dispatch, the agent's Step 0 verifies it's already In Progress rather than doing the transition itself
+
+**Everything else stays exactly as Elixir wrote it:** full status map, workpad protocol, Steps 0-4, PR feedback sweep, blocked-access escape hatch, completion bar, guardrails, workpad template, continuation retry prompt.
+
+## Change 4: Port Codex Skills
+
+**Start from:** Copy all 5 skill directories from `/Volumes/EVO/kata/openai-symphony/.codex/skills/` to `/.codex/skills/` at the repo root:
+
+- `commit/SKILL.md`
+- `push/SKILL.md`
+- `pull/SKILL.md`
+- `land/SKILL.md`
+- `linear/SKILL.md`
+
+**Changes:** Read each skill file and adapt any Elixir-specific references (e.g. `mix` commands, Elixir paths). These are agent instruction documents, not code — they should be mostly repo-agnostic.
+
+**Files:** 5 new markdown files in `/.codex/skills/`
+
+## Change 5: Linear Custom States
+
+**Done by user.** Three custom workflow states added to the KAT team:
+- Human Review (started)
+- Merging (started)
+- Rework (started)
+
+Plus existing: Agent Review (started) — used by other workflows, not by Symphony.
+
+## What This Does NOT Include
+
+- Real-time event streaming from worker to orchestrator (dashboard is blind during execution)
+- Live token counter during turns
+- TUI terminal dashboard
+- Video/media upload to Linear comments
+- `debug` skill
+- Persistent retry queue across restarts
+- Configurable workspace repo bootstrap (KAT-800 — stays as a hook for now)
+
+These are Phase 2/3 items. After Phase 1 works, they become Linear tickets for Symphony to build itself.
+
+## Verification
+
+1. Start Symphony pointed at the Symphony project
+2. Create a test ticket in Todo with clear acceptance criteria
+3. Observe: orchestrator picks it up, moves to In Progress, agent clones repo, does work, opens PR, moves to Human Review
+4. Move issue to Merging in Linear
+5. Observe: agent lands PR, moves to Done
+6. Confirm: next Todo ticket gets dispatched
+
+## Architecture Notes
+
+**Two actors:**
+- **Orchestrator** — long-running state machine. Polls Linear, dispatches workers, reacts to results. One write: moves issue to "In Progress" on dispatch.
+- **Worker agents** — short-lived Codex sessions. Get a workspace + prompt. Write back to Linear via `linear_graphql` tool. Handle all state transitions after In Progress.
+
+**Continuation loop:** Worker completes turn → orchestrator schedules continuation retry → re-fetches issue from Linear → if still active → dispatch again (same workspace, fresh session) → if terminal → stop, slot opens, next ticket.

--- a/apps/symphony/src/codex/app_server.rs
+++ b/apps/symphony/src/codex/app_server.rs
@@ -383,11 +383,9 @@ where
                             .and_then(|m| m.as_str())
                             .map(|s| s.to_string());
 
-                        // Debug: log every message from Codex
                         tracing::debug!(
                             issue_id = %handle.issue_id,
                             method = method.as_deref().unwrap_or("(none)"),
-                            payload = %text,
                             "codex message received"
                         );
 
@@ -420,8 +418,12 @@ where
                                         .unwrap_or("turn completed with failed status");
                                     let error_code = payload
                                         .pointer("/params/turn/error/codexErrorInfo")
-                                        .and_then(|c| c.as_str())
-                                        .unwrap_or("unknown");
+                                        .map(|c| {
+                                            c.as_str()
+                                                .map(String::from)
+                                                .unwrap_or_else(|| c.to_string())
+                                        })
+                                        .unwrap_or_else(|| "unknown".to_string());
 
                                     tracing::error!(
                                         issue_id = %handle.issue_id,

--- a/apps/symphony/src/codex/app_server.rs
+++ b/apps/symphony/src/codex/app_server.rs
@@ -383,6 +383,14 @@ where
                             .and_then(|m| m.as_str())
                             .map(|s| s.to_string());
 
+                        // Debug: log every message from Codex
+                        tracing::debug!(
+                            issue_id = %handle.issue_id,
+                            method = method.as_deref().unwrap_or("(none)"),
+                            payload = %text,
+                            "codex message received"
+                        );
+
                         // ── Token accounting ──────────────────────────
                         let delta = extract_token_delta(&token_state, &payload);
                         turn_input_tokens += delta.input_tokens;
@@ -398,6 +406,45 @@ where
                         match method.as_deref() {
                             // ── turn/completed ────────────────────────
                             Some("turn/completed") => {
+                                // Check if turn/completed carries a failure status
+                                // (e.g. usageLimitExceeded, model unavailable)
+                                let turn_status = payload
+                                    .pointer("/params/turn/status")
+                                    .and_then(|s| s.as_str())
+                                    .unwrap_or("completed");
+
+                                if turn_status == "failed" {
+                                    let error_msg = payload
+                                        .pointer("/params/turn/error/message")
+                                        .and_then(|m| m.as_str())
+                                        .unwrap_or("turn completed with failed status");
+                                    let error_code = payload
+                                        .pointer("/params/turn/error/codexErrorInfo")
+                                        .and_then(|c| c.as_str())
+                                        .unwrap_or("unknown");
+
+                                    tracing::error!(
+                                        issue_id = %handle.issue_id,
+                                        session_id = %session_id,
+                                        error_code = %error_code,
+                                        error = %error_msg,
+                                        "Codex turn failed"
+                                    );
+
+                                    let event = AgentEvent::TurnFailed {
+                                        timestamp: Utc::now(),
+                                        codex_app_server_pid: handle.pid.clone(),
+                                        turn_id: turn_id.clone(),
+                                        error: error_msg.to_string(),
+                                    };
+                                    event_callback(event.clone());
+                                    events.push(event);
+
+                                    return Err(SymphonyError::TurnFailed(format!(
+                                        "{error_code}: {error_msg}"
+                                    )));
+                                }
+
                                 let event = AgentEvent::TurnCompleted {
                                     timestamp: Utc::now(),
                                     codex_app_server_pid: handle.pid.clone(),

--- a/apps/symphony/src/codex/app_server.rs
+++ b/apps/symphony/src/codex/app_server.rs
@@ -425,7 +425,7 @@ where
                                         })
                                         .unwrap_or_else(|| "unknown".to_string());
 
-                                    tracing::error!(
+                                    tracing::warn!(
                                         issue_id = %handle.issue_id,
                                         session_id = %session_id,
                                         error_code = %error_code,
@@ -437,7 +437,7 @@ where
                                         timestamp: Utc::now(),
                                         codex_app_server_pid: handle.pid.clone(),
                                         turn_id: turn_id.clone(),
-                                        error: error_msg.to_string(),
+                                        error: format!("{error_code}: {error_msg}"),
                                     };
                                     event_callback(event.clone());
                                     events.push(event);

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -396,7 +396,12 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let raw_root = raw_workspace
         .root
         .unwrap_or_else(|| defaults.workspace.root.clone());
-    let strategy = match raw_workspace.strategy.as_deref().unwrap_or("clone") {
+    let strategy = match raw_workspace
+        .strategy
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("clone")
+    {
         "clone" => WorkspaceRepoStrategy::Clone,
         "worktree" => WorkspaceRepoStrategy::Worktree,
         other => {
@@ -405,21 +410,30 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
             )));
         }
     };
-    let repo = raw_workspace
-        .repo
-        .map(|value| expand_tilde(&value))
-        .filter(|value| !value.trim().is_empty());
-    let branch_prefix = raw_workspace
-        .branch_prefix
-        .unwrap_or_else(|| defaults.workspace.branch_prefix.clone());
-    let clone_branch = raw_workspace.clone_branch.and_then(|value| {
-        let trimmed = value.trim();
+    let repo = raw_workspace.repo.and_then(|value| {
+        let resolved = resolve_env(&value);
+        let trimmed = resolved.trim();
         if trimmed.is_empty() {
             None
         } else {
-            Some(trimmed.to_string())
+            Some(expand_tilde(trimmed))
         }
     });
+    let branch_prefix = raw_workspace
+        .branch_prefix
+        .map(|value| resolve_env(&value))
+        .unwrap_or_else(|| defaults.workspace.branch_prefix.clone());
+    let clone_branch = raw_workspace
+        .clone_branch
+        .map(|value| resolve_env(&value))
+        .and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        });
     let workspace = WorkspaceConfig {
         root: expand_tilde(&raw_root),
         repo,

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -12,7 +12,7 @@ use serde_yaml::{Mapping, Value};
 
 use crate::domain::{
     AgentConfig, ApiKey, CodexConfig, HooksConfig, PollingConfig, ServerConfig, ServiceConfig,
-    TrackerConfig, WorkerConfig, WorkspaceConfig,
+    TrackerConfig, WorkerConfig, WorkspaceConfig, WorkspaceRepoStrategy,
 };
 use crate::error::{Result, SymphonyError};
 
@@ -177,6 +177,9 @@ struct RawPollingConfig {
 #[serde(default)]
 struct RawWorkspaceConfig {
     root: Option<String>,
+    repo: Option<String>,
+    strategy: Option<String>,
+    branch_prefix: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -391,8 +394,27 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let raw_root = raw_workspace
         .root
         .unwrap_or_else(|| defaults.workspace.root.clone());
+    let strategy = match raw_workspace.strategy.as_deref().unwrap_or("clone") {
+        "clone" => WorkspaceRepoStrategy::Clone,
+        "worktree" => WorkspaceRepoStrategy::Worktree,
+        other => {
+            return Err(SymphonyError::InvalidWorkflowConfig(format!(
+                "workspace.strategy must be 'clone' or 'worktree' (got '{other}')"
+            )));
+        }
+    };
+    let repo = raw_workspace
+        .repo
+        .map(|value| expand_tilde(&value))
+        .filter(|value| !value.trim().is_empty());
+    let branch_prefix = raw_workspace
+        .branch_prefix
+        .unwrap_or_else(|| defaults.workspace.branch_prefix.clone());
     let workspace = WorkspaceConfig {
         root: expand_tilde(&raw_root),
+        repo,
+        strategy,
+        branch_prefix,
     };
 
     // ── WorkerConfig ──────────────────────────────────────────────────────
@@ -537,7 +559,33 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
         ));
     }
 
+    // workspace.branch_prefix must be present and non-empty
+    if config.workspace.branch_prefix.trim().is_empty() {
+        return Err(SymphonyError::InvalidWorkflowConfig(
+            "workspace.branch_prefix must be non-empty".to_string(),
+        ));
+    }
+
+    // workspace.strategy=worktree requires a local workspace.repo path
+    if config.workspace.strategy == WorkspaceRepoStrategy::Worktree {
+        let repo = config.workspace.repo.as_deref().ok_or_else(|| {
+            SymphonyError::InvalidWorkflowConfig(
+                "workspace.repo is required when workspace.strategy is 'worktree'".to_string(),
+            )
+        })?;
+        if repo_is_remote(repo) {
+            return Err(SymphonyError::InvalidWorkflowConfig(
+                "workspace.strategy 'worktree' requires workspace.repo to be a local path"
+                    .to_string(),
+            ));
+        }
+    }
+
     Ok(ValidatedServiceConfig(config.clone()))
+}
+
+fn repo_is_remote(repo: &str) -> bool {
+    repo.contains("://") || repo.starts_with("git@")
 }
 
 // ── Unit tests ────────────────────────────────────────────────────────────────

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -15,6 +15,7 @@ use crate::domain::{
     TrackerConfig, WorkerConfig, WorkspaceConfig, WorkspaceRepoStrategy,
 };
 use crate::error::{Result, SymphonyError};
+use crate::repo_url::repo_is_remote;
 
 // ── Key normalization and null-dropping ───────────────────────────────────────
 
@@ -180,6 +181,7 @@ struct RawWorkspaceConfig {
     repo: Option<String>,
     strategy: Option<String>,
     branch_prefix: Option<String>,
+    clone_branch: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -410,11 +412,20 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let branch_prefix = raw_workspace
         .branch_prefix
         .unwrap_or_else(|| defaults.workspace.branch_prefix.clone());
+    let clone_branch = raw_workspace.clone_branch.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
     let workspace = WorkspaceConfig {
         root: expand_tilde(&raw_root),
         repo,
         strategy,
-        branch_prefix,
+        branch_prefix: branch_prefix.trim().to_string(),
+        clone_branch,
     };
 
     // ── WorkerConfig ──────────────────────────────────────────────────────
@@ -583,11 +594,6 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
 
     Ok(ValidatedServiceConfig(config.clone()))
 }
-
-fn repo_is_remote(repo: &str) -> bool {
-    repo.contains("://") || repo.starts_with("git@")
-}
-
 // ── Unit tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -183,6 +183,7 @@ pub struct WorkspaceConfig {
     pub repo: Option<String>,
     pub strategy: WorkspaceRepoStrategy,
     pub branch_prefix: String,
+    pub clone_branch: Option<String>,
 }
 
 /// Workspace repository bootstrap strategy.
@@ -199,6 +200,7 @@ impl Default for WorkspaceConfig {
             repo: None,
             strategy: WorkspaceRepoStrategy::Clone,
             branch_prefix: "symphony".to_string(),
+            clone_branch: None,
         }
     }
 }

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -180,12 +180,25 @@ impl Default for PollingConfig {
 #[derive(Debug, Clone)]
 pub struct WorkspaceConfig {
     pub root: String,
+    pub repo: Option<String>,
+    pub strategy: WorkspaceRepoStrategy,
+    pub branch_prefix: String,
+}
+
+/// Workspace repository bootstrap strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceRepoStrategy {
+    Clone,
+    Worktree,
 }
 
 impl Default for WorkspaceConfig {
     fn default() -> Self {
         Self {
             root: default_workspace_root(),
+            repo: None,
+            strategy: WorkspaceRepoStrategy::Clone,
+            branch_prefix: "symphony".to_string(),
         }
     }
 }

--- a/apps/symphony/src/lib.rs
+++ b/apps/symphony/src/lib.rs
@@ -8,6 +8,7 @@ pub mod linear;
 
 pub mod path_safety;
 pub mod prompt_builder;
+pub mod repo_url;
 pub mod ssh;
 pub mod workspace;
 

--- a/apps/symphony/src/linear/adapter.rs
+++ b/apps/symphony/src/linear/adapter.rs
@@ -6,7 +6,7 @@
 use async_trait::async_trait;
 
 use crate::domain::Issue;
-use crate::error::{Result, SymphonyError};
+use crate::error::Result;
 use crate::linear::client::LinearClient;
 
 // ── TrackerAdapter trait (spec §4.1.1, matches Elixir `tracker.ex`) ────
@@ -37,7 +37,7 @@ pub trait TrackerAdapter: Send + Sync {
 // ── LinearAdapter ──────────────────────────────────────────────────────
 
 /// Linear-backed tracker adapter. Delegates read operations to `LinearClient`.
-/// Write operations are not yet implemented (returns `SymphonyError::Other`).
+/// Write operations delegate to `LinearClient`.
 pub struct LinearAdapter {
     client: LinearClient,
 }
@@ -63,11 +63,11 @@ impl TrackerAdapter for LinearAdapter {
         self.client.fetch_issue_states_by_ids(issue_ids).await
     }
 
-    async fn create_comment(&self, _issue_id: &str, _body: &str) -> Result<()> {
-        Err(SymphonyError::Other("not implemented".to_string()))
+    async fn create_comment(&self, issue_id: &str, body: &str) -> Result<()> {
+        self.client.create_comment(issue_id, body).await
     }
 
-    async fn update_issue_state(&self, _issue_id: &str, _state_name: &str) -> Result<()> {
-        Err(SymphonyError::Other("not implemented".to_string()))
+    async fn update_issue_state(&self, issue_id: &str, state_name: &str) -> Result<()> {
+        self.client.update_issue_state(issue_id, state_name).await
     }
 }

--- a/apps/symphony/src/linear/client.rs
+++ b/apps/symphony/src/linear/client.rs
@@ -109,6 +109,34 @@ query SymphonyLinearIssuesById($ids: [ID!]!, $first: Int!, $relationFirst: Int!)
 }
 "#;
 
+const QUERY_RESOLVE_STATE_ID: &str = r#"
+query SymphonyResolveStateId($issueId: String!, $stateName: String!) {
+    issue(id: $issueId) {
+        team {
+            states(filter: {name: {eq: $stateName}}, first: 1) {
+                nodes { id }
+            }
+        }
+    }
+}
+"#;
+
+const MUTATION_UPDATE_ISSUE_STATE: &str = r#"
+mutation SymphonyUpdateIssueState($issueId: String!, $stateId: String!) {
+    issueUpdate(id: $issueId, input: {stateId: $stateId}) {
+        success
+    }
+}
+"#;
+
+const MUTATION_CREATE_COMMENT: &str = r#"
+mutation SymphonyCreateComment($issueId: String!, $body: String!) {
+    commentCreate(input: {issueId: $issueId, body: $body}) {
+        success
+    }
+}
+"#;
+
 const VIEWER_QUERY: &str = r#"
 query SymphonyLinearViewer {
   viewer {
@@ -244,6 +272,98 @@ impl LinearClient {
             "fetched issues by IDs"
         );
         Ok(all_issues)
+    }
+
+    // ── Write operations ──────────────────────────────────────────────
+
+    /// Resolve a workflow state ID by name for the team that owns the given issue.
+    pub async fn resolve_state_id(&self, issue_id: &str, state_name: &str) -> Result<String> {
+        let body = self
+            .graphql(
+                QUERY_RESOLVE_STATE_ID,
+                serde_json::json!({
+                    "issueId": issue_id,
+                    "stateName": state_name,
+                }),
+            )
+            .await?;
+
+        body.get("data")
+            .and_then(|d| d.get("issue"))
+            .and_then(|i| i.get("team"))
+            .and_then(|t| t.get("states"))
+            .and_then(|s| s.get("nodes"))
+            .and_then(|n| n.as_array())
+            .and_then(|nodes| nodes.first())
+            .and_then(|node| node.get("id"))
+            .and_then(|id| id.as_str())
+            .map(String::from)
+            .ok_or_else(|| {
+                SymphonyError::Other(format!(
+                    "state '{}' not found for issue '{}'",
+                    state_name, issue_id
+                ))
+            })
+    }
+
+    /// Update an issue's workflow state by resolving the state name to an ID first.
+    pub async fn update_issue_state(&self, issue_id: &str, state_name: &str) -> Result<()> {
+        let state_id = self.resolve_state_id(issue_id, state_name).await?;
+
+        let body = self
+            .graphql(
+                MUTATION_UPDATE_ISSUE_STATE,
+                serde_json::json!({
+                    "issueId": issue_id,
+                    "stateId": state_id,
+                }),
+            )
+            .await?;
+
+        let success = body
+            .get("data")
+            .and_then(|d| d.get("issueUpdate"))
+            .and_then(|u| u.get("success"))
+            .and_then(|s| s.as_bool())
+            .unwrap_or(false);
+
+        if success {
+            Ok(())
+        } else {
+            Err(SymphonyError::Other(format!(
+                "issueUpdate failed for issue '{}' to state '{}'",
+                issue_id, state_name
+            )))
+        }
+    }
+
+    /// Create a comment on an issue.
+    pub async fn create_comment(&self, issue_id: &str, body: &str) -> Result<()> {
+        let resp = self
+            .graphql(
+                MUTATION_CREATE_COMMENT,
+                serde_json::json!({
+                    "issueId": issue_id,
+                    "body": body,
+                }),
+            )
+            .await?;
+
+        let success = resp
+            .get("data")
+            .and_then(|d| d.get("commentCreate"))
+            .and_then(|c| c.get("success"))
+            .and_then(|s| s.as_bool())
+            .unwrap_or(false);
+
+        if success {
+            Ok(())
+        } else {
+            Err(SymphonyError::Other(format!(
+                "commentCreate failed for issue '{}'",
+                issue_id
+            )))
+        }
     }
 
     // ── GraphQL transport ──────────────────────────────────────────────

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -98,6 +98,10 @@ impl OrchestratorPort for LinearOrchestratorPort {
         let issues = self.block_on(self.adapter.fetch_issue_states_by_ids(&issue_ids))?;
         Ok(issues.into_iter().next())
     }
+
+    fn update_issue_state(&mut self, issue_id: &str, state_name: &str) -> error::Result<()> {
+        self.block_on(self.adapter.update_issue_state(issue_id, state_name))
+    }
 }
 
 #[derive(Default)]

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -24,17 +24,13 @@ pub struct Cli {
     #[arg(default_value = "WORKFLOW.md")]
     pub workflow_path: String,
 
-    /// HTTP server port
-    #[arg(long)]
+    /// HTTP server port (default: 8080)
+    #[arg(long, default_value = "8080")]
     pub port: Option<u16>,
 
     /// Log file root directory
     #[arg(long)]
     pub logs_root: Option<String>,
-
-    /// Acknowledge that this runs without guardrails
-    #[arg(long = "i-understand-that-this-will-be-running-without-the-usual-guardrails")]
-    pub acknowledge_guardrails: bool,
 }
 
 pub trait BootstrapDeps {
@@ -200,7 +196,7 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             http_host = http_binding.as_ref().map(|binding| binding.host.as_str()).unwrap_or("n/a"),
             http_port = http_binding.as_ref().map(|binding| binding.port),
             logs_root_configured = cli.logs_root.is_some(),
-            guardrails_acknowledged = cli.acknowledge_guardrails,
+
             "constructed orchestrator runtime"
         );
 
@@ -399,6 +395,9 @@ fn run_entrypoint(args: impl IntoIterator<Item = OsString>) -> i32 {
 
 #[tokio::main]
 async fn main() {
+    // Load .env file if present (silently ignore if missing)
+    let _ = dotenvy::dotenv();
+
     init_tracing();
 
     let code = run_entrypoint(std::env::args_os());

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -19,6 +19,16 @@ use crate::{path_safety, prompt_builder, workspace};
 
 // ── Standalone Worker Task ──────────────────────────────────────────────
 
+/// All configuration needed by a spawned worker task.
+/// Bundled into a struct to avoid too-many-arguments lint.
+struct WorkerTaskConfig {
+    workspace: WorkspaceConfig,
+    hooks: HooksConfig,
+    codex: CodexConfig,
+    tracker: crate::domain::TrackerConfig,
+    prompt_template: String,
+}
+
 /// Run the full worker lifecycle for a single issue. This function is
 /// designed to run in a spawned tokio task — it takes owned/cloned data
 /// and does not require `&mut Orchestrator`.
@@ -27,18 +37,15 @@ use crate::{path_safety, prompt_builder, workspace};
 /// Codex session → stream turn → stop session → after_run hook.
 async fn run_worker_task(
     issue: &Issue,
-    prompt_template: &str,
     attempt: Option<u32>,
     worker_host: Option<&str>,
-    workspace_config: &WorkspaceConfig,
-    hooks_config: &HooksConfig,
-    codex_config: &CodexConfig,
+    config: &WorkerTaskConfig,
 ) -> WorkerResult {
     let issue_id = issue.id.clone();
 
     // 1. Ensure workspace (create dir + after_create hook)
     let workspace_info =
-        match workspace::ensure_workspace(&issue.identifier, workspace_config, hooks_config) {
+        match workspace::ensure_workspace(&issue.identifier, &config.workspace, &config.hooks) {
             Ok(info) => info,
             Err(err) => {
                 tracing::error!(
@@ -62,7 +69,7 @@ async fn run_worker_task(
     let workspace_path = Path::new(&workspace_info.path);
 
     // 2. Before-run hook
-    if let Err(err) = workspace::run_before_run_hook(workspace_path, hooks_config) {
+    if let Err(err) = workspace::run_before_run_hook(workspace_path, &config.hooks) {
         tracing::error!(
             event = "worker_before_run_failed",
             issue_id = %issue_id,
@@ -80,7 +87,7 @@ async fn run_worker_task(
     }
 
     // 3. Render prompt
-    let prompt = match prompt_builder::render_prompt(prompt_template, issue, attempt) {
+    let prompt = match prompt_builder::render_prompt(&config.prompt_template, issue, attempt) {
         Ok(prompt) => prompt,
         Err(err) => {
             tracing::error!(
@@ -101,9 +108,9 @@ async fn run_worker_task(
     };
 
     // 4. Start Codex session
-    let workspace_root = Path::new(&workspace_config.root);
+    let workspace_root = Path::new(&config.workspace.root);
     let mut session = match app_server::start_session(
-        codex_config,
+        &config.codex,
         issue,
         workspace_path,
         workspace_root,
@@ -140,13 +147,12 @@ async fn run_worker_task(
         "worker attempt started"
     );
 
-    // 5. Run turn — use a no-op graphql executor (linear_graphql tool
-    //    requires a real LinearClient; wired up separately when needed)
+    // 5. Run turn — wire real linear_graphql executor via LinearClient
     let mut observed_events: Vec<AgentEvent> = Vec::new();
-    let graphql_executor = |_query: String, _vars: serde_json::Value| async move {
-        Err(crate::error::SymphonyError::InvalidWorkflowConfig(
-            "linear_graphql not configured in worker task".to_string(),
-        ))
+    let linear_client = crate::linear::client::LinearClient::new(config.tracker.clone());
+    let graphql_executor = move |query: String, vars: serde_json::Value| {
+        let client = linear_client.clone();
+        async move { client.graphql_raw(&query, vars).await }
     };
 
     let run_result: Result<_> =
@@ -165,7 +171,7 @@ async fn run_worker_task(
     }
 
     // 7. After-run hook
-    let _ = workspace::run_after_run_hook(workspace_path, hooks_config);
+    let _ = workspace::run_after_run_hook(workspace_path, &config.hooks);
 
     // 8. Build result
     match run_result {
@@ -406,6 +412,9 @@ pub trait OrchestratorPort {
     fn fetch_candidate_issues(&mut self) -> Result<Vec<Issue>>;
 
     fn refresh_issue(&mut self, issue_id: &str) -> Result<Option<Issue>>;
+
+    /// Update an issue's workflow state in the tracker (e.g., move to "In Progress").
+    fn update_issue_state(&mut self, issue_id: &str, state_name: &str) -> Result<()>;
 }
 
 /// S06 runtime authority loop state.
@@ -479,7 +488,7 @@ impl Orchestrator {
 
             match self.tick(port) {
                 Ok(tick_result) => {
-                    self.spawn_workers_for_dispatched(&tick_result.dispatched_issues);
+                    self.spawn_workers_for_dispatched(&tick_result.dispatched_issues, port);
                 }
                 Err(err) => {
                     tracing::warn!(
@@ -491,7 +500,7 @@ impl Orchestrator {
             }
 
             let retry_dispatched = self.process_due_retries(port, Utc::now().timestamp_millis());
-            self.spawn_workers_for_dispatched(&retry_dispatched);
+            self.spawn_workers_for_dispatched(&retry_dispatched, port);
             self.publish_snapshot();
 
             // Sleep until next poll interval, but wake early on refresh request
@@ -534,8 +543,23 @@ impl Orchestrator {
     }
 
     /// Spawn a tokio task for each newly dispatched issue.
-    fn spawn_workers_for_dispatched(&mut self, dispatched: &[DispatchedIssue]) {
+    fn spawn_workers_for_dispatched(
+        &mut self,
+        dispatched: &[DispatchedIssue],
+        port: &mut dyn OrchestratorPort,
+    ) {
         for d in dispatched {
+            // Move issue to "In Progress" in Linear (best-effort)
+            if let Err(err) = port.update_issue_state(&d.issue.id, "In Progress") {
+                tracing::warn!(
+                    event = "writeback_failed",
+                    issue_id = %d.issue.id,
+                    issue_identifier = %d.issue.identifier,
+                    error = %err,
+                    "failed to move issue to In Progress; continuing with dispatch"
+                );
+            }
+
             // Update status from "scheduled" to "running"
             if let Some(attempt) = self.state.running.get_mut(&d.issue.id) {
                 attempt.status = "running".to_string();
@@ -544,22 +568,17 @@ impl Orchestrator {
             let attempt = d.attempt;
             let worker_host = d.worker_host.clone();
             let tx = self.worker_result_tx.clone();
-            let prompt_template = self.prompt_template.clone();
-            let workspace_config = self.config.workspace.clone();
-            let hooks_config = self.config.hooks.clone();
-            let codex_config = self.config.codex.clone();
+            let task_config = WorkerTaskConfig {
+                workspace: self.config.workspace.clone(),
+                hooks: self.config.hooks.clone(),
+                codex: self.config.codex.clone(),
+                tracker: self.config.tracker.clone(),
+                prompt_template: self.prompt_template.clone(),
+            };
 
             tokio::spawn(async move {
-                let result = run_worker_task(
-                    &issue,
-                    &prompt_template,
-                    attempt,
-                    worker_host.as_deref(),
-                    &workspace_config,
-                    &hooks_config,
-                    &codex_config,
-                )
-                .await;
+                let result =
+                    run_worker_task(&issue, attempt, worker_host.as_deref(), &task_config).await;
 
                 if let Err(err) = tx.send(result) {
                     tracing::error!(

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -45,7 +45,7 @@ async fn run_worker_task(
 
     // 1. Ensure workspace (create dir + after_create hook)
     let workspace_info =
-        match workspace::ensure_workspace(&issue.identifier, &config.workspace, &config.hooks) {
+        match workspace::ensure_workspace_for_issue(issue, &config.workspace, &config.hooks) {
             Ok(info) => info,
             Err(err) => {
                 tracing::error!(
@@ -69,7 +69,8 @@ async fn run_worker_task(
     let workspace_path = Path::new(&workspace_info.path);
 
     // 2. Before-run hook
-    if let Err(err) = workspace::run_before_run_hook(workspace_path, &config.hooks) {
+    if let Err(err) = workspace::run_before_run_hook_for_issue(workspace_path, &config.hooks, issue)
+    {
         tracing::error!(
             event = "worker_before_run_failed",
             issue_id = %issue_id,
@@ -171,7 +172,7 @@ async fn run_worker_task(
     }
 
     // 7. After-run hook
-    let _ = workspace::run_after_run_hook(workspace_path, &config.hooks);
+    let _ = workspace::run_after_run_hook_for_issue(workspace_path, &config.hooks, issue);
 
     // 8. Build result
     match run_result {
@@ -999,8 +1000,8 @@ impl Orchestrator {
         E: Fn(String, serde_json::Value) -> EFut + Clone + Send,
         EFut: Future<Output = Result<serde_json::Value>> + Send,
     {
-        let workspace_info = workspace::ensure_workspace(
-            &issue.identifier,
+        let workspace_info = workspace::ensure_workspace_for_issue(
+            issue,
             &self.config.workspace,
             &self.config.hooks,
         )?;
@@ -1032,7 +1033,9 @@ impl Orchestrator {
         self.state.retry_attempts.remove(&issue.id);
 
         let workspace_path = Path::new(&workspace_info.path);
-        if let Err(err) = workspace::run_before_run_hook(workspace_path, &self.config.hooks) {
+        if let Err(err) =
+            workspace::run_before_run_hook_for_issue(workspace_path, &self.config.hooks, issue)
+        {
             self.handle_worker_completion(
                 &issue.id,
                 WorkerCompletion::Failed {
@@ -1107,7 +1110,7 @@ impl Orchestrator {
             );
         }
 
-        let _ = workspace::run_after_run_hook(workspace_path, &self.config.hooks);
+        let _ = workspace::run_after_run_hook_for_issue(workspace_path, &self.config.hooks, issue);
 
         match run_result {
             Ok(turn_result) => {

--- a/apps/symphony/src/repo_url.rs
+++ b/apps/symphony/src/repo_url.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 
 /// Returns true when a repo reference looks like a remote URL.
 pub fn repo_is_remote(repo: &str) -> bool {
-    repo.contains("://") || repo.starts_with("git@")
+    repo.contains("://") || repo.contains('@')
 }
 
 /// Redacts URL user-info segments (`scheme://user[:pass]@host`) in command output.

--- a/apps/symphony/src/repo_url.rs
+++ b/apps/symphony/src/repo_url.rs
@@ -1,0 +1,39 @@
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Returns true when a repo reference looks like a remote URL.
+pub fn repo_is_remote(repo: &str) -> bool {
+    repo.contains("://") || repo.starts_with("git@")
+}
+
+/// Redacts URL user-info segments (`scheme://user[:pass]@host`) in command output.
+pub fn redact_url_credentials(input: &str) -> String {
+    static URL_USERINFO_RE: OnceLock<Regex> = OnceLock::new();
+    let re = URL_USERINFO_RE.get_or_init(|| {
+        Regex::new(r"([A-Za-z][A-Za-z0-9+.\-]*://)([^/@\s]+)@")
+            .expect("repo URL redaction regex must compile")
+    });
+    re.replace_all(input, "$1[REDACTED]@").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_repo_is_remote() {
+        assert!(repo_is_remote("https://github.com/org/repo.git"));
+        assert!(repo_is_remote("git@github.com:org/repo.git"));
+        assert!(!repo_is_remote("/tmp/local-repo"));
+    }
+
+    #[test]
+    fn test_redact_url_credentials() {
+        let output = "fatal: could not read from https://user:token@example.com/repo";
+        let redacted = redact_url_credentials(output);
+        assert!(
+            redacted.contains("https://[REDACTED]@example.com/repo"),
+            "expected URL credentials to be redacted, got: {redacted}"
+        );
+    }
+}

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -199,6 +199,12 @@ fn bootstrap_repository(
                 ));
             }
 
+            // Older git versions require a non-existent target path for
+            // `git worktree add`. remove the pre-created empty directory first.
+            if workspace.exists() {
+                std::fs::remove_dir(workspace)?;
+            }
+
             let mut worktree_cmd = Command::new("git");
             worktree_cmd
                 .arg("-C")

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -3,10 +3,42 @@
 //! Full implementation in S04/T03. This is the public API skeleton so tests compile.
 
 use std::path::Path;
+use std::process::Command;
 
-use crate::domain::{HooksConfig, Workspace, WorkspaceConfig};
+use crate::domain::{HooksConfig, Issue, Workspace, WorkspaceConfig, WorkspaceRepoStrategy};
 use crate::error::{Result, SymphonyError};
 use crate::path_safety;
+
+#[derive(Debug, Clone)]
+struct HookIssueContext {
+    issue_id: String,
+    issue_identifier: String,
+    issue_title: String,
+}
+
+impl HookIssueContext {
+    fn from_identifier(identifier: &str) -> Self {
+        Self {
+            issue_id: String::new(),
+            issue_identifier: identifier.to_string(),
+            issue_title: String::new(),
+        }
+    }
+
+    fn from_issue(issue: &Issue) -> Self {
+        Self {
+            issue_id: issue.id.clone(),
+            issue_identifier: issue.identifier.clone(),
+            issue_title: issue.title.clone(),
+        }
+    }
+
+    fn from_issue_or_identifier(issue: Option<&Issue>, identifier: &str) -> Self {
+        issue
+            .map(Self::from_issue)
+            .unwrap_or_else(|| Self::from_identifier(identifier))
+    }
+}
 
 /// Create or reuse a workspace directory for the given identifier.
 ///
@@ -14,13 +46,34 @@ use crate::path_safety;
 /// - Computes the workspace path under `config.root`
 /// - Validates that the workspace stays within the root (no symlink escapes)
 /// - Creates the directory if missing, reuses if present, replaces non-dirs
+/// - Runs repository bootstrap (when configured) before `after_create`
 /// - Runs the `after_create` hook if the directory was newly created
 pub fn ensure_workspace(
     identifier: &str,
     config: &WorkspaceConfig,
     hooks: &HooksConfig,
 ) -> Result<Workspace> {
+    ensure_workspace_internal(identifier, None, config, hooks)
+}
+
+/// Issue-aware variant that injects full issue metadata into hook env vars.
+pub fn ensure_workspace_for_issue(
+    issue: &Issue,
+    config: &WorkspaceConfig,
+    hooks: &HooksConfig,
+) -> Result<Workspace> {
+    ensure_workspace_internal(&issue.identifier, Some(issue), config, hooks)
+}
+
+fn ensure_workspace_internal(
+    identifier: &str,
+    issue: Option<&Issue>,
+    config: &WorkspaceConfig,
+    hooks: &HooksConfig,
+) -> Result<Workspace> {
     let safe_id = path_safety::sanitize_identifier(identifier);
+    let hook_issue = HookIssueContext::from_issue_or_identifier(issue, identifier);
+
     let root_path = Path::new(&config.root);
     let canonical_root = path_safety::canonicalize(root_path)?;
     let workspace_path = canonical_root.join(&safe_id);
@@ -45,10 +98,21 @@ pub fn ensure_workspace(
         (canonical_workspace.clone(), true)
     };
 
-    // Run after_create hook if newly created — clean up on failure
+    // Run bootstrap + after_create hook if newly created — clean up on failure
     if created_now {
+        if let Err(err) = bootstrap_repository(&final_path, config, &hook_issue.issue_identifier) {
+            let _ = std::fs::remove_dir_all(&final_path);
+            return Err(err);
+        }
+
         if let Some(ref command) = hooks.after_create {
-            if let Err(err) = run_hook("after_create", command, &final_path, hooks.timeout_ms) {
+            if let Err(err) = run_hook(
+                "after_create",
+                command,
+                &final_path,
+                hooks.timeout_ms,
+                &hook_issue,
+            ) {
                 // Remove the partially-initialized workspace so the next call
                 // doesn't silently reuse it with created_now=false
                 let _ = std::fs::remove_dir_all(&final_path);
@@ -90,9 +154,112 @@ pub fn validate_workspace_path(workspace: &Path, root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Run repository bootstrap (clone/worktree + branch creation) when configured.
+fn bootstrap_repository(
+    workspace: &Path,
+    config: &WorkspaceConfig,
+    issue_identifier: &str,
+) -> Result<()> {
+    let Some(repo) = config.repo.as_deref() else {
+        return Ok(());
+    };
+
+    let branch_name = format!("{}/{}", config.branch_prefix, issue_identifier);
+    let workspace_str = workspace.to_string_lossy().to_string();
+
+    match config.strategy {
+        WorkspaceRepoStrategy::Clone => {
+            // Keep CLI parity with the proposal: git clone <repo> . --single-branch
+            let mut clone_cmd = Command::new("git");
+            clone_cmd
+                .arg("clone")
+                .arg(repo)
+                .arg(".")
+                .arg("--single-branch")
+                .current_dir(workspace);
+            run_git_command(clone_cmd, "workspace clone bootstrap")?;
+
+            let mut checkout_cmd = Command::new("git");
+            checkout_cmd
+                .arg("checkout")
+                .arg("-b")
+                .arg(&branch_name)
+                .current_dir(workspace);
+            run_git_command(checkout_cmd, "workspace branch bootstrap")
+        }
+        WorkspaceRepoStrategy::Worktree => {
+            if repo_is_remote(repo) {
+                return Err(SymphonyError::InvalidWorkflowConfig(
+                    "workspace.strategy 'worktree' requires workspace.repo to be a local path"
+                        .to_string(),
+                ));
+            }
+
+            let mut worktree_cmd = Command::new("git");
+            worktree_cmd
+                .arg("-C")
+                .arg(repo)
+                .arg("worktree")
+                .arg("add")
+                .arg(&workspace_str)
+                .arg("-b")
+                .arg(&branch_name);
+            run_git_command(worktree_cmd, "workspace worktree bootstrap")
+        }
+    }
+}
+
+/// Remove a worktree checkout from the source repository.
+fn cleanup_worktree_checkout(workspace: &Path, config: &WorkspaceConfig) -> Result<()> {
+    if config.strategy != WorkspaceRepoStrategy::Worktree {
+        return Ok(());
+    }
+
+    let Some(repo) = config.repo.as_deref() else {
+        return Ok(());
+    };
+
+    let workspace_str = workspace.to_string_lossy().to_string();
+    let mut worktree_remove = Command::new("git");
+    worktree_remove
+        .arg("-C")
+        .arg(repo)
+        .arg("worktree")
+        .arg("remove")
+        .arg("--force")
+        .arg(&workspace_str);
+    run_git_command(worktree_remove, "workspace worktree cleanup")
+}
+
+fn repo_is_remote(repo: &str) -> bool {
+    repo.contains("://") || repo.starts_with("git@")
+}
+
+fn run_git_command(mut command: Command, context: &str) -> Result<()> {
+    let output = command.output().map_err(SymphonyError::Io)?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let status = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    let truncated = truncate_output(&combined, 2048);
+
+    Err(SymphonyError::Other(format!(
+        "{context} failed (status {status}): {truncated}"
+    )))
+}
+
 /// Run a hook command via `sh -lc` in the workspace directory with a timeout.
-fn run_hook(name: &str, command: &str, workspace: &Path, timeout_ms: u64) -> Result<()> {
-    use std::process::Command;
+fn run_hook(
+    name: &str,
+    command: &str,
+    workspace: &Path,
+    timeout_ms: u64,
+    issue: &HookIssueContext,
+) -> Result<()> {
     use std::time::Duration;
 
     tracing::info!(
@@ -104,9 +271,14 @@ fn run_hook(name: &str, command: &str, workspace: &Path, timeout_ms: u64) -> Res
     #[cfg(unix)]
     use std::os::unix::process::CommandExt;
 
+    let workspace_path = workspace.to_string_lossy().to_string();
     let mut cmd = Command::new("sh");
     cmd.args(["-lc", command])
         .current_dir(workspace)
+        .env("SYMPHONY_ISSUE_ID", &issue.issue_id)
+        .env("SYMPHONY_ISSUE_IDENTIFIER", &issue.issue_identifier)
+        .env("SYMPHONY_ISSUE_TITLE", &issue.issue_title)
+        .env("SYMPHONY_WORKSPACE_PATH", &workspace_path)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
@@ -196,8 +368,36 @@ unsafe fn libc_kill(pid: i32, sig: i32) -> i32 {
 
 /// Run the `before_run` hook — failure is fatal.
 pub fn run_before_run_hook(workspace: &Path, hooks: &HooksConfig) -> Result<()> {
+    run_before_run_hook_internal(workspace, hooks, None)
+}
+
+/// Issue-aware variant that injects full issue metadata into hook env vars.
+pub fn run_before_run_hook_for_issue(
+    workspace: &Path,
+    hooks: &HooksConfig,
+    issue: &Issue,
+) -> Result<()> {
+    run_before_run_hook_internal(workspace, hooks, Some(issue))
+}
+
+fn run_before_run_hook_internal(
+    workspace: &Path,
+    hooks: &HooksConfig,
+    issue: Option<&Issue>,
+) -> Result<()> {
     if let Some(ref command) = hooks.before_run {
-        run_hook("before_run", command, workspace, hooks.timeout_ms)
+        let fallback_identifier = workspace
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        let hook_issue = HookIssueContext::from_issue_or_identifier(issue, fallback_identifier);
+        run_hook(
+            "before_run",
+            command,
+            workspace,
+            hooks.timeout_ms,
+            &hook_issue,
+        )
     } else {
         Ok(())
     }
@@ -205,8 +405,36 @@ pub fn run_before_run_hook(workspace: &Path, hooks: &HooksConfig) -> Result<()> 
 
 /// Run the `after_run` hook — failure is logged and ignored.
 pub fn run_after_run_hook(workspace: &Path, hooks: &HooksConfig) -> Result<()> {
+    run_after_run_hook_internal(workspace, hooks, None)
+}
+
+/// Issue-aware variant that injects full issue metadata into hook env vars.
+pub fn run_after_run_hook_for_issue(
+    workspace: &Path,
+    hooks: &HooksConfig,
+    issue: &Issue,
+) -> Result<()> {
+    run_after_run_hook_internal(workspace, hooks, Some(issue))
+}
+
+fn run_after_run_hook_internal(
+    workspace: &Path,
+    hooks: &HooksConfig,
+    issue: Option<&Issue>,
+) -> Result<()> {
     if let Some(ref command) = hooks.after_run {
-        match run_hook("after_run", command, workspace, hooks.timeout_ms) {
+        let fallback_identifier = workspace
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        let hook_issue = HookIssueContext::from_issue_or_identifier(issue, fallback_identifier);
+        match run_hook(
+            "after_run",
+            command,
+            workspace,
+            hooks.timeout_ms,
+            &hook_issue,
+        ) {
             Ok(()) => Ok(()),
             Err(e) => {
                 tracing::warn!(error = %e, "after_run hook failure ignored");
@@ -224,15 +452,47 @@ pub fn remove_workspace(
     config: &WorkspaceConfig,
     hooks: &HooksConfig,
 ) -> Result<()> {
+    remove_workspace_internal(workspace, config, hooks, None)
+}
+
+/// Issue-aware variant that injects full issue metadata into hook env vars.
+pub fn remove_workspace_for_issue(
+    workspace: &Path,
+    config: &WorkspaceConfig,
+    hooks: &HooksConfig,
+    issue: &Issue,
+) -> Result<()> {
+    remove_workspace_internal(workspace, config, hooks, Some(issue))
+}
+
+fn remove_workspace_internal(
+    workspace: &Path,
+    config: &WorkspaceConfig,
+    hooks: &HooksConfig,
+    issue: Option<&Issue>,
+) -> Result<()> {
     let canonical_root = path_safety::canonicalize(Path::new(&config.root))?;
 
     if workspace.exists() {
         validate_workspace_path(workspace, &canonical_root)?;
+        let canonical_workspace = path_safety::canonicalize(workspace)?;
 
         // Run before_remove hook (failure ignored)
         if let Some(ref command) = hooks.before_remove {
-            if workspace.is_dir() {
-                match run_hook("before_remove", command, workspace, hooks.timeout_ms) {
+            if canonical_workspace.is_dir() {
+                let fallback_identifier = canonical_workspace
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("");
+                let hook_issue =
+                    HookIssueContext::from_issue_or_identifier(issue, fallback_identifier);
+                match run_hook(
+                    "before_remove",
+                    command,
+                    &canonical_workspace,
+                    hooks.timeout_ms,
+                    &hook_issue,
+                ) {
                     Ok(()) => {}
                     Err(e) => {
                         tracing::warn!(error = %e, "before_remove hook failure ignored");
@@ -241,7 +501,11 @@ pub fn remove_workspace(
             }
         }
 
-        std::fs::remove_dir_all(workspace)?;
+        cleanup_worktree_checkout(&canonical_workspace, config)?;
+
+        if canonical_workspace.exists() {
+            std::fs::remove_dir_all(&canonical_workspace)?;
+        }
     }
 
     Ok(())

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 use crate::domain::{HooksConfig, Issue, Workspace, WorkspaceConfig, WorkspaceRepoStrategy};
 use crate::error::{Result, SymphonyError};
 use crate::path_safety;
+use crate::repo_url::{redact_url_credentials, repo_is_remote};
 
 #[derive(Debug, Clone)]
 struct HookIssueContext {
@@ -175,8 +176,11 @@ fn bootstrap_repository(
                 .arg("clone")
                 .arg(repo)
                 .arg(".")
-                .arg("--single-branch")
-                .current_dir(workspace);
+                .arg("--single-branch");
+            if let Some(clone_branch) = config.clone_branch.as_deref() {
+                clone_cmd.arg("--branch").arg(clone_branch);
+            }
+            clone_cmd.current_dir(workspace);
             run_git_command(clone_cmd, "workspace clone bootstrap")?;
 
             let mut checkout_cmd = Command::new("git");
@@ -231,10 +235,6 @@ fn cleanup_worktree_checkout(workspace: &Path, config: &WorkspaceConfig) -> Resu
     run_git_command(worktree_remove, "workspace worktree cleanup")
 }
 
-fn repo_is_remote(repo: &str) -> bool {
-    repo.contains("://") || repo.starts_with("git@")
-}
-
 fn run_git_command(mut command: Command, context: &str) -> Result<()> {
     let output = command.output().map_err(SymphonyError::Io)?;
     if output.status.success() {
@@ -245,7 +245,8 @@ fn run_git_command(mut command: Command, context: &str) -> Result<()> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let combined = format!("{stdout}{stderr}");
-    let truncated = truncate_output(&combined, 2048);
+    let redacted = redact_url_credentials(&combined);
+    let truncated = truncate_output(&redacted, 2048);
 
     Err(SymphonyError::Other(format!(
         "{context} failed (status {status}): {truncated}"
@@ -501,7 +502,13 @@ fn remove_workspace_internal(
             }
         }
 
-        cleanup_worktree_checkout(&canonical_workspace, config)?;
+        if let Err(err) = cleanup_worktree_checkout(&canonical_workspace, config) {
+            tracing::warn!(
+                error = %err,
+                workspace = %canonical_workspace.display(),
+                "worktree cleanup failed; continuing workspace directory removal"
+            );
+        }
 
         if canonical_workspace.exists() {
             std::fs::remove_dir_all(&canonical_workspace)?;

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -250,15 +250,17 @@ fn test_effective_http_binding_prefers_cli_port_override() {
 }
 
 #[test]
-fn test_effective_http_binding_returns_none_without_any_port() {
+fn test_effective_http_binding_defaults_to_8080() {
     let mut config = ServiceConfig::default();
     config.server.port = None;
 
     let cli =
         main_bin::parse_cli_from(["symphony", "WORKFLOW.md"]).expect("CLI parse should succeed");
 
+    let binding = main_bin::effective_http_binding(&config, &cli);
     assert!(
-        main_bin::effective_http_binding(&config, &cli).is_none(),
-        "orchestrator should run without HTTP listener when no effective port is configured"
+        binding.is_some(),
+        "HTTP binding should default to port 8080"
     );
+    assert_eq!(binding.unwrap().port, 8080);
 }

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -901,7 +901,9 @@ async fn test_create_comment_success() {
         .await;
 
     let client = test_client(&server, None);
-    let result = client.create_comment("issue-1", "Hello from Symphony").await;
+    let result = client
+        .create_comment("issue-1", "Hello from Symphony")
+        .await;
     assert!(result.is_ok());
     mock.assert_async().await;
 }

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -777,30 +777,133 @@ async fn test_adapter_fetch_by_ids() {
 }
 
 #[tokio::test]
-async fn test_adapter_create_comment_not_implemented() {
-    let server = Server::new_async().await;
-    let adapter = test_adapter(&server, None);
+async fn test_resolve_state_id_returns_matching_state() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/graphql")
+        .with_body(
+            json!({
+                "data": {
+                    "issue": {
+                        "team": {
+                            "states": {
+                                "nodes": [{"id": "state-in-progress-123"}]
+                            }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
 
-    let err = adapter.create_comment("id-1", "hello").await.unwrap_err();
-    match err {
-        SymphonyError::Other(msg) => assert_eq!(msg, "not implemented"),
-        other => panic!("expected Other(not implemented), got: {:?}", other),
-    }
+    let client = test_client(&server, None);
+    let result = client.resolve_state_id("issue-1", "In Progress").await;
+    assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
+    assert_eq!(result.unwrap(), "state-in-progress-123");
+    mock.assert_async().await;
 }
 
 #[tokio::test]
-async fn test_adapter_update_issue_state_not_implemented() {
-    let server = Server::new_async().await;
-    let adapter = test_adapter(&server, None);
+async fn test_resolve_state_id_returns_error_when_not_found() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/graphql")
+        .with_body(
+            json!({
+                "data": {
+                    "issue": {
+                        "team": {
+                            "states": {
+                                "nodes": []
+                            }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
 
-    let err = adapter
-        .update_issue_state("id-1", "Done")
-        .await
-        .unwrap_err();
-    match err {
-        SymphonyError::Other(msg) => assert_eq!(msg, "not implemented"),
-        other => panic!("expected Other(not implemented), got: {:?}", other),
-    }
+    let client = test_client(&server, None);
+    let result = client.resolve_state_id("issue-1", "Nonexistent").await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("not found"), "expected 'not found' in: {err}");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_update_issue_state_resolves_and_updates() {
+    let mut server = Server::new_async().await;
+
+    // First call: resolve state ID
+    let state_mock = server
+        .mock("POST", "/graphql")
+        .with_body(
+            json!({
+                "data": {
+                    "issue": {
+                        "team": {
+                            "states": {
+                                "nodes": [{"id": "state-done-456"}]
+                            }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    // Second call: update issue state
+    let update_mock = server
+        .mock("POST", "/graphql")
+        .with_body(
+            json!({
+                "data": {
+                    "issueUpdate": {
+                        "success": true
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let client = test_client(&server, None);
+    let result = client.update_issue_state("issue-1", "Done").await;
+    assert!(result.is_ok());
+    state_mock.assert_async().await;
+    update_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_create_comment_success() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/graphql")
+        .with_body(
+            json!({
+                "data": {
+                    "commentCreate": {
+                        "success": true
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let client = test_client(&server, None);
+    let result = client.create_comment("issue-1", "Hello from Symphony").await;
+    assert!(result.is_ok());
+    mock.assert_async().await;
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -68,6 +68,12 @@ impl OrchestratorPort for FakePort {
             .find(|issue| issue.id == issue_id)
             .cloned())
     }
+
+    fn update_issue_state(&mut self, issue_id: &str, state_name: &str) -> Result<()> {
+        self.calls
+            .push(format!("update_issue_state:{issue_id}:{state_name}"));
+        Ok(())
+    }
 }
 
 fn test_config(max_concurrent_agents: u32) -> ServiceConfig {

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -9,7 +9,9 @@ use std::io::Write;
 use tempfile::NamedTempFile;
 
 use symphony::config::{from_workflow, validate};
-use symphony::domain::{CodexConfig, ServiceConfig, TrackerConfig};
+use symphony::domain::{
+    CodexConfig, ServiceConfig, TrackerConfig, WorkspaceConfig, WorkspaceRepoStrategy,
+};
 use symphony::error::SymphonyError;
 use symphony::workflow::parse_workflow;
 use symphony::workflow_store::WorkflowStore;
@@ -132,6 +134,9 @@ fn test_config_defaults() {
     assert_eq!(config.polling.interval_ms, 30_000);
     assert_eq!(config.agent.max_concurrent_agents, 10);
     assert_eq!(config.agent.max_turns, 20);
+    assert_eq!(config.workspace.repo, None);
+    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
+    assert_eq!(config.workspace.branch_prefix, "symphony");
 }
 
 #[test]
@@ -193,6 +198,93 @@ fn test_config_tilde_expansion() {
         Some(home) => std::env::set_var("HOME", home),
         None => std::env::remove_var("HOME"),
     }
+}
+
+#[test]
+fn test_workspace_repo_strategy_and_branch_prefix_parse() {
+    let yaml_str = r#"
+workspace:
+  root: ~/workspaces
+  repo: https://github.com/gannonh/kata.git
+  strategy: clone
+  branch_prefix: symphony
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace bootstrap config should parse");
+
+    assert_eq!(
+        config.workspace.repo.as_deref(),
+        Some("https://github.com/gannonh/kata.git")
+    );
+    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
+    assert_eq!(config.workspace.branch_prefix, "symphony");
+}
+
+#[test]
+fn test_workspace_strategy_invalid_value_errors() {
+    let yaml_str = r#"
+workspace:
+  repo: /tmp/local-repo
+  strategy: invalid
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let result = from_workflow(&raw);
+
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.strategy")),
+        "invalid workspace.strategy should return InvalidWorkflowConfig, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_config_validation_rejects_worktree_without_repo() {
+    let config = ServiceConfig {
+        tracker: TrackerConfig {
+            kind: Some("linear".to_string()),
+            api_key: Some("test-key".into()),
+            project_slug: Some("my-project".to_string()),
+            ..TrackerConfig::default()
+        },
+        workspace: WorkspaceConfig {
+            strategy: WorkspaceRepoStrategy::Worktree,
+            repo: None,
+            ..WorkspaceConfig::default()
+        },
+        ..ServiceConfig::default()
+    };
+
+    let result = validate(&config);
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.repo")),
+        "worktree strategy without repo should fail validation, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_config_validation_rejects_worktree_with_remote_repo() {
+    let config = ServiceConfig {
+        tracker: TrackerConfig {
+            kind: Some("linear".to_string()),
+            api_key: Some("test-key".into()),
+            project_slug: Some("my-project".to_string()),
+            ..TrackerConfig::default()
+        },
+        workspace: WorkspaceConfig {
+            strategy: WorkspaceRepoStrategy::Worktree,
+            repo: Some("https://github.com/gannonh/kata.git".to_string()),
+            ..WorkspaceConfig::default()
+        },
+        ..ServiceConfig::default()
+    };
+
+    let result = validate(&config);
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.strategy") && msg.contains("local")),
+        "worktree strategy with remote repo should fail validation, got: {:?}",
+        result
+    );
 }
 
 #[test]

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -137,6 +137,7 @@ fn test_config_defaults() {
     assert_eq!(config.workspace.repo, None);
     assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
     assert_eq!(config.workspace.branch_prefix, "symphony");
+    assert_eq!(config.workspace.clone_branch, None);
 }
 
 #[test]
@@ -207,7 +208,8 @@ workspace:
   root: ~/workspaces
   repo: https://github.com/gannonh/kata.git
   strategy: clone
-  branch_prefix: symphony
+  branch_prefix: " symphony "
+  clone_branch: elixir-feature-parity
 "#;
     let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
     let config = from_workflow(&raw).expect("workspace bootstrap config should parse");
@@ -218,6 +220,21 @@ workspace:
     );
     assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
     assert_eq!(config.workspace.branch_prefix, "symphony");
+    assert_eq!(
+        config.workspace.clone_branch.as_deref(),
+        Some("elixir-feature-parity")
+    );
+}
+
+#[test]
+fn test_workspace_clone_branch_blank_is_ignored() {
+    let yaml_str = r#"
+workspace:
+  clone_branch: "   "
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace clone branch should parse");
+    assert_eq!(config.workspace.clone_branch, None);
 }
 
 #[test]

--- a/apps/symphony/tests/workspace_prompt_tests.rs
+++ b/apps/symphony/tests/workspace_prompt_tests.rs
@@ -110,6 +110,7 @@ fn workspace_config(root: &Path) -> WorkspaceConfig {
         repo: None,
         strategy: WorkspaceRepoStrategy::Clone,
         branch_prefix: "symphony".to_string(),
+        clone_branch: None,
     }
 }
 
@@ -188,6 +189,24 @@ fn init_git_repo(path: &Path) {
         .current_dir(path)
         .args(["commit", "-m", "initial commit"]);
     command_success(commit, "git commit source repo files");
+}
+
+fn create_branch_with_commit(path: &Path, branch: &str, file: &str, contents: &str) {
+    let mut checkout = Command::new("git");
+    checkout.current_dir(path).args(["checkout", "-b", branch]);
+    command_success(checkout, "git checkout new source branch");
+
+    fs::write(path.join(file), contents).unwrap();
+
+    let mut add = Command::new("git");
+    add.current_dir(path).args(["add", file]);
+    command_success(add, "git add branch-specific file");
+
+    let mut commit = Command::new("git");
+    commit
+        .current_dir(path)
+        .args(["commit", "-m", "branch-specific commit"]);
+    command_success(commit, "git commit branch-specific file");
 }
 
 fn shell_quote(path: &Path) -> String {
@@ -433,12 +452,19 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
     let source_repo = tmp.path().join("source-repo");
     fs::create_dir_all(&root).unwrap();
     init_git_repo(&source_repo);
+    create_branch_with_commit(
+        &source_repo,
+        "elixir-feature-parity",
+        "BASE_BRANCH.txt",
+        "elixir-feature-parity\n",
+    );
 
     let config = WorkspaceConfig {
         root: root.to_string_lossy().to_string(),
         repo: Some(source_repo.to_string_lossy().to_string()),
         strategy: WorkspaceRepoStrategy::Clone,
         branch_prefix: "symphony".to_string(),
+        clone_branch: Some("elixir-feature-parity".to_string()),
     };
     let hooks = HooksConfig {
         after_create: Some("git rev-parse --abbrev-ref HEAD > hook_branch.txt".to_string()),
@@ -459,6 +485,10 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
     assert!(
         ws_path.join("README.md").exists(),
         "cloned workspace should contain source repo files"
+    );
+    assert!(
+        ws_path.join("BASE_BRANCH.txt").exists(),
+        "clone bootstrap should clone the configured source branch"
     );
 
     let mut branch_cmd = Command::new("git");
@@ -490,6 +520,7 @@ fn test_workspace_worktree_bootstrap_and_cleanup() {
         repo: Some(source_repo.to_string_lossy().to_string()),
         strategy: WorkspaceRepoStrategy::Worktree,
         branch_prefix: "symphony".to_string(),
+        clone_branch: None,
     };
     let hooks = hooks_config_none();
     let issue = make_test_issue("KAT-801");
@@ -612,6 +643,41 @@ fn test_workspace_remove_runs_before_remove_hook() {
     assert!(
         !ws_path.exists(),
         "workspace should be removed even if hook fails"
+    );
+}
+
+#[test]
+fn test_workspace_remove_continues_when_worktree_cleanup_fails() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(source_repo.to_string_lossy().to_string()),
+        strategy: WorkspaceRepoStrategy::Worktree,
+        branch_prefix: "symphony".to_string(),
+        clone_branch: None,
+    };
+    let hooks = hooks_config_none();
+    let issue = make_test_issue("KAT-803");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+    let ws_path = PathBuf::from(&ws.path);
+
+    // Break worktree cleanup by moving the source repo path away.
+    fs::rename(&source_repo, tmp.path().join("moved-source-repo")).unwrap();
+
+    let result = symphony::workspace::remove_workspace_for_issue(&ws_path, &config, &hooks, &issue);
+    assert!(
+        result.is_ok(),
+        "workspace removal should continue after cleanup failure"
+    );
+    assert!(
+        !ws_path.exists(),
+        "workspace directory should still be deleted if worktree cleanup fails"
     );
 }
 

--- a/apps/symphony/tests/workspace_prompt_tests.rs
+++ b/apps/symphony/tests/workspace_prompt_tests.rs
@@ -5,11 +5,12 @@
 use std::fs;
 use std::os::unix::fs as unix_fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use chrono::{DateTime, Utc};
 use tempfile::TempDir;
 
-use symphony::domain::{BlockerRef, HooksConfig, Issue, WorkspaceConfig};
+use symphony::domain::{BlockerRef, HooksConfig, Issue, WorkspaceConfig, WorkspaceRepoStrategy};
 use symphony::error::SymphonyError;
 use symphony::path_safety;
 
@@ -106,6 +107,9 @@ fn test_canonicalize_nested_symlink() {
 fn workspace_config(root: &Path) -> WorkspaceConfig {
     WorkspaceConfig {
         root: root.to_string_lossy().to_string(),
+        repo: None,
+        strategy: WorkspaceRepoStrategy::Clone,
+        branch_prefix: "symphony".to_string(),
     }
 }
 
@@ -137,6 +141,58 @@ fn make_test_issue(identifier: &str) -> Issue {
         created_at: None,
         updated_at: None,
     }
+}
+
+fn command_success(mut cmd: Command, context: &str) -> String {
+    let output = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("{context}: failed to spawn command: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "{context}: command failed\nstatus: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        stdout,
+        stderr
+    );
+    stdout.trim().to_string()
+}
+
+fn init_git_repo(path: &Path) {
+    fs::create_dir_all(path).unwrap();
+    fs::write(path.join("README.md"), "hello from source repo\n").unwrap();
+
+    let mut init = Command::new("git");
+    init.current_dir(path).arg("init");
+    command_success(init, "git init source repo");
+
+    let mut set_name = Command::new("git");
+    set_name
+        .current_dir(path)
+        .args(["config", "user.name", "Symphony Test"]);
+    command_success(set_name, "git config user.name");
+
+    let mut set_email = Command::new("git");
+    set_email
+        .current_dir(path)
+        .args(["config", "user.email", "symphony-tests@example.com"]);
+    command_success(set_email, "git config user.email");
+
+    let mut add = Command::new("git");
+    add.current_dir(path).args(["add", "."]);
+    command_success(add, "git add source repo files");
+
+    let mut commit = Command::new("git");
+    commit
+        .current_dir(path)
+        .args(["commit", "-m", "initial commit"]);
+    command_success(commit, "git commit source repo files");
+}
+
+fn shell_quote(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    format!("'{}'", raw.replace('\'', "'\"'\"'"))
 }
 
 #[test]
@@ -368,6 +424,145 @@ fn test_workspace_after_create_hook_timeout() {
         }
         other => panic!("Expected WorkspaceHookTimeout, got: {:?}", other),
     }
+}
+
+#[test]
+fn test_workspace_clone_bootstrap_and_branch_creation() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(source_repo.to_string_lossy().to_string()),
+        strategy: WorkspaceRepoStrategy::Clone,
+        branch_prefix: "symphony".to_string(),
+    };
+    let hooks = HooksConfig {
+        after_create: Some("git rev-parse --abbrev-ref HEAD > hook_branch.txt".to_string()),
+        before_run: None,
+        after_run: None,
+        before_remove: None,
+        timeout_ms: 5_000,
+    };
+    let issue = make_test_issue("KAT-800");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+    let ws_path = PathBuf::from(&ws.path);
+
+    assert!(
+        ws.created_now,
+        "new clone workspace should be newly created"
+    );
+    assert!(
+        ws_path.join("README.md").exists(),
+        "cloned workspace should contain source repo files"
+    );
+
+    let mut branch_cmd = Command::new("git");
+    branch_cmd.args(["-C", &ws.path, "rev-parse", "--abbrev-ref", "HEAD"]);
+    let branch = command_success(branch_cmd, "read clone workspace branch");
+    assert_eq!(
+        branch, "symphony/KAT-800",
+        "clone bootstrap should create and checkout issue branch"
+    );
+
+    let hook_branch = fs::read_to_string(ws_path.join("hook_branch.txt")).unwrap();
+    assert_eq!(
+        hook_branch.trim(),
+        "symphony/KAT-800",
+        "after_create hook should run after bootstrap and see the created branch"
+    );
+}
+
+#[test]
+fn test_workspace_worktree_bootstrap_and_cleanup() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(source_repo.to_string_lossy().to_string()),
+        strategy: WorkspaceRepoStrategy::Worktree,
+        branch_prefix: "symphony".to_string(),
+    };
+    let hooks = hooks_config_none();
+    let issue = make_test_issue("KAT-801");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+    let ws_path = PathBuf::from(&ws.path);
+    assert!(
+        ws_path.join("README.md").exists(),
+        "worktree workspace should expose source repo files"
+    );
+
+    let source_repo_str = source_repo.to_string_lossy().to_string();
+    let mut list_before_cmd = Command::new("git");
+    list_before_cmd.args(["-C", &source_repo_str, "worktree", "list", "--porcelain"]);
+    let list_before = command_success(list_before_cmd, "list worktrees before cleanup");
+    assert!(
+        list_before.contains(&ws.path),
+        "source repo should track new worktree path"
+    );
+
+    symphony::workspace::remove_workspace_for_issue(&ws_path, &config, &hooks, &issue).unwrap();
+    assert!(!ws_path.exists(), "workspace directory should be removed");
+
+    let mut list_after_cmd = Command::new("git");
+    list_after_cmd.args(["-C", &source_repo_str, "worktree", "list", "--porcelain"]);
+    let list_after = command_success(list_after_cmd, "list worktrees after cleanup");
+    assert!(
+        !list_after.contains(&ws.path),
+        "source repo should no longer track removed worktree"
+    );
+}
+
+#[test]
+fn test_workspace_hooks_receive_issue_metadata_env() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    fs::create_dir_all(&root).unwrap();
+    let before_remove_log = tmp.path().join("before_remove_env.txt");
+    let before_remove_log_quoted = shell_quote(&before_remove_log);
+    let env_dump =
+        "printf '%s|%s|%s|%s' \"$SYMPHONY_ISSUE_ID\" \"$SYMPHONY_ISSUE_IDENTIFIER\" \"$SYMPHONY_ISSUE_TITLE\" \"$SYMPHONY_WORKSPACE_PATH\"";
+
+    let hooks = HooksConfig {
+        after_create: Some(format!("{env_dump} > after_create_env.txt")),
+        before_run: Some(format!("{env_dump} > before_run_env.txt")),
+        after_run: Some(format!("{env_dump} > after_run_env.txt")),
+        before_remove: Some(format!("{env_dump} > {before_remove_log_quoted}")),
+        timeout_ms: 5_000,
+    };
+    let config = workspace_config(&root);
+    let issue = make_test_issue("KAT-802");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+    let ws_path = PathBuf::from(&ws.path);
+    let expected = format!(
+        "{}|{}|{}|{}",
+        issue.id, issue.identifier, issue.title, ws.path
+    );
+
+    let after_create_env = fs::read_to_string(ws_path.join("after_create_env.txt")).unwrap();
+    assert_eq!(after_create_env, expected);
+
+    symphony::workspace::run_before_run_hook_for_issue(&ws_path, &hooks, &issue).unwrap();
+    let before_run_env = fs::read_to_string(ws_path.join("before_run_env.txt")).unwrap();
+    assert_eq!(before_run_env, expected);
+
+    symphony::workspace::run_after_run_hook_for_issue(&ws_path, &hooks, &issue).unwrap();
+    let after_run_env = fs::read_to_string(ws_path.join("after_run_env.txt")).unwrap();
+    assert_eq!(after_run_env, expected);
+
+    symphony::workspace::remove_workspace_for_issue(&ws_path, &config, &hooks, &issue).unwrap();
+    let before_remove_env = fs::read_to_string(before_remove_log).unwrap();
+    assert_eq!(before_remove_env, expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This branch brings Symphony from a test-only orchestrator to a fully functional autonomous agent system that completed its first real ticket (KAT-800) end-to-end.

### What's new

**Core runtime:**
- Worker task spawning — dispatch actually launches Codex sessions (KAT-808)
- Real `linear_graphql` executor wired into worker tasks — agents can read/write Linear
- Orchestrator moves issues to "In Progress" on dispatch (writeback)
- `turn/completed` with `status: "failed"` properly treated as failure (prevents tight retry loops)
- `.env` file auto-loading, default port 8080, removed guardrails flag

**Workspace bootstrap (KAT-800, built by Symphony):**
- `workspace.repo` — clone from URL or local path
- `workspace.strategy` — `clone` (default) or `worktree`
- `workspace.branch_prefix` — auto-create issue branches
- `workspace.clone_branch` — specify which branch to clone
- Hook env vars: `SYMPHONY_ISSUE_ID`, `SYMPHONY_ISSUE_IDENTIFIER`, `SYMPHONY_ISSUE_TITLE`, `SYMPHONY_WORKSPACE_PATH`
- Worktree cleanup on workspace removal
- Credential redaction in git error output

**Workflow & skills:**
- Full WORKFLOW.md ported from Elixir reference (status map, workpad protocol, PR feedback sweep, completion bar, guardrails)
- 5 Codex skills ported: linear, commit, push, pull, land
- Custom Linear states: Human Review, Merging, Rework

**Configuration:**
- `codex.stall_timeout_ms` configurable (default raised to 15min for Rust builds)
- `codex.approval_policy: never` for headless operation
- `danger-full-access` sandbox for local development

### Test results

- 224 tests passing (was 211 before this branch)
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean

### Proof of work

Symphony autonomously completed KAT-800:
1. Orchestrator dispatched ticket, moved to In Progress
2. Agent cloned repo, created workpad on Linear issue, planned implementation
3. Agent implemented 814 lines across 10 files (config, domain, workspace, orchestrator, tests, docs)
4. Agent pushed branch, created PR #114, moved to Human Review
5. Human posted review feedback (missing `clone_branch` field)
6. Agent addressed all review comments + Greptile feedback, pushed fixes
7. Human approved, moved to Merging
8. Agent merged PR via `land` skill, moved to Done

### Remaining gaps (tracked in Linear)

14 tickets in the Symphony project backlog — see [Feature Parity Roadmap](https://linear.app/kata-sh/document/symphony-feature-parity-roadmap-b971a0abd4f1) for the full plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * .env support for environment variables
  * Workspace repo management with clone and worktree strategies and branch bootstrapping
  * Automatic tracker issue state updates during task dispatch and execution
  * Create comments on tracked issues
  * Hooks now receive issue metadata via environment variables

* **Improvements**
  * CLI no longer requires guardrails acknowledgment; default HTTP port is 8080
  * Better error logging and quicker failure reporting

* **Tests**
  * Expanded integration and unit tests for workspace, tracker, and client behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR graduates Symphony from a test-only scaffolding into a working autonomous agent loop by wiring together all the runtime pieces: real workspace bootstrap (git clone/worktree), a live Linear GraphQL executor for worker tasks, Linear writeback on dispatch, and proper `turn/failed` handling. The changes are well-structured, carry solid test coverage (224 passing, 13 new tests), and follow the existing patterns in the codebase.

Key changes:
- **Workspace bootstrap** (`workspace.rs`, `config.rs`, `domain.rs`): two strategies (`clone` / `worktree`) with branch auto-creation, worktree cleanup on removal, and issue metadata injected into all hook env vars via `SYMPHONY_ISSUE_*`
- **Real Linear executor** (`orchestrator.rs`, `linear/client.rs`, `linear/adapter.rs`): worker tasks now use a live `LinearClient` for `linear_graphql` tool calls; write mutations (`update_issue_state`, `create_comment`) are implemented and tested
- **Orchestrator writeback** (`orchestrator.rs`): issues are moved to "In Progress" on dispatch (best-effort, with warning on failure)
- **`turn/failed` handling** (`codex/app_server.rs`): Codex turns that complete with `status: "failed"` are now surfaced as `TurnFailed` errors instead of being treated as success, preventing tight retry loops
- **Quality-of-life** (`main.rs`): `.env` auto-loading, default port 8080, removal of the guardrails acknowledgement flag, `WorkerTaskConfig` struct to reduce argument count
- **Skills & workflow docs** (`.codex/skills/`, `WORKFLOW.md`): five skills ported from the Elixir reference plus the full workflow protocol

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor follow-ups; no blocking bugs found.
- The core runtime logic is sound and all 224 tests pass. The two flagged logic concerns are low-severity: the `repo_is_remote` gap only affects scp-style URLs with non-`git` usernames (uncommon), and the `codexErrorInfo` extraction issue only affects error message quality in logs. The full Codex payload debug log is the most actionable item since it could expose sensitive data when debug logging is enabled for troubleshooting.
- apps/symphony/src/codex/app_server.rs (debug payload logging), apps/symphony/src/repo_url.rs (scp-style URL detection)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/workspace.rs | Large extension adding repository bootstrap (clone + worktree strategies), worktree cleanup on removal, and issue metadata injection into all hook env vars. Logic is well-structured with proper cleanup on failure paths. The `remove_dir` call before `git worktree add` is safe because the directory is always freshly-empty at that point. |
| apps/symphony/src/orchestrator.rs | Wires real LinearClient for worker graphql_executor, adds "In Progress" writeback on dispatch, and refactors run_worker_task args into WorkerTaskConfig. The writeback call is synchronous and blocks the dispatch loop for N×2 Linear API round trips per batch. |
| apps/symphony/src/codex/app_server.rs | Adds turn/failed status detection to prevent tight retry loops. Includes a debug log that dumps the full raw Codex payload (potentially sensitive) and may silently lose error detail if codexErrorInfo is a non-string JSON value. |
| apps/symphony/src/repo_url.rs | New module for remote URL detection and credential redaction. The `repo_is_remote` heuristic misses scp-style URLs with non-`git` usernames; the regex-based redaction is correct for scheme URLs but doesn't apply to SSH-style references (which don't embed credentials anyway). |
| apps/symphony/src/linear/client.rs | Adds resolve_state_id, update_issue_state, and create_comment write operations. Implementation is clean and consistent with existing read patterns; state resolution via two-step ID lookup is correct. |
| apps/symphony/tests/workspace_prompt_tests.rs | Comprehensive new integration tests covering clone bootstrap, worktree bootstrap+cleanup, hook env var injection, and graceful worktree cleanup failure. Tests are well-structured and use real git commands for realistic coverage. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Orch as Orchestrator
    participant Port as OrchestratorPort
    participant Linear as LinearClient
    participant WS as workspace
    participant Git as git (subprocess)
    participant Codex as Codex AppServer

    Orch->>Port: fetch_candidate_issues()
    Port->>Linear: GraphQL fetch
    Linear-->>Port: [Issue]
    Port-->>Orch: dispatched issues

    loop For each dispatched issue
        Orch->>Port: update_issue_state("In Progress")
        Port->>Linear: resolve_state_id + issueUpdate
        Linear-->>Port: ok
        Orch->>WS: ensure_workspace_for_issue(issue)
        WS->>Git: git clone / git worktree add
        Git-->>WS: ok
        WS->>WS: run after_create hook (SYMPHONY_ISSUE_* env)
        WS-->>Orch: Workspace

        Orch->>Codex: start_session(issue, workspace)
        Orch->>Codex: run_turn(prompt, linear_graphql_executor)
        Codex-->>Orch: TurnCompleted / TurnFailed

        Orch->>WS: run_after_run_hook_for_issue
        Orch->>WS: remove_workspace_for_issue (on cleanup)
        WS->>Git: git worktree remove --force (if worktree strategy)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/codex/app_server.rs
Line: 383-390

Comment:
**Debug comment and sensitive payload logging**

The `// Debug: log every message from Codex` comment reads like a temporary development note, and more importantly the `payload = %text` field logs the full raw JSON message from Codex at `debug` level. Codex turn messages can contain prompt text, tool call arguments, and potentially credentials passed through tools (e.g. Linear API keys injected by the agent). When debug-level logging is enabled for troubleshooting, this would dump all of that to the log.

Consider removing the comment, and consider removing `payload` from the debug log (or replacing it with a bounded excerpt) to avoid credential exposure when debug logging is enabled:

```suggestion
                        // Log method + bounded payload excerpt at debug level
                        tracing::debug!(
                            issue_id = %handle.issue_id,
                            method = method.as_deref().unwrap_or("(none)"),
                            "codex message received"
                        );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/codex/app_server.rs
Line: 419-422

Comment:
**`codexErrorInfo` silently falls back when non-string**

`codexErrorInfo` is extracted with `.and_then(|c| c.as_str())`. If the Codex protocol returns this field as a JSON object (which is common in error info payloads), `as_str()` returns `None` and the code silently falls back to `"unknown"`. The actual error detail would be swallowed in logs and the `TurnFailed` error message.

Consider using `serde_json::to_string` as a fallback so the raw value is preserved:

```suggestion
                                let error_code = payload
                                    .pointer("/params/turn/error/codexErrorInfo")
                                    .map(|c| {
                                        c.as_str()
                                            .map(String::from)
                                            .unwrap_or_else(|| c.to_string())
                                    })
                                    .unwrap_or_else(|| "unknown".to_string());
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 544-557

Comment:
**Blocking Linear API calls inside the orchestrator's hot dispatch loop**

`port.update_issue_state` is called synchronously inside `spawn_workers_for_dispatched` via the `block_on` pattern, and `update_issue_state` itself makes **two** serial HTTP round-trips (resolve state ID + mutation). With N issues dispatched in one tick, the orchestrator loop blocks for N × 2 Linear API calls before returning — potentially many seconds with slow network or Linear latency.

This is consistent with the existing `fetch_candidate_issues`/`refresh_issue` approach, so it's not a regression; but now that write mutations are in the loop it may be worth a note in a follow-up ticket, since a slow or unavailable Linear can now directly delay worker spawning for all issues in the batch.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/repo_url.rs
Line: 5-7

Comment:
**SCP-like URLs with non-`git` user misclassified as local**

`repo_is_remote` handles `://` scheme URLs and the `git@` convention, but scp-style URLs that use a different SSH user — e.g. `deploy@bitbucket.org:org/repo.git` — would return `false` and be treated as a local path.

In the `Worktree` strategy path inside `bootstrap_repository`, a misclassified remote URL gets passed directly to `git -C <url> worktree add ...`, which produces a confusing git error rather than the clear `InvalidWorkflowConfig` message.

A conservative fix is to also match on `contains('@')`, since paths with a literal `@` character are extremely rare:

```suggestion
pub fn repo_is_remote(repo: &str) -> bool {
    repo.contains("://") || repo.starts_with("git@") || repo.contains('@')
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["chore(symphony): swi..."](https://github.com/gannonh/kata/commit/6f1844e561dc41170c4671939b45e207bd35552c)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->