### PR TITLE
docs(symphony): update docs for tui and observability changes

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -27,7 +27,7 @@ cargo build --release
 ## Running
 
 ```sh
-symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui] [--i-understand-that-this-will-be-running-without-the-usual-guardrails]
+symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
 ```
 
 ### CLI Flag Reference
@@ -35,10 +35,9 @@ symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui] [--i-understand-
 | Flag                                                                    | Type | Default       | Description                                                                                                                          |
 | ----------------------------------------------------------------------- | ---- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `WORKFLOW.md` (positional)                                              | path | `WORKFLOW.md` | Path to the WORKFLOW.md configuration file                                                                                           |
-| `--port PORT`                                                           | u16  | _(none)_      | Bind the HTTP dashboard and API on this port. When omitted, no HTTP server is started. Overrides `server.port` in the workflow file. |
+| `--port PORT`                                                           | u16  | `8080`        | Bind the HTTP dashboard and API on this port. Overrides `server.port` in the workflow file.                                         |
 | `--logs-root PATH`                                                      | path | _(none)_      | Directory root for agent log files.                                                                                                  |
 | `--tui`                                                                 | flag | `false`       | Render a Ratatui terminal dashboard. When enabled with no `--logs-root`, stdout logs are suppressed to avoid corrupting the TUI.   |
-| `--i-understand-that-this-will-be-running-without-the-usual-guardrails` | flag | `false`       | Acknowledge that Symphony runs Codex sessions without interactive guardrails.                                                        |
 
 ### Exit Codes
 
@@ -59,6 +58,11 @@ RUST_LOG=symphony=trace,info symphony WORKFLOW.md   # trace symphony, info every
 ```
 
 Default level is `info`.
+
+When `--logs-root` is set, logs write to rotating files under
+`<logs-root>/log/symphony.log` and stdout shows only the startup banner.
+Without `--logs-root`, logs stream to stdout as structured JSON unless `--tui`
+is enabled.
 
 ---
 
@@ -314,12 +318,14 @@ workflow file (e.g. `0.0.0.0` to bind all interfaces).
     "issue-id-123": {
       "issue_id": "issue-id-123",
       "issue_identifier": "ENG-42",
+      "issue_title": "Ship dashboard metrics",
       "status": "running",
       "attempt": 1,
       "error": null,
       "worker_host": null,
       "workspace_path": "/tmp/symphony_workspaces/ENG-42",
-      "started_at": "2026-03-22T15:40:00Z"
+      "started_at": "2026-03-22T15:40:00Z",
+      "linear_state": "In Progress"
     }
   },
   "running_session_info": {
@@ -346,7 +352,14 @@ workflow file (e.g. `0.0.0.0` to bind all interfaces).
       "workspace_path": "/tmp/symphony_workspaces/ENG-99"
     }
   ],
-  "completed": ["issue-id-001", "issue-id-002"],
+  "completed": [
+    {
+      "issue_id": "issue-id-001",
+      "identifier": "ENG-12",
+      "title": "Initial bootstrap",
+      "completed_at": "2026-03-22T15:20:00Z"
+    }
+  ],
   "codex_totals": {
     "total_tokens": 148230,
     "input_tokens": 120000,
@@ -354,7 +367,10 @@ workflow file (e.g. `0.0.0.0` to bind all interfaces).
   },
   "codex_rate_limits": null,
   "polling": {
-    "last_poll_at": 1714000000000,
+    "checking": false,
+    "next_poll_in_ms": 15000,
+    "poll_interval_ms": 30000,
+    "last_poll_at": "2026-03-22T15:45:00Z",
     "poll_count": 12
   }
 }
@@ -367,14 +383,20 @@ workflow file (e.g. `0.0.0.0` to bind all interfaces).
   "issue": {
     "issue_id": "issue-id-123",
     "issue_identifier": "ENG-42",
+    "issue_title": "Ship dashboard metrics",
     "status": "running",
     "attempt": 1,
     "error": null,
     "worker_host": "worker1.example.com",
-    "workspace_path": "/tmp/symphony_workspaces/ENG-42"
+    "workspace_path": "/tmp/symphony_workspaces/ENG-42",
+    "linear_state": "In Progress"
   }
 }
 ```
+
+`running` entries in `/api/v1/state` are serialized `RunAttempt` records.
+Dashboard observability fields (`turn_count`, `max_turns`, `last_activity_ms`,
+`session_tokens`) are provided alongside each run in `running_session_info`.
 
 ### Sample JSON — `POST /api/v1/refresh`
 
@@ -433,9 +455,28 @@ configured `codex.command`).
 
 ---
 
