### PR TITLE
Improve startup DX with banner output and logs-root stdout suppression

### DIFF
--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 use std::future::{pending, Future};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, Once};
 
@@ -270,13 +271,29 @@ fn display_path_with_home_alias(path: &Path) -> String {
     }
 }
 
+fn format_dashboard_url(host: &str, port: u16) -> String {
+    let host = match host.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V6(_)) if !host.starts_with('[') => format!("[{host}]"),
+        _ if host.contains(':') && !host.starts_with('[') && !host.ends_with(']') => {
+            format!("[{host}]")
+        }
+        _ => host.to_string(),
+    };
+
+    if port == 0 {
+        format!("http://{host}:<ephemeral>")
+    } else {
+        format!("http://{host}:{port}")
+    }
+}
+
 pub(crate) fn build_startup_banner(
     cli: &Cli,
     config: &ServiceConfig,
     http_binding: Option<&HttpBinding>,
 ) -> String {
     let dashboard = http_binding
-        .map(|binding| format!("http://{}:{}", binding.host, binding.port))
+        .map(|binding| format_dashboard_url(&binding.host, binding.port))
         .unwrap_or_else(|| "disabled".to_string());
 
     let logs = cli
@@ -302,6 +319,9 @@ pub(crate) fn build_startup_banner(
 
 fn print_startup_banner(cli: &Cli, config: &ServiceConfig, http_binding: Option<&HttpBinding>) {
     print!("{}", build_startup_banner(cli, config, http_binding));
+    if let Err(err) = std::io::stdout().flush() {
+        eprintln!("failed to flush startup banner to stdout: {err}");
+    }
 }
 
 pub fn execute_cli(cli: &Cli, deps: &mut dyn BootstrapDeps) -> Result<(), String> {

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -13,7 +13,6 @@ use symphony::orchestrator::{Orchestrator, OrchestratorPort};
 use symphony::workflow_store::WorkflowStore;
 use symphony::{config, error};
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::fmt::writer::MakeWriterExt;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Debug, Clone)]
@@ -180,6 +179,7 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
     fn start_orchestrator(&mut self, workflow_path: &Path, cli: &Cli) -> Result<(), String> {
         let context = self.take_or_load_validated_context(workflow_path)?;
         let http_binding = effective_http_binding(&context.effective_config, cli);
+        print_startup_banner(cli, &context.effective_config, http_binding.as_ref());
 
         let workflow_store = Arc::new(context.workflow_store);
         let mut tracker_port = LinearOrchestratorPort::new(Arc::clone(&workflow_store));
@@ -247,6 +247,61 @@ pub(crate) fn effective_http_binding(config: &ServiceConfig, cli: &Cli) -> Optio
         host: config.server.host.clone(),
         port,
     })
