### PR TITLE
KAT-886: show running worker turn/activity/token metrics

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -298,7 +298,7 @@ workflow file (e.g. `0.0.0.0` to bind all interfaces).
 
 | Method | Path                        | Description                                                                                                                                                                      |
 | ------ | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET`  | `/`                         | HTML dashboard — auto-refreshes every 2 seconds. Shows summary cards, running sessions table, retry queue table, completed issue list, token breakdown, polling diagnostics, and collapsible rate-limit JSON. |
+| `GET`  | `/`                         | HTML dashboard — auto-refreshes every 2 seconds. Shows summary cards, running sessions table (including turn/max-turns, last activity age, and per-session tokens), retry queue table, completed issue list, token breakdown, polling diagnostics, and collapsible rate-limit JSON. |
 | `GET`  | `/api/v1/state`             | Full orchestrator state as JSON.                                                                                                                                                 |
 | `GET`  | `/api/v1/:issue_identifier` | Per-issue projection. `:issue_identifier` must match the pattern `TEAM-NNN` (uppercase prefix, hyphen, digits). Returns 404 when the issue is not running or in the retry queue. |
 | `POST` | `/api/v1/refresh`           | Request an immediate Linear poll. Requests are coalesced — multiple concurrent POSTs result in one actual refresh. Returns 202.                                                  |
@@ -313,10 +313,24 @@ workflow file (e.g. `0.0.0.0` to bind all interfaces).
     "issue-id-123": {
       "issue_id": "issue-id-123",
       "issue_identifier": "ENG-42",
+      "status": "running",
       "attempt": 1,
       "error": null,
       "worker_host": null,
-      "workspace_path": "/tmp/symphony_workspaces/ENG-42"
+      "workspace_path": "/tmp/symphony_workspaces/ENG-42",
+      "started_at": "2026-03-22T15:40:00Z"
+    }
+  },
+  "running_session_info": {
+    "issue-id-123": {
+      "turn_count": 3,
+      "max_turns": 20,
+      "last_activity_ms": 1760000000000,
+      "session_tokens": {
+        "input_tokens": 1200,
+        "output_tokens": 430,
+        "total_tokens": 1630
+      }
     }
   },
   "claimed": ["issue-id-456"],
@@ -325,7 +339,7 @@ workflow file (e.g. `0.0.0.0` to bind all interfaces).
       "issue_id": "issue-id-789",
       "identifier": "ENG-99",
       "attempt": 2,
-      "retry_after_ms": 1714000000000,
+      "due_in_ms": 30000,
       "error": "stall timeout exceeded",
       "worker_host": null,
       "workspace_path": "/tmp/symphony_workspaces/ENG-99"

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -362,6 +362,30 @@ pub struct RunAttempt {
     pub linear_state: Option<String>,
 }
 
+/// Per-session token usage scoped to a single running worker session.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct SessionTokenUsage {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub total_tokens: u64,
+}
+
+/// Live worker-session diagnostics for dashboard rendering.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct WorkerSessionInfo {
+    #[serde(default)]
+    pub turn_count: u32,
+    #[serde(default)]
+    pub max_turns: u32,
+    #[serde(default)]
+    pub last_activity_ms: Option<i64>,
+    #[serde(default)]
+    pub session_tokens: SessionTokenUsage,
+}
+
 // ── LiveSession (spec §4.1.6) ─────────────────────────────────────────
 
 /// Tracks the active Codex session for a running issue.
@@ -490,6 +514,8 @@ pub struct OrchestratorSnapshot {
     pub poll_interval_ms: u64,
     pub max_concurrent_agents: u32,
     pub running: BTreeMap<String, RunAttempt>,
+    #[serde(default)]
+    pub running_session_info: BTreeMap<String, WorkerSessionInfo>,
     pub claimed: BTreeSet<String>,
     pub retry_queue: Vec<RetrySnapshotEntry>,
     pub completed: Vec<CompletedEntry>,

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -10,7 +10,7 @@ use tokio::net::TcpListener;
 
 use crate::domain::{
     CodexTotals, OrchestratorSnapshot, PollingSnapshot, RefreshRequestOutcome, RetrySnapshotEntry,
-    RunAttempt,
+    RunAttempt, WorkerSessionInfo,
 };
 use crate::orchestrator::{RefreshSender, SnapshotHandle};
 
@@ -103,6 +103,7 @@ struct StateResponse {
     poll_interval_ms: u64,
     max_concurrent_agents: u32,
     running: std::collections::BTreeMap<String, RunAttempt>,
+    running_session_info: std::collections::BTreeMap<String, WorkerSessionInfo>,
     claimed: std::collections::BTreeSet<String>,
     retry_queue: Vec<RetrySnapshotEntry>,
     completed: Vec<crate::domain::CompletedEntry>,
@@ -215,6 +216,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     th {{ color: #a8b8cc; font-size: 12px; text-transform: uppercase; letter-spacing: .03em; }}
     td {{ color: #d7e1ee; }}
     td.mono {{ word-break: break-all; }}
+    .stale-activity {{ color: #fca5a5; font-weight: 600; }}
     .list {{ margin: 0; padding-left: 20px; }}
     .muted {{ color: #94a3b8; }}
     .error {{ margin-top: 12px; color: #fca5a5; }}
@@ -252,13 +254,16 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
             <th>Linear State</th>
             <th>Status</th>
             <th>Attempt</th>
+            <th>Turn</th>
+            <th>Last Activity</th>
             <th>Elapsed</th>
+            <th>Tokens</th>
             <th>Workspace</th>
             <th>Worker host</th>
           </tr>
         </thead>
         <tbody id="running-table-body">
-          <tr><td class="muted" colspan="7">Loading...</td></tr>
+          <tr><td class="muted" colspan="10">Loading...</td></tr>
         </tbody>
       </table>
     </div>
@@ -310,6 +315,8 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
   <p id="refresh-error" class="error" hidden></p>
 
   <script>
+    const STALE_ACTIVITY_THRESHOLD_MS = 120000;
+
     function escapeHtml(value) {{
       return String(value)
         .replace(/&/g, '&amp;')
@@ -333,6 +340,20 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       return sign + seconds + 's';
     }}
 
+    function formatTimeAgo(ms) {{
+      const numeric = Number(ms);
+      if (!Number.isFinite(numeric)) return 'n/a';
+      if (numeric <= 0) return 'just now';
+      const totalSeconds = Math.floor(numeric / 1000);
+      if (totalSeconds < 60) return totalSeconds + 's ago';
+      const totalMinutes = Math.floor(totalSeconds / 60);
+      if (totalMinutes < 60) return totalMinutes + 'm ago';
+      const totalHours = Math.floor(totalMinutes / 60);
+      if (totalHours < 24) return totalHours + 'h ago';
+      const totalDays = Math.floor(totalHours / 24);
+      return totalDays + 'd ago';
+    }}
+
     function formatRetryDelay(ms) {{
       const numeric = Number(ms);
       if (!Number.isFinite(numeric)) return 'n/a';
@@ -352,25 +373,48 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       return Number.isNaN(parsed.getTime()) ? String(value) : parsed.toISOString();
     }}
 
-    function renderRunningTable(running) {{
-      const rows = Object.values(running || {{}}).sort(function(a, b) {{
-        return String(a.issue_identifier || '').localeCompare(String(b.issue_identifier || ''));
+    function renderRunningTable(running, sessionInfoByIssue) {{
+      const rows = Object.entries(running || {{}}).sort(function(a, b) {{
+        return String(a[1].issue_identifier || '').localeCompare(String(b[1].issue_identifier || ''));
       }});
 
       if (rows.length === 0) {{
-        return '<tr><td class="muted" colspan="7">No running sessions.</td></tr>';
+        return '<tr><td class="muted" colspan="10">No running sessions.</td></tr>';
       }}
 
-      return rows.map(function(run) {{
+      return rows.map(function(entry) {{
+        const issueId = entry[0];
+        const run = entry[1];
+        const sessionInfo = (sessionInfoByIssue && sessionInfoByIssue[issueId]) || {{}};
         const startedAt = Date.parse(run.started_at || '');
         const elapsed = Number.isFinite(startedAt) ? formatDuration(Date.now() - startedAt) : 'n/a';
         const attempt = run.attempt ?? 1;
+        const maxTurns = Number(sessionInfo.max_turns);
+        const turnCount = Number(sessionInfo.turn_count);
+        const turnLabel = Number.isFinite(turnCount) && turnCount > 0
+          ? String(turnCount) + '/' + (Number.isFinite(maxTurns) && maxTurns > 0 ? String(maxTurns) : '?')
+          : 'n/a';
+        const lastActivityValue = sessionInfo.last_activity_ms;
+        const lastActivityMs = Number(lastActivityValue);
+        const lastActivityAge = Number.isFinite(lastActivityMs) ? Math.max(0, Date.now() - lastActivityMs) : null;
+        const lastActivityLabel = lastActivityAge === null ? 'n/a' : formatTimeAgo(lastActivityAge);
+        const lastActivityClass = lastActivityAge !== null && lastActivityAge > STALE_ACTIVITY_THRESHOLD_MS
+          ? 'mono stale-activity'
+          : 'mono';
+        const sessionTokens = sessionInfo.session_tokens || {{}};
+        const tokenInput = Number(sessionTokens.input_tokens ?? 0);
+        const tokenOutput = Number(sessionTokens.output_tokens ?? 0);
+        const tokenTotal = Number(sessionTokens.total_tokens ?? 0);
+        const tokenLabel = tokenInput + ' / ' + tokenOutput + ' / ' + tokenTotal;
         return '<tr>' +
           '<td class="mono">' + escapeHtml(run.issue_identifier || '-') + '</td>' +
           '<td>' + escapeHtml(run.linear_state || '-') + '</td>' +
           '<td>' + escapeHtml(run.status || '-') + '</td>' +
           '<td>' + escapeHtml(attempt) + '</td>' +
+          '<td class="mono">' + escapeHtml(turnLabel) + '</td>' +
+          '<td class="' + escapeHtml(lastActivityClass) + '">' + escapeHtml(lastActivityLabel) + '</td>' +
           '<td class="mono">' + escapeHtml(elapsed) + '</td>' +
+          '<td class="mono">' + escapeHtml(tokenLabel) + '</td>' +
           '<td class="mono">' + escapeHtml(run.workspace_path || '-') + '</td>' +
           '<td>' + escapeHtml(run.worker_host || 'local') + '</td>' +
           '</tr>';
@@ -455,7 +499,10 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         document.getElementById('retry-count').textContent = retryQueue.length;
         document.getElementById('claimed-count').textContent = (state.claimed || []).length;
         document.getElementById('completed-count').textContent = completed.length;
-        document.getElementById('running-table-body').innerHTML = renderRunningTable(running);
+        document.getElementById('running-table-body').innerHTML = renderRunningTable(
+          running,
+          state.running_session_info || {{}}
+        );
         document.getElementById('retry-table-body').innerHTML = renderRetryTable(retryQueue);
         document.getElementById('completed-list').innerHTML = renderCompleted(completed);
         document.getElementById('token-input').textContent = state.codex_totals?.input_tokens ?? 0;
@@ -485,6 +532,7 @@ async fn get_state(State(state): State<HttpServerState>) -> impl IntoResponse {
         poll_interval_ms: snapshot.poll_interval_ms,
         max_concurrent_agents: snapshot.max_concurrent_agents,
         running: snapshot.running,
+        running_session_info: snapshot.running_session_info,
         claimed: snapshot.claimed,
         retry_queue: snapshot.retry_queue,
         completed: snapshot.completed,

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -395,7 +395,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
           ? String(turnCount) + '/' + (Number.isFinite(maxTurns) && maxTurns > 0 ? String(maxTurns) : '?')
           : 'n/a';
         const lastActivityValue = sessionInfo.last_activity_ms;
-        const lastActivityMs = Number(lastActivityValue);
+        const lastActivityMs = lastActivityValue != null ? Number(lastActivityValue) : NaN;
         const lastActivityAge = Number.isFinite(lastActivityMs) ? Math.max(0, Date.now() - lastActivityMs) : null;
         const lastActivityLabel = lastActivityAge === null ? 'n/a' : formatTimeAgo(lastActivityAge);
         const lastActivityClass = lastActivityAge !== null && lastActivityAge > STALE_ACTIVITY_THRESHOLD_MS

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1214,7 +1214,9 @@ impl Orchestrator {
                 last_activity_ms,
                 session_tokens: SessionTokenUsage::default(),
             });
-        info.max_turns = max_turns;
+        if info.max_turns == 0 {
+            info.max_turns = max_turns;
+        }
         if info.turn_count == 0 {
             info.turn_count = 1;
         }
@@ -1272,20 +1274,22 @@ impl Orchestrator {
             ..
         } = event
         {
-            if let Some(session_info) = self.worker_session_info.get_mut(issue_id) {
-                session_info.session_tokens.input_tokens = session_info
-                    .session_tokens
-                    .input_tokens
-                    .saturating_add(*input_tokens);
-                session_info.session_tokens.output_tokens = session_info
-                    .session_tokens
-                    .output_tokens
-                    .saturating_add(*output_tokens);
-                session_info.session_tokens.total_tokens = session_info
-                    .session_tokens
-                    .total_tokens
-                    .saturating_add(*total_tokens);
-            }
+            let session_info = self
+                .worker_session_info
+                .get_mut(issue_id)
+                .expect("session info must exist after ensure_worker_session_info");
+            session_info.session_tokens.input_tokens = session_info
+                .session_tokens
+                .input_tokens
+                .saturating_add(*input_tokens);
+            session_info.session_tokens.output_tokens = session_info
+                .session_tokens
+                .output_tokens
+                .saturating_add(*output_tokens);
+            session_info.session_tokens.total_tokens = session_info
+                .session_tokens
+                .total_tokens
+                .saturating_add(*total_tokens);
             self.advance_turn_counter(issue_id);
             self.apply_turn_metrics(&TurnMetrics {
                 input_tokens: *input_tokens,

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -11,7 +11,8 @@ use crate::config;
 use crate::domain::{
     AgentEvent, CodexConfig, CodexTotals, CompletedEntry, HooksConfig, Issue, OrchestratorSnapshot,
     OrchestratorState, PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetryEntry,
-    RetrySnapshotEntry, RunAttempt, ServiceConfig, TrackerConfig, WorkspaceConfig,
+    RetrySnapshotEntry, RunAttempt, ServiceConfig, SessionTokenUsage, TrackerConfig,
+    WorkerSessionInfo, WorkspaceConfig,
 };
 use crate::error::{Result, SymphonyError};
 use crate::ssh::{self, WorkerHostSelection};
@@ -628,6 +629,7 @@ pub struct Orchestrator {
     events: Vec<RuntimeEvent>,
     retry_tokens: HashMap<String, String>,
     worker_last_activity_ms: HashMap<String, i64>,
+    worker_session_info: HashMap<String, WorkerSessionInfo>,
     worker_session_ids: HashMap<String, String>,
     pending_terminal_cleanup: HashMap<String, PendingTerminalCleanup>,
     /// Normalized running issue state cache used for per-state slot accounting.
@@ -701,6 +703,7 @@ impl Orchestrator {
             events: vec![],
             retry_tokens: HashMap::new(),
             worker_last_activity_ms: HashMap::new(),
+            worker_session_info: HashMap::new(),
             worker_session_ids: HashMap::new(),
             pending_terminal_cleanup: HashMap::new(),
             running_issue_states: HashMap::new(),
@@ -1194,6 +1197,38 @@ impl Orchestrator {
     pub fn record_worker_activity(&mut self, issue_id: &str, timestamp_ms: i64) {
         self.worker_last_activity_ms
             .insert(issue_id.to_string(), timestamp_ms);
+        if let Some(info) = self.worker_session_info.get_mut(issue_id) {
+            info.last_activity_ms = Some(timestamp_ms);
+        }
+    }
+
+    fn ensure_worker_session_info(&mut self, issue_id: &str) -> &mut WorkerSessionInfo {
+        let max_turns = self.config.agent.max_turns.max(1);
+        let last_activity_ms = self.worker_last_activity_ms.get(issue_id).copied();
+        let info = self
+            .worker_session_info
+            .entry(issue_id.to_string())
+            .or_insert(WorkerSessionInfo {
+                turn_count: 1,
+                max_turns,
+                last_activity_ms,
+                session_tokens: SessionTokenUsage::default(),
+            });
+        info.max_turns = max_turns;
+        if info.turn_count == 0 {
+            info.turn_count = 1;
+        }
+        if info.last_activity_ms.is_none() {
+            info.last_activity_ms = last_activity_ms;
+        }
+        info
+    }
+
+    fn advance_turn_counter(&mut self, issue_id: &str) {
+        let session_info = self.ensure_worker_session_info(issue_id);
+        let max_turns = session_info.max_turns.max(1);
+        let current = session_info.turn_count.max(1);
+        session_info.turn_count = current.saturating_add(1).min(max_turns);
     }
 
     pub fn ingest_agent_event(&mut self, issue_id: &str, event: &AgentEvent) {
@@ -1206,6 +1241,7 @@ impl Orchestrator {
             return;
         }
 
+        let _ = self.ensure_worker_session_info(issue_id);
         self.record_worker_activity(issue_id, event_timestamp_ms(event));
 
         if let Some(session_id) = event_session_id(event) {
@@ -1236,6 +1272,21 @@ impl Orchestrator {
             ..
         } = event
         {
+            if let Some(session_info) = self.worker_session_info.get_mut(issue_id) {
+                session_info.session_tokens.input_tokens = session_info
+                    .session_tokens
+                    .input_tokens
+                    .saturating_add(*input_tokens);
+                session_info.session_tokens.output_tokens = session_info
+                    .session_tokens
+                    .output_tokens
+                    .saturating_add(*output_tokens);
+                session_info.session_tokens.total_tokens = session_info
+                    .session_tokens
+                    .total_tokens
+                    .saturating_add(*total_tokens);
+            }
+            self.advance_turn_counter(issue_id);
             self.apply_turn_metrics(&TurnMetrics {
                 input_tokens: *input_tokens,
                 output_tokens: *output_tokens,
@@ -1275,6 +1326,7 @@ impl Orchestrator {
         self.state.claimed.remove(issue_id);
         self.running_issue_states.remove(issue_id);
         self.worker_last_activity_ms.remove(issue_id);
+        self.worker_session_info.remove(issue_id);
 
         let issue_identifier = run_attempt.issue_identifier.clone();
         let session_id = self.worker_session_ids.remove(issue_id);
@@ -1405,6 +1457,7 @@ impl Orchestrator {
                 linear_state: Some(issue.state.clone()),
             },
         );
+        let _ = self.ensure_worker_session_info(&issue.id);
         self.state.claimed.insert(issue.id.clone());
         self.running_issue_states
             .insert(issue.id.clone(), normalize_issue_state(&issue.state));
@@ -1668,6 +1721,16 @@ impl Orchestrator {
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        let running_session_info: BTreeMap<String, WorkerSessionInfo> = self
+            .state
+            .running
+            .keys()
+            .filter_map(|issue_id| {
+                self.worker_session_info
+                    .get(issue_id)
+                    .map(|info| (issue_id.clone(), info.clone()))
+            })
+            .collect();
 
         let claimed: BTreeSet<String> = self.state.claimed.iter().cloned().collect();
         let mut completed: Vec<CompletedEntry> = self.state.completed.values().cloned().collect();
@@ -1698,6 +1761,7 @@ impl Orchestrator {
             poll_interval_ms: self.state.poll_interval_ms,
             max_concurrent_agents: self.state.max_concurrent_agents,
             running,
+            running_session_info,
             claimed,
             retry_queue,
             completed,
@@ -1917,6 +1981,7 @@ impl Orchestrator {
         };
 
         self.state.running.insert(issue.id.clone(), attempt);
+        let _ = self.ensure_worker_session_info(&issue.id);
         self.state.claimed.insert(issue.id.clone());
         self.state.retry_attempts.remove(&issue.id);
         self.running_issue_states
@@ -2172,6 +2237,7 @@ impl Orchestrator {
         self.running_issue_states.remove(issue_id);
         self.retry_tokens.remove(issue_id);
         self.worker_last_activity_ms.remove(issue_id);
+        self.worker_session_info.remove(issue_id);
         self.worker_session_ids.remove(issue_id);
     }
 

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -255,6 +255,7 @@ fn test_orchestrator_snapshot_serializes() {
             );
             m
         },
+        running_session_info: BTreeMap::new(),
         claimed: {
             let mut s = BTreeSet::new();
             s.insert("c-claim".to_string());

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -8,7 +8,7 @@ use chrono::{TimeZone, Utc};
 use serde_json::{json, Value};
 use symphony::domain::{
     CodexTotals, CompletedEntry, OrchestratorSnapshot, PollingSnapshot, RateLimitInfo,
-    RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt,
+    RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt, SessionTokenUsage, WorkerSessionInfo,
 };
 use symphony::http_server::{build_router, HttpServerState, RefreshControl, SnapshotSource};
 use tower::ServiceExt;
@@ -76,6 +76,19 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
             );
             running
         },
+        running_session_info: BTreeMap::from([(
+            "issue-123".to_string(),
+            WorkerSessionInfo {
+                turn_count: 3,
+                max_turns: 20,
+                last_activity_ms: Some(started_at.timestamp_millis() + 70_000),
+                session_tokens: SessionTokenUsage {
+                    input_tokens: 35,
+                    output_tokens: 12,
+                    total_tokens: 47,
+                },
+            },
+        )]),
         claimed: BTreeSet::from(["issue-123".to_string()]),
         retry_queue: vec![RetrySnapshotEntry {
             issue_id: "issue-777".to_string(),
@@ -178,6 +191,22 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "dashboard shell should include running sessions table section"
     );
     assert!(
+        body.contains("<th>Turn</th>"),
+        "running table should include the turn column header"
+    );
+    assert!(
+        body.contains("<th>Last Activity</th>"),
+        "running table should include the last activity column header"
+    );
+    assert!(
+        body.contains("<th>Tokens</th>"),
+        "running table should include the per-session token column header"
+    );
+    assert!(
+        body.contains("stale-activity"),
+        "dashboard script should include stale activity highlighting styles/logic"
+    );
+    assert!(
         body.contains("Retry queue"),
         "dashboard shell should include retry queue table section"
     );
@@ -233,6 +262,14 @@ async fn test_get_api_state_returns_snapshot_projection() {
     assert_eq!(
         payload["running"]["issue-123"]["issue_identifier"],
         "SIM-123"
+    );
+    assert_eq!(
+        payload["running_session_info"]["issue-123"]["turn_count"],
+        3
+    );
+    assert_eq!(
+        payload["running_session_info"]["issue-123"]["session_tokens"]["total_tokens"],
+        47
     );
     assert_eq!(payload["retry_queue"][0]["identifier"], "SIM-777");
     assert_eq!(payload["codex_totals"]["total_tokens"], 200);

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -207,6 +207,10 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "dashboard script should include stale activity highlighting styles/logic"
     );
     assert!(
+        body.contains("lastActivityValue != null ? Number(lastActivityValue) : NaN"),
+        "dashboard script should treat null last_activity_ms as missing instead of coercing to 0"
+    );
+    assert!(
         body.contains("Retry queue"),
         "dashboard shell should include retry queue table section"
     );

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -937,6 +937,38 @@ fn test_streamed_turn_completed_events_update_token_totals_in_real_time() {
         18,
         "total token count should continue accumulating across streamed turns"
     );
+
+    let snapshot = orchestrator.snapshot(now_ms + 5_000);
+    let session_info = snapshot
+        .running_session_info
+        .get("issue-stream-metrics")
+        .expect("running session info should exist for active issue");
+
+    assert_eq!(
+        session_info.turn_count, 3,
+        "turn count should advance as streamed turn-completed events are ingested"
+    );
+    assert_eq!(
+        session_info.max_turns, 20,
+        "running session info should retain configured max-turn budget"
+    );
+    assert_eq!(
+        session_info.session_tokens.input_tokens, 12,
+        "session token accounting should accumulate input tokens per running session"
+    );
+    assert_eq!(
+        session_info.session_tokens.output_tokens, 6,
+        "session token accounting should accumulate output tokens per running session"
+    );
+    assert_eq!(
+        session_info.session_tokens.total_tokens, 18,
+        "session token accounting should accumulate total tokens per running session"
+    );
+    assert_eq!(
+        session_info.last_activity_ms,
+        Some(event_time.timestamp_millis()),
+        "last activity should track the most recent streamed event timestamp"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add per-session worker diagnostics to the orchestrator snapshot via `running_session_info`
  (`turn_count`, `max_turns`, `last_activity_ms`, and per-session token totals)
- update event ingestion to maintain session info in real time from worker events while preserving
  existing aggregate token accounting
- update the dashboard running sessions table to show **Turn**, **Last Activity**, and
  **Tokens (in/out/total)**, including stale activity highlighting when activity is older than 2 minutes
- update Symphony AGENTS API/dashboard docs and expand HTTP/orchestrator tests for the new behavior

## Testing
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`