+## Module Map
+
+Core Rust modules:
+
+| Module | Source file | Responsibility |
+| --- | --- | --- |
+| CLI/runtime entrypoint | `src/main.rs` | CLI parsing, startup validation, tracing setup, runtime wiring |
+| Orchestrator loop | `src/orchestrator.rs` | Poll/dispatch loop, retries, worker lifecycle, state snapshots |
+| HTTP dashboard/API | `src/http_server.rs` | `/`, `/api/v1/state`, `/api/v1/:issue_identifier`, refresh endpoint |
+| Terminal dashboard | `src/tui.rs` | Ratatui renderer, keyboard handling, live snapshot display |
+| Workflow/config parser | `src/workflow.rs`, `src/config.rs` | Front-matter parsing, env/tilde resolution, typed config defaults |
+| Domain model | `src/domain.rs` | Shared runtime/config structs (`RunAttempt`, snapshots, worker/session info) |
+| Tracker adapter/client | `src/linear/adapter.rs`, `src/linear/client.rs` | Linear GraphQL fetch/update operations and issue normalization |
+| Workspace + git bootstrap | `src/workspace.rs` | clone/worktree bootstrapping, branch naming, hooks |
+| Codex app-server bridge | `src/codex/app_server.rs` | Session subprocess lifecycle, turn streaming, tool execution |
+| SSH helpers | `src/ssh.rs` | Remote target parsing, command escaping, host selection helpers |
+
+---
+
 ## Testing
 
-Run the full test suite:
+Run the full test suite (280+ tests):
 
 ```sh
 cargo test

--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -383,20 +383,19 @@ workflow file (e.g. `0.0.0.0` to bind all interfaces).
   "issue": {
     "issue_id": "issue-id-123",
     "issue_identifier": "ENG-42",
-    "issue_title": "Ship dashboard metrics",
     "status": "running",
     "attempt": 1,
     "error": null,
     "worker_host": "worker1.example.com",
-    "workspace_path": "/tmp/symphony_workspaces/ENG-42",
-    "linear_state": "In Progress"
+    "workspace_path": "/tmp/symphony_workspaces/ENG-42"
   }
 }
 ```
 
-`running` entries in `/api/v1/state` are serialized `RunAttempt` records.
-Dashboard observability fields (`turn_count`, `max_turns`, `last_activity_ms`,
-`session_tokens`) are provided alongside each run in `running_session_info`.
+`running` entries in `/api/v1/state` are serialized `RunAttempt` records (which
+include fields like `issue_title` and `linear_state`). Dashboard observability
+fields (`turn_count`, `max_turns`, `last_activity_ms`, `session_tokens`) are
+provided alongside each run in `running_session_info`.
 
 ### Sample JSON — `POST /api/v1/refresh`
 

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -14,7 +14,8 @@ Headless orchestrator that polls a Linear project for candidate issues and dispa
 - **Workspace cleanup** — auto-remove workspaces when issues reach terminal state
 - **Rotating log files** — structured JSON logs to disk with rotation via `--logs-root`
 - **SSH worker pools** — distribute sessions across remote machines
-- **HTTP dashboard + JSON API** — live session table, token tracking, retry queue, polling stats
+- **HTTP dashboard + JSON API** — live session table with turn/activity/session-token observability, retry queue, polling stats
+- **Terminal dashboard (`--tui`)** — Ratatui observability view for local runs
 
 ## Quick Start
 
@@ -46,14 +47,15 @@ Press Ctrl+C to stop.
 ## CLI Flags
 
 ```
-symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH]
+symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
 ```
 
 | Flag | Default | Description |
 |---|---|---|
 | `WORKFLOW.md` (positional) | `WORKFLOW.md` | Path to the workflow configuration file |
-| `--port PORT` | *(none)* | HTTP dashboard and API port. Overrides `server.port` in config |
+| `--port PORT` | `8080` | HTTP dashboard and API port. Overrides `server.port` in config |
 | `--logs-root PATH` | *(none)* | Directory for rotating log files. Suppresses stdout log streaming |
+| `--tui` | `false` | Render the Ratatui terminal dashboard. When enabled without `--logs-root`, stdout logs are suppressed to keep the TUI clean |
 
 ### Log verbosity
 
