### PR TITLE
feat: richer Symphony HTTP dashboard session views

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -288,7 +288,7 @@ workflow file (e.g. `0.0.0.0` to bind all interfaces).
 
 | Method | Path                        | Description                                                                                                                                                                      |
 | ------ | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET`  | `/`                         | HTML dashboard — auto-refreshes every 2 seconds. Shows running/retry/claimed/completed counts, token totals, rate limit state, and live JSON state.                              |
+| `GET`  | `/`                         | HTML dashboard — auto-refreshes every 2 seconds. Shows summary cards, running sessions table, retry queue table, completed issue list, token breakdown, polling diagnostics, and collapsible rate-limit JSON. |
 | `GET`  | `/api/v1/state`             | Full orchestrator state as JSON.                                                                                                                                                 |
 | `GET`  | `/api/v1/:issue_identifier` | Per-issue projection. `:issue_identifier` must match the pattern `TEAM-NNN` (uppercase prefix, hyphen, digits). Returns 404 when the issue is not running or in the retry queue. |
 | `POST` | `/api/v1/refresh`           | Request an immediate Linear poll. Requests are coalesced — multiple concurrent POSTs result in one actual refresh. Returns 202.                                                  |

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -180,8 +180,6 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     } else {
         "no"
     };
-    let polling_next_poll_in_ms = snapshot.polling.next_poll_in_ms;
-    let polling_interval_ms = snapshot.polling.poll_interval_ms;
 
     let rate_limit_block = snapshot
         .codex_rate_limits
@@ -298,8 +296,8 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       <div><div class=\"label\">last poll at</div><div class=\"mono\" id=\"polling-last-poll\">n/a</div></div>
       <div><div class=\"label\">poll count</div><div class=\"mono\" id=\"polling-count\">n/a</div></div>
       <div><div class=\"label\">checking</div><div class=\"mono\" id=\"polling-checking\">{polling_checking}</div></div>
-      <div><div class=\"label\">next poll in</div><div class=\"mono\" id=\"polling-next-poll\">{polling_next_poll_in_ms} ms</div></div>
-      <div><div class=\"label\">poll interval</div><div class=\"mono\" id=\"polling-interval\">{polling_interval_ms} ms</div></div>
+      <div><div class=\"label\">next poll in</div><div class=\"mono\" id=\"polling-next-poll\">n/a</div></div>
+      <div><div class=\"label\">poll interval</div><div class=\"mono\" id=\"polling-interval\">n/a</div></div>
     </div>
   </section>
 
@@ -321,6 +319,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     }}
 
     function formatDuration(ms) {{
+      if (ms === null || ms === undefined) return 'n/a';
       const numeric = Number(ms);
       if (!Number.isFinite(numeric)) return 'n/a';
       const sign = numeric < 0 ? '-' : '';
@@ -378,8 +377,13 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
 
     function renderRetryTable(retryQueue) {{
       const rows = Array.isArray(retryQueue) ? retryQueue.slice() : [];
+
+      function retryDelayValue(entry) {{
+        return entry.retry_after_ms ?? entry.due_in_ms;
+      }}
+
       rows.sort(function(a, b) {{
-        return Number(a.due_in_ms ?? a.retry_after_ms ?? 0) - Number(b.due_in_ms ?? b.retry_after_ms ?? 0);
+        return Number(retryDelayValue(a) ?? 0) - Number(retryDelayValue(b) ?? 0);
       }});
 
       if (rows.length === 0) {{
@@ -387,7 +391,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }}
 
       return rows.map(function(retry) {{
-        const retryAfterMs = retry.retry_after_ms ?? retry.due_in_ms;
+        const retryAfterMs = retryDelayValue(retry);
         return '<tr>' +
           '<td class=\"mono\">' + escapeHtml(retry.identifier || '-') + '</td>' +
           '<td>' + escapeHtml(retry.attempt ?? '-') + '</td>' +

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -172,7 +172,16 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     let retry_count = snapshot.retry_queue.len();
     let completed_count = snapshot.completed.len();
     let claimed_count = snapshot.claimed.len();
+    let input_tokens = snapshot.codex_totals.input_tokens;
+    let output_tokens = snapshot.codex_totals.output_tokens;
     let total_tokens = snapshot.codex_totals.total_tokens;
+    let polling_checking = if snapshot.polling.checking {
+        "yes"
+    } else {
+        "no"
+    };
+    let polling_next_poll_in_ms = snapshot.polling.next_poll_in_ms;
+    let polling_interval_ms = snapshot.polling.poll_interval_ms;
 
     let rate_limit_block = snapshot
         .codex_rate_limits
@@ -191,50 +200,261 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
   <title>Symphony Dashboard</title>
   <style>
     :root {{ color-scheme: dark; }}
-    body {{ font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; background: #10131a; color: #f1f5f9; margin: 0; padding: 24px; }}
-    h1 {{ margin-top: 0; }}
-    .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 16px; }}
+    body {{ font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; background: #10131a; color: #f1f5f9; margin: 0; padding: 24px; line-height: 1.45; }}
+    h1 {{ margin-top: 0; margin-bottom: 12px; }}
+    h2 {{ margin: 0 0 10px; font-size: 18px; }}
+    .grid {{ display: grid; gap: 12px; margin-bottom: 16px; }}
+    .summary-grid {{ grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }}
+    .token-grid {{ grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); margin-bottom: 0; }}
     .card {{ background: #1c2430; border: 1px solid #314154; border-radius: 10px; padding: 12px; }}
     .label {{ color: #94a3b8; font-size: 12px; text-transform: uppercase; letter-spacing: .03em; }}
     .value {{ font-size: 24px; font-weight: 700; margin-top: 4px; }}
-    pre {{ white-space: pre-wrap; word-break: break-word; background: #0b1119; border: 1px solid #27354a; border-radius: 8px; padding: 10px; }}
+    .mono {{ font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }}
+    .section {{ margin-top: 12px; }}
+    .table-wrap {{ overflow-x: auto; }}
+    table {{ width: 100%; border-collapse: collapse; font-size: 14px; }}
+    th, td {{ padding: 8px; border-bottom: 1px solid #2b3a4e; text-align: left; vertical-align: top; }}
+    th {{ color: #a8b8cc; font-size: 12px; text-transform: uppercase; letter-spacing: .03em; }}
+    td {{ color: #d7e1ee; }}
+    td.mono {{ word-break: break-all; }}
+    .list {{ margin: 0; padding-left: 20px; }}
+    .muted {{ color: #94a3b8; }}
+    .error {{ margin-top: 12px; color: #fca5a5; }}
+    .polling-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 8px; margin: 0; }}
+    .polling-grid div {{ background: #0f1724; border: 1px solid #27354a; border-radius: 8px; padding: 8px; }}
+    details summary {{ cursor: pointer; font-weight: 600; }}
+    pre {{ white-space: pre-wrap; word-break: break-word; background: #0b1119; border: 1px solid #27354a; border-radius: 8px; padding: 10px; margin-top: 10px; }}
   </style>
 </head>
 <body>
   <h1>Symphony Dashboard</h1>
-  <div class=\"grid\">
+  <div class=\"grid summary-grid\">
     <section class=\"card\"><div class=\"label\">running</div><div class=\"value\" id=\"running-count\">{running_count}</div></section>
     <section class=\"card\"><div class=\"label\">retry</div><div class=\"value\" id=\"retry-count\">{retry_count}</div></section>
     <section class=\"card\"><div class=\"label\">claimed</div><div class=\"value\" id=\"claimed-count\">{claimed_count}</div></section>
     <section class=\"card\"><div class=\"label\">completed</div><div class=\"value\" id=\"completed-count\">{completed_count}</div></section>
-    <section class=\"card\"><div class=\"label\">token_total</div><div class=\"value\" id=\"token-total\">{total_tokens}</div></section>
   </div>
 
-  <section class=\"card\">
-    <h2>Rate limits</h2>
-    <pre id=\"rate-limits\">{rate_limit_block}</pre>
+  <section class=\"card section\">
+    <h2>Token summary</h2>
+    <div class=\"grid token-grid\">
+      <div><div class=\"label\">input tokens</div><div class=\"value\" id=\"token-input\">{input_tokens}</div></div>
+      <div><div class=\"label\">output tokens</div><div class=\"value\" id=\"token-output\">{output_tokens}</div></div>
+      <div><div class=\"label\">total tokens</div><div class=\"value\" id=\"token-total\">{total_tokens}</div></div>
+    </div>
   </section>
 
-  <section class=\"card\" style=\"margin-top: 12px;\">
-    <h2>Live state</h2>
-    <pre id=\"state-json\"></pre>
+  <section class=\"card section\">
+    <h2>Running sessions</h2>
+    <div class=\"table-wrap\">
+      <table>
+        <thead>
+          <tr>
+            <th>Identifier</th>
+            <th>Status</th>
+            <th>Attempt</th>
+            <th>Elapsed</th>
+            <th>Workspace</th>
+            <th>Worker host</th>
+          </tr>
+        </thead>
+        <tbody id=\"running-table-body\">
+          <tr><td class=\"muted\" colspan=\"6\">Loading...</td></tr>
+        </tbody>
+      </table>
+    </div>
   </section>
+
+  <section class=\"card section\">
+    <h2>Retry queue</h2>
+    <div class=\"table-wrap\">
+      <table>
+        <thead>
+          <tr>
+            <th>Identifier</th>
+            <th>Attempt</th>
+            <th>Error</th>
+            <th>Retry after</th>
+            <th>Worker host</th>
+          </tr>
+        </thead>
+        <tbody id=\"retry-table-body\">
+          <tr><td class=\"muted\" colspan=\"5\">Loading...</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class=\"card section\">
+    <h2>Completed issues</h2>
+    <ul id=\"completed-list\" class=\"list\">
+      <li class=\"muted\">Loading...</li>
+    </ul>
+  </section>
+
+  <section class=\"card section\">
+    <h2>Polling</h2>
+    <div class=\"polling-grid\">
+      <div><div class=\"label\">last poll at</div><div class=\"mono\" id=\"polling-last-poll\">n/a</div></div>
+      <div><div class=\"label\">poll count</div><div class=\"mono\" id=\"polling-count\">n/a</div></div>
+      <div><div class=\"label\">checking</div><div class=\"mono\" id=\"polling-checking\">{polling_checking}</div></div>
+      <div><div class=\"label\">next poll in</div><div class=\"mono\" id=\"polling-next-poll\">{polling_next_poll_in_ms} ms</div></div>
+      <div><div class=\"label\">poll interval</div><div class=\"mono\" id=\"polling-interval\">{polling_interval_ms} ms</div></div>
+    </div>
+  </section>
+
+  <details class=\"card section\" open>
+    <summary>Rate limits</summary>
+    <pre id=\"rate-limits\" class=\"mono\">{rate_limit_block}</pre>
+  </details>
+
+  <p id=\"refresh-error\" class=\"error\" hidden></p>
 
   <script>
+    function escapeHtml(value) {{
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }}
+
+    function formatDuration(ms) {{
+      const numeric = Number(ms);
+      if (!Number.isFinite(numeric)) return 'n/a';
+      const sign = numeric < 0 ? '-' : '';
+      const totalSeconds = Math.floor(Math.abs(numeric) / 1000);
+      const hours = Math.floor(totalSeconds / 3600);
+      const minutes = Math.floor((totalSeconds % 3600) / 60);
+      const seconds = totalSeconds % 60;
+      if (hours > 0) return sign + hours + 'h ' + minutes + 'm ' + seconds + 's';
+      if (minutes > 0) return sign + minutes + 'm ' + seconds + 's';
+      return sign + seconds + 's';
+    }}
+
+    function formatRetryDelay(ms) {{
+      const numeric = Number(ms);
+      if (!Number.isFinite(numeric)) return 'n/a';
+      if (numeric <= 0) return 'ready';
+      return 'in ' + formatDuration(numeric);
+    }}
+
+    function formatDate(value) {{
+      if (value === null || value === undefined) return 'n/a';
+      if (typeof value === 'string') {{
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+      }}
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) return String(value);
+      const parsed = new Date(numeric);
+      return Number.isNaN(parsed.getTime()) ? String(value) : parsed.toISOString();
+    }}
+
+    function renderRunningTable(running) {{
+      const rows = Object.values(running || {{}}).sort(function(a, b) {{
+        return String(a.issue_identifier || '').localeCompare(String(b.issue_identifier || ''));
+      }});
+
+      if (rows.length === 0) {{
+        return '<tr><td class=\"muted\" colspan=\"6\">No running sessions.</td></tr>';
+      }}
+
+      return rows.map(function(run) {{
+        const startedAt = Date.parse(run.started_at || '');
+        const elapsed = Number.isFinite(startedAt) ? formatDuration(Date.now() - startedAt) : 'n/a';
+        const attempt = run.attempt ?? 1;
+        return '<tr>' +
+          '<td class=\"mono\">' + escapeHtml(run.issue_identifier || '-') + '</td>' +
+          '<td>' + escapeHtml(run.status || '-') + '</td>' +
+          '<td>' + escapeHtml(attempt) + '</td>' +
+          '<td class=\"mono\">' + escapeHtml(elapsed) + '</td>' +
+          '<td class=\"mono\">' + escapeHtml(run.workspace_path || '-') + '</td>' +
+          '<td>' + escapeHtml(run.worker_host || 'local') + '</td>' +
+          '</tr>';
+      }}).join('');
+    }}
+
+    function renderRetryTable(retryQueue) {{
+      const rows = Array.isArray(retryQueue) ? retryQueue.slice() : [];
+      rows.sort(function(a, b) {{
+        return Number(a.due_in_ms ?? a.retry_after_ms ?? 0) - Number(b.due_in_ms ?? b.retry_after_ms ?? 0);
+      }});
+
+      if (rows.length === 0) {{
+        return '<tr><td class=\"muted\" colspan=\"5\">No pending retries.</td></tr>';
+      }}
+
+      return rows.map(function(retry) {{
+        const retryAfterMs = retry.retry_after_ms ?? retry.due_in_ms;
+        return '<tr>' +
+          '<td class=\"mono\">' + escapeHtml(retry.identifier || '-') + '</td>' +
+          '<td>' + escapeHtml(retry.attempt ?? '-') + '</td>' +
+          '<td>' + escapeHtml(retry.error || '-') + '</td>' +
+          '<td class=\"mono\">' + escapeHtml(formatRetryDelay(retryAfterMs)) + '</td>' +
+          '<td>' + escapeHtml(retry.worker_host || 'local') + '</td>' +
+          '</tr>';
+      }}).join('');
+    }}
+
+    function renderCompleted(completed) {{
+      const items = Array.isArray(completed) ? completed.slice().sort() : [];
+      if (items.length === 0) {{
+        return '<li class=\"muted\">No completed issues yet.</li>';
+      }}
+
+      return items.map(function(issueId) {{
+        return '<li class=\"mono\">' + escapeHtml(issueId) + '</li>';
+      }}).join('');
+    }}
+
+    function updatePolling(polling) {{
+      const poll = polling || {{}};
+      document.getElementById('polling-last-poll').textContent = formatDate(poll.last_poll_at);
+      document.getElementById('polling-count').textContent =
+        poll.poll_count === undefined || poll.poll_count === null ? 'n/a' : String(poll.poll_count);
+      document.getElementById('polling-checking').textContent = poll.checking ? 'yes' : 'no';
+      document.getElementById('polling-next-poll').textContent = formatDuration(poll.next_poll_in_ms);
+      document.getElementById('polling-interval').textContent = formatDuration(poll.poll_interval_ms);
+    }}
+
+    function clearError() {{
+      const error = document.getElementById('refresh-error');
+      error.hidden = true;
+      error.textContent = '';
+    }}
+
+    function showError(message) {{
+      const error = document.getElementById('refresh-error');
+      error.hidden = false;
+      error.textContent = message;
+    }}
+
     async function refreshState() {{
       try {{
         const response = await fetch('/api/v1/state');
         if (!response.ok) throw new Error('state fetch failed: ' + response.status);
         const state = await response.json();
-        document.getElementById('state-json').textContent = JSON.stringify(state, null, 2);
-        document.getElementById('running-count').textContent = Object.keys(state.running || {{}}).length;
-        document.getElementById('retry-count').textContent = (state.retry_queue || []).length;
+        const running = state.running || {{}};
+        const retryQueue = state.retry_queue || [];
+        const completed = state.completed || [];
+
+        document.getElementById('running-count').textContent = Object.keys(running).length;
+        document.getElementById('retry-count').textContent = retryQueue.length;
         document.getElementById('claimed-count').textContent = (state.claimed || []).length;
-        document.getElementById('completed-count').textContent = (state.completed || []).length;
+        document.getElementById('completed-count').textContent = completed.length;
+        document.getElementById('running-table-body').innerHTML = renderRunningTable(running);
+        document.getElementById('retry-table-body').innerHTML = renderRetryTable(retryQueue);
+        document.getElementById('completed-list').innerHTML = renderCompleted(completed);
+        document.getElementById('token-input').textContent = state.codex_totals?.input_tokens ?? 0;
+        document.getElementById('token-output').textContent = state.codex_totals?.output_tokens ?? 0;
         document.getElementById('token-total').textContent = state.codex_totals?.total_tokens ?? 0;
         document.getElementById('rate-limits').textContent = JSON.stringify(state.codex_rate_limits || {{}}, null, 2);
+        updatePolling(state.polling);
+        clearError();
       }} catch (error) {{
-        document.getElementById('state-json').textContent = String(error);
+        showError(String(error));
       }}
     }}
     refreshState();

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -189,6 +189,14 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "dashboard shell should include rate-limit diagnostics section"
     );
     assert!(
+        body.contains("id=\\\"polling-next-poll\\\">n/a"),
+        "dashboard shell should initialize next-poll tile with n/a placeholder"
+    );
+    assert!(
+        body.contains("id=\\\"polling-interval\\\">n/a"),
+        "dashboard shell should initialize poll-interval tile with n/a placeholder"
+    );
+    assert!(
         !body.contains("Live state"),
         "dashboard shell should no longer expose the raw live-state section"
     );

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -130,7 +130,7 @@ async fn body_json(response: axum::response::Response) -> Value {
 }
 
 #[tokio::test]
-async fn test_get_root_returns_html_dashboard_shell_with_state_sections() {
+async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
     let app = test_router();
 
     let response = app
@@ -165,12 +165,32 @@ async fn test_get_root_returns_html_dashboard_shell_with_state_sections() {
         "dashboard shell should include visible product heading"
     );
     assert!(
-        body.contains("running"),
-        "dashboard shell should include running section"
+        body.contains("Running sessions"),
+        "dashboard shell should include running sessions table section"
     );
     assert!(
-        body.contains("retry"),
-        "dashboard shell should include retry diagnostics section"
+        body.contains("Retry queue"),
+        "dashboard shell should include retry queue table section"
+    );
+    assert!(
+        body.contains("Completed issues"),
+        "dashboard shell should include completed issue list section"
+    );
+    assert!(
+        body.contains("Token summary"),
+        "dashboard shell should include token summary section"
+    );
+    assert!(
+        body.contains("Polling"),
+        "dashboard shell should include polling section"
+    );
+    assert!(
+        body.contains("Rate limits"),
+        "dashboard shell should include rate-limit diagnostics section"
+    );
+    assert!(
+        !body.contains("Live state"),
+        "dashboard shell should no longer expose the raw live-state section"
     );
 }
 


### PR DESCRIPTION
## Summary
- replace the raw live-state JSON dashboard block with structured sections for running sessions, retry queue entries, completed issues, token summary, polling diagnostics, and collapsible rate-limit JSON
- keep the existing 2-second `/api/v1/state` refresh loop while rendering rows/lists with formatted elapsed and retry timing
- update HTTP dashboard tests and Symphony endpoint docs to match the richer dashboard surface

## Testing
- `cd apps/symphony && cargo fmt --check && cargo test && cargo clippy -- -D warnings`

## Notes
- dashboard polling fields now render both legacy (`last_poll_at`, `poll_count`) and current snapshot fields (`checking`, `next_poll_in_ms`, `poll_interval_ms`), showing `n/a` when unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned dashboard with improved layout featuring structured tables and lists for running sessions, retry queue, and completed issues
  * Token summary card now breaks down input and output tokens separately
  * Rate limits display is now expandable for a cleaner interface
  * Added polling status card showing current polling information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the raw live-state JSON block in the Symphony HTTP dashboard with a set of structured, auto-refreshing sections: a running-sessions table, retry-queue table, completed-issue list, token breakdown, polling diagnostics, and a collapsible rate-limit JSON block. The 2-second `/api/v1/state` fetch loop is preserved; all new rendering is done client-side via plain JS helpers injected into the server-formatted HTML string.

**Key changes:**
- `http_server.rs` — extracts `input_tokens`, `output_tokens`, and three polling fields from the snapshot for initial server-side render; rewrites the `<style>` block and HTML body; adds `escapeHtml`, `formatDuration`, `formatRetryDelay`, `formatDate`, render helpers, and `updatePolling` to `refreshState`
- `http_server_tests.rs` — test renamed and updated to assert the six new section headings and negatively assert the removal of the old "Live state" section
- `AGENTS.md` — dashboard endpoint description updated to list the new surface

**Issues found:**
- `formatDuration(null)` returns `'0s'` instead of `'n/a'`: `Number(null) === 0` is finite, so any polling field the API returns as JSON `null` (e.g. `next_poll_in_ms` before the first poll) displays `'0s'` rather than the `'n/a'` the PR description promises — while `undefined` correctly returns `'n/a'`
- Retry-queue sort key uses `due_in_ms ?? retry_after_ms` but the displayed "Retry after" cell uses `retry_after_ms ?? due_in_ms`; when both fields are present with different values, the rendered order won't match what the cell shows
- Polling tiles rendered server-side include a hard-coded `" ms"` suffix (e.g. `"5000 ms"`) that JS never clears — after the first successful fetch `updatePolling` replaces the value with formatted duration (e.g. `"5s"`), but on fetch error the stale suffix remains visible

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the formatDuration(null) and retry-sort inconsistencies — neither is a security issue but both produce subtly wrong output
- The HTML/JS changes are self-contained and the Rust-side changes are shallow (field extraction + string interpolation). XSS is properly handled via escapeHtml and textContent throughout. However two JS logic bugs (null vs undefined handling in formatDuration, reversed field preference in retry sort) produce visibly incorrect output in real edge cases, and the stale " ms" suffix is a presentational glitch on fetch error.
- apps/symphony/src/http_server.rs — the embedded JavaScript helpers need attention for the null-handling and retry-sort issues

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/http_server.rs | Replaces raw live-state JSON with rich structured dashboard sections; introduces several JS helpers with two logic gaps: formatDuration(null) returns '0s' instead of 'n/a', and retry-queue sort/display use reversed field-preference order |
| apps/symphony/tests/http_server_tests.rs | Test updated to assert new section headings (Running sessions, Retry queue, Completed issues, Token summary, Polling, Rate limits) and negatively assert removal of "Live state"; coverage is appropriate for the HTML shell |
| apps/symphony/AGENTS.md | Documentation updated to reflect richer dashboard surface; one-line description change, no issues found |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant DashboardRoute as GET /
    participant StateRoute as GET /api/v1/state
    participant Orchestrator

    Browser->>DashboardRoute: HTTP GET /
    DashboardRoute->>Orchestrator: snapshot()
    Orchestrator-->>DashboardRoute: OrchestratorSnapshot<br/>(counts, tokens, polling, rate limits)
    DashboardRoute-->>Browser: HTML shell<br/>(server-rendered: counts, token totals,<br/>polling.checking/next_poll/interval,<br/>rate_limit_block)

    loop every 2 seconds (refreshState)
        Browser->>StateRoute: fetch /api/v1/state
        StateRoute->>Orchestrator: snapshot()
        Orchestrator-->>StateRoute: full JSON state
        StateRoute-->>Browser: JSON (running, retry_queue,<br/>completed, codex_totals, polling,<br/>codex_rate_limits)
        Browser->>Browser: renderRunningTable(running)
        Browser->>Browser: renderRetryTable(retry_queue)
        Browser->>Browser: renderCompleted(completed)
        Browser->>Browser: updatePolling(polling)
        Browser->>Browser: update token / rate-limit elements
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 290-295

Comment:
**`formatDuration(null)` returns `'0s'` instead of `'n/a'`**

The `formatDuration` helper guards only against non-finite numbers. `Number(null)` evaluates to `0`, which *is* finite, so any polling field that arrives as JSON `null` (e.g. `next_poll_in_ms: null` when polling hasn't started yet) will render as `'0s'` rather than the `'n/a'` the PR description promises.

`Number(undefined)` is `NaN` (→ `'n/a'`), so the two nullable primitives are handled inconsistently.

Add a `null`/`undefined` guard at the top of the function:

```suggestion
    function formatDuration(ms) {{
      if (ms === null || ms === undefined) return 'n/a';
      const numeric = Number(ms);
      if (!Number.isFinite(numeric)) return 'n/a';
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 340-350

Comment:
**Inconsistent field-preference between sort key and display value**

The retry-queue rows are sorted by `due_in_ms ?? retry_after_ms`, but the value rendered in the "Retry after" column is `retry_after_ms ?? due_in_ms` — the fallback order is reversed. When an entry has both fields with different values the row is sorted by `due_in_ms` but displays the `retry_after_ms` delay, so the visual order won't match what's shown in the cell.

Pick one canonical field and apply it consistently in both places:

```suggestion
      rows.sort(function(a, b) {{
        return Number(a.retry_after_ms ?? a.due_in_ms ?? 0) - Number(b.retry_after_ms ?? b.due_in_ms ?? 0);
      }});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 420-425

Comment:
**Polling tiles use different number format before first JS refresh**

The server-side template renders `{polling_next_poll_in_ms} ms` and `{polling_interval_ms} ms` (raw milliseconds, e.g. `"5000 ms"`), while `updatePolling` later replaces those values with `formatDuration(...)` output (e.g. `"5s"`). The unit suffix `" ms"` baked into the HTML is therefore left as a stale artefact that the JS never clears — it will briefly appear on load and permanently on any network error (when the catch branch fires `showError` but the polling tiles aren't reset).

Consider either removing the static `" ms"` suffix from the HTML template and relying solely on JS formatting, or initialising those elements to the formatted value on the Rust side too.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(symphony): enri..."](https://github.com/gannonh/kata/commit/7b21d19cb7d56eb6ade1fe47be63dd52ad43e691)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->