### PR TITLE
fix(cli): resolve KAT-887 kata test failures

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -42,6 +42,8 @@
   },
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.60.0",
+    "@mariozechner/pi-tui": "^0.60.0",
+    "@sinclair/typebox": "^0.34.48",
     "playwright": "^1.58.2",
     "proper-lockfile": "^4.1.2"
   },

--- a/apps/cli/src/resources/extensions/kata/session-lock.ts
+++ b/apps/cli/src/resources/extensions/kata/session-lock.ts
@@ -226,6 +226,18 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
 
   mkdirSync(dirname(lp), { recursive: true });
   cleanupStrayLockFiles(normalizedBasePath);
+  const stateDir = kataStateDir(normalizedBasePath);
+  const lockDir = `${stateDir}.lock`;
+
+  // If the lock directory exists but metadata is missing, lock ownership is
+  // indeterminate. Refuse to acquire to avoid stealing an unknown lock owner.
+  if (existsSync(lockDir) && !readExistingLockData(lp)) {
+    return {
+      acquired: false,
+      reason:
+        "Session lock metadata is missing for an existing lock directory. Refusing to acquire.",
+    };
+  }
 
   const lockData: SessionLockData = {
     pid: process.pid,
@@ -242,8 +254,6 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
   } catch {
     return acquireFallbackLock(normalizedBasePath, lp, lockData);
   }
