### PR TITLE
Wt symphony/orchestration

### DIFF
--- a/.agents/skills/releasing-kata/references/cli-release.md
+++ b/.agents/skills/releasing-kata/references/cli-release.md
@@ -25,9 +25,12 @@ CI workflow: `cli-release.yml`
 
 3. **Bump version** in `apps/cli/package.json` only
 
-4. **Update `apps/cli/CHANGELOG.md`** with the new version's changes
+4. **Update `apps/cli/CHANGELOG.md`** and `apps/cli/README.md` with the new version's changes
 
-5. **Update `apps/cli/src/resources/AGENTS.md`** with any relevant changes to agent capabilities or instructions
+5. **Update essential documentation:**
+   1. Preferences Reference: `apps/cli/src/resources/extensions/kata/docs/preferences-reference.md` - Documents every preference field, its type, default, and behavior. Update when adding, removing, or renaming a preference field, changing a field's type or default, or changing how a preference affects runtime behavior.
+   2. Preferences Template: `apps/cli/src/resources/extensions/kata/templates/preferences.md` - YAML frontmatter template copied into new projects on init. Update when adding a new field (add with its default), removing a field, or changing a default value. Keep template and reference in sync: every field in the template should be documented in the reference, and vice versa.
+   3. Agent Context: `apps/cli/src/resources/AGENTS.md` - Tells the agent about CLI architecture, directory structure, extensions, and capabilities. Update when adding or removing extensions, commands, or skills; changing directory structure or file roles; changing how the agent interacts with the system; or adding new agent prompt templates.
 
 6. **Create release branch and PR**
 

--- a/.agents/skills/releasing-kata/references/symphony-release.md
+++ b/.agents/skills/releasing-kata/references/symphony-release.md
@@ -26,7 +26,7 @@ CI workflow: `symphony-release.yml`
 
 3. **Bump version** in `apps/symphony/Cargo.toml` only
 
-4. **Update `apps/symphony/CHANGELOG.md`** with the new version's changes (create if it doesn't exist)
+4. **Update `apps/cli/CHANGELOG.md`** and `apps/cli/README.md` with the new version's changes
 
 5. **Create release branch and PR**
 

