### PR TITLE
KAT-816: Real-time event streaming from worker tasks to orchestrator

### DIFF
--- a/apps/symphony/src/codex/app_server.rs
+++ b/apps/symphony/src/codex/app_server.rs
@@ -452,6 +452,10 @@ where
                                     codex_app_server_pid: handle.pid.clone(),
                                     turn_id: turn_id.clone(),
                                     message: None,
+                                    input_tokens: turn_input_tokens,
+                                    output_tokens: turn_output_tokens,
+                                    total_tokens: turn_total_tokens,
+                                    rate_limits: turn_rate_limits.clone(),
                                 };
                                 event_callback(event.clone());
                                 events.push(event);

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -499,6 +499,10 @@ pub enum AgentEvent {
         codex_app_server_pid: Option<String>,
         turn_id: String,
         message: Option<String>,
+        input_tokens: u64,
+        output_tokens: u64,
+        total_tokens: u64,
+        rate_limits: Option<serde_json::Value>,
     },
     TurnFailed {
         timestamp: DateTime<Utc>,

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -672,54 +672,69 @@ impl Orchestrator {
     pub async fn run(&mut self, port: &mut dyn OrchestratorPort) -> Result<()> {
         self.startup_cleanup(port)?;
         self.publish_snapshot();
+        let mut next_poll_due = tokio::time::Instant::now();
+        let mut tick_requested = true;
 
         loop {
-            let now_ms = Utc::now().timestamp_millis();
-            let stall_timeout_ms = self.config.codex.stall_timeout_ms.min(i64::MAX as u64) as i64;
+            let now = tokio::time::Instant::now();
+            if tick_requested || now >= next_poll_due {
+                let now_ms = Utc::now().timestamp_millis();
+                let stall_timeout_ms =
+                    self.config.codex.stall_timeout_ms.min(i64::MAX as u64) as i64;
 
-            self.detect_stalled_workers(now_ms, stall_timeout_ms);
+                self.detect_stalled_workers(now_ms, stall_timeout_ms);
 
-            match self.tick(port) {
-                Ok(tick_result) => {
-                    self.spawn_workers_for_dispatched(&tick_result.dispatched_issues, port);
+                match self.tick(port) {
+                    Ok(tick_result) => {
+                        self.spawn_workers_for_dispatched(&tick_result.dispatched_issues, port);
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            phase = "tick",
+                            error = %err,
+                            "orchestrator tick failed; continuing"
+                        );
+                    }
                 }
-                Err(err) => {
-                    tracing::warn!(
-                        phase = "tick",
-                        error = %err,
-                        "orchestrator tick failed; continuing"
-                    );
-                }
+
+                let retry_dispatched =
+                    self.process_due_retries(port, Utc::now().timestamp_millis());
+                self.spawn_workers_for_dispatched(&retry_dispatched, port);
+                self.publish_snapshot();
+
+                tick_requested = false;
+                next_poll_due = tokio::time::Instant::now()
+                    + Duration::from_millis(self.state.poll_interval_ms);
             }
 
-            let retry_dispatched = self.process_due_retries(port, Utc::now().timestamp_millis());
-            self.spawn_workers_for_dispatched(&retry_dispatched, port);
-            self.publish_snapshot();
-
-            // Sleep until next poll interval, but wake early on refresh request
-            // or worker result.
-            let sleep_duration = Duration::from_millis(self.state.poll_interval_ms);
+            // Sleep until next poll deadline, but wake early on refresh request
+            // or worker channels.
             let refresh_notify = self.refresh_receiver.as_ref().map(|r| r.notify.clone());
 
             tokio::select! {
-                _ = tokio::time::sleep(sleep_duration) => {},
+                _ = tokio::time::sleep_until(next_poll_due) => {
+                    tick_requested = true;
+                },
                 event = self.worker_event_rx.recv() => {
                     if let Some((issue_id, event)) = event {
                         self.ingest_agent_event(&issue_id, &event);
-                        while let Ok((issue_id, event)) = self.worker_event_rx.try_recv() {
-                            self.ingest_agent_event(&issue_id, &event);
-                        }
+                        self.drain_ready_worker_events();
                         self.publish_snapshot();
                     }
                 },
                 result = self.worker_result_rx.recv() => {
                     if let Some(result) = result {
+                        self.drain_ready_worker_events();
                         self.handle_worker_result(result);
                         self.publish_snapshot();
                     }
                     // Drain any additional ready results.
                     while let Ok(result) = self.worker_result_rx.try_recv() {
+                        self.drain_ready_worker_events();
                         self.handle_worker_result(result);
+                        self.publish_snapshot();
+                    }
+                    if self.drain_ready_worker_events() > 0 {
                         self.publish_snapshot();
                     }
                 },
@@ -737,6 +752,7 @@ impl Orchestrator {
                                 "HTTP refresh request woke orchestrator loop; triggering immediate tick"
                             );
                             self.events.push(RuntimeEvent::RefreshRequested);
+                            tick_requested = true;
                         }
                     }
                 },
@@ -825,6 +841,18 @@ impl Orchestrator {
             result.completion,
             Utc::now().timestamp_millis(),
         );
+    }
+
+    /// Drain any worker events already queued by spawned worker tasks.
+    ///
+    /// Returns the number of events ingested.
+    fn drain_ready_worker_events(&mut self) -> usize {
+        let mut drained = 0usize;
+        while let Ok((issue_id, event)) = self.worker_event_rx.try_recv() {
+            self.ingest_agent_event(&issue_id, &event);
+            drained = drained.saturating_add(1);
+        }
+        drained
     }
 
     pub fn startup_cleanup(&mut self, port: &mut dyn OrchestratorPort) -> Result<()> {
@@ -1089,6 +1117,15 @@ impl Orchestrator {
     }
 
     pub fn ingest_agent_event(&mut self, issue_id: &str, event: &AgentEvent) {
+        if !self.state.running.contains_key(issue_id) {
+            tracing::debug!(
+                issue_id = %issue_id,
+                event = %event_name(event),
+                "ignored codex worker event for non-running issue"
+            );
+            return;
+        }
+
         self.record_worker_activity(issue_id, event_timestamp_ms(event));
 
         if let Some(session_id) = event_session_id(event) {

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -28,6 +28,7 @@ struct WorkerTaskConfig {
     max_turns: u32,
     tracker: TrackerConfig,
     prompt_template: String,
+    event_tx: tokio::sync::mpsc::UnboundedSender<(String, AgentEvent)>,
 }
 
 enum IssueCheck {
@@ -114,17 +115,19 @@ async fn check_issue_still_active(
     }
 }
 
-async fn run_codex_turns_in_session<E, EFut>(
+async fn run_codex_turns_in_session<E, EFut, EventCallback>(
     session: &mut app_server::SessionHandle,
     issue: &Issue,
     initial_prompt: String,
     max_turns: u32,
     tracker_config: &TrackerConfig,
     graphql_executor: E,
+    mut stream_event: EventCallback,
 ) -> std::result::Result<SessionTurnLoopSuccess, SessionTurnLoopFailure>
 where
     E: Fn(String, serde_json::Value) -> EFut + Clone + Send,
     EFut: Future<Output = Result<serde_json::Value>> + Send,
+    EventCallback: FnMut(AgentEvent) + Send,
 {
     let capped_max_turns = max_turns.max(1);
     let mut turn_number: u32 = 1;
@@ -144,6 +147,7 @@ where
 
         let run_result =
             app_server::run_turn(session, &prompt, graphql_executor.clone(), |event| {
+                stream_event(event.clone());
                 observed_events.push(event);
             })
             .await;
@@ -175,14 +179,16 @@ where
                 break;
             }
             IssueCheck::Error(err) => {
-                observed_events.push(AgentEvent::Notification {
+                let event = AgentEvent::Notification {
                     timestamp: Utc::now(),
                     codex_app_server_pid: None,
                     message: format!(
                         "inter-turn issue refresh failed for {} ({}): {}",
                         current_issue.identifier, current_issue.id, err
                     ),
-                });
+                };
+                stream_event(event.clone());
+                observed_events.push(event);
                 tracing::warn!(
                     issue_id = %current_issue.id,
                     issue_identifier = %current_issue.identifier,
@@ -334,6 +340,13 @@ async fn run_worker_task(
         config.max_turns,
         &config.tracker,
         graphql_executor,
+        {
+            let event_tx = config.event_tx.clone();
+            let issue_id = issue.id.clone();
+            move |event| {
+                let _ = event_tx.send((issue_id.clone(), event));
+            }
+        },
     )
     .await;
 
@@ -356,7 +369,7 @@ async fn run_worker_task(
             completion: WorkerCompletion::Completed {
                 schedule_continuation: success.schedule_continuation,
             },
-            events: success.events,
+            events: vec![],
             metrics: success.metrics,
         },
         Err(failure) => WorkerResult {
@@ -364,7 +377,7 @@ async fn run_worker_task(
             completion: WorkerCompletion::Failed {
                 error: failure.error.to_string(),
             },
-            events: failure.events,
+            events: vec![],
             metrics: failure.metrics,
         },
     }
@@ -613,6 +626,10 @@ pub struct Orchestrator {
     worker_result_rx: tokio::sync::mpsc::UnboundedReceiver<WorkerResult>,
     /// Sender half cloned into each spawned worker task.
     worker_result_tx: tokio::sync::mpsc::UnboundedSender<WorkerResult>,
+    /// Channel for receiving streamed worker events from spawned worker tasks.
+    worker_event_rx: tokio::sync::mpsc::UnboundedReceiver<(String, AgentEvent)>,
+    /// Sender half cloned into each spawned worker task for event streaming.
+    worker_event_tx: tokio::sync::mpsc::UnboundedSender<(String, AgentEvent)>,
     /// The prompt template from the WORKFLOW.md body, used to render per-issue prompts.
     prompt_template: String,
 }
@@ -622,6 +639,7 @@ impl Orchestrator {
         let poll_interval_ms = config.polling.interval_ms;
         let max_concurrent_agents = config.agent.max_concurrent_agents;
         let (worker_result_tx, worker_result_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (worker_event_tx, worker_event_rx) = tokio::sync::mpsc::unbounded_channel();
 
         Self {
             config,
@@ -645,6 +663,8 @@ impl Orchestrator {
             refresh_receiver: None,
             worker_result_rx,
             worker_result_tx,
+            worker_event_rx,
+            worker_event_tx,
             prompt_template,
         }
     }
@@ -683,6 +703,15 @@ impl Orchestrator {
 
             tokio::select! {
                 _ = tokio::time::sleep(sleep_duration) => {},
+                event = self.worker_event_rx.recv() => {
+                    if let Some((issue_id, event)) = event {
+                        self.ingest_agent_event(&issue_id, &event);
+                        while let Ok((issue_id, event)) = self.worker_event_rx.try_recv() {
+                            self.ingest_agent_event(&issue_id, &event);
+                        }
+                        self.publish_snapshot();
+                    }
+                },
                 result = self.worker_result_rx.recv() => {
                     if let Some(result) = result {
                         self.handle_worker_result(result);
@@ -753,6 +782,7 @@ impl Orchestrator {
                 max_turns: self.config.agent.max_turns,
                 tracker: self.config.tracker.clone(),
                 prompt_template: self.prompt_template.clone(),
+                event_tx: self.worker_event_tx.clone(),
             };
 
             tokio::spawn(async move {
@@ -776,9 +806,17 @@ impl Orchestrator {
             self.ingest_agent_event(&result.issue_id, event);
         }
 
-        // Apply token metrics if present
+        // WorkerResult.metrics is retained as a completion summary payload.
         if let Some(metrics) = &result.metrics {
-            self.apply_turn_metrics(metrics);
+            tracing::info!(
+                event = "worker_result_metrics_summary",
+                issue_id = %result.issue_id,
+                input_tokens = metrics.input_tokens,
+                output_tokens = metrics.output_tokens,
+                total_tokens = metrics.total_tokens,
+                has_rate_limits = metrics.rate_limits.is_some(),
+                "received worker result metrics summary"
+            );
         }
 
         // Handle completion (schedules retry on failure, marks complete on success)
@@ -1073,6 +1111,22 @@ impl Orchestrator {
             }
         }
 
+        if let AgentEvent::TurnCompleted {
+            input_tokens,
+            output_tokens,
+            total_tokens,
+            rate_limits,
+            ..
+        } = event
+        {
+            self.apply_turn_metrics(&TurnMetrics {
+                input_tokens: *input_tokens,
+                output_tokens: *output_tokens,
+                total_tokens: *total_tokens,
+                rate_limits: rate_limits.clone(),
+            });
+        }
+
         tracing::debug!(
             issue_id = %issue_id,
             session_id = self
@@ -1286,6 +1340,7 @@ impl Orchestrator {
             self.config.agent.max_turns,
             &self.config.tracker,
             graphql_executor,
+            |_event| {},
         )
         .await;
 
@@ -1311,9 +1366,6 @@ impl Orchestrator {
 
         match loop_result {
             Ok(success) => {
-                if let Some(metrics) = &success.metrics {
-                    self.apply_turn_metrics(metrics);
-                }
                 self.handle_worker_completion(
                     &issue.id,
                     WorkerCompletion::Completed {
@@ -1325,9 +1377,6 @@ impl Orchestrator {
                 Ok(())
             }
             Err(failure) => {
-                if let Some(metrics) = &failure.metrics {
-                    self.apply_turn_metrics(metrics);
-                }
                 let error = failure.error;
                 let error_text = error.to_string();
                 self.handle_worker_completion(

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -339,6 +339,10 @@ fn test_agent_event_variants() {
             codex_app_server_pid: None,
             turn_id: "t1".into(),
             message: Some("done".into()),
+            input_tokens: 10,
+            output_tokens: 4,
+            total_tokens: 14,
+            rate_limits: None,
         },
         AgentEvent::TurnFailed {
             timestamp: Utc::now(),

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -705,6 +705,20 @@ fn test_streamed_events_keep_refreshing_stall_detection_window() {
 #[test]
 fn test_streamed_turn_completed_events_update_token_totals_in_real_time() {
     let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let now_ms = 3_000_000;
+    orchestrator.state_mut().running.insert(
+        "issue-stream-metrics".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-stream-metrics".to_string(),
+            issue_identifier: "SIM-STREAM-3".to_string(),
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-stream-metrics".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+        },
+    );
 
     let event_time = Utc::now();
     orchestrator.ingest_agent_event(
@@ -765,6 +779,59 @@ fn test_streamed_turn_completed_events_update_token_totals_in_real_time() {
         orchestrator.state().codex_totals.total_tokens,
         18,
         "total token count should continue accumulating across streamed turns"
+    );
+}
+
+#[test]
+fn test_late_streamed_event_after_completion_is_ignored() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let now_ms = 4_000_000;
+    let issue_id = "issue-late-stream";
+
+    orchestrator.state_mut().running.insert(
+        issue_id.to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: issue_id.to_string(),
+            issue_identifier: "SIM-STREAM-LATE".to_string(),
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-stream-late".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+        },
+    );
+
+    orchestrator.handle_worker_completion(
+        issue_id,
+        WorkerCompletion::Completed {
+            schedule_continuation: false,
+        },
+        now_ms,
+    );
+
+    orchestrator.ingest_agent_event(
+        issue_id,
+        &AgentEvent::TurnCompleted {
+            timestamp: utc_ms(now_ms - 1_000),
+            codex_app_server_pid: Some("4444".to_string()),
+            turn_id: "turn-late".to_string(),
+            message: None,
+            input_tokens: 11,
+            output_tokens: 7,
+            total_tokens: 18,
+            rate_limits: Some(json!({ "remaining": 77 })),
+        },
+    );
+
+    assert!(
+        !orchestrator.state().running.contains_key(issue_id),
+        "late streamed events must not resurrect completed run attempts"
+    );
+    assert_eq!(
+        orchestrator.state().codex_totals.total_tokens,
+        0,
+        "late streamed events for completed issues should be ignored"
     );
 }
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use chrono::{Duration, Utc};
+use chrono::{Duration, TimeZone, Utc};
 use mockito::{Server, ServerGuard};
 use serde_json::json;
 use tempfile::tempdir;
@@ -127,6 +127,12 @@ fn issue(
         created_at: Some(Utc::now() + Duration::seconds(created_at_offset_secs)),
         updated_at: Some(Utc::now()),
     }
+}
+
+fn utc_ms(ms: i64) -> chrono::DateTime<Utc> {
+    Utc.timestamp_millis_opt(ms)
+        .single()
+        .expect("millisecond timestamp should be representable")
 }
 
 #[test]
@@ -584,6 +590,181 @@ fn test_stall_detection_schedules_forced_retry() {
     assert!(
         stalled_event,
         "stalled worker path should emit worker_stalled diagnostic event"
+    );
+}
+
+#[test]
+fn test_streamed_event_updates_activity_before_worker_completion() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+
+    let now_ms = 1_000_000;
+    orchestrator.state_mut().running.insert(
+        "issue-stream-activity".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-stream-activity".to_string(),
+            issue_identifier: "SIM-STREAM-1".to_string(),
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-stream-activity".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        "issue-stream-activity",
+        &AgentEvent::SessionStarted {
+            timestamp: utc_ms(now_ms - 5_000),
+            codex_app_server_pid: Some("1234".to_string()),
+            session_id: "thread-stream-1-turn-1".to_string(),
+        },
+    );
+
+    orchestrator.detect_stalled_workers(now_ms, 30_000);
+
+    assert!(
+        orchestrator
+            .state()
+            .running
+            .contains_key("issue-stream-activity"),
+        "recent streamed events should refresh activity and keep the worker running"
+    );
+    assert!(
+        !orchestrator
+            .state()
+            .retry_attempts
+            .contains_key("issue-stream-activity"),
+        "worker should not be retried while streamed activity is within stall timeout"
+    );
+}
+
+#[test]
+fn test_streamed_events_keep_refreshing_stall_detection_window() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+
+    let start_ms = 2_000_000;
+    orchestrator.state_mut().running.insert(
+        "issue-stream-window".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-stream-window".to_string(),
+            issue_identifier: "SIM-STREAM-2".to_string(),
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-stream-window".to_string(),
+            started_at: utc_ms(start_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        "issue-stream-window",
+        &AgentEvent::SessionStarted {
+            timestamp: utc_ms(start_ms - 20_000),
+            codex_app_server_pid: Some("2222".to_string()),
+            session_id: "thread-stream-2-turn-1".to_string(),
+        },
+    );
+    orchestrator.detect_stalled_workers(start_ms, 30_000);
+    assert!(
+        orchestrator
+            .state()
+            .running
+            .contains_key("issue-stream-window"),
+        "first streamed event should prevent stall at initial check"
+    );
+
+    let later_ms = start_ms + 35_000;
+    orchestrator.ingest_agent_event(
+        "issue-stream-window",
+        &AgentEvent::Notification {
+            timestamp: utc_ms(later_ms - 5_000),
+            codex_app_server_pid: Some("2222".to_string()),
+            message: "progress update".to_string(),
+        },
+    );
+    orchestrator.detect_stalled_workers(later_ms, 30_000);
+
+    assert!(
+        orchestrator
+            .state()
+            .running
+            .contains_key("issue-stream-window"),
+        "subsequent streamed events should keep extending the non-stalled window"
+    );
+    assert!(
+        !orchestrator
+            .state()
+            .retry_attempts
+            .contains_key("issue-stream-window"),
+        "stalled retry should remain unscheduled when streamed activity continues"
+    );
+}
+
+#[test]
+fn test_streamed_turn_completed_events_update_token_totals_in_real_time() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+
+    let event_time = Utc::now();
+    orchestrator.ingest_agent_event(
+        "issue-stream-metrics",
+        &AgentEvent::TurnCompleted {
+            timestamp: event_time,
+            codex_app_server_pid: Some("3333".to_string()),
+            turn_id: "turn-1".to_string(),
+            message: None,
+            input_tokens: 9,
+            output_tokens: 4,
+            total_tokens: 13,
+            rate_limits: Some(json!({ "remaining": 91 })),
+        },
+    );
+
+    assert_eq!(
+        orchestrator.state().codex_totals.input_tokens,
+        9,
+        "streamed turn-completed events should apply input-token totals immediately"
+    );
+    assert_eq!(
+        orchestrator.state().codex_totals.output_tokens,
+        4,
+        "streamed turn-completed events should apply output-token totals immediately"
+    );
+    assert_eq!(
+        orchestrator.state().codex_totals.total_tokens,
+        13,
+        "streamed turn-completed events should apply total-token totals immediately"
+    );
+
+    orchestrator.ingest_agent_event(
+        "issue-stream-metrics",
+        &AgentEvent::TurnCompleted {
+            timestamp: event_time,
+            codex_app_server_pid: Some("3333".to_string()),
+            turn_id: "turn-2".to_string(),
+            message: None,
+            input_tokens: 3,
+            output_tokens: 2,
+            total_tokens: 5,
+            rate_limits: None,
+        },
+    );
+
+    assert_eq!(
+        orchestrator.state().codex_totals.input_tokens,
+        12,
+        "token totals should continue accumulating across streamed turns"
+    );
+    assert_eq!(
+        orchestrator.state().codex_totals.output_tokens,
+        6,
+        "output totals should continue accumulating across streamed turns"
+    );
+    assert_eq!(
+        orchestrator.state().codex_totals.total_tokens,
+        18,
+        "total token count should continue accumulating across streamed turns"
     );
 }
 


### PR DESCRIPTION
## Summary
- add a worker event stream channel to orchestrator and wire spawned worker tasks to emit `AgentEvent` updates immediately
- process streamed worker events in the runtime `tokio::select!` loop and publish snapshots after ingesting ready batches
- carry token/rate-limit deltas on `TurnCompleted` events, ingest them in real time, and keep `WorkerResult.metrics` as completion-summary logging data
- add coverage for streamed activity/stall-window behavior and streamed token accumulation

## Validation
- cd apps/symphony && cargo fmt
- cd apps/symphony && cargo test
- cd apps/symphony && cargo clippy -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-turn token accounting and rate-limit metadata tracking to turn completion events for better visibility into resource usage.
  * Implemented real-time event streaming between workers and orchestrator for immediate metrics updates.
  * Enhanced stall detection with activity-based monitoring via streamed events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces real-time event streaming from spawned worker tasks to the orchestrator by adding a dedicated `UnboundedSender<(String, AgentEvent)>` channel pair and wiring `TurnCompleted` events (now carrying per-turn token/rate-limit data) through it. The runtime loop drains the event channel on each wake and publishes a fresh snapshot immediately, replacing the previous approach of batching all events in `WorkerResult` and processing them only at task completion.

Key changes:
- `AgentEvent::TurnCompleted` gains `input_tokens`, `output_tokens`, `total_tokens`, and `rate_limits` fields, populated in `app_server.rs` from the turn-level counters already available there.
- `ingest_agent_event` is extended to call `apply_turn_metrics` for every `TurnCompleted` event, replacing the single end-of-session `apply_turn_metrics(metrics)` call in the worker/inline paths.
- `WorkerResult.events` is now always `vec![]` for spawned workers; `WorkerResult.metrics` is retained only as a completion-summary log payload.
- The inline run path passes `|_event| {}` as the stream callback (correct, since the orchestrator is blocked during that await) and continues to ingest events post-loop via `ingest_agent_event`.
- Three new orchestrator tests validate real-time stall-detection refreshing and cumulative token accounting.

Issues found:
- The `for event in &result.events` loop in `handle_worker_result` is now dead code for spawned workers (events are always empty) and its comment is misleading.
- A race between `worker_event_rx` and `worker_result_rx` can cause `record_worker_activity` to re-insert a stale timestamp for a completed issue after `handle_worker_completion` has already cleaned it up; this could suppress stall detection at the start of an immediately-following retry run.
- The `|_event| {}` inline callback lacks a comment explaining why real-time streaming is intentionally skipped for that code path.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge; the streaming design is sound, but a dead-code loop and a stale-activity-timestamp race should be addressed before the PR lands.
- The overall architecture is correct: events are streamed in real-time, token metrics accumulate per-event, and the inline path correctly falls back to post-loop ingestion. However, the dead `result.events` iteration loop in `handle_worker_result` is misleading, and the ordering race between the event channel and the result channel can silently leave a stale entry in `worker_last_activity_ms` that could delay stall detection for a retry run. Neither issue causes incorrect token accounting, but the race is a subtle correctness concern for stall detection edge cases.
- `apps/symphony/src/orchestrator.rs` — specifically `handle_worker_result` (dead events loop) and `ingest_agent_event` / `record_worker_activity` (stale-timestamp race after worker completion).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Core of the PR: adds `worker_event_rx/tx` channel pair, wires streamed events into `ingest_agent_event` (which now also applies token metrics for `TurnCompleted`), and removes batch event/metrics application from the worker result path. Contains a dead event-ingestion loop, a potential stale-activity-timestamp race, and an undocumented no-op inline callback. |
| apps/symphony/src/domain.rs | Adds `input_tokens`, `output_tokens`, `total_tokens`, and `rate_limits` fields to `AgentEvent::TurnCompleted`. Straightforward struct extension; no issues found. |
| apps/symphony/src/codex/app_server.rs | Wires the per-turn token counters (`turn_input_tokens`, `turn_output_tokens`, `turn_total_tokens`, `turn_rate_limits`) into the new `TurnCompleted` event fields. Change is minimal and correctly mirrors the existing `TurnResult` fields. |
| apps/symphony/tests/orchestrator_tests.rs | Adds three new focused tests: real-time activity refreshing stall detection, sliding stall window via sequential streamed events, and cumulative token accumulation across multiple `TurnCompleted` events. Covers the main behavioral promises of the PR well. |
| apps/symphony/tests/domain_tests.rs | Minor update to populate the four new `TurnCompleted` fields in the existing `test_agent_event_variants` fixture. No issues. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OL as Orchestrator run_loop
    participant WT as Worker Task (tokio::spawn)
    participant CS as run_codex_turns_in_session
    participant WE as worker_event_tx (UnboundedSender)
    participant WR as worker_result_tx (UnboundedSender)
    participant ER as worker_event_rx
    participant RR as worker_result_rx

    OL->>WT: spawn(run_worker_task, event_tx)
    activate WT
    WT->>CS: run_codex_turns_in_session(..., stream_event)
    loop Per turn
        CS->>WE: stream_event(TurnCompleted{tokens,...})
        WE-->>ER: (issue_id, TurnCompleted)
        ER-->>OL: select! wakes
        OL->>OL: ingest_agent_event → apply_turn_metrics
        OL->>OL: publish_snapshot()
        CS->>CS: observed_events.push(event)
    end
    CS-->>WT: Ok(SessionTurnLoopSuccess{events, metrics})
    WT->>WR: send(WorkerResult{events: vec![], metrics})
    deactivate WT
    WR-->>OL: select! wakes
    OL->>OL: handle_worker_result (logs metrics only, events loop is no-op)
    OL->>OL: handle_worker_completion
    OL->>OL: publish_snapshot()
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/symphony/src/orchestrator.rs`, line 803-807 ([link](https://github.com/gannonh/kata/blob/11c9b7d71d7f5e7d2ea896c0243e17f233f31f26/apps/symphony/src/orchestrator.rs#L803-L807)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Dead event-ingestion loop after event stream migration**

   Since this PR sets `events: vec![]` for every spawned `WorkerResult` (lines 372 and 381), the `for event in &result.events` loop below will never execute for spawned workers. The comment "Ingest agent events (for activity tracking, token accounting, etc.)" is now misleading — all actual event ingestion happens in real-time via the `worker_event_rx` channel. Any future developer reading this may assume the loop is still doing meaningful work.

   The entire loop can be removed (or replaced with a debug assertion) since events have already been fully processed before the `WorkerResult` arrives:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/orchestrator.rs
   Line: 803-807

   Comment:
   **Dead event-ingestion loop after event stream migration**

   Since this PR sets `events: vec![]` for every spawned `WorkerResult` (lines 372 and 381), the `for event in &result.events` loop below will never execute for spawned workers. The comment "Ingest agent events (for activity tracking, token accounting, etc.)" is now misleading — all actual event ingestion happens in real-time via the `worker_event_rx` channel. Any future developer reading this may assume the loop is still doing meaningful work.

   The entire loop can be removed (or replaced with a debug assertion) since events have already been fully processed before the `WorkerResult` arrives:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/symphony/src/orchestrator.rs`, line 1336-1344 ([link](https://github.com/gannonh/kata/blob/11c9b7d71d7f5e7d2ea896c0243e17f233f31f26/apps/symphony/src/orchestrator.rs#L1336-L1344)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inline path silently discards real-time events**

   The inline run path passes `|_event| {}` as the `stream_event` callback, so `TurnCompleted` (and `Notification`) events are not streamed at all during execution. This is architecturally consistent — the orchestrator is blocked awaiting this call, so it can't consume a channel in parallel — but it creates an asymmetry worth documenting: the inline path's stall detection is only updated _after_ the entire session loop completes (when `ingest_agent_event` is called over `observed_events`), whereas spawned workers get continuous real-time updates.

   A comment here would make the intent clear and prevent future contributors from trying to wire up real-time streaming for the inline path without understanding why it doesn't work:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/orchestrator.rs
   Line: 1336-1344

   Comment:
   **Inline path silently discards real-time events**

   The inline run path passes `|_event| {}` as the `stream_event` callback, so `TurnCompleted` (and `Notification`) events are not streamed at all during execution. This is architecturally consistent — the orchestrator is blocked awaiting this call, so it can't consume a channel in parallel — but it creates an asymmetry worth documenting: the inline path's stall detection is only updated _after_ the entire session loop completes (when `ingest_agent_event` is called over `observed_events`), whereas spawned workers get continuous real-time updates.

   A comment here would make the intent clear and prevent future contributors from trying to wire up real-time streaming for the inline path without understanding why it doesn't work:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 803-807

Comment:
**Dead event-ingestion loop after event stream migration**

Since this PR sets `events: vec![]` for every spawned `WorkerResult` (lines 372 and 381), the `for event in &result.events` loop below will never execute for spawned workers. The comment "Ingest agent events (for activity tracking, token accounting, etc.)" is now misleading — all actual event ingestion happens in real-time via the `worker_event_rx` channel. Any future developer reading this may assume the loop is still doing meaningful work.

The entire loop can be removed (or replaced with a debug assertion) since events have already been fully processed before the `WorkerResult` arrives:

```suggestion
    // Agent events for spawned workers are ingested in real-time via the
    // worker_event_rx channel. result.events is always empty for spawned workers.
    debug_assert!(result.events.is_empty(), "spawned worker results should carry no events");

```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 706-714

Comment:
**Race between event stream and worker result may cause stale `worker_last_activity_ms` entry**

The `worker_event_rx` and `worker_result_rx` are independent channels in the same `tokio::select!`. A worker always sends its final event (e.g., the last `TurnCompleted`) to `worker_event_tx` _before_ sending `WorkerResult` to `worker_result_tx`, but the select can pick up `worker_result_rx` first if both are ready concurrently.

If `WorkerResult` is processed before the final streamed event:
1. `handle_worker_completion` calls `self.worker_last_activity_ms.remove(issue_id)` — cleaning up the entry.
2. The late `TurnCompleted` event then arrives and `record_worker_activity` re-inserts a stale timestamp for the now-completed issue.
3. If the issue is immediately re-dispatched (e.g., on retry), the new run inherits this stale timestamp, making it appear as if there was recent activity at the timestamp of the _previous_ run's final turn, which could suppress stall detection for the new run's initial window.

Since `handle_worker_completion` also re-inserts into `running` for retry attempts, and `detect_stalled_workers` uses `worker_last_activity_ms` keyed by `issue_id`, a stale entry from the prior run could delay the stall window for the new run by up to however long it takes for the first fresh event to arrive.

A lightweight mitigation is to skip `record_worker_activity` if the issue is no longer in `running`:
```rust
// In record_worker_activity or at the ingest_agent_event call-site:
if self.state.running.contains_key(issue_id) {
    self.record_worker_activity(issue_id, event_timestamp_ms(event));
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 1336-1344

Comment:
**Inline path silently discards real-time events**

The inline run path passes `|_event| {}` as the `stream_event` callback, so `TurnCompleted` (and `Notification`) events are not streamed at all during execution. This is architecturally consistent — the orchestrator is blocked awaiting this call, so it can't consume a channel in parallel — but it creates an asymmetry worth documenting: the inline path's stall detection is only updated _after_ the entire session loop completes (when `ingest_agent_event` is called over `observed_events`), whereas spawned workers get continuous real-time updates.

A comment here would make the intent clear and prevent future contributors from trying to wire up real-time streaming for the inline path without understanding why it doesn't work:

```suggestion
        // The inline path runs synchronously on the orchestrator's own task; the run_loop
        // is blocked until this await completes, so there is no consumer for a streaming
        // channel. Events are collected in `observed_events` and ingested after the loop.
        |_event| {},
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(symphony): stre..."](https://github.com/gannonh/kata/commit/11c9b7d71d7f5e7d2ea896c0243e17f233f31f26)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->