-
-  const stateDir = kataStateDir(normalizedBasePath);
 
   try {
     mkdirSync(stateDir, { recursive: true });

--- a/apps/cli/src/resources/extensions/kata/session-lock.ts
+++ b/apps/cli/src/resources/extensions/kata/session-lock.ts
@@ -291,7 +291,6 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
 
     if (existingPid && !isPidAlive(existingPid)) {
       try {
-        const lockDir = `${stateDir}.lock`;
         if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
         if (existsSync(lp)) unlinkSync(lp);
 

--- a/apps/cli/src/resources/extensions/kata/tests/repo-identity.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/repo-identity.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
 import {
   getRemoteUrl,

--- a/apps/cli/src/resources/extensions/kata/tests/resolve-ts.mjs
+++ b/apps/cli/src/resources/extensions/kata/tests/resolve-ts.mjs
@@ -7,5 +7,20 @@
 
 import { register } from 'node:module';
 import { pathToFileURL } from 'node:url';
+import { after, afterEach, before, beforeEach, describe, it, test } from 'node:test';
+
+// Provide Bun-like test globals when running Node's test runner so legacy tests
+// that use bare `test()` / `describe()` remain executable.
+Object.assign(globalThis, {
+  after,
+  afterAll: after,
+  afterEach,
+  before,
+  beforeAll: before,
+  beforeEach,
+  describe,
+  it,
+  test,
+});
 
 register(new URL('./resolve-ts-hooks.mjs', import.meta.url), pathToFileURL('./'));

--- a/apps/cli/src/resources/extensions/kata/tests/worktree-resolver.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/worktree-resolver.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
 
 import { canonicalizeExistingPath } from "../repo-identity.ts";
 import {

--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,8 @@
       },
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.60.0",
+        "@mariozechner/pi-tui": "^0.60.0",
+        "@sinclair/typebox": "^0.34.48",
         "playwright": "^1.58.2",
         "proper-lockfile": "^4.1.2",
       },


### PR DESCRIPTION
## Summary
- add missing Node test BDD imports in `repo-identity.test.ts` and `worktree-resolver.test.ts`
- harden `acquireSessionLock` to refuse acquisition when lock metadata is missing
- expose Node test globals in `resolve-ts.mjs` so the Node runner can execute existing bare `test`/`describe` suites
- add direct CLI deps for imported modules: `@mariozechner/pi-tui` and `@sinclair/typebox`

## Validation
- `cd apps/cli && node --import ./src/resources/extensions/kata/tests/resolve-ts.mjs --experimental-strip-types --test 'src/resources/extensions/kata/tests/repo-identity.test.ts' 'src/resources/extensions/kata/tests/session-lock.test.ts' 'src/resources/extensions/kata/tests/worktree-resolver.test.ts'`
- `cd apps/cli && node --import ./src/resources/extensions/kata/tests/resolve-ts.mjs --experimental-strip-types --test 'src/resources/extensions/kata/tests/*.test.ts' 'src/tests/*.test.ts'`
- `cd apps/cli && npx tsc --noEmit`

Closes KAT-887


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session lock acquisition now validates lock metadata before taking a lock, preventing stale or unreadable-lock scenarios.

* **Tests**
  * Test infrastructure updated to support Node.js built-in test runner so existing tests run without code changes.

* **Chores**
  * Updated CLI runtime dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes failing kata test suite runs by adding missing Node test runner imports, hardening lock acquisition against indeterminate-ownership edge cases, and promoting two transitive dependencies to explicit direct deps.

- **Test imports** (`repo-identity.test.ts`, `worktree-resolver.test.ts`): Added `import { describe, it } from "node:test"` so these files are self-contained when run directly via `node --test` rather than relying on Bun globals.
- **Global shim** (`resolve-ts.mjs`): The `--import` loader now injects Bun-compatible aliases (`beforeAll`/`afterAll`, bare `test`, etc.) into `globalThis`, allowing legacy suites that omit the import to execute correctly under Node's test runner.
- **Lock hardening** (`session-lock.ts`): A new guard before the `lockSync` call returns `acquired: false` when the proper-lockfile directory (`.kata-cli.lock`) exists but the JSON metadata file (`auto.lock`) is absent. This prevents silently stealing a lock whose owner is unknown. The `stateDir`/`lockDir` variables were hoisted out of the `try` block to make them available for this check.
- **Dependencies** (`package.json` / `bun.lock`): `@mariozechner/pi-tui` and `@sinclair/typebox` are now declared as direct dependencies instead of relying on transitive resolution through `@mariozechner/pi-coding-agent`.

<h3>Confidence Score: 4/5</h3>

- PR is safe to merge; all changes are targeted bug fixes with corresponding tests and no breaking API surface.
- The logic changes are narrow and well-tested (a dedicated `session-lock.test.ts` case covers the new guard), the test-infrastructure fixes are straightforward, and the dependency additions are low-risk promotions of already-used packages. One minor variable-shadowing issue exists in `session-lock.ts` but does not affect correctness.
- apps/cli/src/resources/extensions/kata/session-lock.ts — review the `lockDir` shadowing inside the catch block.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/session-lock.ts | Adds a pre-acquisition guard that refuses to take the lock when the proper-lockfile directory exists but JSON metadata is absent, preventing silent ownership theft. Minor: the outer-scope `lockDir` const is shadowed by a redundant re-declaration inside the catch block. |
| apps/cli/src/resources/extensions/kata/tests/resolve-ts.mjs | Injects Bun-compatible test globals (`test`, `describe`, `it`, `before`/`beforeAll`, `after`/`afterAll`, `beforeEach`, `afterEach`) into `globalThis` via the `--import` loader, enabling legacy bare-`test()` suites to run under Node's test runner without modification. |
| apps/cli/src/resources/extensions/kata/tests/repo-identity.test.ts | Adds missing `import { describe, it } from "node:test"` so explicit Node test runner invocations no longer rely solely on globals. Straightforward fix. |
| apps/cli/src/resources/extensions/kata/tests/worktree-resolver.test.ts | Same as `repo-identity.test.ts` — adds explicit `import { describe, it } from "node:test"` for Node runner compatibility. |
| apps/cli/package.json | Promotes `@mariozechner/pi-tui` and `@sinclair/typebox` from implicit transitive to declared direct dependencies; `bun.lock` updated accordingly. |
| bun.lock | Lock file updated to reflect the two newly declared direct dependencies; no other changes. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[acquireSessionLock called] --> B[mkdirSync + cleanupStrayLockFiles]
    B --> C{lockDir exists?}
    C -- No --> E[Build lockData]
    C -- Yes --> D{readExistingLockData?}
    D -- Missing metadata --> REFUSE[Return acquired: false\nmetadata missing guard NEW]
    D -- Metadata present --> E
    E --> F{proper-lockfile available?}
    F -- No --> FALLBACK[acquireFallbackLock]
    F -- Yes --> G[lockSync stateDir]
    G -- Success --> H[Write metadata\nReturn acquired: true]
    G -- ELOCKED thrown --> I{existingPid alive?}
    I -- Dead pid --> J[Remove lockDir + lockFile\nRetry lockSync]
    J -- Success --> H
    J -- Fail --> CONTEND[Return acquired: false\ncontention]
    I -- Alive or unknown --> CONTEND
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/cli/src/resources/extensions/kata/session-lock.ts`, line 294-295 ([link](https://github.com/gannonh/kata/blob/9ae40be01dab5d3dc957674fea4fe7c5b1bec5bd/apps/cli/src/resources/extensions/kata/session-lock.ts#L294-L295)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`lockDir` variable shadows outer declaration**

   The outer scope of `acquireSessionLock` now declares `const lockDir` at line 230, but the `catch` block at line 294 re-declares an identical `const lockDir` (same expression: `` `${stateDir}.lock` ``). This shadowing is harmless in practice (both resolve to the same value), but it will trigger no-shadow ESLint/TypeScript rules and creates unnecessary confusion. The inner declaration should be removed in favour of referencing the outer `lockDir`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/extensions/kata/session-lock.ts
   Line: 294-295

   Comment:
   **`lockDir` variable shadows outer declaration**

   The outer scope of `acquireSessionLock` now declares `const lockDir` at line 230, but the `catch` block at line 294 re-declares an identical `const lockDir` (same expression: `` `${stateDir}.lock` ``). This shadowing is harmless in practice (both resolve to the same value), but it will trigger no-shadow ESLint/TypeScript rules and creates unnecessary confusion. The inner declaration should be removed in favour of referencing the outer `lockDir`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/session-lock.ts
Line: 294-295

Comment:
**`lockDir` variable shadows outer declaration**

The outer scope of `acquireSessionLock` now declares `const lockDir` at line 230, but the `catch` block at line 294 re-declares an identical `const lockDir` (same expression: `` `${stateDir}.lock` ``). This shadowing is harmless in practice (both resolve to the same value), but it will trigger no-shadow ESLint/TypeScript rules and creates unnecessary confusion. The inner declaration should be removed in favour of referencing the outer `lockDir`.

```suggestion
        if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix(cli): resolve KA..."](https://github.com/gannonh/kata/commit/9ae40be01dab5d3dc957674fea4fe7c5b1bec5bd)</sub>

<!-- /greptile_comment -->