### PR TITLE
KAT-815: Dynamic WORKFLOW.md reload updates orchestrator runtime config

### DIFF
--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -52,22 +52,28 @@ pub(crate) struct HttpBinding {
 }
 
 struct LinearOrchestratorPort {
-    adapter: LinearAdapter,
+    workflow_store: Arc<WorkflowStore>,
 }
 
 impl LinearOrchestratorPort {
-    fn new(adapter: LinearAdapter) -> Self {
-        Self { adapter }
+    fn new(workflow_store: Arc<WorkflowStore>) -> Self {
+        Self { workflow_store }
     }
 
     fn block_on<T>(&self, future: impl Future<Output = error::Result<T>>) -> error::Result<T> {
         tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
     }
+
+    fn tracker_adapter(&self) -> LinearAdapter {
+        let (_, effective_config) = self.workflow_store.effective_config();
+        LinearAdapter::new(LinearClient::new(effective_config.tracker))
+    }
 }
 
 impl OrchestratorPort for LinearOrchestratorPort {
     fn startup_terminal_issues(&mut self, terminal_states: &[String]) -> error::Result<Vec<Issue>> {
-        self.block_on(self.adapter.fetch_issues_by_states(terminal_states))
+        let adapter = self.tracker_adapter();
+        self.block_on(adapter.fetch_issues_by_states(terminal_states))
     }
 
     fn reconcile_running_issues(
@@ -78,7 +84,8 @@ impl OrchestratorPort for LinearOrchestratorPort {
             return Ok(vec![]);
         }
 
-        self.block_on(self.adapter.fetch_issue_states_by_ids(running_issue_ids))
+        let adapter = self.tracker_adapter();
+        self.block_on(adapter.fetch_issue_states_by_ids(running_issue_ids))
     }
 
     fn validate_dispatch_preflight(&mut self, config: &ServiceConfig) -> error::Result<()> {
@@ -86,17 +93,20 @@ impl OrchestratorPort for LinearOrchestratorPort {
     }
 
     fn fetch_candidate_issues(&mut self) -> error::Result<Vec<Issue>> {
-        self.block_on(self.adapter.fetch_candidate_issues())
+        let adapter = self.tracker_adapter();
+        self.block_on(adapter.fetch_candidate_issues())
     }
 
     fn refresh_issue(&mut self, issue_id: &str) -> error::Result<Option<Issue>> {
+        let adapter = self.tracker_adapter();
         let issue_ids = vec![issue_id.to_string()];
-        let issues = self.block_on(self.adapter.fetch_issue_states_by_ids(&issue_ids))?;
+        let issues = self.block_on(adapter.fetch_issue_states_by_ids(&issue_ids))?;
         Ok(issues.into_iter().next())
     }
 
     fn update_issue_state(&mut self, issue_id: &str, state_name: &str) -> error::Result<()> {
-        self.block_on(self.adapter.update_issue_state(issue_id, state_name))
+        let adapter = self.tracker_adapter();
+        self.block_on(adapter.update_issue_state(issue_id, state_name))
     }
 }
 
@@ -166,20 +176,15 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
     }
 
     fn start_orchestrator(&mut self, workflow_path: &Path, cli: &Cli) -> Result<(), String> {
-        let mut context = self.take_or_load_validated_context(workflow_path)?;
+        let context = self.take_or_load_validated_context(workflow_path)?;
         let http_binding = effective_http_binding(&context.effective_config, cli);
 
-        if let Some(port) = cli.port {
-            context.effective_config.server.port = Some(port);
-        }
-
-        // Build runtime dependencies so startup failures surface at bootstrap time.
-        let tracker_client = LinearClient::new(context.effective_config.tracker.clone());
-        let tracker_adapter = LinearAdapter::new(tracker_client);
-        let mut tracker_port = LinearOrchestratorPort::new(tracker_adapter);
-
         let workflow_store = Arc::new(context.workflow_store);
-        let mut orchestrator = Orchestrator::new_with_workflow_store(Arc::clone(&workflow_store));
+        let mut tracker_port = LinearOrchestratorPort::new(Arc::clone(&workflow_store));
+        let mut orchestrator = Orchestrator::new_with_workflow_store_and_port_override(
+            Arc::clone(&workflow_store),
+            cli.port,
+        );
 
         let snapshot_handle = orchestrator.create_snapshot_handle();
         let refresh_sender = orchestrator.create_refresh_channel();

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -178,11 +178,8 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
         let tracker_adapter = LinearAdapter::new(tracker_client);
         let mut tracker_port = LinearOrchestratorPort::new(tracker_adapter);
 
-        // Get the prompt template from the workflow store.
-        let (workflow_def, _) = context.workflow_store.effective_config();
-        let prompt_template = workflow_def.prompt_template.clone();
-
-        let mut orchestrator = Orchestrator::new(context.effective_config.clone(), prompt_template);
+        let workflow_store = Arc::new(context.workflow_store);
+        let mut orchestrator = Orchestrator::new_with_workflow_store(Arc::clone(&workflow_store));
 
         let snapshot_handle = orchestrator.create_snapshot_handle();
         let refresh_sender = orchestrator.create_refresh_channel();
@@ -214,9 +211,6 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
                 "HTTP server disabled; running orchestrator-only mode"
             );
         }
