### PR TITLE
fix: port debug skill guidance away from Elixir references

### DIFF
--- a/.codex/skills/debug/SKILL.md
+++ b/.codex/skills/debug/SKILL.md
@@ -16,11 +16,14 @@ description:
 
 ## Log Sources
 
-- Primary runtime log: `log/symphony.log`
-  - Default comes from `SymphonyElixir.LogFile` (`log/symphony.log`).
+- Primary runtime log file: `<logs-root>/log/symphony.log`
+  - When Symphony runs with `--logs-root`, it writes rotating JSON logs under
+    this path (see `apps/symphony/README.md`).
   - Includes orchestrator, agent runner, and Codex app-server lifecycle logs.
-- Rotated runtime logs: `log/symphony.log*`
-  - Check these when the relevant run is older.
+- Rotated runtime logs: `<logs-root>/log/symphony.log*`
+  - Check these when the relevant run is older than the active file.
+- Stdout fallback: structured JSON log stream
+  - Without `--logs-root`, logs stream to stdout instead of a file.
 
 ## Correlation Keys
 
@@ -28,8 +31,9 @@ description:
 - `issue_id`: Linear UUID (stable internal ID)
 - `session_id`: Codex thread-turn pair (`<thread_id>-<turn_id>`)
 
-`elixir/docs/logging.md` requires these fields for issue/session lifecycle logs. Use
-them as your join keys during debugging.
+These fields are emitted by Symphony runtime lifecycle logs (notably in
+`apps/symphony/src/orchestrator.rs` and `apps/symphony/src/codex/app_server.rs`).
+Use them as your join keys during debugging.
 
 ## Quick Triage (Stuck Run)
 
@@ -44,20 +48,23 @@ them as your join keys during debugging.
 ## Commands
 
 ```bash
+# Set this to your runtime log location from the Symphony startup banner.
+LOG_GLOB="${LOG_GLOB:-log/symphony.log*}"
+
 # 1) Narrow by ticket key (fastest entry point)
-rg -n "issue_identifier=MT-625" log/symphony.log*
+rg -n "issue_identifier=MT-625" "$LOG_GLOB"
 
 # 2) If needed, narrow by Linear UUID
-rg -n "issue_id=<linear-uuid>" log/symphony.log*
+rg -n "issue_id=<linear-uuid>" "$LOG_GLOB"
 
 # 3) Pull session IDs seen for that ticket
-rg -o "session_id=[^ ;]+" log/symphony.log* | sort -u
+rg -o "session_id=[^ ;]+" "$LOG_GLOB" | sort -u
 
 # 4) Trace one session end-to-end
-rg -n "session_id=<thread>-<turn>" log/symphony.log*
+rg -n "session_id=<thread>-<turn>" "$LOG_GLOB"
 
 # 5) Focus on stuck/retry signals
-rg -n "Issue stalled|scheduling retry|turn_timeout|turn_failed|Codex session failed|Codex session ended with error" log/symphony.log*
+rg -n "Issue stalled|scheduling retry|turn_timeout|turn_failed|Codex session failed|Codex session ended with error" "$LOG_GLOB"
 ```
 
 ## Investigation Flow
@@ -99,7 +106,7 @@ For one specific session investigation, keep the trace narrow:
 
 1. Capture one `session_id` for the ticket.
 2. Build a timestamped slice for only that session:
-    - `rg -n "session_id=<thread>-<turn>" log/symphony.log*`
+    - `rg -n "session_id=<thread>-<turn>" "$LOG_GLOB"`
 3. Mark the exact failing stage:
     - Startup failure before stream events (`Codex session failed ...`).
     - Turn/runtime failure after stream events (`turn_*` / `ended with error`).
@@ -113,6 +120,9 @@ concurrent runs.
 ## Notes
 
 - Prefer `rg` over `grep` for speed on large logs.
-- Check rotated logs (`log/symphony.log*`) before concluding data is missing.
+- Check rotated logs (`<logs-root>/log/symphony.log*`) before concluding data is
+  missing.
 - If required context fields are missing in new log statements, align with
-  `elixir/docs/logging.md` conventions.
+  existing structured lifecycle logging in
+  `apps/symphony/src/orchestrator.rs` and
+  `apps/symphony/src/codex/app_server.rs`.

--- a/.codex/skills/debug/SKILL.md
+++ b/.codex/skills/debug/SKILL.md
@@ -48,23 +48,31 @@ Use them as your join keys during debugging.
 ## Commands
 
 ```bash
-# Set this to your runtime log location from the Symphony startup banner.
-LOG_GLOB="${LOG_GLOB:-log/symphony.log*}"
+# File-log mode (`--logs-root` enabled): expand to active + rotated files.
+LOG_PATHS=( ${LOG_GLOB:-log/symphony.log*} )
 
 # 1) Narrow by ticket key (fastest entry point)
-rg -n "issue_identifier=MT-625" "$LOG_GLOB"
+rg -n "issue_identifier=MT-625" "${LOG_PATHS[@]}"
 
 # 2) If needed, narrow by Linear UUID
-rg -n "issue_id=<linear-uuid>" "$LOG_GLOB"
+rg -n "issue_id=<linear-uuid>" "${LOG_PATHS[@]}"
 
 # 3) Pull session IDs seen for that ticket
-rg -o "session_id=[^ ;]+" "$LOG_GLOB" | sort -u
+rg -o "session_id=[^ ;]+" "${LOG_PATHS[@]}" | sort -u
 
 # 4) Trace one session end-to-end
-rg -n "session_id=<thread>-<turn>" "$LOG_GLOB"
+rg -n "session_id=<thread>-<turn>" "${LOG_PATHS[@]}"
 
 # 5) Focus on stuck/retry signals
-rg -n "Issue stalled|scheduling retry|turn_timeout|turn_failed|Codex session failed|Codex session ended with error" "$LOG_GLOB"
+rg -n "Issue stalled|scheduling retry|turn_timeout|turn_failed|Codex session failed|Codex session ended with error" "${LOG_PATHS[@]}"
+
+# Stdout mode (startup banner shows `Logs: stdout`): use your runtime stream.
+journalctl -u symphony --since "30 minutes ago" --no-pager \
+  | rg -n "issue_identifier=MT-625|issue_id=<linear-uuid>|session_id=<thread>-<turn>|Issue stalled|scheduling retry|turn_timeout|turn_failed|Codex session failed|Codex session ended with error"
+
+# Containerized deploys can use docker logs instead of journalctl.
+docker logs <symphony-container> --since 30m 2>&1 \
+  | rg -n "issue_identifier=MT-625|issue_id=<linear-uuid>|session_id=<thread>-<turn>|Issue stalled|scheduling retry|turn_timeout|turn_failed|Codex session failed|Codex session ended with error"
 ```
 
 ## Investigation Flow


