### PR TITLE
fix: set upstream tracking on first agent push

### DIFF
--- a/.codex/skills/push/SKILL.md
+++ b/.codex/skills/push/SKILL.md
@@ -34,7 +34,9 @@ description:
 4. If push is not clean/rejected:
    - If the failure is a non-fast-forward or sync problem, run the `pull`
      skill to merge `origin/main`, resolve conflicts, and rerun validation.
-   - Push again; use `--force-with-lease` only when history was rewritten.
+   - Retry with `git push -u origin "$branch"` so upstream is set even when the
+     first push failed before tracking was recorded.
+   - Use `--force-with-lease` only when history was rewritten.
    - If the failure is due to auth, permissions, or workflow restrictions on
      the configured remote, stop and surface the exact error instead of
      rewriting remotes or switching protocols as a workaround.
@@ -70,6 +72,9 @@ git push -u origin "$branch"
 
 # If that failed because the remote moved, use the pull skill. After
 # pull-skill resolution and re-validation, retry the normal push:
+git push -u origin "$branch"
+
+# After upstream is set, routine branch updates can use:
 git push
 
 # If the configured remote rejects the push for auth, permissions, or workflow

--- a/.codex/skills/push/SKILL.md
+++ b/.codex/skills/push/SKILL.md
@@ -27,8 +27,10 @@ description:
 
 1. Identify current branch and confirm remote state.
 2. Run local validation (`cd apps/symphony && cargo test && cargo clippy -- -D warnings`) before pushing.
-3. Push branch to `origin` with upstream tracking if needed, using whatever
-   remote URL is already configured.
+3. Push branch to `origin` using explicit first-push upstream setup:
+   - first publish of a new branch: `git push -u origin "$branch"`
+   - subsequent updates: `git push`
+   Use whatever remote URL is already configured.
 4. If push is not clean/rejected:
    - If the failure is a non-fast-forward or sync problem, run the `pull`
      skill to merge `origin/main`, resolve conflicts, and rerun validation.
@@ -63,12 +65,12 @@ branch=$(git branch --show-current)
 # Minimal validation gate
 cd apps/symphony && cargo test && cargo clippy -- -D warnings
 
-# Initial push: respect the current origin remote.
-git push -u origin HEAD
+# Initial push for a new branch: set upstream explicitly.
+git push -u origin "$branch"
 
 # If that failed because the remote moved, use the pull skill. After
 # pull-skill resolution and re-validation, retry the normal push:
-git push -u origin HEAD
+git push
 
 # If the configured remote rejects the push for auth, permissions, or workflow
 # restrictions, stop and surface the exact error.


### PR DESCRIPTION
## Summary
- update `.codex/skills/push/SKILL.md` to use `git push -u origin "$branch"` for first publish of a new branch
- document normal `git push` for subsequent branch updates
- keep force-push guidance unchanged (`--force-with-lease` only when needed)

## Validation
- `rg -n "git push" .codex/skills/push/SKILL.md`
- first publish command run: `git push -u origin "symphony/KAT-826"`
- tracking check: `git branch -vv` shows `[origin/symphony/KAT-826]`
- subsequent publish check: `git push` returned `Everything up-to-date`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `push` skill to replace the ambiguous `git push -u origin HEAD` with the explicit `git push -u origin "$branch"` for the initial publish of a new branch, and documents that subsequent pushes should use a bare `git push`. The fix correctly avoids potential issues with `HEAD` resolution and is validated in the PR description.

**Key changes:**
- Step 3 in the Steps section now distinguishes between a first publish (`git push -u origin "$branch"`) and subsequent updates (`git push`)
- The Commands section initial-push command switches from `HEAD` to the explicit `"$branch"` variable
- The retry command after pull-skill resolution changes from `git push -u origin HEAD` to a bare `git push`

