### PR TITLE
feat(symphony): show Linear project URL in TUI and HTTP dashboard

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -84,6 +84,7 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | `tracker.kind`            | string   | _(required)_                                               | Must be `"linear"`.                                                                                  |
 | `tracker.api_key`         | string   | _(required)_                                               | Linear personal API key. Supports `$VAR` env-var indirection (e.g. `$LINEAR_API_KEY`). Never logged. |
 | `tracker.project_slug`    | string   | _(required)_                                               | Linear project URL slug (the identifier shown in project URLs). Supports `$VAR` indirection.         |
+| `tracker.workspace_slug`  | string   | `"kata-sh"`                                                | Linear workspace slug used when building dashboard project links (`https://linear.app/<workspace>/project/<slug>`). Supports `$VAR` indirection. |
 | `tracker.endpoint`        | string   | `https://api.linear.app/graphql`                           | Linear GraphQL endpoint. Override for self-hosted Linear.                                            |
 | `tracker.assignee`        | string   | _(none)_                                                   | Filter candidate issues to this Linear username. Supports `$VAR` indirection.                        |
 | `tracker.active_states`   | string[] | `["Todo", "In Progress"]`                                  | Issue states that are eligible for dispatch.                                                         |

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -30,6 +30,10 @@ tracker:
   # https://linear.app/<workspace>/project/<slug>
   project_slug: "89d4761fddf0"
 
