### PR TITLE
KAT-833: add slice-aware workflow and Linear hierarchy queries

### DIFF
--- a/.codex/skills/linear/SKILL.md
+++ b/.codex/skills/linear/SKILL.md
@@ -199,6 +199,7 @@ query SliceChildren($id: String!) {
         title
         state {
           name
+          type
         }
       }
     }
@@ -246,6 +247,22 @@ query IssueMilestone($id: String!) {
     projectMilestone {
       id
       name
+    }
+  }
+}
+```
+
+Get milestone documents:
+
+```graphql
+query MilestoneDocuments($id: String!) {
+  projectMilestone(id: $id) {
+    documents {
+      nodes {
+        id
+        title
+        content
+      }
     }
   }
 }

--- a/.codex/skills/linear/SKILL.md
+++ b/.codex/skills/linear/SKILL.md
@@ -182,6 +182,75 @@ query IssueDetails($id: String!) {
 }
 ```
 
+### Query slice hierarchy and planning documents
+
+Use these when an issue represents a parent slice with child tasks and attached
+plan docs.
+
+Get child issues of a slice:
+
+```graphql
+query SliceChildren($id: String!) {
+  issue(id: $id) {
+    children {
+      nodes {
+        id
+        identifier
+        title
+        state {
+          name
+        }
+      }
+    }
+  }
+}
+```
+
+Get documents attached to an issue:
+
+```graphql
+query IssueDocuments($id: String!) {
+  issue(id: $id) {
+    documents {
+      nodes {
+        id
+        title
+        content
+      }
+    }
+  }
+}
+```
+
+Get project documents:
+
+```graphql
+query ProjectDocuments($id: String!) {
+  project(id: $id) {
+    documents {
+      nodes {
+        id
+        title
+        content
+      }
+    }
+  }
+}
+```
+
+Get milestone from issue:
+
+```graphql
+query IssueMilestone($id: String!) {
+  issue(id: $id) {
+    projectMilestone {
+      id
+      name
+    }
+  }
+}
+```
+
 ### Query team workflow states for an issue
 
 Use this before changing issue state when you need the exact `stateId`:

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -69,17 +69,37 @@ When `--logs-root` is set, logs write to rotating files under `<logs-root>/log/s
 
 ## Multiple Workflows
 
-Symphony reads one workflow file per instance. Run different projects with different workflows:
+Symphony reads one workflow file per instance. Use the workflow file as the
+execution contract for each project:
+
+| Workflow file | Project | Dispatch model |
+|---|---|---|
+| `WORKFLOW.md` | Symphony | Flat tickets (single issue per run) |
+| `cli-WORKFLOW.md` | Kata CLI | Slice-aware parent issue with ordered child tasks and hierarchy docs |
+
+`WORKFLOW.md` remains the default flat-ticket workflow for Symphony self-build
+work. `cli-WORKFLOW.md` adds parent/child issue awareness and document-loading
+rules for Kata CLI planned slices.
+
+Run different projects with different workflows:
 
 ```bash
 # Self-build workflow (flat tickets)
 symphony WORKFLOW.md --port 8080
 
 # Kata CLI workflow (slice-aware, parent/child issues)
+symphony cli-WORKFLOW.md --port 8080
+```
+
+If you run both at the same time, use different ports:
+
+```bash
+symphony WORKFLOW.md --port 8080
 symphony cli-WORKFLOW.md --port 8081
 ```
 
-Each workflow has its own tracker config, workspace settings, and prompt template.
+Each workflow has its own tracker configuration, workspace settings, and prompt
+template.
 
 ## Ticket Lifecycle
 

--- a/apps/symphony/cli-WORKFLOW.md
+++ b/apps/symphony/cli-WORKFLOW.md
@@ -14,6 +14,8 @@ tracker:
     - Done
     - Closed
     - Cancelled
+    - Canceled
+    - Duplicate
 polling:
   interval_ms: 30000
 workspace:
@@ -320,10 +322,12 @@ Use one persistent workpad comment and include task-level progress:
 
 - `Backlog` -> out of scope for this workflow; do not modify.
 - `Todo` -> orchestrator moves to `In Progress` on dispatch; verify then execute.
