### PR TITLE
KAT-824: Auto-cleanup workspaces on terminal issues

### DIFF
--- a/apps/online-docs/content/docs/symphony/index.mdx
+++ b/apps/online-docs/content/docs/symphony/index.mdx
@@ -16,3 +16,14 @@ Symphony compiles to a standalone binary. It communicates with the rest of the m
 ## Usage
 
 Symphony is invoked through the CLI or directly as a binary. See the monorepo's `apps/symphony/` directory for build instructions.
+
+## Workspace Cleanup
+
+Symphony can automatically clean up per-issue workspaces when an issue reaches a terminal state (`Done`, `Canceled`, etc.).
+
+```yaml
+workspace:
+  cleanup_on_done: true # default: false
+```
+
+When enabled, Symphony runs the `before_remove` hook first, then removes the workspace (including `git worktree remove` for worktree strategy). Cleanup failures are logged and do not stop orchestration.

--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -100,7 +100,6 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | `workspace.branch_prefix` | string | `"symphony"`                  | Branch prefix used for auto-created issue branches (`<prefix>/<issue-identifier>`).                             |
 | `workspace.clone_branch`  | string | _(none)_                      | Optional branch name to clone for `workspace.strategy: clone`. When set, Symphony runs clone bootstrap with `--branch <clone_branch>`. |
 | `workspace.cleanup_on_done` | bool | `false` | Remove the issue workspace when the issue reaches a terminal state. Runs `hooks.before_remove` and ignores cleanup failures. |
-| `workspace.cleanup_on_done` | bool | `false` | Remove the issue workspace when the issue reaches a terminal state. Runs `hooks.before_remove` and ignores cleanup failures. |
 
 #### `agent` section
 
@@ -167,7 +166,6 @@ workspace:
   branch_prefix: symphony
   clone_branch: elixir-feature-parity
   cleanup_on_done: true
-  cleanup_on_done: true
 
 codex:
   command: codex app-server
@@ -202,7 +200,6 @@ workspace:
   repo: /Users/alice/code/kata
   strategy: worktree
   branch_prefix: symphony
-  cleanup_on_done: true
   cleanup_on_done: true
 
 agent:

--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -99,6 +99,8 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | `workspace.strategy`      | string | `"clone"`                     | Bootstrap strategy: `"clone"` (default) or `"worktree"`. `worktree` requires `workspace.repo` to be local path. |
 | `workspace.branch_prefix` | string | `"symphony"`                  | Branch prefix used for auto-created issue branches (`<prefix>/<issue-identifier>`).                             |
 | `workspace.clone_branch`  | string | _(none)_                      | Optional branch name to clone for `workspace.strategy: clone`. When set, Symphony runs clone bootstrap with `--branch <clone_branch>`. |
+| `workspace.cleanup_on_done` | bool | `false` | Remove the issue workspace when the issue reaches a terminal state. Runs `hooks.before_remove` and ignores cleanup failures. |
+| `workspace.cleanup_on_done` | bool | `false` | Remove the issue workspace when the issue reaches a terminal state. Runs `hooks.before_remove` and ignores cleanup failures. |
 
 #### `agent` section
 
@@ -164,6 +166,8 @@ workspace:
   strategy: clone
   branch_prefix: symphony
   clone_branch: elixir-feature-parity
+  cleanup_on_done: true
+  cleanup_on_done: true
 
 codex:
   command: codex app-server
@@ -198,6 +202,8 @@ workspace:
   repo: /Users/alice/code/kata
   strategy: worktree
   branch_prefix: symphony
+  cleanup_on_done: true
+  cleanup_on_done: true
 
 agent:
   max_concurrent_agents: 5

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -182,6 +182,7 @@ struct RawWorkspaceConfig {
     strategy: Option<String>,
     branch_prefix: Option<String>,
     clone_branch: Option<String>,
+    cleanup_on_done: Option<bool>,
 }
 
 #[derive(Deserialize, Default)]
@@ -440,6 +441,9 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         strategy,
         branch_prefix: branch_prefix.trim().to_string(),
         clone_branch,
+        cleanup_on_done: raw_workspace
+            .cleanup_on_done
+            .unwrap_or(defaults.workspace.cleanup_on_done),
     };
 
     // ── WorkerConfig ──────────────────────────────────────────────────────

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -184,6 +184,7 @@ pub struct WorkspaceConfig {
     pub strategy: WorkspaceRepoStrategy,
     pub branch_prefix: String,
     pub clone_branch: Option<String>,
+    pub cleanup_on_done: bool,
 }
 
 /// Workspace repository bootstrap strategy.
@@ -201,6 +202,7 @@ impl Default for WorkspaceConfig {
             strategy: WorkspaceRepoStrategy::Clone,
             branch_prefix: "symphony".to_string(),
             clone_branch: None,
+            cleanup_on_done: false,
         }
     }
 }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -569,6 +569,12 @@ pub struct WorkerResult {
 }
 
 #[derive(Debug, Clone)]
