### PR TITLE
docs(symphony): define Agent Review as PR feedback loop

### DIFF
--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -123,7 +123,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 - `Backlog` -> out of scope for this workflow; do not modify.
 - `Todo` -> queued; the orchestrator moves this to `In Progress` on dispatch. Verify state is `In Progress` before active work.
-  - Special case: if a PR is already attached, treat as feedback loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `Human Review`).
+  - Special case: if a PR is already attached, move the issue to `Agent Review` and run the full PR feedback sweep (address or explicitly push back on each comment, revalidate, push updates, then return to `Human Review`).
 - `In Progress` -> implementation actively underway.
 - `Agent Review` -> PR feedback needs addressing. Run full PR feedback sweep, make targeted fixes, push to existing branch, then move to `Human Review`.
 - `Human Review` -> PR is attached and validated; waiting on human approval. Do not code or change ticket content.

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -122,7 +122,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 - `Backlog` -> out of scope for this workflow; do not modify.
 - `Todo` -> queued; the orchestrator moves this to `In Progress` on dispatch. Verify state is `In Progress` before active work.
-  - Special case: if a PR is already attached, treat as feedback loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `Human Review`).
+  - Special case: if a PR is already attached, move the issue to `Agent Review` and run the full PR feedback sweep (address or explicitly push back on each comment, revalidate, push updates, then return to `Human Review`).
 - `In Progress` -> implementation actively underway.
 - `Agent Review` -> PR feedback needs addressing. Run full PR feedback sweep, make targeted fixes, push to existing branch, then move to `Human Review`.
 - `Human Review` -> PR is attached and validated; waiting on human approval. Do not code or change ticket content.

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -123,13 +123,21 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 - `Backlog` -> out of scope for this workflow; do not modify.
 - `Todo` -> queued; the orchestrator moves this to `In Progress` on dispatch. Verify state is `In Progress` before active work.
-  - Special case: if a PR is already attached, treat as feedback/rework loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `Human Review`).
+  - Special case: if a PR is already attached, treat as feedback loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `Human Review`).
 - `In Progress` -> implementation actively underway.
 - `Agent Review` -> PR feedback needs addressing. Run full PR feedback sweep, make targeted fixes, push to existing branch, then move to `Human Review`.
 - `Human Review` -> PR is attached and validated; waiting on human approval. Do not code or change ticket content.
 - `Merging` -> approved by human; execute the `land` skill flow (do not call `gh pr merge` directly).
-- `Rework` -> reviewer requested changes; planning + implementation required.
+- `Rework` -> reviewer rejected the current approach; close the current PR and restart from a fresh branch.
 - `Done` -> terminal state; no further action required.
+
+### Full lifecycle
+
+```
+Todo -> In Progress -> Human Review -> (human approves) -> Merging -> Done
+                               -> (human requests changes) -> Agent Review -> Human Review
+                               -> (human rejects approach) -> Rework -> In Progress
+```
 
 ## Step 0: Determine current ticket state and route
 
@@ -262,10 +270,11 @@ Use this only when completion is blocked by missing required tools or missing au
 
 1. When the issue is in `Human Review`, do not code or change ticket content.
 2. Poll for updates as needed, including GitHub PR review comments from humans and bots.
-3. If review feedback requires changes, move the issue to `Rework` and follow the rework flow.
-4. If approved, human moves the issue to `Merging`.
-5. When the issue is in `Merging`, open and follow `.codex/skills/land/SKILL.md`, then run the `land` skill in a loop until the PR is merged. Do not call `gh pr merge` directly.
-6. After merge is complete, move the issue to `Done`.
+3. If review feedback requires changes, move the issue to `Agent Review` and run the full PR feedback sweep loop.
+4. If review feedback rejects the current approach and requires a reset, move the issue to `Rework` and follow the rework flow.
+5. If approved, human moves the issue to `Merging`.
+6. When the issue is in `Merging`, open and follow `.codex/skills/land/SKILL.md`, then run the `land` skill in a loop until the PR is merged. Do not call `gh pr merge` directly.
+7. After merge is complete, move the issue to `Done`.
 
 ## Step 4: Rework handling
 

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -122,13 +122,21 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 - `Backlog` -> out of scope for this workflow; do not modify.
 - `Todo` -> queued; the orchestrator moves this to `In Progress` on dispatch. Verify state is `In Progress` before active work.
-  - Special case: if a PR is already attached, treat as feedback/rework loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `Human Review`).
+  - Special case: if a PR is already attached, treat as feedback loop (run full PR feedback sweep, address or explicitly push back, revalidate, return to `Human Review`).
 - `In Progress` -> implementation actively underway.
 - `Agent Review` -> PR feedback needs addressing. Run full PR feedback sweep, make targeted fixes, push to existing branch, then move to `Human Review`.
 - `Human Review` -> PR is attached and validated; waiting on human approval. Do not code or change ticket content.
 - `Merging` -> approved by human; execute the `land` skill flow (do not call `gh pr merge` directly).
-- `Rework` -> reviewer requested changes; planning + implementation required.
+- `Rework` -> reviewer rejected the current approach; close the current PR and restart from a fresh branch.
 - `Done` -> terminal state; no further action required.
+
+### Full lifecycle
+
+```
+Todo -> In Progress -> Human Review -> (human approves) -> Merging -> Done
+                               -> (human requests changes) -> Agent Review -> Human Review
+                               -> (human rejects approach) -> Rework -> In Progress
+```
 
 ## Step 0: Determine current ticket state and route
 
@@ -261,10 +269,11 @@ Use this only when completion is blocked by missing required tools or missing au
 
 1. When the issue is in `Human Review`, do not code or change ticket content.
 2. Poll for updates as needed, including GitHub PR review comments from humans and bots.