+}
+
+fn format_polling_interval(interval_ms: u64) -> String {
+    if interval_ms.is_multiple_of(1_000) {
+        format!("every {}s", interval_ms / 1_000)
+    } else {
+        format!("every {interval_ms}ms")
+    }
+}
+
+fn display_path_with_home_alias(path: &Path) -> String {
+    let home = match std::env::var("HOME") {
+        Ok(home) => PathBuf::from(home),
+        Err(_) => return path.display().to_string(),
+    };
+
+    match path.strip_prefix(&home) {
+        Ok(stripped) if stripped.as_os_str().is_empty() => "~".to_string(),
+        Ok(stripped) => format!("~/{}", stripped.display()),
+        Err(_) => path.display().to_string(),
+    }
+}
+
+pub(crate) fn build_startup_banner(
+    cli: &Cli,
+    config: &ServiceConfig,
+    http_binding: Option<&HttpBinding>,
+) -> String {
+    let dashboard = http_binding
+        .map(|binding| format!("http://{}:{}", binding.host, binding.port))
+        .unwrap_or_else(|| "disabled".to_string());
+
+    let logs = cli
+        .logs_root
+        .as_deref()
+        .map(|logs_root| Path::new(logs_root).join("log").join("symphony.log"))
+        .map(|path| display_path_with_home_alias(&path))
+        .unwrap_or_else(|| "stdout".to_string());
+
+    let project_slug = config
+        .tracker
+        .project_slug
+        .as_deref()
+        .unwrap_or("unknown_project_slug");
+
+    format!(
+        "Symphony v{version}\nDashboard: {dashboard}\nLogs: {logs}\nProject: Symphony ({project_slug})\nWorkers: {workers} max concurrent\nPolling: {polling}\n\nPress Ctrl+C to stop.\n",
+        version = env!("CARGO_PKG_VERSION"),
+        workers = config.agent.max_concurrent_agents,
+        polling = format_polling_interval(config.polling.interval_ms),
+    )
+}
+
+fn print_startup_banner(cli: &Cli, config: &ServiceConfig, http_binding: Option<&HttpBinding>) {
+    print!("{}", build_startup_banner(cli, config, http_binding));
 }
 
 pub fn execute_cli(cli: &Cli, deps: &mut dyn BootstrapDeps) -> Result<(), String> {
@@ -404,9 +459,7 @@ fn init_tracing(logs_root: Option<&Path>) {
                 Ok((file_writer, guard)) => match FILE_LOG_GUARD.lock() {
                     Ok(mut guard_slot) => {
                         *guard_slot = Some(guard);
-                        subscriber_builder
-                            .with_writer(std::io::stdout.and(file_writer))
-                            .try_init()
+                        subscriber_builder.with_writer(file_writer).try_init()
                     }
                     Err(err) => {
                         eprintln!(

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -293,8 +293,9 @@ fn test_startup_banner_includes_expected_runtime_summary_fields() {
         "banner should include dashboard URL, got: {banner}"
     );
     assert!(
-        banner.contains("Logs: /tmp/symphony/log/symphony.log"),
-        "banner should include resolved log file path, got: {banner}"
+        banner.contains("Logs: /tmp/symphony/log/symphony.log")
+            || banner.contains("Logs: ~/symphony/log/symphony.log"),
+        "banner should include resolved log file path (raw or home-aliased), got: {banner}"
     );
     assert!(
         banner.contains("Project: Symphony (89d4761fddf0)"),
@@ -311,6 +312,46 @@ fn test_startup_banner_includes_expected_runtime_summary_fields() {
     assert!(
         banner.contains("Press Ctrl+C to stop."),
         "banner should include shutdown hint, got: {banner}"
+    );
+}
+
+#[test]
+fn test_startup_banner_brackets_ipv6_dashboard_host() {
+    let mut config = ServiceConfig::default();
+    config.tracker.project_slug = Some("89d4761fddf0".to_string());
+
+    let cli =
+        main_bin::parse_cli_from(["symphony", "WORKFLOW.md"]).expect("CLI parse should succeed");
+
+    let binding = main_bin::HttpBinding {
+        host: "::1".to_string(),
+        port: 8080,
+    };
+
+    let banner = main_bin::build_startup_banner(&cli, &config, Some(&binding));
+    assert!(
+        banner.contains("Dashboard: http://[::1]:8080"),
+        "banner should bracket IPv6 host in URL, got: {banner}"
+    );
+}
+
+#[test]
+fn test_startup_banner_marks_ephemeral_dashboard_port() {
+    let mut config = ServiceConfig::default();
+    config.tracker.project_slug = Some("89d4761fddf0".to_string());
+
+    let cli =
+        main_bin::parse_cli_from(["symphony", "WORKFLOW.md"]).expect("CLI parse should succeed");
+
+    let binding = main_bin::HttpBinding {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+    };
+
+    let banner = main_bin::build_startup_banner(&cli, &config, Some(&binding));
+    assert!(
+        banner.contains("Dashboard: http://127.0.0.1:<ephemeral>"),
+        "banner should mark ephemeral dashboard ports, got: {banner}"
     );
 }
 
@@ -335,6 +376,10 @@ fn test_logs_root_writes_startup_logs_to_file_and_suppresses_stdout_logs() {
     assert!(
         !stdout.contains("starting CLI bootstrap"),
         "stdout should suppress startup log stream when --logs-root is set; got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\"phase\":\"startup\""),
+        "stdout should not include startup JSON fields when --logs-root is set; got: {stdout}"
     );
 
     let log_file_path = logs_root.path().join("log").join("symphony.log");

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -268,7 +268,54 @@ fn test_effective_http_binding_defaults_to_8080() {
 }
 
 #[test]
-fn test_logs_root_writes_startup_logs_to_file_and_stdout() {
+fn test_startup_banner_includes_expected_runtime_summary_fields() {
+    let mut config = ServiceConfig::default();
+    config.tracker.project_slug = Some("89d4761fddf0".to_string());
+    config.agent.max_concurrent_agents = 3;
+    config.polling.interval_ms = 30_000;
+
+    let cli = main_bin::parse_cli_from(["symphony", "WORKFLOW.md", "--logs-root", "/tmp/symphony"])
+        .expect("CLI parse should succeed");
+
+    let binding = main_bin::HttpBinding {
+        host: "127.0.0.1".to_string(),
+        port: 8080,
+    };
+
+    let banner = main_bin::build_startup_banner(&cli, &config, Some(&binding));
+
+    assert!(
+        banner.contains("Symphony v"),
+        "banner should include version line, got: {banner}"
+    );
+    assert!(
+        banner.contains("Dashboard: http://127.0.0.1:8080"),
+        "banner should include dashboard URL, got: {banner}"
+    );
+    assert!(
+        banner.contains("Logs: /tmp/symphony/log/symphony.log"),
+        "banner should include resolved log file path, got: {banner}"
+    );
+    assert!(
+        banner.contains("Project: Symphony (89d4761fddf0)"),
+        "banner should include project info, got: {banner}"
+    );
+    assert!(
+        banner.contains("Workers: 3 max concurrent"),
+        "banner should include worker count, got: {banner}"
+    );
+    assert!(
+        banner.contains("Polling: every 30s"),
+        "banner should include polling cadence, got: {banner}"
+    );
+    assert!(
+        banner.contains("Press Ctrl+C to stop."),
+        "banner should include shutdown hint, got: {banner}"
+    );
+}
+
+#[test]
+fn test_logs_root_writes_startup_logs_to_file_and_suppresses_stdout_logs() {
     let logs_root = tempfile::tempdir().expect("temp dir should be created");
     let missing_workflow = logs_root.path().join("missing-workflow.md");
 
@@ -286,8 +333,8 @@ fn test_logs_root_writes_startup_logs_to_file_and_stdout() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("starting CLI bootstrap"),
-        "stdout should include startup logs when --logs-root is set; got: {stdout}"
+        !stdout.contains("starting CLI bootstrap"),
+        "stdout should suppress startup log stream when --logs-root is set; got: {stdout}"
     );
 
     let log_file_path = logs_root.path().join("log").join("symphony.log");


### PR DESCRIPTION
## Summary
- add a startup summary banner that prints version, dashboard URL, log destination, project slug, worker limit, and polling cadence
- change tracing initialization so `--logs-root` writes logs to file without streaming JSON logs to stdout
- keep existing stdout log streaming behavior when `--logs-root` is not configured
- add/adjust CLI tests for startup banner content and stdout suppression behavior

## Validation
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `cd apps/symphony && cargo run --quiet -- WORKFLOW.md --port 0`
- `cd apps/symphony && cargo run --quiet -- WORKFLOW.md --port 0 --logs-root /tmp/kat861-postchange/logs`

## Manual QA Plan
1. Run `symphony WORKFLOW.md --port 8080` and confirm startup shows the summary banner and JSON logs continue streaming to stdout.
2. Run `symphony WORKFLOW.md --port 8080 --logs-root <dir>` and confirm startup shows only the summary banner on stdout while logs are written to `<dir>/log/symphony.log`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup banner now displays runtime summary: version, dashboard URL (IPv6/bracketed and ephemeral-port aware), logs location (with home-directory shortening), project name, active workers, and polling interval.

* **Improvements**
  * File-based logging initialization refined to improve output behavior and ensure startup banner is flushed.

* **Tests**
  * Tests updated to validate banner contents and stdout/log-file semantics (including suppressed startup stream when logs are routed to files).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the startup developer experience for the Symphony orchestrator by printing a human-readable summary banner at launch and suppressing noisy JSON log streaming to stdout when `--logs-root` is configured.

Key changes:
- **Startup banner**: `build_startup_banner` constructs a one-shot human-readable summary (version, dashboard URL, log path, project slug, worker count, polling cadence) printed via `print_startup_banner` at the beginning of `start_orchestrator`. A path-alias helper (`display_path_with_home_alias`) shortens the log-file path using `~` when possible.
- **Log routing change**: The `init_tracing` function no longer uses `.and(file_writer)` to mirror logs to both stdout and a file simultaneously. When `--logs-root` is set, structured JSON logs go exclusively to the file; without it, they continue streaming to stdout.
- **Tests**: A new unit test verifies all expected banner fields; the renamed integration test flips its assertion to confirm stdout log suppression.

Two issues were found:
- `print_startup_banner` uses `print!` without an explicit `std::io::stdout().flush()`. If the orchestrator fails after the banner is printed and the process exits via `std::process::exit(1)`, the buffered banner bytes can be silently discarded, especially when stdout is a pipe (CI, scripts).
- The new `test_startup_banner_includes_expected_runtime_summary_fields` test hard-codes the literal path `Logs: /tmp/symphony/log/symphony.log`, but `display_path_with_home_alias` will substitute `~` for any prefix that matches `$HOME`. In environments where `$HOME=/tmp`, this assertion fails as a false-negative.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the environment-sensitive test assertion and the missing stdout flush.
- The core logic changes (banner printing and log routing) are correct and well-motivated. However, the missing `stdout().flush()` means the banner can be silently dropped on failure exit paths in piped/CI contexts, and the `$HOME`-sensitive test assertion introduces a potential CI reliability issue that warrants a fix before merging.
- `apps/symphony/tests/cli_tests.rs` (environment-sensitive assertion) and `apps/symphony/src/main.rs` (missing stdout flush in `print_startup_banner`).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/main.rs | Adds a startup banner (version, dashboard URL, log destination, project slug, worker limit, polling cadence) printed via `print_startup_banner` before the orchestrator loop. Changes `init_tracing` so that supplying `--logs-root` directs structured JSON logs exclusively to the file rather than duplicating them to stdout. Minor concern: the banner is written with `print!` but never explicitly flushed, which can silently drop output when the process exits via `std::process::exit` on failure paths. |
| apps/symphony/tests/cli_tests.rs | Adds a unit test for `build_startup_banner` field coverage and updates the integration test to assert that JSON logs are suppressed from stdout when `--logs-root` is set. The new banner test has an environment-dependent assertion (`Logs: /tmp/symphony/log/symphony.log`) that can silently break in CI environments where `$HOME=/tmp`, because `display_path_with_home_alias` would replace the prefix with `~`. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant M as main()
    participant T as init_tracing()
    participant E as execute_cli()
    participant S as start_orchestrator()
    participant B as print_startup_banner()
    participant F as File Logger
    participant O as stdout

    alt --logs-root provided
        U->>M: symphony WORKFLOW.md --logs-root /path
        M->>T: init_tracing(Some(logs_root))
        T->>F: build_non_blocking_file_writer()
        T-->>T: subscriber writes to file only
        M->>E: execute_cli()
        E->>S: start_orchestrator()
        S->>B: print_startup_banner()
        B->>O: print!(banner) [JSON logs suppressed]
        S->>F: tracing::info!("constructed orchestrator runtime")
        S-->>M: run until shutdown
    else no --logs-root
        U->>M: symphony WORKFLOW.md
        M->>T: init_tracing(None)
        T-->>T: subscriber writes to stdout
        M->>E: execute_cli()
        E->>S: start_orchestrator()
        S->>B: print_startup_banner()
        B->>O: print!(banner)
        S->>O: tracing::info!("constructed orchestrator runtime") as JSON
        S-->>M: run until shutdown
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/main.rs
Line: 303-305

Comment:
**Missing stdout flush after `print!`**

`print!` writes through Rust's `BufWriter`-backed `Stdout`, which is NOT automatically flushed when the process exits via `std::process::exit`. In `main`, if `run_entrypoint` returns a non-zero code, `std::process::exit(code)` is called — bypassing all Rust destructors and buffer flushes. In that scenario (e.g. the orchestrator fails to bind its port), the banner bytes may still be sitting in the in-process buffer and will be silently dropped before they reach the terminal.

Adding an explicit flush ensures the banner is always visible, even in piped / CI contexts:

```suggestion
fn print_startup_banner(cli: &Cli, config: &ServiceConfig, http_binding: Option<&HttpBinding>) {
    print!("{}", build_startup_banner(cli, config, http_binding));
    let _ = std::io::Write::flush(&mut std::io::stdout());
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/tests/cli_tests.rs
Line: 295-299

Comment:
**Assertion is `$HOME`-sensitive and can fail in CI**

`display_path_with_home_alias` reads `$HOME` at runtime and strips it from the path, replacing the prefix with `~`. The test hard-codes `--logs-root /tmp/symphony` and then asserts the literal string `Logs: /tmp/symphony/log/symphony.log`. In any environment where `$HOME=/tmp` (common in some Docker base images and root-run containers), the helper will produce `~/symphony/log/symphony.log` instead, causing this assertion to fail as a false-negative.

A reliable fix is to control the `HOME` env variable for this specific assertion, or use a path that will never overlap with a realistic `HOME`:

```rust
// Option 1 – use a path deep enough to be safe, and assert the aliased form
let cli = main_bin::parse_cli_from([
    "symphony", "WORKFLOW.md",
    "--logs-root", "/nonexistent/logs-root-sentinel",
]).expect("CLI parse should succeed");
// ...
assert!(
    banner.contains("Logs: /nonexistent/logs-root-sentinel/log/symphony.log"),
    "banner should include resolved log file path, got: {banner}"
);
```

Alternatively, shadow `$HOME` for the duration of the test:

```rust
// Option 2 – temporarily unset HOME so display_path_with_home_alias returns the raw path
std::env::remove_var("HOME");
let banner = main_bin::build_startup_banner(&cli, &config, Some(&binding));
// restore HOME if needed
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(symphony): prin..."](https://github.com/gannonh/kata/commit/b67c9f3e9933033248eb62a8e1c8f8059d28377f)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->