### PR TITLE
fix(symphony): require publish proofs before Human Review

### DIFF
--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -253,7 +253,12 @@ Use this only when completion is blocked by missing required tools or missing au
     - Do not include PR URL in the workpad comment; keep PR linkage on the issue via attachment/link fields.
     - Add a short `### Confusions` section at the bottom when any part of task execution was unclear/confusing, with concise bullets.
     - Do not post any additional completion summary comment.
-11. Before moving to `Human Review`, poll PR feedback and checks:
+11. Before moving to `Human Review`, run publish proofs, then poll PR feedback/checks:
+    - Run and record these publish proofs in the workpad `Notes` section:
+      - `git ls-remote --exit-code --heads origin "$(git branch --show-current)"`
+      - `gh pr view --json url,state,headRefName,baseRefName`
+    - Confirm `gh pr view` reports `state: OPEN` and `headRefName` equals the current branch.
+    - If either publish proof fails, do not move state; fix publish/PR linkage first.
     - Read the PR `Manual QA Plan` comment (when present) and use it to sharpen UI/runtime test coverage for the current change.
     - Run the full PR feedback sweep protocol.
     - Confirm PR checks are passing (green) after the latest changes.
@@ -295,7 +300,8 @@ Use this only when completion is blocked by missing required tools or missing au
 - Acceptance criteria and required ticket-provided validation items are complete.
 - Validation/tests are green for the latest commit.
 - PR feedback sweep is complete and no actionable comments remain.
-- PR checks are green, branch is pushed, and PR is linked on the issue.
+- Publish proof is recorded in the workpad: `git ls-remote --exit-code --heads origin "$(git branch --show-current)"` succeeds and `gh pr view --json url,state,headRefName,baseRefName` confirms an `OPEN` PR for the current branch.
+- PR checks are green and the PR is linked on the issue.
 - Required PR metadata is present (`symphony` label).
 - If app-touching, runtime validation/media requirements from `App runtime validation (required)` are complete.
 

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -395,7 +395,12 @@ Use this only when completion is blocked by missing required tools or missing au
     - Do not include PR URL in the workpad comment; keep PR linkage on the issue via attachment/link fields.
     - Add a short `### Confusions` section at the bottom when any part of task execution was unclear/confusing, with concise bullets.
     - Do not post any additional completion summary comment.
-11. Before moving to `Human Review`, poll PR feedback and checks:
+11. Before moving to `Human Review`, run publish proofs, then poll PR feedback/checks:
+    - Run and record these publish proofs in the workpad `Notes` section:
+      - `git ls-remote --exit-code --heads origin "$(git branch --show-current)"`
+      - `gh pr view --json url,state,headRefName,baseRefName`
+    - Confirm `gh pr view` reports `state: OPEN` and `headRefName` equals the current branch.
+    - If either publish proof fails, do not move state; fix publish/PR linkage first.
     - Read the PR `Manual QA Plan` comment (when present) and use it to sharpen UI/runtime test coverage for the current change.
     - Run the full PR feedback sweep protocol.
     - Confirm PR checks are passing (green) after the latest changes.
@@ -436,7 +441,8 @@ Use this only when completion is blocked by missing required tools or missing au
 - Acceptance criteria and required ticket-provided validation items are complete.
 - Validation/tests are green for the latest commit.
 - PR feedback sweep is complete and no actionable comments remain.
-- PR checks are green, branch is pushed, and PR is linked on the issue.
+- Publish proof is recorded in the workpad: `git ls-remote --exit-code --heads origin "$(git branch --show-current)"` succeeds and `gh pr view --json url,state,headRefName,baseRefName` confirms an `OPEN` PR for the current branch.
+- PR checks are green and the PR is linked on the issue.
 - Required PR metadata is present (`symphony` label).
 - If app-touching, runtime validation/media requirements from `App runtime validation (required)` are complete.
 

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -6,6 +6,7 @@
 
 use serial_test::serial;
 use std::io::Write;
+use std::path::Path;
 use tempfile::NamedTempFile;
 
 use symphony::config::{from_workflow, validate};
