### PR TITLE
[kata/apps-cli/M007/S02] Search provider abstraction and Tavily support

### DIFF
--- a/apps/cli/src/resources/extensions/search-the-web/index.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/index.ts
@@ -38,6 +38,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerSearchTool } from "./tool-search";
 import { registerFetchPageTool } from "./tool-fetch-page";
 import { registerLLMContextTool } from "./tool-llm-context";
+import { registerNativeSearchHooks } from "./native-search.js";
 
 export default function (pi: ExtensionAPI) {
   // Register all tools
@@ -45,21 +46,26 @@ export default function (pi: ExtensionAPI) {
   registerFetchPageTool(pi);
   registerLLMContextTool(pi);
 
+  // Register native Anthropic web search hooks
+  registerNativeSearchHooks(pi);
+
   // Startup diagnostics
   pi.on("session_start", async (_event, ctx) => {
     const hasBrave = !!process.env.BRAVE_API_KEY;
     const hasJina = !!process.env.JINA_API_KEY;
     const hasAnswers = !!process.env.BRAVE_ANSWERS_KEY;
+    const hasTavily = !!process.env.TAVILY_API_KEY;
 
-    if (!hasBrave) {
+    if (!hasBrave && !hasTavily) {
       ctx.ui.notify(
-        "Web search: Set BRAVE_API_KEY for web search + LLM context capability",
+        "Web search: Set BRAVE_API_KEY or TAVILY_API_KEY for web search capability",
         "warning"
       );
     }
 
     const parts: string[] = ["Web search v3 loaded"];
-    if (hasBrave) parts.push("Search ✓");
+    if (hasBrave) parts.push("Brave ✓");
+    if (hasTavily) parts.push("Tavily ✓");
     if (hasAnswers) parts.push("Answers ✓");
     if (hasJina) parts.push("Jina ✓");
 

--- a/apps/cli/src/resources/extensions/search-the-web/native-search.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/native-search.ts
@@ -93,6 +93,7 @@ export function registerNativeSearchHooks(
 ): { getIsAnthropic: () => boolean } {
   let isAnthropicProvider = false;
   let modelSelectFired = false;
+  let activeToolsBeforeNative: string[] | null = null;
 
   // Session-level native search counter.
   // Tracks cumulative web_search_tool_result blocks across all turns in a session.
@@ -111,17 +112,15 @@ export function registerNativeSearchHooks(
     // native web_search is server-side and more reliable.
     if (isAnthropicProvider && !preferBraveSearch()) {
       const active = pi.getActiveTools();
+      if (!wasAnthropic) activeToolsBeforeNative = [...active];
       pi.setActiveTools(
         active.filter((t: string) => !CUSTOM_SEARCH_TOOL_NAMES.includes(t))
       );
     } else if (!isAnthropicProvider && wasAnthropic) {
-      // Switching away from Anthropic — re-enable custom search tools
-      const active = pi.getActiveTools();
-      const toAdd = CUSTOM_SEARCH_TOOL_NAMES.filter(
-        (t) => !active.includes(t)
-      );
-      if (toAdd.length > 0) {
-        pi.setActiveTools([...active, ...toAdd]);
+      // Switching away from Anthropic — restore the exact tool set from before
+      if (activeToolsBeforeNative) {
+        pi.setActiveTools(activeToolsBeforeNative);
+        activeToolsBeforeNative = null;
       }
     }
 
@@ -139,7 +138,9 @@ export function registerNativeSearchHooks(
       !wasAnthropic &&
       event.source !== "restore"
     ) {
-      ctx.ui.notify("Brave search active (PREFER_BRAVE_SEARCH)", "info");
+      const provider = process.env.SEARCH_PROVIDER?.toLowerCase();
+      const label = provider === "tavily" ? "Tavily" : "Brave";
+      ctx.ui.notify(`${label} search active (SEARCH_PROVIDER override)`, "info");
     } else if (!isAnthropicProvider && !hasBrave) {
       ctx.ui.notify(
         "Web search: Set BRAVE_API_KEY or use an Anthropic model for built-in search",

--- a/apps/cli/src/resources/extensions/search-the-web/native-search.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/native-search.ts
@@ -1,0 +1,234 @@
+/**
+ * Native Anthropic web search hook logic.
+ *
+ * Extracted from index.ts so it can be unit-tested without importing
+ * the heavy tool-registration modules.
+ */
+
+/** Tool names for the Brave-backed custom search tools */
+export const BRAVE_TOOL_NAMES = ["search-the-web", "search_and_read"];
+
+/** All custom search tool names that should be disabled when native search is active */
+export const CUSTOM_SEARCH_TOOL_NAMES = [
+  "search-the-web",
+  "search_and_read",
+  "google_search",
+];
+
+/** Thinking block types that require signature validation by the API */
+const THINKING_TYPES = new Set(["thinking", "redacted_thinking"]);
+
+/**
+ * Maximum number of native web searches allowed per session (agent unit).
+ * The Anthropic API's `max_uses` is per-request — it resets on each API call.
+ * When `pause_turn` triggers a resubmit, the model gets a fresh budget.
+ * This session-level cap prevents unbounded search accumulation.
+ *
+ * 15 = 3 full turns of 5 searches each — generous for research, but bounded.
+ */
+export const MAX_NATIVE_SEARCHES_PER_SESSION = 15;
+
+/**
+ * When true, skip native web search injection and keep Brave/custom tools active on Anthropic.
+ *
+ * Resolution order:
+ * 1. SEARCH_PROVIDER env var: 'brave' or 'tavily' → true, 'native' → false
+ * 2. PREFER_BRAVE_SEARCH env var: '1' or 'true' → true
+ * 3. Default: false (use native search on Anthropic)
+ */
+export function preferBraveSearch(): boolean {
+  const provider = process.env.SEARCH_PROVIDER?.toLowerCase();
+  if (provider === "brave" || provider === "tavily") return true;
+  if (provider === "native") return false;
+  return (
+    process.env.PREFER_BRAVE_SEARCH === "1" ||
+    process.env.PREFER_BRAVE_SEARCH === "true"
+  );
+}
+
+/** Minimal interface matching the subset of ExtensionAPI we use */
+export interface NativeSearchPI {
+  on(event: string, handler: (...args: any[]) => any): void;
+  getActiveTools(): string[];
+  setActiveTools(tools: string[]): void;
+}
+
+/**
+ * Strip thinking/redacted_thinking blocks from assistant messages in the
+ * conversation history.
+ *
+ * Why: The Pi SDK's streaming parser drops `server_tool_use` and
+ * `web_search_tool_result` content blocks (unknown types). When the
+ * conversation is replayed, the assistant messages are incomplete — missing
+ * those blocks. The Anthropic API detects the modification and rejects the
+ * request with "thinking blocks cannot be modified."
+ *
+ * Fix: Remove thinking blocks from all assistant messages in the history.
+ * In Anthropic's Messages API, the messages array always ends with a user
+ * message, so every assistant message is from a previous turn that has been
+ * through a store/replay cycle. The model generates fresh thinking for the
+ * current turn regardless.
+ */
+export function stripThinkingFromHistory(
+  messages: Array<Record<string, unknown>>
+): void {
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    const content = msg.content;
+    if (!Array.isArray(content)) continue;
+    msg.content = content.filter(
+      (block: any) => !THINKING_TYPES.has(block?.type)
+    );
+  }
+}
+
+/**
+ * Register model_select, before_provider_request, and session_start hooks
+ * for native Anthropic web search injection.
+ *
+ * Returns the isAnthropicProvider getter for testing.
+ */
+export function registerNativeSearchHooks(
+  pi: NativeSearchPI
+): { getIsAnthropic: () => boolean } {
+  let isAnthropicProvider = false;
+  let modelSelectFired = false;
+
+  // Session-level native search counter.
+  // Tracks cumulative web_search_tool_result blocks across all turns in a session.
+  // Reset on session_start. Used to compute remaining budget for max_uses.
+  let sessionSearchCount = 0;
+
+  // Track provider changes via model selection
+  pi.on("model_select", async (event: any, ctx: any) => {
+    modelSelectFired = true;
+    const wasAnthropic = isAnthropicProvider;
+    isAnthropicProvider = event.model.provider === "anthropic";
+
+    const hasBrave = !!process.env.BRAVE_API_KEY;
+
+    // When Anthropic (and not preferring Brave): disable custom search tools —
+    // native web_search is server-side and more reliable.
+    if (isAnthropicProvider && !preferBraveSearch()) {
+      const active = pi.getActiveTools();
+      pi.setActiveTools(
+        active.filter((t: string) => !CUSTOM_SEARCH_TOOL_NAMES.includes(t))
+      );
+    } else if (!isAnthropicProvider && wasAnthropic) {
+      // Switching away from Anthropic — re-enable custom search tools
+      const active = pi.getActiveTools();
+      const toAdd = CUSTOM_SEARCH_TOOL_NAMES.filter(
+        (t) => !active.includes(t)
+      );
+      if (toAdd.length > 0) {
+        pi.setActiveTools([...active, ...toAdd]);
+      }
+    }
+
+    // Provider-aware diagnostics on first selection or provider change
+    if (
+      isAnthropicProvider &&
+      !preferBraveSearch() &&
+      !wasAnthropic &&
+      event.source !== "restore"
+    ) {
+      ctx.ui.notify("Native Anthropic web search active", "info");
+    } else if (
+      isAnthropicProvider &&
+      preferBraveSearch() &&
+      !wasAnthropic &&
+      event.source !== "restore"
+    ) {
+      ctx.ui.notify("Brave search active (PREFER_BRAVE_SEARCH)", "info");
+    } else if (!isAnthropicProvider && !hasBrave) {
+      ctx.ui.notify(
+        "Web search: Set BRAVE_API_KEY or use an Anthropic model for built-in search",
+        "warning"
+      );
+    }
+  });
+
+  // Inject native web search into Anthropic API requests
+  pi.on("before_provider_request", (event: any) => {
+    const payload = event.payload as Record<string, unknown>;
+    if (!payload) return;
+
+    // Detect Anthropic provider from event model, model_select flag, or model name heuristic
+    const eventModel = event.model as { provider: string } | undefined;
+    let isAnthropic: boolean;
+    if (eventModel?.provider) {
+      isAnthropic = eventModel.provider === "anthropic";
+    } else if (modelSelectFired) {
+      isAnthropic = isAnthropicProvider;
+    } else {
+      const modelName =
+        typeof payload.model === "string" ? payload.model : "";
+      isAnthropic = modelName.startsWith("claude-");
+    }
+    if (!isAnthropic) return;
+
+    // Strip thinking blocks from history to avoid signature validation errors
+    const messages = payload.messages as
+      | Array<Record<string, unknown>>
+      | undefined;
+    if (Array.isArray(messages)) {
+      stripThinkingFromHistory(messages);
+    }
+
+    // When preferring Brave, skip native search injection entirely
+    if (preferBraveSearch()) return;
+
+    if (!Array.isArray(payload.tools)) payload.tools = [];
+
+    let tools = payload.tools as Array<Record<string, unknown>>;
+
+    // Don't double-inject if already present
+    if (tools.some((t) => t.type === "web_search_20250305")) return;
+
+    // Remove custom search tool definitions from Anthropic requests
+    tools = tools.filter(
+      (t) => !CUSTOM_SEARCH_TOOL_NAMES.includes(t.name as string)
+    );
+    payload.tools = tools;
+
+    // Session-level search budget
+    if (Array.isArray(messages)) {
+      let historySearchCount = 0;
+      for (const msg of messages) {
+        const content = msg.content;
+        if (!Array.isArray(content)) continue;
+        for (const block of content) {
+          if ((block as any)?.type === "web_search_tool_result") {
+            historySearchCount++;
+          }
+        }
+      }
+      sessionSearchCount = historySearchCount;
+    }
+
+    const remaining = Math.max(
+      0,
+      MAX_NATIVE_SEARCHES_PER_SESSION - sessionSearchCount
+    );
+
+    if (remaining <= 0) {
+      // Budget exhausted — don't inject the search tool
+      return payload;
+    }
+
+    tools.push({
+      type: "web_search_20250305",
+      name: "web_search",
+      max_uses: Math.min(5, remaining),
+    });
+
+    return payload;
+  });
+
+  // Reset session-level search budget on new session
+  pi.on("session_start", async () => {
+    sessionSearchCount = 0;
+  });
+
+  return { getIsAnthropic: () => isAnthropicProvider };
+}

--- a/apps/cli/src/resources/extensions/search-the-web/provider.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/provider.ts
@@ -1,0 +1,77 @@
+/**
+ * Search provider selection.
+ *
+ * Single source of truth for which search backend (Tavily vs Brave) to use.
+ * Reads API keys from process.env at call time (not module load time).
+ * Simplified from gsd-pi: no Ollama, no AuthStorage persistence — just
+ * env-var-based resolution with optional SEARCH_PROVIDER override.
+ */
+
+export type SearchProvider = 'tavily' | 'brave'
+export type SearchProviderPreference = SearchProvider | 'auto'
+
+const VALID_PREFERENCES = new Set<string>(['tavily', 'brave', 'auto'])
+
+/** Returns the Tavily API key from the environment, or empty string if not set. */
+export function getTavilyApiKey(): string {
+  return process.env.TAVILY_API_KEY || ''
+}
+
+/** Returns the Brave API key from the environment, or empty string if not set. */
+export function getBraveApiKey(): string {
+  return process.env.BRAVE_API_KEY || ''
+}
+
+/** Standard headers for Brave Search API requests. */
+export function braveHeaders(): Record<string, string> {
+  return {
+    "Accept": "application/json",
+    "Accept-Encoding": "gzip",
+    "X-Subscription-Token": getBraveApiKey(),
+  }
+}
+
+/**
+ * Resolve which search provider to use based on available API keys and preference.
+ *
+ * Logic:
+ * 1. If overridePreference is given and valid, use it as the preference.
+ * 2. Otherwise, read SEARCH_PROVIDER env var.
+ * 3. If preference is 'auto' (or unset): prefer Tavily if TAVILY_API_KEY set, else Brave.
+ * 4. If preference is a specific provider: use it if its key exists, else fall back.
+ * 5. Return null if neither key is available.
+ */
+export function resolveSearchProvider(overridePreference?: string): SearchProvider | null {
+  const hasTavily = getTavilyApiKey().length > 0
+  const hasBrave = getBraveApiKey().length > 0
+
+  // Determine effective preference
+  let pref: SearchProviderPreference
+  if (overridePreference && VALID_PREFERENCES.has(overridePreference)) {
+    pref = overridePreference as SearchProviderPreference
+  } else {
+    const envPref = process.env.SEARCH_PROVIDER || ''
+    pref = VALID_PREFERENCES.has(envPref) ? (envPref as SearchProviderPreference) : 'auto'
+  }
+
+  // Resolve based on preference
+  if (pref === 'auto') {
+    if (hasTavily) return 'tavily'
+    if (hasBrave) return 'brave'
+    return null
+  }
+
+  if (pref === 'tavily') {
+    if (hasTavily) return 'tavily'
+    if (hasBrave) return 'brave'
+    return null
+  }
+
+  if (pref === 'brave') {
+    if (hasBrave) return 'brave'
+    if (hasTavily) return 'tavily'
+    return null
+  }
+
+  return null
+}

--- a/apps/cli/src/resources/extensions/search-the-web/tavily.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/tavily.ts
@@ -1,0 +1,115 @@
+/**
+ * Tavily API types and helper functions for normalizing Tavily search results
+ * into the shared SearchResultFormatted shape.
+ *
+ * All exports are pure functions with no side effects.
+ */
+
+import type { SearchResultFormatted } from "./format.js";
+
+// =============================================================================
+// Tavily API Types
+// =============================================================================
+
+/** A single result from the Tavily Search API. */
+export interface TavilyResult {
+  title: string;
+  url: string;
+  content: string;
+  score: number;
+  raw_content?: string | null;
+  published_date?: string | null;
+  favicon?: string | null;
+}
+
+/** Top-level response from POST https://api.tavily.com/search */
+export interface TavilySearchResponse {
+  query: string;
+  answer?: string | null;
+  results: TavilyResult[];
+  response_time: string | number;
+  usage?: { credits: number } | null;
+  request_id?: string | null;
+}
+
+// =============================================================================
+// Result Normalization
+// =============================================================================
+
+/**
+ * Map a single Tavily result to the shared SearchResultFormatted shape.
+ *
+ * - `content` → `description` (Tavily puts NLP summary or chunks inline)
+ * - `published_date` → `age` via publishedDateToAge()
+ * - No `extra_snippets` — Tavily's content already includes chunk data
+ */
+export function normalizeTavilyResult(r: TavilyResult): SearchResultFormatted {
+  return {
+    title: r.title || "(untitled)",
+    url: r.url,
+    description: r.content || "",
+    age: r.published_date ? publishedDateToAge(r.published_date) : undefined,
+  };
+}
+
+// =============================================================================
+// Date-to-Age Conversion
+// =============================================================================
+
+/**
+ * Convert an ISO 8601 date string to a human-readable relative age string.
+ *
+ * Examples: "3 days ago", "2 hours ago", "1 month ago", "just now"
+ * Returns undefined for unparseable dates or dates in the future.
+ */
+export function publishedDateToAge(isoDate: string): string | undefined {
+  const date = new Date(isoDate);
+  if (isNaN(date.getTime())) return undefined;
+
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+
+  // Future dates — return undefined rather than negative ages
+  if (diffMs < 0) return undefined;
+
+  const seconds = Math.floor(diffMs / 1000);
+  if (seconds < 60) return "just now";
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} ${minutes === 1 ? "minute" : "minutes"} ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} ${hours === 1 ? "hour" : "hours"} ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days} ${days === 1 ? "day" : "days"} ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months} ${months === 1 ? "month" : "months"} ago`;
+
+  const years = Math.floor(months / 12);
+  return `${years} ${years === 1 ? "year" : "years"} ago`;
+}
+
+// =============================================================================
+// Freshness Format Mapping
+// =============================================================================
+
+/** Brave freshness string → Tavily time_range value mapping. */
+const BRAVE_TO_TAVILY_FRESHNESS: Record<string, string> = {
+  pd: "day",
+  pw: "week",
+  pm: "month",
+  py: "year",
+};
+
+/**
+ * Convert a Brave-format freshness string (pd/pw/pm/py) to a Tavily
+ * `time_range` value (day/week/month/year).
+ *
+ * Returns null if input is null or not a recognized Brave freshness value.
+ */
+export function mapFreshnessToTavily(braveFreshness: string | null): string | null {
+  if (braveFreshness === null) return null;
+  return BRAVE_TO_TAVILY_FRESHNESS[braveFreshness] ?? null;
+}

--- a/apps/cli/src/resources/extensions/search-the-web/tests/provider.test.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/tests/provider.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { resolveSearchProvider, getTavilyApiKey, getBraveApiKey, braveHeaders } from '../provider.js'
+
+describe('provider', () => {
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    savedEnv = {
+      TAVILY_API_KEY: process.env.TAVILY_API_KEY,
+      BRAVE_API_KEY: process.env.BRAVE_API_KEY,
+      SEARCH_PROVIDER: process.env.SEARCH_PROVIDER,
+    }
+    delete process.env.TAVILY_API_KEY
+    delete process.env.BRAVE_API_KEY
+    delete process.env.SEARCH_PROVIDER
+  })
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  describe('resolveSearchProvider', () => {
+    test('auto with both keys prefers tavily', () => {
+      process.env.TAVILY_API_KEY = 'tk'
+      process.env.BRAVE_API_KEY = 'bk'
+      expect(resolveSearchProvider()).toBe('tavily')
+    })
+
+    test('auto with only brave key returns brave', () => {
+      process.env.BRAVE_API_KEY = 'bk'
+      expect(resolveSearchProvider()).toBe('brave')
+    })
+
+    test('auto with only tavily key returns tavily', () => {
+      process.env.TAVILY_API_KEY = 'tk'
+      expect(resolveSearchProvider()).toBe('tavily')
+    })
+
+    test('no keys returns null', () => {
+      expect(resolveSearchProvider()).toBeNull()
+    })
+
+    test('SEARCH_PROVIDER=brave overrides auto preference', () => {
+      process.env.TAVILY_API_KEY = 'tk'
+      process.env.BRAVE_API_KEY = 'bk'
+      process.env.SEARCH_PROVIDER = 'brave'
+      expect(resolveSearchProvider()).toBe('brave')
+    })
+
+    test('SEARCH_PROVIDER=tavily with missing tavily key falls back to brave', () => {
+      process.env.BRAVE_API_KEY = 'bk'
+      process.env.SEARCH_PROVIDER = 'tavily'
+      expect(resolveSearchProvider()).toBe('brave')
+    })
+
+    test('override parameter takes priority over env', () => {
+      process.env.TAVILY_API_KEY = 'tk'
+      process.env.BRAVE_API_KEY = 'bk'
+      process.env.SEARCH_PROVIDER = 'tavily'
+      expect(resolveSearchProvider('brave')).toBe('brave')
+    })
+
+    test('invalid override falls back to auto', () => {
+      process.env.TAVILY_API_KEY = 'tk'
+      expect(resolveSearchProvider('invalid')).toBe('tavily')
+    })
+
+    test('brave preference with missing brave key falls back to tavily', () => {
+      process.env.TAVILY_API_KEY = 'tk'
+      expect(resolveSearchProvider('brave')).toBe('tavily')
+    })
+  })
+
+  describe('getTavilyApiKey', () => {
+    test('returns key when set', () => {
+      process.env.TAVILY_API_KEY = 'my-key'
+      expect(getTavilyApiKey()).toBe('my-key')
+    })
+    test('returns empty string when unset', () => {
+      expect(getTavilyApiKey()).toBe('')
+    })
+  })
+
+  describe('getBraveApiKey', () => {
+    test('returns key when set', () => {
+      process.env.BRAVE_API_KEY = 'bk'
+      expect(getBraveApiKey()).toBe('bk')
+    })
+    test('returns empty string when unset', () => {
+      expect(getBraveApiKey()).toBe('')
+    })
+  })
+
+  describe('braveHeaders', () => {
+    test('includes subscription token from env', () => {
+      process.env.BRAVE_API_KEY = 'test-token'
+      const h = braveHeaders()
+      expect(h['X-Subscription-Token']).toBe('test-token')
+      expect(h['Accept']).toBe('application/json')
+    })
+  })
+})

--- a/apps/cli/src/resources/extensions/search-the-web/tests/tavily.test.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/tests/tavily.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from 'bun:test'
+import { normalizeTavilyResult, publishedDateToAge, mapFreshnessToTavily } from '../tavily.js'
+import type { TavilyResult } from '../tavily.js'
+
+describe('tavily', () => {
+  describe('normalizeTavilyResult', () => {
+    test('maps basic result', () => {
+      const input: TavilyResult = {
+        title: 'Test Title',
+        url: 'https://example.com',
+        content: 'Some content',
+        score: 0.95,
+        published_date: null,
+      }
+      const result = normalizeTavilyResult(input)
+      expect(result.title).toBe('Test Title')
+      expect(result.url).toBe('https://example.com')
+      expect(result.description).toBe('Some content')
+      expect(result.age).toBeUndefined()
+    })
+
+    test('uses (untitled) for empty title', () => {
+      const input: TavilyResult = { title: '', url: 'https://x.com', content: 'c', score: 0.5 }
+      expect(normalizeTavilyResult(input).title).toBe('(untitled)')
+    })
+
+    test('uses empty string for empty content', () => {
+      const input: TavilyResult = { title: 'T', url: 'https://x.com', content: '', score: 0.5 }
+      expect(normalizeTavilyResult(input).description).toBe('')
+    })
+
+    test('computes age from published_date', () => {
+      const yesterday = new Date(Date.now() - 86400000).toISOString()
+      const input: TavilyResult = {
+        title: 'T', url: 'https://x.com', content: 'c', score: 0.5,
+        published_date: yesterday,
+      }
+      expect(normalizeTavilyResult(input).age).toBe('1 day ago')
+    })
+  })
+
+  describe('publishedDateToAge', () => {
+    test('just now for recent dates', () => {
+      const now = new Date().toISOString()
+      expect(publishedDateToAge(now)).toBe('just now')
+    })
+
+    test('minutes ago', () => {
+      const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+      expect(publishedDateToAge(fiveMinAgo)).toBe('5 minutes ago')
+    })
+
+    test('1 minute ago (singular)', () => {
+      const oneMinAgo = new Date(Date.now() - 90 * 1000).toISOString()
+      expect(publishedDateToAge(oneMinAgo)).toBe('1 minute ago')
+    })
+
+    test('hours ago', () => {
+      const threeHrsAgo = new Date(Date.now() - 3 * 3600 * 1000).toISOString()
+      expect(publishedDateToAge(threeHrsAgo)).toBe('3 hours ago')
+    })
+
+    test('1 hour ago (singular)', () => {
+      const oneHrAgo = new Date(Date.now() - 3600 * 1000).toISOString()
+      expect(publishedDateToAge(oneHrAgo)).toBe('1 hour ago')
+    })
+
+    test('days ago', () => {
+      const fiveDaysAgo = new Date(Date.now() - 5 * 86400 * 1000).toISOString()
+      expect(publishedDateToAge(fiveDaysAgo)).toBe('5 days ago')
+    })
+
+    test('months ago', () => {
+      const twoMonthsAgo = new Date(Date.now() - 60 * 86400 * 1000).toISOString()
+      expect(publishedDateToAge(twoMonthsAgo)).toBe('2 months ago')
+    })
+
+    test('years ago', () => {
+      const twoYearsAgo = new Date(Date.now() - 730 * 86400 * 1000).toISOString()
+      expect(publishedDateToAge(twoYearsAgo)).toBe('2 years ago')
+    })
+
+    test('future date returns undefined', () => {
+      const future = new Date(Date.now() + 86400 * 1000).toISOString()
+      expect(publishedDateToAge(future)).toBeUndefined()
+    })
+
+    test('invalid date returns undefined', () => {
+      expect(publishedDateToAge('not-a-date')).toBeUndefined()
+    })
+  })
+
+  describe('mapFreshnessToTavily', () => {
+    test('pd → day', () => expect(mapFreshnessToTavily('pd')).toBe('day'))
+    test('pw → week', () => expect(mapFreshnessToTavily('pw')).toBe('week'))
+    test('pm → month', () => expect(mapFreshnessToTavily('pm')).toBe('month'))
+    test('py → year', () => expect(mapFreshnessToTavily('py')).toBe('year'))
+    test('null → null', () => expect(mapFreshnessToTavily(null)).toBeNull())
+    test('unknown → null', () => expect(mapFreshnessToTavily('unknown')).toBeNull())
+  })
+})

--- a/apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts
@@ -103,18 +103,17 @@ function budgetGrounding(grounding: LLMContextSnippet[], maxTokens: number): LLM
 
   for (const item of grounding) {
     if (totalChars >= maxChars) break;
-    const remaining = maxChars - totalChars;
     const snippets: string[] = [];
 
     for (const snippet of item.snippets) {
       if (totalChars >= maxChars) break;
-      if (snippet.length <= remaining - totalChars + (totalChars - totalChars)) {
+      const allowance = maxChars - totalChars;
+      if (snippet.length <= allowance) {
         // Fits entirely
         snippets.push(snippet);
         totalChars += snippet.length;
       } else {
         // Trim to fit
-        const allowance = maxChars - totalChars;
         if (allowance > 100) { // only include if meaningful
           snippets.push(snippet.slice(0, allowance));
           totalChars += allowance;
@@ -287,7 +286,7 @@ export function registerLLMContextTool(pi: ExtensionAPI) {
           // Convert Tavily results to grounding snippets
           grounding = [];
           sources = {};
-          for (const item of data.results) {
+          for (const item of data.results.slice(0, maxUrls)) {
             const content = item.raw_content || item.content || "";
             if (content) {
               grounding.push({

--- a/apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts
@@ -19,6 +19,8 @@ import { LRUTTLCache } from "./cache";
 import { fetchWithRetryTimed, HttpError, classifyError, type RateLimitInfo } from "./http";
 import { normalizeQuery, extractDomain } from "./url-utils";
 import { formatLLMContext, type LLMContextSnippet, type LLMContextSource } from "./format";
+import { resolveSearchProvider, getBraveApiKey, braveHeaders, getTavilyApiKey } from "./provider.js";
+import type { TavilySearchResponse } from "./tavily.js";
 
 // =============================================================================
 // Types
@@ -67,6 +69,7 @@ interface LLMContextDetails {
   rateLimit?: RateLimitInfo;
   threshold?: string;
   maxTokens?: number;
+  provider?: string;
   errorKind?: string;
   error?: string;
   retryAfterMs?: number;
@@ -84,21 +87,48 @@ contextCache.startPurgeInterval(60_000);
 // Helpers
 // =============================================================================
 
-function getBraveApiKey(): string {
-  return process.env.BRAVE_API_KEY || "";
-}
-
-function braveHeaders(): Record<string, string> {
-  return {
-    "Accept": "application/json",
-    "Accept-Encoding": "gzip",
-    "X-Subscription-Token": getBraveApiKey(),
-  };
-}
-
 /** Rough token estimate: ~4 chars per token for English text. */
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
+}
+
+/**
+ * Budget grounding snippets to fit within a token limit.
+ * Trims snippet text from the end to stay within budget.
+ */
+function budgetGrounding(grounding: LLMContextSnippet[], maxTokens: number): LLMContextSnippet[] {
+  const maxChars = maxTokens * 4; // inverse of estimateTokens
+  let totalChars = 0;
+  const result: LLMContextSnippet[] = [];
+
+  for (const item of grounding) {
+    if (totalChars >= maxChars) break;
+    const remaining = maxChars - totalChars;
+    const snippets: string[] = [];
+
+    for (const snippet of item.snippets) {
+      if (totalChars >= maxChars) break;
+      if (snippet.length <= remaining - totalChars + (totalChars - totalChars)) {
+        // Fits entirely
+        snippets.push(snippet);
+        totalChars += snippet.length;
+      } else {
+        // Trim to fit
+        const allowance = maxChars - totalChars;
+        if (allowance > 100) { // only include if meaningful
+          snippets.push(snippet.slice(0, allowance));
+          totalChars += allowance;
+        }
+        break;
+      }
+    }
+
+    if (snippets.length > 0) {
+      result.push({ url: item.url, title: item.title, snippets });
+    }
+  }
+
+  return result;
 }
 
 // =============================================================================
@@ -160,12 +190,12 @@ export function registerLLMContextTool(pi: ExtensionAPI) {
         return { content: [{ type: "text", text: "Search cancelled." }] };
       }
 
-      const apiKey = getBraveApiKey();
-      if (!apiKey) {
+      const provider = resolveSearchProvider();
+      if (!provider) {
         return {
-          content: [{ type: "text", text: "Search unavailable: BRAVE_API_KEY is not set. Use secure_env_collect to set BRAVE_API_KEY." }],
+          content: [{ type: "text", text: "Search unavailable: No search API key set. Set BRAVE_API_KEY or TAVILY_API_KEY. Use secure_env_collect to configure." }],
           isError: true,
-          details: { errorKind: "auth_error", error: "BRAVE_API_KEY not set" } satisfies Partial<LLMContextDetails>,
+          details: { errorKind: "auth_error", error: "No search API key set (BRAVE_API_KEY or TAVILY_API_KEY)" } satisfies Partial<LLMContextDetails>,
         };
       }
 
@@ -210,110 +240,165 @@ export function registerLLMContextTool(pi: ExtensionAPI) {
       onUpdate?.({ content: [{ type: "text", text: `Searching & reading about "${params.query}"...` }] });
 
       try {
-        // ------------------------------------------------------------------
-        // Build LLM Context API request
-        // ------------------------------------------------------------------
-        const url = new URL("https://api.search.brave.com/res/v1/llm/context");
-        url.searchParams.append("q", params.query);
-        url.searchParams.append("count", String(count));
-        url.searchParams.append("maximum_number_of_tokens", String(maxTokens));
-        url.searchParams.append("maximum_number_of_urls", String(maxUrls));
-        url.searchParams.append("context_threshold_mode", threshold);
+        let grounding: LLMContextSnippet[];
+        let sources: Record<string, LLMContextSource>;
+        let estimatedTokens: number;
+        let latencyMs: number | undefined;
+        let rateLimit: RateLimitInfo | undefined;
 
-        // Use a custom fetch flow to read error bodies from the Brave API
-        let timed;
-        try {
-          timed = await fetchWithRetryTimed(url.toString(), {
-            method: "GET",
-            headers: braveHeaders(),
-            signal,
-          }, 2);
-        } catch (fetchErr) {
-          // Try to extract Brave's structured error detail from the response body.
-          // This is especially useful for plan/subscription errors (OPTION_NOT_IN_PLAN).
-          let errorMessage: string | undefined;
-          let errorKindOverride: string | undefined;
-          if (fetchErr instanceof HttpError && fetchErr.response) {
-            try {
-              const body = await fetchErr.response.clone().json().catch(() => null);
-              if (body?.error?.detail) {
-                errorMessage = body.error.detail;
-                if (body.error.code === "OPTION_NOT_IN_PLAN") {
-                  errorKindOverride = "plan_error";
-                  errorMessage = `LLM Context API not available on your current Brave plan. ${body.error.detail} Upgrade at https://api-dashboard.search.brave.com/app/subscriptions — or use search-the-web + fetch_page as an alternative.`;
-                }
-              }
-            } catch { /* body already consumed or parse error — use generic message */ }
-          }
-          const classified = classifyError(fetchErr);
-          const message = errorMessage || classified.message;
-          return {
-            content: [{ type: "text", text: `search_and_read unavailable: ${message}` }],
-            details: {
-              errorKind: errorKindOverride || classified.kind,
-              error: message,
-              retryAfterMs: classified.retryAfterMs,
-              query: params.query,
-            } satisfies Partial<LLMContextDetails>,
-            isError: true,
+        if (provider === 'tavily') {
+          // ----------------------------------------------------------------
+          // Tavily path: use search with raw_content, then budget
+          // ----------------------------------------------------------------
+          const tavilyBody: Record<string, unknown> = {
+            query: params.query,
+            max_results: count,
+            include_raw_content: true,
           };
-        }
 
-        const data: BraveLLMContextResponse = await timed.response.json();
-
-        // ------------------------------------------------------------------
-        // Normalize response
-        // ------------------------------------------------------------------
-        const grounding: LLMContextSnippet[] = [];
-
-        if (data.grounding?.generic) {
-          for (const item of data.grounding.generic) {
-            if (item.snippets && item.snippets.length > 0) {
-              grounding.push({
-                url: item.url,
-                title: item.title,
-                snippets: item.snippets,
-              });
-            }
-          }
-        }
-
-        // Include POI data if present
-        if (data.grounding?.poi && data.grounding.poi.snippets?.length) {
-          grounding.push({
-            url: data.grounding.poi.url,
-            title: data.grounding.poi.title || data.grounding.poi.name,
-            snippets: data.grounding.poi.snippets,
-          });
-        }
-
-        // Include map data if present
-        if (data.grounding?.map) {
-          for (const item of data.grounding.map) {
-            if (item.snippets?.length) {
-              grounding.push({
-                url: item.url,
-                title: item.title || item.name,
-                snippets: item.snippets,
-              });
-            }
-          }
-        }
-
-        const sources: Record<string, LLMContextSource> = {};
-        if (data.sources) {
-          for (const [sourceUrl, sourceInfo] of Object.entries(data.sources)) {
-            sources[sourceUrl] = {
-              title: sourceInfo.title,
-              hostname: sourceInfo.hostname,
-              age: sourceInfo.age,
+          let timed;
+          try {
+            timed = await fetchWithRetryTimed("https://api.tavily.com/search", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${getTavilyApiKey()}`,
+              },
+              body: JSON.stringify(tavilyBody),
+              signal,
+            }, 2);
+          } catch (fetchErr) {
+            const classified = classifyError(fetchErr);
+            return {
+              content: [{ type: "text", text: `search_and_read unavailable: ${classified.message}` }],
+              details: {
+                errorKind: classified.kind,
+                error: classified.message,
+                retryAfterMs: classified.retryAfterMs,
+                query: params.query,
+                provider: 'tavily',
+              } satisfies Partial<LLMContextDetails>,
+              isError: true,
             };
           }
-        }
 
-        // Estimate total token count from all snippets
-        const allText = grounding.map(g => g.snippets.join(" ")).join(" ");
-        const estimatedTokens = estimateTokens(allText);
+          const data: TavilySearchResponse = await timed.response.json();
+
+          // Convert Tavily results to grounding snippets
+          grounding = [];
+          sources = {};
+          for (const item of data.results) {
+            const content = item.raw_content || item.content || "";
+            if (content) {
+              grounding.push({
+                url: item.url,
+                title: item.title || "(untitled)",
+                snippets: [content],
+              });
+            }
+            // Build sources map
+            try {
+              const hostname = new URL(item.url).hostname;
+              sources[item.url] = {
+                title: item.title || "(untitled)",
+                hostname,
+                age: null,
+              };
+            } catch { /* invalid URL — skip source entry */ }
+          }
+
+          // Budget: respect maxTokens by trimming snippets
+          grounding = budgetGrounding(grounding, maxTokens);
+
+          const allText = grounding.map(g => g.snippets.join(" ")).join(" ");
+          estimatedTokens = estimateTokens(allText);
+          latencyMs = timed.latencyMs;
+          rateLimit = timed.rateLimit;
+        } else {
+          // ----------------------------------------------------------------
+          // Brave LLM Context API path (existing logic)
+          // ----------------------------------------------------------------
+          const url = new URL("https://api.search.brave.com/res/v1/llm/context");
+          url.searchParams.append("q", params.query);
+          url.searchParams.append("count", String(count));
+          url.searchParams.append("maximum_number_of_tokens", String(maxTokens));
+          url.searchParams.append("maximum_number_of_urls", String(maxUrls));
+          url.searchParams.append("context_threshold_mode", threshold);
+
+          let timed;
+          try {
+            timed = await fetchWithRetryTimed(url.toString(), {
+              method: "GET",
+              headers: braveHeaders(),
+              signal,
+            }, 2);
+          } catch (fetchErr) {
+            let errorMessage: string | undefined;
+            let errorKindOverride: string | undefined;
+            if (fetchErr instanceof HttpError && fetchErr.response) {
+              try {
+                const body = await fetchErr.response.clone().json().catch(() => null);
+                if (body?.error?.detail) {
+                  errorMessage = body.error.detail;
+                  if (body.error.code === "OPTION_NOT_IN_PLAN") {
+                    errorKindOverride = "plan_error";
+                    errorMessage = `LLM Context API not available on your current Brave plan. ${body.error.detail} Upgrade at https://api-dashboard.search.brave.com/app/subscriptions — or use search-the-web + fetch_page as an alternative.`;
+                  }
+                }
+              } catch { /* body already consumed or parse error — use generic message */ }
+            }
+            const classified = classifyError(fetchErr);
+            const message = errorMessage || classified.message;
+            return {
+              content: [{ type: "text", text: `search_and_read unavailable: ${message}` }],
+              details: {
+                errorKind: errorKindOverride || classified.kind,
+                error: message,
+                retryAfterMs: classified.retryAfterMs,
+                query: params.query,
+                provider: 'brave',
+              } satisfies Partial<LLMContextDetails>,
+              isError: true,
+            };
+          }
+
+          const data: BraveLLMContextResponse = await timed.response.json();
+
+          grounding = [];
+          if (data.grounding?.generic) {
+            for (const item of data.grounding.generic) {
+              if (item.snippets && item.snippets.length > 0) {
+                grounding.push({ url: item.url, title: item.title, snippets: item.snippets });
+              }
+            }
+          }
+          if (data.grounding?.poi && data.grounding.poi.snippets?.length) {
+            grounding.push({
+              url: data.grounding.poi.url,
+              title: data.grounding.poi.title || data.grounding.poi.name,
+              snippets: data.grounding.poi.snippets,
+            });
+          }
+          if (data.grounding?.map) {
+            for (const item of data.grounding.map) {
+              if (item.snippets?.length) {
+                grounding.push({ url: item.url, title: item.title || item.name, snippets: item.snippets });
+              }
+            }
+          }
+
+          sources = {};
+          if (data.sources) {
+            for (const [sourceUrl, sourceInfo] of Object.entries(data.sources)) {
+              sources[sourceUrl] = { title: sourceInfo.title, hostname: sourceInfo.hostname, age: sourceInfo.age };
+            }
+          }
+
+          const allText = grounding.map(g => g.snippets.join(" ")).join(" ");
+          estimatedTokens = estimateTokens(allText);
+          latencyMs = timed.latencyMs;
+          rateLimit = timed.rateLimit;
+        }
 
         // Cache the results
         contextCache.set(cacheKey, { grounding, sources, estimatedTokens });
@@ -340,10 +425,11 @@ export function registerLLMContextTool(pi: ExtensionAPI) {
           snippetCount: totalSnippets,
           estimatedTokens,
           cached: false,
-          latencyMs: timed.latencyMs,
-          rateLimit: timed.rateLimit,
+          latencyMs,
+          rateLimit,
           threshold,
           maxTokens,
+          provider,
         };
 
         return { content: [{ type: "text", text: content }], details };

--- a/apps/cli/src/resources/extensions/search-the-web/tool-search.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/tool-search.ts
@@ -20,6 +20,8 @@ import { LRUTTLCache } from "./cache";
 import { fetchWithRetryTimed, fetchWithRetry, classifyError, type RateLimitInfo } from "./http";
 import { normalizeQuery, toDedupeKey, detectFreshness } from "./url-utils";
 import { formatSearchResults, type SearchResultFormatted, type FormatSearchOptions } from "./format";
+import { resolveSearchProvider, getBraveApiKey, braveHeaders, getTavilyApiKey } from "./provider.js";
+import { normalizeTavilyResult, mapFreshnessToTavily, type TavilySearchResponse } from "./tavily.js";
 
 // =============================================================================
 // Types
@@ -87,6 +89,7 @@ interface SearchDetails {
   originalQuery?: string;
   correctedQuery?: string;
   moreResultsAvailable?: boolean;
+  provider?: string;
   errorKind?: string;
   error?: string;
   retryAfterMs?: number;
@@ -106,18 +109,6 @@ const summarizerCache = new LRUTTLCache<string>({ max: 50, ttlMs: 900_000 });
 // =============================================================================
 // Brave API helpers
 // =============================================================================
-
-function getBraveApiKey(): string {
-  return process.env.BRAVE_API_KEY || "";
-}
-
-function braveHeaders(): Record<string, string> {
-  return {
-    "Accept": "application/json",
-    "Accept-Encoding": "gzip",
-    "X-Subscription-Token": getBraveApiKey(),
-  };
-}
 
 /**
  * Normalize a Brave result into our formatted result type.
@@ -233,12 +224,12 @@ export function registerSearchTool(pi: ExtensionAPI) {
         return { content: [{ type: "text", text: "Search cancelled." }] };
       }
 
-      const apiKey = getBraveApiKey();
-      if (!apiKey) {
+      const provider = resolveSearchProvider();
+      if (!provider) {
         return {
-          content: [{ type: "text", text: "Web search unavailable: BRAVE_API_KEY is not set. Use secure_env_collect to set BRAVE_API_KEY." }],
+          content: [{ type: "text", text: "Web search unavailable: No search API key set. Set BRAVE_API_KEY or TAVILY_API_KEY. Use secure_env_collect to configure." }],
           isError: true,
-          details: { errorKind: "auth_error", error: "BRAVE_API_KEY not set" } satisfies Partial<SearchDetails>,
+          details: { errorKind: "auth_error", error: "No search API key set (BRAVE_API_KEY or TAVILY_API_KEY)" } satisfies Partial<SearchDetails>,
         };
       }
 
@@ -320,82 +311,140 @@ export function registerSearchTool(pi: ExtensionAPI) {
       onUpdate?.({ content: [{ type: "text", text: `Searching for "${params.query}"...` }] });
 
       try {
-        // ------------------------------------------------------------------
-        // Build Brave API request
-        // ------------------------------------------------------------------
-        const url = new URL("https://api.search.brave.com/res/v1/web/search");
-        url.searchParams.append("q", effectiveQuery);
-        url.searchParams.append("count", "10"); // Extra for dedup headroom
-        url.searchParams.append("extra_snippets", "true");
-        url.searchParams.append("text_decorations", "false");
-
-        if (freshness) {
-          url.searchParams.append("freshness", freshness);
-        }
-        if (wantSummary) {
-          url.searchParams.append("summary", "1");
-        }
-
-        // ------------------------------------------------------------------
-        // Execute with timing
-        // ------------------------------------------------------------------
-        let timed;
-        try {
-          timed = await fetchWithRetryTimed(url.toString(), {
-            method: "GET",
-            headers: braveHeaders(),
-            signal,
-          }, 2);
-        } catch (fetchErr) {
-          const classified = classifyError(fetchErr);
-          return {
-            content: [{ type: "text", text: `Search failed: ${classified.message}` }],
-            details: {
-              errorKind: classified.kind,
-              error: classified.message,
-              retryAfterMs: classified.retryAfterMs,
-              query: params.query,
-            } satisfies Partial<SearchDetails>,
-            isError: true,
-          };
-        }
-
-        const data: BraveSearchResponse = await timed.response.json();
-        const rawResults: BraveWebResult[] = data.web?.results ?? [];
-        const summarizerKey: string | undefined = data.summarizer?.key;
-
-        // ------------------------------------------------------------------
-        // Extract spellcheck/correction info
-        // ------------------------------------------------------------------
-        const queryInfo = data.query;
-        const queryCorrected = !!(queryInfo?.altered && queryInfo.altered !== queryInfo.original);
-        const originalQuery = queryCorrected ? (queryInfo?.original ?? params.query) : undefined;
-        const correctedQuery = queryCorrected ? queryInfo?.altered : undefined;
-        const moreResultsAvailable = queryInfo?.more_results_available ?? false;
-
-        // ------------------------------------------------------------------
-        // Normalize, deduplicate, cache
-        // ------------------------------------------------------------------
-        const normalized = rawResults.map(normalizeBraveResult);
-        const deduplicated = deduplicateResults(normalized);
-
-        searchCache.set(cacheKey, {
-          results: deduplicated,
-          summarizerKey,
-          queryCorrected,
-          originalQuery,
-          correctedQuery,
-          moreResultsAvailable,
-        });
-
-        const results = deduplicated.slice(0, count);
-
-        // ------------------------------------------------------------------
-        // Optionally fetch AI summary (best-effort)
-        // ------------------------------------------------------------------
+        let results: SearchResultFormatted[];
         let summaryText: string | undefined;
-        if (wantSummary && summarizerKey) {
-          summaryText = (await fetchSummary(summarizerKey, signal)) ?? undefined;
+        let latencyMs: number | undefined;
+        let rateLimit: RateLimitInfo | undefined;
+        let queryCorrected: boolean | undefined;
+        let originalQuery: string | undefined;
+        let correctedQuery: string | undefined;
+        let moreResultsAvailable: boolean | undefined;
+
+        if (provider === 'tavily') {
+          // ----------------------------------------------------------------
+          // Tavily path
+          // ----------------------------------------------------------------
+          const tavilyBody: Record<string, unknown> = {
+            query: effectiveQuery,
+            max_results: count,
+            include_answer: wantSummary,
+          };
+          const tavilyFreshness = mapFreshnessToTavily(freshness);
+          if (tavilyFreshness) {
+            tavilyBody.time_range = tavilyFreshness;
+          }
+
+          let timed;
+          try {
+            timed = await fetchWithRetryTimed("https://api.tavily.com/search", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${getTavilyApiKey()}`,
+              },
+              body: JSON.stringify(tavilyBody),
+              signal,
+            }, 2);
+          } catch (fetchErr) {
+            const classified = classifyError(fetchErr);
+            return {
+              content: [{ type: "text", text: `Search failed: ${classified.message}` }],
+              details: {
+                errorKind: classified.kind,
+                error: classified.message,
+                retryAfterMs: classified.retryAfterMs,
+                query: params.query,
+                provider: 'tavily',
+              } satisfies Partial<SearchDetails>,
+              isError: true,
+            };
+          }
+
+          const data: TavilySearchResponse = await timed.response.json();
+          const normalized = data.results.map(normalizeTavilyResult);
+          const deduplicated = deduplicateResults(normalized);
+
+          searchCache.set(cacheKey, {
+            results: deduplicated,
+            summarizerKey: undefined,
+            queryCorrected: false,
+            originalQuery: undefined,
+            correctedQuery: undefined,
+            moreResultsAvailable: false,
+          });
+
+          results = deduplicated.slice(0, count);
+          summaryText = (wantSummary && data.answer) ? data.answer : undefined;
+          latencyMs = timed.latencyMs;
+          rateLimit = timed.rateLimit;
+        } else {
+          // ----------------------------------------------------------------
+          // Brave path (existing logic)
+          // ----------------------------------------------------------------
+          const url = new URL("https://api.search.brave.com/res/v1/web/search");
+          url.searchParams.append("q", effectiveQuery);
+          url.searchParams.append("count", "10");
+          url.searchParams.append("extra_snippets", "true");
+          url.searchParams.append("text_decorations", "false");
+
+          if (freshness) {
+            url.searchParams.append("freshness", freshness);
+          }
+          if (wantSummary) {
+            url.searchParams.append("summary", "1");
+          }
+
+          let timed;
+          try {
+            timed = await fetchWithRetryTimed(url.toString(), {
+              method: "GET",
+              headers: braveHeaders(),
+              signal,
+            }, 2);
+          } catch (fetchErr) {
+            const classified = classifyError(fetchErr);
+            return {
+              content: [{ type: "text", text: `Search failed: ${classified.message}` }],
+              details: {
+                errorKind: classified.kind,
+                error: classified.message,
+                retryAfterMs: classified.retryAfterMs,
+                query: params.query,
+                provider: 'brave',
+              } satisfies Partial<SearchDetails>,
+              isError: true,
+            };
+          }
+
+          const data: BraveSearchResponse = await timed.response.json();
+          const rawResults: BraveWebResult[] = data.web?.results ?? [];
+          const summarizerKey: string | undefined = data.summarizer?.key;
+
+          const queryInfo = data.query;
+          queryCorrected = !!(queryInfo?.altered && queryInfo.altered !== queryInfo.original);
+          originalQuery = queryCorrected ? (queryInfo?.original ?? params.query) : undefined;
+          correctedQuery = queryCorrected ? queryInfo?.altered : undefined;
+          moreResultsAvailable = queryInfo?.more_results_available ?? false;
+
+          const normalized = rawResults.map(normalizeBraveResult);
+          const deduplicated = deduplicateResults(normalized);
+
+          searchCache.set(cacheKey, {
+            results: deduplicated,
+            summarizerKey,
+            queryCorrected,
+            originalQuery,
+            correctedQuery,
+            moreResultsAvailable,
+          });
+
+          results = deduplicated.slice(0, count);
+          latencyMs = timed.latencyMs;
+          rateLimit = timed.rateLimit;
+
+          if (wantSummary && summarizerKey) {
+            summaryText = (await fetchSummary(summarizerKey, signal)) ?? undefined;
+          }
         }
 
         // ------------------------------------------------------------------
@@ -427,12 +476,13 @@ export function registerSearchTool(pi: ExtensionAPI) {
           cached: false,
           freshness: freshness || "none",
           hasSummary: !!summaryText,
-          latencyMs: timed.latencyMs,
-          rateLimit: timed.rateLimit,
+          latencyMs,
+          rateLimit,
           queryCorrected,
           originalQuery,
           correctedQuery,
           moreResultsAvailable,
+          provider,
         };
 
         return { content: [{ type: "text", text: content }], details };

--- a/apps/cli/src/resources/extensions/search-the-web/tool-search.ts
+++ b/apps/cli/src/resources/extensions/search-the-web/tool-search.ts
@@ -68,6 +68,8 @@ interface BraveSearchResponse {
 interface CachedSearchResult {
   results: SearchResultFormatted[];
   summarizerKey?: string;
+  summaryText?: string;
+  provider?: string;
   queryCorrected?: boolean;
   originalQuery?: string;
   correctedQuery?: string;
@@ -262,14 +264,16 @@ export function registerSearchTool(pi: ExtensionAPI) {
       // ------------------------------------------------------------------
       // Cache lookup
       // ------------------------------------------------------------------
-      const cacheKey = normalizeQuery(effectiveQuery) + `|f:${freshness || ""}|s:${wantSummary}`;
+      const cacheKey = normalizeQuery(effectiveQuery) + `|p:${provider}|c:${count}|f:${freshness || ""}|s:${wantSummary}`;
       const cached = searchCache.get(cacheKey);
 
       if (cached) {
         const limited = cached.results.slice(0, count);
 
         let summaryText: string | undefined;
-        if (wantSummary && cached.summarizerKey) {
+        if (wantSummary && cached.summaryText) {
+          summaryText = cached.summaryText;
+        } else if (wantSummary && cached.summarizerKey) {
           summaryText = (await fetchSummary(cached.summarizerKey, signal)) ?? undefined;
         }
 
@@ -367,6 +371,8 @@ export function registerSearchTool(pi: ExtensionAPI) {
           searchCache.set(cacheKey, {
             results: deduplicated,
             summarizerKey: undefined,
+            summaryText: data.answer ?? undefined,
+            provider: 'tavily',
             queryCorrected: false,
             originalQuery: undefined,
             correctedQuery: undefined,


### PR DESCRIPTION
## What Changed
See slice plan: S02: Namespace slice branches for monorepo safety

## Must-Haves
- R002 (owned): New slice branches are namespaced by project scope and cannot silently reuse stale branches from unrelated projects.
- R002 (owned): Legacy `kata/<M>/<S>` branches remain compatible during transition (parse + checkout continuity).
- R001 (supporting): `worktree.ts` provenance checks consume `runGit()`/`getCurrentBranch()` from `git-service.ts` rather than ad-hoc git shell execution in touched paths.
- Boundary contract closure: `parseBranchToSlice()` + PR context builders operate correctly with namespaced branches and still parse legacy branches.

## Tasks
- T01: Add failing regression tests for namespaced/legacy branch contracts
- T02: Implement namespaced branch generation and provenance guard in worktree layer
- T03: Propagate dual-format parsing and namespaced branch wiring through PR/backends
- T04: Close remaining branch-format drift and prove slice-level integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Tavily as an alternative web search provider alongside Brave
  * Enabled native Anthropic web search integration
  * Implemented intelligent search provider selection with automatic fallback support when a configured provider is unavailable

* **Tests**
  * Added comprehensive test coverage for search provider functionality and result normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a search provider abstraction layer (`provider.ts`) and Tavily support as an alternative to Brave Search, updating both the `search-the-web` and `search_and_read` tools to dispatch to either backend based on available API keys or the `SEARCH_PROVIDER` env var. It also extracts the native Anthropic web search hook logic from `index.ts` into a standalone `native-search.ts` module for testability, and adds unit tests for the new `provider` and `tavily` modules.

The core abstraction (`provider.ts`, `tavily.ts`) is clean and well-tested. However, three issues were found in the integration layer:

- **`budgetGrounding` logic bug** (`tool-llm-context.ts` line 111): The snippet-fit condition uses `remaining - totalChars` where `remaining` is a stale snapshot from the outer loop, producing a doubly-discounted threshold for every item after the first. This causes premature truncation of Tavily `search_and_read` results.
- **`google_search` erroneously re-added on provider switch** (`native-search.ts` lines 117–126): When switching away from Anthropic, the restore logic adds all names in `CUSTOM_SEARCH_TOOL_NAMES` (including `google_search`) even if they were never in the active tools list, rather than only restoring what was removed.
- **Misleading "Brave search active" notification** (`native-search.ts` line 142): `preferBraveSearch()` returns `true` for `SEARCH_PROVIDER=tavily` as well, so a Tavily user sees an incorrect diagnostic message.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge until the budgetGrounding logic bug and the google_search injection issue are fixed.
- Two genuine logic bugs exist: the budgetGrounding condition produces incorrect thresholds for multi-source Tavily responses (premature content truncation), and the provider switch-back path can inject an unregistered tool name into the active tools list. The misleading notification is a UX issue. The new provider abstraction and Tavily normalization layer are solid and well-tested, but the integration bugs in the tool layer lower confidence.
- apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts (budgetGrounding bug) and apps/cli/src/resources/extensions/search-the-web/native-search.ts (google_search re-injection, misleading notification)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/search-the-web/provider.ts | New provider abstraction: clean, well-tested resolution logic for Brave vs Tavily with proper fallback semantics. |
| apps/cli/src/resources/extensions/search-the-web/tavily.ts | New Tavily API types and normalizers; pure functions with no side effects — straightforward and well-covered by tests. |
| apps/cli/src/resources/extensions/search-the-web/native-search.ts | Extracted from index.ts; contains two bugs: provider switch-back erroneously injects `google_search`, and the Tavily notification message says "Brave search active" regardless of actual provider. |
| apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts | Tavily path added; `budgetGrounding` has a logic bug where the snippet-fit condition computes a doubly-discounted threshold for all items after the first, causing premature truncation. |
| apps/cli/src/resources/extensions/search-the-web/tool-search.ts | Tavily path wired in cleanly; tool description still says "Brave Search API" which is now inaccurate. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[search-the-web / search_and_read tool call] --> B[resolveSearchProvider]
    B --> C{SEARCH_PROVIDER env?}
    C -- brave / tavily --> D[Use specified provider\nwith key fallback]
    C -- auto / unset --> E{Keys available?}
    E -- TAVILY_API_KEY --> F[Tavily]
    E -- BRAVE_API_KEY only --> G[Brave]
    E -- neither --> H[null → auth_error]
    D --> F
    D --> G

    F --> I[POST api.tavily.com/search]
    G --> J[GET api.search.brave.com]

    I --> K[normalizeTavilyResult\nmapFreshnessToTavily]
    J --> L[normalizeBraveResult\nBrave summarizer key]

    K --> M[deduplicateResults → cache → format output]
    L --> M

    N[model_select event] --> O{isAnthropic &\n!preferBraveSearch?}
    O -- yes --> P[Remove CUSTOM_SEARCH_TOOL_NAMES\nfrom active tools]
    O -- no, was Anthropic --> Q[Re-add CUSTOM_SEARCH_TOOL_NAMES\n⚠ may add google_search]

    R[before_provider_request event] --> S{isAnthropic?}
    S -- yes --> T[stripThinkingFromHistory]
    T --> U{preferBraveSearch?}
    U -- no --> V[Inject web_search_20250305\nwith session budget]
    U -- yes --> W[Skip native injection]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/cli/src/resources/extensions/search-the-web/tool-search.ts`, line 187-189 ([link](https://github.com/gannonh/kata/blob/ab5ea1c88fb0aecc506af2b125cdaf980e8f0d67/apps/cli/src/resources/extensions/search-the-web/tool-search.ts#L187-L189)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Tool description still names only Brave Search API**

   The `description` field is surfaced to the LLM to help it decide when to call this tool. Now that Tavily is also a supported backend, the description should be provider-agnostic to avoid confusing the model (or end-users reading tool listings).

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/extensions/search-the-web/tool-search.ts
   Line: 187-189

   Comment:
   **Tool description still names only Brave Search API**

   The `description` field is surfaced to the LLM to help it decide when to call this tool. Now that Tavily is also a supported backend, the description should be provider-agnostic to avoid confusing the model (or end-users reading tool listings).

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts`, line 143-147 ([link](https://github.com/gannonh/kata/blob/ab5ea1c88fb0aecc506af2b125cdaf980e8f0d67/apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts#L143-L147)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Tool description hard-codes Brave LLM Context API**

   The `description` and `promptGuidelines` still reference Brave exclusively. When Tavily is the active provider the Brave-specific advice ("no separate `fetch_page` needed", "Powered by Brave's LLM Context API") is inaccurate and may confuse the model.

   Consider updating to something like:
   ```
   "Search the web AND read page content in a single call. Returns pre-extracted, " +
   "relevance-scored text from multiple pages — no separate fetch_page needed. " +
   "Best when you need content, not just links. " +
   "For selective URL browsing, use search-the-web + fetch_page instead.",
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts
   Line: 143-147

   Comment:
   **Tool description hard-codes Brave LLM Context API**

   The `description` and `promptGuidelines` still reference Brave exclusively. When Tavily is the active provider the Brave-specific advice ("no separate `fetch_page` needed", "Powered by Brave's LLM Context API") is inaccurate and may confuse the model.

   Consider updating to something like:
   ```
   "Search the web AND read page content in a single call. Returns pre-extracted, " +
   "relevance-scored text from multiple pages — no separate fetch_page needed. " +
   "Best when you need content, not just links. " +
   "For selective URL browsing, use search-the-web + fetch_page instead.",
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts
Line: 111

Comment:
**Bug in `budgetGrounding` — condition computes wrong threshold for all items after the first**

The condition on line 111 is:
```ts
if (snippet.length <= remaining - totalChars + (totalChars - totalChars)) {
```
The expression `(totalChars - totalChars)` is always `0`, so it reduces to `snippet.length <= remaining - totalChars`.

`remaining` is computed once at the start of each *outer* loop iteration as `maxChars - totalChars`. Inside the *inner* loop, `totalChars` grows as snippets are accepted. For **item 0** the math happens to cancel out (since `totalChars` starts at 0 when `remaining` is set), but for every subsequent item:

```
remaining  = maxChars - totalChars_outer   (snapshot at start of outer iteration)
condition  = snippet.length <= remaining - totalChars_current
           = snippet.length <= (maxChars - totalChars_outer) - totalChars_current
```

Because `totalChars_current >= totalChars_outer`, this is strictly tighter than the correct budget check `snippet.length <= maxChars - totalChars_current`. Snippets that would fit are rejected, causing premature truncation of search results for all but the first source.

The correct condition is simply:

```suggestion
      if (snippet.length <= maxChars - totalChars) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/search-the-web/native-search.ts
Line: 117-126

Comment:
**`google_search` incorrectly injected into active tools on provider switch-back**

When switching away from Anthropic the code adds every name in `CUSTOM_SEARCH_TOOL_NAMES` that isn't already active:

```ts
const toAdd = CUSTOM_SEARCH_TOOL_NAMES.filter(
  (t) => !active.includes(t)
);
if (toAdd.length > 0) {
  pi.setActiveTools([...active, ...toAdd]);
}
```

`CUSTOM_SEARCH_TOOL_NAMES` contains `"google_search"`. If `google_search` was never registered (and therefore never appeared in `active`), this branch will add it to the active tools list. The symmetric removal path (switching *to* Anthropic) only removes tools that are already active, so `google_search` is never removed — but on the way back it is unconditionally re-added.

The restore logic should only re-enable tools that were actually removed, not the full static list. A simple fix is to track which tools were removed and restore only those:

```ts
// model_select handler — store what was removed
const removedTools: string[] = [];

if (isAnthropicProvider && !preferBraveSearch()) {
  const active = pi.getActiveTools();
  const filtered = active.filter((t: string) => !CUSTOM_SEARCH_TOOL_NAMES.includes(t));
  removedTools.splice(0, removedTools.length, ...active.filter((t) => !filtered.includes(t)));
  pi.setActiveTools(filtered);
} else if (!isAnthropicProvider && wasAnthropic && removedTools.length > 0) {
  const active = pi.getActiveTools();
  const toAdd = removedTools.filter((t) => !active.includes(t));
  if (toAdd.length > 0) pi.setActiveTools([...active, ...toAdd]);
  removedTools.splice(0);
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/search-the-web/native-search.ts
Line: 142

Comment:
**Misleading notification when `SEARCH_PROVIDER=tavily` is active**

`preferBraveSearch()` returns `true` for both `SEARCH_PROVIDER=brave` **and** `SEARCH_PROVIDER=tavily` (line 41). The diagnostic message fired in the `model_select` handler always says `"Brave search active (PREFER_BRAVE_SEARCH)"` regardless of which provider is actually selected, so a user running with `SEARCH_PROVIDER=tavily` will see incorrect output.

```suggestion
      ctx.ui.notify(`${resolveSearchProvider() === 'tavily' ? 'Tavily' : 'Brave'} search active (SEARCH_PROVIDER override)`, "info");
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/search-the-web/tool-search.ts
Line: 187-189

Comment:
**Tool description still names only Brave Search API**

The `description` field is surfaced to the LLM to help it decide when to call this tool. Now that Tavily is also a supported backend, the description should be provider-agnostic to avoid confusing the model (or end-users reading tool listings).

```suggestion
      "Search the web for information. Returns top results with titles, URLs, descriptions, " +
      "extra contextual snippets, result ages, and optional AI summary. " +
      "Supports freshness filtering, domain filtering, and auto-detects recency-sensitive queries.",
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/search-the-web/tool-llm-context.ts
Line: 143-147

Comment:
**Tool description hard-codes Brave LLM Context API**

The `description` and `promptGuidelines` still reference Brave exclusively. When Tavily is the active provider the Brave-specific advice ("no separate `fetch_page` needed", "Powered by Brave's LLM Context API") is inaccurate and may confuse the model.

Consider updating to something like:
```
"Search the web AND read page content in a single call. Returns pre-extracted, " +
"relevance-scored text from multiple pages — no separate fetch_page needed. " +
"Best when you need content, not just links. " +
"For selective URL browsing, use search-the-web + fetch_page instead.",
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(S02/T03): extra..."](https://github.com/gannonh/kata/commit/ab5ea1c88fb0aecc506af2b125cdaf980e8f0d67)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->