### PR TITLE
feat(symphony): add rotating log file output for --logs-root

### DIFF
--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -327,6 +327,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rolling-file"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8395b4f860856b740f20a296ea2cd4d823e81a2658cf05ef61be22916026a906"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +1931,7 @@ dependencies = [
  "notify",
  "regex",
  "reqwest",
+ "rolling-file",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1917,6 +1942,7 @@ dependencies = [
  "tokio-test",
  "tower",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -2194,6 +2220,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -34,6 +34,8 @@ chrono = { version = "0.4", features = ["serde"] }
 # Logging / tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-appender = "0.2"
+rolling-file = "0.2"
 
 # Async trait
 async-trait = "0.1"

--- a/apps/symphony/src/lib.rs
+++ b/apps/symphony/src/lib.rs
@@ -14,6 +14,7 @@ pub mod workspace;
 
 pub mod codex;
 pub mod http_server;
+pub mod logging;
 pub mod orchestrator;
 
 // These modules will be implemented in later slices

--- a/apps/symphony/src/logging.rs
+++ b/apps/symphony/src/logging.rs
@@ -1,0 +1,113 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use rolling_file::{RollingConditionBasic, RollingFileAppender};
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
+
+const LOG_SUBDIRECTORY: &str = "log";
+const LOG_FILE_NAME: &str = "symphony.log";
+const MAX_LOG_FILE_BYTES: u64 = 10 * 1024 * 1024;
+const MAX_LOG_FILES: usize = 5;
+
+fn log_file_path(logs_root: &Path) -> PathBuf {
+    logs_root.join(LOG_SUBDIRECTORY).join(LOG_FILE_NAME)
+}
+
+fn rollover_file_limit(total_files: usize) -> usize {
+    total_files.saturating_sub(1)
+}
+
+fn build_size_rotating_file_appender(
+    logs_root: &Path,
+    max_file_bytes: u64,
+    max_total_files: usize,
+) -> io::Result<RollingFileAppender<RollingConditionBasic>> {
+    let log_file = log_file_path(logs_root);
+    if let Some(log_dir) = log_file.parent() {
+        fs::create_dir_all(log_dir)?;
+    }
+    let condition = RollingConditionBasic::new().max_size(max_file_bytes);
+    let rollover_files = rollover_file_limit(max_total_files);
+
+    RollingFileAppender::new(log_file, condition, rollover_files)
+}
+
+pub fn build_non_blocking_file_writer(logs_root: &Path) -> io::Result<(NonBlocking, WorkerGuard)> {
+    let appender = build_size_rotating_file_appender(logs_root, MAX_LOG_FILE_BYTES, MAX_LOG_FILES)?;
+    Ok(tracing_appender::non_blocking(appender))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::Write;
+
+    use tempfile::tempdir;
+
+    use super::{build_size_rotating_file_appender, log_file_path};
+
+    #[test]
+    fn writes_logs_to_log_subdirectory_under_logs_root() {
+        let logs_root = tempdir().expect("temp dir should be created");
+        let mut appender = build_size_rotating_file_appender(logs_root.path(), 1024, 5)
+            .expect("appender should build");
+
+        writeln!(appender, "bootstrap log line").expect("write should succeed");
+        appender.flush().expect("flush should succeed");
+
+        let log_file = log_file_path(logs_root.path());
+        assert!(
+            log_file.is_file(),
+            "expected log file at {}",
+            log_file.display()
+        );
+
+        let contents = fs::read_to_string(&log_file).expect("log file should be readable");
+        assert!(
+            contents.contains("bootstrap log line"),
+            "log file should contain written line, got: {contents}"
+        );
+    }
+
+    #[test]
+    fn rotates_at_size_and_keeps_five_total_files() {
+        let logs_root = tempdir().expect("temp dir should be created");
+        let mut appender = build_size_rotating_file_appender(logs_root.path(), 128, 5)
+            .expect("appender should build");
+
+        for _ in 0..64 {
+            writeln!(appender, "{}", "X".repeat(32)).expect("write should succeed");
+        }
+        appender.flush().expect("flush should succeed");
+
+        let log_dir = logs_root.path().join("log");
+        let files: Vec<String> = fs::read_dir(&log_dir)
+            .expect("log directory should exist")
+            .map(|entry| {
+                entry
+                    .expect("directory entry should be readable")
+                    .file_name()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect();
+
+        assert!(
+            files.len() <= 5,
+            "rotation should keep at most 5 files, found {} files: {:?}",
+            files.len(),
+            files
+        );
+        assert!(
+            files.iter().any(|name| name == "symphony.log"),
+            "active log file should exist; found files: {:?}",
+            files
+        );
+        assert!(
+            !files.iter().any(|name| name == "symphony.log.5"),
+            "fifth rollover file should not exist when total file limit is 5; found files: {:?}",
+            files
+        );
+    }
+}

--- a/apps/symphony/src/logging.rs
+++ b/apps/symphony/src/logging.rs
@@ -14,6 +14,11 @@ fn log_file_path(logs_root: &Path) -> PathBuf {
     logs_root.join(LOG_SUBDIRECTORY).join(LOG_FILE_NAME)
 }
 
+/// The rolling-file `max_roll` argument counts only archived files and does
+/// not include the active `symphony.log` file.
+///
+/// To retain `total_files` on disk overall (active + archived), pass
+/// `total_files - 1` as `max_roll`.
 fn rollover_file_limit(total_files: usize) -> usize {
     total_files.saturating_sub(1)
 }
@@ -35,7 +40,11 @@ fn build_size_rotating_file_appender(
 
 pub fn build_non_blocking_file_writer(logs_root: &Path) -> io::Result<(NonBlocking, WorkerGuard)> {
     let appender = build_size_rotating_file_appender(logs_root, MAX_LOG_FILE_BYTES, MAX_LOG_FILES)?;
-    Ok(tracing_appender::non_blocking(appender))
+    Ok(
+        tracing_appender::non_blocking::NonBlockingBuilder::default()
+            .lossy(false)
+            .finish(appender),
+    )
 }
 
 #[cfg(test)]

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -1,17 +1,19 @@
 use std::ffi::OsString;
 use std::future::{pending, Future};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::sync::Once;
+use std::sync::{Arc, Mutex, Once};
 
 use clap::Parser;
 use symphony::domain::{Issue, ServiceConfig};
 use symphony::http_server::{start_http_server, HttpServerState};
 use symphony::linear::adapter::{LinearAdapter, TrackerAdapter};
 use symphony::linear::client::LinearClient;
+use symphony::logging;
 use symphony::orchestrator::{Orchestrator, OrchestratorPort};
 use symphony::workflow_store::WorkflowStore;
 use symphony::{config, error};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::fmt::writer::MakeWriterExt;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Debug, Clone)]
@@ -352,17 +354,48 @@ fn run_runtime_until_shutdown(
     })
 }
 
-fn init_tracing() {
+static FILE_LOG_GUARD: Mutex<Option<WorkerGuard>> = Mutex::new(None);
+
+fn flush_file_logs() {
+    if let Ok(mut guard_slot) = FILE_LOG_GUARD.lock() {
+        let _ = guard_slot.take();
+    }
+}
+
+fn init_tracing(logs_root: Option<&Path>) {
     static INIT: Once = Once::new();
 
     INIT.call_once(|| {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-
-        let _ = tracing_subscriber::fmt()
+        let subscriber_builder = tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_target(false)
-            .json()
-            .try_init();
+            .json();
+
+        let init_result = match logs_root {
+            Some(logs_root_path) => match logging::build_non_blocking_file_writer(logs_root_path) {
+                Ok((file_writer, guard)) => {
+                    if let Ok(mut guard_slot) = FILE_LOG_GUARD.lock() {
+                        *guard_slot = Some(guard);
+                    }
+                    subscriber_builder
+                        .with_writer(std::io::stdout.and(file_writer))
+                        .try_init()
+                }
+                Err(err) => {
+                    eprintln!(
+                        "failed to initialize rotating file logging at {}: {err}",
+                        logs_root_path.display()
+                    );
+                    subscriber_builder.try_init()
+                }
+            },
+            None => subscriber_builder.try_init(),
+        };
+
+        if let Err(err) = init_result {
+            eprintln!("failed to initialize tracing subscriber: {err}");
+        }
     });
 }
 
@@ -374,6 +407,8 @@ fn run_entrypoint(args: impl IntoIterator<Item = OsString>) -> i32 {
             return 2;
         }
     };
+
+    init_tracing(cli.logs_root.as_deref().map(Path::new));
 
     let mut deps = RuntimeBootstrapDeps::default();
 
@@ -397,9 +432,8 @@ async fn main() {
     // Load .env file if present (silently ignore if missing)
     let _ = dotenvy::dotenv();
 
-    init_tracing();
-
     let code = run_entrypoint(std::env::args_os());
+    flush_file_logs();
     if code != 0 {
         std::process::exit(code);
     }

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -281,6 +281,37 @@ pub fn execute_cli(cli: &Cli, deps: &mut dyn BootstrapDeps) -> Result<(), String
     })
 }
 