-- `In Progress` -> active implementation and slice task execution.
+- `In Progress` -> active implementation and slice task execution. After PR
+  publish-proof and required validation gates pass, move to `Agent Review`.
 - `Agent Review` -> address review/bot feedback on the existing PR.
 - `Human Review` -> no coding; wait for approval/rejection.
-- `Merging` -> run merge flow and move slice to `Done`.
+- `Merging` -> run `.codex/skills/land/SKILL.md` merge loop, then move slice
+  to `Done`.
 - `Rework` -> close prior PR, create fresh branch from `origin/{{ workspace.base_branch }}`, restart.
 - `Done` -> terminal state; do nothing.
 
@@ -353,12 +357,15 @@ Use one persistent workpad comment and include task-level progress:
 4. After each child task completion, move that child issue to `Done`.
 5. Maintain one PR for the slice.
 6. Before state transition, ensure workpad Plan/Acceptance/Validation exactly match reality.
+7. After publish-proof and required-check gates pass, move issue state from
+   `In Progress` to `Agent Review`.
 
 ## Step 3: Review and merge
 
 1. In `Agent Review`, address all actionable PR comments (top-level + inline + review summaries), push fixes, rerun validation.
 2. Move to `Human Review` only when no unresolved actionable comments remain and checks are green.
-3. In `Merging`, merge approved PR, then move slice issue to `Done`.
+3. In `Merging`, run `.codex/skills/land/SKILL.md` (do not call `gh pr merge`
+   directly), then move slice issue to `Done`.
 4. Ensure children are already `Done`; if not, resolve before marking slice done.
 
 ## Guardrails

