### PR TITLE
feat: add Symphony Ratatui terminal dashboard (--tui)

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -27,7 +27,7 @@ cargo build --release
 ## Running
 
 ```sh
-symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--i-understand-that-this-will-be-running-without-the-usual-guardrails]
+symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui] [--i-understand-that-this-will-be-running-without-the-usual-guardrails]
 ```
 
 ### CLI Flag Reference
@@ -37,6 +37,7 @@ symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--i-understand-that-thi
 | `WORKFLOW.md` (positional)                                              | path | `WORKFLOW.md` | Path to the WORKFLOW.md configuration file                                                                                           |
 | `--port PORT`                                                           | u16  | _(none)_      | Bind the HTTP dashboard and API on this port. When omitted, no HTTP server is started. Overrides `server.port` in the workflow file. |
 | `--logs-root PATH`                                                      | path | _(none)_      | Directory root for agent log files.                                                                                                  |
+| `--tui`                                                                 | flag | `false`       | Render a Ratatui terminal dashboard. When enabled with no `--logs-root`, stdout logs are suppressed to avoid corrupting the TUI.   |
 | `--i-understand-that-this-will-be-running-without-the-usual-guardrails` | flag | `false`       | Acknowledge that Symphony runs Codex sessions without interactive guardrails.                                                        |
 
 ### Exit Codes

--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +213,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +313,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +377,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +409,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -607,6 +701,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -859,6 +955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +994,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1020,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -941,6 +1065,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1029,6 +1162,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1052,7 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc623edee8a618b4543e8e8505584f4847a4e51b805db1af6d9af0a3395d0d57"
 dependencies = [
  "anymap2",
- "itertools",
+ "itertools 0.14.0",
  "kstring",
  "liquid-derive",
  "pest",
@@ -1079,7 +1218,7 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9befeedd61f5995bc128c571db65300aeb50d62e4f0542c88282dbcb5f72372a"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "liquid-core",
  "percent-encoding",
  "regex",
@@ -1107,6 +1246,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "matchers"
@@ -1321,6 +1469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1641,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1773,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1605,7 +1793,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1854,6 +2042,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,6 +2119,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,11 +2155,13 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "crossterm",
  "dotenvy",
  "liquid",
  "liquid-core",
  "mockito",
  "notify",
+ "ratatui",
  "regex",
  "reqwest",
  "rolling-file",
@@ -2007,7 +2240,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2328,6 +2561,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2790,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,6 +2813,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -49,6 +49,8 @@ notify = "7"
 
 # CLI argument parsing
 clap = { version = "4", features = ["derive"] }
+crossterm = "0.28"
+ratatui = "0.29"
 
 # Regex for sanitization
 regex = "1"

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -471,6 +471,17 @@ pub struct CompletedEntry {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
+/// Session-level metrics for a currently running issue.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RunningSessionSnapshot {
+    #[serde(default)]
+    pub turn_count: u32,
+    #[serde(default)]
+    pub last_activity_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub total_tokens: u64,
+}
+
 /// Polling state for the snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PollingSnapshot {
@@ -490,6 +501,8 @@ pub struct OrchestratorSnapshot {
     pub poll_interval_ms: u64,
     pub max_concurrent_agents: u32,
     pub running: BTreeMap<String, RunAttempt>,
+    #[serde(default)]
+    pub running_sessions: BTreeMap<String, RunningSessionSnapshot>,
     pub claimed: BTreeSet<String>,
     pub retry_queue: Vec<RetrySnapshotEntry>,
     pub completed: Vec<CompletedEntry>,

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -10,7 +10,7 @@ use tokio::net::TcpListener;
 
 use crate::domain::{
     CodexTotals, OrchestratorSnapshot, PollingSnapshot, RefreshRequestOutcome, RetrySnapshotEntry,
-    RunAttempt,
+    RunAttempt, RunningSessionSnapshot,
 };
 use crate::orchestrator::{RefreshSender, SnapshotHandle};
 
@@ -103,6 +103,7 @@ struct StateResponse {
     poll_interval_ms: u64,
     max_concurrent_agents: u32,
     running: std::collections::BTreeMap<String, RunAttempt>,
+    running_sessions: std::collections::BTreeMap<String, RunningSessionSnapshot>,
     claimed: std::collections::BTreeSet<String>,
     retry_queue: Vec<RetrySnapshotEntry>,
     completed: Vec<crate::domain::CompletedEntry>,
@@ -485,6 +486,7 @@ async fn get_state(State(state): State<HttpServerState>) -> impl IntoResponse {
         poll_interval_ms: snapshot.poll_interval_ms,
         max_concurrent_agents: snapshot.max_concurrent_agents,
         running: snapshot.running,
+        running_sessions: snapshot.running_sessions,
         claimed: snapshot.claimed,
         retry_queue: snapshot.retry_queue,
         completed: snapshot.completed,

--- a/apps/symphony/src/lib.rs
+++ b/apps/symphony/src/lib.rs
@@ -16,6 +16,7 @@ pub mod codex;
 pub mod http_server;
 pub mod logging;
 pub mod orchestrator;
+pub mod tui;
 
 // These modules will be implemented in later slices
 // pub mod agent_runner;

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -3,6 +3,7 @@ use std::future::{pending, Future};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, Once};
+use std::time::Duration;
 
 use clap::Parser;
 use symphony::domain::{Issue, ServiceConfig};
@@ -11,6 +12,7 @@ use symphony::linear::adapter::{LinearAdapter, TrackerAdapter};
 use symphony::linear::client::LinearClient;
 use symphony::logging;
 use symphony::orchestrator::{Orchestrator, OrchestratorPort};
+use symphony::tui;
 use symphony::workflow_store::WorkflowStore;
 use symphony::{config, error};
 use tracing_appender::non_blocking::WorkerGuard;
@@ -33,6 +35,10 @@ pub struct Cli {
     /// Log file root directory
     #[arg(long)]
     pub logs_root: Option<String>,
+
+    /// Render a live terminal dashboard (Ratatui)
+    #[arg(long)]
+    pub tui: bool,
 }
 
 pub trait BootstrapDeps {
@@ -180,7 +186,9 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
     fn start_orchestrator(&mut self, workflow_path: &Path, cli: &Cli) -> Result<(), String> {
         let context = self.take_or_load_validated_context(workflow_path)?;
         let http_binding = effective_http_binding(&context.effective_config, cli);
-        print_startup_banner(cli, &context.effective_config, http_binding.as_ref());
+        if !cli.tui {
+            print_startup_banner(cli, &context.effective_config, http_binding.as_ref());
+        }
 
         let workflow_store = Arc::new(context.workflow_store);
         let mut tracker_port = LinearOrchestratorPort::new(Arc::clone(&workflow_store));
@@ -190,8 +198,19 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
         );
 
         let snapshot_handle = orchestrator.create_snapshot_handle();
+        let tui_snapshot_handle = snapshot_handle.clone();
         let refresh_sender = orchestrator.create_refresh_channel();
         let http_state = HttpServerState::new(Arc::new(snapshot_handle), Arc::new(refresh_sender));
+
+        let mut tui_shutdown = None;
+        let mut tui_task = None;
+        if cli.tui {
+            let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+            tui_shutdown = Some(shutdown_tx);
+            tui_task = Some(tokio::spawn(async move {
+                tui::run_tui(tui_snapshot_handle, shutdown_rx).await;
+            }));
+        }
 
         tracing::info!(
             phase = "startup",
@@ -201,6 +220,7 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             http_host = http_binding.as_ref().map(|binding| binding.host.as_str()).unwrap_or("n/a"),
             http_port = http_binding.as_ref().map(|binding| binding.port),
             logs_root_configured = cli.logs_root.is_some(),
+            tui_enabled = cli.tui,
 
             "constructed orchestrator runtime"
         );
@@ -220,13 +240,37 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             );
         }
 
-        run_runtime_until_shutdown(
+        let runtime_result = run_runtime_until_shutdown(
             &mut orchestrator,
             &mut tracker_port,
             workflow_path,
             http_binding,
             http_state,
-        )
+        );
+
+        if let Some(shutdown_tx) = tui_shutdown {
+            let _ = shutdown_tx.send(true);
+        }
+
+        if let Some(task) = tui_task {
+            let handle = tokio::runtime::Handle::try_current()
+                .map_err(|err| format!("missing tokio runtime for tui shutdown: {err}"))?;
+            tokio::task::block_in_place(|| {
+                handle.block_on(async {
+                    match tokio::time::timeout(Duration::from_secs(2), task).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(err)) => {
+                            tracing::warn!(error = %err, "tui task ended with join error");
+                        }
+                        Err(_) => {
+                            tracing::warn!("timed out waiting for tui task shutdown");
+                        }
+                    }
+                });
+            });
+        }
+
+        runtime_result
     }
 }
 