+struct PendingTerminalCleanup {
+    issue: Issue,
+    workspace_path: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct TurnMetrics {
     pub input_tokens: u64,
     pub output_tokens: u64,
@@ -618,6 +624,7 @@ pub struct Orchestrator {
     retry_tokens: HashMap<String, String>,
     worker_last_activity_ms: HashMap<String, i64>,
     worker_session_ids: HashMap<String, String>,
+    pending_terminal_cleanup: HashMap<String, PendingTerminalCleanup>,
     /// Normalized running issue state cache used for per-state slot accounting.
     running_issue_states: HashMap<String, String>,
     next_retry_token: u64,
@@ -688,6 +695,7 @@ impl Orchestrator {
             retry_tokens: HashMap::new(),
             worker_last_activity_ms: HashMap::new(),
             worker_session_ids: HashMap::new(),
+            pending_terminal_cleanup: HashMap::new(),
             running_issue_states: HashMap::new(),
             next_retry_token: 0,
             snapshot_handle: None,
@@ -913,7 +921,7 @@ impl Orchestrator {
         let terminal_issues = port.startup_terminal_issues(&self.config.tracker.terminal_states)?;
 
         for issue in terminal_issues {
-            self.mark_issue_terminal(&issue.id);
+            self.mark_issue_terminal(&issue, None);
         }
 
         Ok(())
@@ -1242,7 +1250,16 @@ impl Orchestrator {
         completion: WorkerCompletion,
         now_ms: i64,
     ) -> Option<String> {
-        let run_attempt = self.state.running.remove(issue_id)?;
+        let Some(run_attempt) = self.state.running.remove(issue_id) else {
+            if self.config.workspace.cleanup_on_done {
+                if let Some(pending) = self.pending_terminal_cleanup.remove(issue_id) {
+                    self.cleanup_workspace(&pending.issue, &pending.workspace_path);
+                }
+            } else {
+                self.pending_terminal_cleanup.remove(issue_id);
+            }
+            return None;
+        };
         self.state.claimed.remove(issue_id);
         self.running_issue_states.remove(issue_id);
         self.worker_last_activity_ms.remove(issue_id);
@@ -1690,7 +1707,7 @@ impl Orchestrator {
 
             let normalized_state = normalize_issue_state(&issue.state);
             if terminal_states.contains(&normalized_state) {
-                self.mark_issue_terminal(&issue.id);
+                self.mark_issue_terminal(&issue, None);
                 continue;
             }
 
@@ -1959,7 +1976,7 @@ impl Orchestrator {
                             state = %hidden_state,
                             "retry issue became terminal before active-candidate visibility; marking terminal"
                         );
-                        self.mark_issue_terminal(&hidden_issue.id);
+                        self.mark_issue_terminal(&hidden_issue, retry.workspace_path.as_deref());
                         continue;
                     }
                 }
@@ -1976,7 +1993,7 @@ impl Orchestrator {
 
             let normalized_state = normalize_issue_state(&issue.state);
             if self.terminal_state_set().contains(&normalized_state) {
-                self.mark_issue_terminal(&issue.id);
+                self.mark_issue_terminal(&issue, retry.workspace_path.as_deref());
                 continue;
             }
 
@@ -2064,11 +2081,42 @@ impl Orchestrator {
             .to_string()
     }
 
-    fn mark_issue_terminal(&mut self, issue_id: &str) {
+    fn mark_issue_terminal(&mut self, issue: &Issue, workspace_path_hint: Option<&str>) {
+        let issue_id = issue.id.as_str();
+
         if self.config.workspace.cleanup_on_done {
-            if let Some(attempt) = self.state.running.get(issue_id) {
-                let workspace_path = attempt.workspace_path.clone();
-                self.cleanup_workspace(issue_id, &workspace_path);
+            let workspace_path = self
+                .state
+                .running
+                .get(issue_id)
+                .map(|attempt| attempt.workspace_path.clone())
+                .or_else(|| {
+                    self.state
+                        .retry_attempts
+                        .get(issue_id)
+                        .and_then(|retry| retry.workspace_path.clone())
+                })
+                .or_else(|| workspace_path_hint.map(str::to_string));
+
+            if let Some(workspace_path) = workspace_path {
+                if self.worker_session_ids.contains_key(issue_id) {
+                    self.pending_terminal_cleanup.insert(
+                        issue_id.to_string(),
+                        PendingTerminalCleanup {
+                            issue: issue.clone(),
+                            workspace_path,
+                        },
+                    );
+                    tracing::info!(
+                        event = "terminal_workspace_cleanup_deferred_active_worker",
+                        issue_id = %issue_id,
+                        issue_identifier = %issue.identifier,
+                        "deferring workspace cleanup until worker completion"
+                    );
+                } else {
+                    self.pending_terminal_cleanup.remove(issue_id);
+                    self.cleanup_workspace(issue, &workspace_path);
+                }
             }
         }
 
@@ -2082,23 +2130,30 @@ impl Orchestrator {
         self.worker_session_ids.remove(issue_id);
     }
 
-    fn cleanup_workspace(&self, issue_id: &str, workspace_path: &str) {
+    fn cleanup_workspace(&self, issue: &Issue, workspace_path: &str) {
         let workspace = Path::new(workspace_path);
         if !workspace.exists() {
             tracing::debug!(
                 event = "terminal_workspace_cleanup_skipped_missing_path",
-                issue_id = %issue_id,
+                issue_id = %issue.id,
+                issue_identifier = %issue.identifier,
                 workspace_path = %workspace.display(),
                 "workspace cleanup skipped because path does not exist"
             );
             return;
         }
 
-        match workspace::remove_workspace(workspace, &self.config.workspace, &self.config.hooks) {
+        match workspace::remove_workspace_for_issue(
+            workspace,
+            &self.config.workspace,
+            &self.config.hooks,
+            issue,
+        ) {
             Ok(()) => {
                 tracing::info!(
                     event = "terminal_workspace_cleanup_succeeded",
-                    issue_id = %issue_id,
+                    issue_id = %issue.id,
+                    issue_identifier = %issue.identifier,
                     workspace_path = %workspace.display(),
                     "removed workspace after issue reached terminal state"
                 );
@@ -2106,7 +2161,8 @@ impl Orchestrator {
             Err(err) => {
                 tracing::warn!(
                     event = "terminal_workspace_cleanup_failed",
-                    issue_id = %issue_id,
+                    issue_id = %issue.id,
+                    issue_identifier = %issue.identifier,
                     workspace_path = %workspace.display(),
                     error = %err,
                     "workspace cleanup failed; continuing terminal transition"

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -2065,6 +2065,13 @@ impl Orchestrator {
     }
 
     fn mark_issue_terminal(&mut self, issue_id: &str) {
+        if self.config.workspace.cleanup_on_done {
+            if let Some(attempt) = self.state.running.get(issue_id) {
+                let workspace_path = attempt.workspace_path.clone();
+                self.cleanup_workspace(issue_id, &workspace_path);
+            }
+        }
+
         self.state.completed.insert(issue_id.to_string());
         self.state.running.remove(issue_id);
         self.state.claimed.remove(issue_id);
@@ -2073,6 +2080,39 @@ impl Orchestrator {
         self.retry_tokens.remove(issue_id);
         self.worker_last_activity_ms.remove(issue_id);
         self.worker_session_ids.remove(issue_id);
+    }
+
+    fn cleanup_workspace(&self, issue_id: &str, workspace_path: &str) {
+        let workspace = Path::new(workspace_path);
+        if !workspace.exists() {
+            tracing::debug!(
+                event = "terminal_workspace_cleanup_skipped_missing_path",
+                issue_id = %issue_id,
+                workspace_path = %workspace.display(),
+                "workspace cleanup skipped because path does not exist"
+            );
+            return;
+        }
+
+        match workspace::remove_workspace(workspace, &self.config.workspace, &self.config.hooks) {
+            Ok(()) => {
+                tracing::info!(
+                    event = "terminal_workspace_cleanup_succeeded",
+                    issue_id = %issue_id,
+                    workspace_path = %workspace.display(),
+                    "removed workspace after issue reached terminal state"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    event = "terminal_workspace_cleanup_failed",
+                    issue_id = %issue_id,
+                    workspace_path = %workspace.display(),
+                    error = %err,
+                    "workspace cleanup failed; continuing terminal transition"
+                );
+            }
+        }
     }
 
     fn release_issue(&mut self, issue_id: &str) {

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration as StdDuration, Instant};
 
@@ -1658,6 +1659,354 @@ fn test_reconcile_non_active_state_stops_run_without_cleanup() {
     assert!(
         !orchestrator.state().completed.contains("issue-non-active"),
         "non-terminal state stop must not add issue to completed (no cleanup semantic)"
+    );
+}
+
+fn command_success(mut cmd: Command, context: &str) -> String {
+    let output = cmd
+        .output()
+        .unwrap_or_else(|err| panic!("{context}: failed to run command: {err}"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "{context}: command failed\nstatus: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        stdout,
+        stderr
+    );
+    stdout.trim().to_string()
+}
+
+fn init_git_repo(path: &Path) {
+    fs::create_dir_all(path).expect("source repo directory should be created");
+    fs::write(path.join("README.md"), "hello\n").expect("source repo file should be written");
+
+    let mut init = Command::new("git");
+    init.current_dir(path).arg("init");
+    command_success(init, "git init source repo");
+
+    let mut set_name = Command::new("git");
+    set_name
+        .current_dir(path)
+        .args(["config", "user.name", "Symphony Test"]);
+    command_success(set_name, "git config user.name");
+
+    let mut set_email = Command::new("git");
+    set_email
+        .current_dir(path)
+        .args(["config", "user.email", "symphony-tests@example.com"]);
+    command_success(set_email, "git config user.email");
+
+    let mut add = Command::new("git");
+    add.current_dir(path).args(["add", "."]);
+    command_success(add, "git add source repo files");
+
+    let mut commit = Command::new("git");
+    commit
+        .current_dir(path)
+        .args(["commit", "-m", "initial commit"]);
+    command_success(commit, "git commit source repo files");
+}
+
+fn shell_quote(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    format!("'{}'", raw.replace('\'', "'\"'\"'"))
+}
+
+#[test]
+fn test_terminal_state_cleanup_removes_workspace_when_enabled() {
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let workspace_path = workspace_root.path().join("SIM-98");
+    fs::create_dir_all(&workspace_path).expect("workspace should exist before cleanup");
+    fs::write(workspace_path.join("artifact.txt"), "temp")
+        .expect("workspace file should exist before cleanup");
+
+    let mut config = test_config(2);
+    config.workspace.root = workspace_root.path().to_string_lossy().to_string();
+    config.workspace.cleanup_on_done = true;
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let attempt = symphony::domain::RunAttempt {
+        issue_id: "issue-terminal-cleanup".to_string(),
+        issue_identifier: "SIM-98".to_string(),
+        attempt: None,
+        workspace_path: workspace_path.to_string_lossy().to_string(),
+        started_at: Utc::now(),
+        status: "running".to_string(),
+        error: None,
+        worker_host: None,
+    };
+    orchestrator
+        .state_mut()
+        .running
+        .insert("issue-terminal-cleanup".to_string(), attempt);
+
+    let mut port = FakePort {
+        reconciled_issues: vec![issue(
+            "issue-terminal-cleanup",
+            "SIM-98",
+            "Done",
+            Some(1),
+            0,
+        )],
+        ..FakePort::default()
+    };
+
+    orchestrator
+        .tick(&mut port)
+        .expect("tick should succeed while cleaning terminal workspace");
+
+    assert!(
+        !workspace_path.exists(),
+        "terminal cleanup should remove workspace directory when enabled"
+    );
+}
+
+#[test]
+fn test_terminal_state_cleanup_preserves_workspace_when_disabled() {
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let workspace_path = workspace_root.path().join("SIM-99");
+    fs::create_dir_all(&workspace_path).expect("workspace should exist before reconcile");
+
+    let mut config = test_config(2);
+    config.workspace.root = workspace_root.path().to_string_lossy().to_string();
+    config.workspace.cleanup_on_done = false;
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let attempt = symphony::domain::RunAttempt {
+        issue_id: "issue-terminal-no-cleanup".to_string(),
+        issue_identifier: "SIM-99".to_string(),
+        attempt: None,
+        workspace_path: workspace_path.to_string_lossy().to_string(),
+        started_at: Utc::now(),
+        status: "running".to_string(),
+        error: None,
+        worker_host: None,
+    };
+    orchestrator
+        .state_mut()
+        .running
+        .insert("issue-terminal-no-cleanup".to_string(), attempt);
+
+    let mut port = FakePort {
+        reconciled_issues: vec![issue(
+            "issue-terminal-no-cleanup",
+            "SIM-99",
+            "Done",
+            Some(1),
+            0,
+        )],
+        ..FakePort::default()
+    };
+
+    orchestrator
+        .tick(&mut port)
+        .expect("tick should succeed with cleanup disabled");
+
+    assert!(
+        workspace_path.exists(),
+        "workspace should be preserved when cleanup_on_done is false"
+    );
+}
+
+#[test]
+fn test_terminal_state_cleanup_runs_before_remove_hook() {
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let workspace_path = workspace_root.path().join("SIM-100");
+    let before_remove_log = workspace_root.path().join("before_remove.log");
+    fs::create_dir_all(&workspace_path).expect("workspace should exist before cleanup");
+
+    let mut config = test_config(2);
+    config.workspace.root = workspace_root.path().to_string_lossy().to_string();
+    config.workspace.cleanup_on_done = true;
+    config.hooks.before_remove = Some(format!(
+        "printf 'before-remove' > {}",
+        shell_quote(&before_remove_log)
+    ));
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let attempt = symphony::domain::RunAttempt {
+        issue_id: "issue-before-remove-hook".to_string(),
+        issue_identifier: "SIM-100".to_string(),
+        attempt: None,
+        workspace_path: workspace_path.to_string_lossy().to_string(),
+        started_at: Utc::now(),
+        status: "running".to_string(),
+        error: None,
+        worker_host: None,
+    };
+    orchestrator
+        .state_mut()
+        .running
+        .insert("issue-before-remove-hook".to_string(), attempt);
+
+    let mut port = FakePort {
+        reconciled_issues: vec![issue(
+            "issue-before-remove-hook",
+            "SIM-100",
+            "Done",
+            Some(1),
+            0,
+        )],
+        ..FakePort::default()
+    };
+
+    orchestrator
+        .tick(&mut port)
+        .expect("tick should succeed while running before_remove hook");
+
+    let hook_output =
+        fs::read_to_string(&before_remove_log).expect("before_remove hook should write log");
+    assert_eq!(hook_output, "before-remove");
+    assert!(
+        !workspace_path.exists(),
+        "workspace should still be removed after before_remove hook runs"
+    );
+}
+
+#[test]
+fn test_terminal_state_cleanup_removes_worktree_checkout_when_enabled() {
+    let tmp = tempdir().expect("test root should be created");
+    let workspace_root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    fs::create_dir_all(&workspace_root).expect("workspace root should be created");
+    init_git_repo(&source_repo);
+
+    let mut config = test_config(2);
+    config.workspace.root = workspace_root.to_string_lossy().to_string();
+    config.workspace.repo = Some(source_repo.to_string_lossy().to_string());
+    config.workspace.strategy = symphony::domain::WorkspaceRepoStrategy::Worktree;
+    config.workspace.cleanup_on_done = true;
+
+    let active_issue = issue(
+        "issue-worktree-cleanup",
+        "SIM-101",
+        "In Progress",
+        Some(1),
+        0,
+    );
+    let workspace = symphony::workspace::ensure_workspace_for_issue(
+        &active_issue,
+        &config.workspace,
+        &config.hooks,
+    )
+    .expect("worktree workspace should be created");
+    let workspace_path = PathBuf::from(&workspace.path);
+
+    let source_repo_str = source_repo.to_string_lossy().to_string();
+    let mut list_before_cmd = Command::new("git");
+    list_before_cmd.args(["-C", &source_repo_str, "worktree", "list", "--porcelain"]);
+    let list_before = command_success(list_before_cmd, "list worktrees before cleanup");
+    assert!(
+        list_before.contains(&workspace.path),
+        "source repo should track worktree before terminal cleanup"
+    );
+
+    let mut orchestrator = Orchestrator::new(config, String::new());
+    let attempt = symphony::domain::RunAttempt {
+        issue_id: "issue-worktree-cleanup".to_string(),
+        issue_identifier: "SIM-101".to_string(),
+        attempt: None,
+        workspace_path: workspace.path.clone(),
+        started_at: Utc::now(),
+        status: "running".to_string(),
+        error: None,
+        worker_host: None,
+    };
+    orchestrator
+        .state_mut()
+        .running
+        .insert("issue-worktree-cleanup".to_string(), attempt);
+
+    let mut port = FakePort {
+        reconciled_issues: vec![issue(
+            "issue-worktree-cleanup",
+            "SIM-101",
+            "Done",
+            Some(1),
+            0,
+        )],
+        ..FakePort::default()
+    };
+
+    orchestrator
+        .tick(&mut port)
+        .expect("tick should succeed while cleaning terminal worktree");
+
+    assert!(
+        !workspace_path.exists(),
+        "terminal cleanup should remove worktree directory"
+    );
+
+    let mut list_after_cmd = Command::new("git");
+    list_after_cmd.args(["-C", &source_repo_str, "worktree", "list", "--porcelain"]);
+    let list_after = command_success(list_after_cmd, "list worktrees after cleanup");
+    assert!(
+        !list_after.contains(&workspace.path),
+        "terminal cleanup should detach worktree from source repository"
+    );
+}
+
+#[test]
+fn test_terminal_state_cleanup_failure_is_non_fatal() {
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let outside_root = tempdir().expect("outside root should be created");
+    let outside_workspace = outside_root.path().join("SIM-102");
+    fs::create_dir_all(&outside_workspace).expect("outside workspace should be created");
+
+    let mut config = test_config(2);
+    config.workspace.root = workspace_root.path().to_string_lossy().to_string();
+    config.workspace.cleanup_on_done = true;
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let attempt = symphony::domain::RunAttempt {
+        issue_id: "issue-cleanup-failure".to_string(),
+        issue_identifier: "SIM-102".to_string(),
+        attempt: None,
+        workspace_path: outside_workspace.to_string_lossy().to_string(),
+        started_at: Utc::now(),
+        status: "running".to_string(),
+        error: None,
+        worker_host: None,
+    };
+    orchestrator
+        .state_mut()
+        .running
+        .insert("issue-cleanup-failure".to_string(), attempt);
+
+    let mut port = FakePort {
+        reconciled_issues: vec![issue(
+            "issue-cleanup-failure",
+            "SIM-102",
+            "Done",
+            Some(1),
+            0,
+        )],
+        ..FakePort::default()
+    };
+
+    orchestrator
+        .tick(&mut port)
+        .expect("cleanup failure should not fail orchestrator tick");
+
+    assert!(
+        orchestrator
+            .state()
+            .completed
+            .contains("issue-cleanup-failure"),
+        "issue should still transition to completed despite cleanup failure"
+    );
+    assert!(
+        !orchestrator
+            .state()
+            .running
+            .contains_key("issue-cleanup-failure"),
+        "running entry should still be removed despite cleanup failure"
+    );
+    assert!(
+        outside_workspace.exists(),
+        "cleanup failure scenario should preserve outside-root workspace path"
     );
 }
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -16,8 +16,8 @@ use symphony::domain::{
 };
 use symphony::error::{Result, SymphonyError};
 use symphony::orchestrator::{
-    refresh_channel, Orchestrator, OrchestratorPort, RetryKind, RuntimeEvent, TurnMetrics,
-    WorkerCompletion, CONTINUATION_RETRY_DELAY_MS,
+    refresh_channel, Orchestrator, OrchestratorPort, RetryContext, RetryKind, RuntimeEvent,
+    TurnMetrics, WorkerCompletion, CONTINUATION_RETRY_DELAY_MS,
 };
 use symphony::workflow_store::WorkflowStore;
 
@@ -1816,12 +1816,16 @@ fn test_terminal_state_cleanup_runs_before_remove_hook() {
     let workspace_path = workspace_root.path().join("SIM-100");
     let before_remove_log = workspace_root.path().join("before_remove.log");
     fs::create_dir_all(&workspace_path).expect("workspace should exist before cleanup");
+    let expected_workspace_path = fs::canonicalize(&workspace_path)
+        .expect("workspace path should canonicalize")
+        .to_string_lossy()
+        .to_string();
 
     let mut config = test_config(2);
     config.workspace.root = workspace_root.path().to_string_lossy().to_string();
     config.workspace.cleanup_on_done = true;
     config.hooks.before_remove = Some(format!(
-        "printf 'before-remove' > {}",
+        "printf 'before-remove|%s|%s|%s|%s' \"$SYMPHONY_ISSUE_ID\" \"$SYMPHONY_ISSUE_IDENTIFIER\" \"$SYMPHONY_ISSUE_TITLE\" \"$SYMPHONY_WORKSPACE_PATH\" > {}",
         shell_quote(&before_remove_log)
     ));
     let mut orchestrator = Orchestrator::new(config, String::new());
@@ -1858,10 +1862,142 @@ fn test_terminal_state_cleanup_runs_before_remove_hook() {
 
     let hook_output =
         fs::read_to_string(&before_remove_log).expect("before_remove hook should write log");
-    assert_eq!(hook_output, "before-remove");
+    let mut fields = hook_output.splitn(5, '|');
+    assert_eq!(fields.next(), Some("before-remove"));
+    assert_eq!(fields.next(), Some("issue-before-remove-hook"));
+    assert_eq!(fields.next(), Some("SIM-100"));
+    assert_eq!(fields.next(), Some("Issue SIM-100"));
+    assert_eq!(fields.next(), Some(expected_workspace_path.as_str()));
     assert!(
         !workspace_path.exists(),
         "workspace should still be removed after before_remove hook runs"
+    );
+}
+
+#[test]
+fn test_terminal_state_cleanup_defers_until_worker_completion() {
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let workspace_path = workspace_root.path().join("SIM-103");
+    fs::create_dir_all(&workspace_path).expect("workspace should exist before cleanup");
+
+    let mut config = test_config(2);
+    config.workspace.root = workspace_root.path().to_string_lossy().to_string();
+    config.workspace.cleanup_on_done = true;
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let issue_id = "issue-terminal-deferred-cleanup";
+    orchestrator.state_mut().running.insert(
+        issue_id.to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: issue_id.to_string(),
+            issue_identifier: "SIM-103".to_string(),
+            attempt: None,
+            workspace_path: workspace_path.to_string_lossy().to_string(),
+            started_at: Utc::now(),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+        },
+    );
+    orchestrator.schedule_retry_with_context(
+        issue_id,
+        "SIM-103",
+        1,
+        RetryKind::Failure,
+        0,
+        None,
+        RetryContext {
+            worker_host: None,
+            workspace_path: None,
+            session_id: Some("session-103".to_string()),
+        },
+    );
+    orchestrator.state_mut().retry_attempts.remove(issue_id);
+
+    let mut port = FakePort {
+        reconciled_issues: vec![issue(issue_id, "SIM-103", "Done", Some(1), 0)],
+        ..FakePort::default()
+    };
+
+    orchestrator
+        .tick(&mut port)
+        .expect("tick should succeed while marking active worker issue terminal");
+
+    assert!(
+        workspace_path.exists(),
+        "workspace cleanup should be deferred while worker is still active"
+    );
+
+    let completion_result = orchestrator.handle_worker_completion(
+        issue_id,
+        WorkerCompletion::Completed {
+            schedule_continuation: false,
+        },
+        0,
+    );
+    assert!(
+        completion_result.is_none(),
+        "terminal issue completion after deferred cleanup should not enqueue follow-up work"
+    );
+    assert!(
+        !workspace_path.exists(),
+        "deferred terminal cleanup should remove workspace when worker completion arrives"
+    );
+}
+
+#[tokio::test]
+async fn test_terminal_state_cleanup_removes_retry_workspace_when_enabled() {
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let workspace_path = workspace_root.path().join("SIM-104");
+    fs::create_dir_all(&workspace_path).expect("retry workspace should exist before cleanup");
+    fs::write(workspace_path.join("artifact.txt"), "retry-temp")
+        .expect("retry workspace artifact should exist before cleanup");
+
+    let mut config = test_config(1);
+    config.workspace.root = workspace_root.path().to_string_lossy().to_string();
+    config.workspace.cleanup_on_done = true;
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let issue_id = "issue-terminal-retry-cleanup";
+    orchestrator.schedule_retry_with_context(
+        issue_id,
+        "SIM-104",
+        1,
+        RetryKind::Continuation,
+        0,
+        None,
+        RetryContext {
+            worker_host: None,
+            workspace_path: Some(workspace_path.to_string_lossy().to_string()),
+            session_id: None,
+        },
+    );
+
+    let mut port = FakePort {
+        refreshed_issues: HashMap::from([(
+            issue_id.to_string(),
+            Some(issue(issue_id, "SIM-104", "Done", Some(1), 0)),
+        )]),
+        ..FakePort::default()
+    };
+
+    let run_result = tokio::time::timeout(
+        tokio::time::Duration::from_millis(200),
+        orchestrator.run(&mut port),
+    )
+    .await;
+    assert!(
+        run_result.is_err(),
+        "orchestrator run loop should be canceled by timeout in test harness"
+    );
+
+    assert!(
+        !workspace_path.exists(),
+        "terminal retry issue should remove retained workspace path when cleanup is enabled"
+    );
+    assert!(
+        !orchestrator.state().retry_attempts.contains_key(issue_id),
+        "terminal retry issue should be removed from retry queue after cleanup"
     );
 }
 

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -162,6 +162,7 @@ fn test_config_defaults() {
     assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
     assert_eq!(config.workspace.branch_prefix, "symphony");
     assert_eq!(config.workspace.clone_branch, None);
+    assert!(!config.workspace.cleanup_on_done);
 }
 
 #[test]
@@ -259,6 +260,25 @@ workspace:
     let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
     let config = from_workflow(&raw).expect("workspace clone branch should parse");
     assert_eq!(config.workspace.clone_branch, None);
+}
+
+#[test]
+fn test_workspace_cleanup_on_done_parses_true_and_false() {
+    let yaml_true = r#"
+workspace:
+  cleanup_on_done: true
+"#;
+    let raw_true: serde_yaml::Value = serde_yaml::from_str(yaml_true).unwrap();
+    let config_true = from_workflow(&raw_true).expect("cleanup_on_done=true should parse");
+    assert!(config_true.workspace.cleanup_on_done);
+
+    let yaml_false = r#"
+workspace:
+  cleanup_on_done: false
+"#;
+    let raw_false: serde_yaml::Value = serde_yaml::from_str(yaml_false).unwrap();
+    let config_false = from_workflow(&raw_false).expect("cleanup_on_done=false should parse");
+    assert!(!config_false.workspace.cleanup_on_done);
 }
 
 #[test]

--- a/apps/symphony/tests/workspace_prompt_tests.rs
+++ b/apps/symphony/tests/workspace_prompt_tests.rs
@@ -111,6 +111,7 @@ fn workspace_config(root: &Path) -> WorkspaceConfig {
         strategy: WorkspaceRepoStrategy::Clone,
         branch_prefix: "symphony".to_string(),
         clone_branch: None,
+        cleanup_on_done: false,
     }
 }
 
@@ -465,6 +466,7 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
         strategy: WorkspaceRepoStrategy::Clone,
         branch_prefix: "symphony".to_string(),
         clone_branch: Some("elixir-feature-parity".to_string()),
+        cleanup_on_done: false,
     };
     let hooks = HooksConfig {
         after_create: Some("git rev-parse --abbrev-ref HEAD > hook_branch.txt".to_string()),
@@ -521,6 +523,7 @@ fn test_workspace_worktree_bootstrap_and_cleanup() {
         strategy: WorkspaceRepoStrategy::Worktree,
         branch_prefix: "symphony".to_string(),
         clone_branch: None,
+        cleanup_on_done: false,
     };
     let hooks = hooks_config_none();
     let issue = make_test_issue("KAT-801");
@@ -660,6 +663,7 @@ fn test_workspace_remove_continues_when_worktree_cleanup_fails() {
         strategy: WorkspaceRepoStrategy::Worktree,
         branch_prefix: "symphony".to_string(),
         clone_branch: None,
+        cleanup_on_done: false,
     };
     let hooks = hooks_config_none();
     let issue = make_test_issue("KAT-803");


### PR DESCRIPTION
## Summary
- add `workspace.cleanup_on_done` config parsing with default `false`
- run workspace cleanup from `mark_issue_terminal()` before removing running state
- reuse workspace removal hooks/strategy behavior and add coverage for enabled/disabled, hook execution, worktree cleanup, and non-fatal failures
- update Symphony docs for the new workspace cleanup option

## Validation
- cd apps/symphony && cargo test --test workflow_config_tests --test orchestrator_tests
- cd apps/symphony && cargo test
- cd apps/symphony && cargo clippy -- -D warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces automatic workspace cleanup when an issue transitions to a terminal state. A new `workspace.cleanup_on_done` boolean config field (default `false`) is parsed and stored in `WorkspaceConfig`. When enabled, `mark_issue_terminal` looks up the running `RunAttempt`, delegates to a new `cleanup_workspace` helper that calls the existing `remove_workspace` logic (running the `before_remove` hook, handling worktree deregistration, and deleting the directory), and treats any failure as non-fatal so orchestration is never interrupted. Five new integration tests cover the happy paths for clone and worktree strategies, hook execution, and the disabled/failure cases.

**Issues found:**
- `workspace.cleanup_on_done` is listed twice in the `AGENTS.md` reference table, and `cleanup_on_done: true` appears as a duplicate YAML key in both the minimal and full YAML code examples. These duplicates should be removed.
- `cleanup_workspace` calls `workspace::remove_workspace` (the non-issue-aware variant). As a result, when the `before_remove` hook fires during terminal cleanup, `SYMPHONY_ISSUE_ID` and `SYMPHONY_ISSUE_TITLE` will be empty strings. The `RunAttempt` available at call time carries `issue_id` and `issue_identifier`, so at minimum those values could be threaded through to give the hook the context the documentation promises.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor fixes — the core logic is sound but the before_remove hook env vars are incomplete and the docs contain duplicates.
- The implementation is well-structured: the config plumbing is correct, cleanup is non-fatal, and test coverage is thorough across all key scenarios. The score is held back by two issues: (1) the `before_remove` hook will silently receive empty `SYMPHONY_ISSUE_ID` and `SYMPHONY_ISSUE_TITLE` values when triggered from terminal cleanup, which breaks a documented contract and could cause hook scripts to misbehave; (2) AGENTS.md has multiple duplicate entries that will mislead users consulting the reference docs.
- `apps/symphony/src/orchestrator.rs` (missing issue context passed to `remove_workspace`) and `apps/symphony/AGENTS.md` (duplicate table row and YAML keys).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Adds `mark_issue_terminal` cleanup logic and a new `cleanup_workspace` helper; the helper calls the non-issue-aware `remove_workspace`, leaving `SYMPHONY_ISSUE_ID` and `SYMPHONY_ISSUE_TITLE` empty for `before_remove` hooks triggered from this path. |
| apps/symphony/AGENTS.md | Documents new `workspace.cleanup_on_done` option, but the table row and the YAML key in both code examples are each duplicated, which is misleading and will be confusing to readers. |
| apps/symphony/src/config.rs | Correctly adds `cleanup_on_done: Option<bool>` to `RawWorkspaceConfig` and wires it into `WorkspaceConfig` with a `false` default. |
| apps/symphony/src/domain.rs | Adds `cleanup_on_done: bool` field to `WorkspaceConfig` struct and its `Default` impl with value `false`; straightforward and correct. |
| apps/symphony/tests/orchestrator_tests.rs | Adds five integration tests covering enabled/disabled cleanup, `before_remove` hook execution, worktree deregistration, and non-fatal failure; coverage is thorough and the helper utilities (`init_git_repo`, `shell_quote`, `command_success`) are clean. |
| apps/symphony/tests/workflow_config_tests.rs | Adds default-value assertion and a round-trip parse test for `cleanup_on_done`; correct and complete. |
| apps/symphony/tests/workspace_prompt_tests.rs | Updates three `WorkspaceConfig` literals to include the new `cleanup_on_done: false` field; no logic changes. |
| apps/online-docs/content/docs/symphony/index.mdx | Adds a concise "Workspace Cleanup" section describing the new option, its YAML form, and the non-fatal failure semantics; documentation is accurate. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Tracker
    participant Orchestrator
    participant WorkspaceModule
    participant Filesystem
    participant Hook as before_remove hook

    Tracker->>Orchestrator: issue reaches terminal state (Done/Canceled)
    Orchestrator->>Orchestrator: mark_issue_terminal(issue_id)

    alt cleanup_on_done = true AND issue in running state
        Orchestrator->>Orchestrator: clone workspace_path from RunAttempt
        Orchestrator->>WorkspaceModule: remove_workspace(path, config, hooks)
        WorkspaceModule->>Filesystem: path.exists()?
        alt path exists
            WorkspaceModule->>WorkspaceModule: validate_workspace_path (must be under root)
            alt before_remove hook configured
                WorkspaceModule->>Hook: run_hook(before_remove, workspace_path)<br/>⚠️ SYMPHONY_ISSUE_ID & SYMPHONY_ISSUE_TITLE are empty
                Hook-->>WorkspaceModule: result (failure ignored)
            end
            alt strategy = worktree
                WorkspaceModule->>Filesystem: git worktree remove
            end
            WorkspaceModule->>Filesystem: fs::remove_dir_all(workspace)
        else path missing
            WorkspaceModule-->>Orchestrator: Ok(())
        end
        alt remove_workspace error
            WorkspaceModule-->>Orchestrator: Err(e)
            Orchestrator->>Orchestrator: log warning — non-fatal
        else remove_workspace success
            WorkspaceModule-->>Orchestrator: Ok(())
            Orchestrator->>Orchestrator: log info
        end
    end

    Orchestrator->>Orchestrator: state.completed.insert(issue_id)
    Orchestrator->>Orchestrator: state.running.remove(issue_id)
    Orchestrator->>Orchestrator: clear claimed / retry / session state
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/AGENTS.md
Line: 102-103

Comment:
**Duplicate table row for `workspace.cleanup_on_done`**

The `workspace.cleanup_on_done` row is listed twice in the reference table. The second copy should be removed.

```suggestion
| `workspace.cleanup_on_done` | bool | `false` | Remove the issue workspace when the issue reaches a terminal state. Runs `hooks.before_remove` and ignores cleanup failures. |
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/AGENTS.md
Line: 169-170

Comment:
**Duplicate YAML key in minimal example**

`cleanup_on_done: true` is listed twice in the minimal working example code block. YAML parsers typically only keep the last value for duplicate keys, but having it twice is misleading to readers. The second occurrence should be removed.

```suggestion
  cleanup_on_done: true
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/AGENTS.md
Line: 205-206

Comment:
**Duplicate YAML key in full example**

Same duplicate `cleanup_on_done: true` appears in the full example block. The second occurrence should be removed.

```suggestion
  cleanup_on_done: true
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 2097

Comment:
**`before_remove` hook receives empty `SYMPHONY_ISSUE_ID` and `SYMPHONY_ISSUE_TITLE`**

`cleanup_workspace` calls `workspace::remove_workspace` — the non-issue-aware variant — so `remove_workspace_internal` falls back to deriving the identifier from the directory name and leaves `SYMPHONY_ISSUE_ID` and `SYMPHONY_ISSUE_TITLE` as empty strings in the hook's environment.

The docs (`AGENTS.md`, `hooks` section) promise that all hooks receive `SYMPHONY_ISSUE_ID`, `SYMPHONY_ISSUE_IDENTIFIER`, `SYMPHONY_ISSUE_TITLE`, and `SYMPHONY_WORKSPACE_PATH`, but when the hook fires from this path, the first and third of those variables will be blank.

At the point `cleanup_workspace` is called, the `RunAttempt` in `self.state.running` still holds `issue_id` and `issue_identifier`. A minimal fix is to pass those through to the cleanup function and thread them into a partial `HookIssueContext`, or — if an `Issue` struct is not available here — introduce a new `remove_workspace_for_run_attempt` helper analogous to `remove_workspace_for_issue` that accepts the identifiers directly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(symphony): auto..."](https://github.com/gannonh/kata/commit/a7d705a67de5deb460f343e6b3129ff436c84d0e)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->