@@ -65,7 +67,7 @@ RUST_LOG=debug symphony WORKFLOW.md                   # verbose
 RUST_LOG=symphony=trace,info symphony WORKFLOW.md     # trace symphony, info everything else
 ```
 
-When `--logs-root` is set, logs write to rotating files under `<logs-root>/log/symphony.log` and stdout shows only the startup banner. Without `--logs-root`, logs stream to stdout as structured JSON.
+When `--logs-root` is set, logs write to rotating files under `<logs-root>/log/symphony.log` and stdout shows only the startup banner. Without `--logs-root`, logs stream to stdout as structured JSON unless `--tui` is enabled.
 
 ## Multiple Workflows
 
@@ -160,6 +162,8 @@ server:
   port: 8080
 ```
 
+`workspace.isolation: docker` is currently a preview setting: it is accepted by config parsing and logs a warning, but containerized execution is not implemented yet.
+
 ### Workspace Strategies
 
 | Strategy | Command | Best for |
@@ -177,7 +181,7 @@ The HTTP dashboard at `localhost:<port>` shows:
 
 - **Summary cards** — running, retry, claimed, completed counts
 - **Token summary** — input/output/total token usage
-- **Running sessions table** — identifier, Linear state, status, attempt, elapsed time, workspace, worker host
+- **Running sessions table** — identifier, Linear state, status, attempt, elapsed time, turn count/max turns, last activity age, per-session tokens, workspace, worker host
 - **Retry queue** — pending retries with errors and timing
 - **Completed issues** — ticket identifier, title, completion date
 - **Polling stats** — last poll time, poll count, interval
@@ -191,7 +195,7 @@ Auto-refreshes every 2 seconds. JSON API at `/api/v1/state` and `/api/v1/{ISSUE-
 # Build
 cargo build
 
-# Test (276 tests)
+# Test (280+ tests)
 cargo test
 
 # Lint

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -41,6 +41,8 @@ tracker:
 
   # Issue states eligible for dispatch. Issues in these states are candidates
   # for agent work. The orchestrator polls for issues in these states.
+  # Default parser value: ["Todo", "In Progress"].
+  # This template extends that set so the agent can run full review/merge loops.
   active_states:
     - Todo
     - In Progress
@@ -145,6 +147,7 @@ hooks:
 agent:
   # Maximum number of agent sessions running simultaneously.
   # New dispatches are held until a slot opens.
+  # Default parser value: 10.
   max_concurrent_agents: 1
 
   # Maximum turns (Codex interactions) per session before the run is
@@ -165,6 +168,7 @@ agent:
 # Configures the Codex app-server process that runs inside each agent session.
 codex:
   # Command to start Codex. Can be a string (whitespace-split) or list.
+  # Default parser value: `codex app-server`.
   command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
 
   # Hard timeout per Codex turn in milliseconds (default: 3600000 = 1 hour).
@@ -172,18 +176,23 @@ codex:
 
   # Time (ms) before a non-progressing session is considered stalled.
   # Reset on each agent event. Set high for long builds (e.g. cargo test).
+  # Default parser value: 300000.
   stall_timeout_ms: 900000
 
   # Timeout waiting for Codex process output in milliseconds.
   # read_timeout_ms: 5000
 
-  # Approval policy for sandbox actions. "never" = headless, no human prompts.
+  # Approval policy for sandbox actions.
+  # Default parser value: reject sandbox/rules/MCP elicitations.
+  # `never` enables unattended auto-approval behavior for this workflow.
   approval_policy: never
 
   # Sandbox mode for the agent thread.
+  # Default parser value: workspace-write.
   thread_sandbox: danger-full-access
 
   # Per-turn sandbox policy override.
+  # Default parser value: unset.
   turn_sandbox_policy:
     type: dangerFullAccess
 
@@ -202,6 +211,7 @@ codex:
 # HTTP dashboard and JSON API. Serves live orchestrator state.
 server:
   # Port to bind. Also settable via --port CLI flag (CLI takes precedence).
+  # CLI default is currently 8080.
   port: 8080
 
   # Bind address. Use "0.0.0.0" to expose on all interfaces.


### PR DESCRIPTION
## Summary
- update `apps/symphony/README.md` for current docs state:
  - test count now 280+
  - documented `--tui` terminal dashboard flag
  - expanded dashboard observability details (turns, last activity, per-session tokens)
  - added docker isolation preview note
- update `apps/symphony/AGENTS.md`:
  - add module map including `src/tui.rs`
  - refresh CLI and API examples to current shapes (`RunAttempt` and polling fields)
  - align logging/flag/test-count docs with current behavior
- update `apps/symphony/docs/WORKFLOW-REFERENCE.md`:
  - clarify parser defaults versus template overrides for active states and codex/agent/server fields

## Validation
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `git push -u origin symphony/KAT-892` (ran repo pre-push validation hook: lint/typecheck/test for `@kata/symphony`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only PR that brings three Symphony markdown files (`AGENTS.md`, `README.md`, `WORKFLOW-REFERENCE.md`) in line with the current state of the Rust codebase. Key updates verified against the source:

- **Removed deprecated flag**: `--i-understand-that-this-will-be-running-without-the-usual-guardrails` no longer exists in the `Cli` struct in `main.rs`; its removal from docs is correct.
- **Port default corrected to 8080**: Matches `#[arg(long, default_value = "8080")]` in `main.rs`. Note that because the CLI always carries `Some(8080)`, the `effective_http_binding` function (`cli.port.or(config.server.port)`) means `server.port` in the workflow YAML is always shadowed by the CLI default — the WORKFLOW-REFERENCE.md's new comment "CLI default is currently 8080" is the clearest callout of this behavior and could be mirrored in the flag reference tables.
- **API shape updates**: `completed: Vec<CompletedEntry>` (objects, not strings), `RunAttempt` fields `issue_title`/`linear_state`, and the new `PollingSnapshot` fields (`checking`, `next_poll_in_ms`, `poll_interval_ms`, ISO-string `last_poll_at`) all verified accurate against `domain.rs`.
- **`--tui` / logging behavior**: Accurately documents `src/tui.rs` integration and the `std::io::sink` stdout suppression logic in `init_tracing`.
- **Module map**: Matches the module imports visible in `main.rs`.