### PR DESCRIPTION
## Summary
- update `.codex/skills/debug/SKILL.md` to remove Elixir-specific references
- align log-source guidance with current Symphony runtime behavior (`--logs-root` and stdout fallback)
- point lifecycle correlation guidance to current Rust source paths and make command examples configurable via `LOG_GLOB`

## Validation
- `cd apps/symphony && cargo test && cargo clippy -- -D warnings`
- `test -f .codex/skills/debug/SKILL.md`
- `rg -n -i "\b(mix|mise)\b|SymphonyElixir|elixir/docs|\bElixir\b" .codex/skills/debug/SKILL.md`
- `rg -n "^name: debug$" .codex/skills/debug/SKILL.md`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `.codex/skills/debug/SKILL.md` to remove outdated Elixir-specific references (e.g., `SymphonyElixir.LogFile`, `elixir/docs/logging.md`) and replaces them with accurate guidance pointing at the current Rust Symphony runtime — using the `--logs-root` flag pattern, a configurable `LOG_GLOB` variable, and source-file pointers to `apps/symphony/src/orchestrator.rs` and `apps/symphony/src/codex/app_server.rs`.

**Key changes:**
- Log path references updated from hardcoded `log/symphony.log*` to the `<logs-root>/log/symphony.log*` placeholder throughout most of the document.
- A `LOG_GLOB` shell variable introduced in the `Commands` block to make log location configurable.
- Stdout fallback behavior documented for when `--logs-root` is not supplied.
- Correlation key guidance redirected from the deleted `elixir/docs/logging.md` to the Rust source files.

**Issue found:**
- Line 95 in "Reading Codex Session Logs" still uses the old hardcoded `log/symphony.log` path rather than the updated `<logs-root>/log/symphony.log` placeholder, leaving one stale inconsistency in the document.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — documentation-only change with one minor stale reference on line 95.
- The change is purely documentation and carries no runtime risk. The overall migration away from Elixir references is thorough and accurate, with only a single missed update to `log/symphony.log` on line 95 that was not converted to the new `<logs-root>/log/symphony.log` placeholder.
- `.codex/skills/debug/SKILL.md` line 95 — stale hardcoded log path

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .codex/skills/debug/SKILL.md | Removes Elixir-specific references and aligns log-source guidance with current Rust Symphony runtime, but leaves one stale hardcoded `log/symphony.log` reference in the "Reading Codex Session Logs" section (line 95) that was not updated to the new `<logs-root>/log/symphony.log` placeholder. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Symphony starts] --> B{--logs-root provided?}
    B -- Yes --> C["Write rotating JSON logs\n<logs-root>/log/symphony.log*"]
    B -- No --> D["Stream structured JSON\nto stdout"]
    C --> E["Debug skill: set LOG_GLOB\nfrom startup banner"]
    D --> E
    E --> F["rg commands use $LOG_GLOB\nto search log lines"]
    F --> G["Correlate via issue_identifier\nissue_id, session_id"]
    G --> H["Source: orchestrator.rs\n& codex/app_server.rs"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.codex/skills/debug/SKILL.md`, line 95-96 ([link](https://github.com/gannonh/kata/blob/f87224ee2d5f7f53a2f10959a42b42bba615bb3f/.codex/skills/debug/SKILL.md#L95-L96)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale hardcoded log path not updated**

   The "Reading Codex Session Logs" section still references the old hardcoded `log/symphony.log` path rather than the updated `<logs-root>/log/symphony.log` placeholder used everywhere else in the file after this PR. This is inconsistent with the rest of the document.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .codex/skills/debug/SKILL.md
   Line: 95-96

   Comment:
   **Stale hardcoded log path not updated**

   The "Reading Codex Session Logs" section still references the old hardcoded `log/symphony.log` path rather than the updated `<logs-root>/log/symphony.log` placeholder used everywhere else in the file after this PR. This is inconsistent with the rest of the document.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .codex/skills/debug/SKILL.md
Line: 95-96

Comment:
**Stale hardcoded log path not updated**

The "Reading Codex Session Logs" section still references the old hardcoded `log/symphony.log` path rather than the updated `<logs-root>/log/symphony.log` placeholder used everywhere else in the file after this PR. This is inconsistent with the rest of the document.

```suggestion
In Symphony, Codex session diagnostics are emitted into `<logs-root>/log/symphony.log` and
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix(skills): adapt d..."](https://github.com/gannonh/kata/commit/f87224ee2d5f7f53a2f10959a42b42bba615bb3f)</sub>

<!-- /greptile_comment -->