### PR TITLE
feat(symphony): add workspace.base_branch config for prompts

### DIFF
--- a/.codex/skills/land/SKILL.md
+++ b/.codex/skills/land/SKILL.md
@@ -10,7 +10,8 @@ description:
 
 ## Goals
 
-- Ensure the PR is conflict-free with main.
+- Ensure the PR is conflict-free with the configured base branch (default:
+  `main`).
 - Keep CI green and fix failures when they occur.
 - Squash-merge the PR once checks pass.
 - Do not yield to the user until the PR is merged; keep the watcher loop running
@@ -29,9 +30,12 @@ description:
 2. Confirm the full gauntlet is green locally before any push.
 3. If the working tree has uncommitted changes, commit with the `commit` skill
    and push with the `push` skill before proceeding.
-4. Check mergeability and conflicts against main.
-5. If conflicts exist, use the `pull` skill to fetch/merge `origin/main` and
-   resolve conflicts, then use the `push` skill to publish the updated branch.
+4. Determine the target base branch from task context (for Symphony workflows,
+   use `workspace.base_branch`; otherwise default to `main`), then check
+   mergeability/conflicts against that base branch.
+5. If conflicts exist, use the `pull` skill to fetch/merge
+   `origin/<base-branch>` and resolve conflicts, then use the `push` skill to
+   publish the updated branch.
 6. Ensure Codex review comments (if present) are acknowledged and any required
    fixes are handled before merging.
 7. Watch checks until complete.
@@ -60,6 +64,7 @@ description:
 ```
 # Ensure branch and PR context
 branch=$(git branch --show-current)
+base_branch="${BASE_BRANCH:-main}"
 pr_number=$(gh pr view --json number -q .number)
 pr_title=$(gh pr view --json title -q .title)
 pr_body=$(gh pr view --json body -q .body)
@@ -122,10 +127,11 @@ Exit codes:
   timeout on only one platform), you may proceed without fixing it.
 - If CI pushes an auto-fix commit (authored by GitHub Actions), it does not
   trigger a fresh CI run. Detect the updated PR head, pull locally, merge
-  `origin/main` if needed, add a real author commit, and force-push to retrigger
-  CI, then restart the checks loop.
+  `origin/<base-branch>` if needed, add a real author commit, and force-push to
+  retrigger CI, then restart the checks loop.
 - If all jobs fail with corrupted pnpm lockfile errors on the merge commit, the
-  remediation is to fetch latest `origin/main`, merge, force-push, and rerun CI.
+  remediation is to fetch latest `origin/<base-branch>`, merge, force-push, and
+  rerun CI.
 - If mergeability is `UNKNOWN`, wait and re-check.
 - Do not merge while review comments (human or Codex review) are outstanding.
 - Codex review jobs retry on failure and are non-blocking; use the presence of

--- a/.codex/skills/pull/SKILL.md
+++ b/.codex/skills/pull/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: pull
 description:
-  Pull latest origin/main into the current local branch and resolve merge
-  conflicts (aka update-branch). Use when Codex needs to sync a feature branch
-  with origin, perform a merge-based update (not rebase), and guide conflict
-  resolution best practices.
+  Pull latest origin/<base-branch> into the current local branch and resolve
+  merge conflicts (aka update-branch). Use when Codex needs to sync a feature
+  branch with origin, perform a merge-based update (not rebase), and guide
+  conflict resolution best practices.
 ---
 
 # Pull
@@ -18,20 +18,25 @@ description:
 3. Confirm remotes and branches:
    - Ensure the `origin` remote exists.
    - Ensure the current branch is the one to receive the merge.
-4. Fetch latest refs:
+4. Determine the base branch merge target:
+   - Use a workflow-configured base branch when the task context provides one
+     (for Symphony workflows, this is `workspace.base_branch`).
+   - Default to `main` when no explicit base branch is available.
+   - Shell helper: `base_branch="${BASE_BRANCH:-main}"`.
+5. Fetch latest refs:
    - `git fetch origin`
-5. Sync the remote feature branch first:
+6. Sync the remote feature branch first:
    - `git pull --ff-only origin $(git branch --show-current)`
    - This pulls branch updates made remotely (for example, a GitHub auto-commit)
-     before merging `origin/main`.
-6. Merge in order:
-   - Prefer `git -c merge.conflictstyle=zdiff3 merge origin/main` for clearer
-     conflict context.
-7. If conflicts appear, resolve them (see conflict guidance below), then:
+     before merging `origin/$base_branch`.
+7. Merge in order:
+   - Prefer `git -c merge.conflictstyle=zdiff3 merge "origin/$base_branch"` for
+     clearer conflict context.
+8. If conflicts appear, resolve them (see conflict guidance below), then:
    - `git add <files>`
    - `git commit` (or `git merge --continue` if the merge is paused)
-8. Verify with project checks (follow repo policy in `AGENTS.md`).
-9. Summarize the merge:
+9. Verify with project checks (follow repo policy in `AGENTS.md`).
+10. Summarize the merge:
    - Call out the most challenging conflicts/files and how they were resolved.
    - Note any assumptions or follow-ups.
 

--- a/.codex/skills/push/SKILL.md
+++ b/.codex/skills/push/SKILL.md
@@ -2,7 +2,8 @@
 name: push
 description:
   Push current branch changes to origin and create or update the corresponding
-  pull request; use when asked to push, publish updates, or create pull request.
+  pull request (with the correct base branch); use when asked to push, publish
+  updates, or create pull request.
 ---
 
 # Push
@@ -26,14 +27,19 @@ description:
 ## Steps
 
 1. Identify current branch and confirm remote state.
-2. Run local validation (`cd apps/symphony && cargo test && cargo clippy -- -D warnings`) before pushing.
-3. Push branch to `origin` using explicit first-push upstream setup:
+2. Determine the PR/merge base branch:
+   - Use a workflow-configured base branch when task context provides one (for
+     Symphony workflows, this is `workspace.base_branch`).
+   - Default to `main` when no explicit base branch is available.
+3. Run local validation (`cd apps/symphony && cargo test && cargo clippy -- -D warnings`) before pushing.
+4. Push branch to `origin` using explicit first-push upstream setup:
    - first publish of a new branch: `git push -u origin "$branch"`
    - subsequent updates: `git push`
    Use whatever remote URL is already configured.
-4. If push is not clean/rejected:
+5. If push is not clean/rejected:
    - If the failure is a non-fast-forward or sync problem, run the `pull`
-     skill to merge `origin/main`, resolve conflicts, and rerun validation.
+     skill to merge `origin/<base-branch>`, resolve conflicts, and rerun
+     validation.
    - Retry with `git push -u origin "$branch"` so upstream is set even when the
      first push failed before tracking was recorded.
    - Use `--force-with-lease` only when history was rewritten.
@@ -41,14 +47,14 @@ description:
      the configured remote, stop and surface the exact error instead of
      rewriting remotes or switching protocols as a workaround.
 
-5. Ensure a PR exists for the branch:
+6. Ensure a PR exists for the branch:
    - If no PR exists, create one.
    - If a PR exists and is open, update it.
    - If branch is tied to a closed/merged PR, create a new branch + PR.
    - Write a proper PR title that clearly describes the change outcome
    - For branch updates, explicitly reconsider whether current PR title still
      matches the latest scope; update it if it no longer does.
-6. Write/update PR body explicitly using `.github/pull_request_template.md`:
+7. Write/update PR body explicitly using `.github/pull_request_template.md`:
    - Fill every section with concrete content for this change.
    - Replace all placeholder comments (`<!-- ... -->`).
    - Keep bullets/checkboxes where template expects them.
@@ -63,6 +69,7 @@ description:
 ```sh
 # Identify branch
 branch=$(git branch --show-current)