-
-        // Keep the watcher-backed store alive for the lifetime of the run.
-        let _workflow_store = context.workflow_store;
 
         run_runtime_until_shutdown(
             &mut orchestrator,

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -599,6 +599,7 @@ pub trait OrchestratorPort {
 pub struct Orchestrator {
     workflow_store: Option<Arc<WorkflowStore>>,
     config: ServiceConfig,
+    server_port_override: Option<u16>,
     state: OrchestratorState,
     events: Vec<RuntimeEvent>,
     retry_tokens: HashMap<String, String>,
@@ -621,18 +622,31 @@ pub struct Orchestrator {
 
 impl Orchestrator {
     pub fn new_with_workflow_store(workflow_store: Arc<WorkflowStore>) -> Self {
+        Self::new_with_workflow_store_and_port_override(workflow_store, None)
+    }
+
+    pub fn new_with_workflow_store_and_port_override(
+        workflow_store: Arc<WorkflowStore>,
+        server_port_override: Option<u16>,
+    ) -> Self {
         let (workflow_def, config) = workflow_store.effective_config();
-        Self::from_runtime_config(config, workflow_def.prompt_template, Some(workflow_store))
+        Self::from_runtime_config(
+            config,
+            workflow_def.prompt_template,
+            Some(workflow_store),
+            server_port_override,
+        )
     }
 
     pub fn new(config: ServiceConfig, prompt_template: String) -> Self {
-        Self::from_runtime_config(config, prompt_template, None)
+        Self::from_runtime_config(config, prompt_template, None, None)
     }
 
     fn from_runtime_config(
         config: ServiceConfig,
         prompt_template: String,
         workflow_store: Option<Arc<WorkflowStore>>,
+        server_port_override: Option<u16>,
     ) -> Self {
         let poll_interval_ms = config.polling.interval_ms;
         let max_concurrent_agents = config.agent.max_concurrent_agents;
@@ -641,6 +655,7 @@ impl Orchestrator {
         Self {
             workflow_store,
             config,
+            server_port_override,
             state: OrchestratorState {
                 poll_interval_ms,
                 max_concurrent_agents,
@@ -672,6 +687,10 @@ impl Orchestrator {
             self.prompt_template = workflow_def.prompt_template;
         }
 
+        if let Some(port) = self.server_port_override {
+            self.config.server.port = Some(port);
+        }
+
         self.state.max_concurrent_agents = self.config.agent.max_concurrent_agents;
         self.state.poll_interval_ms = self.config.polling.interval_ms;
     }
@@ -687,7 +706,7 @@ impl Orchestrator {
 
             self.detect_stalled_workers(now_ms, stall_timeout_ms);
 
-            match self.tick(port) {
+            match self.tick_with_refresh(port, false) {
                 Ok(tick_result) => {
                     self.spawn_workers_for_dispatched(&tick_result.dispatched_issues, port);
                 }
@@ -818,7 +837,6 @@ impl Orchestrator {
     }
 
     pub fn startup_cleanup(&mut self, port: &mut dyn OrchestratorPort) -> Result<()> {
-        self.refresh_runtime_config();
         self.events.push(RuntimeEvent::StartupCleanup);
         tracing::info!(
             phase = "startup_cleanup",
@@ -835,7 +853,18 @@ impl Orchestrator {
     }
 
     pub fn tick(&mut self, port: &mut dyn OrchestratorPort) -> Result<TickResult> {
-        self.refresh_runtime_config();
+        self.tick_with_refresh(port, true)
+    }
+
+    fn tick_with_refresh(
+        &mut self,
+        port: &mut dyn OrchestratorPort,
+        refresh_runtime_config: bool,
+    ) -> Result<TickResult> {
+        if refresh_runtime_config {
+            self.refresh_runtime_config();
+        }
+
         self.events.push(RuntimeEvent::Reconcile);
         tracing::info!(phase = "reconcile", "starting orchestrator tick phase");
         self.reconcile_running(port)?;

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -15,6 +15,7 @@ use crate::domain::{
 };
 use crate::error::{Result, SymphonyError};
 use crate::ssh::{self, WorkerHostSelection};
+use crate::workflow_store::WorkflowStore;
 use crate::{path_safety, prompt_builder, workspace};
 
 // ── Standalone Worker Task ──────────────────────────────────────────────
@@ -596,6 +597,7 @@ pub trait OrchestratorPort {
 /// state in this process. State mutation only happens through `&mut self`
 /// methods (startup cleanup, tick, retry handlers).
 pub struct Orchestrator {
+    workflow_store: Option<Arc<WorkflowStore>>,
     config: ServiceConfig,
     state: OrchestratorState,
     events: Vec<RuntimeEvent>,
@@ -618,12 +620,26 @@ pub struct Orchestrator {
 }
 
 impl Orchestrator {
+    pub fn new_with_workflow_store(workflow_store: Arc<WorkflowStore>) -> Self {
+        let (workflow_def, config) = workflow_store.effective_config();
+        Self::from_runtime_config(config, workflow_def.prompt_template, Some(workflow_store))
+    }
+
     pub fn new(config: ServiceConfig, prompt_template: String) -> Self {
+        Self::from_runtime_config(config, prompt_template, None)
+    }
+
+    fn from_runtime_config(
+        config: ServiceConfig,
+        prompt_template: String,
+        workflow_store: Option<Arc<WorkflowStore>>,
+    ) -> Self {
         let poll_interval_ms = config.polling.interval_ms;
         let max_concurrent_agents = config.agent.max_concurrent_agents;
         let (worker_result_tx, worker_result_rx) = tokio::sync::mpsc::unbounded_channel();
 
         Self {
+            workflow_store,
             config,
             state: OrchestratorState {
                 poll_interval_ms,
@@ -649,11 +665,23 @@ impl Orchestrator {
         }
     }
 
+    fn refresh_runtime_config(&mut self) {
+        if let Some(workflow_store) = self.workflow_store.as_ref() {
+            let (workflow_def, config) = workflow_store.effective_config();
+            self.config = config;
+            self.prompt_template = workflow_def.prompt_template;
+        }
+
+        self.state.max_concurrent_agents = self.config.agent.max_concurrent_agents;
+        self.state.poll_interval_ms = self.config.polling.interval_ms;
+    }
+
     pub async fn run(&mut self, port: &mut dyn OrchestratorPort) -> Result<()> {
         self.startup_cleanup(port)?;
         self.publish_snapshot();
 
         loop {
+            self.refresh_runtime_config();
             let now_ms = Utc::now().timestamp_millis();
             let stall_timeout_ms = self.config.codex.stall_timeout_ms.min(i64::MAX as u64) as i64;
 
@@ -790,6 +818,7 @@ impl Orchestrator {
     }
 
     pub fn startup_cleanup(&mut self, port: &mut dyn OrchestratorPort) -> Result<()> {
+        self.refresh_runtime_config();
         self.events.push(RuntimeEvent::StartupCleanup);
         tracing::info!(
             phase = "startup_cleanup",
@@ -806,6 +835,7 @@ impl Orchestrator {
     }
 
     pub fn tick(&mut self, port: &mut dyn OrchestratorPort) -> Result<TickResult> {
+        self.refresh_runtime_config();
         self.events.push(RuntimeEvent::Reconcile);
         tracing::info!(phase = "reconcile", "starting orchestrator tick phase");
         self.reconcile_running(port)?;

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -27,6 +27,7 @@ struct FakePort {
     reconciled_issues: Vec<Issue>,
     candidate_issues: Vec<Issue>,
     refreshed_issues: HashMap<String, Option<Issue>>,
+    validated_server_ports: Vec<Option<u16>>,
     validate_should_fail: bool,
     reconcile_should_fail: bool,
 }
@@ -52,8 +53,9 @@ impl OrchestratorPort for FakePort {
         Ok(self.reconciled_issues.clone())
     }
 
-    fn validate_dispatch_preflight(&mut self, _config: &ServiceConfig) -> Result<()> {
+    fn validate_dispatch_preflight(&mut self, config: &ServiceConfig) -> Result<()> {
         self.calls.push("validate_dispatch_preflight".to_string());
+        self.validated_server_ports.push(config.server.port);
         if self.validate_should_fail {
             Err(SymphonyError::MissingLinearApiToken)
         } else {
@@ -156,7 +158,7 @@ fn wait_for_workflow_config(
     expected_stall_timeout_ms: u64,
     expected_prompt_fragment: &str,
 ) {
-    let deadline = Instant::now() + StdDuration::from_secs(3);
+    let deadline = Instant::now() + StdDuration::from_secs(6);
 
     loop {
         let (workflow_def, config) = store.effective_config();
@@ -185,7 +187,7 @@ fn wait_for_workflow_config(
             );
         }
 
-        std::thread::sleep(StdDuration::from_millis(50));
+        std::thread::sleep(StdDuration::from_millis(100));
     }
 }
 
@@ -234,6 +236,39 @@ fn test_tick_refreshes_runtime_state_from_workflow_store_reload() {
         orchestrator.state().poll_interval_ms,
         2222,
         "tick should sync state.poll_interval_ms from reloaded workflow config"
+    );
+}
+
+#[test]
+fn test_tick_applies_server_port_override_over_workflow_store_config() {
+    let workflow = NamedTempFile::new().expect("temp workflow should be created");
+    let mut file = File::create(workflow.path()).expect("workflow file should be writable");
+    writeln!(
+        file,
+        "---\ntracker:\n  kind: linear\n  api_key: test-key\n  project_slug: project\nserver:\n  port: 9100\n---\nPrompt v1"
+    )
+    .expect("workflow file should be written");
+
+    let workflow_store = Arc::new(
+        WorkflowStore::new(workflow.path())
+            .expect("workflow store should initialize from temp file"),
+    );
+
+    let mut orchestrator = Orchestrator::new_with_workflow_store_and_port_override(
+        Arc::clone(&workflow_store),
+        Some(7777),
+    );
+    let mut port = FakePort::default();
+
+    let tick = orchestrator.tick(&mut port).expect("tick should succeed");
+    assert!(
+        tick.dispatched_issue_ids.is_empty(),
+        "tick should not dispatch without candidates"
+    );
+    assert_eq!(
+        port.validated_server_ports,
+        vec![Some(7777)],
+        "CLI override should be preserved in the runtime config passed to preflight validation"
     );
 }
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1,10 +1,14 @@
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration as StdDuration, Instant};
 
 use chrono::{Duration, Utc};
 use mockito::{Server, ServerGuard};
 use serde_json::json;
-use tempfile::tempdir;
+use tempfile::{tempdir, NamedTempFile};
 
 use symphony::domain::{
     AgentConfig, AgentEvent, ApiKey, BlockerRef, Issue, ServiceConfig, TrackerConfig,
@@ -14,6 +18,7 @@ use symphony::orchestrator::{
     refresh_channel, Orchestrator, OrchestratorPort, RetryKind, RuntimeEvent, TurnMetrics,
     WorkerCompletion, CONTINUATION_RETRY_DELAY_MS,
 };
+use symphony::workflow_store::WorkflowStore;
 
 #[derive(Default)]
 struct FakePort {
@@ -127,6 +132,109 @@ fn issue(
         created_at: Some(Utc::now() + Duration::seconds(created_at_offset_secs)),
         updated_at: Some(Utc::now()),
     }
+}
+
+fn overwrite_workflow_file(
+    path: &Path,
+    poll_interval_ms: u64,
+    max_concurrent_agents: u32,
+    stall_timeout_ms: u64,
+    prompt_template: &str,
+) {
+    let mut file = File::create(path).expect("workflow file should be writable");
+    writeln!(
+        file,
+        "---\ntracker:\n  kind: linear\n  api_key: test-key\n  project_slug: project\npolling:\n  interval_ms: {poll_interval_ms}\nagent:\n  max_concurrent_agents: {max_concurrent_agents}\ncodex:\n  stall_timeout_ms: {stall_timeout_ms}\n---\n{prompt_template}"
+    )
+    .expect("workflow file should be updated");
+}
+
+fn wait_for_workflow_config(
+    store: &WorkflowStore,
+    expected_poll_interval_ms: u64,
+    expected_max_concurrent_agents: u32,
+    expected_stall_timeout_ms: u64,
+    expected_prompt_fragment: &str,
+) {
+    let deadline = Instant::now() + StdDuration::from_secs(3);
+
+    loop {
+        let (workflow_def, config) = store.effective_config();
+        let matches = config.polling.interval_ms == expected_poll_interval_ms
+            && config.agent.max_concurrent_agents == expected_max_concurrent_agents
+            && config.codex.stall_timeout_ms == expected_stall_timeout_ms
+            && workflow_def
+                .prompt_template
+                .contains(expected_prompt_fragment);
+
+        if matches {
+            return;
+        }
+
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for workflow reload (poll={}, max_agents={}, stall={}, prompt={:?}); observed poll={}, max_agents={}, stall={}, prompt={:?}",
+                expected_poll_interval_ms,
+                expected_max_concurrent_agents,
+                expected_stall_timeout_ms,
+                expected_prompt_fragment,
+                config.polling.interval_ms,
+                config.agent.max_concurrent_agents,
+                config.codex.stall_timeout_ms,
+                workflow_def.prompt_template
+            );
+        }
+
+        std::thread::sleep(StdDuration::from_millis(50));
+    }
+}
+
+#[test]
+fn test_tick_refreshes_runtime_state_from_workflow_store_reload() {
+    let workflow = NamedTempFile::new().expect("temp workflow should be created");
+    overwrite_workflow_file(workflow.path(), 1000, 1, 60_000, "Prompt v1");
+
+    let workflow_store = Arc::new(
+        WorkflowStore::new(workflow.path())
+            .expect("workflow store should initialize from temp file"),
+    );
+
+    wait_for_workflow_config(&workflow_store, 1000, 1, 60_000, "Prompt v1");
+
+    let mut orchestrator = Orchestrator::new_with_workflow_store(Arc::clone(&workflow_store));
+    let mut port = FakePort::default();
+
+    let initial_tick = orchestrator
+        .tick(&mut port)
+        .expect("initial tick should succeed");
+    assert!(
+        initial_tick.dispatched_issue_ids.is_empty(),
+        "baseline tick should not dispatch without candidates"
+    );
+    assert_eq!(orchestrator.state().max_concurrent_agents, 1);
+    assert_eq!(orchestrator.state().poll_interval_ms, 1000);
+
+    overwrite_workflow_file(workflow.path(), 2222, 4, 90_000, "Prompt v2");
+    wait_for_workflow_config(&workflow_store, 2222, 4, 90_000, "Prompt v2");
+
+    let after_reload_tick = orchestrator
+        .tick(&mut port)
+        .expect("tick after workflow reload should succeed");
+    assert!(
+        after_reload_tick.dispatched_issue_ids.is_empty(),
+        "reload tick should remain non-dispatching without candidates"
+    );
+
+    assert_eq!(
+        orchestrator.state().max_concurrent_agents,
+        4,
+        "tick should sync state.max_concurrent_agents from reloaded workflow config"
+    );
+    assert_eq!(
+        orchestrator.state().poll_interval_ms,
+        2222,
+        "tick should sync state.poll_interval_ms from reloaded workflow config"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add orchestrator bootstrap constructor that owns an Arc<WorkflowStore>
- refresh effective config/prompt template at runtime (loop + tick) so WORKFLOW.md hot reload is applied without restart
- keep existing direct-config constructor for tests and add a regression test that verifies tick picks up reloaded polling.interval_ms and agent.max_concurrent_agents

## Validation
- cd apps/symphony && cargo fmt
- cd apps/symphony && cargo test --test orchestrator_tests
- cd apps/symphony && cargo test
- cd apps/symphony && cargo clippy -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orchestrator now reloads workflow configuration at runtime so polling intervals, agent concurrency, prompt templates, and timeouts update without restart.
  * Added optional server port override so an explicit port can take precedence over workflow config.

* **Behavioral Changes**
  * External API interactions now use the latest workflow configuration on each call, ensuring tracker/client behavior follows live config.

* **Tests**
  * Added tests covering runtime config reload and port-override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the existing hot-reload `WorkflowStore` into the `Orchestrator` so that changes to WORKFLOW.md take effect at runtime without a process restart. A new `new_with_workflow_store(Arc<WorkflowStore>)` constructor stores the `Arc` on the orchestrator, a new `refresh_runtime_config()` private method reads the current `(WorkflowDefinition, ServiceConfig)` snapshot from the store and syncs `state.poll_interval_ms` and `state.max_concurrent_agents`, and that method is invoked at the top of `run()`'s poll loop, in `startup_cleanup`, and in `tick()`. A regression test validates the full hot-reload path against a `NamedTempFile`-backed store.

**Key issues found:**

- **Double refresh per `run()` iteration with potential config skew** (`orchestrator.rs` line 684): `run()` calls `self.refresh_runtime_config()` at the top of the loop, then immediately calls `self.tick(port)`, which also calls `refresh_runtime_config()`. This means two separate `RwLock` reads occur within the same logical tick. Values derived from `self.config` between the two calls (e.g., `stall_timeout_ms` on line 686) can be based on the first snapshot while `tick()` operates on a different, more recently-reloaded snapshot. The fix is to remove the explicit call from the `run()` loop body and rely solely on the call inside `tick()`.

- **CLI `--port` override silently bypassed** (`main.rs` line 181–182): Prior to this PR, the orchestrator was constructed from `context.effective_config`, to which the CLI port override had already been applied. The new code reads the initial config directly from `workflow_store.effective_config()`, which has no knowledge of the CLI override. Any orchestrator logic that reads `self.config.server.port` will see the WORKFLOW.md value, not the `--port` argument.

- **Redundant third refresh at startup** (`orchestrator.rs` line 818): `startup_cleanup` calls `refresh_runtime_config()`, but it is only invoked from `run()`, which then enters a loop adding two more refreshes before any dispatch decision is made. Removing the call from `startup_cleanup` simplifies the call graph without losing any correctness.

- **Tight test deadline for hot-reload** (`orchestrator_tests.rs` line 158): The `wait_for_workflow_config` helper uses a 3-second deadline with a 50 ms sleep against a store that applies a 400 ms debounce, leaving only ~6 retry windows after the debounce on slow CI environments.

<h3>Confidence Score: 3/5</h3>

- Needs fixes before merge — the double-refresh in `run()` introduces a within-iteration config skew, and the CLI `--port` override is silently detached from the orchestrator's initial config.
- The core hot-reload mechanism (WorkflowStore, Arc sharing, RwLock) is sound and well-tested in isolation. However, two logic issues were introduced: (1) `refresh_runtime_config` is called in the `run()` loop body AND inside `tick()`, so every iteration acquires the lock twice with a config-skew window between them, and (2) the CLI `--port` mutation on `context.effective_config` is now silently bypassed because the orchestrator reads its initial config directly from the workflow store. These require code changes before the feature behaves exactly as intended.
- `apps/symphony/src/orchestrator.rs` (double refresh in `run()` loop) and `apps/symphony/src/main.rs` (CLI `--port` override bypass)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Adds `workflow_store: Option<Arc<WorkflowStore>>` field, new `new_with_workflow_store` constructor, and `refresh_runtime_config()` private method. The method is called in `run()`'s loop, `startup_cleanup`, and `tick()` — but `run()` calls both `tick()` and places its own explicit refresh at the top of the loop, causing a double-refresh per iteration and a potential within-iteration config skew for `stall_timeout_ms`. |
| apps/symphony/src/main.rs | Switches from `Orchestrator::new(context.effective_config.clone(), ...)` to `Orchestrator::new_with_workflow_store(Arc::clone(&workflow_store))`, which correctly keeps the store alive via the orchestrator's Arc. However, the CLI `--port` override applied to `context.effective_config` is now silently bypassed because the orchestrator reads its initial config directly from `workflow_store.effective_config()`. |
| apps/symphony/tests/orchestrator_tests.rs | Adds a regression test `test_tick_refreshes_runtime_state_from_workflow_store_reload` that writes a `NamedTempFile`-backed WORKFLOW.md, creates a `WorkflowStore`, waits for the initial load, overwrites the file, waits for hot-reload, then asserts `state.poll_interval_ms` and `state.max_concurrent_agents` are updated after the next `tick()`. Tests `tick()` in isolation (not `run()`), so the double-refresh issue in `run()` is not covered. The 3-second busy-poll deadline may be tight on slow CI environments. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FS as Filesystem (WORKFLOW.md)
    participant WS as WorkflowStore (Arc<RwLock>)
    participant Orch as Orchestrator
    participant Run as run() loop
    participant Tick as tick()

    Note over FS,WS: notify watcher + 400ms debounce thread
    FS->>WS: file change event → force_reload_inner()
    WS->>WS: write-lock: update (WorkflowDef, ServiceConfig)

    Note over Run,Tick: Production runtime path
    Run->>Orch: startup_cleanup() → refresh_runtime_config() [#1]
    WS-->>Orch: effective_config() clone
    Run->>Run: loop start → refresh_runtime_config() [#2 redundant]
    WS-->>Orch: effective_config() clone
    Run->>Tick: self.tick(port)
    Tick->>Orch: refresh_runtime_config() [#3 redundant]
    WS-->>Orch: effective_config() clone
    Orch->>Orch: state.poll_interval_ms = config.polling.interval_ms
    Orch->>Orch: state.max_concurrent_agents = config.agent.max_concurrent_agents
    Tick-->>Run: TickResult

    Note over Run,Tick: Test path (tick called directly)
    Tick->>Orch: refresh_runtime_config() [single call ✓]
    WS-->>Orch: effective_config() clone
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/src/orchestrator.rs`, line 684-690 ([link](https://github.com/gannonh/kata/blob/17518d0a585a45b723d8ef71cf3c2d5f261efc10/apps/symphony/src/orchestrator.rs#L684-L690)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Double refresh per loop iteration — within-iteration config skew**

   `refresh_runtime_config()` is called **twice** in every `run()` loop iteration:

   1. Line 684 — explicit call at the top of the loop
   2. Line 690 — `self.tick(port)` immediately calls `refresh_runtime_config()` again (line 835 in the `tick` method)

   This creates a window where values derived from the first call can diverge from values used in `tick`. Concretely, `stall_timeout_ms` is computed from `self.config` on line 686 *after* the first refresh but *before* the second one inside `tick`. If the workflow file reloads between these two lock acquisitions, `stall_timeout_ms` will be based on the old config while `tick` operates on the new one.

   Because `run()` already delegates its core reconcile work to `tick()`, the safest fix is to remove the redundant call from the `run()` loop body:

   

   This leaves `tick()` as the single place the refresh happens for all callers (both the production `run()` loop and direct test calls), and eliminates the skew window entirely.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/orchestrator.rs
   Line: 684-690

   Comment:
   **Double refresh per loop iteration — within-iteration config skew**

   `refresh_runtime_config()` is called **twice** in every `run()` loop iteration:

   1. Line 684 — explicit call at the top of the loop
   2. Line 690 — `self.tick(port)` immediately calls `refresh_runtime_config()` again (line 835 in the `tick` method)

   This creates a window where values derived from the first call can diverge from values used in `tick`. Concretely, `stall_timeout_ms` is computed from `self.config` on line 686 *after* the first refresh but *before* the second one inside `tick`. If the workflow file reloads between these two lock acquisitions, `stall_timeout_ms` will be based on the old config while `tick` operates on the new one.

   Because `run()` already delegates its core reconcile work to `tick()`, the safest fix is to remove the redundant call from the `run()` loop body:

   

   This leaves `tick()` as the single place the refresh happens for all callers (both the production `run()` loop and direct test calls), and eliminates the skew window entirely.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 684-690

Comment:
**Double refresh per loop iteration — within-iteration config skew**

`refresh_runtime_config()` is called **twice** in every `run()` loop iteration:

1. Line 684 — explicit call at the top of the loop
2. Line 690 — `self.tick(port)` immediately calls `refresh_runtime_config()` again (line 835 in the `tick` method)

This creates a window where values derived from the first call can diverge from values used in `tick`. Concretely, `stall_timeout_ms` is computed from `self.config` on line 686 *after* the first refresh but *before* the second one inside `tick`. If the workflow file reloads between these two lock acquisitions, `stall_timeout_ms` will be based on the old config while `tick` operates on the new one.

Because `run()` already delegates its core reconcile work to `tick()`, the safest fix is to remove the redundant call from the `run()` loop body:

```suggestion
        loop {
            let now_ms = Utc::now().timestamp_millis();
```

This leaves `tick()` as the single place the refresh happens for all callers (both the production `run()` loop and direct test calls), and eliminates the skew window entirely.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 818-820

Comment:
**Redundant startup refresh — three calls before first tick**

`startup_cleanup` now calls `refresh_runtime_config()` (this line), but `startup_cleanup` is only ever called from `run()`, which then enters a loop that already calls `refresh_runtime_config()` itself (and `tick()` calls it a third time). At startup this means the config is refreshed three times before any meaningful work is done.

`startup_cleanup` doesn't dispatch agents or compute time-sensitive values from the config — it just marks terminal issues complete. The refresh here doesn't add correctness value and inflates lock-acquisition noise during startup. Consider removing it from `startup_cleanup` and relying on the refresh in `tick()` (which is already present and correctly applies before any dispatch decision).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/main.rs
Line: 181-182

Comment:
**CLI `--port` override silently detached from orchestrator config**

Before this PR the orchestrator was constructed from `context.effective_config` (line 173 in the old code), which had the CLI port override already applied via `context.effective_config.server.port = Some(port)`. After this PR the orchestrator reads its initial config directly from `workflow_store.effective_config()` inside `new_with_workflow_store`, completely bypassing that mutation.

Any code path inside `Orchestrator` that reads `self.config.server.port` will now see the value from WORKFLOW.md, not the value passed via `--port`. If the HTTP server binding is derived solely from `http_binding` (computed above) this may be harmless today, but it silently breaks the invariant that `self.config` reflects the fully-resolved runtime config, and creates a trap for future callers.

A minimal fix is to apply CLI overrides to the store snapshot before handing it to the orchestrator, or to store the resolved `ServiceConfig` alongside the `Arc<WorkflowStore>` and use that as the initial config:

```rust
let (workflow_def, mut initial_config) = workflow_store.effective_config();
if let Some(port) = cli.port {
    initial_config.server.port = Some(port);
}
let mut orchestrator = Orchestrator::new(initial_config, workflow_def.prompt_template);
// (or a dedicated constructor that also stores the workflow_store for live reloads)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/tests/orchestrator_tests.rs
Line: 158-185

Comment:
**Busy-poll test helper with no back-off exposes flakiness surface on slow CI**

`wait_for_workflow_config` loops with a fixed 50 ms sleep and a hard 3-second wall-clock deadline. The underlying `notify` watcher adds a 400 ms debounce before reloading, so the effective minimum wait is already ≥ 400 ms. On a busy CI machine that suspends threads for longer than 50 ms at a time this helper can fail spuriously, and the 3-second deadline provides only ~6 retry windows after the debounce.

Consider extending the timeout to at least 5–6 seconds, or using an exponential/capped back-off so normal fast paths are quick while slow environments have more headroom:

```rust
let deadline = Instant::now() + StdDuration::from_secs(6);
// ...
std::thread::sleep(StdDuration::from_millis(100));
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(symphony): hot-..."](https://github.com/gannonh/kata/commit/17518d0a585a45b723d8ef71cf3c2d5f261efc10)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->