@@ -116,6 +117,28 @@ fn test_parse_workflow_non_map_yaml() {
         matches!(result, Err(SymphonyError::WorkflowFrontMatterNotAMap)),
         "non-map YAML front matter should return WorkflowFrontMatterNotAMap, got: {:?}",
         result
+    );
+}
+
+#[test]
+fn test_repo_workflow_requires_publish_gate_before_human_review() {
+    let def = parse_workflow(Path::new("WORKFLOW.md"))
+        .expect("repo WORKFLOW.md should parse for publish-gate contract assertions");
+
+    assert!(
+        def.prompt_template
+            .contains("git ls-remote --exit-code --heads origin \"$(git branch --show-current)\""),
+        "WORKFLOW.md must require explicit remote-branch proof before Human Review"
+    );
+    assert!(
+        def.prompt_template
+            .contains("gh pr view --json url,state,headRefName,baseRefName"),
+        "WORKFLOW.md must require explicit PR proof before Human Review"
+    );
+    assert!(
+        def.prompt_template
+            .contains("Do not move to `Human Review`"),
+        "WORKFLOW.md must explicitly block Human Review transition until publish checks pass"
     );
 }
 

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -122,7 +122,8 @@ fn test_parse_workflow_non_map_yaml() {
 
 #[test]
 fn test_repo_workflow_requires_publish_gate_before_human_review() {
-    let def = parse_workflow(Path::new("WORKFLOW.md"))
+    let workflow_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("WORKFLOW.md");
+    let def = parse_workflow(&workflow_path)
         .expect("repo WORKFLOW.md should parse for publish-gate contract assertions");
 
     assert!(
@@ -137,7 +138,7 @@ fn test_repo_workflow_requires_publish_gate_before_human_review() {
     );
     assert!(
         def.prompt_template
-            .contains("Do not move to `Human Review`"),
+            .contains("If either publish proof fails, do not move state"),
         "WORKFLOW.md must explicitly block Human Review transition until publish checks pass"
     );
 }


### PR DESCRIPTION
## Summary
- require explicit publish proofs before a session can move an issue to `Human Review`
- add mandatory command checks in `apps/symphony/WORKFLOW.md` for remote branch existence and open PR metadata
- mirror the same publish-gate language in `apps/symphony/docs/WORKFLOW-REFERENCE.md`
- add `test_repo_workflow_requires_publish_gate_before_human_review` to lock the contract

## Validation
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `cd apps/symphony && cargo fmt -- --check`

## Linear
- KAT-811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for workflow configuration to validate enforcement of publishing requirements and approval gates before transitioning to human review stage. Test verifies branch validation checks and pull request state monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens the agent workflow by requiring explicit "publish proofs" — a `git ls-remote` check that the remote branch exists and a `gh pr view` check that an OPEN PR exists for the current branch — before the agent is permitted to transition an issue to `Human Review`. Both `WORKFLOW.md` and its companion reference document are updated identically, and a new integration test is added to lock the contract.

**Key changes:**
- `WORKFLOW.md` & `docs/WORKFLOW-REFERENCE.md`: Step 11 of the execution phase now mandates recording publish proofs in the workpad before proceeding; the Completion Bar checklist item is updated accordingly to match.
- `tests/workflow_config_tests.rs`: `test_repo_workflow_requires_publish_gate_before_human_review` validates that the two new proof commands are present in the parsed workflow template.
- **Potential regression gap**: The third assertion in the new test checks for `"Do not move to \`Human Review\`"` — a string that already existed in the file before this PR (in the Guardrails and Blocked-access sections). It does **not** assert the new, specific blocking phrase added by this PR (`"If either publish proof fails, do not move state"`), leaving that clause unguarded against accidental deletion.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the workflow documentation changes are correct and well-scoped, with only a minor test-coverage gap in the new integration test.
- All changes are documentation and test-only; no production Rust logic is modified. The two new proof commands are correctly added to both WORKFLOW.md files in parity. The test's first two assertions correctly lock in the new command strings. The only concern is the third assertion targeting pre-existing text rather than the newly added blocking language, which means that specific phrase could be removed in a future refactor without failing this test.
- apps/symphony/tests/workflow_config_tests.rs — third assertion in the new test does not guard the new publish-gate blocking clause against regression.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/WORKFLOW.md | Adds publish-proof gate (git ls-remote + gh pr view) before Human Review transition; also updates the Completion Bar checklist. Changes are clear, well-scoped, and consistent with the companion docs file. |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Mirrors the identical publish-gate additions from WORKFLOW.md; parity between the two files is correctly maintained. |
| apps/symphony/tests/workflow_config_tests.rs | Adds test_repo_workflow_requires_publish_gate_before_human_review; first two assertions correctly lock in the new commands, but the third assertion checks for a string already present in the file before this PR, so it does not actually guard the new blocking language against regression. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Step 2 complete\nWorkpad updated] --> B[Run publish proofs]
    B --> C{git ls-remote succeeds?\nRemote branch exists?}
    C -- No --> D[Fix branch push\nDo not move state]
    D --> B
    C -- Yes --> E{gh pr view: state=OPEN\nheadRefName=current branch?}
    E -- No --> F[Fix PR linkage\nDo not move state]
    F --> B
    E -- Yes --> G[Record proofs in workpad Notes]
    G --> H[Poll PR feedback & checks\nRun feedback sweep protocol]
    H --> I{All checks green?\nNo actionable comments?}
    I -- No --> J[Address feedback / fix CI]
    J --> H
    I -- Yes --> K[Move issue to Human Review]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/tests/workflow_config_tests.rs
Line: 138-143

Comment:
**Third assertion tests pre-existing text, not the new publish-gate language**

The string `"Do not move to \`Human Review\`"` is NOT new text introduced by this PR. It already existed in `WORKFLOW.md` in two unrelated places:
- Guardrails section: `"Do not move to \`Human Review\` unless the \`Completion bar before Human Review\` is satisfied."`
- Blocked-access section: `"Do not move to \`Human Review\` for GitHub access/auth until…"`

This means the assertion was already passing before this PR landed and will continue to pass even if the newly added publish-gate language (`"If either publish proof fails, do not move state; fix publish/PR linkage first."`) is accidentally deleted. The test therefore does not actually lock in the contract it claims to verify.

The assertion should target the specific new blocking phrase, for example:

```suggestion
    assert!(
        def.prompt_template
            .contains("If either publish proof fails, do not move state"),
        "WORKFLOW.md must explicitly block Human Review transition until publish checks pass"
    );
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix(symphony): enfor..."](https://github.com/gannonh/kata/commit/1edce2c843484013a713ec1e240b62c1c8c48d87)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->