+base_branch="${BASE_BRANCH:-main}"
 
 # Minimal validation gate
 cd apps/symphony && cargo test && cargo clippy -- -D warnings
@@ -93,10 +100,10 @@ fi
 # Write a clear, human-friendly title that summarizes the shipped change.
 pr_title="<clear PR title written for this change>"
 if [ -z "$pr_state" ]; then
-  gh pr create --title "$pr_title"
+  gh pr create --base "$base_branch" --title "$pr_title"
 else
   # Reconsider title on every branch update; edit if scope shifted.
-  gh pr edit --title "$pr_title"
+  gh pr edit --base "$base_branch" --title "$pr_title"
 fi
 
 # Write/edit PR body to match .github/pull_request_template.md before validation.

--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -101,6 +101,7 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | `workspace.isolation`       | string | `"local"`                     | Workspace runtime isolation model: `"local"` (current behavior) or `"docker"` (accepted but not implemented yet; logs a warning).    |
 | `workspace.branch_prefix`   | string | `"symphony"`                  | Branch prefix used for auto-created issue branches (`<prefix>/<issue-identifier>`).                                                 |
 | `workspace.clone_branch`    | string | _(none)_                      | Optional source branch for clone-based bootstraps (`clone-local`, `clone-remote`, or `auto` when clone is selected).                |
+| `workspace.base_branch`     | string | `"main"`                      | Base branch used by workflow instructions for merge/rebase/pull targets (for example `origin/{{ workspace.base_branch }}`).          |
 | `workspace.cleanup_on_done` | bool   | `false`                       | Remove the issue workspace when the issue reaches a terminal state. Runs `hooks.before_remove` and ignores cleanup failures.         |
 
 #### `agent` section
@@ -168,6 +169,7 @@ workspace:
   isolation: local
   branch_prefix: symphony
   clone_branch: elixir-feature-parity
+  base_branch: main
   cleanup_on_done: true
 
 codex:
@@ -204,6 +206,7 @@ workspace:
   git_strategy: worktree
   isolation: local
   branch_prefix: symphony
+  base_branch: main
   cleanup_on_done: true
 
 agent:

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -25,6 +25,7 @@ workspace:
   isolation: local
   branch_prefix: symphony
   clone_branch: main
+  base_branch: main
 hooks:
   timeout_ms: 120000
 agent:
