### PR TITLE
CLI v0.5.0

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **Test suite fixes** — resolved `describe`/`it` not defined errors in repo-identity and worktree-resolver tests (missing `node:test` imports). Fixed session-lock logic to not steal locks when metadata is missing.
 - **Subagent cleanup** — try/finally for worker registry cleanup on abort, consistent stopReason failure detection, cancel dangling timers, fix 59999ms elapsed rounding.
 - **Search provider review fixes** — budgetGrounding math, tool restore, maxUrls, cache, notification improvements.
+- **Remove Opus 4.6 context window patch** — upstream pi-ai 0.60.0 now has the correct 1M context window for `claude-opus-4-6`. Removed the runtime patches from `cli.ts` and `kata/index.ts` (KAT-487).
 
 ## 0.4.1
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.5.0
+
+### Features
+
+- **Session lock for auto-mode** — OS-level exclusive locking prevents multiple kata processes from running auto-mode concurrently on the same project. Uses `proper-lockfile` for cross-platform file locking with stale lock detection and metadata tracking (PID, hostname, timestamp).
+- **Repo identity** — stable SHA-256 fingerprint for any git repository, consistent across subdirectories and worktrees. Used for session lock isolation and state management.
+- **Worktree resolver** — resolves git worktree paths, finds the main repo from a worktree, and maps paths between worktrees. Enables correct behavior in monorepo worktree setups.
+- **Atomic file writes** — crash-safe file writes using rename-into-place pattern via `atomic-write.ts`. Prevents partial writes on crash or power loss.
+- **Subagent worker registry** — global registry of active subagent sessions for dashboard visibility. Tracks agent name, task, status, start time, and batch ID.
+- **Subagent elapsed timing** — parallel, chain, and single subagent calls now show elapsed time in output. Chain mode shows per-step and total timing. Error messages include elapsed time.
+- **Search provider abstraction** — pluggable search provider layer with Tavily support. `tool-search.ts` and `tool-llm-context.ts` routed through the provider abstraction. Native search extracted to `native-search.ts`.
+
+### Fixes
+
+- **Test suite fixes** — resolved `describe`/`it` not defined errors in repo-identity and worktree-resolver tests (missing `node:test` imports). Fixed session-lock logic to not steal locks when metadata is missing.
+- **Subagent cleanup** — try/finally for worker registry cleanup on abort, consistent stopReason failure detection, cancel dangling timers, fix 59999ms elapsed rounding.
+- **Search provider review fixes** — budgetGrounding math, tool restore, maxUrls, cache, notification improvements.
+
 ## 0.4.1
 
 ### Features

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -75,18 +75,6 @@ if (!isPrintMode) {
 
 const modelRegistry = new ModelRegistry(authStorage)
 
-// TODO(KAT-487): Remove this patch once pi-ai updates models.generated.js.
-// Opus 4.6 context window — upstream pi-ai still has 200K, actual is 1M.
-const OPUS_CONTEXT_PATCHES: Record<string, number> = {
-  'claude-opus-4-6': 1_000_000,
-}
-for (const [modelId, contextWindow] of Object.entries(OPUS_CONTEXT_PATCHES)) {
-  const model = modelRegistry.find('anthropic', modelId)
-  if (model && model.contextWindow < contextWindow) {
-    model.contextWindow = contextWindow
-  }
-}
-
 const settingsManager = SettingsManager.create(agentDir)
 
 // Always ensure defaults: anthropic/claude-sonnet-4-6, thinking off.

--- a/apps/cli/src/resources/AGENTS.md
+++ b/apps/cli/src/resources/AGENTS.md
@@ -28,13 +28,23 @@ apps/cli/
       agents/              — Agent prompt templates (worker, scout, researcher)
       extensions/
         kata/              — Main extension: /kata command, auto-mode, planning, state
+          auto.ts          — Auto-mode loop with session lock integration
+          session-lock.ts  — OS-level exclusive locking for auto-mode sessions
+          repo-identity.ts — Stable SHA-256 repo fingerprint across subdirs/worktrees
+          worktree-resolver.ts — Git worktree path resolution
+          atomic-write.ts  — Crash-safe file writes (rename-into-place)
         browser-tools/     — Playwright-based browser automation
         subagent/          — Spawns child kata processes for parallel work
+          worker-registry.ts — Global registry of active subagent sessions
+          elapsed.ts       — Human-readable elapsed time formatting
         slash-commands/     — create-slash-command, create-extension, audit slash commands
         shared/            — Shared UI components used by multiple extensions
         bg-shell/          — Background shell execution
         context7/          — Context7 library documentation lookup
-        search-the-web/    — Web search via Brave API
+        search-the-web/    — Web search via Brave API + pluggable provider abstraction
+          provider.ts      — Search provider interface and registry
+          tavily.ts        — Tavily search provider implementation
+          native-search.ts — Brave native search (default provider)
         mac-tools/         — macOS-specific utilities
         linear/            — Built-in Linear integration (GraphQL client + tools)
       skills/              — Bundled skills

--- a/apps/cli/src/resources/KATA-WORKFLOW.md
+++ b/apps/cli/src/resources/KATA-WORKFLOW.md
@@ -5,7 +5,7 @@
 > **When to read this:** At the start of any session working on Kata-managed work, or when told `read @KATA-WORKFLOW.md`.
 >
 > **After reading this:**
-> - **File mode:** Read `.kata/state.md` to find out what's next. If the milestone has a `context.md`, read that too.
+> - **File mode:** Read `.kata/STATE.md` to find out what's next. If the milestone has a `CONTEXT.md`, read that too.
 > - **Linear mode:** Call `kata_derive_state` to find out what's next. Do not read `.kata/` files — all state and artifacts live in Linear.
 
 ---
@@ -16,13 +16,13 @@
 
 Read these files in order and act on what they say:
 
-1. **`.kata/state.md`** — Where are we? What's the next action?
-2. **`.kata/milestones/<active>/roadmap.md`** — What's the plan? Which slices are done? (state.md tells you which milestone is active)
-3. **`.kata/milestones/<active>/context.md`** — Project-specific decisions, reference paths, constraints. Read this before doing implementation work.
-4. If a slice is active, read its **`plan.md`** — Which tasks exist? Which are done?
+1. **`.kata/STATE.md`** — Where are we? What's the next action?
+2. **`.kata/milestones/<active>/ROADMAP.md`** — What's the plan? Which slices are done? (STATE.md tells you which milestone is active)
+3. **`.kata/milestones/<active>/CONTEXT.md`** — Project-specific decisions, reference paths, constraints. Read this before doing implementation work.
+4. If a slice is active, read its **`PLAN.md`** — Which tasks exist? Which are done?
 5. If a task was interrupted, check for **`continue.md`** in the active slice directory — Resume from there.
 
-Then do the thing `state.md` says to do next.
+Then do the thing `STATE.md` says to do next.
 
 ### Linear Mode
 
@@ -97,25 +97,25 @@ All artifacts live in `.kata/` at the project root:
 
 ```
 .kata/
-  state.md                                  # Dashboard — always read first
-  decisions.md                              # Append-only decisions register
+  STATE.md                                  # Dashboard — always read first
+  DECISIONS.md                              # Append-only decisions register
   milestones/
     M001/
-      roadmap.md                            # Milestone plan (checkboxes = state)
-      context.md                            # Optional: user decisions from discuss phase
-      research.md                           # Optional: codebase/tech research
-      summary.md                            # Milestone rollup (updated as slices complete)
+      ROADMAP.md                            # Milestone plan (checkboxes = state)
+      CONTEXT.md                            # Optional: user decisions from discuss phase
+      RESEARCH.md                           # Optional: codebase/tech research
+      SUMMARY.md                            # Milestone rollup (updated as slices complete)
       slices/
         S01/
-          plan.md                           # Task decomposition for this slice
-          context.md                        # Optional: slice-level user decisions
-          research.md                       # Optional: slice-level research
-          summary.md                        # Slice summary (written on completion)
-          uat.md                            # Non-blocking human test script (written on completion)
+          PLAN.md                           # Task decomposition for this slice
+          CONTEXT.md                        # Optional: slice-level user decisions
+          RESEARCH.md                       # Optional: slice-level research
+          SUMMARY.md                        # Slice summary (written on completion)
+          UAT.md                            # Non-blocking human test script (written on completion)
           continue.md                       # Ephemeral: resume point if interrupted
           tasks/
-            T01-plan.md                     # Individual task plan
-            T01-summary.md                  # Task summary with frontmatter
+            T01-PLAN.md                     # Individual task plan
+            T01-SUMMARY.md                  # Task summary with frontmatter
 ```
 
 ### Artifact Storage (Linear Mode)
@@ -152,7 +152,7 @@ Titles are unique within the project scope. `kata_write_document` is an upsert �
 
 ## File Format Reference
 
-### `roadmap.md`
+### `ROADMAP.md`
 
 ```markdown
 # M001: Title of the Milestone
@@ -181,7 +181,7 @@ Titles are unique within the project scope. `kata_write_document` is an upsert �
 
 > **Linear mode:** Same format, stored as `M001-ROADMAP` document. In Linear mode, use `* [ ]` and `* [x]` instead of `- [ ]` and `- [x]` for D028 compatibility.
 
-**Boundary Map** (required section in roadmap.md):
+**Boundary Map** (required section in ROADMAP.md):
 
 After the slices section, include a `## Boundary Map` that shows what each slice produces and consumes:
 
@@ -211,7 +211,7 @@ The boundary map is a **planning artifact** — not runnable code. It:
 - Enables deterministic verification that slices actually connect
 - Gets updated during slice planning if new interfaces emerge
 
-### `plan.md` (slice-level)
+### `PLAN.md` (slice-level)
 
 ```markdown
 # S01: Slice Title
@@ -236,7 +236,7 @@ The boundary map is a **planning artifact** — not runnable code. It:
 - path/to/another.ts
 ```
 
-### `TNN-plan.md` (task-level)
+### `TNN-PLAN.md` (task-level)
 
 ```markdown
 # T01: Task Title
@@ -276,7 +276,7 @@ Critical wiring between artifacts:
 
 **Must-haves are what make verification mechanically checkable.** Truths are checked by running commands or reading output. Artifacts are checked by confirming files exist with real content. Key links are checked by confirming imports/references actually connect the pieces.
 
-### `state.md`
+### `STATE.md`
 
 ```markdown
 # Kata State
@@ -297,9 +297,9 @@ Critical wiring between artifacts:
 Exact next thing to do.
 ```
 
-> **Linear mode:** There is no `state.md`. Call `kata_derive_state` instead — it returns equivalent information as a JSON object.
+> **Linear mode:** There is no `STATE.md`. Call `kata_derive_state` instead — it returns equivalent information as a JSON object.
 
-### `context.md` (from discuss phase)
+### `CONTEXT.md` (from discuss phase)
 
 ```markdown
 # S01: Slice Title — Context
@@ -318,7 +318,7 @@ Exact next thing to do.
 - Ideas that came up but belong in other slices
 ```
 
-### `decisions.md` (append-only register)
+### `DECISIONS.md` (append-only register)
 
 ```markdown
 # Decisions Register
@@ -357,7 +357,7 @@ Work flows through these phases. Each phase produces a file (or a LinearDocument
 ### Phase 1: Discuss (Optional)
 
 **Purpose:** Capture user decisions on gray areas before planning.
-**Produces:** `context.md` at milestone or slice level.
+**Produces:** `CONTEXT.md` at milestone or slice level.
 **When to use:** When the scope has ambiguities the user should weigh in on.
 **When to skip:** When the user already knows exactly what they want, or told you to just go.
 
@@ -365,7 +365,7 @@ Work flows through these phases. Each phase produces a file (or a LinearDocument
 1. Read the roadmap to understand the scope.
 2. Identify 3-5 gray areas — implementation decisions the user cares about.
 3. Use `ask_user_questions` to discuss each area.
-4. Write decisions to `context.md`.
+4. Write decisions to `CONTEXT.md`.
 5. Do NOT discuss how to implement — only what the user wants.
 
 > **Linear mode:** Do NOT create `.kata/milestones/` directories. Do NOT write files to disk. Do NOT run `mkdir` or `git commit` for planning artifacts. Write all documents (PROJECT, REQUIREMENTS, CONTEXT, ROADMAP, DECISIONS) via `kata_write_document`. Create milestones via `kata_create_milestone`. Linear IS the store — no local files.
@@ -373,15 +373,15 @@ Work flows through these phases. Each phase produces a file (or a LinearDocument
 ### Phase 2: Research (Optional)
 
 **Purpose:** Scout the codebase and relevant docs before planning.
-**Produces:** `research.md` at milestone or slice level.
+**Produces:** `RESEARCH.md` at milestone or slice level.
 **When to use:** When working in unfamiliar code, with unfamiliar libraries, or on complex integrations.
 **When to skip:** When the codebase is familiar and the work is straightforward.
 
 **How to do it manually:**
-1. Read `context.md` if it exists — know what decisions are locked.
+1. Read `CONTEXT.md` if it exists — know what decisions are locked.
 2. Scout relevant code: `rg`, `find`, read key files.
 3. Use `resolve_library` / `get_library_docs` if needed.
-4. Write findings to `research.md` with these sections:
+4. Write findings to `RESEARCH.md` with these sections:
 
 ```markdown
 # S01: Slice Title — Research
@@ -418,24 +418,24 @@ The **Don't Hand-Roll** and **Common Pitfalls** sections prevent the most expens
 ### Phase 3: Plan
 
 **Purpose:** Decompose work into context-window-sized tasks with must-haves.
-**Produces:** `plan.md` + individual `T01-plan.md` files.
+**Produces:** `PLAN.md` + individual `T01-PLAN.md` files.
 
 **For a milestone (roadmap):**
-1. Read `context.md`, `research.md`, and `.kata/decisions.md` if they exist.
+1. Read `CONTEXT.md`, `RESEARCH.md`, and `.kata/DECISIONS.md` if they exist.
 2. Decompose the vision into 4-10 demoable vertical slices.
 3. Order by risk (high-risk first to validate feasibility early).
-4. Write `roadmap.md` with checkboxes, risk levels, dependencies, demo sentences.
+4. Write `ROADMAP.md` with checkboxes, risk levels, dependencies, demo sentences.
 5. **Write the boundary map** — for each slice, specify what it produces (functions, types, interfaces, endpoints) and what it consumes from upstream slices. This forces interface thinking before implementation and enables deterministic verification that slices actually connect.
 
 **For a slice (task decomposition):**
-1. Read the slice's entry in `roadmap.md` **and its boundary map section** — know what interfaces this slice must produce and consume.
-2. Read `context.md`, `research.md`, and `.kata/decisions.md` if they exist for this slice.
+1. Read the slice's entry in `ROADMAP.md` **and its boundary map section** — know what interfaces this slice must produce and consume.
+2. Read `CONTEXT.md`, `RESEARCH.md`, and `.kata/DECISIONS.md` if they exist for this slice.
 3. Read summaries from dependency slices (check `depends:[]` in roadmap).
 4. Verify that upstream slices' actual outputs match what the boundary map says this slice consumes. If they diverge, update the boundary map.
 5. Decompose into 1-7 tasks, each fitting one context window.
 6. Each task needs: title, description, steps (3-10), must-haves (observable verification criteria).
 7. Must-haves should reference boundary map contracts — e.g. "exports `generateToken()` as specified in boundary map S01→S02".
-8. Write `plan.md` and individual `TNN-plan.md` files.
+8. Write `PLAN.md` and individual `TNN-PLAN.md` files.
 
 ### Phase 4: Execute
 
@@ -443,10 +443,10 @@ The **Don't Hand-Roll** and **Common Pitfalls** sections prevent the most expens
 **Produces:** Code changes + `[DONE:n]` markers.
 
 **How to do it manually:**
-1. Read the task's `TNN-plan.md`.
+1. Read the task's `TNN-PLAN.md`.
 2. Read relevant summaries from prior tasks (for context on what's already built).
 3. Execute each step. Mark progress with `[DONE:n]` in responses.
-4. If you made an architectural, pattern, or library decision, append it to `.kata/decisions.md`.
+4. If you made an architectural, pattern, or library decision, append it to `.kata/DECISIONS.md`.
 5. If interrupted or context is getting full, write `continue.md` (see below).
 
 > **Linear mode:** Read the task plan via `kata_read_document("T01-PLAN")`. Append decisions via `kata_write_document("DECISIONS", ...)`. There is no `continue.md` — issue state is the continue protocol (see below).
@@ -496,7 +496,7 @@ When verification finds gaps, include a **Gaps** section with what's missing, im
 ### Phase 6: Summarize
 
 **Purpose:** Record what happened for downstream tasks.
-**Produces:** `TNN-summary.md`, and when slice completes, `summary.md`.
+**Produces:** `TNN-SUMMARY.md`, and when slice completes, `SUMMARY.md`.
 
 **Task summary format:**
 ```markdown
@@ -517,7 +517,7 @@ key_decisions:
 patterns_established:
   - "Pattern name and where it lives"
 drill_down_paths:
-  - .kata/milestones/M001/slices/S01/tasks/T01-plan.md
+  - .kata/milestones/M001/slices/S01/tasks/T01-PLAN.md
 duration: 15min
 verification_result: pass
 completed_at: 2026-03-07T16:00:00Z
@@ -541,7 +541,7 @@ What differed from the plan and why (or "None").
 
 The one-liner must be substantive: "JWT auth with refresh rotation using jose" not "Authentication implemented."
 
-**Slice summary:** Written when all tasks in a slice complete. Compresses all task summaries. Includes `drill_down_paths` to each task summary. During slice completion, review task summaries for `key_decisions` and ensure any significant ones are captured in `.kata/decisions.md`.
+**Slice summary:** Written when all tasks in a slice complete. Compresses all task summaries. Includes `drill_down_paths` to each task summary. During slice completion, review task summaries for `key_decisions` and ensure any significant ones are captured in `.kata/DECISIONS.md`.
 
 **Milestone summary:** Updated each time a slice completes. Compresses all slice summaries. This is what gets injected into later slice planning instead of loading many individual summaries.
 
@@ -552,16 +552,16 @@ The one-liner must be substantive: "JWT auth with refresh rotation using jose" n
 **Purpose:** Mark work done and move to the next thing.
 
 **After a task completes:**
-1. Mark the task done in `plan.md` (checkbox).
+1. Mark the task done in `PLAN.md` (checkbox).
 2. Check if there's a next task in the slice → execute it.
-3. If slice is complete → write slice summary, mark slice done in `roadmap.md`.
+3. If slice is complete → write slice summary, mark slice done in `ROADMAP.md`.
 
 **After a slice completes:**
-1. Write slice `summary.md` (compresses all task summaries).
-2. Write slice `uat.md` — a non-blocking human test script derived from the slice's must-haves and demo sentence. The agent does NOT wait for UAT results.
-3. Mark the slice checkbox in `roadmap.md` as `[x]`.
-4. Update `state.md` with new position.
-5. Update milestone `summary.md` with the completed slice's contributions.
+1. Write slice `SUMMARY.md` (compresses all task summaries).
+2. Write slice `UAT.md` — a non-blocking human test script derived from the slice's must-haves and demo sentence. The agent does NOT wait for UAT results.
+3. Mark the slice checkbox in `ROADMAP.md` as `[x]`.
+4. Update `STATE.md` with new position.
+5. Update milestone `SUMMARY.md` with the completed slice's contributions.
 6. Continue to next slice immediately. The user tests the UAT whenever convenient.
 7. If the user reports UAT failures later, create fix tasks in the current or a new slice.
 8. If all slices done → milestone complete.
@@ -632,23 +632,23 @@ The EXACT first thing to do when resuming. Not vague. Specific.
 
 ## State Management
 
-### `state.md` is a derived cache
+### `STATE.md` is a derived cache
 
 It is NOT the source of truth. It's a convenience dashboard.
 
 **Sources of truth:**
-- `roadmap.md` → which slices exist and which are done
-- `plan.md` → which tasks exist within a slice
-- `TNN-summary.md` → what happened during a task
-- `summary.md` (slice/milestone) → compressed outcomes
+- `ROADMAP.md` → which slices exist and which are done
+- `PLAN.md` → which tasks exist within a slice
+- `TNN-SUMMARY.md` → what happened during a task
+- `SUMMARY.md` (slice/milestone) → compressed outcomes
 
-**Update `state.md`** after every significant action:
+**Update `STATE.md`** after every significant action:
 - Active milestone/slice/task
 - Recent decisions (last 3-5)
 - Blockers
 - Next action (most important — this is what a fresh session reads first)
 
-> **Linear mode:** `kata_derive_state` replaces `state.md`. It derives state from Linear issue states and milestone structure. No need to manually update state — Linear issue state IS the source of truth.
+> **Linear mode:** `kata_derive_state` replaces `STATE.md`. It derives state from Linear issue states and milestone structure. No need to manually update state — Linear issue state IS the source of truth.
 
 ### Reconciliation
 
@@ -732,9 +732,9 @@ Tasks completed:
 
 When planning or executing a task, load relevant prior context:
 
-1. Check the current slice's `depends:[]` in `roadmap.md`.
+1. Check the current slice's `depends:[]` in `ROADMAP.md`.
 2. Load summaries from those dependency slices.
-3. Start with the **highest available level** — milestone `summary.md` first.
+3. Start with the **highest available level** — milestone `SUMMARY.md` first.
 4. Only drill down to slice/task summaries if you need specific detail.
 5. Stay within **~2500 tokens** of total injected summary context.
 6. If the dependency chain is too large, drop the oldest/least-relevant summaries first.
@@ -753,11 +753,11 @@ These are soft caps — exceed them when genuinely needed, but don't let summari
 
 ## Project-Specific Context
 
-This methodology doc is generic. Project-specific guidance belongs in the milestone's `context.md`:
+This methodology doc is generic. Project-specific guidance belongs in the milestone's `CONTEXT.md`:
 
-- **`.kata/milestones/<active>/context.md`** — Architecture decisions, reference file paths, per-slice doc reading guides, implementation constraints, and any project-specific protocols (worktrees, testing, etc.)
+- **`.kata/milestones/<active>/CONTEXT.md`** — Architecture decisions, reference file paths, per-slice doc reading guides, implementation constraints, and any project-specific protocols (worktrees, testing, etc.)
 
-**Always read the active milestone's `context.md` before starting implementation work.** It tells you what decisions are locked, what files to reference, and how to verify your work in this specific project.
+**Always read the active milestone's `CONTEXT.md` before starting implementation work.** It tells you what decisions are locked, what files to reference, and how to verify your work in this specific project.
 
 > **Linear mode:** Call `kata_read_document("M001-CONTEXT")` before starting implementation work on any milestone.
 
@@ -767,17 +767,17 @@ This methodology doc is generic. Project-specific guidance belongs in the milest
 
 ### File Mode
 
-1. Read `.kata/state.md` — what's the next action?
+1. Read `.kata/STATE.md` — what's the next action?
 2. Check for `continue.md` in the active slice — is there interrupted work?
 3. If resuming: read `continue.md`, delete it, pick up from "Next Action".
-4. If starting fresh: read the active slice's `plan.md`, find the next incomplete task.
-5. If in a planning or research phase, read `.kata/decisions.md` — respect existing decisions.
+4. If starting fresh: read the active slice's `PLAN.md`, find the next incomplete task.
+5. If in a planning or research phase, read `.kata/DECISIONS.md` — respect existing decisions.
 6. Read relevant summaries from prior tasks/slices for context.
 7. Do the work.
 8. Verify the must-haves.
 9. Write the summary.
-10. Mark done, update `state.md`, advance.
-11. If context is getting full or you're done for now: write `continue.md` if mid-task, or update `state.md` with next action if between tasks.
+10. Mark done, update `STATE.md`, advance.
+11. If context is getting full or you're done for now: write `continue.md` if mid-task, or update `STATE.md` with next action if between tasks.
 
 ### Linear Mode
 
@@ -798,7 +798,7 @@ If you sense context pressure (many files read, long execution, lots of tool out
 ### File Mode
 
 1. **If mid-task:** Write `continue.md` with exact resume state. Tell the user: "Context is getting full. I've saved progress to continue.md. Start a new session and say `read @KATA-WORKFLOW.md - what's next?`"
-2. **If between tasks:** Just update `state.md` with the next action. No continue file needed — the next session will read state.md and pick up the next task cleanly.
+2. **If between tasks:** Just update `STATE.md` with the next action. No continue file needed — the next session will read STATE.md and pick up the next task cleanly.
 3. **Don't fight it.** The whole system is designed for this. A fresh session with the right files loaded is better than a stale session with degraded reasoning.
 
 ### Linear Mode

--- a/apps/cli/src/resources/extensions/kata/index.ts
+++ b/apps/cli/src/resources/extensions/kata/index.ts
@@ -98,14 +98,6 @@ export default function (pi: ExtensionAPI) {
 
   // ── session_start: render branded Kata header ───────────────────────────
   pi.on("session_start", async (_event, ctx) => {
-    // Patch Opus 4.6 context window — pi-mono caps at 200K but
-    // Anthropic's API supports 1M natively.
-    for (const model of ctx.modelRegistry.getAll()) {
-      if (model.id === "claude-opus-4-6" && model.provider === "anthropic") {
-        model.contextWindow = 1_000_000;
-      }
-    }
-
     const theme = ctx.ui.theme;
     const version = process.env.KATA_VERSION || "0.0.0";
 

--- a/apps/online-docs/content/docs/cli/extensions.mdx
+++ b/apps/online-docs/content/docs/cli/extensions.mdx
@@ -1,18 +1,68 @@
 ---
 title: Extensions
-description: Extend the CLI with built-in and custom extensions.
+description: Built-in extensions that ship with Kata CLI.
 ---
 
 # Extensions
 
+Kata CLI ships with built-in extensions that provide tools and capabilities to the agent. Extensions live in `apps/cli/src/resources/extensions/` and are synced to `~/.kata-cli/agent/extensions/` on startup.
+
 ## Built-in Extensions
 
-The CLI ships with a set of built-in extensions that provide common development tools out of the box.
+### kata
 
-Placeholder: list of built-in extensions will be documented here.
+The core extension providing the `/kata` command, auto-mode execution, planning methodology, and project state management.
 
-## Creating Extensions
+Key modules:
+- **auto.ts** — Auto-mode execution loop with session lock integration
+- **session-lock.ts** — OS-level exclusive locking prevents multiple kata processes from running auto-mode on the same project simultaneously. Uses `proper-lockfile` with stale lock detection, metadata tracking (PID, hostname, timestamp), and heartbeat validation.
+- **repo-identity.ts** — Generates a stable SHA-256 fingerprint for any git repository, consistent across subdirectories and worktrees. Used for session lock isolation.
+- **worktree-resolver.ts** — Resolves git worktree paths, finds the main repo from a worktree, and maps paths between worktrees.
+- **atomic-write.ts** — Crash-safe file writes using rename-into-place pattern.
 
-You can create custom extensions to add new tools and capabilities to the agent.
+### subagent
 
-Placeholder: extension authoring guide will be documented here.
+Spawns child kata processes for parallel, sequential (chain), or single-agent task execution.
+
+Key modules:
+- **worker-registry.ts** — Global registry of active subagent sessions for dashboard visibility. Tracks agent name, task, status, start time, and batch ID.
+- **elapsed.ts** — Human-readable elapsed time formatting (`0.3s`, `12.3s`, `1m 23s`). Integrated into parallel, chain, and single subagent output.
+
+### search-the-web
+
+Web search with pluggable provider abstraction.
+
+Key modules:
+- **provider.ts** — Search provider interface and registry. Supports multiple backends.
+- **native-search.ts** — Brave Search provider (default). Uses `BRAVE_API_KEY`.
+- **tavily.ts** — Tavily search provider. Uses `TAVILY_API_KEY`.
+- **tool-search.ts** — The `search-the-web` tool exposed to the agent.
+- **tool-llm-context.ts** — The `search_and_read` tool for comprehensive content extraction.
+
+### browser-tools
+
+Playwright-based browser automation for interacting with web pages.
+
+### linear
+
+Built-in Linear integration with a custom GraphQL client. Provides native tools for issue management, project tracking, and workflow state transitions.
+
+### context7
+
+Context7 library documentation lookup. Fetches up-to-date docs for libraries and frameworks.
+
+### bg-shell
+
+Background shell execution for long-running processes (servers, watchers, builds).
+
+### mac-tools
+
+macOS-specific utilities for controlling native applications via Accessibility APIs.
+
+### slash-commands
+
+Meta-commands for creating new slash commands, extensions, and auditing existing ones.
+
+### shared
+
+Shared UI components used by multiple extensions. Not an entry point — imported by other extensions.


### PR DESCRIPTION
## CLI Release v0.5.0

### Features
- Session lock for auto-mode (OS-level exclusive locking)
- Repo identity (stable SHA-256 fingerprint)
- Worktree resolver (worktree path resolution)
- Atomic file writes (crash-safe rename-into-place)
- Subagent worker registry (dashboard visibility)
- Subagent elapsed timing (parallel, chain, single)
- Search provider abstraction (Tavily support)

### Fixes
- Test suite fixes (BDD imports, session-lock logic)
- Subagent cleanup (registry, timers, rounding)
- Search provider review fixes

### Tests
- 380 tests passing, 0 failures
- TypeScript clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@kata-sh/cli` from **v0.4.1 to v0.5.0** and adds the corresponding changelog entry. All substantive code changes (session locking, repo identity, worktree resolver, atomic writes, subagent registry/timing, search provider abstraction) are already in the repository and are simply being versioned here.

- `apps/cli/package.json` — single-line version bump `0.4.1` → `0.5.0`; `proper-lockfile ^4.1.2` (used by the new session-lock feature) is already listed in `dependencies`, so no dependency changes are needed.
- `apps/cli/CHANGELOG.md` — new `## 0.5.0` section accurately summarises the features and fixes shipping in this release.
- No logic, security, or dependency issues are introduced by these two files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only a version bump and a changelog update with no functional code changes.
- Both changed files are purely metadata: a semver increment in `package.json` and a new changelog section in `CHANGELOG.md`. There is no executable code, no dependency modifications, and no logic changes that could introduce regressions.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/CHANGELOG.md | Adds v0.5.0 changelog section documenting new features and fixes; content is accurate and well-structured. |
| apps/cli/package.json | Version field bumped from 0.4.1 to 0.5.0; `proper-lockfile` dependency (used by the new session-lock feature) is already present. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([kata auto-mode start]) --> B{Session lock\nacquired?}
    B -- No, lock exists --> C[Read lock metadata\nPID · hostname · timestamp]
    C --> D{Stale lock?\nProcess dead?}
    D -- Yes --> E[Steal lock &\nwrite new metadata]
    D -- No --> F([Exit: another process\nalready running])
    E --> G
    B -- Yes --> G[Write metadata\nPID · hostname · timestamp]
    G --> H[Run auto-mode\nsession]
    H --> I{Session ends\nor aborts}
    I --> J[Release lock\ntry/finally]
    J --> K([Done])

    style A fill:#4caf50,color:#fff
    style F fill:#f44336,color:#fff
    style K fill:#4caf50,color:#fff
```

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump cli to 0.5.0"](https://github.com/gannonh/kata/commit/abdfe4bdbc30e0e8e94f8fc50253583a15d1f2ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25965749)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bump for CLI package to 0.5.0
  * No user-facing behavioral changes in CLI runtime

* **Documentation**
  * Expanded CLI extensions docs with descriptions, locations, and per-extension details for built-in extensions and shared components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->