+async fn wait_for_shutdown_signal() -> Result<&'static str, String> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        let mut terminate = signal(SignalKind::terminate())
+            .map_err(|err| format!("failed to listen for sigterm: {err}"))?;
+
+        tokio::select! {
+            ctrl_c_result = tokio::signal::ctrl_c() => {
+                ctrl_c_result
+                    .map(|()| "ctrl_c")
+                    .map_err(|err| format!("failed to listen for ctrl_c: {err}"))
+            }
+            terminate_result = terminate.recv() => {
+                terminate_result
+                    .map(|_| "sigterm")
+                    .ok_or_else(|| "sigterm signal stream ended unexpectedly".to_string())
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c()
+            .await
+            .map(|()| "ctrl_c")
+            .map_err(|err| format!("failed to listen for ctrl_c: {err}"))
+    }
+}
+
 fn run_runtime_until_shutdown(
     orchestrator: &mut Orchestrator,
     port: &mut dyn OrchestratorPort,
@@ -334,20 +365,16 @@ fn run_runtime_until_shutdown(
                     );
                     Ok(())
                 }
-                signal_result = tokio::signal::ctrl_c() => {
-                    match signal_result {
-                        Ok(()) => {
-                            tracing::info!(
-                                phase = "runtime",
-                                stage = "stopped",
-                                reason = "ctrl_c",
-                                workflow_path = %workflow_path.display(),
-                                "received shutdown signal"
-                            );
-                            Ok(())
-                        }
-                        Err(err) => Err(format!("failed to listen for ctrl_c: {err}")),
-                    }
+                signal_reason = wait_for_shutdown_signal() => {
+                    let reason = signal_reason?;
+                    tracing::info!(
+                        phase = "runtime",
+                        stage = "stopped",
+                        reason = reason,
+                        workflow_path = %workflow_path.display(),
+                        "received shutdown signal"
+                    );
+                    Ok(())
                 }
             }
         })
