### PR TITLE
fix(symphony): resolve tracker assignee names and emails

### DIFF
--- a/apps/symphony/src/linear/client.rs
+++ b/apps/symphony/src/linear/client.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde_json::Value;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, OnceCell};
 use tracing::{error, info, warn};
 
 use crate::domain::{BlockerRef, Issue, TrackerConfig};
@@ -189,7 +189,7 @@ pub struct LinearClient {
     http: reqwest::Client,
     config: TrackerConfig,
     assignee_resolution_cache: Arc<Mutex<HashMap<String, String>>>,
-    users_cache: Arc<Mutex<Option<Vec<LinearUser>>>>,
+    users_cache: Arc<OnceCell<Vec<LinearUser>>>,
 }
 
 impl LinearClient {
@@ -203,7 +203,7 @@ impl LinearClient {
             http,
             config,
             assignee_resolution_cache: Arc::new(Mutex::new(HashMap::new())),
-            users_cache: Arc::new(Mutex::new(None)),
+            users_cache: Arc::new(OnceCell::new()),
         }
     }
 
@@ -621,21 +621,11 @@ impl LinearClient {
     }
 
     async fn list_linear_users(&self) -> Result<Vec<LinearUser>> {
-        if let Some(cached) = self.users_cache.lock().await.clone() {
-            return Ok(cached);
-        }
-
-        let fetched = self.fetch_linear_users().await?;
-        let mut cache = self.users_cache.lock().await;
-        if cache.is_none() {
-            *cache = Some(fetched);
-        }
-        match cache.as_ref() {
-            Some(cached) => Ok(cached.clone()),
-            None => Err(SymphonyError::Other(
-                "Linear users cache unexpectedly empty".to_string(),
-            )),
-        }
+        let users = self
+            .users_cache
+            .get_or_try_init(|| async { self.fetch_linear_users().await })
+            .await?;
+        Ok(users.clone())
     }
 
     async fn fetch_linear_users(&self) -> Result<Vec<LinearUser>> {

--- a/apps/symphony/src/linear/client.rs
+++ b/apps/symphony/src/linear/client.rs
@@ -7,9 +7,11 @@
 //! - `fetch_issue_states_by_ids` — batched ID-based fetch with order preservation
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde_json::Value;
+use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
 use crate::domain::{BlockerRef, Issue, TrackerConfig};
@@ -18,6 +20,7 @@ use crate::error::{Result, SymphonyError};
 // ── Constants ──────────────────────────────────────────────────────────
 
 const ISSUE_PAGE_SIZE: usize = 50;
+const USER_PAGE_SIZE: usize = 100;
 const REQUEST_TIMEOUT_SECS: u64 = 30;
 const MAX_ERROR_BODY_LOG_BYTES: usize = 1_000;
 
@@ -145,12 +148,37 @@ query SymphonyLinearViewer {
 }
 "#;
 
+const QUERY_LIST_USERS: &str = r#"
+query SymphonyLinearListUsers($first: Int!, $after: String) {
+  users(first: $first, after: $after) {
+    nodes {
+      id
+      displayName
+      name
+      email
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+"#;
+
 // ── AssigneeFilter ─────────────────────────────────────────────────────
 
 /// Filter for routing issues to the current worker based on assignee.
 #[derive(Debug, Clone)]
 pub struct AssigneeFilter {
     pub match_values: HashSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LinearUser {
+    id: String,
+    display_name: Option<String>,
+    name: Option<String>,
+    email: Option<String>,
 }
 
 // ── LinearClient ───────────────────────────────────────────────────────
@@ -160,6 +188,8 @@ pub struct AssigneeFilter {
 pub struct LinearClient {
     http: reqwest::Client,
     config: TrackerConfig,
+    assignee_resolution_cache: Arc<Mutex<HashMap<String, String>>>,
+    users_cache: Arc<Mutex<Option<Vec<LinearUser>>>>,
 }
 
 impl LinearClient {
@@ -169,7 +199,12 @@ impl LinearClient {
             .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
             .build()
             .expect("failed to build reqwest client");
-        Self { http, config }
+        Self {
+            http,
+            config,
+            assignee_resolution_cache: Arc::new(Mutex::new(HashMap::new())),
+            users_cache: Arc::new(Mutex::new(None)),
+        }
     }
 
     // ── Public fetch operations ────────────────────────────────────────
@@ -514,7 +549,8 @@ impl LinearClient {
     /// Build the assignee filter from `TrackerConfig.assignee`.
     /// - `None` or empty → no filter (all issues routable)
     /// - `"me"` → resolve via viewer query
-    /// - anything else → literal match
+    /// - lowercase UUID pattern → literal ID match
+    /// - otherwise resolve via Linear users (`displayName`/`name`/`email`)
     async fn routing_assignee_filter(&self) -> Result<Option<AssigneeFilter>> {
         match &self.config.assignee {
             None => Ok(None),
@@ -545,6 +581,73 @@ impl LinearClient {
             )),
         }
     }
+
+    async fn resolve_named_assignee_filter(&self, assignee: &str) -> Result<AssigneeFilter> {
+        let lookup_key = normalize_assignee_lookup_key(assignee);
+
+        if let Some(cached_id) = self
+            .assignee_resolution_cache
+            .lock()
+            .await
+            .get(&lookup_key)
+            .cloned()
+        {
+            return Ok(single_match_filter(cached_id));
+        }
+
+        let users = self.list_linear_users().await?;
+        if let Some(user_id) = find_user_id_by_lookup(&users, &lookup_key) {
+            self.assignee_resolution_cache
+                .lock()
+                .await
+                .insert(lookup_key, user_id.clone());
+            return Ok(single_match_filter(user_id));
+        }
+
+        let available = format_available_usernames(&users);
+        Err(SymphonyError::Other(format!(
+            "unable to resolve tracker.assignee '{assignee}' to a Linear user id. Available usernames: {available}"
+        )))
+    }
+
+    async fn list_linear_users(&self) -> Result<Vec<LinearUser>> {
+        if let Some(cached) = self.users_cache.lock().await.clone() {
+            return Ok(cached);
+        }
+
+        let fetched = self.fetch_linear_users().await?;
+        let mut cache = self.users_cache.lock().await;
+        if cache.is_none() {
+            *cache = Some(fetched.clone());
+        }
+        Ok(cache.clone().unwrap_or(fetched))
+    }
+
+    async fn fetch_linear_users(&self) -> Result<Vec<LinearUser>> {
+        let mut users: Vec<LinearUser> = Vec::new();
+        let mut after_cursor: Option<String> = None;
+
+        loop {
+            let mut variables = serde_json::json!({
+                "first": USER_PAGE_SIZE,
+            });
+            if let Some(ref cursor) = after_cursor {
+                variables["after"] = Value::String(cursor.clone());
+            }
+
+            let body = self.graphql(QUERY_LIST_USERS, variables).await?;
+            let (page_users, page_info) = decode_linear_users_page_response(&body)?;
+            users.extend(page_users);
+
+            match next_page_cursor(&page_info) {
+                PageCursorResult::Continue(cursor) => after_cursor = Some(cursor),
+                PageCursorResult::Done => break,
+                PageCursorResult::Error => return Err(SymphonyError::LinearMissingEndCursor),
+            }
+        }
+
+        Ok(users)
+    }
 }
 
 // ── Assignee filter construction ───────────────────────────────────────
@@ -564,9 +667,12 @@ async fn build_assignee_filter(
         return Ok(Some(filter));
     }
 
-    let mut match_values = HashSet::new();
-    match_values.insert(trimmed.to_string());
-    Ok(Some(AssigneeFilter { match_values }))
+    if is_lowercase_uuid(trimmed) {
+        return Ok(Some(single_match_filter(trimmed.to_string())));
+    }
+
+    let filter = client.resolve_named_assignee_filter(trimmed).await?;
+    Ok(Some(filter))
 }
 
 // ── Normalization ──────────────────────────────────────────────────────
@@ -645,6 +751,13 @@ fn parse_priority(val: Option<&Value>) -> Option<i32> {
             None
         }
     })
+}
+
+fn parse_optional_trimmed_field(val: Option<&Value>) -> Option<String> {
+    val.and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
 }
 
 /// Nil-safe nested field access on the assignee object.
@@ -733,6 +846,22 @@ fn parse_datetime(val: Option<&Value>) -> Option<DateTime<Utc>> {
     val.and_then(|v| v.as_str())
         .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
         .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn parse_linear_user(node: &Value) -> Option<LinearUser> {
+    let id = node
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)?;
+
+    Some(LinearUser {
+        id,
+        display_name: parse_optional_trimmed_field(node.get("displayName")),
+        name: parse_optional_trimmed_field(node.get("name")),
+        email: parse_optional_trimmed_field(node.get("email")),
+    })
 }
 
 // ── Response decoding ──────────────────────────────────────────────────
@@ -824,6 +953,45 @@ fn decode_linear_page_response(
     Err(SymphonyError::LinearUnknownPayload)
 }
 
+fn decode_linear_users_page_response(body: &Value) -> Result<(Vec<LinearUser>, PageInfo)> {
+    let users_obj = body.get("data").and_then(|d| d.get("users"));
+
+    if let Some(users_val) = users_obj {
+        let nodes = users_val.get("nodes").and_then(|n| n.as_array());
+        let page_info_val = users_val.get("pageInfo");
+
+        if let (Some(nodes), Some(pi)) = (nodes, page_info_val) {
+            let users: Vec<LinearUser> = nodes.iter().filter_map(parse_linear_user).collect();
+
+            let has_next_page = pi
+                .get("hasNextPage")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let end_cursor = pi
+                .get("endCursor")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(String::from);
+
+            return Ok((
+                users,
+                PageInfo {
+                    has_next_page,
+                    end_cursor,
+                },
+            ));
+        }
+    }
+
+    if body.get("errors").is_some() {
+        let errors_str = serde_json::to_string(body.get("errors").unwrap())
+            .unwrap_or_else(|_| "unknown".to_string());
+        return Err(SymphonyError::LinearGraphqlErrors(errors_str));
+    }
+
+    Err(SymphonyError::LinearUnknownPayload)
+}
+
 /// Check the page info to determine if we should continue, stop, or error.
 fn next_page_cursor(page_info: &PageInfo) -> PageCursorResult {
     if page_info.has_next_page {
@@ -872,6 +1040,76 @@ fn dedup_strings(input: &[String]) -> Vec<String> {
         .filter(|s| seen.insert((*s).clone()))
         .cloned()
         .collect()
+}
+
+fn normalize_assignee_lookup_key(raw: &str) -> String {
+    raw.trim().to_lowercase()
+}
+
+fn is_lowercase_uuid(value: &str) -> bool {
+    if value.len() != 36 {
+        return false;
+    }
+
+    value.chars().enumerate().all(|(idx, ch)| {
+        if matches!(idx, 8 | 13 | 18 | 23) {
+            ch == '-'
+        } else {
+            ch.is_ascii_digit() || matches!(ch, 'a'..='f')
+        }
+    })
+}
+
+fn single_match_filter(id: String) -> AssigneeFilter {
+    let mut match_values = HashSet::new();
+    match_values.insert(id);
+    AssigneeFilter { match_values }
+}
+
+fn find_user_id_by_lookup(users: &[LinearUser], lookup_key: &str) -> Option<String> {
+    users.iter().find_map(|user| {
+        [
+            user.display_name.as_deref(),
+            user.name.as_deref(),
+            user.email.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .find(|candidate| normalize_assignee_lookup_key(candidate) == lookup_key)
+        .map(|_| user.id.clone())
+    })
+}
+
+fn format_available_usernames(users: &[LinearUser]) -> String {
+    let mut unique_values: HashMap<String, String> = HashMap::new();
+
+    for user in users {
+        for candidate in [
+            user.name.as_deref(),
+            user.display_name.as_deref(),
+            user.email.as_deref(),
+        ] {
+            if let Some(value) = candidate.map(str::trim).filter(|v| !v.is_empty()) {
+                unique_values
+                    .entry(value.to_lowercase())
+                    .or_insert_with(|| value.to_string());
+            }
+        }
+    }
+
+    let mut values: Vec<String> = unique_values.into_values().collect();
+    values.sort_by_key(|value| value.to_lowercase());
+    if values.is_empty() {
+        return "none returned by Linear users query".to_string();
+    }
+
+    const MAX_VALUES: usize = 25;
+    if values.len() <= MAX_VALUES {
+        values.join(", ")
+    } else {
+        let total = values.len();
+        format!("{}, ... ({} total)", values[..MAX_VALUES].join(", "), total)
+    }
 }
 
 /// Truncate an error body to ≤1000 bytes for logging.

--- a/apps/symphony/src/linear/client.rs
+++ b/apps/symphony/src/linear/client.rs
@@ -596,12 +596,22 @@ impl LinearClient {
         }
 
         let users = self.list_linear_users().await?;
-        if let Some(user_id) = find_user_id_by_lookup(&users, &lookup_key) {
-            self.assignee_resolution_cache
-                .lock()
-                .await
-                .insert(lookup_key, user_id.clone());
-            return Ok(single_match_filter(user_id));
+        let matched_user_ids = find_user_ids_by_lookup(&users, &lookup_key);
+        match matched_user_ids.as_slice() {
+            [user_id] => {
+                self.assignee_resolution_cache
+                    .lock()
+                    .await
+                    .insert(lookup_key, user_id.clone());
+                return Ok(single_match_filter(user_id.clone()));
+            }
+            [] => {}
+            _ => {
+                let ids = matched_user_ids.join(", ");
+                return Err(SymphonyError::Other(format!(
+                    "tracker.assignee '{assignee}' matched multiple Linear users ({ids}). Use email or UUID for an exact match."
+                )));
+            }
         }
 
         let available = format_available_assignee_identifiers(&users);
@@ -1072,18 +1082,26 @@ fn single_match_filter(id: String) -> AssigneeFilter {
     AssigneeFilter { match_values }
 }
 
-fn find_user_id_by_lookup(users: &[LinearUser], lookup_key: &str) -> Option<String> {
-    users.iter().find_map(|user| {
-        [
+fn find_user_ids_by_lookup(users: &[LinearUser], lookup_key: &str) -> Vec<String> {
+    let mut seen_ids: HashSet<String> = HashSet::new();
+    let mut matched_ids: Vec<String> = Vec::new();
+
+    for user in users {
+        let matches_lookup = [
             user.display_name.as_deref(),
             user.name.as_deref(),
             user.email.as_deref(),
         ]
         .into_iter()
         .flatten()
-        .find(|candidate| normalize_assignee_lookup_key(candidate) == lookup_key)
-        .map(|_| user.id.clone())
-    })
+        .any(|candidate| normalize_assignee_lookup_key(candidate) == lookup_key);
+
+        if matches_lookup && seen_ids.insert(user.id.clone()) {
+            matched_ids.push(user.id.clone());
+        }
+    }
+
+    matched_ids
 }
 
 fn format_available_assignee_identifiers(users: &[LinearUser]) -> String {

--- a/apps/symphony/src/linear/client.rs
+++ b/apps/symphony/src/linear/client.rs
@@ -604,9 +604,9 @@ impl LinearClient {
             return Ok(single_match_filter(user_id));
         }
 
-        let available = format_available_usernames(&users);
+        let available = format_available_assignee_identifiers(&users);
         Err(SymphonyError::Other(format!(
-            "unable to resolve tracker.assignee '{assignee}' to a Linear user id. Available usernames: {available}"
+            "unable to resolve tracker.assignee '{assignee}' to a Linear user id. Available names/emails: {available}"
         )))
     }
 
@@ -618,9 +618,14 @@ impl LinearClient {
         let fetched = self.fetch_linear_users().await?;
         let mut cache = self.users_cache.lock().await;
         if cache.is_none() {
-            *cache = Some(fetched.clone());
+            *cache = Some(fetched);
         }
-        Ok(cache.clone().unwrap_or(fetched))
+        match cache.as_ref() {
+            Some(cached) => Ok(cached.clone()),
+            None => Err(SymphonyError::Other(
+                "Linear users cache unexpectedly empty".to_string(),
+            )),
+        }
     }
 
     async fn fetch_linear_users(&self) -> Result<Vec<LinearUser>> {
@@ -667,8 +672,9 @@ async fn build_assignee_filter(
         return Ok(Some(filter));
     }
 
-    if is_lowercase_uuid(trimmed) {
-        return Ok(Some(single_match_filter(trimmed.to_string())));
+    let normalized_uuid = trimmed.to_lowercase();
+    if is_uuid_pattern(&normalized_uuid) {
+        return Ok(Some(single_match_filter(normalized_uuid)));
     }
 
     let filter = client.resolve_named_assignee_filter(trimmed).await?;
@@ -1046,7 +1052,7 @@ fn normalize_assignee_lookup_key(raw: &str) -> String {
     raw.trim().to_lowercase()
 }
 
-fn is_lowercase_uuid(value: &str) -> bool {
+fn is_uuid_pattern(value: &str) -> bool {
     if value.len() != 36 {
         return false;
     }
@@ -1055,7 +1061,7 @@ fn is_lowercase_uuid(value: &str) -> bool {
         if matches!(idx, 8 | 13 | 18 | 23) {
             ch == '-'
         } else {
-            ch.is_ascii_digit() || matches!(ch, 'a'..='f')
+            ch.is_ascii_hexdigit()
         }
     })
 }
@@ -1080,7 +1086,7 @@ fn find_user_id_by_lookup(users: &[LinearUser], lookup_key: &str) -> Option<Stri
     })
 }
 
-fn format_available_usernames(users: &[LinearUser]) -> String {
+fn format_available_assignee_identifiers(users: &[LinearUser]) -> String {
     let mut unique_values: HashMap<String, String> = HashMap::new();
 
     for user in users {

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -117,6 +117,35 @@ fn viewer_response(viewer_id: &str) -> Value {
     })
 }
 
+/// Users query response.
+fn users_response(nodes: Vec<Value>, has_next_page: bool, end_cursor: Option<&str>) -> Value {
+    json!({
+        "data": {
+            "users": {
+                "nodes": nodes,
+                "pageInfo": {
+                    "hasNextPage": has_next_page,
+                    "endCursor": end_cursor
+                }
+            }
+        }
+    })
+}
+
+fn user_node(
+    id: &str,
+    display_name: Option<&str>,
+    name: Option<&str>,
+    email: Option<&str>,
+) -> Value {
+    json!({
+        "id": id,
+        "displayName": display_name,
+        "name": name,
+        "email": email
+    })
+}
+
 /// Create a mock for any POST to /graphql returning the given body.
 async fn mock_graphql(server: &mut ServerGuard, response_body: &Value) -> Mock {
     server
@@ -967,4 +996,176 @@ async fn test_fetch_candidates_with_me_filters_out_unassigned() {
     // Issue returned but with assigned_to_worker: false
     assert_eq!(issues.len(), 1);
     assert!(!issues[0].assigned_to_worker);
+}
+
+#[tokio::test]
+async fn test_fetch_candidates_with_username_assignee() {
+    let mut server = Server::new_async().await;
+
+    let users_resp = users_response(
+        vec![user_node(
+            "user-alice",
+            Some("Alice Example"),
+            Some("alice"),
+            Some("alice@example.com"),
+        )],
+        false,
+        None,
+    );
+    let m_users = mock_graphql(&mut server, &users_resp).await;
+
+    let issue = json!({
+        "id": "id-1",
+        "identifier": "PROJ-1",
+        "title": "T",
+        "state": { "name": "Todo" },
+        "assignee": { "id": "user-alice" },
+        "labels": { "nodes": [] },
+        "inverseRelations": { "nodes": [] }
+    });
+    let candidates_resp = paginated_response(vec![issue], false, None);
+    let m_candidates = mock_graphql(&mut server, &candidates_resp).await;
+
+    let client = test_client(&server, Some("alice"));
+    let issues = client.fetch_candidates().await.unwrap();
+
+    m_users.assert_async().await;
+    m_candidates.assert_async().await;
+    assert_eq!(issues.len(), 1);
+    assert!(issues[0].assigned_to_worker);
+}
+
+#[tokio::test]
+async fn test_fetch_candidates_with_email_assignee() {
+    let mut server = Server::new_async().await;
+
+    let users_resp = users_response(
+        vec![user_node(
+            "user-alice",
+            Some("Alice Example"),
+            Some("alice"),
+            Some("alice@example.com"),
+        )],
+        false,
+        None,
+    );
+    let m_users = mock_graphql(&mut server, &users_resp).await;
+
+    let issue = json!({
+        "id": "id-1",
+        "identifier": "PROJ-1",
+        "title": "T",
+        "state": { "name": "Todo" },
+        "assignee": { "id": "user-alice" },
+        "labels": { "nodes": [] },
+        "inverseRelations": { "nodes": [] }
+    });
+    let candidates_resp = paginated_response(vec![issue], false, None);
+    let m_candidates = mock_graphql(&mut server, &candidates_resp).await;
+
+    let client = test_client(&server, Some("alice@example.com"));
+    let issues = client.fetch_candidates().await.unwrap();
+
+    m_users.assert_async().await;
+    m_candidates.assert_async().await;
+    assert_eq!(issues.len(), 1);
+    assert!(issues[0].assigned_to_worker);
+}
+
+#[tokio::test]
+async fn test_fetch_candidates_with_uuid_assignee_skips_users_query() {
+    let mut server = Server::new_async().await;
+
+    let assignee_id = "123e4567-e89b-12d3-a456-426614174000";
+    let issue = json!({
+        "id": "id-1",
+        "identifier": "PROJ-1",
+        "title": "T",
+        "state": { "name": "Todo" },
+        "assignee": { "id": assignee_id },
+        "labels": { "nodes": [] },
+        "inverseRelations": { "nodes": [] }
+    });
+    let candidates_resp = paginated_response(vec![issue], false, None);
+    let m_candidates = mock_graphql(&mut server, &candidates_resp).await;
+
+    let client = test_client(&server, Some(assignee_id));
+    let issues = client.fetch_candidates().await.unwrap();
+
+    m_candidates.assert_async().await;
+    assert_eq!(issues.len(), 1);
+    assert!(issues[0].assigned_to_worker);
+}
+
+#[tokio::test]
+async fn test_fetch_candidates_with_unresolvable_assignee_errors_with_usernames() {
+    let mut server = Server::new_async().await;
+
+    let users_resp = users_response(
+        vec![
+            user_node("user-alice", Some("Alice Example"), Some("alice"), None),
+            user_node("user-bob", Some("Bob Example"), Some("bob"), None),
+        ],
+        false,
+        None,
+    );
+    let m_users = mock_graphql(&mut server, &users_resp).await;
+
+    let client = test_client(&server, Some("carol"));
+    let err = client.fetch_candidates().await.unwrap_err();
+    m_users.assert_async().await;
+
+    match err {
+        SymphonyError::Other(message) => {
+            assert!(message.contains("carol"));
+            assert!(message.contains("Available usernames"));
+            assert!(message.contains("alice"));
+            assert!(message.contains("bob"));
+        }
+        other => panic!("expected SymphonyError::Other, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_fetch_candidates_named_assignee_uses_session_cache() {
+    let mut server = Server::new_async().await;
+
+    let users_resp = users_response(
+        vec![user_node(
+            "user-alice",
+            Some("Alice Example"),
+            Some("alice"),
+            Some("alice@example.com"),
+        )],
+        false,
+        None,
+    );
+    let m_users = mock_graphql(&mut server, &users_resp).await;
+
+    let issue = json!({
+        "id": "id-1",
+        "identifier": "PROJ-1",
+        "title": "T",
+        "state": { "name": "Todo" },
+        "assignee": { "id": "user-alice" },
+        "labels": { "nodes": [] },
+        "inverseRelations": { "nodes": [] }
+    });
+    let candidates_resp_1 = paginated_response(vec![issue.clone()], false, None);
+    let m_candidates_1 = mock_graphql(&mut server, &candidates_resp_1).await;
+    let candidates_resp_2 = paginated_response(vec![issue], false, None);
+    let m_candidates_2 = mock_graphql(&mut server, &candidates_resp_2).await;
+
+    let client = test_client(&server, Some("alice"));
+    let first = client.fetch_candidates().await.unwrap();
+    let second = client.fetch_candidates().await.unwrap();
+
+    m_users.assert_async().await;
+    m_candidates_1.assert_async().await;
+    m_candidates_2.assert_async().await;
+
+    assert_eq!(first.len(), 1);
+    assert!(first[0].assigned_to_worker);
+    assert_eq!(second.len(), 1);
+    assert!(second[0].assigned_to_worker);
 }

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -3,7 +3,7 @@
 //! Uses `mockito` to mock the Linear GraphQL endpoint — no live API calls.
 //! Tests cover all verification items from S03-PLAN.md.
 
-use mockito::{Mock, Server, ServerGuard};
+use mockito::{Matcher, Mock, Server, ServerGuard};
 use serde_json::{json, Value};
 use symphony::domain::{ApiKey, TrackerConfig};
 use symphony::error::SymphonyError;
@@ -1269,6 +1269,63 @@ async fn test_fetch_candidates_named_assignee_uses_session_cache() {
     m_candidates_1.assert_async().await;
     m_candidates_2.assert_async().await;
 
+    assert_eq!(first.len(), 1);
+    assert!(first[0].assigned_to_worker);
+    assert_eq!(second.len(), 1);
+    assert!(second[0].assigned_to_worker);
+}
+
+#[tokio::test]
+async fn test_fetch_candidates_named_assignee_concurrent_requests_share_users_fetch() {
+    let mut server = Server::new_async().await;
+
+    let users_resp = users_response(
+        vec![user_node(
+            "user-alice",
+            Some("Alice Example"),
+            Some("alice"),
+            Some("alice@example.com"),
+        )],
+        false,
+        None,
+    );
+    let m_users = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("SymphonyLinearListUsers".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(serde_json::to_string(&users_resp).unwrap())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issue = json!({
+        "id": "id-1",
+        "identifier": "PROJ-1",
+        "title": "T",
+        "state": { "name": "Todo" },
+        "assignee": { "id": "user-alice" },
+        "labels": { "nodes": [] },
+        "inverseRelations": { "nodes": [] }
+    });
+    let candidates_resp = paginated_response(vec![issue], false, None);
+    let m_candidates = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("SymphonyLinearPoll".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(serde_json::to_string(&candidates_resp).unwrap())
+        .expect(2)
+        .create_async()
+        .await;
+
+    let client = test_client(&server, Some("alice"));
+    let (first, second) = tokio::join!(client.fetch_candidates(), client.fetch_candidates());
+    let first = first.unwrap();
+    let second = second.unwrap();
+
+    m_users.assert_async().await;
+    m_candidates.assert_async().await;
     assert_eq!(first.len(), 1);
     assert!(first[0].assigned_to_worker);
     assert_eq!(second.len(), 1);

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -1073,6 +1073,56 @@ async fn test_fetch_candidates_with_email_assignee() {
 }
 
 #[tokio::test]
+async fn test_fetch_candidates_with_username_assignee_paginates_users_query() {
+    let mut server = Server::new_async().await;
+
+    let users_page_1 = users_response(
+        vec![user_node(
+            "user-bob",
+            Some("Bob Example"),
+            Some("bob"),
+            Some("bob@example.com"),
+        )],
+        true,
+        Some("cursor-1"),
+    );
+    let m_users_page_1 = mock_graphql(&mut server, &users_page_1).await;
+
+    let users_page_2 = users_response(
+        vec![user_node(
+            "user-alice",
+            Some("Alice Example"),
+            Some("alice"),
+            Some("alice@example.com"),
+        )],
+        false,
+        None,
+    );
+    let m_users_page_2 = mock_graphql(&mut server, &users_page_2).await;
+
+    let issue = json!({
+        "id": "id-1",
+        "identifier": "PROJ-1",
+        "title": "T",
+        "state": { "name": "Todo" },
+        "assignee": { "id": "user-alice" },
+        "labels": { "nodes": [] },
+        "inverseRelations": { "nodes": [] }
+    });
+    let candidates_resp = paginated_response(vec![issue], false, None);
+    let m_candidates = mock_graphql(&mut server, &candidates_resp).await;
+
+    let client = test_client(&server, Some("alice"));
+    let issues = client.fetch_candidates().await.unwrap();
+
+    m_users_page_1.assert_async().await;
+    m_users_page_2.assert_async().await;
+    m_candidates.assert_async().await;
+    assert_eq!(issues.len(), 1);
+    assert!(issues[0].assigned_to_worker);
+}
+
+#[tokio::test]
 async fn test_fetch_candidates_with_uuid_assignee_skips_users_query() {
     let mut server = Server::new_async().await;
 
@@ -1098,7 +1148,33 @@ async fn test_fetch_candidates_with_uuid_assignee_skips_users_query() {
 }
 
 #[tokio::test]
-async fn test_fetch_candidates_with_unresolvable_assignee_errors_with_usernames() {
+async fn test_fetch_candidates_with_uppercase_uuid_assignee_normalizes_to_lowercase() {
+    let mut server = Server::new_async().await;
+
+    let assignee_id = "123e4567-e89b-12d3-a456-426614174000";
+    let assignee_upper = assignee_id.to_uppercase();
+    let issue = json!({
+        "id": "id-1",
+        "identifier": "PROJ-1",
+        "title": "T",
+        "state": { "name": "Todo" },
+        "assignee": { "id": assignee_id },
+        "labels": { "nodes": [] },
+        "inverseRelations": { "nodes": [] }
+    });
+    let candidates_resp = paginated_response(vec![issue], false, None);
+    let m_candidates = mock_graphql(&mut server, &candidates_resp).await;
+
+    let client = test_client(&server, Some(assignee_upper.as_str()));
+    let issues = client.fetch_candidates().await.unwrap();
+
+    m_candidates.assert_async().await;
+    assert_eq!(issues.len(), 1);
+    assert!(issues[0].assigned_to_worker);
+}
+
+#[tokio::test]
+async fn test_fetch_candidates_with_unresolvable_assignee_errors_with_identifiers() {
     let mut server = Server::new_async().await;
 
     let users_resp = users_response(
@@ -1118,7 +1194,7 @@ async fn test_fetch_candidates_with_unresolvable_assignee_errors_with_usernames(
     match err {
         SymphonyError::Other(message) => {
             assert!(message.contains("carol"));
-            assert!(message.contains("Available usernames"));
+            assert!(message.contains("Available names/emails"));
             assert!(message.contains("alice"));
             assert!(message.contains("bob"));
         }

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -1203,6 +1203,35 @@ async fn test_fetch_candidates_with_unresolvable_assignee_errors_with_identifier
 }
 
 #[tokio::test]
+async fn test_fetch_candidates_with_ambiguous_assignee_errors() {
+    let mut server = Server::new_async().await;
+
+    let users_resp = users_response(
+        vec![
+            user_node("user-1", Some("Alex"), Some("alex"), None),
+            user_node("user-2", Some("Alex"), Some("alex"), None),
+        ],
+        false,
+        None,
+    );
+    let m_users = mock_graphql(&mut server, &users_resp).await;
+
+    let client = test_client(&server, Some("alex"));
+    let err = client.fetch_candidates().await.unwrap_err();
+    m_users.assert_async().await;
+
+    match err {
+        SymphonyError::Other(message) => {
+            assert!(message.contains("matched multiple Linear users"));
+            assert!(message.contains("user-1"));
+            assert!(message.contains("user-2"));
+            assert!(message.contains("Use email or UUID"));
+        }
+        other => panic!("expected SymphonyError::Other, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn test_fetch_candidates_named_assignee_uses_session_cache() {
     let mut server = Server::new_async().await;
 


### PR DESCRIPTION
## Summary
- preserve existing `tracker.assignee` handling for `me`
- preserve lowercase UUID assignee passthrough
- resolve non-UUID assignee values by querying Linear users and matching against `displayName`, `name`, or `email`
- cache resolved assignee IDs and fetched Linear users for the session lifetime
- fail fast with a helpful error listing available usernames when an assignee cannot be resolved

## Testing
- [x] `cd apps/symphony && cargo test --test linear_client_tests test_fetch_candidates_with_ -- --nocapture`
- [x] `cd apps/symphony && cargo test --test linear_client_tests test_fetch_candidates_named_assignee_uses_session_cache -- --nocapture`
- [x] `cd apps/symphony && cargo test`
- [x] `cd apps/symphony && cargo clippy -- -D warnings`

## Issue
- Linear: `KAT-825`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `LinearClient` to resolve human-readable assignee values (`displayName`, `name`, email) against the Linear users API, with session-scoped caching of both the resolved ID and the raw user list. Existing `"me"` and lowercase-UUID passthrough paths are preserved.

Key changes:
- New `QUERY_LIST_USERS` GraphQL query with full cursor-based pagination and a `LinearUser` struct
- `resolve_named_assignee_filter` performs user lookup after checking `assignee_resolution_cache`; `list_linear_users` populates `users_cache` on first miss
- `is_lowercase_uuid` guard keeps the literal-ID fast path for UUID-shaped values
- Fail-fast error enumerates up to 25 available usernames/emails when resolution fails
- Five new integration tests covering username, email, UUID, unresolvable, and cache-hit scenarios

One logic concern: `is_lowercase_uuid` accepts only strictly-lowercase hex, which is a narrowing from the previous behaviour where _any_ non-`"me"` string was used as-is. A `tracker.assignee` value with uppercase hex digits (valid RFC 4122, returned by some tooling) would previously work as a literal ID but now fails with a confusing resolution error.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with low risk, but the uppercase-UUID behaviour change should be intentionally acknowledged before shipping.
- The implementation is well-structured with proper async caching, good test coverage of the new paths, and clean pagination handling. The score is reduced because `is_lowercase_uuid` introduces a silent regression for users whose `tracker.assignee` config contains a UUID with uppercase hex digits — a valid format that the previous code handled transparently. The `list_linear_users` double-clone is a minor cleanliness issue, and multi-page user list pagination is untested.
- apps/symphony/src/linear/client.rs — specifically the `is_lowercase_uuid` guard in `build_assignee_filter` (line 670) and the `unwrap_or` in `list_linear_users` (line 623).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/linear/client.rs | Adds named-assignee resolution via a new `QUERY_LIST_USERS` GraphQL query with full pagination, session-scoped caching (`assignee_resolution_cache` and `users_cache`), and a fail-fast error listing available names. Contains a logic issue where uppercase UUIDs that previously passed through as literal IDs now trigger a failed user-lookup, and a minor clarity issue in the `list_linear_users` cache-write path. |
| apps/symphony/tests/linear_client_tests.rs | Adds five integration tests covering username, email, UUID, unresolvable assignee, and session-cache hit paths — good coverage of the new resolution logic, though multi-page user pagination is not exercised. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[routing_assignee_filter] --> B{config.assignee?}
    B -- None/empty --> C[No filter — all issues routable]
    B -- Some --> D[build_assignee_filter]
    D --> E{trimmed == 'me'?}
    E -- yes --> F[resolve_viewer_assignee_filter\nviewer GraphQL query]
    E -- no --> G{is_lowercase_uuid?}
    G -- yes --> H[single_match_filter\nliteral ID passthrough]
    G -- no --> I[resolve_named_assignee_filter]
    I --> J{assignee_resolution_cache hit?}
    J -- yes --> K[Return cached AssigneeFilter]
    J -- no --> L[list_linear_users]
    L --> M{users_cache hit?}
    M -- yes --> N[Return cached Vec<LinearUser>]
    M -- no --> O[fetch_linear_users\nPaginated QUERY_LIST_USERS]
    O --> P[Populate users_cache]
    P --> N
    N --> Q{find_user_id_by_lookup\ndisplayName / name / email}
    Q -- found --> R[Populate assignee_resolution_cache\nReturn AssigneeFilter]
    Q -- not found --> S[Err: list available usernames]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/linear/client.rs
Line: 619-623

Comment:
**`unwrap_or(fetched)` is unreachable — intent is obscured**

After the `if cache.is_none()` block, `cache` is always `Some(...)` (either it was already populated by a concurrent caller, or we just set it). The `.unwrap_or(fetched)` branch is dead code, and the extra `fetched.clone()` inside the `if` block creates a superfluous allocation. The intent is clearer as:

```suggestion
        if cache.is_none() {
            *cache = Some(fetched);
        }
        Ok(cache.as_ref().unwrap().clone())
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/linear/client.rs
Line: 608-610

Comment:
**Error label "Available usernames" is misleading**

`format_available_usernames` aggregates `name`, `displayName`, and `email` fields together. The error message at the call-site says "Available usernames", which could confuse a user who provided an email address or full display name and sees their own email listed under "usernames". A more accurate label would be "Available names/emails" or "Available identifiers":

```suggestion
        "unable to resolve tracker.assignee '{assignee}' to a Linear user id. Available names/emails: {available}"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/tests/linear_client_tests.rs
Line: 997

Comment:
**No test for multi-page user list pagination**

`fetch_linear_users` implements a full cursor-based pagination loop (mirrors the issue fetch loop), but none of the new tests exercise the `hasNextPage = true` path for the users query. A page-turn scenario — where the first users response has `hasNextPage: true` with a cursor and the second completes the list — would validate that all users are collected and the correct one is matched.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/linear/client.rs
Line: 670-672

Comment:
**Uppercase UUID configs break silently after this change**

`is_lowercase_uuid` strictly requires all hex digits to be lowercase (`'a'..='f'`). Before this PR, _any_ non-`"me"` string was passed through as a literal ID match. After this PR, a `tracker.assignee` value containing an uppercase hex UUID (valid per RFC 4122) would fall through to `resolve_named_assignee_filter`, fail to match any user's `displayName`/`name`/`email`, and return a resolution error.

Linear's own API returns lowercase UUIDs, but users who copy their ID from a browser URL or another tool that renders it in uppercase would hit this failure. Consider normalising to lowercase before the check so mixed-case UUIDs still pass through as literals:

```suggestion
    if is_lowercase_uuid(&trimmed.to_lowercase()) {
        return Ok(Some(single_match_filter(trimmed.to_lowercase())));
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix(symphony): resol..."](https://github.com/gannonh/kata/commit/1580ecab528a11c15fc591fcb1ff15e32e9c7223)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Assignees can now be resolved by username or email in addition to UUID format
* UUID assignee identifiers are normalized for case-insensitive matching
* Enhanced error handling provides available user identifiers when an assignee cannot be resolved, improving troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->