@@ -83,7 +84,7 @@ This is the **kata-mono** monorepo. The Symphony crate lives at `apps/symphony/`
 - Test: `cd apps/symphony && cargo test`
 - Lint: `cd apps/symphony && cargo clippy -- -D warnings`
 - Format: `cd apps/symphony && cargo fmt`
-- Base branch: `main`. All merges, rebases, and PR base targets use this branch.
+- Base branch: `{{ workspace.base_branch }}`. All merges, rebases, and PR base targets use this branch.
 
 Read `apps/symphony/AGENTS.md` for full architecture reference.
 
@@ -221,7 +222,7 @@ mutation AttachURL($issueId: String!, $url: String!, $title: String) {
 - `linear`: interact with Linear. **MANDATORY: read `.codex/skills/linear/SKILL.md` before ANY `linear_graphql` tool call.** It contains the exact correct query shapes, field names, and argument types. Do not guess Linear GraphQL schema — use the skill.
 - `commit`: produce clean, logical commits during implementation.
 - `push`: keep remote branch current and publish updates.
-- `pull`: keep branch updated before handoff. Use `origin/main` as the upstream.
+- `pull`: keep branch updated before handoff. Use `origin/{{ workspace.base_branch }}` as the upstream.
 - `land`: when ticket reaches `Merging`, explicitly open and follow `.codex/skills/land/SKILL.md`, which includes the `land` loop.
 - `address-comments`: **MANDATORY when issue is in `Agent Review`.** Read `.codex/skills/address-comments/SKILL.md` and follow its steps to fetch PR comments, address each thread, resolve threads, and push fixes.
 - `fix-ci`: when CI checks fail on a PR, read `.codex/skills/fix-ci/SKILL.md` and follow its steps to diagnose and fix GitHub Actions failures.
@@ -264,7 +265,7 @@ Todo -> In Progress -> Agent Review (auto, address bot feedback) -> Human Review
    - `Done` -> do nothing and shut down.
 4. Check whether a PR already exists for the current branch and whether it is closed.
    - If a branch PR exists and is `CLOSED` or `MERGED`, treat prior branch work as non-reusable for this run.
-   - Create a fresh branch from `origin/main` and restart execution flow as a new attempt.
+   - Create a fresh branch from `origin/{{ workspace.base_branch }}` and restart execution flow as a new attempt.
 5. For `Todo` tickets, do startup sequencing in this exact order:
    - verify issue is in `In Progress` (orchestrator handles this on dispatch)
    - find/create `## Codex Workpad` bootstrap comment
@@ -295,7 +296,7 @@ Todo -> In Progress -> Agent Review (auto, address bot feedback) -> Human Review
     - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
 7. Run a principal-style self-review of the plan and refine it in the comment.
 8. Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
-9. Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
+9. Run the `pull` skill to sync with latest `origin/{{ workspace.base_branch }}` before any code edits, then record the pull/sync result in the workpad `Notes`.
     - Include a `pull skill evidence` note with:
       - merge source(s),
       - result (`clean` or `conflicts resolved`),
@@ -354,7 +355,7 @@ Use this only when completion is blocked by missing required tools or missing au
 7. Before every `git push` attempt, run the required validation for your scope and confirm it passes; if it fails, address issues and rerun until green, then commit and push changes.
 8. Attach PR URL to the issue (prefer attachment; use the workpad comment only if attachment is unavailable).
     - Ensure the GitHub PR has label `symphony` (add it if missing).
-9. Merge latest `origin/main` into branch, resolve conflicts, and rerun checks.
+9. Merge latest `origin/{{ workspace.base_branch }}` into branch, resolve conflicts, and rerun checks.
 10. Update the workpad comment with final checklist status and validation notes.
     - Mark completed plan/acceptance/validation checklist items as checked.
     - Add final handoff notes (commit + validation summary) in the same workpad comment.
@@ -396,7 +397,7 @@ Use this only when completion is blocked by missing required tools or missing au
 2. Re-read the full issue body and all human comments; explicitly identify what will be done differently this attempt.
 3. Close the existing PR tied to the issue.
 4. Remove the existing `## Codex Workpad` comment from the issue.
-5. Create a fresh branch from `origin/main`.
+5. Create a fresh branch from `origin/{{ workspace.base_branch }}`.
 6. Start over from the normal kickoff flow:
    - If current issue state is `Todo`, move it to `In Progress`; otherwise keep the current state.
    - Create a new bootstrap `## Codex Workpad` comment.
@@ -416,7 +417,7 @@ Use this only when completion is blocked by missing required tools or missing au
 ## Guardrails
 
 - If the branch PR is already closed/merged, do not reuse that branch or prior implementation state for continuation.
-- For closed/merged branch PRs, create a new branch from `origin/main` and restart from reproduction/planning as if starting fresh.
+- For closed/merged branch PRs, create a new branch from `origin/{{ workspace.base_branch }}` and restart from reproduction/planning as if starting fresh.
 - If issue state is `Backlog`, do not modify it; wait for human to move to `Todo`.
 - Do not edit the issue body/description for planning or progress tracking.
 - Use exactly one persistent workpad comment (`## Codex Workpad`) per issue.

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -107,6 +107,11 @@ workspace:
   # Supports $VAR indirection.
   clone_branch: main
 
+  # Base branch for workflow merge/rebase/pull operations.
+  # Prompt instructions can reference this as `{{ workspace.base_branch }}`.
+  # Default: main.
+  base_branch: main
+
   # Whether to auto-remove workspaces when their issue reaches a terminal state.
   # When true, runs `before_remove` hook then deletes the workspace directory.
   # Default: false (workspaces persist for debugging).
@@ -245,7 +250,7 @@ This is the **kata-mono** monorepo. The Symphony crate lives at `apps/symphony/`
 - Test: `cd apps/symphony && cargo test`
 - Lint: `cd apps/symphony && cargo clippy -- -D warnings`
 - Format: `cd apps/symphony && cargo fmt`
-- Base branch: `main`. All merges, rebases, and PR base targets use this branch.
+- Base branch: `{{ workspace.base_branch }}`. All merges, rebases, and PR base targets use this branch.
 
 Read `apps/symphony/AGENTS.md` for full architecture reference.
 
@@ -383,7 +388,7 @@ mutation AttachURL($issueId: String!, $url: String!, $title: String) {
 - `linear`: interact with Linear. **MANDATORY: read `.codex/skills/linear/SKILL.md` before ANY `linear_graphql` tool call.** It contains the exact correct query shapes, field names, and argument types. Do not guess Linear GraphQL schema — use the skill.
 - `commit`: produce clean, logical commits during implementation.
 - `push`: keep remote branch current and publish updates.
-- `pull`: keep branch updated before handoff. Use `origin/main` as the upstream.
+- `pull`: keep branch updated before handoff. Use `origin/{{ workspace.base_branch }}` as the upstream.
 - `land`: when ticket reaches `Merging`, explicitly open and follow `.codex/skills/land/SKILL.md`, which includes the `land` loop.
 
 ## Status map
@@ -415,7 +420,7 @@ mutation AttachURL($issueId: String!, $url: String!, $title: String) {
    - `Done` -> do nothing and shut down.
 4. Check whether a PR already exists for the current branch and whether it is closed.
    - If a branch PR exists and is `CLOSED` or `MERGED`, treat prior branch work as non-reusable for this run.
-   - Create a fresh branch from `origin/main` and restart execution flow as a new attempt.
+   - Create a fresh branch from `origin/{{ workspace.base_branch }}` and restart execution flow as a new attempt.
 5. For `Todo` tickets, do startup sequencing in this exact order:
    - verify issue is in `In Progress` (orchestrator handles this on dispatch)
    - find/create `## Codex Workpad` bootstrap comment
@@ -446,7 +451,7 @@ mutation AttachURL($issueId: String!, $url: String!, $title: String) {
     - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
 7. Run a principal-style self-review of the plan and refine it in the comment.
 8. Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
-9. Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
+9. Run the `pull` skill to sync with latest `origin/{{ workspace.base_branch }}` before any code edits, then record the pull/sync result in the workpad `Notes`.
     - Include a `pull skill evidence` note with:
       - merge source(s),
       - result (`clean` or `conflicts resolved`),
@@ -505,7 +510,7 @@ Use this only when completion is blocked by missing required tools or missing au
 7. Before every `git push` attempt, run the required validation for your scope and confirm it passes; if it fails, address issues and rerun until green, then commit and push changes.
 8. Attach PR URL to the issue (prefer attachment; use the workpad comment only if attachment is unavailable).
     - Ensure the GitHub PR has label `symphony` (add it if missing).
-9. Merge latest `origin/main` into branch, resolve conflicts, and rerun checks.
+9. Merge latest `origin/{{ workspace.base_branch }}` into branch, resolve conflicts, and rerun checks.
 10. Update the workpad comment with final checklist status and validation notes.
     - Mark completed plan/acceptance/validation checklist items as checked.
     - Add final handoff notes (commit + validation summary) in the same workpad comment.
@@ -546,7 +551,7 @@ Use this only when completion is blocked by missing required tools or missing au
 2. Re-read the full issue body and all human comments; explicitly identify what will be done differently this attempt.
 3. Close the existing PR tied to the issue.
 4. Remove the existing `## Codex Workpad` comment from the issue.
-5. Create a fresh branch from `origin/main`.
+5. Create a fresh branch from `origin/{{ workspace.base_branch }}`.
 6. Start over from the normal kickoff flow:
    - If current issue state is `Todo`, move it to `In Progress`; otherwise keep the current state.
    - Create a new bootstrap `## Codex Workpad` comment.
@@ -566,7 +571,7 @@ Use this only when completion is blocked by missing required tools or missing au
 ## Guardrails
 
 - If the branch PR is already closed/merged, do not reuse that branch or prior implementation state for continuation.
-- For closed/merged branch PRs, create a new branch from `origin/main` and restart from reproduction/planning as if starting fresh.
+- For closed/merged branch PRs, create a new branch from `origin/{{ workspace.base_branch }}` and restart from reproduction/planning as if starting fresh.
 - If issue state is `Backlog`, do not modify it; wait for human to move to `Todo`.
 - Do not edit the issue body/description for planning or progress tracking.
 - Use exactly one persistent workpad comment (`## Codex Workpad`) per issue.

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -184,6 +184,7 @@ struct RawWorkspaceConfig {
     isolation: Option<String>,
     branch_prefix: Option<String>,
     clone_branch: Option<String>,
+    base_branch: Option<String>,
     cleanup_on_done: Option<bool>,
 }
 
@@ -492,6 +493,18 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
                 Some(trimmed.to_string())
             }
         });
+    let base_branch = raw_workspace
+        .base_branch
+        .map(|value| resolve_env(&value))
+        .and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .or_else(|| defaults.workspace.base_branch.clone());
     let workspace = WorkspaceConfig {
         root: expand_tilde(&raw_root),
         repo,
@@ -499,6 +512,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         isolation,
         branch_prefix: branch_prefix.trim().to_string(),
         clone_branch,
+        base_branch,
         cleanup_on_done: raw_workspace
             .cleanup_on_done
             .unwrap_or(defaults.workspace.cleanup_on_done),

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -185,6 +185,7 @@ pub struct WorkspaceConfig {
     pub isolation: WorkspaceIsolation,
     pub branch_prefix: String,
     pub clone_branch: Option<String>,
+    pub base_branch: Option<String>,
     pub cleanup_on_done: bool,
 }
 
@@ -213,6 +214,7 @@ impl Default for WorkspaceConfig {
             isolation: WorkspaceIsolation::Local,
             branch_prefix: "symphony".to_string(),
             clone_branch: None,
+            base_branch: Some("main".to_string()),
             cleanup_on_done: false,
         }
     }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -267,7 +267,12 @@ async fn run_worker_task(
     }
 
     // 3. Render prompt
-    let prompt = match prompt_builder::render_prompt(&config.prompt_template, issue, attempt) {
+    let prompt = match prompt_builder::render_prompt(
+        &config.prompt_template,
+        issue,
+        attempt,
+        config.workspace.base_branch.as_deref(),
+    ) {
         Ok(prompt) => prompt,
         Err(err) => {
             tracing::error!(
@@ -1419,7 +1424,12 @@ impl Orchestrator {
             return Err(err);
         }
 
-        let prompt = match prompt_builder::render_prompt(prompt_template, issue, attempt) {
+        let prompt = match prompt_builder::render_prompt(
+            prompt_template,
+            issue,
+            attempt,
+            self.config.workspace.base_branch.as_deref(),
+        ) {
             Ok(prompt) => prompt,
             Err(err) => {
                 self.handle_worker_completion(

--- a/apps/symphony/src/prompt_builder.rs
+++ b/apps/symphony/src/prompt_builder.rs
@@ -7,16 +7,22 @@
 use crate::domain::Issue;
 use crate::error::{Result, SymphonyError};
 
-/// Render a Liquid template with `issue` and `attempt` variables.
+/// Render a Liquid template with `issue`, `attempt`, and `workspace` variables.
 ///
 /// - `template`: Liquid template string (Liquid markup)
 /// - `issue`: Issue data to bind as `issue.*` variables
 /// - `attempt`: Optional attempt number, bound as `attempt`
+/// - `workspace_base_branch`: Optional base branch, bound as `workspace.base_branch`
 ///
 /// Uses strict mode — unknown variables produce `TemplateRenderError`.
 /// DateTime fields render as ISO 8601 strings. `None` fields render as
 /// empty string. `Vec<BlockerRef>` is iterable via `{% for %}`.
-pub fn render_prompt(template: &str, issue: &Issue, attempt: Option<u32>) -> Result<String> {
+pub fn render_prompt(
+    template: &str,
+    issue: &Issue,
+    attempt: Option<u32>,
+    workspace_base_branch: Option<&str>,
+) -> Result<String> {
     // 1. Parse the template
     let parser = liquid::ParserBuilder::with_stdlib()
         .build()
@@ -31,15 +37,28 @@ pub fn render_prompt(template: &str, issue: &Issue, attempt: Option<u32>) -> Res
     let issue_obj = liquid::to_object(issue)
         .map_err(|e| SymphonyError::TemplateRenderError(format!("issue serialization: {e}")))?;
 
-    // 3. Build globals: { "issue": <object>, "attempt": <value> }
+    // 3. Build globals: { "issue": <object>, "attempt": <value>, "workspace": <object> }
     let attempt_val = match attempt {
         None => liquid_core::model::Value::Nil,
         Some(n) => liquid_core::model::Value::scalar(n as i64),
     };
+    let base_branch = workspace_base_branch
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("main");
+    let mut workspace_obj = liquid::Object::new();
+    workspace_obj.insert(
+        "base_branch".into(),
+        liquid_core::model::Value::scalar(base_branch.to_string()),
+    );
 
     let mut globals = liquid::Object::new();
     globals.insert("issue".into(), liquid_core::model::Value::Object(issue_obj));
     globals.insert("attempt".into(), attempt_val);
+    globals.insert(
+        "workspace".into(),
+        liquid_core::model::Value::Object(workspace_obj),
+    );
 
     // 4. Render (liquid-rs is strict by default — unknown variables error)
     compiled

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -164,6 +164,7 @@ fn test_config_defaults() {
     assert_eq!(config.workspace.isolation, WorkspaceIsolation::Local);
     assert_eq!(config.workspace.branch_prefix, "symphony");
     assert_eq!(config.workspace.clone_branch, None);
+    assert_eq!(config.workspace.base_branch.as_deref(), Some("main"));
     assert!(!config.workspace.cleanup_on_done);
 }
 
@@ -254,6 +255,7 @@ workspace:
         config.workspace.clone_branch.as_deref(),
         Some("elixir-feature-parity")
     );
+    assert_eq!(config.workspace.base_branch.as_deref(), Some("main"));
 }
 
 #[test]
@@ -299,6 +301,31 @@ workspace:
     let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
     let config = from_workflow(&raw).expect("workspace clone branch should parse");
     assert_eq!(config.workspace.clone_branch, None);
+}
+
+#[test]
+fn test_workspace_base_branch_parses_and_trims() {
+    let yaml_str = r#"
+workspace:
+  base_branch: " elixir-feature-parity "
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace base branch should parse");
+    assert_eq!(
+        config.workspace.base_branch.as_deref(),
+        Some("elixir-feature-parity")
+    );
+}
+
+#[test]
+fn test_workspace_base_branch_blank_uses_default_main() {
+    let yaml_str = r#"
+workspace:
+  base_branch: "   "
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace base branch blank should parse");
+    assert_eq!(config.workspace.base_branch.as_deref(), Some("main"));
 }
 
 #[test]

--- a/apps/symphony/tests/workspace_prompt_tests.rs
+++ b/apps/symphony/tests/workspace_prompt_tests.rs
@@ -114,6 +114,7 @@ fn workspace_config(root: &Path) -> WorkspaceConfig {
         isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: None,
+        base_branch: Some("main".to_string()),
         cleanup_on_done: false,
     }
 }
@@ -504,6 +505,7 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
         isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: Some("elixir-feature-parity".to_string()),
+        base_branch: Some("main".to_string()),
         cleanup_on_done: false,
     };
     let hooks = HooksConfig {
@@ -582,6 +584,7 @@ fn test_workspace_clone_remote_uses_single_branch_behavior() {
         isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: Some("elixir-feature-parity".to_string()),
+        base_branch: Some("main".to_string()),
         cleanup_on_done: false,
     };
     let hooks = hooks_config_none();
@@ -624,6 +627,7 @@ fn test_workspace_auto_strategy_selects_local_clone_for_local_repo_path() {
         isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: Some("elixir-feature-parity".to_string()),
+        base_branch: Some("main".to_string()),
         cleanup_on_done: false,
     };
     let hooks = hooks_config_none();
@@ -668,6 +672,7 @@ fn test_workspace_auto_strategy_selects_remote_clone_for_repo_url() {
         isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: Some("elixir-feature-parity".to_string()),
+        base_branch: Some("main".to_string()),
         cleanup_on_done: false,
     };
     let hooks = hooks_config_none();
@@ -703,6 +708,7 @@ fn test_workspace_worktree_bootstrap_and_cleanup() {
         isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: None,
+        base_branch: Some("main".to_string()),
         cleanup_on_done: false,
     };
     let hooks = hooks_config_none();
@@ -844,6 +850,7 @@ fn test_workspace_remove_continues_when_worktree_cleanup_fails() {
         isolation: WorkspaceIsolation::Local,
         branch_prefix: "symphony".to_string(),
         clone_branch: None,
+        base_branch: Some("main".to_string()),
         cleanup_on_done: false,
     };
     let hooks = hooks_config_none();
@@ -994,7 +1001,8 @@ fn test_render_prompt_basic_fields() {
     let issue = make_full_issue();
     let template = "ID: {{ issue.identifier }}\nTitle: {{ issue.title }}\nLabels: {{ issue.labels | join: ', ' }}\nAttempt: {{ attempt }}";
 
-    let result = symphony::prompt_builder::render_prompt(template, &issue, Some(2)).unwrap();
+    let result =
+        symphony::prompt_builder::render_prompt(template, &issue, Some(2), Some("main")).unwrap();
     assert!(result.contains("ID: MT-42"), "got: {}", result);
     assert!(result.contains("Title: Fix the widget"), "got: {}", result);
     assert!(result.contains("Labels: bug, urgent"), "got: {}", result);
@@ -1002,11 +1010,38 @@ fn test_render_prompt_basic_fields() {
 }
 
 #[test]
+fn test_render_prompt_workspace_base_branch() {
+    let issue = make_full_issue();
+    let template = "Base branch: {{ workspace.base_branch }}";
+
+    let configured = symphony::prompt_builder::render_prompt(
+        template,
+        &issue,
+        None,
+        Some("elixir-feature-parity"),
+    )
+    .unwrap();
+    assert!(
+        configured.contains("Base branch: elixir-feature-parity"),
+        "configured base branch should render, got: {}",
+        configured
+    );
+
+    let defaulted = symphony::prompt_builder::render_prompt(template, &issue, None, None).unwrap();
+    assert!(
+        defaulted.contains("Base branch: main"),
+        "missing workspace base branch should default to main, got: {}",
+        defaulted
+    );
+}
+
+#[test]
 fn test_render_prompt_datetime_fields() {
     let issue = make_full_issue();
     let template = "Created: {{ issue.created_at }}\nUpdated: {{ issue.updated_at }}";
 
-    let result = symphony::prompt_builder::render_prompt(template, &issue, None).unwrap();
+    let result =
+        symphony::prompt_builder::render_prompt(template, &issue, None, Some("main")).unwrap();
     // Should contain ISO 8601 format
     assert!(
         result.contains("2025-01-15"),
@@ -1040,7 +1075,8 @@ fn test_render_prompt_none_fields() {
     };
     let template = "Desc: [{{ issue.description }}] Branch: [{{ issue.branch_name }}]";
 
-    let result = symphony::prompt_builder::render_prompt(template, &issue, None).unwrap();
+    let result =
+        symphony::prompt_builder::render_prompt(template, &issue, None, Some("main")).unwrap();
     // None fields should render as empty
     assert!(
         result.contains("Desc: []"),
@@ -1059,7 +1095,8 @@ fn test_render_prompt_blockers_iterable() {
     let issue = make_full_issue();
     let template = "Blockers:{% for b in issue.blocked_by %} {{ b.identifier }}{% endfor %}";
 
-    let result = symphony::prompt_builder::render_prompt(template, &issue, None).unwrap();
+    let result =
+        symphony::prompt_builder::render_prompt(template, &issue, None, Some("main")).unwrap();
     assert!(
         result.contains("MT-10"),
         "Should iterate blockers, got: {}",
@@ -1077,7 +1114,7 @@ fn test_render_prompt_strict_unknown_variable() {
     let issue = make_full_issue();
     let template = "{{ missing.field }}";
 
-    let result = symphony::prompt_builder::render_prompt(template, &issue, None);
+    let result = symphony::prompt_builder::render_prompt(template, &issue, None, Some("main"));
     match result {
         Err(SymphonyError::TemplateRenderError(_)) => { /* expected */ }
         other => panic!("Expected TemplateRenderError, got: {:?}", other),
@@ -1089,7 +1126,7 @@ fn test_render_prompt_parse_error() {
     let issue = make_full_issue();
     let template = "{% if issue.id %}"; // Unclosed if block
 
-    let result = symphony::prompt_builder::render_prompt(template, &issue, None);
+    let result = symphony::prompt_builder::render_prompt(template, &issue, None, Some("main"));
     match result {
         Err(SymphonyError::TemplateParseError(_)) => { /* expected */ }
         other => panic!("Expected TemplateParseError, got: {:?}", other),
@@ -1102,7 +1139,8 @@ fn test_render_prompt_attempt_none_vs_some() {
     let template = "Attempt: [{{ attempt }}]";
 
     // None → empty
-    let result_none = symphony::prompt_builder::render_prompt(template, &issue, None).unwrap();
+    let result_none =
+        symphony::prompt_builder::render_prompt(template, &issue, None, Some("main")).unwrap();
     assert!(
         result_none.contains("Attempt: []"),
         "attempt=None should render as empty, got: {}",
@@ -1110,7 +1148,8 @@ fn test_render_prompt_attempt_none_vs_some() {
     );
 
     // Some(3) → "3"
-    let result_some = symphony::prompt_builder::render_prompt(template, &issue, Some(3)).unwrap();
+    let result_some =
+        symphony::prompt_builder::render_prompt(template, &issue, Some(3), Some("main")).unwrap();
     assert!(
         result_some.contains("Attempt: [3]"),
         "attempt=Some(3) should render as '3', got: {}",


### PR DESCRIPTION
## Summary
- add `workspace.base_branch` to Symphony workflow config domain/defaults and YAML parsing
- expose base branch to Liquid prompt templates as `workspace.base_branch` (defaulting to `main`)
- replace hardcoded `origin/main` workflow references with `origin/{{ workspace.base_branch }}` and update reference docs
- add tests covering parse/trim/default behavior and prompt rendering with workspace base branch

## Validation
- cd apps/symphony && cargo test
- cd apps/symphony && cargo clippy -- -D warnings
- cd apps/symphony && cargo fmt --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `workspace.base_branch` configuration field to the Symphony workflow engine, replacing all hardcoded `origin/main` references in prompt templates with a configurable `{{ workspace.base_branch }}` Liquid variable (defaulting to `"main"`). The change touches the domain struct, YAML parser, prompt renderer, orchestrator call-sites, documentation, and tests — all consistently and correctly.

Key changes:
- `WorkspaceConfig` gains `base_branch: Option<String>` (default `Some("main")`)
- `config.rs` parsing applies env-var resolution, trimming, blank-to-default normalization, and config-default fallback, matching the pattern used by `clone_branch`
- `render_prompt` receives a new `workspace_base_branch: Option<&str>` argument and exposes `workspace.base_branch` to Liquid templates; a `None`/empty fallback to `"main"` is applied as an extra safety net
- Both orchestrator call-sites are updated; no call-site was missed
- Six `origin/main` references in `WORKFLOW.md` and `WORKFLOW-REFERENCE.md` are replaced with the template variable
- Tests cover trim/blank/default behavior and prompt rendering for both configured and absent values

One design note: `base_branch` is typed as `Option<String>` but is never actually `None` after construction (the default and the parser both guarantee `Some(...)`). A plain `String` (like `branch_prefix`) would be a cleaner type that better reflects the invariant.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all call-sites updated, behavior is backward-compatible (defaults to "main"), and the change is well-tested.
- The implementation is consistent and complete: all `render_prompt` call-sites are updated, the config parser mirrors existing patterns, the default ensures no behavioral regression for existing configs, and the new tests cover trim/blank/default/render paths. The only nit is a typing concern (`Option<String>` vs `String`) that is not a bug.
- apps/symphony/src/domain.rs — minor design concern: `base_branch` typed as `Option<String>` but is never `None` in practice

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/domain.rs | Adds `base_branch: Option<String>` to `WorkspaceConfig` with a default of `Some("main")`. The `Option` wrapper is slightly misleading since the default guarantees a value is always present after construction. |
| apps/symphony/src/config.rs | Adds `base_branch` YAML parsing with env-var resolution, trim/blank normalization, and fallback to `WorkspaceConfig::default()`. Pattern mirrors `clone_branch` exactly and is consistent. |
| apps/symphony/src/prompt_builder.rs | Signature extended with `workspace_base_branch: Option<&str>`; a `workspace` Liquid object is populated with `base_branch` (defaulting to "main" if `None`/empty). The `None`-to-"main" fallback here is redundant given config guarantees but is a safe guard. |
| apps/symphony/src/orchestrator.rs | Both `render_prompt` call sites updated to pass `config.workspace.base_branch.as_deref()`; no call sites were missed. |
| apps/symphony/tests/workflow_config_tests.rs | New tests cover parse/trim/blank-default behavior for `base_branch`; all existing tests updated with the new struct field. |
| apps/symphony/tests/workspace_prompt_tests.rs | New `test_render_prompt_workspace_base_branch` test covers both configured and defaulted (None) paths; all existing tests updated to pass the new argument. |
| apps/symphony/WORKFLOW.md | All six `origin/main` hardcoded references replaced with `origin/{{ workspace.base_branch }}`; `base_branch: main` added to sample YAML config block. |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Mirrors WORKFLOW.md changes — `origin/main` replaced with template variable and `base_branch` documented in the YAML reference block. |
| apps/symphony/AGENTS.md | Configuration reference table updated with `workspace.base_branch` entry and two sample YAML blocks updated to include the new field. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant YAML as workflow.yml
    participant Config as config.rs (from_workflow)
    participant Domain as WorkspaceConfig
    participant Orchestrator as orchestrator.rs
    participant PB as prompt_builder.rs
    participant Template as Liquid Template

    YAML->>Config: base_branch: "develop" (or absent)
    Config->>Config: resolve_env() → trim() → blank check
    Config->>Domain: WorkspaceConfig { base_branch: Some("develop") }
    Note over Config,Domain: Falls back to default Some("main")<br/>if blank or absent
    Orchestrator->>Domain: config.workspace.base_branch.as_deref()
    Orchestrator->>PB: render_prompt(template, issue, attempt, Some("develop"))
    PB->>PB: build workspace_obj { base_branch: "develop" }
    PB->>Template: globals { issue, attempt, workspace }
    Template-->>PB: rendered string with {{ workspace.base_branch }} = "develop"
    PB-->>Orchestrator: Ok(prompt)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/domain.rs
Line: 188

Comment:
**`Option<String>` is misleading — field is never `None` after construction**

`base_branch` is typed as `Option<String>`, but both `WorkspaceConfig::default()` (line 217) and the `from_workflow` parser (which falls back to the default via `.or_else(|| defaults.workspace.base_branch.clone())`) guarantee it is always `Some(...)`. Unlike `clone_branch`, which is genuinely optional with no default, `base_branch` always carries a value.

Using `Option<String>` forces callers to use `.as_deref()` everywhere and creates a misleading contract — future readers may write code that defensively handles a `None` case that can never actually occur. Consider using a plain `String` instead, mirroring `branch_prefix`:

```rust
pub base_branch: String,
```

The corresponding `Default` implementation, `config.rs` parser, orchestrator call-sites, and tests would all simplify (no `.as_deref()`, no `.unwrap_or("main")` guard in `prompt_builder`).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(symphony): add ..."](https://github.com/gannonh/kata/commit/62dd4155bf308f8f952d4c2ce7fe55df0a162ab8)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced workspace `base_branch` configuration option to specify the default branch for operations, defaulting to "main" when unspecified.
  * Base branch is now accessible in workflow templates for dynamic branch references.

* **Tests**
  * Added test coverage for base branch configuration parsing and template variable rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->