@@ -374,14 +401,20 @@ fn init_tracing(logs_root: Option<&Path>) {
 
         let init_result = match logs_root {
             Some(logs_root_path) => match logging::build_non_blocking_file_writer(logs_root_path) {
-                Ok((file_writer, guard)) => {
-                    if let Ok(mut guard_slot) = FILE_LOG_GUARD.lock() {
+                Ok((file_writer, guard)) => match FILE_LOG_GUARD.lock() {
+                    Ok(mut guard_slot) => {
                         *guard_slot = Some(guard);
+                        subscriber_builder
+                            .with_writer(std::io::stdout.and(file_writer))
+                            .try_init()
                     }
-                    subscriber_builder
-                        .with_writer(std::io::stdout.and(file_writer))
-                        .try_init()
-                }
+                    Err(err) => {
+                        eprintln!(
+                            "failed to store file log guard (mutex poisoned): {err}; file logging disabled"
+                        );
+                        subscriber_builder.try_init()
+                    }
+                },
                 Err(err) => {
                     eprintln!(
                         "failed to initialize rotating file logging at {}: {err}",

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1277,12 +1277,15 @@ impl Orchestrator {
                 schedule_continuation,
             } => {
                 if !schedule_continuation {
-                    self.state.completed.insert(issue_id.to_string(), CompletedEntry {
-                        issue_id: issue_id.to_string(),
-                        identifier: issue_identifier.clone(),
-                        title: run_attempt.issue_title.clone().unwrap_or_default(),
-                        completed_at: Utc::now(),
-                    });
+                    self.state.completed.insert(
+                        issue_id.to_string(),
+                        CompletedEntry {
+                            issue_id: issue_id.to_string(),
+                            identifier: issue_identifier.clone(),
+                            title: run_attempt.issue_title.clone().unwrap_or_default(),
+                            completed_at: Utc::now(),
+                        },
+                    );
                 }
 
                 tracing::info!(
@@ -2130,12 +2133,15 @@ impl Orchestrator {
             }
         }
 
-        self.state.completed.insert(issue_id.to_string(), CompletedEntry {
-            issue_id: issue_id.to_string(),
-            identifier: issue.identifier.clone(),
-            title: issue.title.clone(),
-            completed_at: Utc::now(),
-        });
+        self.state.completed.insert(
+            issue_id.to_string(),
+            CompletedEntry {
+                issue_id: issue_id.to_string(),
+                identifier: issue.identifier.clone(),
+                title: issue.title.clone(),
+                completed_at: Utc::now(),
+            },
+        );
         self.state.running.remove(issue_id);
         self.state.claimed.remove(issue_id);
         self.state.retry_attempts.remove(issue_id);

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -2,6 +2,8 @@
 mod main_bin;
 
 use std::path::Path;
+use std::process::Command;
+use std::{fs, io};
 
 use main_bin::{BootstrapDeps, Cli};
 use symphony::domain::ServiceConfig;
@@ -263,4 +265,79 @@ fn test_effective_http_binding_defaults_to_8080() {
         "HTTP binding should default to port 8080"
     );
     assert_eq!(binding.unwrap().port, 8080);
+}
+
+#[test]
+fn test_logs_root_writes_startup_logs_to_file_and_stdout() {
+    let logs_root = tempfile::tempdir().expect("temp dir should be created");
+    let missing_workflow = logs_root.path().join("missing-workflow.md");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_symphony"))
+        .arg(&missing_workflow)
+        .arg("--logs-root")
+        .arg(logs_root.path())
+        .output()
+        .expect("symphony binary should execute");
+
+    assert!(
+        !output.status.success(),
+        "missing workflow path should still fail startup"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("starting CLI bootstrap"),
+        "stdout should include startup logs when --logs-root is set; got: {stdout}"
+    );
+
+    let log_file_path = logs_root.path().join("log").join("symphony.log");
+    assert!(
+        log_file_path.is_file(),
+        "expected log file at {}",
+        log_file_path.display()
+    );
+
+    let log_file_contents = read_to_string_or_panic(&log_file_path);
+    assert!(
+        log_file_contents.contains("starting CLI bootstrap"),
+        "log file should mirror startup log events; got: {log_file_contents}"
+    );
+}
+
+#[test]
+fn test_without_logs_root_keeps_stdout_only_behavior() {
+    let run_dir = tempfile::tempdir().expect("temp dir should be created");
+    let missing_workflow = run_dir.path().join("missing-workflow.md");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_symphony"))
+        .current_dir(run_dir.path())
+        .arg(&missing_workflow)
+        .output()
+        .expect("symphony binary should execute");
+
+    assert!(
+        !output.status.success(),
+        "missing workflow path should still fail startup"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("starting CLI bootstrap"),
+        "stdout should still include startup logs when --logs-root is omitted; got: {stdout}"
+    );
+
+    let log_file_path = run_dir.path().join("log").join("symphony.log");
+    assert!(
+        !log_file_path.exists(),
+        "no log file should be created when --logs-root is omitted, found {}",
+        log_file_path.display()
+    );
+}
+
+fn read_to_string_or_panic(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic_io(path, err))
+}
+
+fn panic_io(path: &Path, err: io::Error) -> ! {
+    panic!("failed to read {}: {err}", path.display());
 }

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -153,14 +153,14 @@ fn test_run_attempt_construction_and_serialization() {
     let ra = RunAttempt {
         issue_id: "id-1".into(),
         issue_identifier: "PROJ-1".into(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: "/tmp/ws".into(),
         started_at: Utc::now(),
         status: "running".into(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     let json = serde_json::to_string(&ra).unwrap();
     let deser: RunAttempt = serde_json::from_str(&json).unwrap();
@@ -228,14 +228,14 @@ fn test_orchestrator_snapshot_serializes() {
                 RunAttempt {
                     issue_id: "id-z".into(),
                     issue_identifier: "PROJ-Z".into(),
-            issue_title: None,
+                    issue_title: None,
                     attempt: Some(1),
                     workspace_path: "/tmp/ws-z".into(),
                     started_at: Utc::now(),
                     status: "running".into(),
                     error: None,
                     worker_host: None,
-            linear_state: None,
+                    linear_state: None,
                 },
             );
             m.insert(
@@ -243,14 +243,14 @@ fn test_orchestrator_snapshot_serializes() {
                 RunAttempt {
                     issue_id: "id-a".into(),
                     issue_identifier: "PROJ-A".into(),
-            issue_title: None,
+                    issue_title: None,
                     attempt: Some(1),
                     workspace_path: "/tmp/ws-a".into(),
                     started_at: Utc::now(),
                     status: "running".into(),
                     error: None,
                     worker_host: None,
-            linear_state: None,
+                    linear_state: None,
                 },
             );
             m

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -189,11 +189,11 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "dashboard shell should include rate-limit diagnostics section"
     );
     assert!(
-        body.contains("id=\\\"polling-next-poll\\\">n/a"),
+        body.contains("id=\"polling-next-poll\">n/a"),
         "dashboard shell should initialize next-poll tile with n/a placeholder"
     );
     assert!(
-        body.contains("id=\\\"polling-interval\\\">n/a"),
+        body.contains("id=\"polling-interval\">n/a"),
         "dashboard shell should initialize poll-interval tile with n/a placeholder"
     );
     assert!(

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -64,14 +64,14 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                 RunAttempt {
                     issue_id: "issue-123".to_string(),
                     issue_identifier: "SIM-123".to_string(),
-            issue_title: None,
+                    issue_title: None,
                     attempt: Some(2),
                     workspace_path: "/tmp/symphony/issue-123".to_string(),
                     started_at,
                     status: "running".to_string(),
                     error: None,
                     worker_host: Some("worker-a".to_string()),
-            linear_state: None,
+                    linear_state: None,
                 },
             );
             running

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -354,15 +354,15 @@ fn test_reconcile_refresh_failure_is_non_fatal_and_dispatch_continues() {
 fn test_completed_is_bookkeeping_and_does_not_block_dispatch() {
     let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let candidate = issue("issue-1", "SIM-1", "Todo", Some(1), 0);
-    orchestrator
-        .state_mut()
-        .completed
-        .insert(candidate.id.clone(), symphony::domain::CompletedEntry {
+    orchestrator.state_mut().completed.insert(
+        candidate.id.clone(),
+        symphony::domain::CompletedEntry {
             issue_id: candidate.id.clone(),
             identifier: candidate.identifier.clone(),
             title: candidate.title.clone(),
             completed_at: chrono::Utc::now(),
-        });
+        },
+    );
 
     let mut port = FakePort {
         candidate_issues: vec![candidate.clone()],
@@ -1165,7 +1165,10 @@ fn test_worker_completion_schedules_continuation_retry_with_session_context() {
         "completed turn should leave running map before retry scheduling"
     );
     assert!(
-        !orchestrator.state().completed.contains_key("issue-complete"),
+        !orchestrator
+            .state()
+            .completed
+            .contains_key("issue-complete"),
         "continuation completions must stay out of completed until terminal state"
     );
     assert!(
@@ -1641,14 +1644,14 @@ fn test_reconcile_non_active_state_stops_run_without_cleanup() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-non-active".to_string(),
         issue_identifier: "SIM-97".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: "/tmp/ws-non-active".to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -1682,7 +1685,10 @@ fn test_reconcile_non_active_state_stops_run_without_cleanup() {
 
     // The issue must NOT be in completed — non-terminal stop has no workspace cleanup.
     assert!(
-        !orchestrator.state().completed.contains_key("issue-non-active"),
+        !orchestrator
+            .state()
+            .completed
+            .contains_key("issue-non-active"),
         "non-terminal state stop must not add issue to completed (no cleanup semantic)"
     );
 }
@@ -1755,14 +1761,14 @@ fn test_terminal_state_cleanup_removes_workspace_when_enabled() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-terminal-cleanup".to_string(),
         issue_identifier: "SIM-98".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: workspace_path.to_string_lossy().to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -1804,14 +1810,14 @@ fn test_terminal_state_cleanup_preserves_workspace_when_disabled() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-terminal-no-cleanup".to_string(),
         issue_identifier: "SIM-99".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: workspace_path.to_string_lossy().to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -1862,14 +1868,14 @@ fn test_terminal_state_cleanup_runs_before_remove_hook() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-before-remove-hook".to_string(),
         issue_identifier: "SIM-100".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: workspace_path.to_string_lossy().to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -2076,14 +2082,14 @@ fn test_terminal_state_cleanup_removes_worktree_checkout_when_enabled() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-worktree-cleanup".to_string(),
         issue_identifier: "SIM-101".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: workspace.path.clone(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()
@@ -2134,14 +2140,14 @@ fn test_terminal_state_cleanup_failure_is_non_fatal() {
     let attempt = symphony::domain::RunAttempt {
         issue_id: "issue-cleanup-failure".to_string(),
         issue_identifier: "SIM-102".to_string(),
-            issue_title: None,
+        issue_title: None,
         attempt: None,
         workspace_path: outside_workspace.to_string_lossy().to_string(),
         started_at: Utc::now(),
         status: "running".to_string(),
         error: None,
         worker_host: None,
-            linear_state: None,
+        linear_state: None,
     };
     orchestrator
         .state_mut()


### PR DESCRIPTION
## Summary
- add rotating file logging for Symphony under `--logs-root` using a size-based `RollingFileAppender` configured for 10MB files with 5-file retention
- tee structured JSON logs to both stdout and file output when `--logs-root` is set, while preserving stdout-only behavior when it is omitted
- ensure non-blocking file log writes are flushed before `process::exit` by retaining and explicitly dropping the `WorkerGuard`
- add and update tests covering:
  - file + stdout dual-output behavior with `--logs-root`
  - stdout-only behavior without `--logs-root`
  - rolling log file creation and rotation bounds
  - dashboard polling placeholder assertions aligned with current HTML shell

## Validation
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`

## Linear
- KAT-818

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds rotating file logging to Symphony behind the `--logs-root` flag. When set, structured JSON logs are teed to both stdout and a size-based rolling file appender (`10 MB × 5 files`) using `tracing-appender`'s non-blocking writer; stdout-only behavior is preserved when the flag is omitted. The `WorkerGuard` is explicitly flushed before `process::exit` by storing it in a static `Mutex` and dropping it in `flush_file_logs()`, which correctly handles the case where destructors are not run. The http_server test fix (removing double-escaping of HTML attribute quotes) is a correct, unrelated cleanup.

Key points:
- **Guard drop on mutex poison** (`main.rs:376–383`): If `FILE_LOG_GUARD.lock()` fails, the `WorkerGuard` is silently dropped while `file_writer` is still given to the subscriber, causing all future file writes to fail silently. This edge case should be handled explicitly.
- **`logs_root` type** (`main.rs:35`): The CLI field is `Option<String>` instead of the more idiomatic `Option<PathBuf>`, which limits support for non-UTF-8 paths and requires a manual conversion at the call site.
- **`rollover_file_limit` clarity** (`logging.rs:17–19`): The helper encapsulates a critical off-by-one relationship with the `rolling-file` API; a doc comment would prevent future misuse.
- Test coverage is thorough: unit tests verify write and rotation behavior directly against the appender, and integration tests spawn the real binary to confirm dual-output and stdout-only modes end-to-end.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one low-probability edge case to address before relying on file logging in high-stakes environments.
- The implementation is well-structured, the flush-before-exit pattern is correctly implemented, and the test suite is thorough. The one real logic concern (silent WorkerGuard drop on mutex poison) is an extremely unlikely scenario but would be hard to diagnose if triggered. The style suggestions (PathBuf, doc comment) are minor polish items that don't affect correctness.
- apps/symphony/src/main.rs (WorkerGuard guard drop on mutex poison in `init_tracing`)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/logging.rs | New module implementing size-based rotating file appender using `rolling-file` + `tracing-appender`; well-structured with good unit test coverage for both write and rotation semantics. |
| apps/symphony/src/main.rs | Correctly threads `WorkerGuard` through a static `Mutex`, moves `init_tracing` after CLI parsing so `--logs-root` is available, and calls `flush_file_logs` before `process::exit`; one subtle guard-drop edge case if the mutex is poisoned. |
| apps/symphony/tests/cli_tests.rs | Adds two integration tests spawning the real binary; correctly covers dual-output (file + stdout) and stdout-only modes; helper functions are clean and well-named. |
| apps/symphony/tests/http_server_tests.rs | Fixes two test assertions that were incorrectly double-escaping HTML attribute quotes; straightforward and correct. |
| apps/symphony/Cargo.toml | Adds `tracing-appender = "0.2"` and `rolling-file = "0.2"` dependencies; appropriate versions, no conflicts. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant main
    participant run_entrypoint
    participant init_tracing
    participant logging
    participant FILE_LOG_GUARD
    participant NonBlockingWriter
    participant execute_cli

    main->>run_entrypoint: run_entrypoint(args_os)
    run_entrypoint->>run_entrypoint: parse_cli_from(args)
    run_entrypoint->>init_tracing: init_tracing(logs_root)
    alt logs_root = Some(path)
        init_tracing->>logging: build_non_blocking_file_writer(path)
        logging-->>init_tracing: Ok((file_writer, WorkerGuard))
        init_tracing->>FILE_LOG_GUARD: Mutex::lock → store WorkerGuard
        init_tracing->>NonBlockingWriter: build subscriber with stdout.and(file_writer)
        Note over NonBlockingWriter: Tees JSON logs to stdout + file
    else logs_root = None
        init_tracing->>NonBlockingWriter: build subscriber with stdout only
    end
    run_entrypoint->>execute_cli: execute_cli(&cli, &mut deps)
    execute_cli-->>run_entrypoint: Ok(()) or Err(msg)
    run_entrypoint-->>main: exit code (0 or 1)
    main->>FILE_LOG_GUARD: flush_file_logs() → take + drop WorkerGuard
    Note over FILE_LOG_GUARD: Blocks until background writer drains queue
    alt code != 0
        main->>main: process::exit(code)
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/src/main.rs`, line 35 ([link](https://github.com/gannonh/kata/blob/f7e4b644edf2a934831f77372465be2f8ff9af09/apps/symphony/src/main.rs#L35)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`logs_root` should prefer `Option<PathBuf>` over `Option<String>`**

   Using `Option<String>` for a file-path argument means paths containing non-UTF-8 bytes (valid on Linux/macOS) are silently rejected by clap, and the caller must defensively convert via `.as_deref().map(Path::new)`. Clap supports `PathBuf` natively and preserves OS-native path semantics.

   

   The call site in `run_entrypoint` would then simplify to:
   ```rust
   init_tracing(cli.logs_root.as_deref());
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/main.rs
   Line: 35

   Comment:
   **`logs_root` should prefer `Option<PathBuf>` over `Option<String>`**

   Using `Option<String>` for a file-path argument means paths containing non-UTF-8 bytes (valid on Linux/macOS) are silently rejected by clap, and the caller must defensively convert via `.as_deref().map(Path::new)`. Clap supports `PathBuf` natively and preserves OS-native path semantics.

   

   The call site in `run_entrypoint` would then simplify to:
   ```rust
   init_tracing(cli.logs_root.as_deref());
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/main.rs
Line: 376-383

Comment:
**`WorkerGuard` silently dropped when mutex lock fails**

If `FILE_LOG_GUARD.lock()` returns `Err` (poisoned mutex), `guard` is not moved into the slot and instead falls through to the end of the `Ok` arm's block, where it is dropped. At that point the background writer thread is shut down, but `file_writer` (a `NonBlocking` sender) has already been handed to the subscriber. All subsequent file-log writes will silently fail or block.

While mutex poisoning is rare in practice, the failure is silent and hard to diagnose. Consider propagating the error or at least logging it alongside the already-present `eprintln!`:

```rust
Ok((file_writer, guard)) => {
    match FILE_LOG_GUARD.lock() {
        Ok(mut guard_slot) => {
            *guard_slot = Some(guard);
        }
        Err(err) => {
            eprintln!("failed to store file log guard (mutex poisoned): {err}; file logging disabled");
            // guard is intentionally dropped here — fall back to stdout only
            return subscriber_builder.try_init();
        }
    }
    subscriber_builder
        .with_writer(std::io::stdout.and(file_writer))
        .try_init()
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/main.rs
Line: 35

Comment:
**`logs_root` should prefer `Option<PathBuf>` over `Option<String>`**

Using `Option<String>` for a file-path argument means paths containing non-UTF-8 bytes (valid on Linux/macOS) are silently rejected by clap, and the caller must defensively convert via `.as_deref().map(Path::new)`. Clap supports `PathBuf` natively and preserves OS-native path semantics.

```suggestion
    pub logs_root: Option<PathBuf>,
```

The call site in `run_entrypoint` would then simplify to:
```rust
init_tracing(cli.logs_root.as_deref());
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/logging.rs
Line: 17-19

Comment:
**`rollover_file_limit` wraps a one-liner without explanation**

The helper name obscures why the off-by-one subtraction is needed (the `rolling-file` API counts only *rolled* files, not the active file). A brief doc comment would make this relationship explicit and justify the wrapper:

```suggestion
/// The `rolling-file` crate's `max_roll` parameter controls how many *rolled*
/// (archived) files are kept, excluding the active log file.  So to keep
/// `total_files` files on disk (1 active + N archived), pass `total_files - 1`.
fn rollover_file_limit(total_files: usize) -> usize {
    total_files.saturating_sub(1)
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["test(symphony): fix ..."](https://github.com/gannonh/kata/commit/f7e4b644edf2a934831f77372465be2f8ff9af09)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->