@@ -464,7 +508,7 @@ fn flush_file_logs() {
     }
 }
 
-fn init_tracing(logs_root: Option<&Path>) {
+fn init_tracing(logs_root: Option<&Path>, tui_enabled: bool) {
     static INIT: Once = Once::new();
 
     INIT.call_once(|| {
@@ -496,6 +540,7 @@ fn init_tracing(logs_root: Option<&Path>) {
                     subscriber_builder.try_init()
                 }
             },
+            None if tui_enabled => subscriber_builder.with_writer(std::io::sink).try_init(),
             None => subscriber_builder.try_init(),
         };
 
@@ -514,7 +559,7 @@ fn run_entrypoint(args: impl IntoIterator<Item = OsString>) -> i32 {
         }
     };
 
-    init_tracing(cli.logs_root.as_deref().map(Path::new));
+    init_tracing(cli.logs_root.as_deref().map(Path::new), cli.tui);
 
     let mut deps = RuntimeBootstrapDeps::default();
 
@@ -542,5 +587,22 @@ async fn main() {
     flush_file_logs();
     if code != 0 {
         std::process::exit(code);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cli_accepts_tui_flag() {
+        let cli = parse_cli_from(["symphony", "WORKFLOW.md", "--tui"]).expect("cli parse");
+        assert!(cli.tui);
+    }
+
+    #[test]
+    fn parse_cli_defaults_tui_to_false() {
+        let cli = parse_cli_from(["symphony", "WORKFLOW.md"]).expect("cli parse");
+        assert!(!cli.tui);
     }
 }

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -186,6 +186,10 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
     fn start_orchestrator(&mut self, workflow_path: &Path, cli: &Cli) -> Result<(), String> {
         let context = self.take_or_load_validated_context(workflow_path)?;
         let http_binding = effective_http_binding(&context.effective_config, cli);
+        if cli.tui {
+            tui::validate_terminal_for_tui()
+                .map_err(|err| format!("tui preflight failed: {err}"))?;
+        }
         if !cli.tui {
             print_startup_banner(cli, &context.effective_config, http_binding.as_ref());
         }

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -207,12 +207,16 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
         let http_state = HttpServerState::new(Arc::new(snapshot_handle), Arc::new(refresh_sender));
 
         let mut tui_shutdown = None;
+        let mut tui_exit = None;
         let mut tui_task = None;
         if cli.tui {
             let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+            let (exit_tx, exit_rx) = tokio::sync::watch::channel(None::<tui::TuiExitReason>);
             tui_shutdown = Some(shutdown_tx);
+            tui_exit = Some(exit_rx);
             tui_task = Some(tokio::spawn(async move {
-                tui::run_tui(tui_snapshot_handle, shutdown_rx).await;
+                let reason = tui::run_tui(tui_snapshot_handle, shutdown_rx).await;
+                let _ = exit_tx.send(Some(reason));
             }));
         }
 
@@ -250,6 +254,7 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             workflow_path,
             http_binding,
             http_state,
+            tui_exit,
         );
 
         if let Some(shutdown_tx) = tui_shutdown {
@@ -441,6 +446,7 @@ fn run_runtime_until_shutdown(
     workflow_path: &Path,
     http_binding: Option<HttpBinding>,
     http_state: HttpServerState,
+    mut tui_exit: Option<tokio::sync::watch::Receiver<Option<tui::TuiExitReason>>>,
 ) -> Result<(), String> {
     let handle = tokio::runtime::Handle::try_current()
         .map_err(|err| format!("missing tokio runtime for orchestrator startup: {err}"))?;
@@ -462,6 +468,19 @@ fn run_runtime_until_shutdown(
                         .map_err(|err| format!("http server failed: {err}"))
                 } else {
                     pending::<Result<(), String>>().await
+                }
+            };
+            let tui_exit_future = async {
+                match tui_exit.as_mut() {
+                    Some(exit_rx) => loop {
+                        if let Some(reason) = *exit_rx.borrow() {
+                            break Some(reason);
+                        }
+                        if exit_rx.changed().await.is_err() {
+                            break Some(tui::TuiExitReason::ShutdownSignal);
+                        }
+                    },
+                    None => pending::<Option<tui::TuiExitReason>>().await,
                 }
             };
 
@@ -499,6 +518,27 @@ fn run_runtime_until_shutdown(
                     );
                     Ok(())
                 }
+                tui_reason = tui_exit_future => {
+                    let Some(tui_reason) = tui_reason else {
+                        return Ok(());
+                    };
+                    match tui_reason {
+                        tui::TuiExitReason::CtrlC | tui::TuiExitReason::ShutdownSignal => {
+                            tracing::info!(
+                                phase = "runtime",
+                                stage = "stopped",
+                                reason = "tui_exit",
+                                workflow_path = %workflow_path.display(),
+                                tui_reason = ?tui_reason,
+                                "tui requested runtime shutdown"
+                            );
+                            Ok(())
+                        }
+                        tui::TuiExitReason::SetupFailed => Err("tui failed to initialize terminal".to_string()),
+                        tui::TuiExitReason::InputError => Err("tui failed while reading terminal input".to_string()),
+                        tui::TuiExitReason::DrawError => Err("tui failed while drawing dashboard".to_string()),
+                    }
+                }
             }
         })
     })
@@ -533,7 +573,11 @@ fn init_tracing(logs_root: Option<&Path>, tui_enabled: bool) {
                         eprintln!(
                             "failed to store file log guard (mutex poisoned): {err}; file logging disabled"
                         );
-                        subscriber_builder.try_init()
+                        if tui_enabled {
+                            subscriber_builder.with_writer(std::io::sink).try_init()
+                        } else {
+                            subscriber_builder.try_init()
+                        }
                     }
                 },
                 Err(err) => {
@@ -541,7 +585,11 @@ fn init_tracing(logs_root: Option<&Path>, tui_enabled: bool) {
                         "failed to initialize rotating file logging at {}: {err}",
                         logs_root_path.display()
                     );
-                    subscriber_builder.try_init()
+                    if tui_enabled {
+                        subscriber_builder.with_writer(std::io::sink).try_init()
+                    } else {
+                        subscriber_builder.try_init()
+                    }
                 }
             },
             None if tui_enabled => subscriber_builder.with_writer(std::io::sink).try_init(),

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -11,7 +11,8 @@ use crate::config;
 use crate::domain::{
     AgentEvent, CodexConfig, CodexTotals, CompletedEntry, HooksConfig, Issue, OrchestratorSnapshot,
     OrchestratorState, PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetryEntry,
-    RetrySnapshotEntry, RunAttempt, ServiceConfig, TrackerConfig, WorkspaceConfig,
+    RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot, ServiceConfig, TrackerConfig,
+    WorkspaceConfig,
 };
 use crate::error::{Result, SymphonyError};
 use crate::ssh::{self, WorkerHostSelection};
