### PR TITLE
CLI v0.4.1

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.4.1
+
+### Features
+
+- **Step badge in auto-mode** — statusline now shows a `step` badge while a dispatch unit is active, clearing on agent turn end. Makes it visible which phase auto-mode is executing.
+- **Remove `kata-run` slash command** — deleted the unused `/kata-run` command and its registration.
+
+### Fixes
+
+- **Linear auto-close recovery in auto-mode** — when Linear's "Auto-close parent issues" setting moves a slice to Done before the complete-slice unit runs, auto-mode now detects the skip (missing slice summary), overrides state to `summarizing`, and forces the complete-slice dispatch. Also runs the PR gate on final completion when the early exit would otherwise skip it.
+- **Stale milestone ID after recovery** — fixed `mid` staying null after recovery path A, which caused the normal stop block to fire and undo the recovery.
+- **Finalize metrics before PR gate** — snapshot unit metrics and save activity log before the PR gate early return in recovery path B, preventing dropped metrics for the complete-slice unit.
+- **Stop on legacy merge failure** — auto-mode now stops on squash merge failure instead of falling through to `skipped`, which could leave the repo in an inconsistent state.
+- **Test reliability** — added 60s timeouts to four slow smoke tests; fixed linear-config integration test skip gating and done-callback timeout.
+
 ## 0.4.0
 
 ### Features

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## CLI v0.4.1

### Features

- **Step badge in auto-mode** — statusline now shows a `step` badge while a dispatch unit is active, clearing on agent turn end.
- **Remove `kata-run` slash command** — deleted the unused `/kata-run` command and its registration.

### Fixes

- **Linear auto-close recovery in auto-mode** — when Linear's "Auto-close parent issues" setting moves a slice to Done before the complete-slice unit runs, auto-mode now detects the skip and forces the complete-slice dispatch. Also runs the PR gate on final completion.
- **Stale milestone ID after recovery** — fixed `mid` staying null after recovery path A.
- **Finalize metrics before PR gate** — snapshot unit metrics and save activity log before the PR gate early return.
- **Stop on legacy merge failure** — auto-mode now stops on squash merge failure instead of falling through.
- **Test reliability** — added 60s timeouts to slow smoke tests; fixed linear-config integration test skip gating.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `@kata-sh/cli` package version from `0.4.0` to `0.4.1` and adds the corresponding `CHANGELOG.md` entry. The diff itself is purely administrative — documenting and publishing the bug-fix/feature release described in the PR description, with no functional code changes present in this changeset.

Key points from the changelog entry:
- New step badge in auto-mode statusline and removal of the unused `/kata-run` slash command are documented as features.
- Five bug fixes are documented, covering Linear auto-close recovery, stale milestone ID, metrics finalization before the PR gate, squash-merge failure handling, and test reliability improvements.
- Version in `package.json` (`0.4.1`) is in sync with the new `## 0.4.1` changelog section.
- Changelog format is consistent with all previous entries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only a version bump and a CHANGELOG update with no functional code changes.
- Both changed files are purely administrative. The version number in `package.json` matches the new changelog section, formatting is consistent, and there are no code logic changes to evaluate.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/CHANGELOG.md | Added 0.4.1 changelog section documenting features and fixes; content is accurate and consistent with the PR description. |
| apps/cli/package.json | Version bumped from 0.4.0 to 0.4.1; consistent with the changelog entry. No other fields modified. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: CLI v0.4.1] --> B[apps/cli/package.json\nversion: 0.4.0 → 0.4.1]
    A --> C[apps/cli/CHANGELOG.md\nAdd ## 0.4.1 section]
    C --> D[Features\n• Step badge in auto-mode\n• Remove kata-run command]
    C --> E[Fixes\n• Linear auto-close recovery\n• Stale milestone ID\n• Finalize metrics before PR gate\n• Stop on legacy merge failure\n• Test reliability]
    B & C --> F[Release @kata-sh/cli@0.4.1]
```

<sub>Last reviewed commit: ["chore(release): bump..."](https://github.com/gannonh/kata/commit/9b9795e5090d9197087fab9917a042de0c5f63da)</sub>

<!-- /greptile_comment -->