### PR TITLE
KAT-823: Refactor workspace strategies (clone-local, clone-remote, worktree, docker)

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -92,14 +92,16 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 
 #### `workspace` section
 
-| Field                     | Type   | Default                       | Description                                                                                                      |
-| ------------------------- | ------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `workspace.root`          | string | `$TMPDIR/symphony_workspaces` | Root directory for per-issue agent workspaces. Supports `~` tilde expansion.                                     |
-| `workspace.repo`          | string | _(none)_                      | Repository URL or local path to bootstrap into each newly-created workspace.                                     |
-| `workspace.strategy`      | string | `"clone"`                     | Bootstrap strategy: `"clone"` (default) or `"worktree"`. `worktree` requires `workspace.repo` to be local path. |
-| `workspace.branch_prefix` | string | `"symphony"`                  | Branch prefix used for auto-created issue branches (`<prefix>/<issue-identifier>`).                             |
-| `workspace.clone_branch`  | string | _(none)_                      | Optional branch name to clone for `workspace.strategy: clone`. When set, Symphony runs clone bootstrap with `--branch <clone_branch>`. |
-| `workspace.cleanup_on_done` | bool | `false` | Remove the issue workspace when the issue reaches a terminal state. Runs `hooks.before_remove` and ignores cleanup failures. |
+| Field                       | Type   | Default                       | Description                                                                                                                          |
+| --------------------------- | ------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `workspace.root`            | string | `$TMPDIR/symphony_workspaces` | Root directory for per-issue agent workspaces. Supports `~` tilde expansion.                                                         |
+| `workspace.repo`            | string | _(none)_                      | Repository URL or local path to bootstrap into each newly-created workspace.                                                         |
+| `workspace.git_strategy`    | string | `"auto"`                      | Git bootstrap strategy: `"clone-local"`, `"clone-remote"`, `"worktree"`, or `"auto"` (detect local path vs remote URL).            |
+| `workspace.strategy`        | string | _(deprecated)_                | Legacy alias accepted for backward compatibility: `"clone"` maps to `git_strategy: auto`, `"worktree"` maps to `git_strategy: worktree`. |
+| `workspace.isolation`       | string | `"local"`                     | Workspace runtime isolation model: `"local"` (current behavior) or `"docker"` (accepted but not implemented yet; logs a warning).    |
+| `workspace.branch_prefix`   | string | `"symphony"`                  | Branch prefix used for auto-created issue branches (`<prefix>/<issue-identifier>`).                                                 |
+| `workspace.clone_branch`    | string | _(none)_                      | Optional source branch for clone-based bootstraps (`clone-local`, `clone-remote`, or `auto` when clone is selected).                |
+| `workspace.cleanup_on_done` | bool   | `false`                       | Remove the issue workspace when the issue reaches a terminal state. Runs `hooks.before_remove` and ignores cleanup failures.         |
 
 #### `agent` section
 
@@ -162,7 +164,8 @@ tracker:
 workspace:
   root: ~/symphony_workspaces
   repo: https://github.com/example/project.git
-  strategy: clone
+  git_strategy: auto
+  isolation: local
   branch_prefix: symphony
   clone_branch: elixir-feature-parity
   cleanup_on_done: true
@@ -198,7 +201,8 @@ polling:
 workspace:
   root: ~/workspaces/symphony
   repo: /Users/alice/code/kata
-  strategy: worktree
+  git_strategy: worktree
+  isolation: local
   branch_prefix: symphony
   cleanup_on_done: true
 

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -21,7 +21,8 @@ polling:
 workspace:
   root: ~/symphony-workspaces
   repo: https://github.com/gannonh/kata.git
-  strategy: clone
+  git_strategy: auto
+  isolation: local
   branch_prefix: symphony
   clone_branch: main
 hooks:

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -78,21 +78,33 @@ workspace:
   repo: https://github.com/gannonh/kata.git
 
   # Git bootstrap strategy:
-  #   - "clone": git clone into the workspace (default)
-  #     - Remote URLs: full network clone
-  #     - Local paths: `git clone --local` (fast, inherits remotes)
+  #   - "clone-local": force local clone (`git clone --local <repo> .`)
+  #     - Requires `repo` to be a local path
+  #     - Keeps remote refs/metadata (no `--single-branch`)
+  #   - "clone-remote": force remote clone (`git clone <repo> . --single-branch`)
   #   - "worktree": git worktree add from the source repo
   #     - Requires `repo` to be a local path
   #     - Lightweight — shares .git objects with source
   #     - Cleanup runs `git worktree remove`
-  strategy: clone
+  #   - "auto" (default): choose clone-local for local paths, clone-remote for URLs
+  git_strategy: auto
+
+  # Legacy field (deprecated): "clone" or "worktree".
+  # If set alongside git_strategy, git_strategy wins.
+  # strategy: clone
+
+  # Runtime isolation model:
+  #   - "local" (default): current behavior
+  #   - "docker": accepted but not implemented yet (startup warning)
+  isolation: local
 
   # Prefix for auto-created issue branches: <prefix>/<issue-identifier>
   # Example: symphony/KAT-814
   branch_prefix: symphony
 