No functional bugs were introduced; all changes are documentation corrections.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all three files are documentation only with no logic changes.
- All documented API shapes, CLI flags, and behavioral descriptions were verified against the live Rust source (domain.rs, main.rs). Removed flag, updated port default, refreshed JSON examples, and new module map are all accurate. No functional code is touched.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/AGENTS.md | Updated CLI flag reference (removed deprecated guardrail flag, corrected port default to 8080), refreshed API shape examples to match current Rust structs (RunAttempt with issue_title/linear_state, completed as Vec<CompletedEntry> objects, new polling fields), and added a useful module map. All changes verified accurate against domain.rs and main.rs. |
| apps/symphony/README.md | Added --tui flag to CLI table, corrected --port default from "(none)" to "8080" (matching Clap's default_value = "8080"), expanded running sessions table description with observability fields, and added a docker isolation preview note. All changes accurately reflect the current source behavior. |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Added inline "Default parser value" comments to clarify what the config parser supplies versus what the template overrides. Changes are consistent with TrackerConfig::default(), AgentConfig::default(), CodexConfig::default(), and the ServerConfig behavior documented elsewhere. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as CLI (main.rs)
    participant Orch as Orchestrator
    participant HTTP as HTTP Server (/api/v1/state)
    participant TUI as TUI (src/tui.rs)

    CLI->>Orch: start (port default 8080, --tui flag)
    CLI->>HTTP: bind on effective port (cli.port ?? config.server.port)
    CLI->>TUI: spawn run_tui task (if --tui)

    loop Poll interval (default 30s)
        Orch->>Orch: fetch_candidate_issues()
        Orch->>Orch: dispatch RunAttempt (issue_id, issue_title, linear_state, …)
        Orch->>Orch: update OrchestratorSnapshot
        Note over Orch: completed = Vec<CompletedEntry><br/>running_session_info = WorkerSessionInfo<br/>polling = PollingSnapshot
    end

    HTTP-->>CLI: GET /api/v1/state → OrchestratorSnapshot (JSON)
    TUI-->>CLI: live snapshot display (turn_count, last_activity_ms, session_tokens)

    CLI->>Orch: shutdown (Ctrl+C / SIGTERM / TUI exit)
```

<sub>Reviews (1): Last reviewed commit: ["docs(symphony): refresh docs for tui and..."](https://github.com/gannonh/kata/commit/d95c865a00d8d94ba93a2137a45ddf2265243c0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25972743)</sub>

<!-- /greptile_comment -->