## Linked Issue
- KAT-886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays per-session metrics including turn counts, last activity timestamps, and real-time token usage (input/output/total).
  * Sessions marked as "stale" when inactivity exceeds 120 seconds.
  * API `/api/v1/state` endpoint exposes running session diagnostics and token counters.

* **Tests**
  * Added test coverage for session tracking and per-session token accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-session worker diagnostics (turn count, max turns, last activity timestamp, and per-session token totals) to the orchestrator snapshot and dashboard. The Rust backend introduces `WorkerSessionInfo` / `SessionTokenUsage` domain structs, a `worker_session_info` map on the `Orchestrator`, and helper methods to maintain them in real time as `TurnCompleted` events are ingested. The HTTP layer surfaces the new data through the existing `/api/v1/state` endpoint and renders it in three new dashboard table columns with a stale-activity highlight for sessions idle for more than 2 minutes.

Key changes:
- New `SessionTokenUsage` and `WorkerSessionInfo` structs in `domain.rs`; `OrchestratorSnapshot` gains `running_session_info: BTreeMap<String, WorkerSessionInfo>`
- `ensure_worker_session_info` / `advance_turn_counter` helpers in `orchestrator.rs` wired into dispatch, `ingest_agent_event`, and both cleanup paths
- Dashboard JS extended with `formatTimeAgo`, stale-activity CSS class, and three new table columns (Turn, Last Activity, Tokens)
- Test coverage expanded across orchestrator, HTTP, and domain test files
- **One logic bug found**: `Number(null) === 0` in the JS stale-activity check incorrectly flags every freshly-dispatched session (where `last_activity_ms` is JSON `null`) as stale before the first worker event arrives

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the `null`-coercion bug that incorrectly highlights new sessions as stale.
- The Rust backend changes are correct and well-tested. The single concrete bug is in the dashboard JavaScript: `Number(null)` evaluates to `0`, which causes `Date.now() - 0 ≈ 1.76 × 10¹²` ms — far above the 120 s stale threshold — so every session appears stale immediately upon dispatch and remains so until the first `TurnCompleted` event arrives. This is a visible UI regression that affects all users of the dashboard. The fix is a one-liner guard (`lastActivityValue != null ? Number(...) : NaN`). Everything else — the domain structs, Rust orchestrator logic, snapshot projection, and test coverage — looks solid.
- apps/symphony/src/http_server.rs — the stale-activity null-coercion fix on line 398

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/http_server.rs | Adds `running_session_info` to the state API response and extends the dashboard JS to render turn, last-activity, and per-session token columns. Contains a logic bug: `Number(null) === 0` causes every freshly-started session (where `last_activity_ms` is JSON `null`) to be rendered with the red stale-activity highlight before any worker event has arrived. |
| apps/symphony/src/orchestrator.rs | Adds `worker_session_info` map and helper methods (`ensure_worker_session_info`, `advance_turn_counter`) to maintain per-session diagnostics; wires them into `ingest_agent_event`, dispatch and cleanup paths, and the snapshot projection. Logic is broadly sound, with minor nits around a redundant defensive check and the turn-counter cap at `max_turns`. |
| apps/symphony/src/domain.rs | Introduces `SessionTokenUsage` and `WorkerSessionInfo` structs with correct `Serialize/Deserialize/Default` derives; adds `running_session_info` to `OrchestratorSnapshot`. Clean, no issues. |
| apps/symphony/tests/orchestrator_tests.rs | Extends existing streaming-turn test to also assert per-session `turn_count`, `max_turns`, token totals, and `last_activity_ms` in the snapshot. Thorough coverage of the new diagnostics. |
| apps/symphony/tests/http_server_tests.rs | Updates fixture snapshot and adds assertions for new dashboard column headers and API payload fields (`running_session_info`). Good coverage. |
| apps/symphony/tests/domain_tests.rs | Minimal update to add `running_session_info: BTreeMap::new()` to the snapshot fixture so the serialisation test compiles. No issues. |
| apps/symphony/AGENTS.md | Documentation updated to reflect new dashboard columns, `running_session_info` API field, and corrects `retry_after_ms` → `due_in_ms` in the example payload. Accurate. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as Worker
    participant O as Orchestrator
    participant S as worker_session_info
    participant API as HTTP /api/v1/state
    participant D as Dashboard JS

    Note over O,S: dispatch_issue / start_running_for_claimed
    O->>S: ensure_worker_session_info(issue_id)<br/>or_insert {turn_count:1, max_turns, last_activity_ms:None}

    W->>O: ingest_agent_event(TurnCompleted)
    O->>S: ensure_worker_session_info (no-op, entry exists)
    O->>S: record_worker_activity → last_activity_ms = timestamp
    O->>S: accumulate session_tokens (input/output/total)
    O->>S: advance_turn_counter → turn_count = min(prev+1, max_turns)

    O->>API: snapshot() → running_session_info from worker_session_info
    D->>API: GET /api/v1/state
    API-->>D: {running_session_info: {issue_id: {turn_count, max_turns, last_activity_ms, session_tokens}}}
    D->>D: renderRunningTable(running, sessionInfoByIssue)<br/>→ Turn / Last Activity / Tokens columns

    Note over O,S: remove_from_running / cleanup_issue
    O->>S: worker_session_info.remove(issue_id)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 398-401

