### PR TITLE
fix: enforce terminal-only completed set semantics

### DIFF
--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1780,6 +1780,44 @@ impl Orchestrator {
                 .into_iter()
                 .find(|issue| issue.id == retry.issue_id)
             else {
+                let refreshed_issue = match port.refresh_issue(&retry.issue_id) {
+                    Ok(issue) => issue,
+                    Err(err) => {
+                        tracing::warn!(
+                            event = "retry_refresh_failed",
+                            issue_id = %retry.issue_id,
+                            issue_identifier = %retry.identifier,
+                            error = %err,
+                            "retry issue refresh failed; rescheduling"
+                        );
+                        self.schedule_retry_with_context(
+                            &retry.issue_id,
+                            &retry.identifier,
+                            retry.attempt.saturating_add(1),
+                            RetryKind::Failure,
+                            now_ms,
+                            Some(format!("retry refresh failed: {err}")),
+                            retry_context,
+                        );
+                        continue;
+                    }
+                };
+
+                if let Some(hidden_issue) = refreshed_issue {
+                    let hidden_state = normalize_issue_state(&hidden_issue.state);
+                    if self.terminal_state_set().contains(&hidden_state) {
+                        tracing::debug!(
+                            event = "retry_issue_terminal_after_refresh",
+                            issue_id = %hidden_issue.id,
+                            issue_identifier = %hidden_issue.identifier,
+                            state = %hidden_state,
+                            "retry issue became terminal before active-candidate visibility; marking terminal"
+                        );
+                        self.mark_issue_terminal(&hidden_issue.id);
+                        continue;
+                    }
+                }
+
                 tracing::debug!(
                     event = "retry_issue_not_visible",
                     issue_id = %retry.issue_id,

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1108,7 +1108,9 @@ impl Orchestrator {
             WorkerCompletion::Completed {
                 schedule_continuation,
             } => {
-                self.state.completed.insert(issue_id.to_string());
+                if !schedule_continuation {
+                    self.state.completed.insert(issue_id.to_string());
+                }
 
                 tracing::info!(
                     event = "worker_completed",

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -686,6 +686,21 @@ fn test_worker_completion_schedules_continuation_retry_with_session_context() {
         retry_entry.workspace_path.as_deref(),
         Some("/tmp/workspace-complete")
     );
+    assert!(
+        !orchestrator.state().running.contains_key("issue-complete"),
+        "completed turn should leave running map before retry scheduling"
+    );
+    assert!(
+        !orchestrator.state().completed.contains("issue-complete"),
+        "continuation completions must stay out of completed until terminal state"
+    );
+    assert!(
+        orchestrator.state().running.len()
+            + orchestrator.state().retry_attempts.len()
+            + orchestrator.state().completed.len()
+            <= 1,
+        "running + retry + completed bookkeeping must not exceed dispatched issue count"
+    );
 
     let worker_completed = orchestrator.events().iter().any(|event| {
         matches!(
@@ -747,6 +762,13 @@ fn test_worker_completion_without_continuation_does_not_queue_retry() {
         orchestrator.state().completed.contains("issue-stop"),
         "issue should still be marked completed in orchestrator bookkeeping"
     );
+    assert!(
+        orchestrator.state().running.len()
+            + orchestrator.state().retry_attempts.len()
+            + orchestrator.state().completed.len()
+            <= 1,
+        "running + retry + completed bookkeeping must not exceed dispatched issue count"
+    );
 }
 
 #[test]
@@ -807,6 +829,17 @@ fn test_worker_failure_preserves_attempt_and_backoff_cap() {
     assert!(
         worker_failed,
         "worker failure diagnostics should retain issue context and failure reason"
+    );
+    assert!(
+        !orchestrator.state().completed.contains("issue-fail"),
+        "failed issues must not be retained in completed bookkeeping"
+    );
+    assert!(
+        orchestrator.state().running.len()
+            + orchestrator.state().retry_attempts.len()
+            + orchestrator.state().completed.len()
+            <= 1,
+        "running + retry + completed bookkeeping must not exceed dispatched issue count"
     );
 }
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -476,6 +476,68 @@ fn test_stale_retry_timer_is_ignored() {
     );
 }
 
+#[tokio::test]
+async fn test_due_continuation_retry_marks_terminal_issue_completed_when_not_visible_in_candidates() {
+    let mut config = test_config(1);
+    config.polling.interval_ms = 60_000;
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    orchestrator.schedule_retry(
+        "issue-terminal-before-retry",
+        "SIM-79",
+        1,
+        RetryKind::Continuation,
+        0,
+        None,
+    );
+
+    let mut port = FakePort {
+        candidate_issues: vec![],
+        refreshed_issues: HashMap::from([(
+            "issue-terminal-before-retry".to_string(),
+            Some(issue(
+                "issue-terminal-before-retry",
+                "SIM-79",
+                "Done",
+                Some(1),
+                0,
+            )),
+        )]),
+        ..FakePort::default()
+    };
+
+    let run_result = tokio::time::timeout(
+        tokio::time::Duration::from_millis(200),
+        orchestrator.run(&mut port),
+    )
+    .await;
+    assert!(
+        run_result.is_err(),
+        "orchestrator run loop should be canceled by timeout in test harness"
+    );
+
+    assert!(
+        orchestrator
+            .state()
+            .completed
+            .contains("issue-terminal-before-retry"),
+        "terminal issue reached during retry visibility gap must be tracked as completed"
+    );
+    assert!(
+        !orchestrator
+            .state()
+            .retry_attempts
+            .contains_key("issue-terminal-before-retry"),
+        "terminal issue should be removed from retry queue after terminal refresh"
+    );
+    assert!(
+        port.call_history()
+            .iter()
+            .any(|call| call == "refresh_issue:issue-terminal-before-retry"),
+        "retry handling should refresh hidden issue by id before releasing it"
+    );
+}
+
 #[test]
 fn test_stall_detection_schedules_forced_retry() {
     let mut orchestrator = Orchestrator::new(test_config(2), String::new());

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -477,7 +477,8 @@ fn test_stale_retry_timer_is_ignored() {
 }
 
 #[tokio::test]
-async fn test_due_continuation_retry_marks_terminal_issue_completed_when_not_visible_in_candidates() {
+async fn test_due_continuation_retry_marks_terminal_issue_completed_when_not_visible_in_candidates()
+{
     let mut config = test_config(1);
     config.polling.interval_ms = 60_000;
     let mut orchestrator = Orchestrator::new(config, String::new());


### PR DESCRIPTION
## Summary
- make `handle_worker_completion` add an issue to `state.completed` only when
  `schedule_continuation` is `false`
- preserve continuation retries in `retry_attempts` without also marking the
  same issue as completed
- strengthen orchestrator tests to verify continuation, terminal completion, and
  failure semantics for `completed` and aggregate bookkeeping counts

## Testing
- `cd apps/symphony && cargo test --test orchestrator_tests`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`

## Linear
- KAT-817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected completion state tracking in the orchestrator to properly handle continuation scheduling scenarios.

* **Tests**
  * Enhanced test coverage with additional state-bookkeeping assertions to validate orchestrator behavior across worker completion and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bookkeeping bug in the orchestrator where issues with a scheduled continuation were prematurely inserted into `state.completed` alongside `state.retry_attempts`, causing the aggregate invariant (`running + retry_attempts + completed <= dispatched issue count`) to be violated. The fix gates the `completed.insert` call on `!schedule_continuation`, so only terminal completions mark an issue as done.

Key changes:
- **`apps/symphony/src/orchestrator.rs`** — `handle_worker_completion`: `state.completed.insert(issue_id)` is now wrapped in an `if !schedule_continuation` guard, making `completed` a strictly terminal-state set.
- **`apps/symphony/tests/orchestrator_tests.rs`** — Three existing tests gain assertions that verify: (1) continuation completions keep issues out of `completed`, (2) terminal completions still mark issues in `completed`, and (3) failed issues do not appear in `completed`. All three tests also assert the aggregate bookkeeping invariant that would have caught the original bug.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-targeted bug fix with no side-effects and comprehensive test coverage.
- The change is exactly two lines of production code (an `if` guard), the logic is straightforward and easy to verify, the three existing tests have been strengthened to directly encode the invariant that was violated, and all code paths (continuation, terminal, failure) are explicitly covered.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Wraps `state.completed.insert(issue_id)` in a `!schedule_continuation` guard inside `handle_worker_completion`, fixing the double-counting bug where issues with a pending continuation retry were incorrectly added to both `completed` and `retry_attempts`. |
| apps/symphony/tests/orchestrator_tests.rs | Adds explicit assertions to three existing tests covering the continuation, terminal-completion, and failure paths — verifying that `completed` never contains an in-flight issue and that the aggregate bookkeeping invariant (`running + retry_attempts + completed <= dispatched`) is upheld in all three cases. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handle_worker_completion] --> B{completion type}
    B -->|WorkerCompletion::Completed| C{schedule_continuation?}
    B -->|WorkerCompletion::Failed| F[completed.remove\nschedule failure retry\nretry_attempts.insert]
    C -->|true| D[emit WorkerCompleted event\nschedule_retry_with_context\nretry_attempts.insert\nNOT added to completed]
    C -->|false| E[completed.insert\nretry_attempts.remove\nreturn None]
    D --> G[return retry token]
    E --> H[return None]
    F --> I[return retry token]

    style D fill:#d4edda,stroke:#28a745
    style E fill:#d4edda,stroke:#28a745
    style F fill:#fff3cd,stroke:#ffc107
```

<sub>Last reviewed commit: ["fix(symphony): keep ..."](https://github.com/gannonh/kata/commit/eedd60c5da3e601da7127ea0e65c1c233aea18ab)</sub>

<!-- /greptile_comment -->