### PR TITLE
KAT-813: Multi-turn sessions within a single Codex thread

### DIFF
--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -75,18 +75,38 @@ fn is_terminal_state(state_name: &str, tracker_config: &TrackerConfig) -> bool {
         .any(|state| normalize_issue_state(state) == normalized)
 }
 
-async fn check_issue_still_active(issue: &Issue, tracker_config: &TrackerConfig) -> IssueCheck {
-    let client = crate::linear::client::LinearClient::new(tracker_config.clone());
+fn is_active_state(state_name: &str, tracker_config: &TrackerConfig) -> bool {
+    let normalized = normalize_issue_state(state_name);
+    tracker_config
+        .active_states
+        .iter()
+        .any(|state| normalize_issue_state(state) == normalized)
+}
+
+fn should_continue_issue_in_session(issue: &Issue, tracker_config: &TrackerConfig) -> bool {
+    issue.assigned_to_worker
+        && is_active_state(&issue.state, tracker_config)
+        && !is_terminal_state(&issue.state, tracker_config)
+}
+
+async fn check_issue_still_active(
+    issue: &Issue,
+    client: &crate::linear::client::LinearClient,
+    tracker_config: &TrackerConfig,
+) -> IssueCheck {
     match client
         .fetch_issue_states_by_ids(std::slice::from_ref(&issue.id))
         .await
     {
         Ok(issues) => match issues.first() {
             Some(refreshed) => {
-                if is_terminal_state(&refreshed.state, tracker_config) {
-                    IssueCheck::Done(refreshed.clone())
-                } else {
+                if should_continue_issue_in_session(refreshed, tracker_config)
+                    && normalize_issue_state(&refreshed.state)
+                        == normalize_issue_state(&issue.state)
+                {
                     IssueCheck::Continue(refreshed.clone())
+                } else {
+                    IssueCheck::Done(refreshed.clone())
                 }
             }
             None => IssueCheck::Done(issue.clone()),
@@ -110,6 +130,7 @@ where
     let capped_max_turns = max_turns.max(1);
     let mut turn_number: u32 = 1;
     let mut current_issue = issue.clone();
+    let issue_state_client = crate::linear::client::LinearClient::new(tracker_config.clone());
     let mut observed_events: Vec<AgentEvent> = Vec::new();
     let mut metrics: Option<TurnMetrics> = None;
     let mut initial_prompt = Some(initial_prompt);
@@ -144,7 +165,7 @@ where
             break;
         }
 
-        match check_issue_still_active(&current_issue, tracker_config).await {
+        match check_issue_still_active(&current_issue, &issue_state_client, tracker_config).await {
             IssueCheck::Continue(refreshed) => {
                 current_issue = refreshed;
                 turn_number = turn_number.saturating_add(1);
@@ -153,6 +174,14 @@ where
                 break;
             }
             IssueCheck::Error(err) => {
+                observed_events.push(AgentEvent::Notification {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: None,
+                    message: format!(
+                        "inter-turn issue refresh failed for {} ({}): {}",
+                        current_issue.identifier, current_issue.id, err
+                    ),
+                });
                 tracing::warn!(
                     issue_id = %current_issue.id,
                     issue_identifier = %current_issue.identifier,

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -39,6 +39,7 @@ enum IssueCheck {
 struct SessionTurnLoopSuccess {
     events: Vec<AgentEvent>,
     metrics: Option<TurnMetrics>,
+    schedule_continuation: bool,
 }
 
 struct SessionTurnLoopFailure {
@@ -48,20 +49,21 @@ struct SessionTurnLoopFailure {
 }
 
 fn accumulate_turn_metrics(metrics: &mut Option<TurnMetrics>, turn: &app_server::TurnResult) {
-    let next_rate_limits = turn.rate_limits.clone();
     match metrics {
         Some(total) => {
             total.input_tokens = total.input_tokens.saturating_add(turn.input_tokens);
             total.output_tokens = total.output_tokens.saturating_add(turn.output_tokens);
             total.total_tokens = total.total_tokens.saturating_add(turn.total_tokens);
-            total.rate_limits = next_rate_limits;
+            if let Some(rate_limits) = turn.rate_limits.clone() {
+                total.rate_limits = Some(rate_limits);
+            }
         }
         None => {
             *metrics = Some(TurnMetrics {
                 input_tokens: turn.input_tokens,
                 output_tokens: turn.output_tokens,
                 total_tokens: turn.total_tokens,
-                rate_limits: next_rate_limits,
+                rate_limits: turn.rate_limits.clone(),
             });
         }
     }
@@ -133,6 +135,7 @@ where
     let issue_state_client = crate::linear::client::LinearClient::new(tracker_config.clone());
     let mut observed_events: Vec<AgentEvent> = Vec::new();
     let mut metrics: Option<TurnMetrics> = None;
+    let mut schedule_continuation = true;
     let mut initial_prompt = Some(initial_prompt);
 
     loop {
@@ -171,6 +174,7 @@ where
                 turn_number = turn_number.saturating_add(1);
             }
             IssueCheck::Done(_refreshed) => {
+                schedule_continuation = false;
                 break;
             }
             IssueCheck::Error(err) => {
@@ -196,6 +200,7 @@ where
     Ok(SessionTurnLoopSuccess {
         events: observed_events,
         metrics,
+        schedule_continuation,
     })
 }
 
@@ -351,7 +356,9 @@ async fn run_worker_task(
     match loop_result {
         Ok(success) => WorkerResult {
             issue_id,
-            completion: WorkerCompletion::Completed,
+            completion: WorkerCompletion::Completed {
+                schedule_continuation: success.schedule_continuation,
+            },
             events: success.events,
             metrics: success.metrics,
         },
@@ -567,7 +574,7 @@ pub struct RetryContext {
 
 #[derive(Debug, Clone)]
 pub enum WorkerCompletion {
-    Completed,
+    Completed { schedule_continuation: bool },
     Failed { error: String },
 }
 
@@ -1101,7 +1108,9 @@ impl Orchestrator {
         };
 
         match completion {
-            WorkerCompletion::Completed => {
+            WorkerCompletion::Completed {
+                schedule_continuation,
+            } => {
                 self.state.completed.insert(issue_id.to_string());
 
                 tracing::info!(
@@ -1109,7 +1118,8 @@ impl Orchestrator {
                     issue_id = %issue_id,
                     issue_identifier = %issue_identifier,
                     session_id = session_id.as_deref().unwrap_or("n/a"),
-                    "worker attempt completed; scheduling continuation retry"
+                    schedule_continuation,
+                    "worker attempt completed"
                 );
 
                 self.events.push(RuntimeEvent::WorkerCompleted {
@@ -1118,15 +1128,20 @@ impl Orchestrator {
                     session_id,
                 });
 
-                Some(self.schedule_retry_with_context(
-                    issue_id,
-                    &issue_identifier,
-                    1,
-                    RetryKind::Continuation,
-                    now_ms,
-                    None,
-                    retry_context,
-                ))
+                if schedule_continuation {
+                    Some(self.schedule_retry_with_context(
+                        issue_id,
+                        &issue_identifier,
+                        1,
+                        RetryKind::Continuation,
+                        now_ms,
+                        None,
+                        retry_context,
+                    ))
+                } else {
+                    self.state.retry_attempts.remove(issue_id);
+                    None
+                }
             }
             WorkerCompletion::Failed { error } => {
                 self.state.completed.remove(issue_id);
@@ -1302,7 +1317,9 @@ impl Orchestrator {
                 }
                 self.handle_worker_completion(
                     &issue.id,
-                    WorkerCompletion::Completed,
+                    WorkerCompletion::Completed {
+                        schedule_continuation: success.schedule_continuation,
+                    },
                     Utc::now().timestamp_millis(),
                 );
 

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -11,9 +11,9 @@ use crate::config;
 use crate::domain::{
     AgentEvent, CodexConfig, CodexTotals, HooksConfig, Issue, OrchestratorSnapshot,
     OrchestratorState, PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetryEntry,
-    RetrySnapshotEntry, RunAttempt, ServiceConfig, WorkspaceConfig,
+    RetrySnapshotEntry, RunAttempt, ServiceConfig, TrackerConfig, WorkspaceConfig,
 };
-use crate::error::Result;
+use crate::error::{Result, SymphonyError};
 use crate::ssh::{self, WorkerHostSelection};
 use crate::{path_safety, prompt_builder, workspace};
 
@@ -25,8 +25,149 @@ struct WorkerTaskConfig {
     workspace: WorkspaceConfig,
     hooks: HooksConfig,
     codex: CodexConfig,
-    tracker: crate::domain::TrackerConfig,
+    max_turns: u32,
+    tracker: TrackerConfig,
     prompt_template: String,
+}
+
+enum IssueCheck {
+    Continue(Issue),
+    Done(Issue),
+    Error(SymphonyError),
+}
+
+struct SessionTurnLoopSuccess {
+    events: Vec<AgentEvent>,
+    metrics: Option<TurnMetrics>,
+}
+
+struct SessionTurnLoopFailure {
+    error: SymphonyError,
+    events: Vec<AgentEvent>,
+    metrics: Option<TurnMetrics>,
+}
+
+fn accumulate_turn_metrics(metrics: &mut Option<TurnMetrics>, turn: &app_server::TurnResult) {
+    let next_rate_limits = turn.rate_limits.clone();
+    match metrics {
+        Some(total) => {
+            total.input_tokens = total.input_tokens.saturating_add(turn.input_tokens);
+            total.output_tokens = total.output_tokens.saturating_add(turn.output_tokens);
+            total.total_tokens = total.total_tokens.saturating_add(turn.total_tokens);
+            total.rate_limits = next_rate_limits;
+        }
+        None => {
+            *metrics = Some(TurnMetrics {
+                input_tokens: turn.input_tokens,
+                output_tokens: turn.output_tokens,
+                total_tokens: turn.total_tokens,
+                rate_limits: next_rate_limits,
+            });
+        }
+    }
+}
+
+fn is_terminal_state(state_name: &str, tracker_config: &TrackerConfig) -> bool {
+    let normalized = normalize_issue_state(state_name);
+    tracker_config
+        .terminal_states
+        .iter()
+        .any(|state| normalize_issue_state(state) == normalized)
+}
+
+async fn check_issue_still_active(issue: &Issue, tracker_config: &TrackerConfig) -> IssueCheck {
+    let client = crate::linear::client::LinearClient::new(tracker_config.clone());
+    match client
+        .fetch_issue_states_by_ids(std::slice::from_ref(&issue.id))
+        .await
+    {
+        Ok(issues) => match issues.first() {
+            Some(refreshed) => {
+                if is_terminal_state(&refreshed.state, tracker_config) {
+                    IssueCheck::Done(refreshed.clone())
+                } else {
+                    IssueCheck::Continue(refreshed.clone())
+                }
+            }
+            None => IssueCheck::Done(issue.clone()),
+        },
+        Err(err) => IssueCheck::Error(err),
+    }
+}
+
+async fn run_codex_turns_in_session<E, EFut>(
+    session: &mut app_server::SessionHandle,
+    issue: &Issue,
+    initial_prompt: String,
+    max_turns: u32,
+    tracker_config: &TrackerConfig,
+    graphql_executor: E,
+) -> std::result::Result<SessionTurnLoopSuccess, SessionTurnLoopFailure>
+where
+    E: Fn(String, serde_json::Value) -> EFut + Clone + Send,
+    EFut: Future<Output = Result<serde_json::Value>> + Send,
+{
+    let capped_max_turns = max_turns.max(1);
+    let mut turn_number: u32 = 1;
+    let mut current_issue = issue.clone();
+    let mut observed_events: Vec<AgentEvent> = Vec::new();
+    let mut metrics: Option<TurnMetrics> = None;
+    let mut initial_prompt = Some(initial_prompt);
+
+    loop {
+        let prompt = if turn_number == 1 {
+            initial_prompt.take().unwrap_or_default()
+        } else {
+            prompt_builder::render_continuation_prompt(turn_number, capped_max_turns)
+        };
+
+        let run_result =
+            app_server::run_turn(session, &prompt, graphql_executor.clone(), |event| {
+                observed_events.push(event);
+            })
+            .await;
+
+        match run_result {
+            Ok(turn_result) => {
+                accumulate_turn_metrics(&mut metrics, &turn_result);
+            }
+            Err(err) => {
+                return Err(SessionTurnLoopFailure {
+                    error: err,
+                    events: observed_events,
+                    metrics,
+                });
+            }
+        }
+
+        if turn_number >= capped_max_turns {
+            break;
+        }
+
+        match check_issue_still_active(&current_issue, tracker_config).await {
+            IssueCheck::Continue(refreshed) => {
+                current_issue = refreshed;
+                turn_number = turn_number.saturating_add(1);
+            }
+            IssueCheck::Done(_refreshed) => {
+                break;
+            }
+            IssueCheck::Error(err) => {
+                tracing::warn!(
+                    issue_id = %current_issue.id,
+                    issue_identifier = %current_issue.identifier,
+                    error = %err,
+                    "failed to refresh issue state between worker turns; ending session-level turn loop"
+                );
+                break;
+            }
+        }
+    }
+
+    Ok(SessionTurnLoopSuccess {
+        events: observed_events,
+        metrics,
+    })
 }
 
 /// Run the full worker lifecycle for a single issue. This function is
@@ -34,7 +175,7 @@ struct WorkerTaskConfig {
 /// and does not require `&mut Orchestrator`.
 ///
 /// Steps: ensure workspace → before_run hook → render prompt → start
-/// Codex session → stream turn → stop session → after_run hook.
+/// Codex session → run up to max_turns on one session → stop session → after_run hook.
 async fn run_worker_task(
     issue: &Issue,
     attempt: Option<u32>,
@@ -148,19 +289,22 @@ async fn run_worker_task(
         "worker attempt started"
     );
 
-    // 5. Run turn — wire real linear_graphql executor via LinearClient
-    let mut observed_events: Vec<AgentEvent> = Vec::new();
+    // 5. Run up to max_turns within the same session.
     let linear_client = crate::linear::client::LinearClient::new(config.tracker.clone());
     let graphql_executor = move |query: String, vars: serde_json::Value| {
         let client = linear_client.clone();
         async move { client.graphql_raw(&query, vars).await }
     };
 
-    let run_result: Result<_> =
-        app_server::run_turn(&mut session, &prompt, graphql_executor, |event| {
-            observed_events.push(event);
-        })
-        .await;
+    let loop_result = run_codex_turns_in_session(
+        &mut session,
+        issue,
+        prompt,
+        config.max_turns,
+        &config.tracker,
+        graphql_executor,
+    )
+    .await;
 
     // 6. Stop session
     if let Err(err) = app_server::stop_session(session).await {
@@ -175,25 +319,20 @@ async fn run_worker_task(
     let _ = workspace::run_after_run_hook_for_issue(workspace_path, &config.hooks, issue);
 
     // 8. Build result
-    match run_result {
-        Ok(turn_result) => WorkerResult {
+    match loop_result {
+        Ok(success) => WorkerResult {
             issue_id,
             completion: WorkerCompletion::Completed,
-            events: observed_events,
-            metrics: Some(TurnMetrics {
-                input_tokens: turn_result.input_tokens,
-                output_tokens: turn_result.output_tokens,
-                total_tokens: turn_result.total_tokens,
-                rate_limits: turn_result.rate_limits,
-            }),
+            events: success.events,
+            metrics: success.metrics,
         },
-        Err(err) => WorkerResult {
+        Err(failure) => WorkerResult {
             issue_id,
             completion: WorkerCompletion::Failed {
-                error: err.to_string(),
+                error: failure.error.to_string(),
             },
-            events: observed_events,
-            metrics: None,
+            events: failure.events,
+            metrics: failure.metrics,
         },
     }
 }
@@ -578,6 +717,7 @@ impl Orchestrator {
                 workspace: self.config.workspace.clone(),
                 hooks: self.config.hooks.clone(),
                 codex: self.config.codex.clone(),
+                max_turns: self.config.agent.max_turns,
                 tracker: self.config.tracker.clone(),
                 prompt_template: self.prompt_template.clone(),
             };
@@ -1096,13 +1236,22 @@ impl Orchestrator {
             "worker attempt started"
         );
 
-        let mut observed_events: Vec<AgentEvent> = Vec::new();
-        let run_result = app_server::run_turn(&mut session, &prompt, graphql_executor, |event| {
-            observed_events.push(event);
-        })
+        let loop_result = run_codex_turns_in_session(
+            &mut session,
+            issue,
+            prompt,
+            self.config.agent.max_turns,
+            &self.config.tracker,
+            graphql_executor,
+        )
         .await;
 
-        for event in &observed_events {
+        let observed_events = match &loop_result {
+            Ok(success) => &success.events,
+            Err(failure) => &failure.events,
+        };
+
+        for event in observed_events {
             self.ingest_agent_event(&issue.id, event);
         }
 
@@ -1117,15 +1266,11 @@ impl Orchestrator {
 
         let _ = workspace::run_after_run_hook_for_issue(workspace_path, &self.config.hooks, issue);
 
-        match run_result {
-            Ok(turn_result) => {
-                self.apply_turn_metrics(&TurnMetrics {
-                    input_tokens: turn_result.input_tokens,
-                    output_tokens: turn_result.output_tokens,
-                    total_tokens: turn_result.total_tokens,
-                    rate_limits: turn_result.rate_limits,
-                });
-
+        match loop_result {
+            Ok(success) => {
+                if let Some(metrics) = &success.metrics {
+                    self.apply_turn_metrics(metrics);
+                }
                 self.handle_worker_completion(
                     &issue.id,
                     WorkerCompletion::Completed,
@@ -1134,15 +1279,18 @@ impl Orchestrator {
 
                 Ok(())
             }
-            Err(err) => {
+            Err(failure) => {
+                if let Some(metrics) = &failure.metrics {
+                    self.apply_turn_metrics(metrics);
+                }
+                let error = failure.error;
+                let error_text = error.to_string();
                 self.handle_worker_completion(
                     &issue.id,
-                    WorkerCompletion::Failed {
-                        error: err.to_string(),
-                    },
+                    WorkerCompletion::Failed { error: error_text },
                     Utc::now().timestamp_millis(),
                 );
-                Err(err)
+                Err(error)
             }
         }
     }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -102,10 +102,7 @@ async fn check_issue_still_active(
     {
         Ok(issues) => match issues.first() {
             Some(refreshed) => {
-                if should_continue_issue_in_session(refreshed, tracker_config)
-                    && normalize_issue_state(&refreshed.state)
-                        == normalize_issue_state(&issue.state)
-                {
+                if should_continue_issue_in_session(refreshed, tracker_config) {
                     IssueCheck::Continue(refreshed.clone())
                 } else {
                     IssueCheck::Done(refreshed.clone())

--- a/apps/symphony/src/prompt_builder.rs
+++ b/apps/symphony/src/prompt_builder.rs
@@ -46,3 +46,15 @@ pub fn render_prompt(template: &str, issue: &Issue, attempt: Option<u32>) -> Res
         .render(&globals)
         .map_err(|e| SymphonyError::TemplateRenderError(e.to_string()))
 }
+
+/// Build a concise continuation prompt for turn 2+ in a multi-turn session.
+pub fn render_continuation_prompt(turn_number: u32, max_turns: u32) -> String {
+    format!(
+        "Continuation guidance:\n\n\
+- The previous Codex turn completed normally, but the Linear issue is still in an active state.\n\
+- This is continuation turn #{turn_number} of {max_turns} for the current agent run.\n\
+- Resume from the current workspace and workpad state instead of restarting from scratch.\n\
+- The original task instructions and prior turn context are already present in this thread, so do not restate them before acting.\n\
+- Focus on the remaining ticket work and do not end the turn while the issue stays active unless you are truly blocked."
+    )
+}

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1563,6 +1563,74 @@ async fn test_execute_worker_attempt_stops_when_issue_leaves_active_state_after_
 }
 
 #[tokio::test]
+async fn test_execute_worker_attempt_stops_when_issue_changes_active_state_between_turns() {
+    let mut server = Server::new_async().await;
+    let issue = issue(
+        "issue-state-change",
+        "SIM-STATECHANGE",
+        "In Progress",
+        Some(1),
+        0,
+    );
+
+    let _state_lookup = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&state_lookup_response(
+                &issue.id,
+                &issue.identifier,
+                "Todo",
+                None,
+            ))
+            .expect("state response should serialize"),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let scripts_dir = tempdir().expect("scripts dir should be created");
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let prompt_log = scripts_dir.path().join("prompts.log");
+    let script = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        &script_two_successful_turns(&prompt_log),
+    );
+
+    let mut orchestrator = Orchestrator::new(
+        make_worker_config(&server, &script, workspace_root.path(), 5),
+        String::new(),
+    );
+
+    let result = orchestrator
+        .execute_worker_attempt(
+            &issue,
+            "First prompt {{ issue.identifier }}",
+            Some(1),
+            |_query, _vars| async { Ok(serde_json::json!({ "data": {} })) },
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "worker should stop cleanly once issue state changes between turns"
+    );
+
+    let prompt_lines: Vec<String> = std::fs::read_to_string(&prompt_log)
+        .expect("prompt log should exist")
+        .lines()
+        .map(|line| line.to_string())
+        .collect();
+    assert_eq!(
+        prompt_lines.len(),
+        1,
+        "state change after turn 1 should end the current session loop"
+    );
+}
+
+#[tokio::test]
 async fn test_execute_worker_attempt_stops_when_issue_unassigned_between_turns() {
     let mut server = Server::new_async().await;
     let issue = issue(

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1462,7 +1462,7 @@ async fn test_execute_worker_attempt_stops_when_issue_turns_terminal_after_first
     );
 
     let mut orchestrator = Orchestrator::new(
-        make_worker_config(&server, &script, workspace_root.path(), 5),
+        make_worker_config(&server, &script, workspace_root.path(), 2),
         String::new(),
     );
 
@@ -1528,7 +1528,7 @@ async fn test_execute_worker_attempt_preserves_last_non_null_rate_limits() {
     );
 
     let mut orchestrator = Orchestrator::new(
-        make_worker_config(&server, &script, workspace_root.path(), 2),
+        make_worker_config(&server, &script, workspace_root.path(), 5),
         String::new(),
     );
 
@@ -1706,78 +1706,6 @@ async fn test_execute_worker_attempt_stops_when_issue_leaves_active_state_after_
     assert!(
         !orchestrator.state().retry_attempts.contains_key(&issue.id),
         "non-active stop should not enqueue continuation retry"
-    );
-}
-
-#[tokio::test]
-async fn test_execute_worker_attempt_stops_when_issue_changes_active_state_between_turns() {
-    let mut server = Server::new_async().await;
-    let issue = issue(
-        "issue-state-change",
-        "SIM-STATECHANGE",
-        "In Progress",
-        Some(1),
-        0,
-    );
-
-    let _state_lookup = server
-        .mock("POST", "/graphql")
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(
-            serde_json::to_string(&state_lookup_response(
-                &issue.id,
-                &issue.identifier,
-                "Todo",
-                None,
-            ))
-            .expect("state response should serialize"),
-        )
-        .expect(1)
-        .create_async()
-        .await;
-
-    let scripts_dir = tempdir().expect("scripts dir should be created");
-    let workspace_root = tempdir().expect("workspace root should be created");
-    let prompt_log = scripts_dir.path().join("prompts.log");
-    let script = write_script(
-        scripts_dir.path(),
-        "codex.sh",
-        &script_two_successful_turns(&prompt_log),
-    );
-
-    let mut orchestrator = Orchestrator::new(
-        make_worker_config(&server, &script, workspace_root.path(), 5),
-        String::new(),
-    );
-
-    let result = orchestrator
-        .execute_worker_attempt(
-            &issue,
-            "First prompt {{ issue.identifier }}",
-            Some(1),
-            |_query, _vars| async { Ok(serde_json::json!({ "data": {} })) },
-        )
-        .await;
-
-    assert!(
-        result.is_ok(),
-        "worker should stop cleanly once issue state changes between turns"
-    );
-
-    let prompt_lines: Vec<String> = std::fs::read_to_string(&prompt_log)
-        .expect("prompt log should exist")
-        .lines()
-        .map(|line| line.to_string())
-        .collect();
-    assert_eq!(
-        prompt_lines.len(),
-        1,
-        "state change after turn 1 should end the current session loop"
-    );
-    assert!(
-        !orchestrator.state().retry_attempts.contains_key(&issue.id),
-        "state-transition stop should not enqueue continuation retry"
     );
 }
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -662,7 +662,13 @@ fn test_worker_completion_schedules_continuation_retry_with_session_context() {
         },
     );
 
-    orchestrator.handle_worker_completion("issue-complete", WorkerCompletion::Completed, 50_000);
+    orchestrator.handle_worker_completion(
+        "issue-complete",
+        WorkerCompletion::Completed {
+            schedule_continuation: true,
+        },
+        50_000,
+    );
 
     let retry_entry = orchestrator
         .state()
@@ -697,6 +703,49 @@ fn test_worker_completion_schedules_continuation_retry_with_session_context() {
     assert!(
         worker_completed,
         "worker completion diagnostics should retain issue/session context"
+    );
+}
+
+#[test]
+fn test_worker_completion_without_continuation_does_not_queue_retry() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+
+    orchestrator.state_mut().running.insert(
+        "issue-stop".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-stop".to_string(),
+            issue_identifier: "SIM-80B".to_string(),
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-stop".to_string(),
+            started_at: Utc::now(),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+        },
+    );
+
+    let scheduled = orchestrator.handle_worker_completion(
+        "issue-stop",
+        WorkerCompletion::Completed {
+            schedule_continuation: false,
+        },
+        50_000,
+    );
+
+    assert!(
+        scheduled.is_none(),
+        "completion without continuation should not enqueue retry"
+    );
+    assert!(
+        !orchestrator
+            .state()
+            .retry_attempts
+            .contains_key("issue-stop"),
+        "retry queue should stay empty when continuation is disabled"
+    );
+    assert!(
+        orchestrator.state().completed.contains("issue-stop"),
+        "issue should still be marked completed in orchestrator bookkeeping"
     );
 }
 
@@ -1246,6 +1295,32 @@ read -r line || true
     )
 }
 
+fn script_second_turn_omits_rate_limits(prompt_log: &Path) -> String {
+    format!(
+        r#"#!/bin/bash
+set -euo pipefail
+PROMPT_LOG="{prompt_log}"
+read -r line
+echo '{{"id":1,"result":{{"capabilities":{{}}}}}}'
+read -r line
+read -r line
+echo '{{"id":2,"result":{{"thread":{{"id":"thread-rate-limits"}}}}}}'
+read -r line
+echo "$line" >> "$PROMPT_LOG"
+echo '{{"id":3,"result":{{"turn":{{"id":"turn-1"}}}}}}'
+echo '{{"method":"token/1","params":{{"tokenUsage":{{"total":{{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}}}}}}'
+echo '{{"method":"turn/completed","params":{{"rate_limits":{{"limit_id":"req","primary":{{"remaining":99}}}}}}}}'
+read -r line
+echo "$line" >> "$PROMPT_LOG"
+echo '{{"id":3,"result":{{"turn":{{"id":"turn-2"}}}}}}'
+echo '{{"method":"token/2","params":{{"tokenUsage":{{"total":{{"input_tokens":6,"output_tokens":3,"total_tokens":9}}}}}}}}'
+echo '{{"method":"turn/completed","params":{{}}}}'
+read -r line || true
+"#,
+        prompt_log = prompt_log.display(),
+    )
+}
+
 #[tokio::test]
 async fn test_execute_worker_attempt_runs_multiple_turns_in_one_session_and_uses_continuation_prompt(
 ) {
@@ -1415,6 +1490,74 @@ async fn test_execute_worker_attempt_stops_when_issue_turns_terminal_after_first
         1,
         "terminal issue state after turn 1 should prevent turn 2"
     );
+    assert!(
+        !orchestrator.state().retry_attempts.contains_key(&issue.id),
+        "terminal stop should not enqueue continuation retry"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_worker_attempt_preserves_last_non_null_rate_limits() {
+    let mut server = Server::new_async().await;
+    let issue = issue("issue-rate-limits", "SIM-RATE", "In Progress", Some(1), 0);
+
+    let _state_lookup = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&state_lookup_response(
+                &issue.id,
+                &issue.identifier,
+                "In Progress",
+                None,
+            ))
+            .expect("state response should serialize"),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let scripts_dir = tempdir().expect("scripts dir should be created");
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let prompt_log = scripts_dir.path().join("prompts.log");
+    let script = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        &script_second_turn_omits_rate_limits(&prompt_log),
+    );
+
+    let mut orchestrator = Orchestrator::new(
+        make_worker_config(&server, &script, workspace_root.path(), 2),
+        String::new(),
+    );
+
+    let result = orchestrator
+        .execute_worker_attempt(
+            &issue,
+            "First prompt {{ issue.identifier }}",
+            Some(1),
+            |_query, _vars| async { Ok(serde_json::json!({ "data": {} })) },
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "worker attempt should complete successfully"
+    );
+
+    let remaining = orchestrator
+        .state()
+        .codex_rate_limits
+        .as_ref()
+        .and_then(|value| value.data.get("primary"))
+        .and_then(|value| value.get("remaining"))
+        .and_then(|value| value.as_u64());
+    assert_eq!(
+        remaining,
+        Some(99),
+        "later turns that omit rate limits should not clear prior payload"
+    );
 }
 
 #[tokio::test]
@@ -1560,6 +1703,10 @@ async fn test_execute_worker_attempt_stops_when_issue_leaves_active_state_after_
         1,
         "non-active issue state after turn 1 should prevent turn 2"
     );
+    assert!(
+        !orchestrator.state().retry_attempts.contains_key(&issue.id),
+        "non-active stop should not enqueue continuation retry"
+    );
 }
 
 #[tokio::test]
@@ -1628,6 +1775,10 @@ async fn test_execute_worker_attempt_stops_when_issue_changes_active_state_betwe
         1,
         "state change after turn 1 should end the current session loop"
     );
+    assert!(
+        !orchestrator.state().retry_attempts.contains_key(&issue.id),
+        "state-transition stop should not enqueue continuation retry"
+    );
 }
 
 #[tokio::test]
@@ -1695,5 +1846,9 @@ async fn test_execute_worker_attempt_stops_when_issue_unassigned_between_turns()
         prompt_lines.len(),
         1,
         "unassigned issue after turn 1 should prevent turn 2"
+    );
+    assert!(
+        !orchestrator.state().retry_attempts.contains_key(&issue.id),
+        "unassigned stop should not enqueue continuation retry"
     );
 }

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1528,7 +1528,7 @@ async fn test_execute_worker_attempt_preserves_last_non_null_rate_limits() {
     );
 
     let mut orchestrator = Orchestrator::new(
-        make_worker_config(&server, &script, workspace_root.path(), 5),
+        make_worker_config(&server, &script, workspace_root.path(), 2),
         String::new(),
     );
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1142,7 +1142,16 @@ fn write_script(dir: &Path, name: &str, content: &str) -> PathBuf {
     path
 }
 
-fn state_lookup_response(issue_id: &str, identifier: &str, state: &str) -> serde_json::Value {
+fn state_lookup_response(
+    issue_id: &str,
+    identifier: &str,
+    state: &str,
+    assignee_id: Option<&str>,
+) -> serde_json::Value {
+    let assignee = assignee_id
+        .map(|id| json!({ "id": id }))
+        .unwrap_or_else(|| json!(null));
+
     json!({
         "data": {
             "issues": {
@@ -1156,7 +1165,7 @@ fn state_lookup_response(issue_id: &str, identifier: &str, state: &str) -> serde
                         "state": { "name": state },
                         "branchName": null,
                         "url": null,
-                        "assignee": null,
+                        "assignee": assignee,
                         "labels": { "nodes": [] },
                         "inverseRelations": { "nodes": [] },
                         "createdAt": "2026-01-01T00:00:00.000Z",
@@ -1252,6 +1261,7 @@ async fn test_execute_worker_attempt_runs_multiple_turns_in_one_session_and_uses
                 &issue.id,
                 &issue.identifier,
                 "In Progress",
+                None,
             ))
             .expect("state response should serialize"),
         )
@@ -1355,8 +1365,13 @@ async fn test_execute_worker_attempt_stops_when_issue_turns_terminal_after_first
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
-            serde_json::to_string(&state_lookup_response(&issue.id, &issue.identifier, "Done"))
-                .expect("state response should serialize"),
+            serde_json::to_string(&state_lookup_response(
+                &issue.id,
+                &issue.identifier,
+                "Done",
+                None,
+            ))
+            .expect("state response should serialize"),
         )
         .expect(1)
         .create_async()
@@ -1416,6 +1431,7 @@ async fn test_execute_worker_attempt_failure_on_turn_two_keeps_turn_one_metrics(
                 &issue.id,
                 &issue.identifier,
                 "In Progress",
+                None,
             ))
             .expect("state response should serialize"),
         )
@@ -1475,5 +1491,141 @@ async fn test_execute_worker_attempt_failure_on_turn_two_keeps_turn_one_metrics(
     assert_eq!(
         retry_entry.attempt, 2,
         "failure retry attempt should increment from the running attempt"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_worker_attempt_stops_when_issue_leaves_active_state_after_first_turn() {
+    let mut server = Server::new_async().await;
+    let issue = issue(
+        "issue-non-active",
+        "SIM-NONACTIVE",
+        "In Progress",
+        Some(1),
+        0,
+    );
+
+    let _state_lookup = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&state_lookup_response(
+                &issue.id,
+                &issue.identifier,
+                "Human Review",
+                None,
+            ))
+            .expect("state response should serialize"),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let scripts_dir = tempdir().expect("scripts dir should be created");
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let prompt_log = scripts_dir.path().join("prompts.log");
+    let script = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        &script_two_successful_turns(&prompt_log),
+    );
+
+    let mut orchestrator = Orchestrator::new(
+        make_worker_config(&server, &script, workspace_root.path(), 5),
+        String::new(),
+    );
+
+    let result = orchestrator
+        .execute_worker_attempt(
+            &issue,
+            "First prompt {{ issue.identifier }}",
+            Some(1),
+            |_query, _vars| async { Ok(serde_json::json!({ "data": {} })) },
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "worker should stop cleanly once issue leaves active states"
+    );
+
+    let prompt_lines: Vec<String> = std::fs::read_to_string(&prompt_log)
+        .expect("prompt log should exist")
+        .lines()
+        .map(|line| line.to_string())
+        .collect();
+    assert_eq!(
+        prompt_lines.len(),
+        1,
+        "non-active issue state after turn 1 should prevent turn 2"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_worker_attempt_stops_when_issue_unassigned_between_turns() {
+    let mut server = Server::new_async().await;
+    let issue = issue(
+        "issue-unassigned",
+        "SIM-UNASSIGNED",
+        "In Progress",
+        Some(1),
+        0,
+    );
+
+    let _state_lookup = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&state_lookup_response(
+                &issue.id,
+                &issue.identifier,
+                "In Progress",
+                None,
+            ))
+            .expect("state response should serialize"),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let scripts_dir = tempdir().expect("scripts dir should be created");
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let prompt_log = scripts_dir.path().join("prompts.log");
+    let script = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        &script_two_successful_turns(&prompt_log),
+    );
+
+    let mut config = make_worker_config(&server, &script, workspace_root.path(), 5);
+    config.tracker.assignee = Some("00000000-0000-0000-0000-000000000001".to_string());
+
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let result = orchestrator
+        .execute_worker_attempt(
+            &issue,
+            "First prompt {{ issue.identifier }}",
+            Some(1),
+            |_query, _vars| async { Ok(serde_json::json!({ "data": {} })) },
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "worker should stop cleanly once issue is no longer assigned to this worker"
+    );
+
+    let prompt_lines: Vec<String> = std::fs::read_to_string(&prompt_log)
+        .expect("prompt log should exist")
+        .lines()
+        .map(|line| line.to_string())
+        .collect();
+    assert_eq!(
+        prompt_lines.len(),
+        1,
+        "unassigned issue after turn 1 should prevent turn 2"
     );
 }

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1,8 +1,14 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use chrono::{Duration, Utc};
+use mockito::{Server, ServerGuard};
+use serde_json::json;
+use tempfile::tempdir;
 
-use symphony::domain::{AgentConfig, AgentEvent, BlockerRef, Issue, ServiceConfig, TrackerConfig};
+use symphony::domain::{
+    AgentConfig, AgentEvent, ApiKey, BlockerRef, Issue, ServiceConfig, TrackerConfig,
+};
 use symphony::error::{Result, SymphonyError};
 use symphony::orchestrator::{
     refresh_channel, Orchestrator, OrchestratorPort, RetryKind, RuntimeEvent, TurnMetrics,
@@ -1116,5 +1122,358 @@ fn test_reconcile_non_active_state_stops_run_without_cleanup() {
     assert!(
         !orchestrator.state().completed.contains("issue-non-active"),
         "non-terminal state stop must not add issue to completed (no cleanup semantic)"
+    );
+}
+
+fn write_script(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, content).expect("script should be written");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&path)
+            .expect("script metadata should be readable")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("script should be executable");
+    }
+
+    path
+}
+
+fn state_lookup_response(issue_id: &str, identifier: &str, state: &str) -> serde_json::Value {
+    json!({
+        "data": {
+            "issues": {
+                "nodes": [
+                    {
+                        "id": issue_id,
+                        "identifier": identifier,
+                        "title": format!("Issue {identifier}"),
+                        "description": "state refresh",
+                        "priority": 2,
+                        "state": { "name": state },
+                        "branchName": null,
+                        "url": null,
+                        "assignee": null,
+                        "labels": { "nodes": [] },
+                        "inverseRelations": { "nodes": [] },
+                        "createdAt": "2026-01-01T00:00:00.000Z",
+                        "updatedAt": "2026-01-01T00:00:00.000Z"
+                    }
+                ]
+            }
+        }
+    })
+}
+
+fn make_worker_config(
+    server: &ServerGuard,
+    script_path: &Path,
+    workspace_root: &Path,
+    max_turns: u32,
+) -> ServiceConfig {
+    let mut config = test_config(1);
+    config.workspace.root = workspace_root.to_string_lossy().to_string();
+    config.workspace.repo = None;
+    config.codex.command = vec![script_path.to_string_lossy().to_string()];
+    config.codex.approval_policy = serde_json::Value::String("never".to_string());
+    config.codex.turn_sandbox_policy = None;
+    config.tracker.endpoint = format!("{}/graphql", server.url());
+    config.tracker.api_key = Some(ApiKey::new("test-api-key"));
+    config.agent.max_turns = max_turns;
+    config
+}
+
+fn script_two_successful_turns(prompt_log: &Path) -> String {
+    format!(
+        r#"#!/bin/bash
+set -euo pipefail
+PROMPT_LOG="{prompt_log}"
+read -r line
+echo '{{"id":1,"result":{{"capabilities":{{}}}}}}'
+read -r line
+read -r line
+echo '{{"id":2,"result":{{"thread":{{"id":"thread-multi-1"}}}}}}'
+read -r line
+echo "$line" >> "$PROMPT_LOG"
+echo '{{"id":3,"result":{{"turn":{{"id":"turn-1"}}}}}}'
+echo '{{"method":"token/1","params":{{"tokenUsage":{{"total":{{"input_tokens":10,"output_tokens":5,"total_tokens":15}}}}}}}}'
+echo '{{"method":"turn/completed","params":{{}}}}'
+read -r line
+echo "$line" >> "$PROMPT_LOG"
+echo '{{"id":3,"result":{{"turn":{{"id":"turn-2"}}}}}}'
+echo '{{"method":"token/2","params":{{"tokenUsage":{{"total":{{"input_tokens":14,"output_tokens":9,"total_tokens":23}}}}}}}}'
+echo '{{"method":"turn/completed","params":{{"rate_limits":{{"limit_id":"req","primary":{{"remaining":42}}}}}}}}'
+read -r line || true
+"#,
+        prompt_log = prompt_log.display(),
+    )
+}
+
+fn script_second_turn_fails(prompt_log: &Path) -> String {
+    format!(
+        r#"#!/bin/bash
+set -euo pipefail
+PROMPT_LOG="{prompt_log}"
+read -r line
+echo '{{"id":1,"result":{{"capabilities":{{}}}}}}'
+read -r line
+read -r line
+echo '{{"id":2,"result":{{"thread":{{"id":"thread-fail-1"}}}}}}'
+read -r line
+echo "$line" >> "$PROMPT_LOG"
+echo '{{"id":3,"result":{{"turn":{{"id":"turn-1"}}}}}}'
+echo '{{"method":"token/1","params":{{"tokenUsage":{{"total":{{"input_tokens":7,"output_tokens":3,"total_tokens":10}}}}}}}}'
+echo '{{"method":"turn/completed","params":{{}}}}'
+read -r line
+echo "$line" >> "$PROMPT_LOG"
+echo '{{"id":3,"result":{{"turn":{{"id":"turn-2"}}}}}}'
+echo '{{"method":"turn/failed","params":{{"message":"boom"}}}}'
+read -r line || true
+"#,
+        prompt_log = prompt_log.display(),
+    )
+}
+
+#[tokio::test]
+async fn test_execute_worker_attempt_runs_multiple_turns_in_one_session_and_uses_continuation_prompt(
+) {
+    let mut server = Server::new_async().await;
+    let issue = issue("issue-multi", "SIM-MULTI", "In Progress", Some(1), 0);
+
+    let _state_lookup = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&state_lookup_response(
+                &issue.id,
+                &issue.identifier,
+                "In Progress",
+            ))
+            .expect("state response should serialize"),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let scripts_dir = tempdir().expect("scripts dir should be created");
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let prompt_log = scripts_dir.path().join("prompts.log");
+    let script = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        &script_two_successful_turns(&prompt_log),
+    );
+
+    let mut orchestrator = Orchestrator::new(
+        make_worker_config(&server, &script, workspace_root.path(), 2),
+        String::new(),
+    );
+
+    let prompt_template = "Full prompt for {{ issue.identifier }} attempt={{ attempt }}";
+    let result = orchestrator
+        .execute_worker_attempt(&issue, prompt_template, Some(1), |_query, _vars| async {
+            Ok(serde_json::json!({ "data": {} }))
+        })
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "multi-turn attempt should succeed: {result:?}"
+    );
+
+    let prompt_lines: Vec<String> = std::fs::read_to_string(&prompt_log)
+        .expect("prompt log should exist")
+        .lines()
+        .map(|line| line.to_string())
+        .collect();
+
+    assert_eq!(
+        prompt_lines.len(),
+        2,
+        "worker should execute exactly 2 turns"
+    );
+    assert!(
+        prompt_lines[0].contains("Full prompt for SIM-MULTI attempt=1"),
+        "turn 1 should use rendered issue prompt"
+    );
+    assert!(
+        prompt_lines[1].contains("Continuation guidance"),
+        "turn 2 should use continuation prompt"
+    );
+    assert!(
+        prompt_lines[0].contains("\"threadId\":\"thread-multi-1\"")
+            && prompt_lines[1].contains("\"threadId\":\"thread-multi-1\""),
+        "both turns should run on the same thread/session id"
+    );
+
+    assert_eq!(
+        orchestrator.state().codex_totals.input_tokens,
+        24,
+        "input tokens should accumulate across turns"
+    );
+    assert_eq!(
+        orchestrator.state().codex_totals.output_tokens,
+        14,
+        "output tokens should accumulate across turns"
+    );
+    assert_eq!(
+        orchestrator.state().codex_totals.total_tokens,
+        38,
+        "total tokens should accumulate across turns"
+    );
+
+    let remaining = orchestrator
+        .state()
+        .codex_rate_limits
+        .as_ref()
+        .and_then(|value| value.data.get("primary"))
+        .and_then(|value| value.get("remaining"))
+        .and_then(|value| value.as_u64());
+    assert_eq!(
+        remaining,
+        Some(42),
+        "latest turn rate-limits payload should be retained"
+    );
+
+    assert!(
+        orchestrator.state().retry_attempts.contains_key(&issue.id),
+        "completed worker attempts should hand off to continuation retry scheduling"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_worker_attempt_stops_when_issue_turns_terminal_after_first_turn() {
+    let mut server = Server::new_async().await;
+    let issue = issue("issue-done", "SIM-DONE", "In Progress", Some(1), 0);
+
+    let _state_lookup = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&state_lookup_response(&issue.id, &issue.identifier, "Done"))
+                .expect("state response should serialize"),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let scripts_dir = tempdir().expect("scripts dir should be created");
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let prompt_log = scripts_dir.path().join("prompts.log");
+    let script = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        &script_two_successful_turns(&prompt_log),
+    );
+
+    let mut orchestrator = Orchestrator::new(
+        make_worker_config(&server, &script, workspace_root.path(), 5),
+        String::new(),
+    );
+
+    let result = orchestrator
+        .execute_worker_attempt(
+            &issue,
+            "First prompt {{ issue.identifier }}",
+            Some(1),
+            |_query, _vars| async { Ok(serde_json::json!({ "data": {} })) },
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "worker should stop cleanly when tracker state becomes terminal"
+    );
+
+    let prompt_lines: Vec<String> = std::fs::read_to_string(&prompt_log)
+        .expect("prompt log should exist")
+        .lines()
+        .map(|line| line.to_string())
+        .collect();
+    assert_eq!(
+        prompt_lines.len(),
+        1,
+        "terminal issue state after turn 1 should prevent turn 2"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_worker_attempt_failure_on_turn_two_keeps_turn_one_metrics() {
+    let mut server = Server::new_async().await;
+    let issue = issue("issue-fail2", "SIM-FAIL2", "In Progress", Some(1), 0);
+
+    let _state_lookup = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&state_lookup_response(
+                &issue.id,
+                &issue.identifier,
+                "In Progress",
+            ))
+            .expect("state response should serialize"),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let scripts_dir = tempdir().expect("scripts dir should be created");
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let prompt_log = scripts_dir.path().join("prompts.log");
+    let script = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        &script_second_turn_fails(&prompt_log),
+    );
+
+    let mut orchestrator = Orchestrator::new(
+        make_worker_config(&server, &script, workspace_root.path(), 5),
+        String::new(),
+    );
+
+    let result = orchestrator
+        .execute_worker_attempt(
+            &issue,
+            "First prompt {{ issue.identifier }}",
+            Some(1),
+            |_query, _vars| async { Ok(serde_json::json!({ "data": {} })) },
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "turn failure on turn 2 should propagate as worker failure"
+    );
+
+    assert_eq!(
+        orchestrator.state().codex_totals.input_tokens,
+        7,
+        "turn 1 metrics should still be applied before turn 2 failure"
+    );
+    assert_eq!(
+        orchestrator.state().codex_totals.output_tokens,
+        3,
+        "turn 1 metrics should still be applied before turn 2 failure"
+    );
+    assert_eq!(
+        orchestrator.state().codex_totals.total_tokens,
+        10,
+        "turn 1 metrics should still be applied before turn 2 failure"
+    );
+
+    let retry_entry = orchestrator
+        .state()
+        .retry_attempts
+        .get(&issue.id)
+        .expect("failed worker attempt should schedule failure retry");
+    assert_eq!(
+        retry_entry.attempt, 2,
+        "failure retry attempt should increment from the running attempt"
     );
 }

--- a/apps/symphony/tests/workspace_prompt_tests.rs
+++ b/apps/symphony/tests/workspace_prompt_tests.rs
@@ -932,3 +932,21 @@ fn test_render_prompt_attempt_none_vs_some() {
         result_some
     );
 }
+
+#[test]
+fn test_render_continuation_prompt_includes_turn_context() {
+    let prompt = symphony::prompt_builder::render_continuation_prompt(2, 5);
+
+    assert!(
+        prompt.contains("Continuation guidance"),
+        "continuation prompt should include a stable heading"
+    );
+    assert!(
+        prompt.contains("turn #2 of 5"),
+        "continuation prompt should include turn ordinal context"
+    );
+    assert!(
+        prompt.contains("already present in this thread"),
+        "continuation prompt should remind the agent to use existing thread context"
+    );
+}


### PR DESCRIPTION
## Summary
- refactor worker execution to run up to `agent.max_turns` on one Codex session/thread
- add inter-turn Linear issue-state refresh and terminal-state stop behavior
- accumulate token metrics across turns while preserving latest rate-limit payload
- add continuation prompt generation for turn 2+ and wire orchestration paths to use the shared loop
- add orchestrator + prompt tests for continuation prompts, terminal stop, turn-2 failure, max-turn completion, and metrics accumulation

## Validation
- cd apps/symphony && cargo test --test orchestrator_tests
- cd apps/symphony && cargo test --test workspace_prompt_tests
- cd apps/symphony && cargo test
- cd apps/symphony && cargo clippy -- -D warnings
- cd apps/symphony && cargo fmt --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-turn execution within a single session with inter-turn issue liveness checks and early exit when an issue is no longer active
  * Aggregated token/usage metrics across turns, preserving the most recent rate-limit info
  * Improved handling so aggregated metrics are applied on both success and failure; retries are scheduled appropriately
* **Tests**
  * New integration tests covering two-turn success, turn-2 failure, early termination (terminal/unassigned), and metric preservation across turns
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the Codex worker execution model to support multi-turn sessions within a single Codex thread, replacing the previous single-turn approach. The core change introduces `run_codex_turns_in_session`, a shared async loop that both `run_worker_task` (spawned path) and `execute_worker_attempt` (inline path) now delegate to, eliminating code duplication and ensuring consistent behavior across both orchestration paths.

Key changes:
- **Multi-turn session loop** (`run_codex_turns_in_session`): runs up to `agent.max_turns` turns on one session handle; uses the initial rendered prompt for turn 1 and `render_continuation_prompt` for subsequent turns.
- **Inter-turn Linear state refresh** (`check_issue_still_active`): fetches the latest issue state between turns; stops the loop early if the issue moves to a terminal state.
- **Token metric accumulation**: `accumulate_turn_metrics` accumulates `input_tokens`, `output_tokens`, and `total_tokens` across all turns using `saturating_add`, while preserving only the latest rate-limit payload — this matches the stated intent and is validated by tests.
- **Partial failure metric preservation**: on turn 2+ failure, metrics from prior successful turns are retained in `SessionTurnLoopFailure` and applied by both orchestration paths.
- **Test coverage**: three new integration tests (multi-turn success, terminal-state early-stop, turn-2 failure with metric retention) using bash-script Codex stubs and mockito, plus a unit test for `render_continuation_prompt`.

The implementation is logically sound. A few style-level observations are noted: `check_issue_still_active` allocates a new `LinearClient` on every inter-turn call, `IssueCheck::Error` exits the loop as a silent `Ok` which could mask persistent API failures, and the `current_issue = refreshed` update in the Continue branch is effectively unused since only `issue.id` is consumed in subsequent state checks.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the multi-turn logic is correct and well-tested, with no critical bugs found.
- The core loop logic, token accumulation, terminal-state detection, and error propagation are all correct and backed by integration tests. Both execution paths are handled consistently. Deductions are for three style-level concerns: a new LinearClient allocated per inter-turn state check (inefficiency for high-turn sessions), silent Ok return on IssueCheck::Error (could mask persistent API failures), and a redundant current_issue field update.
- apps/symphony/src/orchestrator.rs — specifically the IssueCheck::Error branch in run_codex_turns_in_session and the check_issue_still_active helper.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Core refactor: introduces run_codex_turns_in_session loop, IssueCheck enum, and SessionTurnLoop{Success,Failure} structs. Both execution paths (run_worker_task and execute_worker_attempt) now share the multi-turn loop. Token metrics are accumulated across turns. Error handling on inter-turn state checks (IssueCheck::Error) silently converts to Ok, and a new LinearClient is created on every inter-turn state refresh call. |
| apps/symphony/src/prompt_builder.rs | Adds render_continuation_prompt for turn 2+ prompts. Simple, correct string formatting with clear wording. The function takes both turn_number and max_turns to give the agent turn-context awareness. |
| apps/symphony/tests/orchestrator_tests.rs | Adds three new integration tests covering multi-turn success with continuation prompts, terminal-state early-stop, and turn-2 failure with partial metric preservation. Tests use bash script stubs and mockito for the Linear state-check endpoint. Coverage is thorough. |
| apps/symphony/tests/workspace_prompt_tests.rs | Adds a focused unit test for render_continuation_prompt verifying the heading, turn ordinal, and thread-context reminder. Straightforward and correct. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant L as run_codex_turns_in_session
    participant CS as Codex Session
    participant LI as Linear API

    O->>CS: start_session()
    O->>L: run_codex_turns_in_session(session, issue, initial_prompt, max_turns)

    loop turn_number = 1 to capped_max_turns
        alt turn_number == 1
            L->>CS: run_turn(initial_prompt)
        else turn_number > 1
            L->>L: render_continuation_prompt(turn_number, max_turns)
            L->>CS: run_turn(continuation_prompt)
        end

        CS-->>L: Ok(TurnResult) or Err(error)

        alt run_turn failed
            L-->>O: SessionTurnLoopFailure (events + partial metrics)
        else run_turn succeeded
            L->>L: accumulate_turn_metrics()
        end

        alt turn_number >= capped_max_turns
            L->>L: break (max turns reached)
        else
            L->>LI: check_issue_still_active(issue.id)
            alt IssueCheck::Continue
                L->>L: turn_number += 1, continue loop
            else IssueCheck::Done
                L->>L: break (terminal state)
            else IssueCheck::Error
                L->>L: warn + break (API failure)
            end
        end
    end

    L-->>O: SessionTurnLoopSuccess (events + accumulated metrics)
    O->>CS: stop_session()
    O->>O: apply_turn_metrics() / handle_worker_completion()
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 78-96

Comment:
**New LinearClient allocated on every inter-turn state check**

`check_issue_still_active` constructs a fresh `LinearClient` (and clones `TrackerConfig`) on every call. For a session running `max_turns = 20`, this produces 19 client instantiations and 19 config clones between turns.

Consider accepting a pre-built client (or an `Arc<LinearClient>`) as a parameter so the caller can share a single client across all inter-turn checks:

```rust
async fn check_issue_still_active(
    issue: &Issue,
    client: &crate::linear::client::LinearClient,
    tracker_config: &TrackerConfig,
) -> IssueCheck {
    match client
        .fetch_issue_states_by_ids(std::slice::from_ref(&issue.id))
        ...
```

Then in `run_codex_turns_in_session`, create the client once before the loop and pass a reference to it on each call.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 155-163

Comment:
**IssueCheck::Error silently converts to a successful early exit**

When the inter-turn Linear state-check fails, the loop breaks and returns `Ok(SessionTurnLoopSuccess)` with only a WARNING log. For persistent API failures (e.g. network outage, misconfigured endpoint), every session will silently run exactly one turn and be reported as successful, potentially masking a systemic issue entirely.

Consider either:
- Returning a new `IssueCheck` variant that propagates to `SessionTurnLoopFailure` (strongest signal), or
- At minimum, recording a structured metric / event so operators can distinguish "stopped at max turns" from "stopped because state-check failed".

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 148-150

Comment:
**`current_issue` update in Continue branch is redundant**

`current_issue = refreshed` stores the latest issue snapshot, but `check_issue_still_active` only uses `issue.id` for the subsequent API lookup — the id never changes across turns. The refreshed state in `current_issue` is never read again inside the loop, so the assignment has no effect on observable behavior.

Either remove the field and just pass the original `issue` to each `check_issue_still_active` call, or explicitly use `current_issue` for something meaningful (e.g. surfacing the final state to callers via `SessionTurnLoopSuccess`).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(symphony): run ..."](https://github.com/gannonh/kata/commit/5cd0d90172298f4a397b12ee01d9329ce35dd81a)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->