--- a/apps/symphony/cli-WORKFLOW.md
+++ b/apps/symphony/cli-WORKFLOW.md
@@ -1,0 +1,370 @@
+---
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: "c7e76979-df58-407a-bf64-09bfccfef9c4"
+  # assignee: alice
+  active_states:
+    - Todo
+    - In Progress
+    - Agent Review
+    - Merging
+    - Rework
+  terminal_states:
+    - Done
+    - Closed
+    - Cancelled
+polling:
+  interval_ms: 30000
+workspace:
+  root: /Volumes/EVO/symphony-workspaces
+  repo: /Volumes/EVO/kata/kata-mono
+  git_strategy: worktree
+  isolation: local
+  cleanup_on_done: true
+  branch_prefix: symphony
+  clone_branch: main
+  base_branch: main
+hooks:
+  timeout_ms: 120000
+agent:
+  max_concurrent_agents: 3
+  max_turns: 20
+codex:
+  command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
+  stall_timeout_ms: 900000
+  approval_policy: never
+  thread_sandbox: danger-full-access
+  turn_sandbox_policy:
+    type: dangerFullAccess
+server:
+  port: 8080
+  host: "127.0.0.1"
+---
+
+You are working on a Linear ticket `{{ issue.identifier }}`
+
+{% if attempt %}
+Continuation context:
+
+- This is retry attempt #{{ attempt }} because the ticket is still in an active state.
+- Resume from the current workspace state instead of restarting from scratch.
+- Do not repeat already-completed investigation or validation unless needed for new code changes.
+- Do not end the turn while the issue remains in an active state unless you are blocked by missing required permissions/secrets.
+{% endif %}
+
+Issue context:
+Identifier: {{ issue.identifier }}
+Title: {{ issue.title }}
+Current status: {{ issue.state }}
+Labels: {{ issue.labels }}
+URL: {{ issue.url }}
+
+Description:
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+No description provided.
+{% endif %}
+
+Instructions:
+
+1. This is an unattended orchestration session. Never ask a human to perform follow-up actions.
+2. Only stop early for a true blocker (missing required auth/permissions/secrets). If blocked, record it in the workpad and move the issue according to workflow.
+3. Final message must report completed actions and blockers only. Do not include "next steps for user".
+
+Work only in the provided repository copy. Do not touch any other path.
+
+## Repository context
+
+This is the **kata-mono** monorepo. The Symphony crate lives at `apps/symphony/`.
+
+- Build: `cd apps/symphony && cargo build`
+- Test: `cd apps/symphony && cargo test`
+- Lint: `cd apps/symphony && cargo clippy -- -D warnings`
+- Format: `cd apps/symphony && cargo fmt`
+- Base branch: `{{ workspace.base_branch }}`. All merges, rebases, and PR base targets use this branch.
+
+Read `apps/symphony/AGENTS.md` for full architecture reference.
+
+## Prerequisite: Linear MCP or `linear_graphql` tool is available
+
+The agent should be able to talk to Linear, either via a configured Linear MCP server or injected `linear_graphql` tool. If none are present, stop and ask the user to configure Linear.
+
+## Linear GraphQL schema quick reference (always in context)
+
+Use this as an always-on guardrail to avoid invalid Linear queries.
+
+- `Issue.links` is invalid. Use `attachments`, `relations`, or `inverseRelations`.
+- `IssueFilter.identifier` is invalid. For identifier-style filtering, use `team.key` + `number`.
+
+Query by issue identifier (preferred):
+
+```graphql
+query IssueByIdentifier($identifier: String!) {
+  issue(id: $identifier) {
+    id
+    identifier
+    title
+    state {
+      id
+      name
+      type
+    }
+  }
+}
+```
+
+Query by identifier using `issues(filter: ...)`:
+
+```graphql
+query IssueByTeamKeyAndNumber($teamKey: String!, $number: Float!) {
+  issues(
+    filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }
+    first: 1
+  ) {
+    nodes {
+      id
+      identifier
+      title
+    }
+  }
+}
+```
+
+Move issue state by name (resolve `stateId` first):
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    team {
+      states {
+        nodes {
+          id
+          name
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+```graphql
+mutation MoveIssueToState($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue {
+      id
+      state {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
+## Slice Dispatch Unit
+
+This workflow is for Kata CLI planned execution and dispatches a **slice issue** (parent issue).
+
+- Treat an issue as a slice when either condition is true:
+  - issue has label `kata:slice`
+  - issue has one or more child issues
+- Child task issues are typically labeled `kata:task`.
+- If no child issues exist, continue with normal flat execution flow from this file.
+
+## Context Loading Protocol (required order)
+
+Before implementation starts, load context in this exact order:
+
+1. Child issues (`issue.children`) to discover task list and ordering.
+2. Slice issue documents (`issue.documents`) to read task-level plans (`T0N-PLAN`).
+3. Project documents (`project.documents`) to read `PROJECT`, `REQUIREMENTS`, `S0N-PLAN`, `S0N-RESEARCH`.
+4. Milestone documents via `issue.projectMilestone` then `projectMilestone.documents` (`M00N-CONTEXT`, `M00N-ROADMAP`).
+
+Preferred query patterns:
+
+```graphql
+query SliceChildren($id: String!) {
+  issue(id: $id) {
+    children {
+      nodes {
+        id
+        identifier
+        title
+        state {
+          name
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+```graphql
+query IssueDocuments($id: String!) {
+  issue(id: $id) {
+    documents {
+      nodes {
+        id
+        title
+        content
+      }
+    }
+  }
+}
+```
+
+```graphql
+query ProjectDocuments($id: String!) {
+  project(id: $id) {
+    documents {
+      nodes {
+        id
+        title
+        content
+      }
+    }
+  }
+}
+```
+
+```graphql
+query IssueMilestone($id: String!) {
+  issue(id: $id) {
+    projectMilestone {
+      id
+      name
+    }
+  }
+}
+```
+
+```graphql
+query MilestoneDocuments($id: String!) {
+  projectMilestone(id: $id) {
+    documents {
+      nodes {
+        id
+        title
+        content
+      }
+    }
+  }
+}
+```
+
+## Slice Execution Flow
+
+1. Dispatch starts on the slice issue.
+2. Detect slice mode (`kata:slice` label or child issues).
+3. Load hierarchy context per protocol above.
+4. Build an ordered task list from child issues (`T01 -> T02 -> T03` by task prefix when present; otherwise by issue number asc).
+5. Execute tasks in order, following each corresponding task plan document.
+6. After each completed child task:
+   - run required validation for that task,
+   - commit with task reference in the message,
+   - move the child issue to `Done` using `issueUpdate` + resolved `stateId`.
+7. Keep one PR for the entire slice branch.
+8. After all child tasks are done, run review loop and CI checks.
+9. On merge, ensure all children are `Done`, then move the slice issue to `Done`.
+
+## Workpad Format for Slices
+
+Use one persistent workpad comment and include task-level progress:
+
+````md
+## Codex Workpad
+
+```text
+<host>:<abs-workdir>@<short-sha>
+```
+
+### Task Progress
+
+- [ ] T01: <title> (<identifier>) — Pending
+- [ ] T02: <title> (<identifier>) — Pending
+- [ ] T03: <title> (<identifier>) — Pending
+
+### Plan
+
+- [ ] 1\. Load context hierarchy
+- [ ] 2\. Execute T01 per T01-PLAN
+- [ ] 3\. Execute T02 per T02-PLAN
+- [ ] 4\. Execute T03 per T03-PLAN
+- [ ] 5\. Create/update PR for slice
+
+### Acceptance Criteria
+
+- [ ] All child tasks moved to `Done` after implementation and validation
+- [ ] Slice issue moved to `Done` after merge
+- [ ] Single PR covers entire slice implementation
+
+### Validation
+
+- [ ] required tests/lint/build commands for touched scope
+
+### Notes
+
+- <timestamped progress and evidence>
+
+### Confusions
+
+- <only include if something was unclear>
+````
+
+## Status map
+
+- `Backlog` -> out of scope for this workflow; do not modify.
+- `Todo` -> orchestrator moves to `In Progress` on dispatch; verify then execute.
+- `In Progress` -> active implementation and slice task execution.
+- `Agent Review` -> address review/bot feedback on the existing PR.
+- `Human Review` -> no coding; wait for approval/rejection.
+- `Merging` -> run merge flow and move slice to `Done`.
+- `Rework` -> close prior PR, create fresh branch from `origin/{{ workspace.base_branch }}`, restart.
+- `Done` -> terminal state; do nothing.
+
+## Step 0: Determine current ticket state and route
+
+0. Before ANY other action, read `.codex/skills/linear/SKILL.md` and keep it in context.
+1. Fetch the issue by explicit ticket ID.
+2. Route by state.
+3. Ensure one active unresolved `## Codex Workpad` comment exists and reuse it.
+4. Check if a PR already exists for the current branch and whether it is closed/merged.
+   - If closed/merged, create a fresh branch from `origin/{{ workspace.base_branch }}` and restart.
+
+## Step 1: Plan and reproduce (In Progress)
+
+1. Update/reconcile the workpad before any new implementation edits.
+2. Stamp environment line `<host>:<abs-workdir>@<short-sha>`.
+3. Capture a concrete reproduction/context signal in `Notes`.
+4. Run pull-sync against `origin/{{ workspace.base_branch }}` and record merge source/result/HEAD in workpad notes.
+5. For slice issues, load hierarchy context and build task-order checklist.
+6. Do a principal-style plan review and refine plan/checklists before coding.
+
+## Step 2: Execute
+
+1. Implement child tasks in order from the task checklist.
+2. Keep workpad current after each milestone and check completed items immediately.
+3. Run validation continuously; do not defer to the end.
+4. After each child task completion, move that child issue to `Done`.
+5. Maintain one PR for the slice.
+6. Before state transition, ensure workpad Plan/Acceptance/Validation exactly match reality.
+
+## Step 3: Review and merge
+
+1. In `Agent Review`, address all actionable PR comments (top-level + inline + review summaries), push fixes, rerun validation.
+2. Move to `Human Review` only when no unresolved actionable comments remain and checks are green.
+3. In `Merging`, merge approved PR, then move slice issue to `Done`.
+4. Ensure children are already `Done`; if not, resolve before marking slice done.
+
+## Guardrails
+
+- Keep `apps/symphony/WORKFLOW.md` unchanged for flat Symphony ticket flow.
+- Do not edit issue body for planning/progress tracking; use only one persistent workpad comment.
+- Do not use `Issue.links` or `IssueFilter.identifier` in GraphQL.
+- If blocked by missing required non-GitHub auth/tools, capture blocker in workpad and move per workflow.
+- If app behavior is touched, include runtime validation evidence in workpad.


### PR DESCRIPTION
## Summary
- add a new `apps/symphony/cli-WORKFLOW.md` workflow file for Kata CLI slice-aware execution
- document required slice hierarchy/document loading and ordered child-task execution rules
- extend `.codex/skills/linear/SKILL.md` with child issue + issue/project/milestone document query patterns
- update `apps/symphony/README.md` to clarify flat `WORKFLOW.md` vs slice-aware `cli-WORKFLOW.md` usage

## Validation
- pre-push hook: `turbo run lint typecheck test --affected` (passed)
- `git diff -- apps/symphony/cli-WORKFLOW.md .codex/skills/linear/SKILL.md apps/symphony/README.md`
- `rg -n "cli-WORKFLOW.md|WORKFLOW.md|children|documents|projectMilestone|kata:slice|kata:task" apps/symphony/README.md apps/symphony/cli-WORKFLOW.md .codex/skills/linear/SKILL.md`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a slice-aware orchestration workflow (`cli-WORKFLOW.md`) for the Kata CLI project and extends the Linear skill with child/document hierarchy query patterns. The new workflow teaches Symphony's agents how to detect a "slice" parent issue, load a multi-level context hierarchy (issue → project → milestone documents), and execute child tasks in order under a single PR — a meaningful addition to the existing flat-ticket model documented in `WORKFLOW.md`.

Key observations from the review:

- **Missing `MilestoneDocuments` query in `SKILL.md`** — The Context Loading Protocol (step 4) requires agents to query `projectMilestone.documents`, and `cli-WORKFLOW.md` includes the `MilestoneDocuments` GraphQL query for this purpose, but the query was not added to `.codex/skills/linear/SKILL.md`. Since Step 0 of the workflow instructs agents to treat SKILL.md as the authoritative source and not to guess Linear schema, the gap means agents will lack a canonical reference for this query.
- **Incomplete `terminal_states` in `cli-WORKFLOW.md`** — The existing `WORKFLOW.md` defensively lists both `Cancelled` and `Canceled` (covering common Linear spelling variants) plus `Duplicate`. The new file omits `Canceled` and `Duplicate`, which could cause the orchestrator to dispatch agents against already-closed or duplicate Kata CLI issues.
- **`state.type` field missing from SKILL.md's `SliceChildren` query** — The equivalent query in `cli-WORKFLOW.md` includes `state { name type }`, but the SKILL.md version only fetches `state { name }`, creating a subtle inconsistency between the two canonical sources.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge but has two behavioural gaps that could cause incorrect orchestrator/agent behaviour in the Kata CLI workflow.
- The README update is clean. The SKILL.md additions are largely correct. However, the missing `MilestoneDocuments` query in SKILL.md leaves a documentation gap that agents are explicitly told to rely on, and the truncated `terminal_states` list in `cli-WORKFLOW.md` is a functional regression compared to `WORKFLOW.md` that could cause the orchestrator to dispatch against terminal issues.
- `apps/symphony/cli-WORKFLOW.md` (terminal_states) and `.codex/skills/linear/SKILL.md` (MilestoneDocuments query + state.type field) need attention before the workflow is used in production.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/cli-WORKFLOW.md | New slice-aware workflow file with YAML config and prompt template; contains hardcoded machine-specific paths (consistent with WORKFLOW.md), a hardcoded Linear project UUID, and an incomplete `terminal_states` list missing `Canceled` and `Duplicate` variants present in WORKFLOW.md. |
| .codex/skills/linear/SKILL.md | Adds slice hierarchy GraphQL query patterns (SliceChildren, IssueDocuments, ProjectDocuments, IssueMilestone) but is missing the `MilestoneDocuments` query needed to complete the step-4 Context Loading Protocol, and the SliceChildren query omits the `state.type` field present in the cli-WORKFLOW.md counterpart. |
| apps/symphony/README.md | Documentation update adds a workflow comparison table and clarifies single vs. simultaneous execution with different ports; no issues found. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant L as Linear API
    participant A as Agent (Codex)
    participant G as GitHub

    O->>L: Poll active_states (Todo/In Progress/…)
    L-->>O: Slice issue (kata:slice label or children present)
    O->>A: Dispatch with cli-WORKFLOW.md prompt

    A->>L: IssueByIdentifier($id)
    L-->>A: issue {id, state, labels}

    note over A: Context Loading Protocol
    A->>L: SliceChildren($id)
    L-->>A: child tasks [T01, T02, T03]
    A->>L: IssueDocuments($id)
    L-->>A: T0N-PLAN documents
    A->>L: ProjectDocuments($projectId)
    L-->>A: PROJECT / REQUIREMENTS / S0N-PLAN docs
    A->>L: IssueMilestone($id)
    L-->>A: projectMilestone {id, name}
    A->>L: MilestoneDocuments($milestoneId)
    L-->>A: M00N-CONTEXT / M00N-ROADMAP docs

    note over A: Execute T01 → T02 → T03
    loop Each child task
        A->>G: commit with task reference
        A->>L: issueUpdate(childId, stateId=Done)
    end

    A->>G: Create/update single PR for slice
    A->>L: Move slice to Agent Review

    G-->>A: PR review feedback
    A->>G: Push fixes
    A->>L: Move slice to Human Review

    L-->>A: Human approves → Merging
    A->>G: Merge PR (land skill)
    A->>L: Move slice to Done
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .codex/skills/linear/SKILL.md
Line: 241-252

Comment:
**`MilestoneDocuments` query absent from SKILL.md**

The `IssueMilestone` query (added here) retrieves the milestone `id` and `name`, but there is no corresponding `MilestoneDocuments` query in this file to fetch the milestone's attached documents.

The Context Loading Protocol in `cli-WORKFLOW.md` (step 4) explicitly requires agents to load "Milestone documents via `issue.projectMilestone` then `projectMilestone.documents`", and `cli-WORKFLOW.md` contains the `MilestoneDocuments` query. However, Step 0 of that same workflow instructs agents to "read `.codex/skills/linear/SKILL.md` and keep it in context" and to "not guess Linear GraphQL schema — use the skill." An agent following this instruction will find the `IssueMilestone` query but will have no SKILL.md reference for the follow-up `projectMilestone.documents` query, potentially leading to guessed/incorrect schema usage.

The following query (already present in `cli-WORKFLOW.md`) should be added here:

```suggestion
query IssueMilestone($id: String!) {
  issue(id: $id) {
    projectMilestone {
      id
      name
    }
  }
}
```

Get milestone documents:

```graphql
query MilestoneDocuments($id: String!) {
  projectMilestone(id: $id) {
    documents {
      nodes {
        id
        title
        content
      }
    }
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/cli-WORKFLOW.md
Line: 13-16

Comment:
**Incomplete `terminal_states` list vs `WORKFLOW.md`**

`WORKFLOW.md` defensively covers both spellings of the cancelled state and also `Duplicate`:

```yaml
terminal_states:
  - Done
  - Closed
  - Cancelled
  - Canceled   # US spelling used by some Linear workspaces
  - Duplicate
```

`cli-WORKFLOW.md` only lists three states. If the Kata CLI Linear workspace uses `Canceled` (single L — which is the default US-English spelling Linear uses in many accounts) or `Duplicate`, the orchestrator will not recognise those as terminal and may dispatch agent sessions against already-closed or duplicate issues.

```suggestion
  terminal_states:
    - Done
    - Closed
    - Cancelled
    - Canceled
    - Duplicate
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .codex/skills/linear/SKILL.md
Line: 192-207

Comment:
**`SliceChildren` query omits `state.type` present in `cli-WORKFLOW.md`**

The `SliceChildren` query in SKILL.md returns only `state { name }`, but the identical query in `cli-WORKFLOW.md` returns `state { name type }`. The `type` field (e.g. `started`, `completed`, `cancelled`) is useful for agents to programmatically classify states without string-matching, and is already relied upon by the workflow. Keeping both queries consistent avoids agents getting different shape results depending on which file they copied the query from.

```suggestion
query SliceChildren($id: String!) {
  issue(id: $id) {
    children {
      nodes {
        id
        identifier
        title
        state {
          name
          type
        }
      }
    }
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["docs(symphony): alig..."](https://github.com/gannonh/kata/commit/6c02312c1b2cf73a8d0008a8d3d5862c812f0de9)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->