### PR TITLE
[S03] Infrastructure ports — repo-identity, session-lock, worktree-resolver

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -42,7 +42,8 @@
   },
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.60.0",
-    "playwright": "^1.58.2"
+    "playwright": "^1.58.2",
+    "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/apps/cli/src/resources/extensions/kata/atomic-write.ts
+++ b/apps/cli/src/resources/extensions/kata/atomic-write.ts
@@ -1,0 +1,55 @@
+import {
+  mkdirSync,
+  promises as fs,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { dirname } from "node:path";
+
+/**
+ * Atomically writes content to a file by writing to a temp file first,
+ * then renaming. Prevents partial/corrupt files on crash.
+ */
+export function atomicWriteSync(
+  filePath: string,
+  content: string,
+  encoding: BufferEncoding = "utf-8",
+): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp.${randomBytes(4).toString("hex")}`;
+  writeFileSync(tmpPath, content, encoding);
+  try {
+    renameSync(tmpPath, filePath);
+  } catch (error) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // orphan cleanup best-effort
+    }
+    throw error;
+  }
+}
+
+/**
+ * Async variant of atomicWriteSync. Atomically writes content to a file
+ * by writing to a temp file first, then renaming.
+ */
+export async function atomicWriteAsync(
+  filePath: string,
+  content: string,
+  encoding: BufferEncoding = "utf-8",
+): Promise<void> {
+  await fs.mkdir(dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp.${randomBytes(4).toString("hex")}`;
+  await fs.writeFile(tmpPath, content, encoding);
+  try {
+    await fs.rename(tmpPath, filePath);
+  } catch (error) {
+    await fs.unlink(tmpPath).catch(() => {
+      // orphan cleanup best-effort
+    });
+    throw error;
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -318,6 +318,18 @@ export async function startAuto(
   // If resuming from paused state, just re-activate and dispatch next unit.
   // The conversation is still intact — no need to reinitialize everything.
   if (paused) {
+    const lockResult = acquireSessionLock(base);
+    if (!lockResult.acquired) {
+      const pidSuffix = lockResult.existingPid
+        ? ` Existing PID: ${lockResult.existingPid}.`
+        : "";
+      ctx.ui.notify(
+        `Auto-mode resume blocked by session lock: ${lockResult.reason}${pidSuffix}`,
+        "error",
+      );
+      return;
+    }
+
     paused = false;
     active = true;
     stepActive = false;

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -27,6 +27,11 @@ import {
   formatCrashInfo,
 } from "./crash-recovery.js";
 import {
+  acquireSessionLock,
+  releaseSessionLock,
+  updateSessionLock,
+} from "./session-lock.js";
+import {
   clearUnitRuntimeRecord,
   formatExecuteTaskRecoveryStatus,
   inspectExecuteTaskDurability,
@@ -223,7 +228,10 @@ export async function stopAuto(
 ): Promise<void> {
   if (!active && !paused) return;
   clearUnitTimeout();
-  if (basePath) clearLock(basePath);
+  if (basePath) {
+    releaseSessionLock(basePath);
+    clearLock(basePath);
+  }
   clearSkillSnapshot();
 
   providerErrorStreak = 0;
@@ -275,7 +283,10 @@ export async function pauseAuto(
 ): Promise<void> {
   if (!active) return;
   clearUnitTimeout();
-  if (basePath) clearLock(basePath);
+  if (basePath) {
+    releaseSessionLock(basePath);
+    clearLock(basePath);
+  }
   active = false;
   paused = true;
   // Preserve: lastUnit, currentUnit, basePath, verbose, cmdCtx,
@@ -385,6 +396,18 @@ export async function startAuto(
       await showSmartEntry(ctx, pi, base);
       return;
     }
+  }
+
+  const lockResult = acquireSessionLock(base);
+  if (!lockResult.acquired) {
+    const pidSuffix = lockResult.existingPid
+      ? ` Existing PID: ${lockResult.existingPid}.`
+      : "";
+    ctx.ui.notify(
+      `Auto-mode start blocked by session lock: ${lockResult.reason}${pidSuffix}`,
+      "error",
+    );
+    return;
   }
 
   active = true;
@@ -1362,6 +1385,13 @@ async function dispatchNextUnit(
   // 16. Lock file
   const sessionFile = ctx.sessionManager.getSessionFile();
   writeLock(basePath, unitType, unitId, completedUnits.length, sessionFile);
+  updateSessionLock(
+    basePath,
+    unitType,
+    unitId,
+    completedUnits.length,
+    sessionFile,
+  );
 
   // 17. Crash recovery + retry diagnostic
   let finalPrompt = prompt;

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -230,7 +230,6 @@ export async function stopAuto(
   clearUnitTimeout();
   if (basePath) {
     releaseSessionLock(basePath);
-    clearLock(basePath);
   }
   clearSkillSnapshot();
 
@@ -285,7 +284,6 @@ export async function pauseAuto(
   clearUnitTimeout();
   if (basePath) {
     releaseSessionLock(basePath);
-    clearLock(basePath);
   }
   active = false;
   paused = true;

--- a/apps/cli/src/resources/extensions/kata/repo-identity.ts
+++ b/apps/cli/src/resources/extensions/kata/repo-identity.ts
@@ -1,0 +1,179 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+const kataHome = process.env.KATA_HOME || join(homedir(), ".kata-cli");
+
+/**
+ * Get the git remote URL for "origin", or "" if no remote is configured.
+ * Uses `git config` rather than `git remote get-url` for broader compatibility.
+ */
+export function getRemoteUrl(basePath: string): string {
+  try {
+    return execFileSync("git", ["config", "--get", "remote.origin.url"], {
+      cwd: basePath,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Canonicalize paths when possible while still handling missing paths.
+ */
+export function canonicalizeExistingPath(pathValue: string): string {
+  try {
+    return realpathSync(pathValue);
+  } catch {
+    return resolve(pathValue);
+  }
+}
+
+/**
+ * Resolve git common dir for normal repos and worktrees.
+ */
+export function resolveGitCommonDir(basePath: string): string {
+  try {
+    return execFileSync(
+      "git",
+      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+      {
+        cwd: basePath,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 5_000,
+      },
+    ).trim();
+  } catch {
+    const raw = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+      cwd: basePath,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    }).trim();
+    return resolve(basePath, raw);
+  }
+}
+
+/**
+ * Resolve absolute git-dir for the current checkout.
+ */
+export function resolveGitDir(basePath: string): string {
+  try {
+    return execFileSync("git", ["rev-parse", "--path-format=absolute", "--git-dir"], {
+      cwd: basePath,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    }).trim();
+  } catch {
+    const raw = execFileSync("git", ["rev-parse", "--git-dir"], {
+      cwd: basePath,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    }).trim();
+    return resolve(basePath, raw);
+  }
+}
+
+function resolveGitRoot(basePath: string): string {
+  try {
+    const commonDir = resolveGitCommonDir(basePath);
+    const normalizedCommonDir = commonDir.replaceAll("\\", "/");
+
+    if (normalizedCommonDir.endsWith("/.git")) {
+      return canonicalizeExistingPath(resolve(commonDir, ".."));
+    }
+
+    const worktreeMarker = "/.git/worktrees/";
+    if (normalizedCommonDir.includes(worktreeMarker)) {
+      return canonicalizeExistingPath(resolve(commonDir, "..", ".."));
+    }
+
+    return canonicalizeExistingPath(
+      execFileSync("git", ["rev-parse", "--show-toplevel"], {
+        cwd: basePath,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 5_000,
+      }).trim(),
+    );
+  } catch {
+    return resolve(basePath);
+  }
+}
+
+/**
+ * Validate that a project id is a full SHA-256 hex digest.
+ */
+export function validateProjectId(id: string): boolean {
+  return /^[a-f0-9]{64}$/i.test(id);
+}
+
+/**
+ * Compute a stable repository identity.
+ *
+ * If KATA_PROJECT_ID is set, use it after validation. Otherwise compute
+ * SHA-256 of `${remoteUrl}\n${resolvedRoot}`.
+ */
+export function repoIdentity(basePath: string): string {
+  const projectId = process.env.KATA_PROJECT_ID;
+  if (projectId) {
+    if (!validateProjectId(projectId)) {
+      throw new Error(
+        "KATA_PROJECT_ID must be a 64-character SHA-256 hex string.",
+      );
+    }
+    return projectId.toLowerCase();
+  }
+
+  const remoteUrl = getRemoteUrl(basePath);
+  const root = resolveGitRoot(basePath);
+  const input = `${remoteUrl}\n${root}`;
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * Compute the external kata state directory for a repository.
+ *
+ * Returns `$KATA_STATE_DIR/projects/<hash>` if `KATA_STATE_DIR` is set,
+ * otherwise `~/.kata-cli/projects/<hash>`.
+ */
+export function externalKataRoot(basePath: string): string {
+  const base = process.env.KATA_STATE_DIR || kataHome;
+  return join(base, "projects", repoIdentity(basePath));
+}
+
+/**
+ * Check if the given directory is a git worktree (not the main repo).
+ *
+ * Git worktrees have a `.git` file containing a `gitdir:` pointer.
+ */
+export function isInsideWorktree(cwd: string): boolean {
+  try {
+    const commonDir = canonicalizeExistingPath(resolveGitCommonDir(cwd))
+      .replaceAll("\\", "/");
+    const gitDir = canonicalizeExistingPath(resolveGitDir(cwd))
+      .replaceAll("\\", "/");
+
+    if (gitDir.includes("/.git/worktrees/")) return true;
+    return gitDir !== commonDir;
+  } catch {
+    // Fallback for very old git versions or non-git directories.
+    const gitPath = join(cwd, ".git");
+    try {
+      const stat = lstatSync(gitPath);
+      if (!stat.isFile()) return false;
+      const content = readFileSync(gitPath, "utf-8").trim();
+      return content.startsWith("gitdir:");
+    } catch {
+      return false;
+    }
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/session-lock.ts
+++ b/apps/cli/src/resources/extensions/kata/session-lock.ts
@@ -161,11 +161,17 @@ export function cleanupStrayLockFiles(basePath: string): void {
   }
 }
 
-function ensureExitHandler(stateDir: string): void {
+function ensureExitHandler(): void {
   if (_exitHandlerRegistered) return;
   _exitHandlerRegistered = true;
 
   process.once("exit", () => {
+    const heldPath = _lockedPath;
+    if (!heldPath) return;
+
+    const stateDir = kataStateDir(heldPath);
+    const lp = lockPath(heldPath);
+
     try {
       if (_releaseFunction) {
         _releaseFunction();
@@ -176,8 +182,7 @@ function ensureExitHandler(stateDir: string): void {
     }
 
     try {
-      const lockFile = join(stateDir, LOCK_FILE);
-      if (existsSync(lockFile)) unlinkSync(lockFile);
+      if (existsSync(lp)) unlinkSync(lp);
     } catch {
       // best-effort
     }
@@ -266,7 +271,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     _lockCompromised = false;
     _lockAcquiredAt = Date.now();
 
-    ensureExitHandler(stateDir);
+    ensureExitHandler();
 
     atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
     return { acquired: true };
@@ -303,7 +308,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
         _lockCompromised = false;
         _lockAcquiredAt = Date.now();
 
-        ensureExitHandler(stateDir);
+        ensureExitHandler();
 
         atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
         return { acquired: true };

--- a/apps/cli/src/resources/extensions/kata/session-lock.ts
+++ b/apps/cli/src/resources/extensions/kata/session-lock.ts
@@ -77,9 +77,6 @@ let _lockCompromised = false;
 /** Whether we've registered a process.on("exit") handler already. */
 let _exitHandlerRegistered = false;
 
-/** Snapshotted lock file path captured at acquire time. */
-let _snapshotLockPath: string | null = null;
-
 /** Timestamp when lock was acquired for compromise false-positive suppression. */
 let _lockAcquiredAt = 0;
 
@@ -100,7 +97,6 @@ function kataStateDir(basePath: string): string {
 }
 
 function lockPath(basePath: string): string {
-  if (_snapshotLockPath) return _snapshotLockPath;
   return join(kataStateDir(basePath), LOCK_FILE);
 }
 
@@ -109,7 +105,6 @@ function clearHeldLockState(): void {
   _lockPid = 0;
   _lockCompromised = false;
   _lockAcquiredAt = 0;
-  _snapshotLockPath = null;
 }
 
 // ─── Stray Lock Cleanup ─────────────────────────────────────────────────────
@@ -270,7 +265,6 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     _lockPid = process.pid;
     _lockCompromised = false;
     _lockAcquiredAt = Date.now();
-    _snapshotLockPath = lp;
 
     ensureExitHandler(stateDir);
 
@@ -280,7 +274,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     const existingData = readExistingLockData(lp);
     const existingPid = existingData?.pid;
 
-    if (!existingData || (existingPid && !isPidAlive(existingPid))) {
+    if (existingPid && !isPidAlive(existingPid)) {
       try {
         const lockDir = `${stateDir}.lock`;
         if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
@@ -308,7 +302,6 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
         _lockPid = process.pid;
         _lockCompromised = false;
         _lockAcquiredAt = Date.now();
-        _snapshotLockPath = lp;
 
         ensureExitHandler(stateDir);
 
@@ -358,7 +351,7 @@ export function updateSessionLock(
   sessionFile?: string,
 ): void {
   const normalizedBasePath = normalizeBasePath(basePath);
-  if (_lockedPath !== normalizedBasePath && _lockedPath !== null) return;
+  if (_lockedPath !== normalizedBasePath) return;
 
   const lp = lockPath(normalizedBasePath);
   try {
@@ -437,6 +430,7 @@ export function validateSessionLock(basePath: string): boolean {
 
 export function releaseSessionLock(basePath: string): void {
   const normalizedBasePath = normalizeBasePath(basePath);
+  if (_lockedPath !== normalizedBasePath) return;
 
   if (_releaseFunction) {
     try {

--- a/apps/cli/src/resources/extensions/kata/session-lock.ts
+++ b/apps/cli/src/resources/extensions/kata/session-lock.ts
@@ -1,0 +1,480 @@
+/**
+ * Kata Session Lock — OS-level exclusive locking for auto-mode sessions.
+ *
+ * Prevents multiple kata processes from running auto-mode concurrently on
+ * the same project. Uses proper-lockfile for OS-level file locking
+ * to avoid advisory-lock race conditions.
+ *
+ * The lock file (.kata-cli/auto.lock) stores JSON metadata for diagnostics,
+ * while the actual exclusion is enforced by the OS-level lock.
+ */
+
+import { createRequire } from "node:module";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+import { atomicWriteSync } from "./atomic-write.js";
+import { canonicalizeExistingPath } from "./repo-identity.js";
+
+const _require = createRequire(import.meta.url);
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface SessionLockData {
+  pid: number;
+  startedAt: string;
+  unitType: string;
+  unitId: string;
+  unitStartedAt: string;
+  completedUnits: number;
+  sessionFile?: string;
+}
+
+export type SessionLockResult =
+  | { acquired: true }
+  | { acquired: false; reason: string; existingPid?: number };
+
+export type SessionLockFailureReason =
+  | "compromised"
+  | "missing-metadata"
+  | "pid-mismatch";
+
+export interface SessionLockStatus {
+  valid: boolean;
+  failureReason?: SessionLockFailureReason;
+  existingPid?: number;
+  expectedPid?: number;
+  recovered?: boolean;
+}
+
+// ─── Module State ───────────────────────────────────────────────────────────
+
+/** Release function from proper-lockfile — calling it releases the OS lock. */
+let _releaseFunction: (() => void) | null = null;
+
+/** Canonical base path we currently hold a lock on. */
+let _lockedPath: string | null = null;
+
+/** Our PID at lock acquisition time. */
+let _lockPid = 0;
+
+/** Set true when proper-lockfile fires onCompromised. */
+let _lockCompromised = false;
+
+/** Whether we've registered a process.on("exit") handler already. */
+let _exitHandlerRegistered = false;
+
+/** Snapshotted lock file path captured at acquire time. */
+let _snapshotLockPath: string | null = null;
+
+/** Timestamp when lock was acquired for compromise false-positive suppression. */
+let _lockAcquiredAt = 0;
+
+const LOCK_FILE = "auto.lock";
+const STALE_WINDOW_MS = 1_800_000; // 30m
+
+function normalizeBasePath(basePath: string): string {
+  return canonicalizeExistingPath(basePath);
+}
+
+function kataStateDir(basePath: string): string {
+  return join(normalizeBasePath(basePath), ".kata-cli");
+}
+
+function lockPath(basePath: string): string {
+  if (_snapshotLockPath) return _snapshotLockPath;
+  return join(kataStateDir(basePath), LOCK_FILE);
+}
+
+// ─── Stray Lock Cleanup ─────────────────────────────────────────────────────
+
+/**
+ * Remove numbered lock variants from cloud sync conflicts (e.g. auto 2.lock)
+ * and stray proper-lockfile directories beyond the canonical `.kata-cli.lock`.
+ */
+export function cleanupStrayLockFiles(basePath: string): void {
+  const stateDir = kataStateDir(basePath);
+
+  // Clean numbered auto lock files inside .kata-cli/
+  try {
+    if (existsSync(stateDir)) {
+      for (const entry of readdirSync(stateDir)) {
+        if (entry !== LOCK_FILE && /^auto\s.+\.lock$/i.test(entry)) {
+          try {
+            unlinkSync(join(stateDir, entry));
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    }
+  } catch {
+    // non-fatal
+  }
+
+  // Clean stray proper-lockfile directories (e.g. ".kata-cli 2.lock/")
+  try {
+    const parentDir = dirname(stateDir);
+    const stateDirName = basename(stateDir) || ".kata-cli";
+    if (existsSync(parentDir)) {
+      for (const entry of readdirSync(parentDir)) {
+        if (
+          entry !== `${stateDirName}.lock`
+          && entry.startsWith(stateDirName)
+          && entry.endsWith(".lock")
+        ) {
+          const fullPath = join(parentDir, entry);
+          try {
+            const stat = statSync(fullPath);
+            if (stat.isDirectory()) {
+              rmSync(fullPath, { recursive: true, force: true });
+            }
+          } catch {
+            // best-effort
+          }
+        }
+      }
+    }
+  } catch {
+    // non-fatal
+  }
+}
+
+function ensureExitHandler(stateDir: string): void {
+  if (_exitHandlerRegistered) return;
+  _exitHandlerRegistered = true;
+
+  process.once("exit", () => {
+    try {
+      if (_releaseFunction) {
+        _releaseFunction();
+        _releaseFunction = null;
+      }
+    } catch {
+      // best-effort
+    }
+
+    try {
+      const lockFile = join(stateDir, LOCK_FILE);
+      if (existsSync(lockFile)) unlinkSync(lockFile);
+    } catch {
+      // best-effort
+    }
+
+    try {
+      const lockDir = `${stateDir}.lock`;
+      if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+export function acquireSessionLock(basePath: string): SessionLockResult {
+  const normalizedBasePath = normalizeBasePath(basePath);
+  const lp = lockPath(normalizedBasePath);
+
+  // Re-entrant acquire on same path: release first so timers reset cleanly.
+  if (_releaseFunction && _lockedPath === normalizedBasePath) {
+    try {
+      _releaseFunction();
+    } catch {
+      // may already be released
+    }
+    _releaseFunction = null;
+    _lockedPath = null;
+    _lockPid = 0;
+    _lockCompromised = false;
+  }
+
+  mkdirSync(dirname(lp), { recursive: true });
+  cleanupStrayLockFiles(normalizedBasePath);
+
+  const lockData: SessionLockData = {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    unitType: "starting",
+    unitId: "bootstrap",
+    unitStartedAt: new Date().toISOString(),
+    completedUnits: 0,
+  };
+
+  let lockfile: typeof import("proper-lockfile");
+  try {
+    lockfile = _require("proper-lockfile") as typeof import("proper-lockfile");
+  } catch {
+    return acquireFallbackLock(normalizedBasePath, lp, lockData);
+  }
+
+  const stateDir = kataStateDir(normalizedBasePath);
+
+  try {
+    mkdirSync(stateDir, { recursive: true });
+
+    const release = lockfile.lockSync(stateDir, {
+      realpath: false,
+      stale: STALE_WINDOW_MS,
+      update: 10_000,
+      onCompromised: () => {
+        const elapsed = Date.now() - _lockAcquiredAt;
+        if (elapsed < STALE_WINDOW_MS) {
+          process.stderr.write(
+            `[kata] Lock heartbeat mismatch after ${Math.round(elapsed / 1000)}s; continuing.\n`,
+          );
+          return;
+        }
+        _lockCompromised = true;
+        _releaseFunction = null;
+      },
+    });
+
+    _releaseFunction = release;
+    _lockedPath = normalizedBasePath;
+    _lockPid = process.pid;
+    _lockCompromised = false;
+    _lockAcquiredAt = Date.now();
+    _snapshotLockPath = lp;
+
+    ensureExitHandler(stateDir);
+
+    atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
+    return { acquired: true };
+  } catch {
+    const existingData = readExistingLockData(lp);
+    const existingPid = existingData?.pid;
+
+    if (!existingData || (existingPid && !isPidAlive(existingPid))) {
+      try {
+        const lockDir = `${stateDir}.lock`;
+        if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+        if (existsSync(lp)) unlinkSync(lp);
+
+        const release = lockfile.lockSync(stateDir, {
+          realpath: false,
+          stale: STALE_WINDOW_MS,
+          update: 10_000,
+          onCompromised: () => {
+            const elapsed = Date.now() - _lockAcquiredAt;
+            if (elapsed < STALE_WINDOW_MS) {
+              process.stderr.write(
+                `[kata] Lock heartbeat mismatch after ${Math.round(elapsed / 1000)}s; continuing.\n`,
+              );
+              return;
+            }
+            _lockCompromised = true;
+            _releaseFunction = null;
+          },
+        });
+
+        _releaseFunction = release;
+        _lockedPath = normalizedBasePath;
+        _lockPid = process.pid;
+        _lockCompromised = false;
+        _lockAcquiredAt = Date.now();
+        _snapshotLockPath = lp;
+
+        ensureExitHandler(stateDir);
+
+        atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
+        return { acquired: true };
+      } catch {
+        // fall through to contention path
+      }
+    }
+
+    const reason = existingPid
+      ? `Another auto-mode session (PID ${existingPid}) appears to be running.`
+      : "Another auto-mode session is already running on this project.";
+
+    return { acquired: false, reason, existingPid };
+  }
+}
+
+function acquireFallbackLock(
+  normalizedBasePath: string,
+  lp: string,
+  lockData: SessionLockData,
+): SessionLockResult {
+  const existing = readExistingLockData(lp);
+  if (existing && existing.pid !== process.pid) {
+    if (isPidAlive(existing.pid)) {
+      return {
+        acquired: false,
+        reason: `Another auto-mode session (PID ${existing.pid}) is already running on this project.`,
+        existingPid: existing.pid,
+      };
+    }
+    // stale lock from dead process: continue and take over
+  }
+
+  atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
+  _lockedPath = normalizedBasePath;
+  _lockPid = process.pid;
+  return { acquired: true };
+}
+
+export function updateSessionLock(
+  basePath: string,
+  unitType: string,
+  unitId: string,
+  completedUnits: number,
+  sessionFile?: string,
+): void {
+  const normalizedBasePath = normalizeBasePath(basePath);
+  if (_lockedPath !== normalizedBasePath && _lockedPath !== null) return;
+
+  const lp = lockPath(normalizedBasePath);
+  try {
+    const data: SessionLockData = {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      unitType,
+      unitId,
+      unitStartedAt: new Date().toISOString(),
+      completedUnits,
+      sessionFile,
+    };
+    atomicWriteSync(lp, JSON.stringify(data, null, 2));
+  } catch {
+    // non-fatal
+  }
+}
+
+export function getSessionLockStatus(basePath: string): SessionLockStatus {
+  const normalizedBasePath = normalizeBasePath(basePath);
+
+  if (_lockCompromised) {
+    const lp = lockPath(normalizedBasePath);
+    const existing = readExistingLockData(lp);
+    if (existing && existing.pid === process.pid) {
+      try {
+        const result = acquireSessionLock(normalizedBasePath);
+        if (result.acquired) {
+          process.stderr.write(
+            "[kata] Lock recovered after onCompromised; lock file PID matched.\n",
+          );
+          return { valid: true, recovered: true };
+        }
+      } catch {
+        // fall through
+      }
+    }
+    return {
+      valid: false,
+      failureReason: "compromised",
+      existingPid: existing?.pid,
+      expectedPid: process.pid,
+    };
+  }
+
+  if (_releaseFunction && _lockedPath === normalizedBasePath) {
+    return { valid: true };
+  }
+
+  const lp = lockPath(normalizedBasePath);
+  const existing = readExistingLockData(lp);
+  if (!existing) {
+    return {
+      valid: false,
+      failureReason: "missing-metadata",
+      expectedPid: process.pid,
+    };
+  }
+
+  if (existing.pid !== process.pid) {
+    return {
+      valid: false,
+      failureReason: "pid-mismatch",
+      existingPid: existing.pid,
+      expectedPid: process.pid,
+    };
+  }
+
+  return { valid: true };
+}
+
+export function validateSessionLock(basePath: string): boolean {
+  return getSessionLockStatus(basePath).valid;
+}
+
+export function releaseSessionLock(basePath: string): void {
+  const normalizedBasePath = normalizeBasePath(basePath);
+
+  if (_releaseFunction) {
+    try {
+      _releaseFunction();
+    } catch {
+      // may already be released
+    }
+    _releaseFunction = null;
+  }
+
+  const lp = lockPath(normalizedBasePath);
+  try {
+    if (existsSync(lp)) unlinkSync(lp);
+  } catch {
+    // non-fatal
+  }
+
+  try {
+    const lockDir = `${kataStateDir(normalizedBasePath)}.lock`;
+    if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+  } catch {
+    // non-fatal
+  }
+
+  cleanupStrayLockFiles(normalizedBasePath);
+
+  _lockedPath = null;
+  _lockPid = 0;
+  _lockCompromised = false;
+  _lockAcquiredAt = 0;
+  _snapshotLockPath = null;
+}
+
+export function readSessionLockData(basePath: string): SessionLockData | null {
+  return readExistingLockData(lockPath(normalizeBasePath(basePath)));
+}
+
+export function isSessionLockProcessAlive(data: SessionLockData): boolean {
+  return isPidAlive(data.pid);
+}
+
+export function isSessionLockHeld(basePath: string): boolean {
+  const normalizedBasePath = normalizeBasePath(basePath);
+  return _lockedPath === normalizedBasePath && _lockPid === process.pid;
+}
+
+// ─── Internal Helpers ───────────────────────────────────────────────────────
+
+function readExistingLockData(lp: string): SessionLockData | null {
+  try {
+    if (!existsSync(lp)) return null;
+    const raw = readFileSync(lp, "utf-8");
+    return JSON.parse(raw) as SessionLockData;
+  } catch {
+    return null;
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (pid === process.pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EPERM") return true;
+    return false;
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/session-lock.ts
+++ b/apps/cli/src/resources/extensions/kata/session-lock.ts
@@ -23,8 +23,13 @@ import { basename, dirname, join } from "node:path";
 
 import { atomicWriteSync } from "./atomic-write.js";
 import { canonicalizeExistingPath } from "./repo-identity.js";
+import { getMainRepoPath } from "./worktree-resolver.js";
 
-const _require = createRequire(import.meta.url);
+const _require = createRequire(
+  process.env.PI_PACKAGE_DIR
+    ? join(process.env.PI_PACKAGE_DIR, "package.json")
+    : import.meta.url,
+);
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -82,7 +87,12 @@ const LOCK_FILE = "auto.lock";
 const STALE_WINDOW_MS = 1_800_000; // 30m
 
 function normalizeBasePath(basePath: string): string {
-  return canonicalizeExistingPath(basePath);
+  const canonicalBasePath = canonicalizeExistingPath(basePath);
+  try {
+    return getMainRepoPath(canonicalBasePath);
+  } catch {
+    return canonicalBasePath;
+  }
 }
 
 function kataStateDir(basePath: string): string {
@@ -92,6 +102,14 @@ function kataStateDir(basePath: string): string {
 function lockPath(basePath: string): string {
   if (_snapshotLockPath) return _snapshotLockPath;
   return join(kataStateDir(basePath), LOCK_FILE);
+}
+
+function clearHeldLockState(): void {
+  _lockedPath = null;
+  _lockPid = 0;
+  _lockCompromised = false;
+  _lockAcquiredAt = 0;
+  _snapshotLockPath = null;
 }
 
 // ─── Stray Lock Cleanup ─────────────────────────────────────────────────────
@@ -192,9 +210,18 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
       // may already be released
     }
     _releaseFunction = null;
-    _lockedPath = null;
-    _lockPid = 0;
-    _lockCompromised = false;
+    clearHeldLockState();
+  }
+
+  // Holding a lock on a different path. Release before acquiring new path.
+  if (_releaseFunction && _lockedPath && _lockedPath !== normalizedBasePath) {
+    try {
+      _releaseFunction();
+    } catch {
+      // may already be released
+    }
+    _releaseFunction = null;
+    clearHeldLockState();
   }
 
   mkdirSync(dirname(lp), { recursive: true });
@@ -335,9 +362,10 @@ export function updateSessionLock(
 
   const lp = lockPath(normalizedBasePath);
   try {
+    const existing = readExistingLockData(lp);
     const data: SessionLockData = {
       pid: process.pid,
-      startedAt: new Date().toISOString(),
+      startedAt: existing?.startedAt ?? new Date().toISOString(),
       unitType,
       unitId,
       unitStartedAt: new Date().toISOString(),
@@ -435,11 +463,7 @@ export function releaseSessionLock(basePath: string): void {
 
   cleanupStrayLockFiles(normalizedBasePath);
 
-  _lockedPath = null;
-  _lockPid = 0;
-  _lockCompromised = false;
-  _lockAcquiredAt = 0;
-  _snapshotLockPath = null;
+  clearHeldLockState();
 }
 
 export function readSessionLockData(basePath: string): SessionLockData | null {

--- a/apps/cli/src/resources/extensions/kata/tests/repo-identity.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/repo-identity.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+import {
+  getRemoteUrl,
+  isInsideWorktree,
+  repoIdentity,
+  resolveGitCommonDir,
+  validateProjectId,
+} from "../repo-identity.ts";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function detectWorktreeByGit(cwd: string): boolean {
+  const commonDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"])
+    .replaceAll("\\", "/");
+  const gitDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-dir"])
+    .replaceAll("\\", "/");
+  return gitDir.includes("/.git/worktrees/") || gitDir !== commonDir;
+}
+
+describe("repoIdentity", () => {
+  it("returns a stable SHA-256 hash for the same repository", () => {
+    const cwd = process.cwd();
+    const repoHash = repoIdentity(cwd);
+    const nestedHash = repoIdentity(join(cwd, "src", "resources"));
+    assert.equal(repoHash, nestedHash);
+    assert.match(repoHash, /^[a-f0-9]{64}$/);
+  });
+
+  it("uses KATA_PROJECT_ID when present and valid", () => {
+    const original = process.env.KATA_PROJECT_ID;
+    process.env.KATA_PROJECT_ID =
+      "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789";
+    try {
+      const id = repoIdentity(process.cwd());
+      assert.equal(
+        id,
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+      );
+    } finally {
+      if (original === undefined) delete process.env.KATA_PROJECT_ID;
+      else process.env.KATA_PROJECT_ID = original;
+    }
+  });
+});
+
+describe("validateProjectId", () => {
+  it("accepts 64-char SHA-256 hex strings", () => {
+    assert.equal(
+      validateProjectId(
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+      ),
+      true,
+    );
+    assert.equal(
+      validateProjectId(
+        "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+      ),
+      true,
+    );
+  });
+
+  it("rejects invalid project ids", () => {
+    assert.equal(validateProjectId(""), false);
+    assert.equal(validateProjectId("abc123"), false);
+    assert.equal(
+      validateProjectId(
+        "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+      ),
+      false,
+    );
+  });
+});
+
+describe("git helpers", () => {
+  it("isInsideWorktree matches .git file detection", () => {
+    const cwd = process.cwd();
+    assert.equal(isInsideWorktree(cwd), detectWorktreeByGit(cwd));
+  });
+
+  it("resolveGitCommonDir returns a non-empty path", () => {
+    const dir = resolveGitCommonDir(process.cwd());
+    assert.ok(dir.length > 0);
+  });
+
+  it("getRemoteUrl returns a string", () => {
+    const remote = getRemoteUrl(process.cwd());
+    assert.equal(typeof remote, "string");
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/session-lock.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/session-lock.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  acquireSessionLock,
+  isSessionLockHeld,
+  readSessionLockData,
+  releaseSessionLock,
+  updateSessionLock,
+} from "../session-lock.ts";
+
+function makeBaseDir(): string {
+  return mkdtempSync(join(tmpdir(), "kata-session-lock-"));
+}
+
+function lockFile(basePath: string): string {
+  return join(basePath, ".kata-cli", "auto.lock");
+}
+
+function lockDir(basePath: string): string {
+  return `${join(basePath, ".kata-cli")}.lock`;
+}
+
+function seedLockMetadata(basePath: string, pid: number): void {
+  mkdirSync(join(basePath, ".kata-cli"), { recursive: true });
+  writeFileSync(
+    lockFile(basePath),
+    JSON.stringify(
+      {
+        pid,
+        startedAt: new Date().toISOString(),
+        unitType: "execute-task",
+        unitId: "M001/S01/T01",
+        unitStartedAt: new Date().toISOString(),
+        completedUnits: 1,
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+}
+
+describe("session-lock", () => {
+  it("acquire succeeds and release clears lock state", () => {
+    const basePath = makeBaseDir();
+    try {
+      const result = acquireSessionLock(basePath);
+      assert.equal(result.acquired, true);
+      assert.equal(isSessionLockHeld(basePath), true);
+
+      const data = readSessionLockData(basePath);
+      assert.ok(data);
+      assert.equal(data.pid, process.pid);
+
+      releaseSessionLock(basePath);
+      assert.equal(isSessionLockHeld(basePath), false);
+      assert.equal(readSessionLockData(basePath), null);
+    } finally {
+      releaseSessionLock(basePath);
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  it("concurrent acquire reports existing live pid", () => {
+    const basePath = makeBaseDir();
+    const child = spawn(
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1000);"],
+      { stdio: "ignore" },
+    );
+
+    try {
+      assert.ok(child.pid);
+      seedLockMetadata(basePath, child.pid!);
+      mkdirSync(lockDir(basePath), { recursive: true });
+
+      const result = acquireSessionLock(basePath);
+      assert.equal(result.acquired, false);
+      if (!result.acquired) {
+        assert.equal(result.existingPid, child.pid);
+        assert.match(result.reason, /Another auto-mode session/i);
+      }
+    } finally {
+      child.kill("SIGTERM");
+      releaseSessionLock(basePath);
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  it("release then re-acquire succeeds", () => {
+    const basePath = makeBaseDir();
+    try {
+      const first = acquireSessionLock(basePath);
+      assert.equal(first.acquired, true);
+      releaseSessionLock(basePath);
+
+      const second = acquireSessionLock(basePath);
+      assert.equal(second.acquired, true);
+    } finally {
+      releaseSessionLock(basePath);
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  it("readSessionLockData includes updated metadata", () => {
+    const basePath = makeBaseDir();
+    try {
+      const result = acquireSessionLock(basePath);
+      assert.equal(result.acquired, true);
+
+      updateSessionLock(
+        basePath,
+        "execute-task",
+        "M001/S01/T02",
+        3,
+        "/tmp/session.jsonl",
+      );
+
+      const data = readSessionLockData(basePath);
+      assert.ok(data);
+      assert.equal(data.pid, process.pid);
+      assert.equal(data.unitType, "execute-task");
+      assert.equal(data.unitId, "M001/S01/T02");
+      assert.equal(data.completedUnits, 3);
+      assert.equal(data.sessionFile, "/tmp/session.jsonl");
+    } finally {
+      releaseSessionLock(basePath);
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  it("stale lock from dead pid is cleaned up on acquire", () => {
+    const basePath = makeBaseDir();
+    try {
+      const stalePid = 999_999;
+      seedLockMetadata(basePath, stalePid);
+      mkdirSync(lockDir(basePath), { recursive: true });
+      assert.equal(existsSync(lockFile(basePath)), true);
+
+      const result = acquireSessionLock(basePath);
+      assert.equal(result.acquired, true);
+
+      const data = readSessionLockData(basePath);
+      assert.ok(data);
+      assert.equal(data.pid, process.pid);
+    } finally {
+      releaseSessionLock(basePath);
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/session-lock.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/session-lock.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -14,6 +15,27 @@ import {
 
 function makeBaseDir(): string {
   return mkdtempSync(join(tmpdir(), "kata-session-lock-"));
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function initRepoWithWorktree(): { mainRepo: string; worktree: string } {
+  const mainRepo = mkdtempSync(join(tmpdir(), "kata-session-lock-repo-"));
+  const worktree = `${mainRepo}-wt`;
+  git(mainRepo, ["init", "-b", "main"]);
+  git(mainRepo, ["config", "user.name", "Pi Test"]);
+  git(mainRepo, ["config", "user.email", "pi@example.com"]);
+  writeFileSync(join(mainRepo, "README.md"), "hello\n", "utf-8");
+  git(mainRepo, ["add", "README.md"]);
+  git(mainRepo, ["commit", "-m", "init"]);
+  git(mainRepo, ["worktree", "add", worktree]);
+  return { mainRepo, worktree };
 }
 
 function lockFile(basePath: string): string {
@@ -130,6 +152,41 @@ describe("session-lock", () => {
     } finally {
       releaseSessionLock(basePath);
       rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  it("updateSessionLock preserves session startedAt timestamp", () => {
+    const basePath = makeBaseDir();
+    try {
+      const result = acquireSessionLock(basePath);
+      assert.equal(result.acquired, true);
+
+      const before = readSessionLockData(basePath);
+      assert.ok(before);
+
+      updateSessionLock(basePath, "execute-task", "M001/S01/T03", 2);
+
+      const after = readSessionLockData(basePath);
+      assert.ok(after);
+      assert.equal(after.startedAt, before.startedAt);
+    } finally {
+      releaseSessionLock(basePath);
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes worktree paths to a shared repo lock location", () => {
+    const { mainRepo, worktree } = initRepoWithWorktree();
+    try {
+      const acquired = acquireSessionLock(worktree);
+      assert.equal(acquired.acquired, true);
+
+      assert.equal(existsSync(lockFile(mainRepo)), true);
+      assert.equal(existsSync(lockFile(worktree)), false);
+    } finally {
+      releaseSessionLock(worktree);
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(mainRepo, { recursive: true, force: true });
     }
   });
 

--- a/apps/cli/src/resources/extensions/kata/tests/session-lock.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/session-lock.test.ts
@@ -175,6 +175,17 @@ describe("session-lock", () => {
     }
   });
 
+  it("updateSessionLock does not write metadata when no lock is held", () => {
+    const basePath = makeBaseDir();
+    try {
+      updateSessionLock(basePath, "execute-task", "M001/S01/T03", 2);
+      assert.equal(readSessionLockData(basePath), null);
+    } finally {
+      releaseSessionLock(basePath);
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
   it("normalizes worktree paths to a shared repo lock location", () => {
     const { mainRepo, worktree } = initRepoWithWorktree();
     try {
@@ -207,6 +218,42 @@ describe("session-lock", () => {
     } finally {
       releaseSessionLock(basePath);
       rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  it("does not steal a lock when metadata is missing", () => {
+    const basePath = makeBaseDir();
+    try {
+      mkdirSync(lockDir(basePath), { recursive: true });
+      const result = acquireSessionLock(basePath);
+      assert.equal(result.acquired, false);
+    } finally {
+      releaseSessionLock(basePath);
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  it("releaseSessionLock only releases the lock owner path", () => {
+    const ownerPath = makeBaseDir();
+    const otherPath = makeBaseDir();
+    try {
+      const acquired = acquireSessionLock(ownerPath);
+      assert.equal(acquired.acquired, true);
+      assert.equal(isSessionLockHeld(ownerPath), true);
+
+      seedLockMetadata(otherPath, process.pid + 1);
+      mkdirSync(lockDir(otherPath), { recursive: true });
+
+      releaseSessionLock(otherPath);
+
+      assert.equal(isSessionLockHeld(ownerPath), true);
+      assert.equal(existsSync(lockFile(ownerPath)), true);
+      assert.equal(existsSync(lockFile(otherPath)), true);
+      assert.equal(existsSync(lockDir(otherPath)), true);
+    } finally {
+      releaseSessionLock(ownerPath);
+      rmSync(ownerPath, { recursive: true, force: true });
+      rmSync(otherPath, { recursive: true, force: true });
     }
   });
 });

--- a/apps/cli/src/resources/extensions/kata/tests/session-lock.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/session-lock.test.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
 import {
   acquireSessionLock,

--- a/apps/cli/src/resources/extensions/kata/tests/worktree-resolver.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/worktree-resolver.test.ts
@@ -32,8 +32,14 @@ function initMainRepo(): string {
 }
 
 describe("worktree-resolver", () => {
-  it("isInWorktree returns true in this worktree", () => {
-    assert.equal(isInWorktree(process.cwd()), true);
+  it("isInWorktree matches git detection", () => {
+    const cwd = process.cwd();
+    const gitDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-dir"])
+      .replaceAll("\\", "/");
+    const commonDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"])
+      .replaceAll("\\", "/");
+    const expected = gitDir.includes("/.git/worktrees/") || gitDir !== commonDir;
+    assert.equal(isInWorktree(cwd), expected);
   });
 
   it("getWorktreeName returns current worktree name", () => {
@@ -65,7 +71,10 @@ describe("worktree-resolver", () => {
 
   it("resolveWorktreeBasePath returns the effective base path", () => {
     const cwd = process.cwd();
-    assert.equal(resolveWorktreeBasePath(cwd), canonicalizeExistingPath(cwd));
+    const expectedCwd = isInWorktree(cwd)
+      ? getMainRepoPath(cwd)
+      : canonicalizeExistingPath(cwd);
+    assert.equal(resolveWorktreeBasePath(cwd), expectedCwd);
 
     const repo = initMainRepo();
     try {

--- a/apps/cli/src/resources/extensions/kata/tests/worktree-resolver.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/worktree-resolver.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+import { canonicalizeExistingPath } from "../repo-identity.ts";
+import {
+  getMainRepoPath,
+  getWorktreeName,
+  isInWorktree,
+  resolveWorktreeBasePath,
+} from "../worktree-resolver.ts";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function initMainRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kata-worktree-resolver-"));
+  git(dir, ["init", "-b", "main"]);
+  git(dir, ["config", "user.name", "Pi Test"]);
+  git(dir, ["config", "user.email", "pi@example.com"]);
+  writeFileSync(join(dir, "README.md"), "hello\n", "utf-8");
+  git(dir, ["add", "README.md"]);
+  git(dir, ["commit", "-m", "init"]);
+  return dir;
+}
+
+describe("worktree-resolver", () => {
+  it("isInWorktree returns true in this worktree", () => {
+    assert.equal(isInWorktree(process.cwd()), true);
+  });
+
+  it("getWorktreeName returns current worktree name", () => {
+    const cwd = process.cwd();
+    const gitDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-dir"])
+      .replaceAll("\\", "/");
+    const marker = "/.git/worktrees/";
+    const expected = gitDir.includes(marker)
+      ? gitDir.slice(gitDir.indexOf(marker) + marker.length).split("/")[0]
+      : null;
+    assert.equal(getWorktreeName(cwd), expected);
+  });
+
+  it("getWorktreeName returns null in a main repository checkout", () => {
+    const repo = initMainRepo();
+    try {
+      assert.equal(getWorktreeName(repo), null);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("getMainRepoPath resolves the main repo root from a worktree", () => {
+    const cwd = process.cwd();
+    const commonDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+    const expected = canonicalizeExistingPath(resolve(commonDir, ".."));
+    assert.equal(getMainRepoPath(cwd), expected);
+  });
+
+  it("resolveWorktreeBasePath returns the effective base path", () => {
+    const cwd = process.cwd();
+    assert.equal(resolveWorktreeBasePath(cwd), canonicalizeExistingPath(cwd));
+
+    const repo = initMainRepo();
+    try {
+      assert.equal(resolveWorktreeBasePath(repo), canonicalizeExistingPath(repo));
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("getMainRepoPath returns the same repo root when not in a worktree", () => {
+    const repo = initMainRepo();
+    try {
+      const expected = canonicalizeExistingPath(dirname(git(repo, ["rev-parse", "--path-format=absolute", "--git-common-dir"])));
+      assert.equal(getMainRepoPath(repo), expected);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/worktree-resolver.ts
+++ b/apps/cli/src/resources/extensions/kata/worktree-resolver.ts
@@ -69,11 +69,13 @@ export function getMainRepoPath(basePath: string): string {
 
 /**
  * Returns the effective basePath:
- * - worktree path when running in a worktree
- * - provided basePath otherwise
+ * - main repository path when running in a worktree
+ * - provided path (canonicalized) otherwise
  */
 export function resolveWorktreeBasePath(basePath: string): string {
   const canonicalBasePath = canonicalizeExistingPath(basePath);
-  if (isInWorktree(canonicalBasePath)) return canonicalBasePath;
+  if (isInWorktree(canonicalBasePath)) {
+    return getMainRepoPath(canonicalBasePath);
+  }
   return canonicalBasePath;
 }

--- a/apps/cli/src/resources/extensions/kata/worktree-resolver.ts
+++ b/apps/cli/src/resources/extensions/kata/worktree-resolver.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+import {
+  canonicalizeExistingPath,
+  isInsideWorktree,
+  resolveGitCommonDir,
+} from "./repo-identity.js";
+
+function runGit(basePath: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: basePath,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 5_000,
+  }).trim();
+}
+
+function resolveAbsoluteGitDir(basePath: string): string {
+  try {
+    return runGit(basePath, ["rev-parse", "--path-format=absolute", "--git-dir"]);
+  } catch {
+    const raw = runGit(basePath, ["rev-parse", "--git-dir"]);
+    return resolve(basePath, raw);
+  }
+}
+
+/**
+ * Returns true when basePath points at a git worktree checkout.
+ */
+export function isInWorktree(basePath: string): boolean {
+  return isInsideWorktree(basePath);
+}
+
+/**
+ * Returns the worktree name when basePath is a worktree, otherwise null.
+ */
+export function getWorktreeName(basePath: string): string | null {
+  if (!isInWorktree(basePath)) return null;
+
+  const gitDir = resolveAbsoluteGitDir(basePath).replaceAll("\\", "/");
+  const marker = "/.git/worktrees/";
+  const idx = gitDir.indexOf(marker);
+  if (idx < 0) return null;
+
+  const remainder = gitDir.slice(idx + marker.length);
+  const name = remainder.split("/")[0];
+  return name || null;
+}
+
+/**
+ * Resolves the main (non-worktree) repository root path.
+ */
+export function getMainRepoPath(basePath: string): string {
+  const commonDir = resolveGitCommonDir(basePath);
+  const normalized = commonDir.replaceAll("\\", "/");
+
+  if (normalized.endsWith("/.git")) {
+    return canonicalizeExistingPath(resolve(commonDir, ".."));
+  }
+
+  const worktreeMarker = "/.git/worktrees/";
+  if (normalized.includes(worktreeMarker)) {
+    return canonicalizeExistingPath(resolve(commonDir, "..", ".."));
+  }
+
+  return canonicalizeExistingPath(runGit(basePath, ["rev-parse", "--show-toplevel"]));
+}
+
+/**
+ * Returns the effective basePath:
+ * - worktree path when running in a worktree
+ * - provided basePath otherwise
+ */
+export function resolveWorktreeBasePath(basePath: string): string {
+  const canonicalBasePath = canonicalizeExistingPath(basePath);
+  if (isInWorktree(canonicalBasePath)) return canonicalBasePath;
+  return canonicalBasePath;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -88,13 +88,14 @@
     },
     "apps/cli": {
       "name": "@kata-sh/cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "kata-cli": "dist/loader.js",
       },
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.60.0",
         "playwright": "^1.58.2",
+        "proper-lockfile": "^4.1.2",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- ported `atomic-write.ts` and `repo-identity.ts` into the kata extension with naming transforms and helper exports
- ported `session-lock.ts` and wired lock acquire/release/update into auto-mode start/pause/stop flows
- added `worktree-resolver.ts` functional helpers for worktree detection and main-repo resolution
- added focused tests for repo identity, session locking, and worktree resolution
- added `proper-lockfile` dependency used by session-lock

## Validation
- `bun test src/resources/extensions/kata/tests/repo-identity.test.ts`
- `bun test src/resources/extensions/kata/tests/session-lock.test.ts`
- `bun test src/resources/extensions/kata/tests/worktree-resolver.test.ts`
- `npx tsc --noEmit`
- pre-push hook: `turbo run lint typecheck test --affected`

Closes KAT-828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-mode now enforces exclusive per-project session locks to prevent concurrent kata sessions.
  * Stable repository identity mapping and enhanced worktree detection ensure consistent state locations across checkouts.

* **Improvements**
  * Atomic file-write operations for more reliable on-disk state updates.

* **Tests**
  * New test suites covering repo identity, session locking, and worktree resolution.

* **Chores**
  * Added a runtime dependency to support the new locking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports three infrastructure modules — `repo-identity`, `session-lock`, and `worktree-resolver` — into the kata CLI extension, and wires the session lock into the `auto.ts` start/pause/stop lifecycle. The overall architecture is sound and the `atomic-write`, `repo-identity`, and `auto.ts` integration are well-implemented, but two logic bugs were found in `session-lock.ts` and one in `worktree-resolver.ts` that should be addressed before merging.

**Key changes:**
- `repo-identity.ts` — stable SHA-256 repo identity via remote URL + resolved git root, with `KATA_PROJECT_ID` override and `isInsideWorktree` detection
- `session-lock.ts` — OS-level exclusive locking via `proper-lockfile` with stale-lock recovery and diagnostics; **`updateSessionLock` resets `startedAt` on every call** (session start time is lost after the first unit update), and **acquiring a lock on a different path silently leaks the prior OS lock handle**
- `worktree-resolver.ts` — helpers for worktree detection and main-repo resolution; **`resolveWorktreeBasePath` has a dead conditional** where both branches return the same canonicalized path, making the worktree/non-worktree distinction inert
- `auto.ts` — `acquireSessionLock`/`releaseSessionLock`/`updateSessionLock` correctly wired into start/pause/stop flows
- Tests are well-structured with proper temp-directory isolation; one test in `worktree-resolver.test.ts` hardcodes a worktree-context assumption that will fail on main-branch checkouts

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — two logic bugs in session-lock.ts and a dead conditional in worktree-resolver.ts need resolution first.
- Three confirmed logic issues were found: (1) `resolveWorktreeBasePath` has a dead if/else where both branches return the same value, making worktree-aware path resolution non-functional; (2) `updateSessionLock` resets `startedAt` to the current time on every invocation, corrupting diagnostic session-age data; (3) calling `acquireSessionLock` on a second path leaks the OS lock handle for the first path. These are not hypothetical — they directly affect the advertised behavior of the new modules.
- `apps/cli/src/resources/extensions/kata/session-lock.ts` and `apps/cli/src/resources/extensions/kata/worktree-resolver.ts` require fixes before merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/worktree-resolver.ts | New module for worktree detection/resolution; `resolveWorktreeBasePath` has a dead conditional where both branches return the same value, making it a no-op wrapper around `canonicalizeExistingPath`. |
| apps/cli/src/resources/extensions/kata/session-lock.ts | New OS-level session locking module using proper-lockfile; contains two bugs: `updateSessionLock` resets `startedAt` on every call (loses original session start time), and acquiring a lock on a different path leaks the existing OS lock handle. |
| apps/cli/src/resources/extensions/kata/repo-identity.ts | New module for stable repository identity computation via SHA-256; well-structured with graceful fallbacks for old git versions and KATA_PROJECT_ID override support. |
| apps/cli/src/resources/extensions/kata/atomic-write.ts | New utility for atomic file writes (sync and async); correct temp-then-rename pattern with best-effort cleanup on rename failure. |
| apps/cli/src/resources/extensions/kata/auto.ts | Auto-mode now acquires a session lock on start, releases it on stop/pause, and updates it on each dispatched unit; integration looks correct modulo the upstream bugs in session-lock.ts. |
| apps/cli/src/resources/extensions/kata/tests/worktree-resolver.test.ts | Mostly well-written integration tests; the `isInWorktree` test hardcodes a worktree-context assumption that will break on main-branch checkouts. |
| apps/cli/src/resources/extensions/kata/tests/session-lock.test.ts | Good coverage of acquire/release/update/stale-lock scenarios; tests correctly use temp directories and clean up after themselves. |
| apps/cli/src/resources/extensions/kata/tests/repo-identity.test.ts | Solid tests for repo identity hashing, KATA_PROJECT_ID override, and git helpers; env-var state is properly restored in finally blocks. |
| apps/cli/package.json | Adds `proper-lockfile ^4.1.2` as a production dependency to support OS-level locking in session-lock.ts. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller (auto.ts)
    participant SL as session-lock.ts
    participant PL as proper-lockfile
    participant FS as Filesystem

    C->>SL: acquireSessionLock(basePath)
    SL->>FS: mkdirSync(.kata-cli/)
    SL->>SL: cleanupStrayLockFiles()
    SL->>PL: lockSync(.kata-cli/ stateDir)
    PL-->>FS: create .kata-cli.lock/
    PL-->>SL: release()
    SL->>FS: atomicWriteSync(auto.lock, {pid, startedAt, ...})
    SL-->>C: { acquired: true }

    C->>SL: updateSessionLock(basePath, unitType, unitId, n, sessionFile)
    SL->>FS: atomicWriteSync(auto.lock, {pid, startedAt: NOW, unitType, ...})
    Note over SL,FS: ⚠️ startedAt reset to current time

    C->>SL: releaseSessionLock(basePath)
    SL->>PL: release()
    PL-->>FS: remove .kata-cli.lock/
    SL->>FS: unlinkSync(auto.lock)
    SL-->>C: done
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/worktree-resolver.ts
Line: 75-79

Comment:
**Dead conditional — both branches return the same value**

Both the `if (isInWorktree(...))` branch and the `else` path return `canonicalBasePath` unchanged, making the condition completely inert. The function currently behaves identically to `canonicalizeExistingPath(basePath)` for every input. Based on the JSDoc and function name, the worktree branch was likely supposed to return something different (e.g., the main-repo path via `getMainRepoPath(canonicalBasePath)`, or some other resolution). Callers depending on worktree-vs-main differentiation will silently receive the wrong path.

```suggestion
export function resolveWorktreeBasePath(basePath: string): string {
  const canonicalBasePath = canonicalizeExistingPath(basePath);
  if (isInWorktree(canonicalBasePath)) return getMainRepoPath(canonicalBasePath);
  return canonicalBasePath;
}
```
*(Adjust the worktree branch to the intended resolution if `getMainRepoPath` is not the right call.)*

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/session-lock.ts
Line: 338-350

Comment:
**`updateSessionLock` resets `startedAt` on every call**

Every invocation of `updateSessionLock` creates a brand-new `SessionLockData` with `startedAt: new Date().toISOString()`. After the first `dispatchNextUnit` update the lock file's `startedAt` timestamp will reflect the time of that unit dispatch, not when the auto-mode session was originally started. Any diagnostic tooling or conflict resolution logic that reads `startedAt` to understand session age will see an incorrect (too-recent) value.

The `startedAt` from the initial `acquireSessionLock` call should be preserved. One approach is to read the existing metadata and carry the original `startedAt` forward:

```suggestion
export function updateSessionLock(
  basePath: string,
  unitType: string,
  unitId: string,
  completedUnits: number,
  sessionFile?: string,
): void {
  const normalizedBasePath = normalizeBasePath(basePath);
  if (_lockedPath !== normalizedBasePath && _lockedPath !== null) return;

  const lp = lockPath(normalizedBasePath);
  try {
    const existing = readExistingLockData(lp);
    const data: SessionLockData = {
      pid: process.pid,
      startedAt: existing?.startedAt ?? new Date().toISOString(),
      unitType,
      unitId,
      unitStartedAt: new Date().toISOString(),
      completedUnits,
      sessionFile,
    };
    atomicWriteSync(lp, JSON.stringify(data, null, 2));
  } catch {
    // non-fatal
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/session-lock.ts
Line: 183-200

Comment:
**OS lock leaked when acquiring on a different path**

The re-entrant guard on line 188 only releases the existing lock when the *same* path is re-acquired. If `_releaseFunction` is non-null and `_lockedPath !== normalizedBasePath` (i.e., a lock is already held on path A and `acquireSessionLock(pathB)` is called), the guard does not fire. Execution continues to the `lockfile.lockSync` call, and on success `_releaseFunction` is silently overwritten (line 241), permanently losing the release handle for the path-A lock. The OS-level lock directory for path A then persists until process exit.

Adding an explicit check before attempting a new acquire would prevent the leak:

```
// After the same-path re-entrant block, add:
if (_releaseFunction && _lockedPath !== null && _lockedPath !== normalizedBasePath) {
  // Existing lock on a different path — release it before acquiring the new one.
  try { _releaseFunction(); } catch { /* best-effort */ }
  _releaseFunction = null;
  _lockedPath = null;
  _lockPid = 0;
  _lockCompromised = false;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/tests/worktree-resolver.test.ts
Line: 35-37

Comment:
**Test hardcodes a worktree context assumption**

`assert.equal(isInWorktree(process.cwd()), true)` will always fail when the test suite is run from the main repository checkout (e.g., in a fresh CI clone or by a contributor who hasn't checked out a worktree). The adjacent `getWorktreeName` test handles this gracefully by computing the expected value dynamically; apply the same pattern here:

```suggestion
  it("isInWorktree matches git detection", () => {
    const cwd = process.cwd();
    const gitDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-dir"]).replaceAll("\\", "/");
    const commonDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]).replaceAll("\\", "/");
    const expected = gitDir.includes("/.git/worktrees/") || gitDir !== commonDir;
    assert.equal(isInWorktree(cwd), expected);
  });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(kata): port S03..."](https://github.com/gannonh/kata/commit/b8e71224bc9859b18ea293da9ed640f8c7f2b5cf)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->