@@ -594,6 +595,13 @@ pub struct RetryContext {
     pub session_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct RunningSessionStats {
+    turn_count: u32,
+    last_activity_at: Option<DateTime<Utc>>,
+    total_tokens: u64,
+}
+
 #[derive(Debug, Clone)]
 pub enum WorkerCompletion {
     Completed { schedule_continuation: bool },
@@ -629,6 +637,7 @@ pub struct Orchestrator {
     retry_tokens: HashMap<String, String>,
     worker_last_activity_ms: HashMap<String, i64>,
     worker_session_ids: HashMap<String, String>,
+    running_session_stats: HashMap<String, RunningSessionStats>,
     pending_terminal_cleanup: HashMap<String, PendingTerminalCleanup>,
     /// Normalized running issue state cache used for per-state slot accounting.
     running_issue_states: HashMap<String, String>,
@@ -702,6 +711,7 @@ impl Orchestrator {
             retry_tokens: HashMap::new(),
             worker_last_activity_ms: HashMap::new(),
             worker_session_ids: HashMap::new(),
+            running_session_stats: HashMap::new(),
             pending_terminal_cleanup: HashMap::new(),
             running_issue_states: HashMap::new(),
             next_retry_token: 0,
@@ -1207,11 +1217,18 @@ impl Orchestrator {
         }
 
         self.record_worker_activity(issue_id, event_timestamp_ms(event));
+        let event_time = event_timestamp(event);
 
         if let Some(session_id) = event_session_id(event) {
             self.worker_session_ids
                 .insert(issue_id.to_string(), session_id.to_string());
         }
+
+        let session_stats = self
+            .running_session_stats
+            .entry(issue_id.to_string())
+            .or_default();
+        session_stats.last_activity_at = Some(event_time);
 
         if let Some(run_attempt) = self.state.running.get_mut(issue_id) {
             match event {
@@ -1236,6 +1253,8 @@ impl Orchestrator {
             ..
         } = event
         {
+            session_stats.turn_count = session_stats.turn_count.saturating_add(1);
+            session_stats.total_tokens = session_stats.total_tokens.saturating_add(*total_tokens);
             self.apply_turn_metrics(&TurnMetrics {
                 input_tokens: *input_tokens,
                 output_tokens: *output_tokens,
@@ -1275,6 +1294,7 @@ impl Orchestrator {
         self.state.claimed.remove(issue_id);
         self.running_issue_states.remove(issue_id);
         self.worker_last_activity_ms.remove(issue_id);
+        self.running_session_stats.remove(issue_id);
 
         let issue_identifier = run_attempt.issue_identifier.clone();
         let session_id = self.worker_session_ids.remove(issue_id);
@@ -1408,6 +1428,13 @@ impl Orchestrator {
         self.state.claimed.insert(issue.id.clone());
         self.running_issue_states
             .insert(issue.id.clone(), normalize_issue_state(&issue.state));
+        self.running_session_stats
+            .entry(issue.id.clone())
+            .or_insert_with(|| RunningSessionStats {
+                turn_count: 0,
+                last_activity_at: Some(Utc::now()),
+                total_tokens: 0,
+            });
         self.state.retry_attempts.remove(&issue.id);
 
         let workspace_path = Path::new(&workspace_info.path);
@@ -1668,6 +1695,24 @@ impl Orchestrator {
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        let running_sessions: BTreeMap<String, RunningSessionSnapshot> = self
+            .state
+            .running
+            .iter()
+            .map(|(issue_id, run_attempt)| {
+                let stats = self.running_session_stats.get(issue_id);
+                (
+                    issue_id.clone(),
+                    RunningSessionSnapshot {
+                        turn_count: stats.map(|s| s.turn_count).unwrap_or(0),
+                        last_activity_at: stats
+                            .and_then(|s| s.last_activity_at.as_ref().cloned())
+                            .or(Some(run_attempt.started_at)),
+                        total_tokens: stats.map(|s| s.total_tokens).unwrap_or(0),
+                    },
+                )
+            })
+            .collect();
 
         let claimed: BTreeSet<String> = self.state.claimed.iter().cloned().collect();
         let mut completed: Vec<CompletedEntry> = self.state.completed.values().cloned().collect();
@@ -1698,6 +1743,7 @@ impl Orchestrator {
             poll_interval_ms: self.state.poll_interval_ms,
             max_concurrent_agents: self.state.max_concurrent_agents,
             running,
+            running_sessions,
             claimed,
             retry_queue,
             completed,
@@ -1918,6 +1964,14 @@ impl Orchestrator {
 
         self.state.running.insert(issue.id.clone(), attempt);
         self.state.claimed.insert(issue.id.clone());
+        self.running_session_stats.insert(
+            issue.id.clone(),
+            RunningSessionStats {
+                turn_count: 0,
+                last_activity_at: Some(Utc::now()),
+                total_tokens: 0,
+            },
+        );
         self.state.retry_attempts.remove(&issue.id);
         self.running_issue_states
             .insert(issue.id.clone(), normalize_issue_state(&issue.state));
@@ -2173,6 +2227,7 @@ impl Orchestrator {
         self.retry_tokens.remove(issue_id);
         self.worker_last_activity_ms.remove(issue_id);
         self.worker_session_ids.remove(issue_id);
+        self.running_session_stats.remove(issue_id);
     }
 
     fn cleanup_workspace(&self, issue: &Issue, workspace_path: &str) {
@@ -2224,6 +2279,7 @@ impl Orchestrator {
         self.retry_tokens.remove(issue_id);
         self.worker_last_activity_ms.remove(issue_id);
         self.worker_session_ids.remove(issue_id);
+        self.running_session_stats.remove(issue_id);
     }
 
     fn active_state_set(&self) -> HashSet<String> {
@@ -2248,6 +2304,10 @@ impl Orchestrator {
 }
 
 fn event_timestamp_ms(event: &AgentEvent) -> i64 {
+    event_timestamp(event).timestamp_millis()
+}
+
+fn event_timestamp(event: &AgentEvent) -> DateTime<Utc> {
     match event {
         AgentEvent::SessionStarted { timestamp, .. }
         | AgentEvent::StartupFailed { timestamp, .. }
@@ -2264,7 +2324,7 @@ fn event_timestamp_ms(event: &AgentEvent) -> i64 {
         | AgentEvent::UnsupportedToolCall { timestamp, .. }
         | AgentEvent::Notification { timestamp, .. }
         | AgentEvent::OtherMessage { timestamp, .. }
-        | AgentEvent::Malformed { timestamp, .. } => timestamp.timestamp_millis(),
+        | AgentEvent::Malformed { timestamp, .. } => *timestamp,
     }
 }
 

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1706,7 +1706,7 @@ impl Orchestrator {
                     RunningSessionSnapshot {
                         turn_count: stats.map(|s| s.turn_count).unwrap_or(0),
                         last_activity_at: stats
-                            .and_then(|s| s.last_activity_at.as_ref().cloned())
+                            .and_then(|s| s.last_activity_at)
                             .or(Some(run_attempt.started_at)),
                         total_tokens: stats.map(|s| s.total_tokens).unwrap_or(0),
                     },

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -22,6 +22,15 @@ use crate::orchestrator::SnapshotHandle;
 
 const REFRESH_INTERVAL_MS: u64 = 500;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TuiExitReason {
+    ShutdownSignal,
+    CtrlC,
+    SetupFailed,
+    InputError,
+    DrawError,
+}
+
 pub fn validate_terminal_for_tui() -> Result<(), String> {
     if !io::stdout().is_terminal() {
         return Err("stdout is not a terminal; --tui requires an interactive terminal".to_string());
@@ -39,26 +48,28 @@ pub fn validate_terminal_for_tui() -> Result<(), String> {
     Ok(())
 }
 
-pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Receiver<bool>) {
+pub async fn run_tui(
+    snapshot_handle: SnapshotHandle,
+    mut shutdown: watch::Receiver<bool>,
+) -> TuiExitReason {
     let mut terminal = match setup_terminal() {
         Ok(terminal) => terminal,
         Err(err) => {
             tracing::error!(error = %err, "failed to initialize tui terminal");
-            return;
+            return TuiExitReason::SetupFailed;
         }
     };
 
     let mut ticker = tokio::time::interval(Duration::from_millis(REFRESH_INTERVAL_MS));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
     ticker.tick().await;
-
-    loop {
+    let exit_reason = loop {
         match ctrl_c_pressed() {
-            Ok(true) => break,
+            Ok(true) => break TuiExitReason::CtrlC,
             Ok(false) => {}
             Err(err) => {
                 tracing::warn!(error = %err, "failed reading terminal input for ctrl+c");
-                break;
+                break TuiExitReason::InputError;
             }
         }
 
@@ -66,7 +77,7 @@ pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Recei
         let now = Utc::now();
         if let Err(err) = terminal.draw(|frame| draw_dashboard(frame, &snapshot, now)) {
             tracing::error!(error = %err, "failed drawing tui frame");
-            break;
+            break TuiExitReason::DrawError;
         }
 
         tokio::select! {
@@ -75,18 +86,20 @@ pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Recei
                 match changed {
                     Ok(()) => {
                         if *shutdown.borrow() {
-                            break;
+                            break TuiExitReason::ShutdownSignal;
                         }
                     }
-                    Err(_) => break,
+                    Err(_) => break TuiExitReason::ShutdownSignal,
                 }
             }
         }
-    }
+    };
 
     if let Err(err) = restore_terminal(&mut terminal) {
         tracing::warn!(error = %err, "failed restoring terminal after tui shutdown");
     }
+
+    exit_reason
 }
 
 fn ctrl_c_pressed() -> io::Result<bool> {
@@ -107,18 +120,39 @@ fn ctrl_c_pressed() -> io::Result<bool> {
 fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<io::Stdout>>> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    if let Err(err) = execute!(stdout, EnterAlternateScreen) {
+        let _ = disable_raw_mode();
+        return Err(err);
+    }
     let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-    terminal.clear()?;
+    let mut terminal = match Terminal::new(backend) {
+        Ok(terminal) => terminal,
+        Err(err) => {
+            cleanup_partial_terminal_state();
+            return Err(err);
+        }
+    };
+    if let Err(err) = terminal.clear() {
+        cleanup_partial_terminal_state();
+        return Err(err);
+    }
     Ok(terminal)
 }
 
 fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
-    Ok(())
+    let raw_result = disable_raw_mode();
+    let screen_result = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    let cursor_result = terminal.show_cursor();
+
+    raw_result?;
+    screen_result?;
+    cursor_result
+}
+
+fn cleanup_partial_terminal_state() {
+    let _ = disable_raw_mode();
+    let mut stdout = io::stdout();
+    let _ = execute!(stdout, LeaveAlternateScreen);
 }
 
 fn draw_dashboard(frame: &mut Frame, snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) {

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -1,7 +1,9 @@
 use std::io;
+use std::io::IsTerminal;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -20,6 +22,23 @@ use crate::orchestrator::SnapshotHandle;
 
 const REFRESH_INTERVAL_MS: u64 = 500;
 
+pub fn validate_terminal_for_tui() -> Result<(), String> {
+    if !io::stdout().is_terminal() {
+        return Err("stdout is not a terminal; --tui requires an interactive terminal".to_string());
+    }
+
+    enable_raw_mode().map_err(|err| format!("failed to enable raw mode: {err}"))?;
+    let mut stdout = io::stdout();
+    if let Err(err) = execute!(stdout, EnterAlternateScreen, LeaveAlternateScreen) {
+        let _ = disable_raw_mode();
+        return Err(format!(
+            "failed to enter/leave alternate screen during TUI preflight: {err}"
+        ));
+    }
+    disable_raw_mode().map_err(|err| format!("failed to disable raw mode: {err}"))?;
+    Ok(())
+}
+
 pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Receiver<bool>) {
     let mut terminal = match setup_terminal() {
         Ok(terminal) => terminal,
@@ -34,6 +53,15 @@ pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Recei
     ticker.tick().await;
 
     loop {
+        match ctrl_c_pressed() {
+            Ok(true) => break,
+            Ok(false) => {}
+            Err(err) => {
+                tracing::warn!(error = %err, "failed reading terminal input for ctrl+c");
+                break;
+            }
+        }
+
         let snapshot = snapshot_handle.read();
         let now = Utc::now();
         if let Err(err) = terminal.draw(|frame| draw_dashboard(frame, &snapshot, now)) {
@@ -59,6 +87,21 @@ pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Recei
     if let Err(err) = restore_terminal(&mut terminal) {
         tracing::warn!(error = %err, "failed restoring terminal after tui shutdown");
     }
+}
+
+fn ctrl_c_pressed() -> io::Result<bool> {
+    while event::poll(Duration::from_millis(0))? {
+        if let Event::Key(key_event) = event::read()? {
+            let ctrl_c = key_event.modifiers.contains(KeyModifiers::CONTROL)
+                && key_event.code == KeyCode::Char('c')
+                && matches!(key_event.kind, KeyEventKind::Press | KeyEventKind::Repeat);
+            if ctrl_c {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
 }
 
 fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<io::Stdout>>> {
@@ -497,6 +540,17 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("secondary: 34% used")),
             "expected secondary usage summary, got: {summary:?}"
+        );
+    }
+
+    #[test]
+    fn validate_terminal_requires_tty_stdout() {
+        if io::stdout().is_terminal() {
+            return;
+        }
+        assert!(
+            validate_terminal_for_tui().is_err(),
+            "non-interactive stdout should fail tui preflight"
         );
     }
 }

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -1,0 +1,502 @@
+use std::io;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Cell, List, ListItem, Paragraph, Row, Table, Wrap};
+use ratatui::{Frame, Terminal};
+use tokio::sync::watch;
+use tokio::time::MissedTickBehavior;
+
+use crate::domain::OrchestratorSnapshot;
+use crate::orchestrator::SnapshotHandle;
+
+const REFRESH_INTERVAL_MS: u64 = 500;
+
+pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Receiver<bool>) {
+    let mut terminal = match setup_terminal() {
+        Ok(terminal) => terminal,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to initialize tui terminal");
+            return;
+        }
+    };
+
+    let mut ticker = tokio::time::interval(Duration::from_millis(REFRESH_INTERVAL_MS));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    ticker.tick().await;
+
+    loop {
+        let snapshot = snapshot_handle.read();
+        let now = Utc::now();
+        if let Err(err) = terminal.draw(|frame| draw_dashboard(frame, &snapshot, now)) {
+            tracing::error!(error = %err, "failed drawing tui frame");
+            break;
+        }
+
+        tokio::select! {
+            _ = ticker.tick() => {}
+            changed = shutdown.changed() => {
+                match changed {
+                    Ok(()) => {
+                        if *shutdown.borrow() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+    }
+
+    if let Err(err) = restore_terminal(&mut terminal) {
+        tracing::warn!(error = %err, "failed restoring terminal after tui shutdown");
+    }
+}
+
+fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<io::Stdout>>> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+    Ok(terminal)
+}
+
+fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+fn draw_dashboard(frame: &mut Frame, snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) {
+    let root = Block::default()
+        .title("Symphony Dashboard")
+        .borders(Borders::ALL);
+    frame.render_widget(root, frame.area());
+    let inner = Block::default().borders(Borders::ALL).inner(frame.area());
+
+    let sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(8),
+            Constraint::Length(7),
+            Constraint::Length(7),
+            Constraint::Length(2),
+        ])
+        .split(inner);
+
+    let summary = format!(
+        "Running: {}  Retry: {}  Completed: {}  Tokens: {}",
+        snapshot.running.len(),
+        snapshot.retry_queue.len(),
+        snapshot.completed.len(),
+        format_tokens(snapshot.codex_totals.total_tokens)
+    );
+    frame.render_widget(Paragraph::new(summary), sections[0]);
+
+    let running_header = Row::new(vec![
+        Cell::from("ID"),
+        Cell::from("State"),
+        Cell::from("Turn"),
+        Cell::from("Last Activity"),
+        Cell::from("Tokens"),
+        Cell::from("Host"),
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+    let running_rows = running_rows(snapshot, now);
+    let running_table = Table::new(
+        running_rows,
+        [
+            Constraint::Length(12),
+            Constraint::Length(14),
+            Constraint::Length(8),
+            Constraint::Length(14),
+            Constraint::Length(12),
+            Constraint::Length(10),
+        ],
+    )
+    .header(running_header)
+    .block(
+        Block::default()
+            .title("Running Sessions")
+            .borders(Borders::ALL),
+    );
+    frame.render_widget(running_table, sections[1]);
+
+    let retry_header = Row::new(vec![
+        Cell::from("ID"),
+        Cell::from("Attempt"),
+        Cell::from("Retry In"),
+        Cell::from("Host"),
+        Cell::from("Error"),
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+    let retry_rows = retry_rows(snapshot);
+    let retry_table = Table::new(
+        retry_rows,
+        [
+            Constraint::Length(12),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Min(16),
+        ],
+    )
+    .header(retry_header)
+    .block(Block::default().title("Retry Queue").borders(Borders::ALL));
+    frame.render_widget(retry_table, sections[2]);
+
+    let completed_items = completed_items(snapshot);
+    let completed_list =
+        List::new(completed_items).block(Block::default().title("Completed").borders(Borders::ALL));
+    frame.render_widget(completed_list, sections[3]);
+
+    let polling_last = snapshot
+        .polling
+        .last_poll_at
+        .as_deref()
+        .and_then(parse_rfc3339)
+        .map(|ts| format_age(Some(ts), now))
+        .unwrap_or_else(|| "never".to_string());
+    let polling_line = format!(
+        "Polling: last {}  count: {}  interval: {}",
+        polling_last,
+        snapshot.polling.poll_count,
+        format_duration(snapshot.polling.poll_interval_ms as i64),
+    );
+    let rate_summary = rate_summary(snapshot, now);
+    let footer = Paragraph::new(vec![Line::from(polling_line), Line::from(rate_summary)])
+        .wrap(Wrap { trim: true });
+    frame.render_widget(footer, sections[4]);
+}
+
+fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<'static>> {
+    let mut rows = Vec::new();
+    for (issue_id, run) in &snapshot.running {
+        let metrics = snapshot.running_sessions.get(issue_id);
+        let turn_count = metrics.map(|m| m.turn_count).unwrap_or(0);
+        let last_activity = metrics
+            .and_then(|m| m.last_activity_at.as_ref().cloned())
+            .or(Some(run.started_at));
+        let total_tokens = metrics.map(|m| m.total_tokens).unwrap_or(0);
+        let state = run
+            .linear_state
+            .as_deref()
+            .unwrap_or(run.status.as_str())
+            .to_string();
+        rows.push(Row::new(vec![
+            Cell::from(run.issue_identifier.clone()),
+            Cell::from(state),
+            Cell::from(turn_count.to_string()),
+            Cell::from(format_age(last_activity, now)),
+            Cell::from(format_tokens(total_tokens)),
+            Cell::from(
+                run.worker_host
+                    .as_deref()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "local".to_string()),
+            ),
+        ]));
+    }
+
+    if rows.is_empty() {
+        rows.push(Row::new(vec![
+            Cell::from("(none)"),
+            Cell::from(""),
+            Cell::from(""),
+            Cell::from(""),
+            Cell::from(""),
+            Cell::from(""),
+        ]));
+    }
+
+    rows
+}
+
+fn retry_rows(snapshot: &OrchestratorSnapshot) -> Vec<Row<'static>> {
+    let mut rows = Vec::new();
+    for retry in &snapshot.retry_queue {
+        rows.push(Row::new(vec![
+            Cell::from(retry.identifier.clone()),
+            Cell::from(retry.attempt.to_string()),
+            Cell::from(format_retry_delay(retry.due_in_ms)),
+            Cell::from(
+                retry
+                    .worker_host
+                    .as_deref()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "local".to_string()),
+            ),
+            Cell::from(retry.error.clone().unwrap_or_else(|| "-".to_string())),
+        ]));
+    }
+
+    if rows.is_empty() {
+        rows.push(Row::new(vec![
+            Cell::from("(empty)"),
+            Cell::from(""),
+            Cell::from(""),
+            Cell::from(""),
+            Cell::from(""),
+        ]));
+    }
+
+    rows
+}
+
+fn completed_items(snapshot: &OrchestratorSnapshot) -> Vec<ListItem<'static>> {
+    if snapshot.completed.is_empty() {
+        return vec![ListItem::new("(empty)")];
+    }
+
+    snapshot
+        .completed
+        .iter()
+        .map(|entry| {
+            let timestamp = entry
+                .completed_at
+                .as_ref()
+                .map(|dt| dt.format("%-I:%M %p").to_string())
+                .unwrap_or_else(|| "-".to_string());
+            ListItem::new(format!(
+                "{} - {} ({})",
+                entry.identifier, entry.title, timestamp
+            ))
+        })
+        .collect()
+}
+
+fn rate_summary(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> String {
+    let Some(rate_limits) = snapshot.codex_rate_limits.as_ref() else {
+        return "Rate: n/a".to_string();
+    };
+
+    let parts = summarize_rate_limits(&rate_limits.data, now);
+    if parts.is_empty() {
+        "Rate: n/a".to_string()
+    } else {
+        format!("Rate: {}", parts.join("  "))
+    }
+}
+
+fn summarize_rate_limits(data: &serde_json::Value, now: DateTime<Utc>) -> Vec<String> {
+    let mut parts = Vec::new();
+
+    let Some(obj) = data.as_object() else {
+        return parts;
+    };
+
+    for (name, value) in obj {
+        if matches!(name.as_str(), "limit_id" | "limit_name") {
+            continue;
+        }
+        let Some(bucket) = value.as_object() else {
+            continue;
+        };
+        if let Some(text) = bucket_usage_text(name, bucket, now) {
+            parts.push(text);
+        }
+    }
+
+    if parts.is_empty() {
+        if let Some(text) = obj
+            .get("limit_name")
+            .and_then(|v| v.as_str())
+            .and_then(|label| bucket_usage_text(label, obj, now))
+        {
+            parts.push(text);
+        } else if let Some(text) = bucket_usage_text("limit", obj, now) {
+            parts.push(text);
+        }
+    }
+
+    parts.sort();
+    parts
+}
+
+fn bucket_usage_text(
+    label: &str,
+    bucket: &serde_json::Map<String, serde_json::Value>,
+    now: DateTime<Utc>,
+) -> Option<String> {
+    let remaining = bucket.get("remaining").and_then(as_f64)?;
+    let limit = bucket.get("limit").and_then(as_f64)?;
+    if limit <= 0.0 {
+        return None;
+    }
+
+    let used_pct = ((1.0 - (remaining / limit)) * 100.0)
+        .clamp(0.0, 100.0)
+        .round() as i64;
+    let window = bucket_window(bucket, now).unwrap_or_else(|| "-".to_string());
+    Some(format!("{label}: {used_pct}% used ({window})"))
+}
+
+fn bucket_window(
+    bucket: &serde_json::Map<String, serde_json::Value>,
+    now: DateTime<Utc>,
+) -> Option<String> {
+    let reset_at = bucket
+        .get("resets_at")
+        .and_then(|v| v.as_str())
+        .and_then(parse_rfc3339)
+        .or_else(|| {
+            bucket
+                .get("reset_at")
+                .and_then(|v| v.as_str())
+                .and_then(parse_rfc3339)
+        });
+
+    if let Some(reset_at) = reset_at {
+        return Some(format_duration((reset_at - now).num_milliseconds()));
+    }
+
+    if let Some(reset_seconds) = bucket.get("reset_seconds").and_then(as_f64) {
+        return Some(format_duration((reset_seconds * 1000.0) as i64));
+    }
+
+    None
+}
+
+fn parse_rfc3339(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn format_age(timestamp: Option<DateTime<Utc>>, now: DateTime<Utc>) -> String {
+    let Some(timestamp) = timestamp else {
+        return "-".to_string();
+    };
+
+    let delta_ms = (now - timestamp).num_milliseconds().max(0);
+    if delta_ms < 1_000 {
+        "just now".to_string()
+    } else {
+        format!("{} ago", format_duration(delta_ms))
+    }
+}
+
+fn format_retry_delay(due_in_ms: i64) -> String {
+    if due_in_ms <= 0 {
+        "ready".to_string()
+    } else {
+        format_duration(due_in_ms)
+    }
+}
+
+fn format_duration(ms: i64) -> String {
+    let ms = ms.max(0);
+    if ms < 1_000 {
+        return format!("{ms}ms");
+    }
+
+    let seconds = ms / 1_000;
+    if seconds < 60 {
+        return format!("{seconds}s");
+    }
+
+    let minutes = seconds / 60;
+    if minutes < 60 {
+        return format!("{minutes}m");
+    }
+
+    let hours = minutes / 60;
+    if hours < 24 {
+        return format!("{hours}h");
+    }
+
+    let days = hours / 24;
+    format!("{days}d")
+}
+
+fn format_tokens(value: u64) -> String {
+    let digits = value.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (idx, ch) in digits.chars().rev().enumerate() {
+        if idx > 0 && idx % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
+}
+
+fn as_f64(value: &serde_json::Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_u64().map(|v| v as f64))
+        .or_else(|| value.as_i64().map(|v| v as f64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use serde_json::json;
+
+    #[test]
+    fn format_age_returns_seconds_ago() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 22, 15, 0, 10)
+            .single()
+            .expect("valid fixture timestamp");
+        let then = Utc
+            .with_ymd_and_hms(2026, 3, 22, 15, 0, 8)
+            .single()
+            .expect("valid fixture timestamp");
+        assert_eq!(format_age(Some(then), now), "2s ago");
+    }
+
+    #[test]
+    fn format_retry_delay_handles_ready_and_future() {
+        assert_eq!(format_retry_delay(-100), "ready");
+        assert_eq!(format_retry_delay(5_000), "5s");
+    }
+
+    #[test]
+    fn summarize_rate_limits_extracts_usage() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 22, 10, 0, 0)
+            .single()
+            .expect("valid fixture timestamp");
+        let data = json!({
+            "limit_id": "req",
+            "primary": {
+                "remaining": 82,
+                "limit": 100,
+                "reset_seconds": 18_000
+            },
+            "secondary": {
+                "remaining": 33,
+                "limit": 50,
+                "reset_seconds": 604_800
+            }
+        });
+
+        let summary = summarize_rate_limits(&data, now);
+        assert!(
+            summary
+                .iter()
+                .any(|line| line.contains("primary: 18% used")),
+            "expected primary usage summary, got: {summary:?}"
+        );
+        assert!(
+            summary
+                .iter()
+                .any(|line| line.contains("secondary: 34% used")),
+            "expected secondary usage summary, got: {summary:?}"
+        );
+    }
+}

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -255,6 +255,26 @@ fn test_orchestrator_snapshot_serializes() {
             );
             m
         },
+        running_sessions: {
+            let mut m = BTreeMap::new();
+            m.insert(
+                "a-issue".to_string(),
+                RunningSessionSnapshot {
+                    turn_count: 3,
+                    last_activity_at: Some(Utc::now()),
+                    total_tokens: 120,
+                },
+            );
+            m.insert(
+                "z-issue".to_string(),
+                RunningSessionSnapshot {
+                    turn_count: 1,
+                    last_activity_at: Some(Utc::now()),
+                    total_tokens: 40,
+                },
+            );
+            m
+        },
         claimed: {
             let mut s = BTreeSet::new();
             s.insert("c-claim".to_string());
@@ -301,6 +321,7 @@ fn test_orchestrator_snapshot_serializes() {
     assert!(val.get("poll_interval_ms").is_some());
     assert!(val.get("max_concurrent_agents").is_some());
     assert!(val.get("running").is_some());
+    assert!(val.get("running_sessions").is_some());
     assert!(val.get("retry_queue").is_some());
     assert!(val.get("completed").is_some());
     assert!(val.get("codex_totals").is_some());

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -8,7 +8,7 @@ use chrono::{TimeZone, Utc};
 use serde_json::{json, Value};
 use symphony::domain::{
     CodexTotals, CompletedEntry, OrchestratorSnapshot, PollingSnapshot, RateLimitInfo,
-    RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt,
+    RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot,
 };
 use symphony::http_server::{build_router, HttpServerState, RefreshControl, SnapshotSource};
 use tower::ServiceExt;
@@ -75,6 +75,18 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                 },
             );
             running
+        },
+        running_sessions: {
+            let mut sessions = BTreeMap::new();
+            sessions.insert(
+                "issue-123".to_string(),
+                RunningSessionSnapshot {
+                    turn_count: 2,
+                    last_activity_at: Some(started_at),
+                    total_tokens: 200,
+                },
+            );
+            sessions
         },
         claimed: BTreeSet::from(["issue-123".to_string()]),
         retry_queue: vec![RetrySnapshotEntry {

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -937,6 +937,25 @@ fn test_streamed_turn_completed_events_update_token_totals_in_real_time() {
         18,
         "total token count should continue accumulating across streamed turns"
     );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-stream-metrics")
+        .expect("running session snapshot should exist for active issue");
+    assert_eq!(
+        session.turn_count, 2,
+        "running session snapshot should track streamed turn count"
+    );
+    assert_eq!(
+        session.total_tokens, 18,
+        "running session snapshot should track per-session total tokens"
+    );
+    assert_eq!(
+        session.last_activity_at,
+        Some(event_time),
+        "running session snapshot should preserve last activity timestamp"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `--tui` CLI mode that runs a live Ratatui dashboard from the existing orchestrator snapshot handle
- suppress stdout JSON logs in TUI mode unless `--logs-root` is configured (file logs still supported)
- add running-session snapshot metrics (turn count, last activity, per-session tokens) used by the TUI
- keep HTTP dashboard support active when `--port` is set while TUI is running

## Validation
- `cd apps/symphony && cargo fmt -- --check`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `cd apps/symphony && cargo run -- --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional --tui flag launches a live terminal dashboard showing per-issue running session metrics (turn counts, token usage, last activity), retry queue, completed items, and Codex rate-limit summary.

* **API / State**
  * State payloads and snapshots now include per-issue running_sessions diagnostics for real-time monitoring.

* **Tests**
  * Added and extended tests to cover TUI parsing, session metrics, snapshot serialization, and real-time token updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--tui` flag to Symphony that renders a live Ratatui terminal dashboard sourced directly from the existing orchestrator `SnapshotHandle`. It also introduces per-session metrics (`turn_count`, `last_activity_at`, `total_tokens`) tracked in the orchestrator and exposed through `OrchestratorSnapshot.running_sessions`, and suppresses stdout JSON logs when TUI mode is active to avoid corrupting the alternate screen.

Key changes:
- **`tui.rs`** (new): 500-line Ratatui module with a 500ms refresh loop drawing four dashboard sections (running sessions, retry queue, completed, rate-limit footer).
- **`orchestrator.rs`**: Adds `RunningSessionStats` internal map; stats are initialised on dispatch, incremented on `TurnCompleted` events, and removed on worker completion. `event_timestamp_ms` is cleanly refactored into a shared `event_timestamp` helper.
- **`domain.rs`**: `RunningSessionSnapshot` struct and `running_sessions: BTreeMap<String, RunningSessionSnapshot>` added to `OrchestratorSnapshot` with `#[serde(default)]` for backward compatibility.
- **`main.rs`**: Startup banner suppressed in TUI mode; tracing routed to `std::io::sink` when `--tui` is set without `--logs-root`; TUI task is gracefully joined (2-second timeout) after the orchestrator exits.

The two most important issues found:
- **Missing panic-hook terminal restoration** (`tui.rs`): `restore_terminal` is only reachable on a clean loop exit. A panic inside `draw_dashboard` will leave the user's terminal in raw mode / alternate screen. A `std::panic::set_hook` call before setup is the standard fix.
- **No keyboard or signal input handling** (`tui.rs`): Users cannot quit the TUI interactively — the only exit path is the orchestrator shutting down. Pressing Ctrl-C will bypass `restore_terminal` and corrupt the terminal state.
- The fixed `Constraint::Length(7)` panes for the retry/completed sections will silently clip to zero on terminals shorter than ~25 rows.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for non-TUI use; the --tui path has a P1 terminal-safety issue that should be resolved before wide operator use.
- The orchestrator, domain, and test changes are clean and well-tested (50+ passing tests). The main risk is isolated to tui.rs: the missing panic hook means a crash in the draw loop leaves the operator's terminal in an unusable state, and the absence of keyboard/signal handling makes it impossible to exit the TUI cleanly without also crashing the process. These are real UX bugs for anyone running --tui in production, but they don't affect correctness of the underlying orchestration logic.
- apps/symphony/src/tui.rs — terminal lifecycle management (panic hook and keyboard/SIGINT handling)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/tui.rs | New 502-line Ratatui TUI module; missing panic-hook terminal restoration (P1) and no keyboard/SIGINT input handling (P2). Core rendering logic and helper functions are correct. |
| apps/symphony/src/main.rs | Adds --tui CLI flag, suppresses stdout logs in TUI mode, spawns the TUI task, and shuts it down with a 2-second timeout via a watch channel. Shutdown coordination pattern is correct. |
| apps/symphony/src/orchestrator.rs | Adds RunningSessionStats tracking (turn count, last activity, total tokens) that feeds the TUI. Stats are correctly initialised on dispatch, updated on TurnCompleted events, and removed on worker completion. Refactors event_timestamp_ms into event_timestamp helper cleanly. |
| apps/symphony/src/domain.rs | Adds RunningSessionSnapshot struct and running_sessions field to OrchestratorSnapshot. Both are serde-decorated and backward-compatible via #[serde(default)]. |
| apps/symphony/tests/orchestrator_tests.rs | Extends the existing streamed-turn test to assert running_sessions turn_count, total_tokens, and last_activity_at — good coverage of the new stats accumulation logic. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as main.rs
    participant Orch as Orchestrator
    participant TUI as tui::run_tui
    participant Term as Terminal (crossterm)

    Main->>Main: parse --tui flag
    Main->>Main: init_tracing(sink) [suppress stdout]
    Main->>Orch: create_snapshot_handle()
    Main->>TUI: tokio::spawn(run_tui(handle, shutdown_rx))
    activate TUI
    TUI->>Term: enable_raw_mode() + EnterAlternateScreen
    loop Every 500ms
        TUI->>Orch: snapshot_handle.read()
        TUI->>Term: terminal.draw(draw_dashboard)
        TUI->>TUI: tokio::select!(ticker | shutdown_rx)
    end
    Main->>Orch: run_runtime_until_shutdown()
    Orch-->>Main: returns
    Main->>TUI: shutdown_tx.send(true)
    TUI->>Term: restore_terminal()
    deactivate TUI
    Main->>Main: block_in_place → block_on(join tui_task, 2s timeout)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/symphony/src/tui.rs`, line 913-951 ([link](https://github.com/gannonh/kata/blob/308e8e1d1fa7260416f3a97d5372ae10c738ff75/apps/symphony/src/tui.rs#L913-L951)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Terminal not restored on panic**

   `restore_terminal` is only reachable when the event loop exits normally (via `break`). If `draw_dashboard` or any code inside `terminal.draw(...)` panics, the stack unwinds past `restore_terminal`, leaving the user's terminal locked in raw mode with the alternate screen active — the classic "broken terminal after a TUI crash" problem.

   A standard fix is to register a panic hook before entering the TUI that ensures the terminal is restored regardless of how the process exits:

   ```rust
   pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Receiver<bool>) {
       // Install a panic hook so the terminal is always restored on a panic.
       let original_hook = std::panic::take_hook();
       std::panic::set_hook(Box::new(move |info| {
           let _ = disable_raw_mode();
           let _ = execute!(std::io::stderr(), LeaveAlternateScreen);
           original_hook(info);
       }));

       let mut terminal = match setup_terminal() {
           ...
       };
       ...
   }
   ```

   Without this, any bug in `draw_dashboard` (e.g., an unexpected `unwrap()` on a malformed snapshot value) will corrupt the operator's terminal session.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/tui.rs
   Line: 913-951

   Comment:
   **Terminal not restored on panic**

   `restore_terminal` is only reachable when the event loop exits normally (via `break`). If `draw_dashboard` or any code inside `terminal.draw(...)` panics, the stack unwinds past `restore_terminal`, leaving the user's terminal locked in raw mode with the alternate screen active — the classic "broken terminal after a TUI crash" problem.

   A standard fix is to register a panic hook before entering the TUI that ensures the terminal is restored regardless of how the process exits:

   ```rust
   pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Receiver<bool>) {
       // Install a panic hook so the terminal is always restored on a panic.
       let original_hook = std::panic::take_hook();
       std::panic::set_hook(Box::new(move |info| {
           let _ = disable_raw_mode();
           let _ = execute!(std::io::stderr(), LeaveAlternateScreen);
           original_hook(info);
       }));

       let mut terminal = match setup_terminal() {
           ...
       };
       ...
   }
   ```

   Without this, any bug in `draw_dashboard` (e.g., an unexpected `unwrap()` on a malformed snapshot value) will corrupt the operator's terminal session.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/symphony/src/tui.rs`, line 926-947 ([link](https://github.com/gannonh/kata/blob/308e8e1d1fa7260416f3a97d5372ae10c738ff75/apps/symphony/src/tui.rs#L926-L947)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No keyboard input or SIGINT handling**

   The event loop only exits via the `shutdown` watch channel (sent when the orchestrator stops). There is no keyboard event poll, so users cannot press `q` or `Ctrl-C` to exit the TUI themselves.

   If an operator sends `SIGINT` directly (the natural instinct when a terminal UI is running), the process will exit immediately via the OS signal handler — bypassing both the `break` path and `restore_terminal`. The terminal is left in raw mode + alternate screen, requiring `reset` to recover.

   The conventional fix is to poll crossterm keyboard events in the `select!`:

   ```rust
   tokio::select! {
       _ = ticker.tick() => {}
       changed = shutdown.changed() => { /* … */ }
       // Poll crossterm events (non-blocking) so Ctrl-C / 'q' can exit cleanly
       _ = tokio::task::spawn_blocking(crossterm::event::read) => {
           if let Ok(crossterm::event::Event::Key(key)) = crossterm::event::read() {
               if key.code == crossterm::event::KeyCode::Char('q')
                   || key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
                       && key.code == crossterm::event::KeyCode::Char('c')
               {
                   break;
               }
           }
       }
   }
   ```

   Without this, the only graceful exit path is waiting for the orchestrator itself to stop.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/tui.rs
   Line: 926-947

   Comment:
   **No keyboard input or SIGINT handling**

   The event loop only exits via the `shutdown` watch channel (sent when the orchestrator stops). There is no keyboard event poll, so users cannot press `q` or `Ctrl-C` to exit the TUI themselves.

   If an operator sends `SIGINT` directly (the natural instinct when a terminal UI is running), the process will exit immediately via the OS signal handler — bypassing both the `break` path and `restore_terminal`. The terminal is left in raw mode + alternate screen, requiring `reset` to recover.

   The conventional fix is to poll crossterm keyboard events in the `select!`:

   ```rust
   tokio::select! {
       _ = ticker.tick() => {}
       changed = shutdown.changed() => { /* … */ }
       // Poll crossterm events (non-blocking) so Ctrl-C / 'q' can exit cleanly
       _ = tokio::task::spawn_blocking(crossterm::event::read) => {
           if let Ok(crossterm::event::Event::Key(key)) = crossterm::event::read() {
               if key.code == crossterm::event::KeyCode::Char('q')
                   || key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
                       && key.code == crossterm::event::KeyCode::Char('c')
               {
                   break;
               }
           }
       }
   }
   ```

   Without this, the only graceful exit path is waiting for the orchestrator itself to stop.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `apps/symphony/src/tui.rs`, line 971-987 ([link](https://github.com/gannonh/kata/blob/308e8e1d1fa7260416f3a97d5372ae10c738ff75/apps/symphony/src/tui.rs#L971-L987)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Fixed layout constraints may clip on small terminals**

   The layout allocates a fixed minimum of `1 + 8 + 7 + 7 + 2 = 25` rows. On terminals shorter than ~25 rows (common in split-pane setups), Ratatui will silently clip sections — particularly the `Completed` and footer rows collapse to zero height.

   Consider reducing the fixed panes and increasing their minimum from `Length(7)` to `Min(3)` so each section at least shows its header before being hidden:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/tui.rs
   Line: 971-987

   Comment:
   **Fixed layout constraints may clip on small terminals**

   The layout allocates a fixed minimum of `1 + 8 + 7 + 7 + 2 = 25` rows. On terminals shorter than ~25 rows (common in split-pane setups), Ratatui will silently clip sections — particularly the `Completed` and footer rows collapse to zero height.

   Consider reducing the fixed panes and increasing their minimum from `Length(7)` to `Min(3)` so each section at least shows its header before being hidden:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/tui.rs
Line: 913-951

Comment:
**Terminal not restored on panic**

`restore_terminal` is only reachable when the event loop exits normally (via `break`). If `draw_dashboard` or any code inside `terminal.draw(...)` panics, the stack unwinds past `restore_terminal`, leaving the user's terminal locked in raw mode with the alternate screen active — the classic "broken terminal after a TUI crash" problem.

A standard fix is to register a panic hook before entering the TUI that ensures the terminal is restored regardless of how the process exits:

```rust
pub async fn run_tui(snapshot_handle: SnapshotHandle, mut shutdown: watch::Receiver<bool>) {
    // Install a panic hook so the terminal is always restored on a panic.
    let original_hook = std::panic::take_hook();
    std::panic::set_hook(Box::new(move |info| {
        let _ = disable_raw_mode();
        let _ = execute!(std::io::stderr(), LeaveAlternateScreen);
        original_hook(info);
    }));

    let mut terminal = match setup_terminal() {
        ...
    };
    ...
}
```

Without this, any bug in `draw_dashboard` (e.g., an unexpected `unwrap()` on a malformed snapshot value) will corrupt the operator's terminal session.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/tui.rs
Line: 926-947

Comment:
**No keyboard input or SIGINT handling**

The event loop only exits via the `shutdown` watch channel (sent when the orchestrator stops). There is no keyboard event poll, so users cannot press `q` or `Ctrl-C` to exit the TUI themselves.

If an operator sends `SIGINT` directly (the natural instinct when a terminal UI is running), the process will exit immediately via the OS signal handler — bypassing both the `break` path and `restore_terminal`. The terminal is left in raw mode + alternate screen, requiring `reset` to recover.

The conventional fix is to poll crossterm keyboard events in the `select!`:

```rust
tokio::select! {
    _ = ticker.tick() => {}
    changed = shutdown.changed() => { /* … */ }
    // Poll crossterm events (non-blocking) so Ctrl-C / 'q' can exit cleanly
    _ = tokio::task::spawn_blocking(crossterm::event::read) => {
        if let Ok(crossterm::event::Event::Key(key)) = crossterm::event::read() {
            if key.code == crossterm::event::KeyCode::Char('q')
                || key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
                    && key.code == crossterm::event::KeyCode::Char('c')
            {
                break;
            }
        }
    }
}
```

Without this, the only graceful exit path is waiting for the orchestrator itself to stop.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/tui.rs
Line: 971-987

Comment:
**Fixed layout constraints may clip on small terminals**

The layout allocates a fixed minimum of `1 + 8 + 7 + 7 + 2 = 25` rows. On terminals shorter than ~25 rows (common in split-pane setups), Ratatui will silently clip sections — particularly the `Completed` and footer rows collapse to zero height.

Consider reducing the fixed panes and increasing their minimum from `Length(7)` to `Min(3)` so each section at least shows its header before being hidden:

```suggestion
    let sections = Layout::default()
        .direction(Direction::Vertical)
        .constraints([
            Constraint::Length(1),
            Constraint::Min(5),
            Constraint::Min(3),
            Constraint::Min(3),
            Constraint::Length(2),
        ])
        .split(inner);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): add ratatui terminal das..."](https://github.com/gannonh/kata/commit/308e8e1d1fa7260416f3a97d5372ae10c738ff75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25970014)</sub>

<!-- /greptile_comment -->