### PR TITLE
KAT-857: harden Linear GraphQL skill coverage and workflow context

### DIFF
--- a/.codex/skills/linear/SKILL.md
+++ b/.codex/skills/linear/SKILL.md
@@ -75,15 +75,18 @@ query CommentCreateInputShape {
 
 Use these progressively:
 
-- Start with `issue(id: $key)` when you have a ticket key such as `MT-686`.
-- Fall back to `issues(filter: ...)` when you need identifier search semantics.
+- Start with `issue(id: $identifier)` when you have a ticket key such as
+  `MT-686` or `KAT-857`.
+- If you must use `issues(filter: ...)`, split `TEAM-NUMBER` and filter with
+  `team.key` + `number` (do not use `IssueFilter.identifier`; it does not
+  exist).
 - Once you have the internal issue id, prefer `issue(id: $id)` for narrower reads.
 
-Lookup by issue key:
+Lookup by issue key/identifier:
 
 ```graphql
-query IssueByKey($key: String!) {
-  issue(id: $key) {
+query IssueByIdentifier($identifier: String!) {
+  issue(id: $identifier) {
     id
     identifier
     title
@@ -100,22 +103,18 @@ query IssueByKey($key: String!) {
     url
     description
     updatedAt
-    links {
-      nodes {
-        id
-        url
-        title
-      }
-    }
   }
 }
 ```
 
-Lookup by identifier filter:
+Lookup by identifier with `issues(filter: ...)` (valid syntax):
 
 ```graphql
-query IssueByIdentifier($identifier: String!) {
-  issues(filter: { identifier: { eq: $identifier } }, first: 1) {
+query IssueByTeamKeyAndNumber($teamKey: String!, $number: Float!) {
+  issues(
+    filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }
+    first: 1
+  ) {
     nodes {
       id
       identifier
@@ -137,6 +136,8 @@ query IssueByIdentifier($identifier: String!) {
   }
 }
 ```
+
+Given `KAT-857`, use `teamKey = "KAT"` and `number = 857`.
 
 Resolve a key to an internal id:
 
@@ -205,6 +206,30 @@ query IssueTeamStates($id: String!) {
 }
 ```
 
+### Move an issue to a named state (resolve `stateId` first)
+
+Use a two-step flow:
+
+1. Query `issue(id: ...) { team { states { nodes { id name type } } } }`.
+2. Pick the state whose `name` exactly matches your target and pass that
+   `stateId` to `issueUpdate`.
+
+```graphql
+mutation MoveIssueToState($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue {
+      id
+      identifier
+      state {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
 ### Edit an existing comment
 
 Use `commentUpdate` through `linear_graphql`:
@@ -237,27 +262,7 @@ mutation CreateComment($issueId: String!, $body: String!) {
 }
 ```
 
-### Move an issue to a different state
-
-Use `issueUpdate` with the destination `stateId`:
-
-```graphql
-mutation MoveIssueToState($id: String!, $stateId: String!) {
-  issueUpdate(id: $id, input: { stateId: $stateId }) {
-    success
-    issue {
-      id
-      identifier
-      state {
-        id
-        name
-      }
-    }
-  }
-}
-```
-
-### Attach a GitHub PR to an issue
+### Create an attachment/link on an issue
 
 Use the GitHub-specific attachment mutation when linking a PR:
 
@@ -294,6 +299,73 @@ mutation AttachURL($issueId: String!, $url: String!, $title: String) {
   }
 }
 ```
+
+### Query issue attachments and relations
+
+```graphql
+query IssueAttachmentsAndRelations($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    attachments(first: 20) {
+      nodes {
+        id
+        title
+        url
+        sourceType
+      }
+    }
+    relations(first: 20) {
+      nodes {
+        id
+        type
+        relatedIssue {
+          id
+          identifier
+          title
+          state {
+            name
+            type
+          }
+        }
+      }
+    }
+    inverseRelations(first: 20) {
+      nodes {
+        id
+        type
+        issue {
+          id
+          identifier
+          title
+          state {
+            name
+            type
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Common valid `IssueFilter` fields
+
+Use these common fields inside `issues(filter: ...)`:
+
+- `id`
+- `number` (pair with `team.key` for identifier-style lookups)
+- `team`
+- `state`
+- `project`
+- `assignee`
+- `title`
+- `searchableContent`
+- `createdAt`
+- `updatedAt`
+- `and` / `or`
+
+`IssueFilter.identifier` is invalid.
 
 ### Introspection patterns used during schema discovery
 
@@ -378,7 +450,12 @@ mutation FileUpload(
 - Use `linear_graphql` for comment edits, uploads, and ad-hoc Linear API
   queries.
 - Prefer the narrowest issue lookup that matches what you already know:
-  key -> identifier search -> internal id.
+  `issue(id: TEAM-NUMBER)` -> `issues(filter: { team.key + number })` ->
+  internal id.
+- Do not query `Issue.links`; use `Issue.attachments`, `Issue.relations`, and
+  `Issue.inverseRelations` instead.
+- Do not use `IssueFilter.identifier`; use `IssueFilter.number` with
+  `IssueFilter.team.key` when you need identifier-style filtering.
 - For state transitions, fetch team states first and use the exact `stateId`
   instead of hardcoding names inside mutations.
 - Prefer `attachmentLinkGitHubPR` over a generic URL attachment when linking a

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -90,6 +90,111 @@ Read `apps/symphony/AGENTS.md` for full architecture reference.
 
 The agent should be able to talk to Linear, either via a configured Linear MCP server or injected `linear_graphql` tool. If none are present, stop and ask the user to configure Linear.
 
+## Linear GraphQL schema quick reference (always in context)
+
+Use this as an always-on guardrail to avoid invalid Linear queries.
+
+- `Issue.links` is invalid. Use `attachments`, `relations`, or
+  `inverseRelations`.
+- `IssueFilter.identifier` is invalid. For identifier-style filtering, use
+  `team.key` + `number`.
+
+Query by issue identifier (preferred):
+
+```graphql
+query IssueByIdentifier($identifier: String!) {
+  issue(id: $identifier) {
+    id
+    identifier
+    title
+    state {
+      id
+      name
+      type
+    }
+  }
+}
+```
+
+Query by identifier using `issues(filter: ...)`:
+
+```graphql
+query IssueByTeamKeyAndNumber($teamKey: String!, $number: Float!) {
+  issues(
+    filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }
+    first: 1
+  ) {
+    nodes {
+      id
+      identifier
+      title
+    }
+  }
+}
+```
+
+Move issue state by name (resolve `stateId` first):
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    team {
+      states {
+        nodes {
+          id
+          name
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+```graphql
+mutation MoveIssueToState($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue {
+      id
+      state {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
+Add comment:
+
+```graphql
+mutation CreateComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment {
+      id
+      url
+    }
+  }
+}
+```
+
+Attach URL:
+
+```graphql
+mutation AttachURL($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
+    success
+    attachment {
+      id
+      title
+      url
+    }
+  }
+}
+```
+
 ## Default posture
 
 - Start by determining the ticket's current status, then follow the matching flow for that status.
@@ -143,6 +248,7 @@ Todo -> In Progress -> Agent Review (auto, address bot feedback) -> Human Review
 
 ## Step 0: Determine current ticket state and route
 
+0. Before ANY other action, read `.codex/skills/linear/SKILL.md` and keep it in context. Do not guess Linear GraphQL schema.
 1. Fetch the issue by explicit ticket ID.
 2. Read the current state.
 3. Route to the matching flow:

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -242,6 +242,111 @@ Read `apps/symphony/AGENTS.md` for full architecture reference.
 
 The agent should be able to talk to Linear, either via a configured Linear MCP server or injected `linear_graphql` tool. If none are present, stop and ask the user to configure Linear.
 
+## Linear GraphQL schema quick reference (always in context)
+
+Use this as an always-on guardrail to avoid invalid Linear queries.
+
+- `Issue.links` is invalid. Use `attachments`, `relations`, or
+  `inverseRelations`.
+- `IssueFilter.identifier` is invalid. For identifier-style filtering, use
+  `team.key` + `number`.
+
+Query by issue identifier (preferred):
+
+```graphql
+query IssueByIdentifier($identifier: String!) {
+  issue(id: $identifier) {
+    id
+    identifier
+    title
+    state {
+      id
+      name
+      type
+    }
+  }
+}
+```
+
+Query by identifier using `issues(filter: ...)`:
+
+```graphql
+query IssueByTeamKeyAndNumber($teamKey: String!, $number: Float!) {
+  issues(
+    filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }
+    first: 1
+  ) {
+    nodes {
+      id
+      identifier
+      title
+    }
+  }
+}
+```
+
+Move issue state by name (resolve `stateId` first):
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    team {
+      states {
+        nodes {
+          id
+          name
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+```graphql
+mutation MoveIssueToState($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue {
+      id
+      state {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
+Add comment:
+
+```graphql
+mutation CreateComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment {
+      id
+      url
+    }
+  }
+}
+```
+
+Attach URL:
+
+```graphql
+mutation AttachURL($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
+    success
+    attachment {
+      id
+      title
+      url
+    }
+  }
+}
+```
+
 ## Default posture
 
 - Start by determining the ticket's current status, then follow the matching flow for that status.
@@ -284,6 +389,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 ## Step 0: Determine current ticket state and route
 
+0. Before ANY other action, read `.codex/skills/linear/SKILL.md` and keep it in context. Do not guess Linear GraphQL schema.
 1. Fetch the issue by explicit ticket ID.
 2. Read the current state.
 3. Route to the matching flow:

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1277,12 +1277,15 @@ impl Orchestrator {
                 schedule_continuation,
             } => {
                 if !schedule_continuation {
-                    self.state.completed.insert(issue_id.to_string(), CompletedEntry {
-                        issue_id: issue_id.to_string(),
-                        identifier: issue_identifier.clone(),
-                        title: run_attempt.issue_title.clone().unwrap_or_default(),
-                        completed_at: Utc::now(),
-                    });
+                    self.state.completed.insert(
+                        issue_id.to_string(),
+                        CompletedEntry {
+                            issue_id: issue_id.to_string(),
+                            identifier: issue_identifier.clone(),
+                            title: run_attempt.issue_title.clone().unwrap_or_default(),
+                            completed_at: Utc::now(),
+                        },
+                    );
                 }
 
                 tracing::info!(
@@ -2130,12 +2133,15 @@ impl Orchestrator {
             }
         }
 
-        self.state.completed.insert(issue_id.to_string(), CompletedEntry {
-            issue_id: issue_id.to_string(),
-            identifier: issue.identifier.clone(),
-            title: issue.title.clone(),
-            completed_at: Utc::now(),
-        });
+        self.state.completed.insert(
+            issue_id.to_string(),
+            CompletedEntry {
+                issue_id: issue_id.to_string(),
+                identifier: issue.identifier.clone(),
+                title: issue.title.clone(),
+                completed_at: Utc::now(),
+            },
+        );
         self.state.running.remove(issue_id);
         self.state.claimed.remove(issue_id);
         self.state.retry_attempts.remove(issue_id);

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -153,14 +153,14 @@ fn test_run_attempt_construction_and_serialization() {
     let ra = RunAttempt {
         issue_id: "id-1".into(),
         issue_identifier: "PROJ-1".into(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: "/tmp/ws".into(),
         started_at: Utc::now(),
         status: "running".into(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     let json = serde_json::to_string(&ra).unwrap();
     let deser: RunAttempt = serde_json::from_str(&json).unwrap();
@@ -228,14 +228,14 @@ fn test_orchestrator_snapshot_serializes() {
                 RunAttempt {
                     issue_id: "id-z".into(),
                     issue_identifier: "PROJ-Z".into(),
-            issue_title: None,
+                    issue_title: None,
                     attempt: Some(1),
                     workspace_path: "/tmp/ws-z".into(),
                     started_at: Utc::now(),
                     status: "running".into(),
                     error: None,
                     worker_host: None,
-            linear_state: None,
+                    linear_state: None,
                 },
             );
             m.insert(
@@ -243,14 +243,14 @@ fn test_orchestrator_snapshot_serializes() {
                 RunAttempt {
                     issue_id: "id-a".into(),
                     issue_identifier: "PROJ-A".into(),
-            issue_title: None,
+                    issue_title: None,
                     attempt: Some(1),
                     workspace_path: "/tmp/ws-a".into(),
                     started_at: Utc::now(),
                     status: "running".into(),
                     error: None,
                     worker_host: None,
-            linear_state: None,
+                    linear_state: None,
                 },
             );
             m

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -189,11 +189,11 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "dashboard shell should include rate-limit diagnostics section"
     );
     assert!(
-        body.contains("id=\\\"polling-next-poll\\\">n/a"),
+        body.contains("id=\"polling-next-poll\">n/a"),
         "dashboard shell should initialize next-poll tile with n/a placeholder"
     );
     assert!(
-        body.contains("id=\\\"polling-interval\\\">n/a"),
+        body.contains("id=\"polling-interval\">n/a"),
         "dashboard shell should initialize poll-interval tile with n/a placeholder"
     );
     assert!(

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -64,14 +64,14 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                 RunAttempt {
                     issue_id: "issue-123".to_string(),
                     issue_identifier: "SIM-123".to_string(),
-            issue_title: None,
+                    issue_title: None,
                     attempt: Some(2),
                     workspace_path: "/tmp/symphony/issue-123".to_string(),
                     started_at,
                     status: "running".to_string(),
                     error: None,
                     worker_host: Some("worker-a".to_string()),
-            linear_state: None,
+                    linear_state: None,
                 },
             );
             running

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -354,15 +354,15 @@ fn test_reconcile_refresh_failure_is_non_fatal_and_dispatch_continues() {
 fn test_completed_is_bookkeeping_and_does_not_block_dispatch() {
     let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let candidate = issue("issue-1", "SIM-1", "Todo", Some(1), 0);
-    orchestrator
-        .state_mut()
-        .completed
-        .insert(candidate.id.clone(), symphony::domain::CompletedEntry {
+    orchestrator.state_mut().completed.insert(
+        candidate.id.clone(),
+        symphony::domain::CompletedEntry {
             issue_id: candidate.id.clone(),
             identifier: candidate.identifier.clone(),
             title: candidate.title.clone(),
             completed_at: chrono::Utc::now(),
-        });
+        },
+    );
 
     let mut port = FakePort {
         candidate_issues: vec![candidate.clone()],
@@ -1165,7 +1165,10 @@ fn test_worker_completion_schedules_continuation_retry_with_session_context() {
         "completed turn should leave running map before retry scheduling"
     );
     assert!(
-        !orchestrator.state().completed.contains_key("issue-complete"),
+        !orchestrator
+            .state()
+            .completed
+            .contains_key("issue-complete"),
         "continuation completions must stay out of completed until terminal state"
     );
     assert!(
@@ -1641,14 +1644,14 @@ fn test_reconcile_non_active_state_stops_run_without_cleanup() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-non-active".to_string(),
         issue_identifier: "SIM-97".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: "/tmp/ws-non-active".to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -1682,7 +1685,10 @@ fn test_reconcile_non_active_state_stops_run_without_cleanup() {
 
     // The issue must NOT be in completed — non-terminal stop has no workspace cleanup.
     assert!(
-        !orchestrator.state().completed.contains_key("issue-non-active"),
+        !orchestrator
+            .state()
+            .completed
+            .contains_key("issue-non-active"),
         "non-terminal state stop must not add issue to completed (no cleanup semantic)"
     );
 }
@@ -1755,14 +1761,14 @@ fn test_terminal_state_cleanup_removes_workspace_when_enabled() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-terminal-cleanup".to_string(),
         issue_identifier: "SIM-98".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: workspace_path.to_string_lossy().to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -1804,14 +1810,14 @@ fn test_terminal_state_cleanup_preserves_workspace_when_disabled() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-terminal-no-cleanup".to_string(),
         issue_identifier: "SIM-99".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: workspace_path.to_string_lossy().to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -1862,14 +1868,14 @@ fn test_terminal_state_cleanup_runs_before_remove_hook() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-before-remove-hook".to_string(),
         issue_identifier: "SIM-100".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: workspace_path.to_string_lossy().to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -2076,14 +2082,14 @@ fn test_terminal_state_cleanup_removes_worktree_checkout_when_enabled() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-worktree-cleanup".to_string(),
         issue_identifier: "SIM-101".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: workspace.path.clone(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -2134,14 +2140,14 @@ fn test_terminal_state_cleanup_failure_is_non_fatal() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-cleanup-failure".to_string(),
         issue_identifier: "SIM-102".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: outside_workspace.to_string_lossy().to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()


### PR DESCRIPTION
## Summary
- remove invalid Linear GraphQL examples from `.codex/skills/linear/SKILL.md` (`Issue.links`, `IssueFilter.identifier`) and add schema-validated query/mutation patterns
- add coverage for identifier lookup via team key + issue number, state updates by name (stateId resolution), comments, attachments/relations, and common valid `IssueFilter` fields
- inject a Linear GraphQL quick-reference directly into `apps/symphony/WORKFLOW.md` and move the mandatory linear skill read into Step 0

## Validation
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Linear GraphQL guidance consumed by the Symphony AI agent by removing two schema-invalid patterns (`Issue.links` and `IssueFilter.identifier`) and replacing them with correct, schema-validated alternatives. It also injects a compact always-on quick-reference directly into `WORKFLOW.md` so guardrails are in context even before the agent explicitly reads the full skill file, and promotes reading `SKILL.md` to Step 0 of the workflow.

Key changes:
- `IssueByKey` query renamed to `IssueByIdentifier`; the old filter-based `IssueByIdentifier` (using the non-existent `IssueFilter.identifier`) is replaced with `IssueByTeamKeyAndNumber` using the valid `team.key` + `number` pattern.
- `Issue.links` removed from all example queries; `attachments`, `relations`, and `inverseRelations` are now documented as the correct fields.
- The `MoveIssueToState` section moved to directly follow `IssueTeamStates` and now explicitly documents the required two-step resolution flow.
- A "Common valid `IssueFilter` fields" reference list is added to prevent future schema guessing.
- `WORKFLOW.md` gains a self-contained quick-reference block and a Step 0 mandate to read `SKILL.md` before any Linear API call.

No source code is changed; this is a documentation/configuration-only PR. The GraphQL patterns introduced are consistent with the Linear schema, and the guidance between the two files is coherent.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — documentation-only changes that correct invalid GraphQL patterns with schema-accurate replacements.
- Both changed files are Markdown documentation and AI-agent workflow configuration. No source code, tests, or build artifacts are touched. All introduced GraphQL patterns (`issue(id: $identifier)`, `team.key + number` filter, `attachments`/`relations`/`inverseRelations`) are valid per the Linear schema, and the guidance between SKILL.md and WORKFLOW.md is internally consistent. The duplication between the two files is intentional and clearly documented as an always-on context guardrail.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .codex/skills/linear/SKILL.md | Removes invalid `Issue.links` and `IssueFilter.identifier` patterns, renames and corrects lookup queries, restructures state-transition section for clarity, and adds new sections for attachments/relations and valid IssueFilter fields. All updated GraphQL patterns appear schema-valid. |
| apps/symphony/WORKFLOW.md | Injects a "Linear GraphQL schema quick reference" section as an always-on guardrail and promotes reading SKILL.md to Step 0. Quick-reference queries are consistent with the full SKILL.md counterparts. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant WORKFLOW.md as WORKFLOW.md (quick-ref)
    participant SKILL.md as SKILL.md (full ref)
    participant LinearAPI as Linear GraphQL API

    Note over Agent,WORKFLOW.md: Step 0 — always in context
    Agent->>WORKFLOW.md: Read guardrails (Issue.links invalid, IssueFilter.identifier invalid)
    Agent->>SKILL.md: Read full skill before any linear_graphql call

    Note over Agent,LinearAPI: Lookup by identifier (preferred path)
    Agent->>LinearAPI: issue(id: "KAT-857") → id, identifier, title, state…

    Note over Agent,LinearAPI: Fallback: filter by team.key + number
    Agent->>LinearAPI: issues(filter:{team:{key:{eq:"KAT"}},number:{eq:857}}, first:1)

    Note over Agent,LinearAPI: State transition (two-step)
    Agent->>LinearAPI: issue(id:$id){team{states{nodes{id name type}}}}
    LinearAPI-->>Agent: state list
    Agent->>Agent: Pick state by name → stateId
    Agent->>LinearAPI: issueUpdate(id:$id, input:{stateId:$stateId})

    Note over Agent,LinearAPI: Attachments / relations
    Agent->>LinearAPI: issue(id:$id){attachments, relations, inverseRelations}
```

<sub>Last reviewed commit: ["Merge remote-trackin..."](https://github.com/gannonh/kata/commit/3d0931dbf9f3582d2523099e3188c4bf550a218b)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted internal code formatting and indentation for improved readability.

* **Tests**
  * Reformatted test code, struct literals, and assertions for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->