### PR TITLE
[kata/apps-cli/M007/S01] Subagent worker registry, timing, and activity visibility

### DIFF
--- a/apps/cli/src/resources/extensions/subagent/elapsed.ts
+++ b/apps/cli/src/resources/extensions/subagent/elapsed.ts
@@ -5,10 +5,12 @@
 export function formatElapsed(ms: number): string {
   if (ms < 0) ms = 0;
   const totalSeconds = ms / 1000;
-  if (totalSeconds < 60) {
-    return `${totalSeconds.toFixed(1)}s`;
+  const rounded = Math.round(totalSeconds * 10) / 10;
+  if (rounded < 60) {
+    return `${rounded.toFixed(1)}s`;
   }
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = Math.round(totalSeconds % 60);
+  const totalWholeSeconds = Math.round(totalSeconds);
+  const minutes = Math.floor(totalWholeSeconds / 60);
+  const seconds = totalWholeSeconds % 60;
   return `${minutes}m ${seconds}s`;
 }

--- a/apps/cli/src/resources/extensions/subagent/elapsed.ts
+++ b/apps/cli/src/resources/extensions/subagent/elapsed.ts
@@ -1,0 +1,14 @@
+/**
+ * Format elapsed milliseconds into a human-readable string.
+ * <1s: "0.3s", seconds: "12.3s", ≥60s: "1m 23s"
+ */
+export function formatElapsed(ms: number): string {
+  if (ms < 0) ms = 0;
+  const totalSeconds = ms / 1000;
+  if (totalSeconds < 60) {
+    return `${totalSeconds.toFixed(1)}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = Math.round(totalSeconds % 60);
+  return `${minutes}m ${seconds}s`;
+}

--- a/apps/cli/src/resources/extensions/subagent/index.ts
+++ b/apps/cli/src/resources/extensions/subagent/index.ts
@@ -756,30 +756,9 @@ export default function (pi: ExtensionAPI) {
           async (t, index) => {
             const workerId = registerWorker(t.agent, t.task, index, params.tasks!.length, batchId);
             const agentStart = Date.now();
+            let result: SingleResult | undefined;
 
-            let result = await runSingleAgent(
-              ctx.cwd,
-              agents,
-              t.agent,
-              t.task,
-              t.cwd,
-              undefined,
-              signal,
-              // Per-task update callback
-              (partial) => {
-                if (partial.details?.results[0]) {
-                  allResults[index] = partial.details.results[0];
-                  emitParallelUpdate();
-                }
-              },
-              makeDetails("parallel"),
-            );
-
-            // Auto-retry failed tasks (likely API rate limit or transient error)
-            const isFailed =
-              result.exitCode !== 0 ||
-              (result.messages.length === 0 && !signal?.aborted);
-            if (isFailed && MAX_RETRIES > 0 && !signal?.aborted) {
+            try {
               result = await runSingleAgent(
                 ctx.cwd,
                 agents,
@@ -788,6 +767,7 @@ export default function (pi: ExtensionAPI) {
                 t.cwd,
                 undefined,
                 signal,
+                // Per-task update callback
                 (partial) => {
                   if (partial.details?.results[0]) {
                     allResults[index] = partial.details.results[0];
@@ -796,13 +776,42 @@ export default function (pi: ExtensionAPI) {
                 },
                 makeDetails("parallel"),
               );
-            }
 
-            elapsedTimes[index] = Date.now() - agentStart;
-            updateWorker(workerId, result.exitCode === 0 ? "completed" : "failed");
-            allResults[index] = result;
-            emitParallelUpdate();
-            return result;
+              // Auto-retry failed tasks (likely API rate limit or transient error)
+              const isFailed =
+                result.exitCode !== 0 ||
+                (result.messages.length === 0 && !signal?.aborted);
+              if (isFailed && MAX_RETRIES > 0 && !signal?.aborted) {
+                result = await runSingleAgent(
+                  ctx.cwd,
+                  agents,
+                  t.agent,
+                  t.task,
+                  t.cwd,
+                  undefined,
+                  signal,
+                  (partial) => {
+                    if (partial.details?.results[0]) {
+                      allResults[index] = partial.details.results[0];
+                      emitParallelUpdate();
+                    }
+                  },
+                  makeDetails("parallel"),
+                );
+              }
+
+              allResults[index] = result;
+              return result;
+            } finally {
+              elapsedTimes[index] = Date.now() - agentStart;
+              const isError = !result ||
+                result.exitCode !== 0 ||
+                result.stopReason === "error" ||
+                result.stopReason === "aborted";
+              updateWorker(workerId, isError ? "failed" : "completed");
+              if (result) allResults[index] = result;
+              emitParallelUpdate();
+            }
           },
         );
 

--- a/apps/cli/src/resources/extensions/subagent/index.ts
+++ b/apps/cli/src/resources/extensions/subagent/index.ts
@@ -12,6 +12,7 @@
  * Uses JSON mode to capture structured output from subagents.
  */
 
+import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -26,6 +27,8 @@ import {
 import { Container, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
+import { formatElapsed } from "./elapsed.js";
+import { registerWorker, updateWorker } from "./worker-registry.js";
 
 const MAX_PARALLEL_TASKS = 8;
 const MAX_CONCURRENCY = 4;
@@ -614,6 +617,7 @@ export default function (pi: ExtensionAPI) {
       if (params.chain && params.chain.length > 0) {
         const results: SingleResult[] = [];
         let previousOutput = "";
+        const chainStart = Date.now();
 
         for (let i = 0; i < params.chain.length; i++) {
           const step = params.chain[i];
@@ -637,6 +641,7 @@ export default function (pi: ExtensionAPI) {
               }
             : undefined;
 
+          const stepStart = Date.now();
           const result = await runSingleAgent(
             ctx.cwd,
             agents,
@@ -648,6 +653,7 @@ export default function (pi: ExtensionAPI) {
             chainUpdate,
             makeDetails("chain"),
           );
+          const stepElapsed = Date.now() - stepStart;
           results.push(result);
 
           const isError =
@@ -664,7 +670,7 @@ export default function (pi: ExtensionAPI) {
               content: [
                 {
                   type: "text",
-                  text: `Chain stopped at step ${i + 1} (${step.agent}): ${errorMsg}`,
+                  text: `Chain stopped at step ${i + 1} (${step.agent}) after ${formatElapsed(stepElapsed)}: ${errorMsg}`,
                 },
               ],
               details: makeDetails("chain")(results),
@@ -673,13 +679,14 @@ export default function (pi: ExtensionAPI) {
           }
           previousOutput = getFinalOutput(result.messages);
         }
+        const chainElapsed = Date.now() - chainStart;
         return {
           content: [
             {
               type: "text",
               text:
-                getFinalOutput(results[results.length - 1].messages) ||
-                "(no output)",
+                (getFinalOutput(results[results.length - 1].messages) ||
+                "(no output)") + `\n\nChain completed in ${formatElapsed(chainElapsed)}`,
             },
           ],
           details: makeDetails("chain")(results),
@@ -698,8 +705,12 @@ export default function (pi: ExtensionAPI) {
             details: makeDetails("parallel")([]),
           };
 
+        const batchId = randomUUID();
+        const batchStart = Date.now();
+
         // Track all results for streaming updates
         const allResults: SingleResult[] = new Array(params.tasks.length);
+        const elapsedTimes: number[] = new Array(params.tasks.length).fill(0);
 
         // Initialize placeholder results
         for (let i = 0; i < params.tasks.length; i++) {
@@ -743,6 +754,9 @@ export default function (pi: ExtensionAPI) {
           params.tasks,
           MAX_CONCURRENCY,
           async (t, index) => {
+            const workerId = registerWorker(t.agent, t.task, index, params.tasks!.length, batchId);
+            const agentStart = Date.now();
+
             let result = await runSingleAgent(
               ctx.cwd,
               agents,
@@ -784,14 +798,17 @@ export default function (pi: ExtensionAPI) {
               );
             }
 
+            elapsedTimes[index] = Date.now() - agentStart;
+            updateWorker(workerId, result.exitCode === 0 ? "completed" : "failed");
             allResults[index] = result;
             emitParallelUpdate();
             return result;
           },
         );
 
+        const batchElapsed = Date.now() - batchStart;
         const successCount = results.filter((r) => r.exitCode === 0).length;
-        const summaries = results.map((r) => {
+        const summaries = results.map((r, i) => {
           const isError =
             r.exitCode !== 0 ||
             r.stopReason === "error" ||
@@ -804,13 +821,16 @@ export default function (pi: ExtensionAPI) {
             : getFinalOutput(r.messages);
           const preview =
             output.slice(0, 200) + (output.length > 200 ? "..." : "");
-          return `[${r.agent}] ${r.exitCode === 0 ? "completed" : `failed (exit ${r.exitCode})`}: ${preview || "(no output)"}`;
+          const status = r.exitCode === 0
+            ? `completed in ${formatElapsed(elapsedTimes[i])}`
+            : `failed (exit ${r.exitCode}) after ${formatElapsed(elapsedTimes[i])}`;
+          return `[${r.agent}] ${status}: ${preview || "(no output)"}`;
         });
         return {
           content: [
             {
               type: "text",
-              text: `Parallel: ${successCount}/${results.length} succeeded\n\n${summaries.join("\n\n")}`,
+              text: `Parallel: ${successCount}/${results.length} succeeded in ${formatElapsed(batchElapsed)}\n\n${summaries.join("\n\n")}`,
             },
           ],
           details: makeDetails("parallel")(results),
@@ -818,6 +838,7 @@ export default function (pi: ExtensionAPI) {
       }
 
       if (params.agent && params.task) {
+        const singleStart = Date.now();
         const result = await runSingleAgent(
           ctx.cwd,
           agents,
@@ -829,6 +850,7 @@ export default function (pi: ExtensionAPI) {
           onUpdate,
           makeDetails("single"),
         );
+        const singleElapsed = Date.now() - singleStart;
         const isError =
           result.exitCode !== 0 ||
           result.stopReason === "error" ||
@@ -843,7 +865,7 @@ export default function (pi: ExtensionAPI) {
             content: [
               {
                 type: "text",
-                text: `Agent ${result.stopReason || "failed"}: ${errorMsg}`,
+                text: `Agent ${result.stopReason || "failed"} after ${formatElapsed(singleElapsed)}: ${errorMsg}`,
               },
             ],
             details: makeDetails("single")([result]),
@@ -854,7 +876,7 @@ export default function (pi: ExtensionAPI) {
           content: [
             {
               type: "text",
-              text: getFinalOutput(result.messages) || "(no output)",
+              text: (getFinalOutput(result.messages) || "(no output)") + `\n\nCompleted in ${formatElapsed(singleElapsed)}`,
             },
           ],
           details: makeDetails("single")([result]),

--- a/apps/cli/src/resources/extensions/subagent/tests/timing.test.ts
+++ b/apps/cli/src/resources/extensions/subagent/tests/timing.test.ts
@@ -16,7 +16,7 @@ describe("formatElapsed", () => {
   it("formats seconds", () => {
     assert.strictEqual(formatElapsed(1234), "1.2s");
     assert.strictEqual(formatElapsed(12345), "12.3s");
-    assert.strictEqual(formatElapsed(59999), "60.0s");
+    assert.strictEqual(formatElapsed(59999), "1m 0s");
   });
 
   it("formats minutes", () => {

--- a/apps/cli/src/resources/extensions/subagent/tests/timing.test.ts
+++ b/apps/cli/src/resources/extensions/subagent/tests/timing.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from "bun:test";
+import assert from "node:assert/strict";
+import { formatElapsed } from "../elapsed.js";
+
+describe("formatElapsed", () => {
+  it("formats 0ms", () => {
+    assert.strictEqual(formatElapsed(0), "0.0s");
+  });
+
+  it("formats sub-second values", () => {
+    assert.strictEqual(formatElapsed(300), "0.3s");
+    assert.strictEqual(formatElapsed(500), "0.5s");
+    assert.strictEqual(formatElapsed(999), "1.0s");
+  });
+
+  it("formats seconds", () => {
+    assert.strictEqual(formatElapsed(1234), "1.2s");
+    assert.strictEqual(formatElapsed(12345), "12.3s");
+    assert.strictEqual(formatElapsed(59999), "60.0s");
+  });
+
+  it("formats minutes", () => {
+    assert.strictEqual(formatElapsed(60000), "1m 0s");
+    assert.strictEqual(formatElapsed(65000), "1m 5s");
+    assert.strictEqual(formatElapsed(83000), "1m 23s");
+    assert.strictEqual(formatElapsed(125000), "2m 5s");
+  });
+
+  it("handles negative values gracefully", () => {
+    assert.strictEqual(formatElapsed(-100), "0.0s");
+  });
+
+  it("handles large values", () => {
+    assert.strictEqual(formatElapsed(3600000), "60m 0s");
+  });
+});

--- a/apps/cli/src/resources/extensions/subagent/tests/worker-registry.test.ts
+++ b/apps/cli/src/resources/extensions/subagent/tests/worker-registry.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the parallel worker registry used by the dashboard overlay.
+ *
+ * Verifies worker lifecycle (register → update → cleanup), batch grouping,
+ * and the hasActiveWorkers() status check.
+ */
+
+import { describe, it, beforeEach } from "bun:test";
+import assert from "node:assert/strict";
+import {
+  registerWorker,
+  updateWorker,
+  getActiveWorkers,
+  getWorkerBatches,
+  hasActiveWorkers,
+  resetWorkerRegistry,
+} from "../worker-registry.ts";
+
+describe("worker-registry", () => {
+  beforeEach(() => {
+    resetWorkerRegistry();
+  });
+
+  describe("registration", () => {
+    it("registers a worker with correct fields", () => {
+      const id = registerWorker("scout", "Explore codebase", 0, 3, "batch-1");
+      assert.ok(id.startsWith("worker-"), "worker ID has correct prefix");
+      const workers = getActiveWorkers();
+      assert.strictEqual(workers.length, 1);
+      assert.strictEqual(workers[0].agent, "scout");
+      assert.strictEqual(workers[0].task, "Explore codebase");
+      assert.strictEqual(workers[0].status, "running");
+      assert.strictEqual(workers[0].index, 0);
+      assert.strictEqual(workers[0].batchSize, 3);
+      assert.strictEqual(workers[0].batchId, "batch-1");
+    });
+  });
+
+  describe("multiple workers in a batch", () => {
+    it("tracks all workers and groups them into one batch", () => {
+      registerWorker("scout", "Task A", 0, 3, "batch-2");
+      registerWorker("researcher", "Task B", 1, 3, "batch-2");
+      registerWorker("worker", "Task C", 2, 3, "batch-2");
+
+      const workers = getActiveWorkers();
+      assert.strictEqual(workers.length, 3);
+      assert.ok(hasActiveWorkers());
+
+      const batches = getWorkerBatches();
+      assert.strictEqual(batches.size, 1);
+      const batch = batches.get("batch-2");
+      assert.ok(batch !== undefined);
+      assert.strictEqual(batch!.length, 3);
+    });
+  });
+
+  describe("status updates", () => {
+    it("marks individual workers as completed while others remain running", () => {
+      const id1 = registerWorker("scout", "Task A", 0, 2, "batch-3");
+      const id2 = registerWorker("worker", "Task B", 1, 2, "batch-3");
+
+      updateWorker(id1, "completed");
+      const workers = getActiveWorkers();
+      const w1 = workers.find((w) => w.id === id1);
+      assert.strictEqual(w1?.status, "completed");
+
+      const w2 = workers.find((w) => w.id === id2);
+      assert.strictEqual(w2?.status, "running");
+      assert.ok(hasActiveWorkers());
+    });
+  });
+
+  describe("failed worker", () => {
+    it("marks a worker as failed", () => {
+      const id = registerWorker("scout", "Task A", 0, 1, "batch-4");
+      updateWorker(id, "failed");
+      const workers = getActiveWorkers();
+      assert.strictEqual(workers[0].status, "failed");
+    });
+  });
+
+  describe("multiple batches", () => {
+    it("groups workers into separate batches", () => {
+      registerWorker("scout", "Task A", 0, 2, "batch-5");
+      registerWorker("worker", "Task B", 1, 2, "batch-5");
+      registerWorker("researcher", "Task C", 0, 1, "batch-6");
+
+      const batches = getWorkerBatches();
+      assert.strictEqual(batches.size, 2);
+      assert.strictEqual(batches.get("batch-5")!.length, 2);
+      assert.strictEqual(batches.get("batch-6")!.length, 1);
+    });
+  });
+
+  describe("hasActiveWorkers — all completed", () => {
+    it("returns false when all workers are completed", () => {
+      const id1 = registerWorker("scout", "Task A", 0, 2, "batch-7");
+      const id2 = registerWorker("worker", "Task B", 1, 2, "batch-7");
+      updateWorker(id1, "completed");
+      updateWorker(id2, "completed");
+      assert.ok(!hasActiveWorkers());
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all workers", () => {
+      registerWorker("scout", "Task", 0, 1, "batch-8");
+      assert.ok(getActiveWorkers().length > 0);
+      resetWorkerRegistry();
+      assert.strictEqual(getActiveWorkers().length, 0);
+      assert.ok(!hasActiveWorkers());
+    });
+  });
+
+  describe("update non-existent worker", () => {
+    it("is a no-op and does not throw", () => {
+      updateWorker("nonexistent-id", "completed");
+      assert.strictEqual(getActiveWorkers().length, 0);
+    });
+  });
+});

--- a/apps/cli/src/resources/extensions/subagent/tests/worker-registry.test.ts
+++ b/apps/cli/src/resources/extensions/subagent/tests/worker-registry.test.ts
@@ -14,7 +14,7 @@ import {
   getWorkerBatches,
   hasActiveWorkers,
   resetWorkerRegistry,
-} from "../worker-registry.ts";
+} from "../worker-registry.js";
 
 describe("worker-registry", () => {
   beforeEach(() => {

--- a/apps/cli/src/resources/extensions/subagent/worker-registry.ts
+++ b/apps/cli/src/resources/extensions/subagent/worker-registry.ts
@@ -1,0 +1,99 @@
+/**
+ * Worker Registry — Tracks active subagent sessions for dashboard visibility.
+ *
+ * Provides a global registry of currently-running parallel workers so the
+ * GSD dashboard overlay can display real-time worker status.
+ */
+
+export interface WorkerEntry {
+  id: string;
+  agent: string;
+  task: string;
+  startedAt: number;
+  status: "running" | "completed" | "failed";
+  /** Index within a parallel batch (0-based) */
+  index: number;
+  /** Total workers in the parallel batch */
+  batchSize: number;
+  /** Unique batch identifier for grouping parallel runs */
+  batchId: string;
+}
+
+const activeWorkers = new Map<string, WorkerEntry>();
+let workerIdCounter = 0;
+
+/**
+ * Register a new worker. Returns the worker ID for later updates.
+ */
+export function registerWorker(
+  agent: string,
+  task: string,
+  index: number,
+  batchSize: number,
+  batchId: string,
+): string {
+  const id = `worker-${++workerIdCounter}`;
+  activeWorkers.set(id, {
+    id,
+    agent,
+    task,
+    startedAt: Date.now(),
+    status: "running",
+    index,
+    batchSize,
+    batchId,
+  });
+  return id;
+}
+
+/**
+ * Update worker status when it completes or fails.
+ */
+export function updateWorker(id: string, status: "completed" | "failed"): void {
+  const entry = activeWorkers.get(id);
+  if (entry) {
+    entry.status = status;
+    // Remove after a brief display window (5 seconds)
+    setTimeout(() => {
+      activeWorkers.delete(id);
+    }, 5000);
+  }
+}
+
+/**
+ * Get all currently-tracked workers (running + recently completed).
+ */
+export function getActiveWorkers(): WorkerEntry[] {
+  return Array.from(activeWorkers.values());
+}
+
+/**
+ * Get workers grouped by batch.
+ */
+export function getWorkerBatches(): Map<string, WorkerEntry[]> {
+  const batches = new Map<string, WorkerEntry[]>();
+  for (const worker of activeWorkers.values()) {
+    const batch = batches.get(worker.batchId) ?? [];
+    batch.push(worker);
+    batches.set(worker.batchId, batch);
+  }
+  return batches;
+}
+
+/**
+ * Check if any parallel workers are currently running.
+ */
+export function hasActiveWorkers(): boolean {
+  for (const worker of activeWorkers.values()) {
+    if (worker.status === "running") return true;
+  }
+  return false;
+}
+
+/**
+ * Reset registry state. Used for testing.
+ */
+export function resetWorkerRegistry(): void {
+  activeWorkers.clear();
+  workerIdCounter = 0;
+}

--- a/apps/cli/src/resources/extensions/subagent/worker-registry.ts
+++ b/apps/cli/src/resources/extensions/subagent/worker-registry.ts
@@ -20,6 +20,7 @@ export interface WorkerEntry {
 }
 
 const activeWorkers = new Map<string, WorkerEntry>();
+const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
 let workerIdCounter = 0;
 
 /**
@@ -54,9 +55,11 @@ export function updateWorker(id: string, status: "completed" | "failed"): void {
   if (entry) {
     entry.status = status;
     // Remove after a brief display window (5 seconds)
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       activeWorkers.delete(id);
+      pendingTimers.delete(id);
     }, 5000);
+    pendingTimers.set(id, timer);
   }
 }
 
@@ -94,6 +97,8 @@ export function hasActiveWorkers(): boolean {
  * Reset registry state. Used for testing.
  */
 export function resetWorkerRegistry(): void {
+  for (const timer of pendingTimers.values()) clearTimeout(timer);
+  pendingTimers.clear();
   activeWorkers.clear();
   workerIdCounter = 0;
 }


### PR DESCRIPTION
## What Changed
See slice plan: S01: Subagent worker registry, timing, and activity visibility

## Must-Haves
- R015 (owned): `worker-registry.ts` exists with `registerWorker()`, `updateWorker()`, `getActiveWorkers()`, `getWorkerBatches()`, `hasActiveWorkers()`, `resetWorkerRegistry()`, `WorkerEntry` interface
- R015 (owned): Elapsed time displayed in subagent tool result output (per-agent duration)
- R015 (owned): Batch tracking via `batchId`, `index`, `batchSize` on each `WorkerEntry`
- R015 (owned): Worker registry integrated into parallel dispatch in `index.ts`
- `npx tsc --noEmit` passes after changes
- `bun test src/resources/extensions/subagent/tests/` passes

## Tasks
- T01: Create worker-registry module and test file
- T02: Add elapsed-time formatting and integrate registry + timing into subagent dispatch

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `worker-registry` module and per-agent elapsed-time formatting to give the GSD dashboard real-time visibility into parallel subagent execution. The registry tracks each worker's lifecycle (`running` → `completed`/`failed`) with batch grouping, and all three dispatch modes (chain, parallel, single) now append human-readable durations to their output messages.

**Key findings:**

- **Dangling timers in `worker-registry.ts`**: `updateWorker` schedules a 5-second `setTimeout` to remove completed/failed entries, but `resetWorkerRegistry` does not cancel those pending timers. Because the ID counter is also reset to `0`, a stale timer can delete a freshly-registered worker in the next test (or the next parallel batch dispatched in rapid succession). Timer handles should be tracked and cancelled in `resetWorkerRegistry`.
- **`formatElapsed` boundary bug at ~60s**: `59999ms` produces `"60.0s"` because `toFixed(1)` rounds `59.999` up to `60.0` while the branch guard `totalSeconds < 60` still allows it into the sub-minute path. The documented contract (`≥60s → "Xm Ys"`) is violated. The test for this value asserts the buggy output, cementing the regression.
- **Retry duration silently inflates elapsed time**: The `agentStart` clock is not reset before the automatic retry in the parallel path, so a retried task shows a "completed in Xm Ys" time that includes the first failed attempt.
- **Import extension inconsistency**: `worker-registry.test.ts` uses a `.ts` import extension while `timing.test.ts` uses `.js` for the same style of relative import.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor fixes; the dangling-timer bug is latent in tests today but could surface in production or future parallelized test runs.
- The core functionality is well-structured and the registry/timing integration is clean. Two issues prevent a higher score: (1) the `resetWorkerRegistry` timer-leak is a real correctness bug that makes tests non-deterministic over time, and (2) the `formatElapsed` boundary condition violates its own documented contract and the test asserts the wrong expected value, meaning CI currently passes with a known bug enshrined as expected behavior.
- `apps/cli/src/resources/extensions/subagent/worker-registry.ts` (dangling timer), `apps/cli/src/resources/extensions/subagent/elapsed.ts` (boundary condition), and `apps/cli/src/resources/extensions/subagent/tests/timing.test.ts` (asserts the buggy 59999ms value).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/subagent/worker-registry.ts | New module tracking parallel subagent workers; `updateWorker`'s `setTimeout` cleanup is not cancelled by `resetWorkerRegistry`, creating a dangling-timer bug that can corrupt state in tests and in rapid sequential parallel runs. |
| apps/cli/src/resources/extensions/subagent/elapsed.ts | New elapsed-time formatter; boundary condition at 59999ms produces "60.0s" due to floating-point rounding disagreeing with the branch threshold, violating the documented format contract. |
| apps/cli/src/resources/extensions/subagent/index.ts | Integrates worker registry and elapsed timing into all three execution modes (chain, parallel, single); elapsed time for retried parallel tasks inadvertently includes the failed first attempt's duration. |
| apps/cli/src/resources/extensions/subagent/tests/timing.test.ts | Good coverage of `formatElapsed`; the test for 59999ms asserts "60.0s" which validates the boundary bug rather than the intended minutes format. |
| apps/cli/src/resources/extensions/subagent/tests/worker-registry.test.ts | Comprehensive lifecycle tests with `beforeEach` resets; import uses `.ts` extension inconsistently with the sibling test file, and tests are not protected against dangling timers from `updateWorker`. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant index.ts
    participant worker-registry.ts
    participant elapsed.ts
    participant runSingleAgent

    Caller->>index.ts: subagent({ tasks: [...] })
    index.ts->>index.ts: batchId = randomUUID(), batchStart = Date.now()

    loop For each task (concurrency-limited)
        index.ts->>worker-registry.ts: registerWorker(agent, task, index, batchSize, batchId)
        worker-registry.ts-->>index.ts: workerId
        index.ts->>index.ts: agentStart = Date.now()
        index.ts->>runSingleAgent: run first attempt
        runSingleAgent-->>index.ts: result

        alt result failed & MAX_RETRIES > 0
            index.ts->>runSingleAgent: run retry
            runSingleAgent-->>index.ts: result (retry)
        end

        index.ts->>index.ts: elapsedTimes[index] = Date.now() - agentStart
        index.ts->>worker-registry.ts: updateWorker(workerId, "completed"|"failed")
        worker-registry.ts->>worker-registry.ts: entry.status = status
        worker-registry.ts->>worker-registry.ts: setTimeout(() => delete(id), 5000)
    end

    index.ts->>elapsed.ts: formatElapsed(batchElapsed)
    elapsed.ts-->>index.ts: "Xm Ys" or "X.Xs"
    index.ts-->>Caller: "Parallel: N/M succeeded in Xm Ys\n\n[agent] completed in Xm Ys: ..."
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/subagent/worker-registry.ts
Line: 52-61

Comment:
**Dangling `setTimeout` survives `resetWorkerRegistry`**

`updateWorker` schedules a `setTimeout` to delete the worker from `activeWorkers` after 5 seconds, but `resetWorkerRegistry` only clears the map and resets `workerIdCounter` — it never cancels those pending timers.

Because `workerIdCounter` is reset to `0`, the next call to `registerWorker` after a reset will produce IDs starting at `"worker-1"` again. If a dangling timer from a previous test fires after the reset, it will call `activeWorkers.delete("worker-1")` and silently remove a freshly-registered worker from a subsequent test.

Concrete test-execution risk (from `worker-registry.test.ts`):
1. "status updates" test calls `updateWorker(id1, "completed")` → timer for `"worker-1"` queued.
2. `resetWorkerRegistry()` runs for the next test, counter resets to `0`.
3. Next test calls `registerWorker(...)` → new worker gets id `"worker-1"`.
4. 5 seconds later the dangling timer fires and deletes this new `"worker-1"` unexpectedly.

Fix: store `TimeoutHandle` references in the registry and cancel them in `resetWorkerRegistry`:

```ts
const activeWorkers = new Map<string, WorkerEntry>();
const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
let workerIdCounter = 0;

export function updateWorker(id: string, status: "completed" | "failed"): void {
  const entry = activeWorkers.get(id);
  if (entry) {
    entry.status = status;
    const timer = setTimeout(() => {
      activeWorkers.delete(id);
      pendingTimers.delete(id);
    }, 5000);
    pendingTimers.set(id, timer);
  }
}

export function resetWorkerRegistry(): void {
  for (const timer of pendingTimers.values()) clearTimeout(timer);
  pendingTimers.clear();
  activeWorkers.clear();
  workerIdCounter = 0;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/subagent/elapsed.ts
Line: 8-9

Comment:
**`59999ms` displays as `"60.0s"` instead of `"1m 0s"`**

The function uses `totalSeconds < 60` to decide between the sub-minute and minute format, but the display uses `toFixed(1)` which rounds separately. For `ms = 59999`, `totalSeconds = 59.999`, so the `< 60` branch is taken and `toFixed(1)` rounds it up to `"60.0s"`. Meanwhile `ms = 60000` correctly produces `"1m 0s"`.

The test at `timing.test.ts:19` already asserts this edge-case value:
```ts
assert.strictEqual(formatElapsed(59999), "60.0s"); // ← passes but the display is confusing
```

The docstring states `≥60s → "1m 23s"`, so `"60.0s"` is inconsistent with that contract. Fix the branch condition to use the rounded value for the format decision:

```suggestion
  if (totalSeconds < 59.95) {
    return `${totalSeconds.toFixed(1)}s`;
  }
```

Alternatively, compare the rounded value:
```ts
const rounded = Math.round(totalSeconds * 10) / 10;
if (rounded < 60) {
  return `${rounded.toFixed(1)}s`;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/subagent/index.ts
Line: 757-801

Comment:
**Elapsed time silently includes retry duration**

`agentStart` is captured before the first `runSingleAgent` call. When a task fails and enters the retry branch, both the initial failed attempt and the retry are timed together under the same `agentStart`. `elapsedTimes[index]` at line 801 therefore reflects the **total** time including the failed first run.

The resulting summary message says `"completed in Xm Ys"` which may be unexpectedly large (up to 2× actual completion time) for tasks that silently retried. Consider resetting `agentStart` before the retry, or making the displayed time clearly reflect retries (e.g. `"completed in Xm Ys (with 1 retry)"`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/subagent/tests/worker-registry.test.ts
Line: 17

Comment:
**Inconsistent import extension between test files**

`worker-registry.test.ts` imports with a `.ts` extension while the sibling `timing.test.ts` uses a `.js` extension for the same type of relative import:

```
// timing.test.ts
import { formatElapsed } from "../elapsed.js";   ← .js

// worker-registry.test.ts
import { ... } from "../worker-registry.ts";      ← .ts
```

Bun supports both, but the project should use a consistent convention. If other test files follow the `.js` convention (TypeScript compiled to JS, Node ESM-style), this file should follow suit:

```suggestion
} from "../worker-registry.js";
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(S01/T02): add e..."](https://github.com/gannonh/kata/commit/0cfcdb1157fadcdc63819fbd5564481d4807ce27)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subagent runs now display elapsed times for steps and overall execution across chain, parallel, and single-agent modes.
  * Added an in-memory worker registry to track and surface per-task status and timing for parallel batches.

* **Tests**
  * Added tests covering elapsed-time formatting and worker registry behavior (registration, status transitions, batching, and reset).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->