**Issues found:**
- The retry `git push` (line 73) may fail if upstream tracking was never set — this happens when the initial push is rejected (non-fast-forward) before `-u` can register the upstream. Using `git push -u origin "$branch"` on the retry would be idempotent and safe.
- The force-push command on line 79 still uses `HEAD` instead of `"$branch"`, which is inconsistent with the goal of this PR and could reintroduce the same class of ambiguity in detached-HEAD or unusual `push.default` configurations.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for the common case, but the retry-push logic may silently fail in an edge case where the initial push was rejected before upstream tracking could be established.
- The core fix (HEAD → "$branch") is correct and an improvement. However, the retry command regresses slightly by dropping `-u`, which could cause a failure when the initial push never succeeded (and thus never set tracking). This affects a realistic scenario — pushing a branch that already exists on the remote with newer commits — though it may be uncommon in practice for this workflow.
- .codex/skills/push/SKILL.md — lines 73 and 79 need attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .codex/skills/push/SKILL.md | Replaces `git push -u origin HEAD` with `git push -u origin "$branch"` for the initial push (good fix) and changes the retry-after-pull-skill command to a bare `git push`, which may fail if upstream tracking was never established due to the initial push having failed. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Start push skill]) --> B[Identify branch\ngit branch --show-current]
    B --> C[Run validation\ncargo test + clippy]
    C --> D{Validation\npassed?}
    D -- No --> Z([Stop: surface error])
    D -- Yes --> E["Initial push\ngit push -u origin '$branch'"]
    E --> F{Push\nsucceeded?}
    F -- Yes --> G[Upstream tracking set ✓\ngit push works for subsequent updates]
    F -- No: non-fast-forward --> H[Run pull skill\nmerge origin/main + resolve conflicts]
    H --> I[Re-run validation]
    I --> J{Validation\npassed?}
    J -- No --> Z
    J -- Yes --> K["Retry push\ngit push\n⚠ may fail if -u was never set"]
    K --> L{Retry\nsucceeded?}
    L -- Yes --> G
    L -- No: auth/permissions --> Z
    G --> M{PR exists?}
    M -- No --> N[gh pr create]
    M -- Yes, open --> O[gh pr edit]
    M -- Yes, closed/merged --> P[Create new branch + PR]
    N & O & P --> Q[Write/update PR body\nfrom pull_request_template.md]
    Q --> R([Reply with PR URL])

    style K fill:#fff3cd,stroke:#856404
    style J fill:#d1ecf1,stroke:#0c5460
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.codex/skills/push/SKILL.md`, line 79 ([link](https://github.com/gannonh/kata/blob/8d70a926565169c50f3a855f4985b896a4f02b0d/.codex/skills/push/SKILL.md#L79)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inconsistent use of `HEAD` vs `"$branch"` for force-push**

   The surrounding changes standardise on the explicit `"$branch"` variable to avoid any ambiguity that `HEAD` might introduce (e.g. in detached-HEAD state or with non-default `push.default` settings). The force-push command still references `HEAD` instead of the explicit branch name. While it works correctly in normal circumstances, updating it would make the Commands block consistent and safe in the same edge cases this PR was written to address:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .codex/skills/push/SKILL.md
   Line: 79

   Comment:
   **Inconsistent use of `HEAD` vs `"$branch"` for force-push**

   The surrounding changes standardise on the explicit `"$branch"` variable to avoid any ambiguity that `HEAD` might introduce (e.g. in detached-HEAD state or with non-default `push.default` settings). The force-push command still references `HEAD` instead of the explicit branch name. While it works correctly in normal circumstances, updating it would make the Commands block consistent and safe in the same edge cases this PR was written to address:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .codex/skills/push/SKILL.md
Line: 73

Comment:
**Retry push may fail if upstream was never set**

`git push -u` only sets the upstream tracking reference when the push **succeeds**. If the initial `git push -u origin "$branch"` fails due to a non-fast-forward rejection (i.e., the remote branch already exists with newer commits), the upstream is never registered locally. After the pull skill resolves the conflict and re-runs validation, the bare `git push` will fail with "The current branch has no upstream branch" on any Git config where `push.default` is not `current`.

Using `git push -u origin "$branch"` on the retry is idempotent and harmless when tracking is already set, while also covering the case where it wasn't:

```suggestion
git push -u origin "$branch"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .codex/skills/push/SKILL.md
Line: 79

Comment:
**Inconsistent use of `HEAD` vs `"$branch"` for force-push**

The surrounding changes standardise on the explicit `"$branch"` variable to avoid any ambiguity that `HEAD` might introduce (e.g. in detached-HEAD state or with non-default `push.default` settings). The force-push command still references `HEAD` instead of the explicit branch name. While it works correctly in normal circumstances, updating it would make the Commands block consistent and safe in the same edge cases this PR was written to address:

```suggestion
git push --force-with-lease origin "$branch"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix(push-skill): set..."](https://github.com/gannonh/kata/commit/8d70a926565169c50f3a855f4985b896a4f02b0d)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->