Comment:
**`null` coerces to `0`, causing false stale-activity warnings**

`Number(null)` is `0` in JavaScript. When `last_activity_ms` is `null` in the JSON response (i.e., `WorkerSessionInfo.last_activity_ms = None` — which is the case for any session that was just dispatched and hasn't received a `TurnCompleted` event yet), the computation becomes:

```
lastActivityMs = Number(null) = 0
lastActivityAge = Math.max(0, Date.now() - 0) ≈ 1_760_000_000_000
```

This is orders of magnitude larger than `STALE_ACTIVITY_THRESHOLD_MS = 120000`, so the cell gets the red `stale-activity` class immediately on session creation — before the worker has even started.

The fix is to guard the `Number()` conversion against `null`/`undefined`:

```suggestion
        const lastActivityValue = sessionInfo.last_activity_ms;
        const lastActivityMs = lastActivityValue != null ? Number(lastActivityValue) : NaN;
        const lastActivityAge = Number.isFinite(lastActivityMs) ? Math.max(0, Date.now() - lastActivityMs) : null;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 1227-1232

Comment:
**Turn counter initialised at 1, then capped at `max_turns`**

The initial `turn_count: 1` (set in `ensure_worker_session_info`) combined with the `.min(max_turns)` cap in `advance_turn_counter` creates a subtle display edge case: once the agent has completed `max_turns - 1` turns the counter advances from `max_turns - 1` to `max_turns` and then stays there even if further `TurnCompleted` events arrive (e.g. due to tool-use turns that don't count toward the budget). The display would show `20/20` both when the agent is on its last turn *and* after it has finished, making it hard to distinguish those two states.

Consider whether the cap should be removed here and left purely as a display concern in the dashboard JS, or whether the intent is intentionally to clamp to `max_turns`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 1275-1289

Comment:
**Defensive `if let Some` is unreachable after `ensure_worker_session_info`**

`ensure_worker_session_info(issue_id)` was called two lines earlier (line 1244) and always inserts an entry for `issue_id` via `or_insert`. The subsequent `self.worker_session_info.get_mut(issue_id)` here will therefore always succeed, making the `if let Some` guard dead code that silently swallows tokens if the assumption is ever wrong.

Consider using `.expect("session info guaranteed by ensure_worker_session_info")` or — better — restructure so the mutable reference returned by `ensure_worker_session_info` is reused directly, avoiding the second hash-map lookup entirely.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): expose running session t..."](https://github.com/gannonh/kata/commit/1929aae67b09f9233f8b532c5db36d2258ad834e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25969931)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->