+  # Optional: Linear workspace slug for dashboard project links.
+  # When omitted, Symphony falls back to "kata-sh".
+  # workspace_slug: kata-sh
+
   # Optional: Linear GraphQL endpoint. Override for self-hosted Linear.
   # endpoint: https://api.linear.app/graphql
 

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -163,6 +163,7 @@ struct RawTrackerConfig {
     endpoint: Option<String>,
     api_key: Option<String>,
     project_slug: Option<String>,
+    workspace_slug: Option<String>,
     assignee: Option<String>,
     active_states: Option<Vec<String>>,
     terminal_states: Option<Vec<String>>,
@@ -404,6 +405,10 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         .project_slug
         .map(|v| resolve_env(&v))
         .filter(|v| !v.is_empty());
+    let workspace_slug = raw_tracker
+        .workspace_slug
+        .map(|v| resolve_env(&v))
+        .filter(|v| !v.is_empty());
 
     let tracker = TrackerConfig {
         kind: raw_tracker.kind,
@@ -412,6 +417,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
             .unwrap_or(defaults.tracker.endpoint.clone()),
         api_key,
         project_slug,
+        workspace_slug,
         assignee,
         active_states: raw_tracker
             .active_states

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -408,6 +408,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let workspace_slug = raw_tracker
         .workspace_slug
         .map(|v| resolve_env(&v))
+        .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty());
 
     let tracker = TrackerConfig {

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -142,6 +142,8 @@ pub struct TrackerConfig {
     pub terminal_states: Vec<String>,
 }
 
+const DEFAULT_LINEAR_WORKSPACE_SLUG: &str = "kata-sh";
+
 impl Default for TrackerConfig {
     fn default() -> Self {
         Self {
@@ -159,6 +161,24 @@ impl Default for TrackerConfig {
                 "Done".to_string(),
             ],
         }
+    }
+}
+
+impl TrackerConfig {
+    /// Build a browser URL for the configured Linear project.
+    ///
+    /// The project slug comes from workflow config (`tracker.project_slug`).
+    /// Workspace slug is currently fixed to Kata's Linear workspace.
+    pub fn linear_project_url(&self) -> Option<String> {
+        let project_slug = self.project_slug.as_deref()?.trim();
+        if project_slug.is_empty() {
+            return None;
+        }
+
+        Some(format!(
+            "https://linear.app/{}/project/{project_slug}",
+            DEFAULT_LINEAR_WORKSPACE_SLUG
+        ))
     }
 }
 
@@ -524,6 +544,8 @@ pub struct PollingSnapshot {
 pub struct OrchestratorSnapshot {
     pub poll_interval_ms: u64,
     pub max_concurrent_agents: u32,
+    #[serde(default)]
+    pub linear_project_url: Option<String>,
     pub running: BTreeMap<String, RunAttempt>,
     #[serde(default)]
     pub running_sessions: BTreeMap<String, RunningSessionSnapshot>,

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -137,6 +137,7 @@ pub struct TrackerConfig {
     /// appear in debug/tracing output — `{:?}` on this struct prints `[REDACTED]`.
     pub api_key: Option<ApiKey>,
     pub project_slug: Option<String>,
+    pub workspace_slug: Option<String>,
     pub assignee: Option<String>,
     pub active_states: Vec<String>,
     pub terminal_states: Vec<String>,
@@ -151,6 +152,7 @@ impl Default for TrackerConfig {
             endpoint: "https://api.linear.app/graphql".to_string(),
             api_key: None,
             project_slug: None,
+            workspace_slug: None,
             assignee: None,
             active_states: vec!["Todo".to_string(), "In Progress".to_string()],
             terminal_states: vec![
@@ -168,16 +170,24 @@ impl TrackerConfig {
     /// Build a browser URL for the configured Linear project.
     ///
     /// The project slug comes from workflow config (`tracker.project_slug`).
-    /// Workspace slug is currently fixed to Kata's Linear workspace.
+    /// Workspace slug can come from `tracker.workspace_slug`, with a fallback
+    /// to Kata's default workspace for backward compatibility.
     pub fn linear_project_url(&self) -> Option<String> {
         let project_slug = self.project_slug.as_deref()?.trim();
         if project_slug.is_empty() {
             return None;
         }
+        let workspace_slug = self
+            .workspace_slug
+            .as_deref()
+            .unwrap_or(DEFAULT_LINEAR_WORKSPACE_SLUG)
+            .trim();
+        if workspace_slug.is_empty() {
+            return None;
+        }
 
         Some(format!(
-            "https://linear.app/{}/project/{project_slug}",
-            DEFAULT_LINEAR_WORKSPACE_SLUG
+            "https://linear.app/{workspace_slug}/project/{project_slug}"
         ))
     }
 }

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -258,7 +258,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     <section class="card"><div class="label">retry</div><div class="value" id="retry-count">{retry_count}</div></section>
     <section class="card"><div class="label">claimed</div><div class="value" id="claimed-count">{claimed_count}</div></section>
     <section class="card"><div class="label">completed</div><div class="value" id="completed-count">{completed_count}</div></section>
-    {linear_project_card}
+    <div id="linear-project-card">{linear_project_card}</div>
   </div>
 
   <section class="card section">
@@ -490,6 +490,18 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }}).join('');
     }}
 
+    function renderLinearProjectCard(url) {{
+      if (!url) {{
+        return '<section class="card"><div class="label">linear project</div><div class="mono muted">n/a</div></section>';
+      }}
+      const escaped = escapeHtml(url);
+      return '<section class="card"><div class="label">linear project</div><div class="mono"><a id="linear-project-link" href="' +
+        escaped +
+        '" target="_blank" rel="noopener noreferrer">' +
+        escaped +
+        '</a></div></section>';
+    }}
+
     function updatePolling(polling) {{
       const poll = polling || {{}};
       document.getElementById('polling-last-poll').textContent = formatDate(poll.last_poll_at);
@@ -525,6 +537,8 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         document.getElementById('retry-count').textContent = retryQueue.length;
         document.getElementById('claimed-count').textContent = (state.claimed || []).length;
         document.getElementById('completed-count').textContent = completed.length;
+        document.getElementById('linear-project-card').innerHTML =
+          renderLinearProjectCard(state.linear_project_url);
         document.getElementById('running-table-body').innerHTML = renderRunningTable(
           running,
           state.running_session_info || {{}}

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -174,6 +174,7 @@ fn escape_html(value: &str) -> String {
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
+        .replace('\'', "&#x27;")
 }
 
 async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoResponse {

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -102,6 +102,7 @@ struct ApiError {
 struct StateResponse {
     poll_interval_ms: u64,
     max_concurrent_agents: u32,
+    linear_project_url: Option<String>,
     running: std::collections::BTreeMap<String, RunAttempt>,
     running_sessions: std::collections::BTreeMap<String, RunningSessionSnapshot>,
     running_session_info: std::collections::BTreeMap<String, WorkerSessionInfo>,
@@ -167,6 +168,14 @@ pub async fn start_http_server(
 
 // ── Route Handlers ─────────────────────────────────────────────────────
 
+fn escape_html(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
 async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoResponse {
     let snapshot = state.snapshot();
 
@@ -182,6 +191,19 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     } else {
         "no"
     };
+    let linear_project_card = snapshot
+        .linear_project_url
+        .as_deref()
+        .map(|url| {
+            let escaped_url = escape_html(url);
+            format!(
+                r#"<section class="card"><div class="label">linear project</div><div class="mono"><a id="linear-project-link" href="{escaped_url}" target="_blank" rel="noopener noreferrer">{escaped_url}</a></div></section>"#
+            )
+        })
+        .unwrap_or_else(|| {
+            r#"<section class="card"><div class="label">linear project</div><div class="mono muted">n/a</div></section>"#
+                .to_string()
+        });
 
     let rate_limit_block = snapshot
         .codex_rate_limits
@@ -201,6 +223,8 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
   <style>
     :root {{ color-scheme: dark; }}
     body {{ font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; background: #10131a; color: #f1f5f9; margin: 0; padding: 24px; line-height: 1.45; }}
+    a {{ color: #93c5fd; }}
+    a:hover {{ color: #bfdbfe; }}
     h1 {{ margin-top: 0; margin-bottom: 12px; }}
     h2 {{ margin: 0 0 10px; font-size: 18px; }}
     .grid {{ display: grid; gap: 12px; margin-bottom: 16px; }}
@@ -234,6 +258,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     <section class="card"><div class="label">retry</div><div class="value" id="retry-count">{retry_count}</div></section>
     <section class="card"><div class="label">claimed</div><div class="value" id="claimed-count">{claimed_count}</div></section>
     <section class="card"><div class="label">completed</div><div class="value" id="completed-count">{completed_count}</div></section>
+    {linear_project_card}
   </div>
 
   <section class="card section">
@@ -532,6 +557,7 @@ async fn get_state(State(state): State<HttpServerState>) -> impl IntoResponse {
     Json(StateResponse {
         poll_interval_ms: snapshot.poll_interval_ms,
         max_concurrent_agents: snapshot.max_concurrent_agents,
+        linear_project_url: snapshot.linear_project_url,
         running: snapshot.running,
         running_sessions: snapshot.running_sessions,
         running_session_info: snapshot.running_session_info,

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1808,6 +1808,7 @@ impl Orchestrator {
         OrchestratorSnapshot {
             poll_interval_ms: self.state.poll_interval_ms,
             max_concurrent_agents: self.state.max_concurrent_agents,
+            linear_project_url: self.config.tracker.linear_project_url(),
             running,
             running_sessions,
             running_session_info,

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -387,10 +387,8 @@ fn draw_dashboard(
         ])
         .split(inner);
 
-    let summary_lines: Vec<Line<'static>> = summary_lines_data
-        .into_iter()
-        .map(Line::from)
-        .collect();
+    let summary_lines: Vec<Line<'static>> =
+        summary_lines_data.into_iter().map(Line::from).collect();
     frame.render_widget(Paragraph::new(summary_lines), sections[0]);
 
     let running_header = Row::new(vec![

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -178,10 +178,15 @@ fn draw_dashboard(frame: &mut Frame, snapshot: &OrchestratorSnapshot, now: DateT
     frame.render_widget(root, frame.area());
     let inner = Block::default().borders(Borders::ALL).inner(frame.area());
 
+    let summary_height: u16 = if snapshot.linear_project_url.is_some() {
+        2
+    } else {
+        1
+    };
     let sections = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(2),
+            Constraint::Length(summary_height),
             Constraint::Min(8),
             Constraint::Length(7),
             Constraint::Length(7),

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -155,6 +155,22 @@ fn cleanup_partial_terminal_state() {
     let _ = execute!(stdout, LeaveAlternateScreen);
 }
 
+fn build_summary_lines(snapshot: &OrchestratorSnapshot) -> Vec<String> {
+    let mut lines = vec![format!(
+        "Running: {}  Retry: {}  Completed: {}  Tokens: {}",
+        snapshot.running.len(),
+        snapshot.retry_queue.len(),
+        snapshot.completed.len(),
+        format_tokens(snapshot.codex_totals.total_tokens)
+    )];
+
+    if let Some(project_url) = snapshot.linear_project_url.as_deref() {
+        lines.push(format!("Linear Project: {project_url}"));
+    }
+
+    lines
+}
+
 fn draw_dashboard(frame: &mut Frame, snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) {
     let root = Block::default()
         .title("Symphony Dashboard")
@@ -165,7 +181,7 @@ fn draw_dashboard(frame: &mut Frame, snapshot: &OrchestratorSnapshot, now: DateT
     let sections = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),
+            Constraint::Length(2),
             Constraint::Min(8),
             Constraint::Length(7),
             Constraint::Length(7),
@@ -173,14 +189,11 @@ fn draw_dashboard(frame: &mut Frame, snapshot: &OrchestratorSnapshot, now: DateT
         ])
         .split(inner);
 
-    let summary = format!(
-        "Running: {}  Retry: {}  Completed: {}  Tokens: {}",
-        snapshot.running.len(),
-        snapshot.retry_queue.len(),
-        snapshot.completed.len(),
-        format_tokens(snapshot.codex_totals.total_tokens)
-    );
-    frame.render_widget(Paragraph::new(summary), sections[0]);
+    let summary_lines: Vec<Line<'static>> = build_summary_lines(snapshot)
+        .into_iter()
+        .map(Line::from)
+        .collect();
+    frame.render_widget(Paragraph::new(summary_lines), sections[0]);
 
     let running_header = Row::new(vec![
         Cell::from("ID"),
@@ -522,6 +535,30 @@ mod tests {
     use super::*;
     use chrono::TimeZone;
     use serde_json::json;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn empty_snapshot(linear_project_url: Option<&str>) -> OrchestratorSnapshot {
+        OrchestratorSnapshot {
+            poll_interval_ms: 30_000,
+            max_concurrent_agents: 1,
+            linear_project_url: linear_project_url.map(|value| value.to_string()),
+            running: BTreeMap::new(),
+            running_sessions: BTreeMap::new(),
+            running_session_info: BTreeMap::new(),
+            claimed: BTreeSet::new(),
+            retry_queue: vec![],
+            completed: vec![],
+            codex_totals: Default::default(),
+            codex_rate_limits: None,
+            polling: crate::domain::PollingSnapshot {
+                checking: false,
+                next_poll_in_ms: 30_000,
+                poll_interval_ms: 30_000,
+                last_poll_at: None,
+                poll_count: 0,
+            },
+        }
+    }
 
     #[test]
     fn format_age_returns_seconds_ago() {
@@ -574,6 +611,18 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("secondary: 34% used")),
             "expected secondary usage summary, got: {summary:?}"
+        );
+    }
+
+    #[test]
+    fn build_summary_lines_includes_linear_project_url_when_available() {
+        let snapshot = empty_snapshot(Some("https://linear.app/kata-sh/project/symphony"));
+        let lines = build_summary_lines(&snapshot);
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == "Linear Project: https://linear.app/kata-sh/project/symphony"),
+            "summary lines should include the linear project URL when configured"
         );
     }
 

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -335,7 +335,10 @@ fn test_orchestrator_snapshot_serializes() {
     // Contains expected keys
     assert!(val.get("poll_interval_ms").is_some());
     assert!(val.get("max_concurrent_agents").is_some());
-    assert!(val.get("linear_project_url").is_some());
+    assert_eq!(
+        val.get("linear_project_url").and_then(|v| v.as_str()),
+        Some("https://linear.app/kata-sh/project/symphony")
+    );
     assert!(val.get("running").is_some());
     assert!(val.get("running_sessions").is_some());
     assert!(val.get("running_session_info").is_some());

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -137,6 +137,19 @@ fn test_service_config_defaults_match_spec() {
     assert_eq!(cfg.tracker.endpoint, "https://api.linear.app/graphql");
 }
 
+#[test]
+fn test_tracker_linear_project_url_uses_project_slug() {
+    let mut tracker = TrackerConfig::default();
+    tracker.project_slug = Some("symphony".to_string());
+    assert_eq!(
+        tracker.linear_project_url().as_deref(),
+        Some("https://linear.app/kata-sh/project/symphony")
+    );
+
+    tracker.project_slug = None;
+    assert_eq!(tracker.linear_project_url(), None);
+}
+
 // ── ServerConfig default fix (T01 must-have) ───────────────────────────
 
 #[test]
@@ -221,6 +234,7 @@ fn test_orchestrator_snapshot_serializes() {
     let snap = OrchestratorSnapshot {
         poll_interval_ms: 30_000,
         max_concurrent_agents: 5,
+        linear_project_url: Some("https://linear.app/kata-sh/project/symphony".to_string()),
         running: {
             let mut m = BTreeMap::new();
             m.insert(
@@ -321,6 +335,7 @@ fn test_orchestrator_snapshot_serializes() {
     // Contains expected keys
     assert!(val.get("poll_interval_ms").is_some());
     assert!(val.get("max_concurrent_agents").is_some());
+    assert!(val.get("linear_project_url").is_some());
     assert!(val.get("running").is_some());
     assert!(val.get("running_sessions").is_some());
     assert!(val.get("running_session_info").is_some());

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -138,12 +138,18 @@ fn test_service_config_defaults_match_spec() {
 }
 
 #[test]
-fn test_tracker_linear_project_url_uses_project_slug() {
+fn test_tracker_linear_project_url_uses_project_and_workspace_slug() {
     let mut tracker = TrackerConfig::default();
     tracker.project_slug = Some("symphony".to_string());
     assert_eq!(
         tracker.linear_project_url().as_deref(),
         Some("https://linear.app/kata-sh/project/symphony")
+    );
+
+    tracker.workspace_slug = Some("acme".to_string());
+    assert_eq!(
+        tracker.linear_project_url().as_deref(),
+        Some("https://linear.app/acme/project/symphony")
     );
 
     tracker.project_slug = None;

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -58,6 +58,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
     OrchestratorSnapshot {
         poll_interval_ms: 30_000,
         max_concurrent_agents: 4,
+        linear_project_url: Some("https://linear.app/kata-sh/project/symphony".to_string()),
         running: {
             let mut running = BTreeMap::new();
             running.insert(
@@ -236,6 +237,14 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "dashboard shell should include token summary section"
     );
     assert!(
+        body.contains(r#"id="linear-project-link""#),
+        "dashboard shell should include clickable Linear project link in summary section"
+    );
+    assert!(
+        body.contains("https://linear.app/kata-sh/project/symphony"),
+        "dashboard shell should render the configured Linear project URL"
+    );
+    assert!(
         body.contains("Polling"),
         "dashboard shell should include polling section"
     );
@@ -291,6 +300,10 @@ async fn test_get_api_state_returns_snapshot_projection() {
     assert_eq!(payload["retry_queue"][0]["identifier"], "SIM-777");
     assert_eq!(payload["codex_totals"]["total_tokens"], 200);
     assert_eq!(payload["codex_rate_limits"]["remaining"], 88);
+    assert_eq!(
+        payload["linear_project_url"],
+        "https://linear.app/kata-sh/project/symphony"
+    );
     assert_eq!(payload["polling"]["next_poll_in_ms"], 5_000);
 }
 

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -21,6 +21,7 @@ fn test_config(server: &ServerGuard, assignee: Option<&str>) -> TrackerConfig {
         endpoint: server.url() + "/graphql",
         api_key: Some(ApiKey::new("test-api-key")),
         project_slug: Some("test-proj".to_string()),
+        workspace_slug: None,
         assignee: assignee.map(String::from),
         active_states: vec!["Todo".to_string(), "In Progress".to_string()],
         terminal_states: vec!["Done".to_string(), "Cancelled".to_string()],
@@ -740,6 +741,7 @@ async fn test_error_transport_error() {
         endpoint: "http://192.0.2.1:1/graphql".to_string(), // TEST-NET-1 (RFC 5737) — guaranteed unreachable
         api_key: Some(ApiKey::new("test-key")),
         project_slug: Some("test-proj".to_string()),
+        workspace_slug: None,
         assignee: None,
         active_states: vec!["Todo".to_string()],
         terminal_states: vec![],

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -197,6 +197,14 @@ fn test_config_workspace_slug_parse() {
 }
 
 #[test]
+fn test_config_workspace_slug_whitespace_is_treated_as_missing() {
+    let yaml_str = "tracker:\n  workspace_slug: \"   \"";
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace slug should parse");
+    assert_eq!(config.tracker.workspace_slug, None);
+}
+
+#[test]
 #[serial]
 fn test_config_empty_literal_api_key_does_not_use_linear_api_key_fallback() {
     let previous_linear_api_key = std::env::var("LINEAR_API_KEY").ok();

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -156,6 +156,7 @@ fn test_config_defaults() {
     assert_eq!(config.tracker.kind, None);
     assert_eq!(config.tracker.api_key, None);
     assert_eq!(config.tracker.project_slug, None);
+    assert_eq!(config.tracker.workspace_slug, None);
     assert_eq!(config.polling.interval_ms, 30_000);
     assert_eq!(config.agent.max_concurrent_agents, 10);
     assert_eq!(config.agent.max_turns, 20);
@@ -185,6 +186,14 @@ fn test_config_env_var_resolution() {
     );
 
     std::env::remove_var("SYMPHONY_TEST_LINEAR_API_KEY");
+}
+
+#[test]
+fn test_config_workspace_slug_parse() {
+    let yaml_str = "tracker:\n  workspace_slug: acme";
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workspace slug should parse");
+    assert_eq!(config.tracker.workspace_slug.as_deref(), Some("acme"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `TrackerConfig::linear_project_url()` and publish it via `OrchestratorSnapshot.linear_project_url`
- show the Linear project URL in the TUI summary header
- show the Linear project URL as a clickable link in the HTTP dashboard summary area
- extend domain/TUI/HTTP tests to cover URL serialization and rendering

## Testing
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`

## Ticket
- KAT-895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard shows a Linear project card; state API now surfaces a Linear project URL; terminal UI summary displays the Linear project when available.
* **Chores**
  * Configuration parsing accepts an optional workspace slug (supports env-var resolution and empty-value handling).
* **Tests**
  * Unit and integration tests updated to cover Linear project URL presence, serialization, rendering, and config parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Linear project URL surfacing to Symphony's HTTP dashboard and TUI summary header. The URL is derived from the already-configurable `tracker.project_slug` field and a new `TrackerConfig::linear_project_url()` helper, then propagated through `OrchestratorSnapshot` to both rendering layers. Domain, TUI, and HTTP tests are extended appropriately.

**Key changes:**
- `TrackerConfig::linear_project_url()` constructs a `https://linear.app/{workspace}/project/{slug}` URL when `project_slug` is set; workspace is hardcoded to `kata-sh`
- `OrchestratorSnapshot` gains a `linear_project_url: Option<String>` field (`#[serde(default)]` for backward-compatible deserialization)
- HTTP dashboard renders the URL as a clickable `<a>` card with a new `escape_html` helper; `/api/state` JSON response also includes the field
- TUI summary header is refactored into `build_summary_lines` and the layout constraint is bumped to `Constraint::Length(2)` to accommodate the optional second line

**Issues found:**
- The Linear workspace slug is hardcoded as `"kata-sh"` in a private constant rather than sourced from config; any deployment targeting a different workspace will silently produce broken project links
- `Constraint::Length(2)` is unconditionally applied to the TUI summary area, leaving a visible empty line in the common case where no project URL is configured
- `escape_html` does not escape single-quote characters (`'`), making it an incomplete HTML-escaping primitive if reused in other contexts

<h3>Confidence Score: 4/5</h3>

- Safe to merge; no runtime errors or security issues — findings are style and configurability concerns only.
- The changes are well-scoped and correctly tested. The three issues (hardcoded workspace slug, fixed TUI constraint height, incomplete `escape_html`) are all P2 style/design suggestions with no impact on correctness or security for the current deployment context.
- `apps/symphony/src/domain.rs` (hardcoded workspace slug) and `apps/symphony/src/tui.rs` (layout constraint) deserve a second look before this pattern is extended further.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/domain.rs | Adds `TrackerConfig::linear_project_url()` and `OrchestratorSnapshot::linear_project_url`; workspace slug is hardcoded to `kata-sh` rather than sourced from config. |
| apps/symphony/src/http_server.rs | Adds a clickable Linear project card to the HTML dashboard and exposes `linear_project_url` in the `/api/state` JSON response; `escape_html` helper is correct for current usage but omits single-quote escaping. |
| apps/symphony/src/tui.rs | Adds `build_summary_lines` to include the Linear project URL in the TUI header; `Constraint::Length(2)` is always used, leaving an extra blank line when no URL is configured. |
| apps/symphony/src/orchestrator.rs | Minimal one-line change to populate `linear_project_url` in `OrchestratorSnapshot` from `TrackerConfig`; straightforward and correct. |
| apps/symphony/tests/domain_tests.rs | Adds tests for `linear_project_url()` (valid slug and `None`); missing coverage for empty-string and whitespace-only slugs, though the logic does handle them correctly. |
| apps/symphony/tests/http_server_tests.rs | Extends HTTP server tests to assert the Linear project card and URL appear in the dashboard HTML and API state response; comprehensive and correct. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cfg as TrackerConfig
    participant Orch as Orchestrator
    participant Snap as OrchestratorSnapshot
    participant TUI as TUI (draw_dashboard)
    participant HTTP as HTTP (get_dashboard / get_state)

    Orch->>Cfg: linear_project_url()
    Cfg-->>Orch: Option<String>
    Orch->>Snap: populate linear_project_url
    par TUI rendering
        Snap->>TUI: build_summary_lines(snapshot)
        TUI-->>TUI: Paragraph::new(summary_lines)
    and HTTP dashboard
        Snap->>HTTP: snapshot.linear_project_url
        HTTP-->>HTTP: escape_html(url) → linear_project_card HTML
    and HTTP API state
        Snap->>HTTP: StateResponse { linear_project_url, … }
        HTTP-->>HTTP: Json(StateResponse)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/domain.rs
Line: 145-181

Comment:
**Hardcoded workspace slug limits reusability**

`DEFAULT_LINEAR_WORKSPACE_SLUG` is baked in as `"kata-sh"`, meaning `linear_project_url()` always produces URLs pointing to the `kata-sh` Linear workspace regardless of the deployer's organisation. The `project_slug` is already read from config, but the workspace slug is not.

If this is intended as an internal-only tool this is fine, but if Symphony is (or will be) deployed by other teams, any non-`kata-sh` user will silently get a link pointing to the wrong workspace.

Consider reading the workspace slug from `TrackerConfig` (e.g. an optional `workspace_slug` field that falls back to the constant for backward-compatibility):

```rust
pub workspace_slug: Option<String>,
// …
pub fn linear_project_url(&self) -> Option<String> {
    let project_slug = self.project_slug.as_deref()?.trim();
    if project_slug.is_empty() {
        return None;
    }
    let workspace = self.workspace_slug.as_deref()
        .unwrap_or(DEFAULT_LINEAR_WORKSPACE_SLUG);
    Some(format!("https://linear.app/{workspace}/project/{project_slug}"))
}
```

At a minimum, a doc comment explaining that the workspace is intentionally fixed to `kata-sh` would help future readers.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/tui.rs
Line: 184

Comment:
**Fixed 2-row summary constraint leaves blank line when no URL is configured**

`Constraint::Length(2)` is always applied to the summary section, but `build_summary_lines` returns only one line when `linear_project_url` is `None`. The extra empty row shows up as a visible blank gap in the TUI header whenever no Linear project is configured, which is the common case until a project slug is set.

A simple fix is to derive the constraint from the actual number of summary lines:

```rust
let summary_lines_data = build_summary_lines(snapshot);
let summary_height = summary_lines_data.len() as u16;
// …
.constraints([
    Constraint::Length(summary_height),
    Constraint::Min(8),
    Constraint::Length(7),
    Constraint::Length(7),
    Constraint::Length(2),
])
```

Alternatively, keep `Length(2)` as a deliberate fixed-height header — but then the intent should be documented with a comment so future contributors don't reduce it back to `1`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 171-177

Comment:
**`escape_html` does not escape single quotes**

The function escapes `&`, `<`, `>`, and `"`, but not the single-quote character `'`. For the current usage (URL placed inside a double-quoted `href` attribute and as text content) this is not exploitable — double-quote escaping already prevents attribute breakout. However, `'` in a URL (technically percent-encoded but can appear in decoded form) inserted into a single-quoted attribute would still be a hazard if this helper is reused elsewhere.

```rust
fn escape_html(value: &str) -> String {
    value
        .replace('&', "&amp;")
        .replace('<', "&lt;")
        .replace('>', "&gt;")
        .replace('"', "&quot;")
        .replace('\'', "&#x27;")   // add single-quote escaping
}
```

This makes the helper safe for both attribute quoting styles and is the conventional complete set of HTML escapes.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): show Linear project URL ..."](https://github.com/gannonh/kata/commit/5e4b73ce0c10dd18b8ffd4086d9a644e6cac9814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25981444)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->