-3. If review feedback requires changes, move the issue to `Rework` and follow the rework flow.
-4. If approved, human moves the issue to `Merging`.
-5. When the issue is in `Merging`, open and follow `.codex/skills/land/SKILL.md`, then run the `land` skill in a loop until the PR is merged. Do not call `gh pr merge` directly.
-6. After merge is complete, move the issue to `Done`.
+3. If review feedback requires changes, move the issue to `Agent Review` and run the full PR feedback sweep loop.
+4. If review feedback rejects the current approach and requires a reset, move the issue to `Rework` and follow the rework flow.
+5. If approved, human moves the issue to `Merging`.
+6. When the issue is in `Merging`, open and follow `.codex/skills/land/SKILL.md`, then run the `land` skill in a loop until the PR is merged. Do not call `gh pr merge` directly.
+7. After merge is complete, move the issue to `Done`.
 
 ## Step 4: Rework handling
 


### PR DESCRIPTION
## Summary
- define `Agent Review` as the PR feedback loop state in `apps/symphony/WORKFLOW.md`
- clarify `Rework` is only for full-reset/rejected-approach cases
- add an explicit lifecycle map showing feedback routing (`Human Review -> Agent Review -> Human Review`)
- update Human Review handling to route actionable feedback to `Agent Review`

## Testing
- `rg -n "active_states|Agent Review|Step 0|Rework|Human Review|PR feedback sweep" apps/symphony/WORKFLOW.md`
- `rg -n "review feedback requires changes|submit for review|move to Human Review" apps/symphony/WORKFLOW.md`

## Risks
- low: documentation-only change

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation-only update to `apps/symphony/WORKFLOW.md` that introduces `Agent Review` as the explicit, tracked state for the PR feedback loop, clearly separates it from `Rework` (now reserved for full approach resets), and adds a lifecycle diagram for clarity.

**Key changes:**
- `Agent Review` state is now formally defined in the status map: run the PR feedback sweep, make targeted fixes, push to the existing branch, then move to `Human Review`.
- `Rework` semantics narrowed from "reviewer requested changes" to "reviewer **rejected the current approach**; close the PR and restart from a fresh branch."
- New `### Full lifecycle` diagram added showing the three exit paths from `Human Review` (approve → Merging, changes requested → Agent Review, approach rejected → Rework).
- Step 3 (Human Review handling) updated to route incremental feedback to `Agent Review` and only route full resets to `Rework`; steps renumbered accordingly.
- The `active_states` YAML list already included `Agent Review` before this PR, so no runtime config change is needed.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — documentation-only change with no runtime impact; one minor wording inconsistency in the `Todo` special case.
- All changes are in a Markdown workflow document with no code or config modifications. The new state definitions are internally consistent with one exception: the `Todo` special case (line 125) still describes routing feedback work without transitioning through the new `Agent Review` state, which could confuse an agent following that path. Everything else — the lifecycle diagram, the narrowed `Rework` definition, and the updated Step 3 routing — is clear and consistent.
- apps/symphony/WORKFLOW.md — line 125 `Todo` special case should reference `Agent Review` to stay consistent with the new state definition.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/WORKFLOW.md | Documentation-only change that introduces `Agent Review` as a dedicated PR feedback state, restricts `Rework` to full approach resets, adds a lifecycle diagram, and updates Step 3 routing; one minor inconsistency where the `Todo` special case does not explicitly route through the new `Agent Review` state. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Backlog[Backlog\nout of scope]
    Todo[Todo\nqueued]
    InProgress[In Progress\nimplementation underway]
    HumanReview[Human Review\nwaiting on human]
    AgentReview[Agent Review\nPR feedback sweep]
    Rework[Rework\nfull approach reset]
    Merging[Merging\nexecute land skill]
    Done([Done\nterminal])

    Backlog -->|human moves| Todo
    Todo -->|orchestrator dispatch| InProgress
    Todo -->|PR already attached\nSpecial case — see note| InProgress
    InProgress -->|PR ready & checks green| HumanReview
    HumanReview -->|human approves| Merging
    HumanReview -->|feedback requires changes| AgentReview
    HumanReview -->|approach rejected| Rework
    AgentReview -->|feedback addressed, push| HumanReview
    Rework -->|close PR, fresh branch| InProgress
    Merging -->|PR merged| Done

    style AgentReview fill:#d4edff,stroke:#0077cc
    style Rework fill:#ffecd4,stroke:#cc5500
    style Done fill:#d4ffd4,stroke:#007700
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/WORKFLOW.md
Line: 125

Comment:
**`Todo` special case bypasses `Agent Review` state**

The `Todo` special case (line 125) says to "run full PR feedback sweep…return to `Human Review`" without explicitly transitioning through the new `Agent Review` state. Meanwhile, the canonical state definition on line 127 specifies:

> `Agent Review` -> PR feedback needs addressing. Run full PR feedback sweep, make targeted fixes, push to existing branch, then move to `Human Review`.

An agent following the `Todo` special case literally would do the feedback-sweep work while the ticket is still in `In Progress` (or `Todo`), never setting it to `Agent Review`, which means the Linear state timeline won't reflect that feedback work happened. Consider aligning the `Todo` special case with the new state, e.g.:

```suggestion
  - Special case: if a PR is already attached, move the issue to `Agent Review` and run the full PR feedback sweep (address or explicitly push back on each comment, revalidate, push updates, then return to `Human Review`).
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["docs(symphony): defi..."](https://github.com/gannonh/kata/commit/6a8de3eb30d65d48e9f4af4620a96b841a389abb)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new capability to retrieve GitHub pull request information including conversation comments, code review submissions, and inline review threads. Automatic pagination support handles large datasets, and all pull request data is consolidated and formatted as JSON for downstream processing and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->