### PR TITLE
KAT-894: TUI last event message and color-coded session status

### DIFF
--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -504,6 +504,12 @@ pub struct RunningSessionSnapshot {
     pub last_activity_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub total_tokens: u64,
+    #[serde(default)]
+    pub last_event: Option<String>,
+    #[serde(default)]
+    pub last_event_message: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 /// Polling state for the snapshot.

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -2545,11 +2545,10 @@ fn notification_event_summary(message: &str) -> (String, Option<String>) {
         .and_then(|method| method.as_str())
         .unwrap_or("notification")
         .to_string();
-    let summary = summarize_notification_payload(&name, &parsed).or_else(|| {
-        parsed
-            .get("params")
-            .map(|params| normalize_whitespace(&params.to_string()))
-    });
+    let mut summary = summarize_notification_payload(&name, &parsed);
+    if summary.is_none() && !fallback_message.is_empty() {
+        summary = Some(fallback_message);
+    }
 
     (name, summary)
 }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -2486,7 +2486,7 @@ fn event_summary(event: &AgentEvent) -> (String, Option<String>) {
         ),
         AgentEvent::ToolCallCompleted { tool_name, .. } => (
             event_name(event).to_string(),
-            Some(format!("running {tool_name}")),
+            Some(format!("completed {tool_name}")),
         ),
         AgentEvent::ToolCallFailed { tool_name, .. } => {
             let message = tool_name
@@ -2636,6 +2636,15 @@ fn other_message_summary(raw: &serde_json::Value) -> (String, Option<String>) {
 }
 
 fn find_preferred_text(value: &serde_json::Value) -> Option<String> {
+    const MAX_TEXT_SEARCH_DEPTH: usize = 5;
+    find_preferred_text_with_depth(value, MAX_TEXT_SEARCH_DEPTH)
+}
+
+fn find_preferred_text_with_depth(value: &serde_json::Value, depth: usize) -> Option<String> {
+    if depth == 0 {
+        return None;
+    }
+
     match value {
         serde_json::Value::String(text) => {
             let normalized = normalize_whitespace(text);
@@ -2656,14 +2665,20 @@ fn find_preferred_text(value: &serde_json::Value) -> Option<String> {
                 "toolName",
                 "name",
             ] {
-                if let Some(found) = map.get(key).and_then(find_preferred_text) {
+                if let Some(found) = map
+                    .get(key)
+                    .and_then(|candidate| find_preferred_text_with_depth(candidate, depth - 1))
+                {
                     return Some(found);
                 }
             }
 
-            map.values().find_map(find_preferred_text)
+            map.values()
+                .find_map(|candidate| find_preferred_text_with_depth(candidate, depth - 1))
         }
-        serde_json::Value::Array(items) => items.iter().find_map(find_preferred_text),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .find_map(|candidate| find_preferred_text_with_depth(candidate, depth - 1)),
         _ => None,
     }
 }
@@ -2743,4 +2758,29 @@ fn issue_identifier_sort_key(issue: &Issue) -> (&str, &str) {
 
 pub fn rate_limit_info(data: serde_json::Value) -> RateLimitInfo {
     RateLimitInfo { data }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn find_preferred_text_stops_searching_past_depth_limit() {
+        let nested = json!({
+            "level_1": {
+                "level_2": {
+                    "level_3": {
+                        "level_4": {
+                            "level_5": {
+                                "message": "too deep"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        assert_eq!(find_preferred_text(&nested), None);
+    }
 }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -600,6 +600,9 @@ struct RunningSessionStats {
     turn_count: u32,
     last_activity_at: Option<DateTime<Utc>>,
     total_tokens: u64,
+    last_event: Option<String>,
+    last_event_message: Option<String>,
+    session_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1261,11 +1264,15 @@ impl Orchestrator {
                 .insert(issue_id.to_string(), session_id.to_string());
         }
 
+        let (last_event, last_event_message) = event_summary(event);
         let session_stats = self
             .running_session_stats
             .entry(issue_id.to_string())
             .or_default();
         session_stats.last_activity_at = Some(event_time);
+        session_stats.last_event = Some(last_event);
+        session_stats.last_event_message = last_event_message;
+        session_stats.session_id = self.worker_session_ids.get(issue_id).cloned();
 
         if let Some(run_attempt) = self.state.running.get_mut(issue_id) {
             match event {
@@ -1490,6 +1497,9 @@ impl Orchestrator {
                 turn_count: 0,
                 last_activity_at: Some(Utc::now()),
                 total_tokens: 0,
+                last_event: None,
+                last_event_message: None,
+                session_id: None,
             });
         self.state.retry_attempts.remove(&issue.id);
 
@@ -1765,6 +1775,11 @@ impl Orchestrator {
                             .and_then(|s| s.last_activity_at)
                             .or(Some(run_attempt.started_at)),
                         total_tokens: stats.map(|s| s.total_tokens).unwrap_or(0),
+                        last_event: stats.and_then(|s| s.last_event.clone()),
+                        last_event_message: stats.and_then(|s| s.last_event_message.clone()),
+                        session_id: stats
+                            .and_then(|s| s.session_id.clone())
+                            .or_else(|| self.worker_session_ids.get(issue_id).cloned()),
                     },
                 )
             })
@@ -2038,6 +2053,9 @@ impl Orchestrator {
                 turn_count: 0,
                 last_activity_at: Some(Utc::now()),
                 total_tokens: 0,
+                last_event: None,
+                last_event_message: None,
+                session_id: None,
             },
         );
         self.state.retry_attempts.remove(&issue.id);
@@ -2423,6 +2441,275 @@ fn event_name(event: &AgentEvent) -> &'static str {
         AgentEvent::OtherMessage { .. } => "other_message",
         AgentEvent::Malformed { .. } => "malformed",
     }
+}
+
+fn event_summary(event: &AgentEvent) -> (String, Option<String>) {
+    let (name, message) = match event {
+        AgentEvent::SessionStarted { session_id, .. } => (
+            event_name(event).to_string(),
+            Some(format!("session {}", compact_session_id(session_id))),
+        ),
+        AgentEvent::StartupFailed { error, .. } => {
+            (event_name(event).to_string(), Some(error.clone()))
+        }
+        AgentEvent::TurnCompleted { message, .. } => (
+            event_name(event).to_string(),
+            Some(
+                message
+                    .clone()
+                    .unwrap_or_else(|| "turn completed".to_string()),
+            ),
+        ),
+        AgentEvent::TurnFailed { error, .. } => {
+            (event_name(event).to_string(), Some(error.clone()))
+        }
+        AgentEvent::TurnCancelled { .. } => (
+            event_name(event).to_string(),
+            Some("turn cancelled".to_string()),
+        ),
+        AgentEvent::TurnEndedWithError { error, .. } => {
+            (event_name(event).to_string(), Some(error.clone()))
+        }
+        AgentEvent::TurnInputRequired { prompt, .. } => (
+            event_name(event).to_string(),
+            prompt
+                .clone()
+                .or_else(|| Some("input required".to_string())),
+        ),
+        AgentEvent::ApprovalAutoApproved { tool_call, .. } => (
+            event_name(event).to_string(),
+            Some(format!("auto-approved {tool_call}")),
+        ),
+        AgentEvent::ApprovalRequired { method, .. } => (
+            event_name(event).to_string(),
+            Some(format!("approval required: {method}")),
+        ),
+        AgentEvent::ToolCallCompleted { tool_name, .. } => (
+            event_name(event).to_string(),
+            Some(format!("running {tool_name}")),
+        ),
+        AgentEvent::ToolCallFailed { tool_name, .. } => {
+            let message = tool_name
+                .as_ref()
+                .map(|name| format!("tool {name} failed"))
+                .unwrap_or_else(|| "tool call failed".to_string());
+            (event_name(event).to_string(), Some(message))
+        }
+        AgentEvent::ToolInputAutoAnswered { .. } => (
+            event_name(event).to_string(),
+            Some("tool input auto-answered".to_string()),
+        ),
+        AgentEvent::UnsupportedToolCall { tool_name, .. } => (
+            event_name(event).to_string(),
+            Some(format!("unsupported tool {tool_name}")),
+        ),
+        AgentEvent::Notification { message, .. } => notification_event_summary(message),
+        AgentEvent::OtherMessage { raw, .. } => other_message_summary(raw),
+        AgentEvent::Malformed {
+            parse_error,
+            raw_text,
+            ..
+        } => (
+            event_name(event).to_string(),
+            Some(format!(
+                "malformed event: {parse_error}; {}",
+                normalize_whitespace(raw_text)
+            )),
+        ),
+    };
+
+    (
+        name,
+        message
+            .as_deref()
+            .map(|value| truncate_for_summary(value, 160))
+            .filter(|value| !value.is_empty()),
+    )
+}
+
+fn notification_event_summary(message: &str) -> (String, Option<String>) {
+    let fallback_message = normalize_whitespace(message);
+    let parsed = match serde_json::from_str::<serde_json::Value>(message) {
+        Ok(parsed) => parsed,
+        Err(_) => {
+            return (
+                "notification".to_string(),
+                (!fallback_message.is_empty()).then_some(fallback_message),
+            )
+        }
+    };
+
+    let name = parsed
+        .get("method")
+        .and_then(|method| method.as_str())
+        .unwrap_or("notification")
+        .to_string();
+    let summary = summarize_notification_payload(&name, &parsed).or_else(|| {
+        parsed
+            .get("params")
+            .map(|params| normalize_whitespace(&params.to_string()))
+    });
+
+    (name, summary)
+}
+
+fn summarize_notification_payload(name: &str, payload: &serde_json::Value) -> Option<String> {
+    if name.contains("token_count") {
+        let input = first_u64_at_paths(
+            payload,
+            &[
+                &["params", "tokenUsage", "total", "input_tokens"],
+                &["params", "tokenUsage", "total", "inputTokens"],
+                &[
+                    "params",
+                    "msg",
+                    "payload",
+                    "info",
+                    "total_token_usage",
+                    "input_tokens",
+                ],
+            ],
+        );
+        let output = first_u64_at_paths(
+            payload,
+            &[
+                &["params", "tokenUsage", "total", "output_tokens"],
+                &["params", "tokenUsage", "total", "outputTokens"],
+                &[
+                    "params",
+                    "msg",
+                    "payload",
+                    "info",
+                    "total_token_usage",
+                    "output_tokens",
+                ],
+            ],
+        );
+        let total = first_u64_at_paths(
+            payload,
+            &[
+                &["params", "tokenUsage", "total", "total_tokens"],
+                &["params", "tokenUsage", "total", "totalTokens"],
+                &[
+                    "params",
+                    "msg",
+                    "payload",
+                    "info",
+                    "total_token_usage",
+                    "total_tokens",
+                ],
+            ],
+        );
+
+        let mut pieces = Vec::new();
+        if let Some(value) = input {
+            pieces.push(format!("in {value}"));
+        }
+        if let Some(value) = output {
+            pieces.push(format!("out {value}"));
+        }
+        if let Some(value) = total {
+            pieces.push(format!("total {value}"));
+        }
+        if !pieces.is_empty() {
+            return Some(format!("tokens {}", pieces.join(" / ")));
+        }
+    }
+
+    payload
+        .get("params")
+        .and_then(find_preferred_text)
+        .or_else(|| find_preferred_text(payload))
+}
+
+fn other_message_summary(raw: &serde_json::Value) -> (String, Option<String>) {
+    let name = raw
+        .get("method")
+        .and_then(|method| method.as_str())
+        .unwrap_or("other_message")
+        .to_string();
+    let summary = raw
+        .get("params")
+        .and_then(find_preferred_text)
+        .or_else(|| find_preferred_text(raw));
+    (name, summary)
+}
+
+fn find_preferred_text(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(text) => {
+            let normalized = normalize_whitespace(text);
+            if normalized.is_empty() {
+                None
+            } else {
+                Some(normalized)
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for key in [
+                "summary",
+                "message",
+                "text",
+                "title",
+                "command",
+                "tool_name",
+                "toolName",
+                "name",
+            ] {
+                if let Some(found) = map.get(key).and_then(find_preferred_text) {
+                    return Some(found);
+                }
+            }
+
+            map.values().find_map(find_preferred_text)
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(find_preferred_text),
+        _ => None,
+    }
+}
+
+fn first_u64_at_paths(value: &serde_json::Value, paths: &[&[&str]]) -> Option<u64> {
+    paths
+        .iter()
+        .find_map(|path| value_at_path(value, path).and_then(integer_like))
+}
+
+fn value_at_path<'a>(value: &'a serde_json::Value, path: &[&str]) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+fn integer_like(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::Number(number) => number.as_u64(),
+        serde_json::Value::String(text) => text.trim().parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+fn compact_session_id(session_id: &str) -> String {
+    session_id.chars().take(8).collect()
+}
+
+fn normalize_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_for_summary(value: &str, max_chars: usize) -> String {
+    let normalized = normalize_whitespace(value);
+    if normalized.chars().count() <= max_chars {
+        return normalized;
+    }
+
+    let mut out = String::new();
+    for ch in normalized.chars().take(max_chars.saturating_sub(1)) {
+        out.push(ch);
+    }
+    out.push('…');
+    out
 }
 
 fn normalize_issue_state(state_name: &str) -> String {

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -363,7 +363,7 @@ fn status_color(
         .map(|event| event.trim().to_ascii_lowercase())
         .unwrap_or_default();
 
-    if normalized.contains("turn_completed") || normalized == "turn/completed" {
+    if is_turn_completed_event(&normalized) {
         Color::Magenta
     } else if normalized.contains("token_count") {
         Color::Yellow
@@ -375,6 +375,12 @@ fn status_color(
     } else {
         Color::Blue
     }
+}
+
+fn is_turn_completed_event(normalized_event: &str) -> bool {
+    normalized_event.contains("turn_completed")
+        || normalized_event.contains("turn/completed")
+        || (normalized_event.contains("turn") && normalized_event.contains("completed"))
 }
 
 fn is_stale_session(last_activity: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
@@ -709,6 +715,10 @@ mod tests {
         );
         assert_eq!(
             status_color(Some("turn_completed"), Some(fresh), now),
+            Color::Magenta
+        );
+        assert_eq!(
+            status_color(Some("codex/event/turn/completed"), Some(fresh), now),
             Color::Magenta
         );
         assert_eq!(

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -10,8 +10,8 @@ use crossterm::terminal::{
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, List, ListItem, Paragraph, Row, Table, Wrap};
 use ratatui::{Frame, Terminal};
 use tokio::sync::watch;
@@ -21,6 +21,7 @@ use crate::domain::OrchestratorSnapshot;
 use crate::orchestrator::SnapshotHandle;
 
 const REFRESH_INTERVAL_MS: u64 = 500;
+const STALE_ACTIVITY_THRESHOLD_MS: i64 = 120_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TuiExitReason {
@@ -183,9 +184,13 @@ fn draw_dashboard(frame: &mut Frame, snapshot: &OrchestratorSnapshot, now: DateT
     frame.render_widget(Paragraph::new(summary), sections[0]);
 
     let running_header = Row::new(vec![
+        Cell::from(""),
         Cell::from("ID"),
+        Cell::from("Session"),
         Cell::from("State"),
         Cell::from("Turn"),
+        Cell::from("Last Event"),
+        Cell::from("Message"),
         Cell::from("Last Activity"),
         Cell::from("Tokens"),
         Cell::from("Host"),
@@ -195,9 +200,13 @@ fn draw_dashboard(frame: &mut Frame, snapshot: &OrchestratorSnapshot, now: DateT
     let running_table = Table::new(
         running_rows,
         [
+            Constraint::Length(2),
+            Constraint::Length(10),
             Constraint::Length(12),
             Constraint::Length(14),
             Constraint::Length(8),
+            Constraint::Length(24),
+            Constraint::Min(16),
             Constraint::Length(14),
             Constraint::Length(12),
             Constraint::Length(10),
@@ -267,16 +276,34 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
             .and_then(|m| m.last_activity_at.as_ref().cloned())
             .or(Some(run.started_at));
         let total_tokens = metrics.map(|m| m.total_tokens).unwrap_or(0);
+        let last_event = metrics.and_then(|m| m.last_event.as_deref());
+        let last_event_message = metrics.and_then(|m| m.last_event_message.as_deref());
+        let session_id = metrics.and_then(|m| m.session_id.as_deref());
+        let stale = is_stale_session(last_activity, now);
         let state = run
             .linear_state
             .as_deref()
             .unwrap_or(run.status.as_str())
             .to_string();
+        let last_activity_text = format_age(last_activity, now);
+        let last_activity_cell = if stale {
+            Cell::from(Span::styled(
+                last_activity_text,
+                Style::default().fg(Color::Red),
+            ))
+        } else {
+            Cell::from(last_activity_text)
+        };
+
         rows.push(Row::new(vec![
+            Cell::from(status_dot(last_event, last_activity, now)),
             Cell::from(run.issue_identifier.clone()),
+            Cell::from(compact_session_id(session_id)),
             Cell::from(state),
             Cell::from(turn_count.to_string()),
-            Cell::from(format_age(last_activity, now)),
+            Cell::from(truncate_for_cell(last_event.unwrap_or("-"), 32)),
+            Cell::from(truncate_for_cell(last_event_message.unwrap_or("-"), 60)),
+            last_activity_cell,
             Cell::from(format_tokens(total_tokens)),
             Cell::from(
                 run.worker_host
@@ -289,7 +316,11 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
 
     if rows.is_empty() {
         rows.push(Row::new(vec![
+            Cell::from(""),
             Cell::from("(none)"),
+            Cell::from(""),
+            Cell::from(""),
+            Cell::from(""),
             Cell::from(""),
             Cell::from(""),
             Cell::from(""),
@@ -299,6 +330,73 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
     }
 
     rows
+}
+
+fn compact_session_id(session_id: Option<&str>) -> String {
+    session_id
+        .map(|value| value.chars().take(8).collect::<String>())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn status_dot(
+    last_event: Option<&str>,
+    last_activity: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Span<'static> {
+    Span::styled(
+        "●",
+        Style::default().fg(status_color(last_event, last_activity, now)),
+    )
+}
+
+fn status_color(
+    last_event: Option<&str>,
+    last_activity: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Color {
+    if last_event.is_none() || is_stale_session(last_activity, now) {
+        return Color::Red;
+    }
+
+    let normalized = last_event
+        .map(|event| event.trim().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if normalized.contains("turn_completed") || normalized == "turn/completed" {
+        Color::Magenta
+    } else if normalized.contains("token_count") {
+        Color::Yellow
+    } else if normalized.contains("task_started")
+        || normalized.contains("tool_call")
+        || normalized.contains("item/tool/call")
+    {
+        Color::Green
+    } else {
+        Color::Blue
+    }
+}
+
+fn is_stale_session(last_activity: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    let Some(last_activity) = last_activity else {
+        return true;
+    };
+
+    (now - last_activity).num_milliseconds() > STALE_ACTIVITY_THRESHOLD_MS
+}
+
+fn truncate_for_cell(value: &str, max_chars: usize) -> String {
+    let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.chars().count() <= max_chars {
+        return normalized;
+    }
+
+    let mut out = String::new();
+    for ch in normalized.chars().take(max_chars.saturating_sub(1)) {
+        out.push(ch);
+    }
+    out.push('…');
+    out
 }
 
 fn retry_rows(snapshot: &OrchestratorSnapshot) -> Vec<Row<'static>> {
@@ -574,6 +672,53 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("secondary: 34% used")),
             "expected secondary usage summary, got: {summary:?}"
+        );
+    }
+
+    #[test]
+    fn compact_session_id_truncates_to_first_eight_chars() {
+        assert_eq!(
+            compact_session_id(Some("1234567890abcdef")),
+            "12345678".to_string()
+        );
+        assert_eq!(compact_session_id(None), "-".to_string());
+    }
+
+    #[test]
+    fn status_color_respects_event_mapping_and_staleness() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 22, 15, 0, 0)
+            .single()
+            .expect("valid fixture timestamp");
+        let fresh = Utc
+            .with_ymd_and_hms(2026, 3, 22, 14, 59, 30)
+            .single()
+            .expect("valid fixture timestamp");
+        let stale = Utc
+            .with_ymd_and_hms(2026, 3, 22, 14, 55, 0)
+            .single()
+            .expect("valid fixture timestamp");
+
+        assert_eq!(
+            status_color(Some("codex/event/task_started"), Some(fresh), now),
+            Color::Green
+        );
+        assert_eq!(
+            status_color(Some("codex/event/token_count"), Some(fresh), now),
+            Color::Yellow
+        );
+        assert_eq!(
+            status_color(Some("turn_completed"), Some(fresh), now),
+            Color::Magenta
+        );
+        assert_eq!(
+            status_color(Some("notification"), Some(fresh), now),
+            Color::Blue
+        );
+        assert_eq!(status_color(None, Some(fresh), now), Color::Red);
+        assert_eq!(
+            status_color(Some("turn_completed"), Some(stale), now),
+            Color::Red
         );
     }
 

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -572,7 +572,9 @@ fn status_color(
         .map(|event| event.trim().to_ascii_lowercase())
         .unwrap_or_default();
 
-    if is_turn_completed_event(&normalized) {
+    if is_failure_event(&normalized) {
+        Color::Red
+    } else if is_turn_completed_event(&normalized) {
         Color::Magenta
     } else if normalized.contains("token_count") {
         Color::Yellow
@@ -584,6 +586,13 @@ fn status_color(
     } else {
         Color::Blue
     }
+}
+
+fn is_failure_event(normalized_event: &str) -> bool {
+    normalized_event.contains("failed")
+        || normalized_event.contains("error")
+        || normalized_event.contains("cancelled")
+        || normalized_event.contains("canceled")
 }
 
 fn is_turn_completed_event(normalized_event: &str) -> bool {
@@ -983,6 +992,14 @@ mod tests {
         assert_eq!(
             status_color(Some("codex/event/turn/completed"), Some(fresh), now),
             Color::Magenta
+        );
+        assert_eq!(
+            status_color(Some("codex/event/tool_call_failed"), Some(fresh), now),
+            Color::Red
+        );
+        assert_eq!(
+            status_color(Some("startup_failed"), Some(fresh), now),
+            Color::Red
         );
         assert_eq!(
             status_color(Some("notification"), Some(fresh), now),

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -263,6 +263,9 @@ fn test_orchestrator_snapshot_serializes() {
                     turn_count: 3,
                     last_activity_at: Some(Utc::now()),
                     total_tokens: 120,
+                    last_event: None,
+                    last_event_message: None,
+                    session_id: None,
                 },
             );
             m.insert(
@@ -271,6 +274,9 @@ fn test_orchestrator_snapshot_serializes() {
                     turn_count: 1,
                     last_activity_at: Some(Utc::now()),
                     total_tokens: 40,
+                    last_event: None,
+                    last_event_message: None,
+                    session_id: None,
                 },
             );
             m

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -85,6 +85,9 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                     turn_count: 2,
                     last_activity_at: Some(started_at),
                     total_tokens: 200,
+                    last_event: Some("codex/event/task_started".to_string()),
+                    last_event_message: Some("running cargo test".to_string()),
+                    session_id: Some("session-12345678".to_string()),
                 },
             );
             sessions

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -919,6 +919,47 @@ fn test_streamed_notification_records_event_method_and_message() {
 }
 
 #[test]
+fn test_streamed_tool_call_completed_uses_completed_summary() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let now_ms = 3_500_000;
+    orchestrator.state_mut().running.insert(
+        "issue-tool-call".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-tool-call".to_string(),
+            issue_identifier: "SIM-STREAM-TOOL".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-tool-call".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            linear_state: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        "issue-tool-call",
+        &AgentEvent::ToolCallCompleted {
+            timestamp: utc_ms(now_ms - 1_000),
+            codex_app_server_pid: Some("4444".to_string()),
+            tool_name: "cargo test".to_string(),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-tool-call")
+        .expect("running session snapshot should include tool call issue");
+    assert_eq!(session.last_event.as_deref(), Some("tool_call_completed"));
+    assert_eq!(
+        session.last_event_message.as_deref(),
+        Some("completed cargo test")
+    );
+}
+
+#[test]
 fn test_streamed_turn_completed_events_update_token_totals_in_real_time() {
     let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let now_ms = 3_000_000;

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -790,6 +790,21 @@ fn test_streamed_event_updates_activity_before_worker_completion() {
             .contains_key("issue-stream-activity"),
         "worker should not be retried while streamed activity is within stall timeout"
     );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-stream-activity")
+        .expect("running session snapshot should include stream activity issue");
+    assert_eq!(session.last_event.as_deref(), Some("session_started"));
+    assert_eq!(
+        session.last_event_message.as_deref(),
+        Some("session thread-s")
+    );
+    assert_eq!(
+        session.session_id.as_deref(),
+        Some("thread-stream-1-turn-1")
+    );
 }
 
 #[test]
@@ -854,6 +869,52 @@ fn test_streamed_events_keep_refreshing_stall_detection_window() {
             .retry_attempts
             .contains_key("issue-stream-window"),
         "stalled retry should remain unscheduled when streamed activity continues"
+    );
+}
+
+#[test]
+fn test_streamed_notification_records_event_method_and_message() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let now_ms = 3_000_000;
+    orchestrator.state_mut().running.insert(
+        "issue-notification".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-notification".to_string(),
+            issue_identifier: "SIM-STREAM-3".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-notification".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            linear_state: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        "issue-notification",
+        &AgentEvent::Notification {
+            timestamp: utc_ms(now_ms - 3_000),
+            codex_app_server_pid: Some("3333".to_string()),
+            message:
+                r#"{"method":"codex/event/task_started","params":{"message":"running cargo test"}}"#
+                    .to_string(),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-notification")
+        .expect("running session snapshot should include notification issue");
+    assert_eq!(
+        session.last_event.as_deref(),
+        Some("codex/event/task_started")
+    );
+    assert_eq!(
+        session.last_event_message.as_deref(),
+        Some("running cargo test")
     );
 }
 


### PR DESCRIPTION
## Summary
- add per-session event metadata to running session snapshots (`last_event`, `last_event_message`, `session_id`)
- update streamed event ingestion to capture event names/messages (including codex notification method parsing)
- extend TUI running sessions table with status dot, compact session id, last event, and message columns
- add stale/no-event red highlighting and tests for event projection + color mapping

## Validation
- cd apps/symphony && cargo test
- cd apps/symphony && cargo fmt --check
- cd apps/symphony && cargo clippy -- -D warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the Symphony TUI's running-sessions table with richer per-session status information: a color-coded status dot, compact session ID, last event name, and last event message. It also adds the plumbing in the orchestrator to capture this metadata from the live event stream, including JSON parsing of Codex notification payloads to extract the `method` and human-readable message fields.

Key changes:
- `RunningSessionSnapshot` / `RunningSessionStats` gain three new optional fields: `last_event`, `last_event_message`, `session_id`
- New `event_summary` / `notification_event_summary` / `other_message_summary` helpers in `orchestrator.rs` parse each `AgentEvent` into a (name, message) pair, with special handling for Codex JSON notification payloads
- TUI table gains 4 new columns (dot, session, last event, message) with stale-activity red highlighting and color-coded status dots
- Unit and integration tests cover the new event projection and color-mapping logic
- One functional issue: `AgentEvent::ToolCallCompleted` produces the message `"running {tool_name}"` despite the tool having already completed, which is misleading in the TUI
- `compact_session_id` and the truncation helpers (`truncate_for_summary` / `truncate_for_cell`) are independently re-implemented in both `orchestrator.rs` and `tui.rs`; consolidating them would reduce drift risk

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one misleading display string worth correcting before release.
- The domain and serialization changes are backward-compatible (all new fields have serde defaults). The orchestrator and TUI logic is well-tested. The only functional concern is the misleading "running {tool_name}" message for a completed tool call event, which is a UX bug but not a data-correctness or safety issue. The code duplication and pattern-matching inconsistency are style concerns that don't affect correctness.
- apps/symphony/src/orchestrator.rs — ToolCallCompleted message string and duplicated utility functions

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Adds event_summary, notification parsing, and helper utilities to capture last event name/message per running session. The ToolCallCompleted arm produces a misleading "running {tool_name}" message; compact_session_id and truncation helpers are duplicated from tui.rs; find_preferred_text performs an unbounded recursive tree walk. |
| apps/symphony/src/tui.rs | Extends running-sessions table with status dot, compact session ID, last event, and message columns. Color-coding and staleness logic is well-structured; mixed contains/equality matching for turn_completed color is minor but worth standardising. |
| apps/symphony/src/domain.rs | Adds last_event, last_event_message, and session_id optional fields to RunningSessionSnapshot with serde defaults; straightforward and backward-compatible. |
| apps/symphony/tests/orchestrator_tests.rs | Adds integration tests for streamed event metadata and notification JSON parsing; assertions are precise and well-structured. |
| apps/symphony/tests/domain_tests.rs | Minimal fixture updates to populate new optional fields with None; no issues. |
| apps/symphony/tests/http_server_tests.rs | Fixture snapshot updated with realistic last_event, last_event_message, and session_id values; no issues. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Codex Agent
    participant Orch as Orchestrator
    participant Stats as RunningSessionStats
    participant Snap as RunningSessionSnapshot
    participant TUI as TUI

    Agent->>Orch: AgentEvent (e.g. Notification, ToolCallCompleted)
    Orch->>Orch: event_summary(event) → (name, message)
    Orch->>Stats: update last_event, last_event_message, session_id, last_activity_at
    TUI->>Orch: snapshot(now_ms)
    Orch->>Snap: build RunningSessionSnapshot (copies stats fields)
    Snap-->>TUI: OrchestratorSnapshot
    TUI->>TUI: running_rows() → status_dot color, compact_session_id, truncate columns
    TUI->>TUI: render table with status dot · ID · Session · State · Turn · Last Event · Message · Last Activity · Tokens · Host
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 2487-2490

Comment:
**Misleading message for `ToolCallCompleted`**

The message for `AgentEvent::ToolCallCompleted` is `"running {tool_name}"`, but this event fires *after* the tool has finished. In the TUI a user would see:

- Last Event: `tool_call_completed`
- Message: `running cargo build`

That combination is contradictory — "completed" in the event name and "running" in the message. Consider using `"completed {tool_name}"` instead.

```suggestion
        AgentEvent::ToolCallCompleted { tool_name, .. } => (
            event_name(event).to_string(),
            Some(format!("completed {tool_name}")),
        ),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 2693-2695

Comment:
**`compact_session_id` duplicated across modules**

`compact_session_id` is now defined identically in both `orchestrator.rs` (taking `&str`) and `tui.rs` (taking `Option<&str>`), and the same `truncate`/`normalize_whitespace` helpers are separately re-implemented in both files (`truncate_for_summary` vs `truncate_for_cell`). Moving these utilities to a shared module (e.g., `utils.rs` or `domain.rs`) would eliminate the duplication and make future changes consistent.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 2638-2668

Comment:
**`find_preferred_text` unbounded recursive tree walk**

After checking the preferred key list, the fallback `map.values().find_map(find_preferred_text)` recursively descends into every value in an object. For notification payloads that may contain large or deeply-nested JSON (e.g., full tool outputs embedded in `params`), this can trigger a deep traversal on every ingested event, potentially causing a stack overflow for pathologically nested payloads or degraded performance on large messages.

Consider adding a depth guard or capping exploration at a shallow depth:

```rust
fn find_preferred_text_depth(value: &serde_json::Value, depth: usize) -> Option<String> {
    if depth == 0 {
        return None;
    }
    // ... same logic, pass depth - 1 in recursive calls
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/tui.rs
Line: 366-367

Comment:
**Inconsistent pattern matching for `turn_completed`**

The first branch uses `contains("turn_completed")` (substring match) but also includes an exact equality check `normalized == "turn/completed"` for the same color. The slash-separated form `"turn/completed"` would already be caught by the `contains("turn_completed")` check since it does not contain the underscore variant and the equality guard is unreachable via `contains`. If `"turn/completed"` is a real event name produced by a different backend, the `contains` check would never match it (no `_`), so the equality guard acts as the only catch.

This mixed approach (substring vs equality for the same logical group) is fragile — consider normalising to a consistent strategy such as checking for both substrings, or routing all slash-separated variants through a separate `contains("turn")` + `contains("completed")` guard.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): show last session event ..."](https://github.com/gannonh/kata/commit/227787edc673c31b8204494694a48d92c7f8c631) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25981476)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced "Running Sessions" table with new columns displaying Session ID, Last Event, and Activity Message for improved session visibility.
  * Color-coded status indicators reflecting event types (turn completion, token updates, task/tool operations).
  * Automatic staleness detection highlighting inactive sessions with red styling when activity is absent or exceeds the inactivity threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->