### PR TITLE
Add regression tests for failed turn/completed worker failures

### DIFF
--- a/apps/symphony/tests/codex_tests.rs
+++ b/apps/symphony/tests/codex_tests.rs
@@ -787,6 +787,12 @@ async fn test_turn_completed_with_usage_limit_exceeded_surfaces_error_message() 
 
     assert_eq!(turn_failed_errors.len(), 1, "expected one TurnFailed event");
     assert!(
+        !collected
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TurnCompleted { .. })),
+        "did not expect TurnCompleted event for failed turn/completed status"
+    );
+    assert!(
         turn_failed_errors[0].contains("usageLimitExceeded"),
         "expected event error to include codexErrorInfo, got: {}",
         turn_failed_errors[0]

--- a/apps/symphony/tests/codex_tests.rs
+++ b/apps/symphony/tests/codex_tests.rs
@@ -469,6 +469,30 @@ echo '{"id":3,"result":{"turn":{"id":"turn-fail"}}}'
 echo '{"method":"turn/failed","params":{"reason":"something went wrong"}}'
 "#;
 
+/// Handshake script that emits `turn/completed` with `turn.status=failed`.
+const SCRIPT_TURN_COMPLETED_FAILED_STATUS: &str = r#"#!/bin/bash
+read -r line
+echo '{"id":1,"result":{"capabilities":{}}}'
+read -r line
+read -r line
+echo '{"id":2,"result":{"thread":{"id":"thread-failed-status"}}}'
+read -r line
+echo '{"id":3,"result":{"turn":{"id":"turn-failed-status"}}}'
+echo '{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"Model temporarily unavailable","codexErrorInfo":"modelUnavailable"}}}}'
+"#;
+
+/// Handshake script that emits a usage limit failure via `turn/completed`.
+const SCRIPT_TURN_COMPLETED_USAGE_LIMIT_EXCEEDED: &str = r#"#!/bin/bash
+read -r line
+echo '{"id":1,"result":{"capabilities":{}}}'
+read -r line
+read -r line
+echo '{"id":2,"result":{"thread":{"id":"thread-usage-limit"}}}'
+read -r line
+echo '{"id":3,"result":{"turn":{"id":"turn-usage-limit"}}}'
+echo '{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"Usage limit exceeded for model","codexErrorInfo":"usageLimitExceeded"}}}}'
+"#;
+
 /// Handshake script that emits `turn/cancelled`.
 const SCRIPT_TURN_CANCELLATION: &str = r#"#!/bin/bash
 read -r line
@@ -654,6 +678,123 @@ async fn test_app_server_turn_failure() {
             .iter()
             .any(|e| matches!(e, AgentEvent::TurnFailed { .. })),
         "expected TurnFailed event in callback"
+    );
+}
+
+#[tokio::test]
+async fn test_turn_completed_with_failed_status_treated_as_failure() {
+    let scripts_dir = tempfile::tempdir().unwrap();
+    let root_dir = tempfile::tempdir().unwrap();
+    let workspace = root_dir.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let script_path = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        SCRIPT_TURN_COMPLETED_FAILED_STATUS,
+    );
+    let config = make_codex_config(&script_path);
+    let issue = make_test_issue();
+
+    let mut collected: Vec<AgentEvent> = Vec::new();
+
+    let mut handle = app_server::start_session(&config, &issue, &workspace, root_dir.path(), None)
+        .await
+        .expect("start_session should succeed");
+
+    let result = app_server::run_turn(&mut handle, "hello", never_executor, |ev| {
+        collected.push(ev)
+    })
+    .await;
+    app_server::stop_session(handle).await.ok();
+
+    let err = match result {
+        Err(SymphonyError::TurnFailed(msg)) => msg,
+        other => panic!("expected TurnFailed error, got: {other:?}"),
+    };
+    assert!(
+        err.contains("modelUnavailable"),
+        "expected codexErrorInfo in error message, got: {err}"
+    );
+    assert!(
+        err.contains("Model temporarily unavailable"),
+        "expected error message from payload, got: {err}"
+    );
+    assert!(
+        collected
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TurnFailed { .. })),
+        "expected TurnFailed event in callback"
+    );
+    assert!(
+        !collected
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TurnCompleted { .. })),
+        "did not expect TurnCompleted event for failed turn/completed status"
+    );
+}
+
+#[tokio::test]
+async fn test_turn_completed_with_usage_limit_exceeded_surfaces_error_message() {
+    let scripts_dir = tempfile::tempdir().unwrap();
+    let root_dir = tempfile::tempdir().unwrap();
+    let workspace = root_dir.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let script_path = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        SCRIPT_TURN_COMPLETED_USAGE_LIMIT_EXCEEDED,
+    );
+    let config = make_codex_config(&script_path);
+    let issue = make_test_issue();
+
+    let mut collected: Vec<AgentEvent> = Vec::new();
+
+    let mut handle = app_server::start_session(&config, &issue, &workspace, root_dir.path(), None)
+        .await
+        .expect("start_session should succeed");
+
+    let result = app_server::run_turn(&mut handle, "hello", never_executor, |ev| {
+        collected.push(ev)
+    })
+    .await;
+    app_server::stop_session(handle).await.ok();
+
+    let err = match result {
+        Err(SymphonyError::TurnFailed(msg)) => msg,
+        other => panic!("expected TurnFailed error, got: {other:?}"),
+    };
+    assert!(
+        err.contains("usageLimitExceeded"),
+        "expected codexErrorInfo to surface, got: {err}"
+    );
+    assert!(
+        err.contains("Usage limit exceeded for model"),
+        "expected payload error message to surface, got: {err}"
+    );
+
+    let turn_failed_errors: Vec<&str> = collected
+        .iter()
+        .filter_map(|e| {
+            if let AgentEvent::TurnFailed { error, .. } = e {
+                Some(error.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert_eq!(turn_failed_errors.len(), 1, "expected one TurnFailed event");
+    assert!(
+        turn_failed_errors[0].contains("usageLimitExceeded"),
+        "expected event error to include codexErrorInfo, got: {}",
+        turn_failed_errors[0]
+    );
+    assert!(
+        turn_failed_errors[0].contains("Usage limit exceeded for model"),
+        "expected event error to include payload message, got: {}",
+        turn_failed_errors[0]
     );
 }
 


### PR DESCRIPTION
## Summary
- add regression coverage for `turn/completed` payloads where `params.turn.status` is `failed`
- verify this path emits `TurnFailed` and returns `SymphonyError::TurnFailed` instead of treating the turn as successful
- verify `usageLimitExceeded` payload details are surfaced in both the returned error and emitted event

## Testing
- cd apps/symphony && cargo test test_turn_completed_with_failed_status_treated_as_failure -- --exact
- cd apps/symphony && cargo test test_turn_completed_with_usage_limit_exceeded_surfaces_error_message -- --exact
- cd apps/symphony && cargo test
- cd apps/symphony && cargo clippy -- -D warnings

## Linear
- KAT-814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests covering turn failure scenarios where turns report failures (e.g., model unavailable, usage limit exceeded) and include error details.
  * Tests validate error strings surface both service error codes and human messages, and that failure callbacks/events are emitted while successful completion events are not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two regression integration tests to `apps/symphony/tests/codex_tests.rs` covering the `turn/completed` payload path when `params.turn.status` is `"failed"`. These tests verify that the `app_server` correctly treats such payloads as failures — emitting `AgentEvent::TurnFailed` and returning `SymphonyError::TurnFailed` — rather than silently treating them as successful completions.

- Adds `SCRIPT_TURN_COMPLETED_FAILED_STATUS`: a minimal bash stub that emits `turn/completed` with `status:"failed"` and `codexErrorInfo:"modelUnavailable"`.
- Adds `SCRIPT_TURN_COMPLETED_USAGE_LIMIT_EXCEEDED`: a parallel stub using `codexErrorInfo:"usageLimitExceeded"` to cover the usage-limit error path specifically.
- `test_turn_completed_with_failed_status_treated_as_failure` asserts that the returned `SymphonyError::TurnFailed` message contains both the `codexErrorInfo` code and the human-readable `error.message`, and that `TurnFailed` (not `TurnCompleted`) is emitted to the event stream.
- `test_turn_completed_with_usage_limit_exceeded_surfaces_error_message` additionally inspects the `error` field of the emitted `AgentEvent::TurnFailed` to confirm both the `codexErrorInfo` code and the payload message are surfaced there as well.
- All new bash stubs correctly follow the established handshake pattern (four `read -r line` calls matching `initialize`, `initialized`, `thread/start`, and `turn/start`), and the assertions are tightly aligned with the `"{error_code}: {error_msg}"` format produced by `app_server::run_turn`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — purely additive test code with no production logic changes.
- The change is entirely test-only. The new scripts follow established patterns, the assertions are correctly aligned with the production implementation in `app_server.rs`, and both tests are independently verifiable with the provided `cargo test` commands. The only finding is a minor style inconsistency (missing symmetrical assertion in the second test) that does not affect correctness.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/tests/codex_tests.rs | Adds two regression integration tests for the `turn/completed` + `status:"failed"` path. Scripts, assertions, and error-message format all align correctly with the `app_server` implementation; one minor inconsistency (missing `TurnCompleted` absence check in the second test). |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant app_server (run_turn)
    participant BashScript

    Test->>app_server (run_turn): start_session(config, issue, workspace)
    app_server (run_turn)->>BashScript: spawn subprocess
    app_server (run_turn)->>BashScript: initialize (id=1)
    BashScript-->>app_server (run_turn): {"id":1,"result":{"capabilities":{}}}
    app_server (run_turn)->>BashScript: initialized (notification)
    app_server (run_turn)->>BashScript: thread/start (id=2)
    BashScript-->>app_server (run_turn): {"id":2,"result":{"thread":{"id":"..."}}}
    Test->>app_server (run_turn): run_turn(handle, "hello", ...)
    app_server (run_turn)->>BashScript: turn/start (id=3)
    BashScript-->>app_server (run_turn): {"id":3,"result":{"turn":{"id":"..."}}}
    BashScript-->>app_server (run_turn): turn/completed {status:"failed", error:{message, codexErrorInfo}}
    app_server (run_turn)->>Test: emit AgentEvent::TurnFailed{error:"{code}: {msg}"}
    app_server (run_turn)-->>Test: Err(SymphonyError::TurnFailed("{code}: {msg}"))
    Test->>app_server (run_turn): stop_session(handle)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/tests/codex_tests.rs
Line: 765-773

Comment:
**Missing `TurnCompleted` absence assertion**

`test_turn_completed_with_failed_status_treated_as_failure` explicitly guards that no `TurnCompleted` event is emitted for a failed `turn/completed` payload, but the companion test `test_turn_completed_with_usage_limit_exceeded_surfaces_error_message` omits the same assertion. For consistency and completeness it would be worth adding the same check here:

```suggestion
    assert_eq!(turn_failed_errors.len(), 1, "expected one TurnFailed event");
    assert!(
        !collected
            .iter()
            .any(|e| matches!(e, AgentEvent::TurnCompleted { .. })),
        "did not expect TurnCompleted event for failed turn/completed status"
    );
    assert!(
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["test(codex): cover f..."](https://github.com/gannonh/kata/commit/db38478317ce483d0eb0ccd5e00b50a1f8308993)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->