--- a/apps/symphony/docs/plans/2026-03-22-docker-isolation.md
+++ b/apps/symphony/docs/plans/2026-03-22-docker-isolation.md
@@ -1,0 +1,685 @@
+# Docker Container Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run worker agents in disposable Docker containers instead of directly on the host, providing full isolation while preserving the existing JSON-RPC communication protocol.
+
+**Architecture:** Symphony spawns Docker containers per-issue using `docker run`, communicates with Codex via `docker exec -i` stdin/stdout pipe (same as SSH model), and destroys containers after sessions complete. Setup scripts are cached as derived Docker image layers.
+
+**Tech Stack:** Rust (tokio, serde), Docker CLI, shell scripts
+
+**Spec:** `apps/symphony/docs/specs/2026-03-22-docker-isolation.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `src/docker.rs` | Container lifecycle: image resolution, start, exec, stop, availability check |
+| `docker/Dockerfile.symphony` | Orchestrator container image (multi-stage Rust build) |
+| `docker/Dockerfile.worker` | Base worker image (Node + git + gh + Codex) |
+| `docker/docker-compose.yml` | One-command local/VPS deployment |
+| `docker/.env.example` | Template for required environment variables |
+| `docker/setups/rust.sh` | Rust toolchain setup script |
+| `docker/setups/python.sh` | Python 3.12 setup script |
+| `docker/setups/go.sh` | Go setup script |
+| `docker/setups/bun.sh` | Bun runtime setup script |
+| `tests/docker_tests.rs` | Unit tests for docker module (mocked) |
+
+### Modified files
+
+| File | What changes |
+|---|---|
+| `src/domain.rs` | Add `DockerConfig`, `DockerCodexAuth` structs; add `docker` field to `WorkspaceConfig` |
+| `src/config.rs` | Parse `docker:` YAML section; add `RawDockerConfig` |
+| `src/lib.rs` | Add `pub mod docker;` |
+| `src/codex/app_server.rs` | Add Docker variant in `start_session` alongside Local and SSH |
+| `src/workspace.rs` | Docker path for `bootstrap_repository` and hooks (via `docker exec`) |
+| `src/orchestrator.rs` | Docker container lifecycle in `run_worker_task` |
+| `src/error.rs` | Add Docker-specific error variants |
+| `apps/symphony/Cargo.toml` | No new deps needed (uses `tokio::process::Command` for docker CLI) |
+
+---
+
+### Task 1: Domain types and config parsing
+
+**Files:**
+- Modify: `src/domain.rs`
+- Modify: `src/config.rs`
+- Modify: `src/error.rs`
+- Test: `tests/workflow_config_tests.rs`
+
+- [ ] **Step 1: Add Docker domain types to `src/domain.rs`**
+
+After `WorkspaceIsolation` enum, add:
+
+```rust
+/// Codex authentication mode for Docker containers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DockerCodexAuth {
+    /// OPENAI_API_KEY env var if set, else mount auth.json, else error.
+    Auto,
+    /// Force bind-mount of ~/.codex/auth.json (local only).
+    Mount,
+    /// Force OPENAI_API_KEY env var only (cloud deployments).
+    Env,
+}
+
+/// Docker-specific workspace configuration.
+#[derive(Debug, Clone)]
+pub struct DockerConfig {
+    /// Docker image name (e.g. "symphony-worker:latest").
+    pub image: String,
+    /// Optional setup script path, cached as derived image layer.
+    pub setup: Option<String>,
+    /// How to authenticate Codex inside the container.
+    pub codex_auth: DockerCodexAuth,
+    /// Additional environment variables passed to the container.
+    pub env: Vec<String>,
+    /// Additional read-only volume mounts (e.g. "~/.ssh:/root/.ssh:ro").
+    pub volumes: Vec<String>,
+}
+
+impl Default for DockerConfig {
+    fn default() -> Self {
+        Self {
+            image: "symphony-worker:latest".to_string(),
+            setup: None,
+            codex_auth: DockerCodexAuth::Auto,
+            env: vec![],
+            volumes: vec![],
+        }
+    }
+}
+```
+
+Add `docker: Option<DockerConfig>` field to `WorkspaceConfig`. Update `Default` impl to set `docker: None`.
+
+- [ ] **Step 2: Add Docker error variants to `src/error.rs`**
+
+```rust
+DockerNotAvailable,
+DockerContainerFailed(String),
+DockerImageBuildFailed(String),
+DockerAuthError(String),
+```
+
+- [ ] **Step 3: Add raw config struct and parsing in `src/config.rs`**
+
+Add `RawDockerConfig`:
+
+```rust
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct RawDockerConfig {
+    image: Option<String>,
+    setup: Option<String>,
+    codex_auth: Option<String>,
+    env: Option<Vec<String>>,
+    volumes: Option<Vec<String>>,
+}
+```
+
+Add `docker: Option<RawDockerConfig>` to `RawWorkspaceConfig`.
+
+Parse in the workspace config section. When `isolation == Docker`, require docker config (use defaults if section absent). Remove the existing "not yet implemented" warning for Docker isolation.
+
+Parse `codex_auth`: `"auto"` | `"mount"` | `"env"`, default `"auto"`.
+
+- [ ] **Step 4: Write config parsing tests**
+
+In `tests/workflow_config_tests.rs`:
+
+```rust
+#[test]
+fn test_docker_isolation_parses_with_defaults() { ... }
+
+#[test]
+fn test_docker_isolation_parses_full_config() { ... }
+
+#[test]
+fn test_docker_codex_auth_values() { ... }
+
+#[test]
+fn test_docker_config_absent_when_local_isolation() { ... }
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --test workflow_config_tests
+cargo clippy -- -D warnings
+git add src/domain.rs src/config.rs src/error.rs tests/workflow_config_tests.rs
+git commit -m "feat(symphony): add DockerConfig domain types and config parsing (KAT-821)"
+```
+
+---
+
+### Task 2: Docker module — container lifecycle
+
+**Files:**
+- Create: `src/docker.rs`
+- Modify: `src/lib.rs`
+- Test: `tests/docker_tests.rs`
+
+- [ ] **Step 1: Create `src/docker.rs` with availability check**
+
+```rust
+use std::process::Stdio;
+use tokio::process::Command;
+use crate::error::{Result, SymphonyError};
+
+/// Check if Docker daemon is reachable.
+pub async fn is_docker_available() -> bool {
+    Command::new("docker")
+        .args(["info", "--format", "{{.ServerVersion}}"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+```
+
+- [ ] **Step 2: Add `pub mod docker;` to `src/lib.rs`**
+
+- [ ] **Step 3: Add image resolution and derived image caching**
+
+```rust
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+
+/// Resolve the effective Docker image. If a setup script is configured,
+/// build a derived image with the setup script as a RUN layer.
+pub async fn resolve_image(
+    base_image: &str,
+    setup_script: Option<&str>,
+) -> Result<String> { ... }
+
+/// Compute a deterministic tag for a derived image from the setup script content.
+fn derived_image_tag(base_image: &str, setup_content: &str) -> String { ... }
+
+/// Check if a Docker image exists locally.
+async fn image_exists(tag: &str) -> bool { ... }
+
+/// Build a derived image: base + RUN <setup script>.
+async fn build_derived_image(base_image: &str, setup_content: &str, tag: &str) -> Result<()> { ... }
+```
+
+- [ ] **Step 4: Add container start/stop**
+
+```rust
+use crate::domain::{DockerCodexAuth, DockerConfig, Issue};
+
+/// Start a Docker container for a worker session.
+/// Returns the container ID.
+pub async fn start_container(
+    image: &str,
+    issue: &Issue,
+    config: &DockerConfig,
+    env_vars: &[(&str, &str)],  // LINEAR_API_KEY, GH_TOKEN, etc.
+) -> Result<String> { ... }
+
+/// Stop and remove a Docker container.
+pub async fn stop_container(container_id: &str) -> Result<()> { ... }
+
+/// Build a `tokio::process::Command` for `docker exec -i <container> <cmd>`.
+pub fn exec_command(container_id: &str, cmd: &str) -> Command { ... }
+
+/// Run a command inside the container and wait for completion.
+pub async fn exec_in_container(container_id: &str, cmd: &str) -> Result<String> { ... }
+```
+
+- [ ] **Step 5: Add auth resolution**
+
+```rust
+/// Resolve Codex auth arguments for container start.
+/// Returns (env_vars, volume_mounts) to add to docker run.
+pub fn resolve_codex_auth(
+    auth_mode: DockerCodexAuth,
+) -> Result<(Vec<(String, String)>, Vec<String>)> { ... }
+```
+
+Logic:
+- `Auto`: check `OPENAI_API_KEY` env → if set, pass as env var. Else check `~/.codex/auth.json` → if exists, mount. Else error.
+- `Mount`: mount `~/.codex/auth.json` or error if missing.
+- `Env`: require `OPENAI_API_KEY` or error.
+
+- [ ] **Step 6: Write unit tests**
+
+Create `tests/docker_tests.rs`:
+
+```rust
+#[test]
+fn test_derived_image_tag_is_deterministic() { ... }
+
+#[test]
+fn test_derived_image_tag_changes_with_content() { ... }
+
+#[test]
+fn test_resolve_codex_auth_auto_with_api_key() { ... }
+
+#[test]
+fn test_resolve_codex_auth_auto_with_auth_json() { ... }
+
+#[test]
+fn test_resolve_codex_auth_auto_neither_errors() { ... }
+
+#[test]
+fn test_resolve_codex_auth_mount_missing_errors() { ... }
+
+#[test]
+fn test_resolve_codex_auth_env_missing_errors() { ... }
+
+#[test]
+fn test_exec_command_builds_correct_args() { ... }
+
+#[test]
+fn test_container_name_from_issue() { ... }
+```
+
+- [ ] **Step 7: Run tests and commit**
+
+```bash
+cargo test --test docker_tests
+cargo clippy -- -D warnings
+git add src/docker.rs src/lib.rs tests/docker_tests.rs
+git commit -m "feat(symphony): add docker module — container lifecycle and auth (KAT-821)"
+```
+
+---
+
+### Task 3: Wire Docker into app_server session spawning
+
+**Files:**
+- Modify: `src/codex/app_server.rs`
+
+- [ ] **Step 1: Add Docker variant to `start_session`**
+
+In `start_session`, the `match worker_host` block currently has `None` (local) and `Some(host)` (SSH). Add a new parameter or check `isolation` from the config. The cleanest approach: add an `isolation: &WorkspaceIsolation` parameter and an optional `container_id: Option<&str>`.
+
+When `isolation == Docker` and `container_id` is `Some(id)`:
+
+```rust
+Some(container_id) if isolation == &WorkspaceIsolation::Docker => {
+    let workspace_str = workspace_path.to_string_lossy().to_string();
+
+    tracing::info!(
+        container_id = %container_id,
+        issue_id = %issue.id,
+        cmd = %cmd_str,
+        "Spawning Codex via Docker exec"
+    );
+
+    let remote_cmd = format!(
+        "cd {} && {}",
+        crate::ssh::shell_escape(&workspace_str),
+        cmd_str
+    );
+    let child = crate::docker::exec_command(container_id, &remote_cmd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| SymphonyError::DockerContainerFailed(e.to_string()))?;
+
+    (workspace_str, child)
+}
+```
+
+- [ ] **Step 2: Update `start_session` signature**
+
+Add `container_id: Option<&str>` parameter. All existing callers pass `None` for non-Docker mode.
+
+- [ ] **Step 3: Update all callers of `start_session`**
+
+In `run_worker_task` and `execute_worker_attempt`, pass `None` for container_id when not in Docker mode.
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+cargo test
+cargo clippy -- -D warnings
+git add src/codex/app_server.rs src/orchestrator.rs
+git commit -m "feat(symphony): wire Docker exec into app_server session spawning (KAT-821)"
+```
+
+---
+
+### Task 4: Wire Docker into workspace setup and worker task
+
+**Files:**
+- Modify: `src/workspace.rs`
+- Modify: `src/orchestrator.rs`
+
+- [ ] **Step 1: Add Docker workspace setup path**
+
+In `workspace.rs`, add a function for Docker workspace bootstrap:
+
+```rust
+/// Bootstrap repository inside a Docker container.
+pub async fn docker_bootstrap_repository(
+    container_id: &str,
+    config: &WorkspaceConfig,
+    issue_identifier: &str,
+) -> Result<()> {
+    let repo = config.repo.as_deref().ok_or_else(|| {
+        SymphonyError::InvalidWorkflowConfig("workspace.repo required for docker isolation".into())
+    })?;
+
+    let branch_name = format!("{}/{}", config.branch_prefix, issue_identifier);
+
+    // Clone inside container
+    let clone_cmd = if let Some(clone_branch) = config.clone_branch.as_deref() {
+        format!("git clone {} /workspace --branch {} && cd /workspace && git checkout -b {}", repo, clone_branch, branch_name)
+    } else {
+        format!("git clone {} /workspace && cd /workspace && git checkout -b {}", repo, branch_name)
+    };
+
+    docker::exec_in_container(container_id, &clone_cmd).await?;
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Add Docker hook execution**
+
+```rust
+/// Run a hook command inside a Docker container.
+pub async fn run_hook_in_container(
+    container_id: &str,
+    hook_cmd: &str,
+    issue: &Issue,
+    timeout_ms: u64,
+) -> Result<()> { ... }
+```
+
+Set hook env vars (`SYMPHONY_ISSUE_ID`, etc.) via the docker exec command.
+
+- [ ] **Step 3: Add Docker path to `run_worker_task` in `orchestrator.rs`**
+
+Before the existing workspace/session flow, add:
+
+```rust
+if config.workspace.isolation == WorkspaceIsolation::Docker {
+    let docker_config = config.workspace.docker.as_ref()
+        .unwrap_or(&DockerConfig::default());
+
+    // 1. Check Docker available
+    if !docker::is_docker_available().await {
+        return WorkerResult { ... Failed: "Docker not available" };
+    }
+
+    // 2. Resolve image (with setup script caching)
+    let image = docker::resolve_image(&docker_config.image, docker_config.setup.as_deref()).await?;
+
+    // 3. Start container
+    let env_vars = [
+        ("LINEAR_API_KEY", std::env::var("LINEAR_API_KEY").unwrap_or_default()),
+        ("GH_TOKEN", std::env::var("GH_TOKEN").unwrap_or_default()),
+    ];
+    let container_id = docker::start_container(&image, issue, docker_config, &env_vars).await?;
+
+    // 4. Bootstrap workspace inside container
+    workspace::docker_bootstrap_repository(&container_id, &config.workspace, &issue.identifier).await?;
+
+    // 5. Run before_run hook inside container
+    if let Some(hook) = &config.hooks.before_run {
+        workspace::run_hook_in_container(&container_id, hook, issue, config.hooks.timeout_ms).await?;
+    }
+
+    // 6. Start Codex session via docker exec
+    let session = app_server::start_session(
+        &config.codex, issue, Path::new("/workspace"), Path::new("/"),
+        None,  // no SSH host
+        Some(&container_id),  // Docker container
+    ).await?;
+
+    // 7. Multi-turn loop (unchanged)
+    // ... existing turn loop code ...
+
+    // 8. Stop container
+    docker::stop_container(&container_id).await?;
+
+    return WorkerResult { ... };
+}
+// ... existing local/SSH path unchanged ...
+```
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+cargo test
+cargo clippy -- -D warnings
+git add src/workspace.rs src/orchestrator.rs
+git commit -m "feat(symphony): wire Docker lifecycle into worker task and workspace setup (KAT-821)"
+```
+
+---
+
+### Task 5: Docker files — Dockerfiles, compose, setup scripts
+
+**Files:**
+- Create: `docker/Dockerfile.symphony`
+- Create: `docker/Dockerfile.worker`
+- Create: `docker/docker-compose.yml`
+- Create: `docker/.env.example`
+- Create: `docker/setups/rust.sh`
+- Create: `docker/setups/python.sh`
+- Create: `docker/setups/go.sh`
+- Create: `docker/setups/bun.sh`
+
+- [ ] **Step 1: Create `docker/Dockerfile.worker`**
+
+```dockerfile
+FROM node:22-slim
+RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @openai/codex
+WORKDIR /workspace
+```
+
+- [ ] **Step 2: Create `docker/Dockerfile.symphony`**
+
+```dockerfile
+FROM rust:slim AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY src/ src/
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://get.docker.com | sh  # installs docker-cli
+COPY --from=builder /build/target/release/symphony /usr/local/bin/symphony
+WORKDIR /app
+ENTRYPOINT ["symphony"]
+CMD ["WORKFLOW.md", "--port", "8080"]
+```
+
+- [ ] **Step 3: Create `docker/docker-compose.yml`**
+
+```yaml
+version: "3.8"
+
+services:
+  symphony:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.symphony
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ../WORKFLOW.md:/app/WORKFLOW.md:ro
+    env_file: .env
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+  worker:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.worker
+    profiles: ["build-only"]
+```
+
+- [ ] **Step 4: Create `docker/.env.example`**
+
+```bash
+# Required
+LINEAR_API_KEY=lin_api_...
+OPENAI_API_KEY=sk-...
+
+# Optional — for GitHub PR operations
+GH_TOKEN=ghp_...
+GITHUB_TOKEN=ghp_...
+```
+
+- [ ] **Step 5: Create setup scripts**
+
+`docker/setups/rust.sh`:
+```bash
+#!/bin/bash
+set -euo pipefail
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+echo 'source $HOME/.cargo/env' >> ~/.bashrc
+```
+
+`docker/setups/python.sh`:
+```bash
+#!/bin/bash
+set -euo pipefail
+apt-get update && apt-get install -y python3 python3-pip python3-venv && rm -rf /var/lib/apt/lists/*
+```
+
+`docker/setups/go.sh`:
+```bash
+#!/bin/bash
+set -euo pipefail
+GO_VERSION=$(curl -sL 'https://go.dev/VERSION?m=text' | head -1)
+curl -sL "https://go.dev/dl/${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" | tar -C /usr/local -xz
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+```
+
+`docker/setups/bun.sh`:
+```bash
+#!/bin/bash
+set -euo pipefail
+curl -fsSL https://bun.sh/install | bash
+echo 'export PATH=$HOME/.bun/bin:$PATH' >> ~/.bashrc
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker/
+git commit -m "feat(symphony): add Docker files — worker image, compose, setup scripts (KAT-821)"
+```
+
+---
+
+### Task 6: Documentation and WORKFLOW.md reference update
+
+**Files:**
+- Modify: `apps/symphony/README.md`
+- Modify: `apps/symphony/docs/WORKFLOW-REFERENCE.md`
+- Modify: `apps/symphony/AGENTS.md`
+
+- [ ] **Step 1: Update README with Docker deployment section**
+
+Add a "Docker Deployment" section covering:
+- Local: `docker compose up`
+- VPS: clone, configure, `docker compose up -d`
+- Custom worker images via setup scripts
+- Auth configuration
+
+- [ ] **Step 2: Update WORKFLOW-REFERENCE.md**
+
+Add the `docker:` config section with all fields documented.
+
+- [ ] **Step 3: Update AGENTS.md**
+
+Add `docker.rs` to the module listing. Document the Docker container lifecycle.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/symphony/README.md apps/symphony/docs/WORKFLOW-REFERENCE.md apps/symphony/AGENTS.md
+git commit -m "docs(symphony): Docker deployment documentation (KAT-821)"
+```
+
+---
+
+### Task 7: Integration test (gated)
+
+**Files:**
+- Create: `tests/docker_integration_tests.rs`
+
+- [ ] **Step 1: Write integration test gated behind env var**
+
+```rust
+//! Integration tests for Docker container isolation.
+//! Requires Docker daemon running and SYMPHONY_DOCKER_TESTS=1.
+
+#[cfg(test)]
+mod tests {
+    fn docker_tests_enabled() -> bool {
+        std::env::var("SYMPHONY_DOCKER_TESTS").unwrap_or_default() == "1"
+    }
+
+    #[tokio::test]
+    async fn test_docker_available() {
+        if !docker_tests_enabled() { return; }
+        assert!(symphony::docker::is_docker_available().await);
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop_container() {
+        if !docker_tests_enabled() { return; }
+        // ... start container, verify running, stop, verify removed
+    }
+
+    #[tokio::test]
+    async fn test_exec_in_container() {
+        if !docker_tests_enabled() { return; }
+        // ... start container, exec "echo hello", verify output
+    }
+
+    #[tokio::test]
+    async fn test_auth_resolution_auto() {
+        if !docker_tests_enabled() { return; }
+        // ... verify auth env/mount args
+    }
+}
+```
+
+- [ ] **Step 2: Run unit tests (always) and integration tests (if Docker available)**
+
+```bash
+cargo test
+cargo clippy -- -D warnings
+# Optional: SYMPHONY_DOCKER_TESTS=1 cargo test --test docker_integration_tests
+git add tests/docker_integration_tests.rs
+git commit -m "test(symphony): Docker integration tests (KAT-821)"
+```
+
+---
+
+## Task summary
+
+| Task | Description | Est |
+|---|---|---|
+| 1 | Domain types + config parsing | 15 min |
+| 2 | Docker module — container lifecycle | 30 min |
+| 3 | Wire into app_server session | 15 min |
+| 4 | Wire into workspace + worker task | 25 min |
+| 5 | Docker files (Dockerfiles, compose, scripts) | 15 min |
+| 6 | Documentation | 10 min |
+| 7 | Integration tests | 10 min |

--- a/apps/symphony/docs/specs/2026-03-22-docker-isolation.md
+++ b/apps/symphony/docs/specs/2026-03-22-docker-isolation.md
@@ -1,0 +1,316 @@
+# Docker Container Isolation for Symphony Workers
+
+**Date:** 2026-03-22
+**Ticket:** KAT-821
+**Status:** Approved design
+
+## Problem
+
+Worker agents currently run with full host access (`danger-full-access` sandbox) because Codex's built-in sandbox prevents network sockets needed for testing. The production model: each worker runs in a disposable Docker container with full access inside the container, completely isolated from the host.
+
+## Goals
+
+- **Local safety** — agents can't touch host filesystem
+- **Cloud deployment** — run Symphony on a VPS with `docker compose up`
+- **DX** — one command to start, bundled setup scripts for common stacks
+
+## Architecture
+
+Symphony's orchestrator stays on the host (or in its own container). When `isolation: docker`, it spawns a Docker container per issue instead of a local subprocess. Communication uses `docker exec -i` piping stdin/stdout — identical to the SSH worker model. Same JSON-RPC protocol, same event streaming, same multi-turn loop.
+
+```
+Orchestrator (host or container)
+    │
+    ├── docker exec -i worker-KAT-123 codex app-server
+    │       └── stdin/stdout JSON-RPC (same as local/SSH)
+    │
+    ├── docker exec -i worker-KAT-456 codex app-server
+    │       └── stdin/stdout JSON-RPC
+    │
+    └── ... (up to max_concurrent_agents)
+```
+
+### Process spawning abstraction
+
+```
+WorkerHostSelection::Local      → Command::new("codex")
+WorkerHostSelection::Remote(h)  → Command::new("ssh").args([h, "codex"])
+WorkerHostSelection::Docker(c)  → Command::new("docker").args(["exec", "-i", c, "codex"])
+```
+
+Same interface, different transport. Adding future backends (K8s, ECS) is another variant.
+
+## Container Lifecycle
+
+```
+1. Resolve image
+   - Base image + setup script → check for cached derived image
+   - No cache → docker build (setup script as RUN layer), tag as symphony-worker-<hash>
+   - Cached → use it
+
+2. Start container
+   - docker run --rm -d --name symphony-<issue-identifier>
+   - Auth: OPENAI_API_KEY env var OR mount ~/.codex/auth.json:ro
+   - Env: LINEAR_API_KEY, GH_TOKEN, GITHUB_TOKEN + user-configured env
+   - Volumes: user-configured read-only mounts (e.g. ~/.ssh)
+   - Network: full access (default bridge)
+
+3. Workspace setup (inside container)
+   - git clone <repo> /workspace
+   - git checkout -b <branch_prefix>/<identifier>
+   - hooks.after_create runs inside container
+
+4. Agent session
+   - docker exec -i <container> codex app-server
+   - Symphony communicates via stdin/stdout JSON-RPC
+   - Multi-turn loop runs normally
+   - Events stream back to orchestrator
+
+5. Cleanup
+   - hooks.after_run inside container
+   - docker rm -f (container destroyed)
+   - Derived image stays cached for next run
+```
+
+## Auth Resolution
+
+Order of precedence:
+
+1. `OPENAI_API_KEY` env var set → pass into container as env var (API key auth)
+2. `~/.codex/auth.json` exists on host → mount read-only into container (ChatGPT subscription auth)
+3. Neither → error at container start: "Codex auth required: set OPENAI_API_KEY or authenticate via `codex auth`"
+
+Config option:
+- `codex_auth: auto` (default) — follow the resolution order above
+- `codex_auth: mount` — force auth.json mount (local only)
+- `codex_auth: env` — force OPENAI_API_KEY only (cloud deployments)
+
+## Images and Setup Scripts
+
+### Tiered approach
+
+| Layer | What it provides | When it runs |
+|---|---|---|
+| **Base image** | OS, git, gh, Node, Codex | Pulled once |
+| **Setup script** | Project-specific runtimes (Rust, Python, etc.) | Cached as derived image layer |
+| **after_create hook** | Per-container deps (`bun install`, `cargo build`) | Every container |
+
+### Base image (`docker/Dockerfile.worker`)
+
+```dockerfile
+FROM node:22-slim
+RUN apt-get update && apt-get install -y git gh curl && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @openai/codex
+WORKDIR /workspace
+```
+
+~200MB. Just enough to run Codex with git and GitHub CLI.
+
+### Bundled setup scripts (`docker/setups/`)
+
+| Script | Installs |
+|---|---|
+| `rust.sh` | Rust stable toolchain, cargo |
+| `python.sh` | Python 3.12, pip, venv |
+| `go.sh` | Go latest |
+| `bun.sh` | Bun runtime |
+
+Users can combine: `setup: "docker/setups/rust.sh && docker/setups/bun.sh"`
+
+### Derived image caching
+
+When `docker.setup` is configured, Symphony:
+1. Hashes the setup script content
+2. Checks for existing image tagged `symphony-worker-<hash>`
+3. If missing, builds: base image + `RUN <setup script>` → tags as derived image
+4. Uses derived image for all containers
+
+First run is slow (builds the image). Subsequent runs are instant.
+
+## Configuration
+
+```yaml
+workspace:
+  root: ~/symphony-workspaces
+  repo: https://github.com/you/repo.git
+  git_strategy: clone-remote
+  isolation: docker
+  branch_prefix: symphony
+  clone_branch: main
+  cleanup_on_done: true
+  docker:
+    image: "symphony-worker:latest"
+    setup: "docker/setups/rust.sh"
+    codex_auth: auto
+    env:
+      - CARGO_HOME=/usr/local/cargo
+    volumes:
+      - ~/.ssh:/root/.ssh:ro
+```
+
+## Docker Compose
+
+### `docker-compose.yml`
+
+```yaml
+version: "3.8"
+
+services:
+  symphony:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.symphony
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./WORKFLOW.md:/app/WORKFLOW.md:ro
+    env_file: .env
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+  worker:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker
+    profiles: ["build-only"]
+```
+
+### `docker/Dockerfile.symphony`
+
+```dockerfile
+FROM rust:slim AS builder
+WORKDIR /build
+COPY apps/symphony/ .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates docker-cli && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /build/target/release/symphony /usr/local/bin/symphony
+WORKDIR /app
+ENTRYPOINT ["symphony"]
+CMD ["WORKFLOW.md", "--port", "8080"]
+```
+
+Symphony container mounts the Docker socket to spawn sibling worker containers.
+
+### Usage
+
+```bash
+# Local
+echo "LINEAR_API_KEY=lin_api_..." > .env
+echo "OPENAI_API_KEY=sk-..." >> .env
+echo "GH_TOKEN=ghp_..." >> .env
+docker compose build
+docker compose up
+
+# VPS
+git clone https://github.com/gannonh/kata.git
+cd kata/apps/symphony
+cp .env.example .env  # edit with your keys
+docker compose up -d
+```
+
+## Implementation
+
+### New module: `src/docker.rs`
+
+Container lifecycle manager:
+- `build_or_resolve_image(config)` — check for cached derived image, build if needed
+- `start_container(image, issue, env, volumes, auth)` — `docker run --rm -d`, returns container ID
+- `exec_codex(container_id, codex_command)` → `tokio::process::Command`
+- `exec_in_container(container_id, command)` — run arbitrary commands inside container
+- `stop_container(container_id)` — `docker rm -f`
+- `is_docker_available()` — check if Docker daemon is reachable
+
+### Changes to `src/codex/app_server.rs`
+
+`start_session` gains an isolation parameter:
+```rust
+match isolation {
+    Local => Command::new(&codex_command),
+    Docker(container_id) => docker::exec_codex(&container_id, &codex_command),
+}
+```
+
+### Changes to `src/workspace.rs`
+
+`bootstrap_repository` in Docker mode runs git commands inside the container via `docker::exec_in_container`. Hooks also run inside the container.
+
+### Changes to `src/orchestrator.rs`
+
+`run_worker_task` gains a Docker path:
+```rust
+if config.workspace.isolation == Docker {
+    let container_id = docker::start_container(...)?;
+    docker::exec_workspace_setup(&container_id, ...)?;
+    // session uses docker exec
+    ...
+    docker::stop_container(&container_id);
+}
+```
+
+### Config changes: `src/domain.rs` + `src/config.rs`
+
+```rust
+pub struct DockerConfig {
+    pub image: String,
+    pub setup: Option<String>,
+    pub codex_auth: DockerCodexAuth,
+    pub env: Vec<String>,
+    pub volumes: Vec<String>,
+}
+
+pub enum DockerCodexAuth {
+    Auto,
+    Mount,
+    Env,
+}
+```
+
+### New files
+
+```
+docker/
+  Dockerfile.symphony
+  Dockerfile.worker
+  docker-compose.yml
+  .env.example
+  setups/
+    rust.sh
+    python.sh
+    go.sh
+    bun.sh
+```
+
+### Tests
+
+- Config parsing: docker section with all fields
+- Auth resolution: auto/mount/env logic
+- Container lifecycle: mock docker commands, verify correct args
+- Image caching: setup script hash → derived image tag
+- Integration: actual docker run/exec/rm (gated behind `SYMPHONY_DOCKER_TESTS=1`)
+
+## What does NOT change
+
+- JSON-RPC protocol
+- Multi-turn loop
+- Event streaming
+- Dashboard (shows container name in workspace column)
+- SSH workers (coexists)
+- Linear integration
+
+## Deployment models
+
+| Model | How it works | MVP? |
+|---|---|---|
+| **Local Docker** | Symphony on host, workers in containers | ✅ |
+| **VPS** | Symphony + Docker on a VPS, `docker compose up` | ✅ |
+| **Remote Docker host** | `DOCKER_HOST` env var pointing to remote daemon | Works but untested |
+| **Kubernetes** | Future `isolation: kubernetes` variant | ❌ Post-MVP |
+| **Cloud containers (ECS, Fly, Modal)** | Future variants with cloud-specific APIs | ❌ Post-MVP |
+
+## Security notes
+
+- Docker socket mount gives Symphony full Docker control on the host. For production, consider a Docker socket proxy.
+- Containers have full network access by default. Restrict with `docker.network` config if needed (future).
+- `OPENAI_API_KEY` is passed as env var — visible in `docker inspect`. Use Docker secrets for higher security (future).


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds documentation and planning artifacts for Docker container isolation in the Symphony orchestrator (spec + implementation plan), and updates the CLI and Symphony release guides. The core design — using `docker exec -i` as a transport for Codex sessions, analogous to the existing SSH model — is sound and well-specified.

Key changes and issues found:
- **Critical error in `symphony-release.md`**: Step 4 was updated to reference `apps/cli/CHANGELOG.md` and `apps/cli/README.md` instead of the symphony app's own files. This is a copy-paste error from the `cli-release.md` edits and would cause symphony releases to update CLI documentation rather than symphony documentation.
- **Non-deterministic cache key in the plan**: The `docker.rs` implementation plan uses `std::collections::hash_map::DefaultHasher` to generate derived image tags — this hash is not stable across Rust versions and could silently break the setup-script image caching mechanism.
- **Wrong Docker installation command in plan's `Dockerfile.symphony`**: The plan uses `curl -fsSL https://get.docker.com | sh` (installs the full Docker Engine daemon) while the spec correctly uses `apt-get install -y docker-cli`. These two documents should agree, and only the CLI binary is needed.
- **Build context mismatch**: The `docker-compose.yml` in the plan correctly uses `context: ..`, while the spec uses `context: .` — when the compose file is inside `apps/symphony/docker/`, only `context: ..` (pointing to the Symphony source root) is valid for the Dockerfile's COPY instructions.
- The `cli-release.md` changes are clean and add useful specificity to the release process.

<h3>Confidence Score: 3/5</h3>

- Safe to merge the spec/plan docs as planning artifacts, but the symphony-release.md copy-paste error will immediately cause incorrect release behavior and should be fixed first.
- The PR is documentation-only (no production code), so no runtime failures are introduced. However, the symphony-release.md has a clear copy-paste bug pointing to CLI files, several plan/spec inconsistencies could mislead the implementing agent, and the non-deterministic cache key design flaw would result in a broken implementation if followed as written.
- `symphony-release.md` has a critical copy-paste error; `plans/2026-03-22-docker-isolation.md` has several implementation issues (DefaultHasher, docker-cli install, docker-compose context) that should be reconciled with the spec before implementation begins.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .agents/skills/releasing-kata/references/symphony-release.md | Step 4 was updated but incorrectly references `apps/cli/CHANGELOG.md` and `apps/cli/README.md` — a copy-paste error from cli-release.md that would cause symphony releases to update the wrong app's documentation. |
| .agents/skills/releasing-kata/references/cli-release.md | Step 4 and step 5 expanded with README.md requirement and detailed documentation update guidance; changes are correct and well-structured. |
| apps/symphony/docs/plans/2026-03-22-docker-isolation.md | Comprehensive 7-task implementation plan for Docker container isolation; contains notable issues: non-deterministic DefaultHasher for cache keys, `curl | sh` installing full Docker Engine instead of CLI only, build context mismatch in docker-compose.yml, and Debian-specific `dpkg` usage in portable setup scripts. |
| apps/symphony/docs/specs/2026-03-22-docker-isolation.md | Architecture spec for Docker worker isolation; well-thought-out design using docker exec -i as transport analogous to SSH. Minor inconsistency with plan in docker-compose.yml build context (`context: .` vs `context: ..`). Security notes are appropriately documented. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant D as docker.rs
    participant Docker as Docker Daemon
    participant C as Worker Container
    participant Codex as Codex (inside container)

    O->>D: is_docker_available()
    D->>Docker: docker info
    Docker-->>D: ok
    D-->>O: true

    O->>D: resolve_image(base_image, setup_script)
    D->>D: hash(base + setup_content) → tag
    D->>Docker: docker image inspect <tag>
    alt cache miss
        D->>Docker: docker build (base + RUN setup_script) → tag
    end
    D-->>O: effective_image

    O->>D: start_container(image, issue, config, env_vars)
    D->>Docker: docker run --rm -d --name symphony-<issue-id>
    Docker-->>D: container_id
    D-->>O: container_id

    O->>D: docker_bootstrap_repository(container_id, config)
    D->>Docker: docker exec -i <id> git clone ...
    Docker->>C: git clone + checkout branch
    C-->>D: done

    O->>D: run_hook_in_container(container_id, before_run)
    D->>Docker: docker exec -i <id> <hook_cmd>
    C-->>D: done

    O->>D: exec_command(container_id, codex_cmd)
    D-->>O: tokio::process::Command (docker exec -i)
    O->>Codex: spawn (stdin/stdout JSON-RPC)
    Codex-->>O: events stream (multi-turn loop)

    O->>D: stop_container(container_id)
    D->>Docker: docker rm -f <id>
    Docker-->>D: removed
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .agents/skills/releasing-kata/references/symphony-release.md
Line: 29

Comment:
**Wrong changelog/README paths (copy-paste error)**

Step 4 now references `apps/cli/CHANGELOG.md` and `apps/cli/README.md` instead of the symphony app's own files. This looks like a direct copy from the `cli-release.md` update and will cause symphony releases to update CLI documentation instead of symphony documentation.

```suggestion
4. **Update `apps/symphony/CHANGELOG.md`** and `apps/symphony/README.md` with the new version's changes
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/docs/plans/2026-03-22-docker-isolation.md
Line: 231-232

Comment:
**`DefaultHasher` is not stable across Rust versions**

`std::collections::hash_map::DefaultHasher` uses a randomized algorithm (SipHash by default) and its output is explicitly not guaranteed to be stable across Rust releases or even between program invocations. Using it to derive cache image tags (e.g. `symphony-worker-<hash>`) would make the caching logic silently unreliable — any Rust version upgrade could invalidate all cached derived images without warning, or worse, produce collisions between different Rust builds.

Use a stable, deterministic hash algorithm instead, such as SHA-256 via the `sha2` crate (already common in the Rust ecosystem):

```rust
use sha2::{Digest, Sha256};

fn derived_image_tag(base_image: &str, setup_content: &str) -> String {
    let mut hasher = Sha256::new();
    hasher.update(base_image.as_bytes());
    hasher.update(b":");
    hasher.update(setup_content.as_bytes());
    let hash = hasher.finalize();
    format!("symphony-worker-{:.16}", hex::encode(hash))
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/docs/plans/2026-03-22-docker-isolation.md
Line: 539

Comment:
**`curl | sh` installs full Docker Engine, not just the CLI**

The comment says "installs docker-cli" but `https://get.docker.com | sh` actually installs the complete Docker Engine (daemon + CLI). Inside the Symphony container this means:
1. ~800MB of unnecessary daemon binaries that will never be used
2. The daemon itself won't run inside the container without `--privileged`, but its binaries and service files will be present
3. The `docker` CLI binary will be present, which is what is actually needed

The spec document (`2026-03-22-docker-isolation.md`, line 916) correctly uses `apt-get install -y ca-certificates docker-cli` — the plan and spec should stay in sync. The plan's Dockerfile should read:

```suggestion
RUN apt-get update && apt-get install -y ca-certificates docker-cli && rm -rf /var/lib/apt/lists/*
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/docs/plans/2026-03-22-docker-isolation.md
Line: 553-558

Comment:
**`docker-compose.yml` build context mismatch between plan and spec**

The plan specifies `context: ..` while the spec (`2026-03-22-docker-isolation.md`) specifies `context: .`. Given the file lives at `apps/symphony/docker/docker-compose.yml`, only `context: ..` (resolving to `apps/symphony/`) is correct — the Dockerfile's `COPY Cargo.toml Cargo.lock ./` and `COPY src/ src/` lines require the Symphony source root as the build context. Using `context: .` would set the Docker build context to the `docker/` subdirectory, causing the COPY instructions to fail immediately.

The spec's `docker-compose.yml` should be corrected to match the plan:

```yaml
build:
  context: ..
  dockerfile: docker/Dockerfile.symphony
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/docs/plans/2026-03-22-docker-isolation.md
Line: 604-607

Comment:
**`dpkg --print-architecture` is Debian-specific in a setup script**

The `go.sh` script calls `dpkg --print-architecture` to determine the CPU architecture for the Go download URL. While the base worker image is `node:22-slim` (Debian-based), this makes the script brittle: any user who runs it on a non-Debian/non-Ubuntu host (e.g., Alpine, RHEL, CentOS) will get a `command not found` error. The script also assumes `dpkg` architecture names match Go's archive naming exactly, which holds for `amd64` and `arm64` but may differ for less common architectures.

A more portable alternative:

```bash
ARCH=$(uname -m)
case "$ARCH" in
  x86_64)  GO_ARCH="amd64" ;;
  aarch64) GO_ARCH="arm64" ;;
  *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
esac
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(release): update release documentat..."](https://github.com/gannonh/kata/commit/4dbbf5643dea6d915d6889d2b2f2748c571a6905) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25974100)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->