-  # Branch to clone/base off. When set, `git clone --branch <clone_branch>`.
-  # When omitted, clones the repo's default branch.
+  # Branch to clone/base off for clone-based strategies.
+  # When set, clone uses `--branch <clone_branch>`.
+  # When omitted, clone uses the repo's default branch.
   # Supports $VAR indirection.
   clone_branch: main
 

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -669,13 +669,17 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
     }
 
     if config.workspace.strategy == WorkspaceRepoStrategy::CloneLocal {
-        if let Some(repo) = config.workspace.repo.as_deref() {
-            if repo_is_remote(repo) {
-                return Err(SymphonyError::InvalidWorkflowConfig(
-                    "workspace.git_strategy 'clone-local' requires workspace.repo to be a local path"
-                        .to_string(),
-                ));
-            }
+        let repo = config.workspace.repo.as_deref().ok_or_else(|| {
+            SymphonyError::InvalidWorkflowConfig(
+                "workspace.repo is required when workspace.git_strategy is 'clone-local'"
+                    .to_string(),
+            )
+        })?;
+        if repo_is_remote(repo) {
+            return Err(SymphonyError::InvalidWorkflowConfig(
+                "workspace.git_strategy 'clone-local' requires workspace.repo to be a local path"
+                    .to_string(),
+            ));
         }
     }
 

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -12,7 +12,7 @@ use serde_yaml::{Mapping, Value};
 
 use crate::domain::{
     AgentConfig, ApiKey, CodexConfig, HooksConfig, PollingConfig, ServerConfig, ServiceConfig,
-    TrackerConfig, WorkerConfig, WorkspaceConfig, WorkspaceRepoStrategy,
+    TrackerConfig, WorkerConfig, WorkspaceConfig, WorkspaceIsolation, WorkspaceRepoStrategy,
 };
 use crate::error::{Result, SymphonyError};
 use crate::repo_url::repo_is_remote;
@@ -180,6 +180,8 @@ struct RawWorkspaceConfig {
     root: Option<String>,
     repo: Option<String>,
     strategy: Option<String>,
+    git_strategy: Option<String>,
+    isolation: Option<String>,
     branch_prefix: Option<String>,
     clone_branch: Option<String>,
     cleanup_on_done: Option<bool>,
@@ -291,6 +293,38 @@ fn parse_codex_command(val: Value) -> Result<Vec<String>> {
     }
 }
 
+fn parse_workspace_git_strategy(value: &str) -> Result<WorkspaceRepoStrategy> {
+    match value {
+        "clone-local" => Ok(WorkspaceRepoStrategy::CloneLocal),
+        "clone-remote" => Ok(WorkspaceRepoStrategy::CloneRemote),
+        "worktree" => Ok(WorkspaceRepoStrategy::Worktree),
+        "auto" => Ok(WorkspaceRepoStrategy::Auto),
+        other => Err(SymphonyError::InvalidWorkflowConfig(format!(
+            "workspace.git_strategy must be 'clone-local', 'clone-remote', 'worktree', or 'auto' (got '{other}')"
+        ))),
+    }
+}
+
+fn parse_legacy_workspace_strategy(value: &str) -> Result<WorkspaceRepoStrategy> {
+    match value {
+        "clone" => Ok(WorkspaceRepoStrategy::Auto),
+        "worktree" => Ok(WorkspaceRepoStrategy::Worktree),
+        other => Err(SymphonyError::InvalidWorkflowConfig(format!(
+            "workspace.strategy must be 'clone' or 'worktree' (got '{other}')"
+        ))),
+    }
+}
+
+fn parse_workspace_isolation(value: &str) -> Result<WorkspaceIsolation> {
+    match value {
+        "local" => Ok(WorkspaceIsolation::Local),
+        "docker" => Ok(WorkspaceIsolation::Docker),
+        other => Err(SymphonyError::InvalidWorkflowConfig(format!(
+            "workspace.isolation must be 'local' or 'docker' (got '{other}')"
+        ))),
+    }
+}
+
 // ── Validated config wrapper ──────────────────────────────────────────────────
 
 /// A [`ServiceConfig`] that has passed [`validate`].
@@ -397,20 +431,43 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let raw_root = raw_workspace
         .root
         .unwrap_or_else(|| defaults.workspace.root.clone());
-    let strategy = match raw_workspace
+    let git_strategy = raw_workspace
+        .git_strategy
+        .map(|value| resolve_env(&value))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let legacy_strategy = raw_workspace
         .strategy
-        .as_deref()
-        .map(str::trim)
-        .unwrap_or("clone")
-    {
-        "clone" => WorkspaceRepoStrategy::Clone,
-        "worktree" => WorkspaceRepoStrategy::Worktree,
-        other => {
-            return Err(SymphonyError::InvalidWorkflowConfig(format!(
-                "workspace.strategy must be 'clone' or 'worktree' (got '{other}')"
-            )));
+        .map(|value| resolve_env(&value))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let strategy = if let Some(value) = git_strategy.as_deref() {
+        if legacy_strategy.is_some() {
+            tracing::warn!(
+                "workspace.strategy is deprecated and ignored because workspace.git_strategy is set"
+            );
         }
+        parse_workspace_git_strategy(value)?
+    } else if let Some(value) = legacy_strategy.as_deref() {
+        tracing::warn!("workspace.strategy is deprecated; use workspace.git_strategy");
+        parse_legacy_workspace_strategy(value)?
+    } else {
+        WorkspaceRepoStrategy::Auto
     };
+    let isolation = raw_workspace
+        .isolation
+        .map(|value| resolve_env(&value))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .as_deref()
+        .map(parse_workspace_isolation)
+        .transpose()?
+        .unwrap_or(WorkspaceIsolation::Local);
+    if isolation == WorkspaceIsolation::Docker {
+        tracing::warn!(
+            "workspace.isolation is set to 'docker', but docker isolation is not yet implemented"
+        );
+    }
     let repo = raw_workspace.repo.and_then(|value| {
         let resolved = resolve_env(&value);
         let trimmed = resolved.trim();
@@ -439,6 +496,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         root: expand_tilde(&raw_root),
         repo,
         strategy,
+        isolation,
         branch_prefix: branch_prefix.trim().to_string(),
         clone_branch,
         cleanup_on_done: raw_workspace
@@ -607,6 +665,17 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
                 "workspace.strategy 'worktree' requires workspace.repo to be a local path"
                     .to_string(),
             ));
+        }
+    }
+
+    if config.workspace.strategy == WorkspaceRepoStrategy::CloneLocal {
+        if let Some(repo) = config.workspace.repo.as_deref() {
+            if repo_is_remote(repo) {
+                return Err(SymphonyError::InvalidWorkflowConfig(
+                    "workspace.git_strategy 'clone-local' requires workspace.repo to be a local path"
+                        .to_string(),
+                ));
+            }
         }
     }
 

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -182,6 +182,7 @@ pub struct WorkspaceConfig {
     pub root: String,
     pub repo: Option<String>,
     pub strategy: WorkspaceRepoStrategy,
+    pub isolation: WorkspaceIsolation,
     pub branch_prefix: String,
     pub clone_branch: Option<String>,
     pub cleanup_on_done: bool,
@@ -190,8 +191,17 @@ pub struct WorkspaceConfig {
 /// Workspace repository bootstrap strategy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkspaceRepoStrategy {
-    Clone,
+    CloneLocal,
+    CloneRemote,
     Worktree,
+    Auto,
+}
+
+/// Workspace runtime isolation strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceIsolation {
+    Local,
+    Docker,
 }
 
 impl Default for WorkspaceConfig {
@@ -199,7 +209,8 @@ impl Default for WorkspaceConfig {
         Self {
             root: default_workspace_root(),
             repo: None,
-            strategy: WorkspaceRepoStrategy::Clone,
+            strategy: WorkspaceRepoStrategy::Auto,
+            isolation: WorkspaceIsolation::Local,
             branch_prefix: "symphony".to_string(),
             clone_branch: None,
             cleanup_on_done: false,

--- a/apps/symphony/src/repo_url.rs
+++ b/apps/symphony/src/repo_url.rs
@@ -3,7 +3,40 @@ use std::sync::OnceLock;
 
 /// Returns true when a repo reference looks like a remote URL.
 pub fn repo_is_remote(repo: &str) -> bool {
-    repo.contains("://") || repo.contains('@')
+    let repo = repo.trim();
+
+    if repo.contains("://") {
+        return true;
+    }
+
+    if is_windows_drive_path(repo) {
+        return false;
+    }
+
+    if repo.starts_with('/') || repo.starts_with("./") || repo.starts_with("../") {
+        return false;
+    }
+
+    if let Some((host, path)) = repo.split_once(':') {
+        if !host.is_empty()
+            && !path.is_empty()
+            && !host.contains('/')
+            && !host.contains('\\')
+            && !host.ends_with('.')
+        {
+            return true;
+        }
+    }
+
+    repo.contains('@')
+}
+
+fn is_windows_drive_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'/' || bytes[2] == b'\\')
 }
 
 /// Redacts URL user-info segments (`scheme://user[:pass]@host`) in command output.
@@ -24,7 +57,13 @@ mod tests {
     fn test_repo_is_remote() {
         assert!(repo_is_remote("https://github.com/org/repo.git"));
         assert!(repo_is_remote("git@github.com:org/repo.git"));
+        assert!(repo_is_remote("github.example.com:org/repo.git"));
+        assert!(repo_is_remote("my-ssh-host:org/repo.git"));
         assert!(!repo_is_remote("/tmp/local-repo"));
+        assert!(!repo_is_remote("./local-repo"));
+        assert!(!repo_is_remote("../local-repo"));
+        assert!(!repo_is_remote("C:/work/repo"));
+        assert!(!repo_is_remote("D:\\work\\repo"));
     }
 
     #[test]

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -167,10 +167,43 @@ fn bootstrap_repository(
 
     let branch_name = format!("{}/{}", config.branch_prefix, issue_identifier);
     let workspace_str = workspace.to_string_lossy().to_string();
+    let effective_strategy = match config.strategy {
+        WorkspaceRepoStrategy::Auto => {
+            if repo_is_remote(repo) {
+                WorkspaceRepoStrategy::CloneRemote
+            } else {
+                WorkspaceRepoStrategy::CloneLocal
+            }
+        }
+        other => other,
+    };
 
-    match config.strategy {
-        WorkspaceRepoStrategy::Clone => {
-            // Keep CLI parity with the proposal: git clone <repo> . --single-branch
+    match effective_strategy {
+        WorkspaceRepoStrategy::CloneLocal => {
+            if repo_is_remote(repo) {
+                return Err(SymphonyError::InvalidWorkflowConfig(
+                    "workspace.git_strategy 'clone-local' requires workspace.repo to be a local path"
+                        .to_string(),
+                ));
+            }
+            let mut clone_cmd = Command::new("git");
+            clone_cmd.arg("clone").arg("--local");
+            if let Some(clone_branch) = config.clone_branch.as_deref() {
+                clone_cmd.arg("--branch").arg(clone_branch);
+            }
+            clone_cmd.arg(repo).arg(".");
+            clone_cmd.current_dir(workspace);
+            run_git_command(clone_cmd, "workspace clone-local bootstrap")?;
+
+            let mut checkout_cmd = Command::new("git");
+            checkout_cmd
+                .arg("checkout")
+                .arg("-b")
+                .arg(&branch_name)
+                .current_dir(workspace);
+            run_git_command(checkout_cmd, "workspace branch bootstrap")
+        }
+        WorkspaceRepoStrategy::CloneRemote => {
             let mut clone_cmd = Command::new("git");
             clone_cmd
                 .arg("clone")
@@ -181,7 +214,7 @@ fn bootstrap_repository(
                 clone_cmd.arg("--branch").arg(clone_branch);
             }
             clone_cmd.current_dir(workspace);
-            run_git_command(clone_cmd, "workspace clone bootstrap")?;
+            run_git_command(clone_cmd, "workspace clone-remote bootstrap")?;
 
             let mut checkout_cmd = Command::new("git");
             checkout_cmd
@@ -216,6 +249,7 @@ fn bootstrap_repository(
                 .arg(&branch_name);
             run_git_command(worktree_cmd, "workspace worktree bootstrap")
         }
+        WorkspaceRepoStrategy::Auto => unreachable!("auto strategy must resolve before bootstrap"),
     }
 }
 

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -467,6 +467,56 @@ fn test_config_validation_rejects_clone_local_with_remote_repo() {
 }
 
 #[test]
+fn test_config_validation_rejects_clone_local_without_repo() {
+    let config = ServiceConfig {
+        tracker: TrackerConfig {
+            kind: Some("linear".to_string()),
+            api_key: Some("test-key".into()),
+            project_slug: Some("my-project".to_string()),
+            ..TrackerConfig::default()
+        },
+        workspace: WorkspaceConfig {
+            strategy: WorkspaceRepoStrategy::CloneLocal,
+            repo: None,
+            ..WorkspaceConfig::default()
+        },
+        ..ServiceConfig::default()
+    };
+
+    let result = validate(&config);
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.repo") && msg.contains("clone-local")),
+        "clone-local strategy without repo should fail validation, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_config_validation_rejects_clone_local_with_scp_style_remote_repo() {
+    let config = ServiceConfig {
+        tracker: TrackerConfig {
+            kind: Some("linear".to_string()),
+            api_key: Some("test-key".into()),
+            project_slug: Some("my-project".to_string()),
+            ..TrackerConfig::default()
+        },
+        workspace: WorkspaceConfig {
+            strategy: WorkspaceRepoStrategy::CloneLocal,
+            repo: Some("github.example.com:org/repo.git".to_string()),
+            ..WorkspaceConfig::default()
+        },
+        ..ServiceConfig::default()
+    };
+
+    let result = validate(&config);
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.git_strategy") && msg.contains("clone-local")),
+        "clone-local strategy with SCP-style remote repo should fail validation, got: {:?}",
+        result
+    );
+}
+
+#[test]
 fn test_config_validation_missing_api_key() {
     let config = ServiceConfig {
         tracker: TrackerConfig {

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -11,7 +11,8 @@ use tempfile::NamedTempFile;
 
 use symphony::config::{from_workflow, validate};
 use symphony::domain::{
-    CodexConfig, ServiceConfig, TrackerConfig, WorkspaceConfig, WorkspaceRepoStrategy,
+    CodexConfig, ServiceConfig, TrackerConfig, WorkspaceConfig, WorkspaceIsolation,
+    WorkspaceRepoStrategy,
 };
 use symphony::error::SymphonyError;
 use symphony::workflow::parse_workflow;
@@ -159,7 +160,8 @@ fn test_config_defaults() {
     assert_eq!(config.agent.max_concurrent_agents, 10);
     assert_eq!(config.agent.max_turns, 20);
     assert_eq!(config.workspace.repo, None);
-    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
+    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Auto);
+    assert_eq!(config.workspace.isolation, WorkspaceIsolation::Local);
     assert_eq!(config.workspace.branch_prefix, "symphony");
     assert_eq!(config.workspace.clone_branch, None);
     assert!(!config.workspace.cleanup_on_done);
@@ -227,12 +229,12 @@ fn test_config_tilde_expansion() {
 }
 
 #[test]
-fn test_workspace_repo_strategy_and_branch_prefix_parse() {
+fn test_workspace_git_strategy_and_branch_prefix_parse() {
     let yaml_str = r#"
 workspace:
   root: ~/workspaces
   repo: https://github.com/gannonh/kata.git
-  strategy: clone
+  git_strategy: clone-remote
   branch_prefix: " symphony "
   clone_branch: elixir-feature-parity
 "#;
@@ -243,12 +245,49 @@ workspace:
         config.workspace.repo.as_deref(),
         Some("https://github.com/gannonh/kata.git")
     );
-    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Clone);
+    assert_eq!(
+        config.workspace.strategy,
+        WorkspaceRepoStrategy::CloneRemote
+    );
     assert_eq!(config.workspace.branch_prefix, "symphony");
     assert_eq!(
         config.workspace.clone_branch.as_deref(),
         Some("elixir-feature-parity")
     );
+}
+
+#[test]
+fn test_workspace_legacy_strategy_clone_maps_to_auto() {
+    let yaml_str = r#"
+workspace:
+  strategy: clone
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("legacy workspace strategy should parse");
+    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Auto);
+}
+
+#[test]
+fn test_workspace_legacy_strategy_worktree_maps_to_worktree() {
+    let yaml_str = r#"
+workspace:
+  strategy: worktree
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("legacy workspace strategy should parse");
+    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::Worktree);
+}
+
+#[test]
+fn test_workspace_git_strategy_takes_precedence_over_legacy_strategy() {
+    let yaml_str = r#"
+workspace:
+  strategy: worktree
+  git_strategy: clone-local
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace strategy precedence should parse");
+    assert_eq!(config.workspace.strategy, WorkspaceRepoStrategy::CloneLocal);
 }
 
 #[test]
@@ -260,6 +299,28 @@ workspace:
     let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
     let config = from_workflow(&raw).expect("workspace clone branch should parse");
     assert_eq!(config.workspace.clone_branch, None);
+}
+
+#[test]
+fn test_workspace_isolation_defaults_to_local() {
+    let yaml_str = r#"
+workspace:
+  repo: /tmp/local-repo
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace defaults should parse");
+    assert_eq!(config.workspace.isolation, WorkspaceIsolation::Local);
+}
+
+#[test]
+fn test_workspace_isolation_docker_parses() {
+    let yaml_str = r#"
+workspace:
+  isolation: docker
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("docker isolation should parse");
+    assert_eq!(config.workspace.isolation, WorkspaceIsolation::Docker);
 }
 
 #[test]
@@ -294,6 +355,38 @@ workspace:
     assert!(
         matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.strategy")),
         "invalid workspace.strategy should return InvalidWorkflowConfig, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_workspace_git_strategy_invalid_value_errors() {
+    let yaml_str = r#"
+workspace:
+  git_strategy: invalid
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let result = from_workflow(&raw);
+
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.git_strategy")),
+        "invalid workspace.git_strategy should return InvalidWorkflowConfig, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_workspace_isolation_invalid_value_errors() {
+    let yaml_str = r#"
+workspace:
+  isolation: invalid
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let result = from_workflow(&raw);
+
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.isolation")),
+        "invalid workspace.isolation should return InvalidWorkflowConfig, got: {:?}",
         result
     );
 }
@@ -344,6 +437,31 @@ fn test_config_validation_rejects_worktree_with_remote_repo() {
     assert!(
         matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.strategy") && msg.contains("local")),
         "worktree strategy with remote repo should fail validation, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_config_validation_rejects_clone_local_with_remote_repo() {
+    let config = ServiceConfig {
+        tracker: TrackerConfig {
+            kind: Some("linear".to_string()),
+            api_key: Some("test-key".into()),
+            project_slug: Some("my-project".to_string()),
+            ..TrackerConfig::default()
+        },
+        workspace: WorkspaceConfig {
+            strategy: WorkspaceRepoStrategy::CloneLocal,
+            repo: Some("https://github.com/gannonh/kata.git".to_string()),
+            ..WorkspaceConfig::default()
+        },
+        ..ServiceConfig::default()
+    };
+
+    let result = validate(&config);
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg.contains("workspace.git_strategy") && msg.contains("clone-local")),
+        "clone-local strategy with remote repo should fail validation, got: {:?}",
         result
     );
 }

--- a/apps/symphony/tests/workspace_prompt_tests.rs
+++ b/apps/symphony/tests/workspace_prompt_tests.rs
@@ -10,7 +10,9 @@ use std::process::Command;
 use chrono::{DateTime, Utc};
 use tempfile::TempDir;
 
-use symphony::domain::{BlockerRef, HooksConfig, Issue, WorkspaceConfig, WorkspaceRepoStrategy};
+use symphony::domain::{
+    BlockerRef, HooksConfig, Issue, WorkspaceConfig, WorkspaceIsolation, WorkspaceRepoStrategy,
+};
 use symphony::error::SymphonyError;
 use symphony::path_safety;
 
@@ -108,7 +110,8 @@ fn workspace_config(root: &Path) -> WorkspaceConfig {
     WorkspaceConfig {
         root: root.to_string_lossy().to_string(),
         repo: None,
-        strategy: WorkspaceRepoStrategy::Clone,
+        strategy: WorkspaceRepoStrategy::Auto,
+        isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: None,
         cleanup_on_done: false,
@@ -208,6 +211,39 @@ fn create_branch_with_commit(path: &Path, branch: &str, file: &str, contents: &s
         .current_dir(path)
         .args(["commit", "-m", "branch-specific commit"]);
     command_success(commit, "git commit branch-specific file");
+}
+
+fn current_branch(path: &Path) -> String {
+    let path_str = path.to_string_lossy().to_string();
+    let mut branch_cmd = Command::new("git");
+    branch_cmd.args(["-C", &path_str, "branch", "--show-current"]);
+    command_success(branch_cmd, "read current branch")
+}
+
+fn init_bare_remote_and_push_all(source_repo: &Path, bare_repo: &Path) -> String {
+    let bare_repo_str = bare_repo.to_string_lossy().to_string();
+    let mut init_bare = Command::new("git");
+    init_bare.args(["init", "--bare", &bare_repo_str]);
+    command_success(init_bare, "init bare remote repo");
+
+    let source_repo_str = source_repo.to_string_lossy().to_string();
+
+    let mut add_remote = Command::new("git");
+    add_remote.args([
+        "-C",
+        &source_repo_str,
+        "remote",
+        "add",
+        "origin",
+        &bare_repo_str,
+    ]);
+    command_success(add_remote, "add source remote");
+
+    let mut push_all = Command::new("git");
+    push_all.args(["-C", &source_repo_str, "push", "--all", "origin"]);
+    command_success(push_all, "push all branches to bare remote");
+
+    format!("file://{bare_repo_str}")
 }
 
 fn shell_quote(path: &Path) -> String {
@@ -453,6 +489,7 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
     let source_repo = tmp.path().join("source-repo");
     fs::create_dir_all(&root).unwrap();
     init_git_repo(&source_repo);
+    let default_branch = current_branch(&source_repo);
     create_branch_with_commit(
         &source_repo,
         "elixir-feature-parity",
@@ -463,7 +500,8 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
     let config = WorkspaceConfig {
         root: root.to_string_lossy().to_string(),
         repo: Some(source_repo.to_string_lossy().to_string()),
-        strategy: WorkspaceRepoStrategy::Clone,
+        strategy: WorkspaceRepoStrategy::CloneLocal,
+        isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: Some("elixir-feature-parity".to_string()),
         cleanup_on_done: false,
@@ -492,6 +530,17 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
         ws_path.join("BASE_BRANCH.txt").exists(),
         "clone bootstrap should clone the configured source branch"
     );
+    let mut remote_branches_cmd = Command::new("git");
+    remote_branches_cmd.args(["-C", &ws.path, "branch", "-r"]);
+    let remote_branches = command_success(remote_branches_cmd, "read clone-local remotes");
+    assert!(
+        remote_branches.contains("origin/elixir-feature-parity"),
+        "clone-local bootstrap should retain selected source branch remote"
+    );
+    assert!(
+        remote_branches.contains(&format!("origin/{default_branch}")),
+        "clone-local bootstrap should not prune default branch remotes"
+    );
 
     let mut branch_cmd = Command::new("git");
     branch_cmd.args(["-C", &ws.path, "rev-parse", "--abbrev-ref", "HEAD"]);
@@ -510,6 +559,136 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
 }
 
 #[test]
+fn test_workspace_clone_remote_uses_single_branch_behavior() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    let bare_repo = tmp.path().join("source-remote.git");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+    let default_branch = current_branch(&source_repo);
+    create_branch_with_commit(
+        &source_repo,
+        "elixir-feature-parity",
+        "BASE_BRANCH.txt",
+        "elixir-feature-parity\n",
+    );
+    let remote_url = init_bare_remote_and_push_all(&source_repo, &bare_repo);
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(remote_url),
+        strategy: WorkspaceRepoStrategy::CloneRemote,
+        isolation: WorkspaceIsolation::Local,
+        branch_prefix: "symphony".to_string(),
+        clone_branch: Some("elixir-feature-parity".to_string()),
+        cleanup_on_done: false,
+    };
+    let hooks = hooks_config_none();
+    let issue = make_test_issue("KAT-804");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+
+    let mut remote_branches_cmd = Command::new("git");
+    remote_branches_cmd.args(["-C", &ws.path, "branch", "-r"]);
+    let remote_branches = command_success(remote_branches_cmd, "read clone-remote remotes");
+    assert!(
+        remote_branches.contains("origin/elixir-feature-parity"),
+        "clone-remote bootstrap should include selected source branch"
+    );
+    assert!(
+        !remote_branches.contains(&format!("origin/{default_branch}")),
+        "clone-remote bootstrap should prune default branch remotes via --single-branch"
+    );
+}
+
+#[test]
+fn test_workspace_auto_strategy_selects_local_clone_for_local_repo_path() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+    let default_branch = current_branch(&source_repo);
+    create_branch_with_commit(
+        &source_repo,
+        "elixir-feature-parity",
+        "BASE_BRANCH.txt",
+        "elixir-feature-parity\n",
+    );
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(source_repo.to_string_lossy().to_string()),
+        strategy: WorkspaceRepoStrategy::Auto,
+        isolation: WorkspaceIsolation::Local,
+        branch_prefix: "symphony".to_string(),
+        clone_branch: Some("elixir-feature-parity".to_string()),
+        cleanup_on_done: false,
+    };
+    let hooks = hooks_config_none();
+    let issue = make_test_issue("KAT-805");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+
+    let mut remote_branches_cmd = Command::new("git");
+    remote_branches_cmd.args(["-C", &ws.path, "branch", "-r"]);
+    let remote_branches = command_success(remote_branches_cmd, "read auto-local remotes");
+    assert!(
+        remote_branches.contains("origin/elixir-feature-parity"),
+        "auto strategy should include selected source branch for local repo"
+    );
+    assert!(
+        remote_branches.contains(&format!("origin/{default_branch}")),
+        "auto strategy should choose clone-local for local repo paths"
+    );
+}
+
+#[test]
+fn test_workspace_auto_strategy_selects_remote_clone_for_repo_url() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    let bare_repo = tmp.path().join("source-remote.git");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+    let default_branch = current_branch(&source_repo);
+    create_branch_with_commit(
+        &source_repo,
+        "elixir-feature-parity",
+        "BASE_BRANCH.txt",
+        "elixir-feature-parity\n",
+    );
+    let remote_url = init_bare_remote_and_push_all(&source_repo, &bare_repo);
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(remote_url),
+        strategy: WorkspaceRepoStrategy::Auto,
+        isolation: WorkspaceIsolation::Local,
+        branch_prefix: "symphony".to_string(),
+        clone_branch: Some("elixir-feature-parity".to_string()),
+        cleanup_on_done: false,
+    };
+    let hooks = hooks_config_none();
+    let issue = make_test_issue("KAT-806");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+
+    let mut remote_branches_cmd = Command::new("git");
+    remote_branches_cmd.args(["-C", &ws.path, "branch", "-r"]);
+    let remote_branches = command_success(remote_branches_cmd, "read auto-remote remotes");
+    assert!(
+        remote_branches.contains("origin/elixir-feature-parity"),
+        "auto strategy should include selected source branch for repo URLs"
+    );
+    assert!(
+        !remote_branches.contains(&format!("origin/{default_branch}")),
+        "auto strategy should choose clone-remote for URL repos"
+    );
+}
+
+#[test]
 fn test_workspace_worktree_bootstrap_and_cleanup() {
     let tmp = TempDir::new().unwrap();
     let root = tmp.path().join("workspaces");
@@ -521,6 +700,7 @@ fn test_workspace_worktree_bootstrap_and_cleanup() {
         root: root.to_string_lossy().to_string(),
         repo: Some(source_repo.to_string_lossy().to_string()),
         strategy: WorkspaceRepoStrategy::Worktree,
+        isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: None,
         cleanup_on_done: false,
@@ -661,6 +841,7 @@ fn test_workspace_remove_continues_when_worktree_cleanup_fails() {
         root: root.to_string_lossy().to_string(),
         repo: Some(source_repo.to_string_lossy().to_string()),
         strategy: WorkspaceRepoStrategy::Worktree,
+        isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: None,
         cleanup_on_done: false,


### PR DESCRIPTION
## Summary
- split workspace repository bootstrap strategy into `clone-local`, `clone-remote`, `worktree`, and `auto`
- add `workspace.isolation` config (`local` default, `docker` accepted with warning) and keep legacy `workspace.strategy` with deprecation mapping
- update bootstrap logic so local clones use `git clone --local` without `--single-branch`, remote clones retain `--single-branch`, and `auto` selects based on `repo_is_remote()`
- extend config/workspace tests for parsing precedence, validation, and clone behavior differences
- update Symphony workflow docs/examples to reflect new config fields

## Validation
- `cd apps/symphony && cargo test --test workflow_config_tests -- --nocapture`
- `cd apps/symphony && cargo test --test workspace_prompt_tests -- --nocapture`
- `cd apps/symphony && cargo test --test orchestrator_tests -- --nocapture`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `cd apps/symphony && cargo fmt`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the workspace bootstrap strategy from a single `Clone`/`Worktree` enum into four distinct strategies — `clone-local`, `clone-remote`, `worktree`, and `auto` — along with a new `isolation` config field (currently `local`/`docker`, with `docker` logging a warning). The legacy `workspace.strategy` field is preserved with a deprecation mapping (`"clone"` → `Auto`, `"worktree"` → `Worktree`), and `git_strategy` takes precedence when both are set. The change fits cleanly into the existing config/domain/workspace layering and the new integration tests clearly demonstrate the behavioral difference between local clones (no `--single-branch`, retains all remote refs) and remote clones (`--single-branch`).

Key observations:
- **Validation gap for `clone-local`**: Unlike `Worktree`, which explicitly rejects a missing `workspace.repo` in `validate()`, the new `CloneLocal` branch only checks whether the repo is a remote URL — it does not require `repo` to be set at all. A config with `git_strategy: clone-local` and no `repo` passes validation and silently produces a workspace with no git bootstrap. This should mirror the `Worktree` pattern (see inline comment).
- **Undocumented invariant in cleanup**: `cleanup_worktree_checkout` checks `config.strategy != Worktree` directly rather than computing an effective strategy. This is currently safe because `Auto` can never resolve to `Worktree`, but the invariant is implicit and worth documenting.
- **Missing test**: There is no counterpart to `test_config_validation_rejects_worktree_without_repo` for the `clone-local` strategy; adding one would both guard against the validation gap and maintain test-coverage symmetry.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the `clone-local` validation gap (missing `repo` check) can cause silent no-op bootstrap that may confuse users.
- The core refactor is well-structured, backward-compatible, and backed by good integration tests. One P1 issue remains: `validate()` does not require `workspace.repo` when `git_strategy: clone-local`, unlike the existing `Worktree` strategy. This means invalid configs pass validation and produce workspaces with no git content. The runtime does not panic (it returns `Ok(())`), but the behavior is silently wrong, which justifies holding the score at 3 until fixed.
- `apps/symphony/src/config.rs` — the `CloneLocal` validation block needs a `repo` presence check analogous to the `Worktree` block.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/config.rs | Adds `git_strategy`/`isolation` parsing with correct precedence and deprecation warnings, but `CloneLocal` validation is weaker than `Worktree`: it doesn't require `repo` to be present, allowing silent no-op bootstrap. |
| apps/symphony/src/workspace.rs | Bootstrap logic correctly resolves `Auto` to `CloneLocal`/`CloneRemote` and uses `unreachable!` as a defensive guard; `CloneLocal` and `CloneRemote` arms are well-formed, but `cleanup_worktree_checkout` uses `config.strategy` directly without documenting the invariant that `Auto` never resolves to `Worktree`. |
| apps/symphony/src/domain.rs | Clean split of `Clone` into `CloneLocal`/`CloneRemote`/`Auto`; new `WorkspaceIsolation` enum and `isolation` field on `WorkspaceConfig` are straightforward and well-defaulted. |
| apps/symphony/tests/workflow_config_tests.rs | Good coverage added for parsing precedence, legacy mapping, isolation parsing, and invalid value errors; missing a test for `clone-local` with no `repo` (analogous to existing `test_config_validation_rejects_worktree_without_repo`). |
| apps/symphony/tests/workspace_prompt_tests.rs | New integration tests clearly verify `clone-local` retains all remote refs, `clone-remote` prunes via `--single-branch`, and `auto` selects the correct strategy for both local paths and remote URLs. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Parse YAML config] --> B{git_strategy set?}
    B -- Yes --> C[parse_workspace_git_strategy]
    B -- No --> D{legacy strategy set?}
    D -- Yes --> E[parse_legacy_workspace_strategy\nwarn: deprecated]
    D -- No --> F[Default: Auto]
    C --> G[WorkspaceRepoStrategy]
    E --> G
    F --> G

    G --> H{isolation set?}
    H -- Yes --> I[parse_workspace_isolation]
    H -- No --> J[Default: Local]
    I --> K{Docker?}
    K -- Yes --> L[warn: not implemented]
    K -- No --> M[WorkspaceIsolation::Local]
    L --> M
    J --> M

    M --> N[validate config]
    N --> O{strategy == CloneLocal\nAND repo is remote URL?}
    O -- Yes --> P[Error: clone-local\nrequires local path]
    O -- No --> Q{strategy == Worktree?}
    Q -- Yes --> R{repo missing?}
    R -- Yes --> S[Error: repo required\nfor worktree]
    R -- No --> T{repo is remote?}
    T -- Yes --> U[Error: worktree\nrequires local path]
    T -- No --> V[ValidatedServiceConfig]
    Q -- No --> V

    V --> W[bootstrap_repository]
    W --> X{effective_strategy =\nresolve Auto}
    X --> Y{CloneLocal?}
    Y -- Yes --> Z[git clone --local\nno --single-branch]
    X --> AA{CloneRemote?}
    AA -- Yes --> AB[git clone --single-branch]
    X --> AC{Worktree?}
    AC -- Yes --> AD[git worktree add]
    X --> AE{Auto after resolve?}
    AE -- Yes --> AF[unreachable!]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/symphony/src/workspace.rs`, line 258-260 ([link](https://github.com/gannonh/kata/blob/3cc9074855f9b8814493216324a8399277b8a40d/apps/symphony/src/workspace.rs#L258-L260)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`cleanup_worktree_checkout` checks `config.strategy`, not effective strategy**

   `cleanup_worktree_checkout` compares `config.strategy != WorkspaceRepoStrategy::Worktree` directly against the raw configured value. This is fine today because `Auto` never resolves to `Worktree`, so no regression exists. However, if a future `Auto` variant or a new strategy ever resolves to `Worktree`, cleanup would be silently skipped for those workspaces.

   More importantly, the worktree cleanup is now using the `config.strategy` field that could reflect a legacy-mapped value (e.g., the old `strategy: worktree` YAML maps to `WorkspaceRepoStrategy::Worktree`), which is fine. But for symmetry with the `bootstrap_repository` pattern that computes `effective_strategy`, it is worth adding a comment explaining why `config.strategy` is used directly here (since `Auto` can never resolve to `Worktree`).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/workspace.rs
   Line: 258-260

   Comment:
   **`cleanup_worktree_checkout` checks `config.strategy`, not effective strategy**

   `cleanup_worktree_checkout` compares `config.strategy != WorkspaceRepoStrategy::Worktree` directly against the raw configured value. This is fine today because `Auto` never resolves to `Worktree`, so no regression exists. However, if a future `Auto` variant or a new strategy ever resolves to `Worktree`, cleanup would be silently skipped for those workspaces.

   More importantly, the worktree cleanup is now using the `config.strategy` field that could reflect a legacy-mapped value (e.g., the old `strategy: worktree` YAML maps to `WorkspaceRepoStrategy::Worktree`), which is fine. But for symmetry with the `bootstrap_repository` pattern that computes `effective_strategy`, it is worth adding a comment explaining why `config.strategy` is used directly here (since `Auto` can never resolve to `Worktree`).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/symphony/tests/workflow_config_tests.rs`, line 523-546 ([link](https://github.com/gannonh/kata/blob/3cc9074855f9b8814493216324a8399277b8a40d/apps/symphony/tests/workflow_config_tests.rs#L523-L546)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing test: `clone-local` with no `workspace.repo` should be rejected**

   There is a new test `test_config_validation_rejects_clone_local_with_remote_repo` but no corresponding test asserting that `git_strategy: clone-local` without any `workspace.repo` is also rejected at validation time. The `Worktree` strategy has `test_config_validation_rejects_worktree_without_repo` for this case. Adding the analogous test would guard against the validation gap noted above and maintain parity with the `Worktree` coverage pattern.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/tests/workflow_config_tests.rs
   Line: 523-546

   Comment:
   **Missing test: `clone-local` with no `workspace.repo` should be rejected**

   There is a new test `test_config_validation_rejects_clone_local_with_remote_repo` but no corresponding test asserting that `git_strategy: clone-local` without any `workspace.repo` is also rejected at validation time. The `Worktree` strategy has `test_config_validation_rejects_worktree_without_repo` for this case. Adding the analogous test would guard against the validation gap noted above and maintain parity with the `Worktree` coverage pattern.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/config.rs
Line: 671-680

Comment:
**Inconsistent required-repo validation for `clone-local`**

The `Worktree` strategy explicitly validates that `workspace.repo` is non-`None` (see lines 657–669) and returns a clear error if it is missing. The new `CloneLocal` block only validates the remote-URL case; if `repo` is `None`, no error is returned.

At runtime, `bootstrap_repository` returns `Ok(())` immediately when `repo` is `None` (line 164–165 of `workspace.rs`). This means a config with `git_strategy: clone-local` and no `workspace.repo` will pass validation, create the workspace directory, skip bootstrapping entirely, and leave the workspace silently without a git repository — even though the user explicitly requested a clone-local strategy.

Consider aligning `CloneLocal` validation with `Worktree`:

```suggestion
    if config.workspace.strategy == WorkspaceRepoStrategy::CloneLocal {
        let repo = config.workspace.repo.as_deref().ok_or_else(|| {
            SymphonyError::InvalidWorkflowConfig(
                "workspace.repo is required when workspace.git_strategy is 'clone-local'"
                    .to_string(),
            )
        })?;
        if repo_is_remote(repo) {
            return Err(SymphonyError::InvalidWorkflowConfig(
                "workspace.git_strategy 'clone-local' requires workspace.repo to be a local path"
                    .to_string(),
            ));
        }
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/workspace.rs
Line: 258-260

Comment:
**`cleanup_worktree_checkout` checks `config.strategy`, not effective strategy**

`cleanup_worktree_checkout` compares `config.strategy != WorkspaceRepoStrategy::Worktree` directly against the raw configured value. This is fine today because `Auto` never resolves to `Worktree`, so no regression exists. However, if a future `Auto` variant or a new strategy ever resolves to `Worktree`, cleanup would be silently skipped for those workspaces.

More importantly, the worktree cleanup is now using the `config.strategy` field that could reflect a legacy-mapped value (e.g., the old `strategy: worktree` YAML maps to `WorkspaceRepoStrategy::Worktree`), which is fine. But for symmetry with the `bootstrap_repository` pattern that computes `effective_strategy`, it is worth adding a comment explaining why `config.strategy` is used directly here (since `Auto` can never resolve to `Worktree`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/tests/workflow_config_tests.rs
Line: 523-546

Comment:
**Missing test: `clone-local` with no `workspace.repo` should be rejected**

There is a new test `test_config_validation_rejects_clone_local_with_remote_repo` but no corresponding test asserting that `git_strategy: clone-local` without any `workspace.repo` is also rejected at validation time. The `Worktree` strategy has `test_config_validation_rejects_worktree_without_repo` for this case. Adding the analogous test would guard against the validation gap noted above and maintain parity with the `Worktree` coverage pattern.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(symphony): refa..."](https://github.com/gannonh/kata/commit/3cc9074855f9b8814493216324a8399277b8a40d)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced workspace configuration with multiple repository cloning strategies
  * Added workspace isolation option supporting local and Docker environments
  * Improved automatic detection of local versus remote repositories
  * Expanded configuration validation for workspace setup consistency

* **Bug Fixes**
  * Improved repository path detection and validation for local and remote sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->