### PR TITLE
feat(symphony): enable TUI by default with --no-tui opt-out

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -27,7 +27,7 @@ cargo build --release
 ## Running
 
 ```sh
-symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
+symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--no-tui]
 ```
 
 ### CLI Flag Reference
@@ -37,7 +37,7 @@ symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
 | `WORKFLOW.md` (positional)                                              | path | `WORKFLOW.md` | Path to the WORKFLOW.md configuration file                                                                                           |
 | `--port PORT`                                                           | u16  | `8080`        | Bind the HTTP dashboard and API on this port. Overrides `server.port` in the workflow file.                                         |
 | `--logs-root PATH`                                                      | path | _(none)_      | Directory root for agent log files.                                                                                                  |
-| `--tui`                                                                 | flag | `false`       | Render a Ratatui terminal dashboard. When enabled with no `--logs-root`, stdout logs are suppressed to avoid corrupting the TUI.   |
+| `--no-tui`                                                              | flag | `false`       | Disable the Ratatui terminal dashboard. Without this flag, TUI is enabled by default and stdout logs are suppressed unless logs write to files. |
 
 ### Exit Codes
 
@@ -61,8 +61,8 @@ Default level is `info`.
 
 When `--logs-root` is set, logs write to rotating files under
 `<logs-root>/log/symphony.log` and stdout shows only the startup banner.
-Without `--logs-root`, logs stream to stdout as structured JSON unless `--tui`
-is enabled.
+Without `--logs-root`, stdout logs are suppressed while the default TUI is
+active. Pass `--no-tui` to stream structured JSON logs to stdout instead.
 
 ---
 

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -17,7 +17,7 @@ Headless orchestrator that polls a Linear project for candidate issues and dispa
 - **Rotating log files** — structured JSON logs to disk with rotation via `--logs-root`
 - **SSH worker pools** — distribute sessions across remote machines
 - **HTTP dashboard + JSON API** — live session table with turn/activity/session-token observability, retry queue, polling stats
-- **Terminal dashboard (`--tui`)** — Ratatui observability view for local runs
+- **Terminal dashboard (default-on)** — Ratatui observability view for local runs; disable with `--no-tui`
 
 <details>
 <summary>HTTP Dashboard</summary>
@@ -86,7 +86,7 @@ Press Ctrl+C to stop.
 ## CLI Flags
 
 ```
-symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
+symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--no-tui]
 ```
 
 | Flag | Default | Description |
@@ -94,7 +94,9 @@ symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
 | `WORKFLOW.md` (positional) | `WORKFLOW.md` | Path to the workflow configuration file |
 | `--port PORT` | `8080` | HTTP dashboard and API port. Overrides `server.port` in config |
 | `--logs-root PATH` | *(none)* | Directory for rotating log files. Suppresses stdout log streaming |
-| `--tui` | `false` | Render the Ratatui terminal dashboard. When enabled without `--logs-root`, stdout logs are suppressed to keep the TUI clean |
+| `--no-tui` | `false` | Disable the Ratatui terminal dashboard. Without this flag, TUI is enabled by default |
+
+Legacy compatibility: `--tui` is still accepted as a no-op.
 
 ### Log verbosity
 
@@ -106,7 +108,7 @@ RUST_LOG=debug symphony WORKFLOW.md                   # verbose
 RUST_LOG=symphony=trace,info symphony WORKFLOW.md     # trace symphony, info everything else
 ```
 
-When `--logs-root` is set, logs write to rotating files under `<logs-root>/log/symphony.log` and stdout shows only the startup banner. Without `--logs-root`, logs stream to stdout as structured JSON unless `--tui` is enabled.
+When `--logs-root` is set, logs write to rotating files under `<logs-root>/log/symphony.log` and stdout shows only the startup banner. Without `--logs-root`, stdout logs are suppressed while the default TUI is active; pass `--no-tui` to stream structured JSON logs to stdout instead.
 
 ## Multiple Workflows
 

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -534,6 +534,12 @@ pub struct RunningSessionSnapshot {
     pub last_activity_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub total_tokens: u64,
+    #[serde(default)]
+    pub last_event: Option<String>,
+    #[serde(default)]
+    pub last_event_message: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 /// Polling state for the snapshot.

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -37,12 +37,12 @@ pub struct Cli {
     pub logs_root: Option<String>,
 
     /// Legacy compatibility flag. TUI is now enabled by default.
-    #[arg(long, hide = true, default_value_t = true)]
+    #[arg(long, hide = true)]
     pub tui: bool,
 
     /// Disable the live terminal dashboard (Ratatui)
     #[arg(long)]
-    no_tui: bool,
+    pub no_tui: bool,
 }
 
 pub trait BootstrapDeps {
@@ -293,9 +293,8 @@ where
     T: Into<OsString> + Clone,
 {
     let mut cli = Cli::try_parse_from(args)?;
-    if cli.no_tui {
-        cli.tui = false;
-    }
+    // TUI is enabled by default; --no-tui is the explicit opt-out.
+    cli.tui = !cli.no_tui;
     Ok(cli)
 }
 

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -36,9 +36,13 @@ pub struct Cli {
     #[arg(long)]
     pub logs_root: Option<String>,
 
-    /// Render a live terminal dashboard (Ratatui)
-    #[arg(long)]
+    /// Legacy compatibility flag. TUI is now enabled by default.
+    #[arg(long, hide = true, default_value_t = true)]
     pub tui: bool,
+
+    /// Disable the live terminal dashboard (Ratatui)
+    #[arg(long)]
+    no_tui: bool,
 }
 
 pub trait BootstrapDeps {
@@ -288,7 +292,11 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    Cli::try_parse_from(args)
+    let mut cli = Cli::try_parse_from(args)?;
+    if cli.no_tui {
+        cli.tui = false;
+    }
+    Ok(cli)
 }
 
 pub fn resolve_workflow_path(cli: &Cli) -> PathBuf {
@@ -653,8 +661,21 @@ mod tests {
     }
 
     #[test]
-    fn parse_cli_defaults_tui_to_false() {
+    fn parse_cli_defaults_tui_to_true() {
         let cli = parse_cli_from(["symphony", "WORKFLOW.md"]).expect("cli parse");
+        assert!(cli.tui);
+    }
+
+    #[test]
+    fn parse_cli_accepts_no_tui_flag() {
+        let cli = parse_cli_from(["symphony", "WORKFLOW.md", "--no-tui"]).expect("cli parse");
+        assert!(!cli.tui);
+    }
+
+    #[test]
+    fn parse_cli_no_tui_wins_when_both_flags_are_present() {
+        let cli =
+            parse_cli_from(["symphony", "WORKFLOW.md", "--tui", "--no-tui"]).expect("cli parse");
         assert!(!cli.tui);
     }
 }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -600,6 +600,9 @@ struct RunningSessionStats {
     turn_count: u32,
     last_activity_at: Option<DateTime<Utc>>,
     total_tokens: u64,
+    last_event: Option<String>,
+    last_event_message: Option<String>,
+    session_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1261,11 +1264,15 @@ impl Orchestrator {
                 .insert(issue_id.to_string(), session_id.to_string());
         }
 
+        let (last_event, last_event_message) = event_summary(event);
         let session_stats = self
             .running_session_stats
             .entry(issue_id.to_string())
             .or_default();
         session_stats.last_activity_at = Some(event_time);
+        session_stats.last_event = Some(last_event);
+        session_stats.last_event_message = last_event_message;
+        session_stats.session_id = self.worker_session_ids.get(issue_id).cloned();
 
         if let Some(run_attempt) = self.state.running.get_mut(issue_id) {
             match event {
@@ -1490,6 +1497,9 @@ impl Orchestrator {
                 turn_count: 0,
                 last_activity_at: Some(Utc::now()),
                 total_tokens: 0,
+                last_event: None,
+                last_event_message: None,
+                session_id: None,
             });
         self.state.retry_attempts.remove(&issue.id);
 
@@ -1765,6 +1775,11 @@ impl Orchestrator {
                             .and_then(|s| s.last_activity_at)
                             .or(Some(run_attempt.started_at)),
                         total_tokens: stats.map(|s| s.total_tokens).unwrap_or(0),
+                        last_event: stats.and_then(|s| s.last_event.clone()),
+                        last_event_message: stats.and_then(|s| s.last_event_message.clone()),
+                        session_id: stats
+                            .and_then(|s| s.session_id.clone())
+                            .or_else(|| self.worker_session_ids.get(issue_id).cloned()),
                     },
                 )
             })
@@ -2039,6 +2054,9 @@ impl Orchestrator {
                 turn_count: 0,
                 last_activity_at: Some(Utc::now()),
                 total_tokens: 0,
+                last_event: None,
+                last_event_message: None,
+                session_id: None,
             },
         );
         self.state.retry_attempts.remove(&issue.id);
@@ -2426,6 +2444,289 @@ fn event_name(event: &AgentEvent) -> &'static str {
     }
 }
 
+fn event_summary(event: &AgentEvent) -> (String, Option<String>) {
+    let (name, message) = match event {
+        AgentEvent::SessionStarted { session_id, .. } => (
+            event_name(event).to_string(),
+            Some(format!("session {}", compact_session_id(session_id))),
+        ),
+        AgentEvent::StartupFailed { error, .. } => {
+            (event_name(event).to_string(), Some(error.clone()))
+        }
+        AgentEvent::TurnCompleted { message, .. } => (
+            event_name(event).to_string(),
+            Some(
+                message
+                    .clone()
+                    .unwrap_or_else(|| "turn completed".to_string()),
+            ),
+        ),
+        AgentEvent::TurnFailed { error, .. } => {
+            (event_name(event).to_string(), Some(error.clone()))
+        }
+        AgentEvent::TurnCancelled { .. } => (
+            event_name(event).to_string(),
+            Some("turn cancelled".to_string()),
+        ),
+        AgentEvent::TurnEndedWithError { error, .. } => {
+            (event_name(event).to_string(), Some(error.clone()))
+        }
+        AgentEvent::TurnInputRequired { prompt, .. } => (
+            event_name(event).to_string(),
+            prompt
+                .clone()
+                .or_else(|| Some("input required".to_string())),
+        ),
+        AgentEvent::ApprovalAutoApproved { tool_call, .. } => (
+            event_name(event).to_string(),
+            Some(format!("auto-approved {tool_call}")),
+        ),
+        AgentEvent::ApprovalRequired { method, .. } => (
+            event_name(event).to_string(),
+            Some(format!("approval required: {method}")),
+        ),
+        AgentEvent::ToolCallCompleted { tool_name, .. } => (
+            event_name(event).to_string(),
+            Some(format!("completed {tool_name}")),
+        ),
+        AgentEvent::ToolCallFailed { tool_name, .. } => {
+            let message = tool_name
+                .as_ref()
+                .map(|name| format!("tool {name} failed"))
+                .unwrap_or_else(|| "tool call failed".to_string());
+            (event_name(event).to_string(), Some(message))
+        }
+        AgentEvent::ToolInputAutoAnswered { .. } => (
+            event_name(event).to_string(),
+            Some("tool input auto-answered".to_string()),
+        ),
+        AgentEvent::UnsupportedToolCall { tool_name, .. } => (
+            event_name(event).to_string(),
+            Some(format!("unsupported tool {tool_name}")),
+        ),
+        AgentEvent::Notification { message, .. } => notification_event_summary(message),
+        AgentEvent::OtherMessage { raw, .. } => other_message_summary(raw),
+        AgentEvent::Malformed {
+            parse_error,
+            raw_text,
+            ..
+        } => (
+            event_name(event).to_string(),
+            Some(format!(
+                "malformed event: {parse_error}; {}",
+                normalize_whitespace(raw_text)
+            )),
+        ),
+    };
+
+    (
+        name,
+        message
+            .as_deref()
+            .map(|value| truncate_for_summary(value, 160))
+            .filter(|value| !value.is_empty()),
+    )
+}
+
+fn notification_event_summary(message: &str) -> (String, Option<String>) {
+    let fallback_message = normalize_whitespace(message);
+    let parsed = match serde_json::from_str::<serde_json::Value>(message) {
+        Ok(parsed) => parsed,
+        Err(_) => {
+            return (
+                "notification".to_string(),
+                (!fallback_message.is_empty()).then_some(fallback_message),
+            )
+        }
+    };
+
+    let name = parsed
+        .get("method")
+        .and_then(|method| method.as_str())
+        .unwrap_or("notification")
+        .to_string();
+    let mut summary = summarize_notification_payload(&name, &parsed);
+    if summary.is_none() && !fallback_message.is_empty() {
+        summary = Some(fallback_message);
+    }
+
+    (name, summary)
+}
+
+fn summarize_notification_payload(name: &str, payload: &serde_json::Value) -> Option<String> {
+    if name.contains("token_count") {
+        let input = first_u64_at_paths(
+            payload,
+            &[
+                &["params", "tokenUsage", "total", "input_tokens"],
+                &["params", "tokenUsage", "total", "inputTokens"],
+                &[
+                    "params",
+                    "msg",
+                    "payload",
+                    "info",
+                    "total_token_usage",
+                    "input_tokens",
+                ],
+            ],
+        );
+        let output = first_u64_at_paths(
+            payload,
+            &[
+                &["params", "tokenUsage", "total", "output_tokens"],
+                &["params", "tokenUsage", "total", "outputTokens"],
+                &[
+                    "params",
+                    "msg",
+                    "payload",
+                    "info",
+                    "total_token_usage",
+                    "output_tokens",
+                ],
+            ],
+        );
+        let total = first_u64_at_paths(
+            payload,
+            &[
+                &["params", "tokenUsage", "total", "total_tokens"],
+                &["params", "tokenUsage", "total", "totalTokens"],
+                &[
+                    "params",
+                    "msg",
+                    "payload",
+                    "info",
+                    "total_token_usage",
+                    "total_tokens",
+                ],
+            ],
+        );
+
+        let mut pieces = Vec::new();
+        if let Some(value) = input {
+            pieces.push(format!("in {value}"));
+        }
+        if let Some(value) = output {
+            pieces.push(format!("out {value}"));
+        }
+        if let Some(value) = total {
+            pieces.push(format!("total {value}"));
+        }
+        if !pieces.is_empty() {
+            return Some(format!("tokens {}", pieces.join(" / ")));
+        }
+    }
+
+    payload
+        .get("params")
+        .and_then(find_preferred_text)
+        .or_else(|| find_preferred_text(payload))
+}
+
+fn other_message_summary(raw: &serde_json::Value) -> (String, Option<String>) {
+    let name = raw
+        .get("method")
+        .and_then(|method| method.as_str())
+        .unwrap_or("other_message")
+        .to_string();
+    let summary = raw
+        .get("params")
+        .and_then(find_preferred_text)
+        .or_else(|| find_preferred_text(raw));
+    (name, summary)
+}
+
+fn find_preferred_text(value: &serde_json::Value) -> Option<String> {
+    const MAX_TEXT_SEARCH_DEPTH: usize = 5;
+    find_preferred_text_with_depth(value, MAX_TEXT_SEARCH_DEPTH)
+}
+
+fn find_preferred_text_with_depth(value: &serde_json::Value, depth: usize) -> Option<String> {
+    if depth == 0 {
+        return None;
+    }
+
+    match value {
+        serde_json::Value::String(text) => {
+            let normalized = normalize_whitespace(text);
+            if normalized.is_empty() {
+                None
+            } else {
+                Some(normalized)
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for key in [
+                "summary",
+                "message",
+                "text",
+                "title",
+                "command",
+                "tool_name",
+                "toolName",
+                "name",
+            ] {
+                if let Some(found) = map
+                    .get(key)
+                    .and_then(|candidate| find_preferred_text_with_depth(candidate, depth - 1))
+                {
+                    return Some(found);
+                }
+            }
+
+            map.values()
+                .find_map(|candidate| find_preferred_text_with_depth(candidate, depth - 1))
+        }
+        serde_json::Value::Array(items) => items
+            .iter()
+            .find_map(|candidate| find_preferred_text_with_depth(candidate, depth - 1)),
+        _ => None,
+    }
+}
+
+fn first_u64_at_paths(value: &serde_json::Value, paths: &[&[&str]]) -> Option<u64> {
+    paths
+        .iter()
+        .find_map(|path| value_at_path(value, path).and_then(integer_like))
+}
+
+fn value_at_path<'a>(value: &'a serde_json::Value, path: &[&str]) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+fn integer_like(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::Number(number) => number.as_u64(),
+        serde_json::Value::String(text) => text.trim().parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+fn compact_session_id(session_id: &str) -> String {
+    session_id.chars().take(8).collect()
+}
+
+fn normalize_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_for_summary(value: &str, max_chars: usize) -> String {
+    let normalized = normalize_whitespace(value);
+    if normalized.chars().count() <= max_chars {
+        return normalized;
+    }
+
+    let mut out = String::new();
+    for ch in normalized.chars().take(max_chars.saturating_sub(1)) {
+        out.push(ch);
+    }
+    out.push('…');
+    out
+}
+
 fn normalize_issue_state(state_name: &str) -> String {
     state_name.trim().to_ascii_lowercase()
 }
@@ -2457,4 +2758,29 @@ fn issue_identifier_sort_key(issue: &Issue) -> (&str, &str) {
 
 pub fn rate_limit_info(data: serde_json::Value) -> RateLimitInfo {
     RateLimitInfo { data }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn find_preferred_text_stops_searching_past_depth_limit() {
+        let nested = json!({
+            "level_1": {
+                "level_2": {
+                    "level_3": {
+                        "level_4": {
+                            "level_5": {
+                                "message": "too deep"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        assert_eq!(find_preferred_text(&nested), None);
+    }
 }

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -10,8 +10,8 @@ use crossterm::terminal::{
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, List, ListItem, Paragraph, Row, Table, Wrap};
 use ratatui::{Frame, Terminal};
 use tokio::sync::watch;
@@ -26,6 +26,7 @@ const SPARKLINE_WINDOW_MS: i64 = 10 * 60 * 1_000;
 const SPARKLINE_BUCKETS: usize = 24;
 const SPARKLINE_BUCKET_MS: i64 = SPARKLINE_WINDOW_MS / SPARKLINE_BUCKETS as i64;
 const SPARKLINE_BLOCKS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+const STALE_ACTIVITY_THRESHOLD_MS: i64 = 120_000;
 
 #[derive(Debug, Default)]
 struct ThroughputTracker {
@@ -392,9 +393,13 @@ fn draw_dashboard(
     frame.render_widget(Paragraph::new(summary_lines), sections[0]);
 
     let running_header = Row::new(vec![
+        Cell::from(""),
         Cell::from("ID"),
+        Cell::from("Session"),
         Cell::from("State"),
         Cell::from("Turn"),
+        Cell::from("Last Event"),
+        Cell::from("Message"),
         Cell::from("Last Activity"),
         Cell::from("Tokens"),
         Cell::from("Host"),
@@ -404,9 +409,13 @@ fn draw_dashboard(
     let running_table = Table::new(
         running_rows,
         [
+            Constraint::Length(2),
+            Constraint::Length(10),
             Constraint::Length(12),
             Constraint::Length(14),
             Constraint::Length(8),
+            Constraint::Length(24),
+            Constraint::Min(16),
             Constraint::Length(14),
             Constraint::Length(12),
             Constraint::Length(10),
@@ -476,16 +485,34 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
             .and_then(|m| m.last_activity_at.as_ref().cloned())
             .or(Some(run.started_at));
         let total_tokens = metrics.map(|m| m.total_tokens).unwrap_or(0);
+        let last_event = metrics.and_then(|m| m.last_event.as_deref());
+        let last_event_message = metrics.and_then(|m| m.last_event_message.as_deref());
+        let session_id = metrics.and_then(|m| m.session_id.as_deref());
+        let stale = is_stale_session(last_activity, now);
         let state = run
             .linear_state
             .as_deref()
             .unwrap_or(run.status.as_str())
             .to_string();
+        let last_activity_text = format_age(last_activity, now);
+        let last_activity_cell = if stale {
+            Cell::from(Span::styled(
+                last_activity_text,
+                Style::default().fg(Color::Red),
+            ))
+        } else {
+            Cell::from(last_activity_text)
+        };
+
         rows.push(Row::new(vec![
+            Cell::from(status_dot(last_event, last_activity, now)),
             Cell::from(run.issue_identifier.clone()),
+            Cell::from(compact_session_id(session_id)),
             Cell::from(state),
             Cell::from(turn_count.to_string()),
-            Cell::from(format_age(last_activity, now)),
+            Cell::from(truncate_for_cell(last_event.unwrap_or("-"), 32)),
+            Cell::from(truncate_for_cell(last_event_message.unwrap_or("-"), 60)),
+            last_activity_cell,
             Cell::from(format_tokens(total_tokens)),
             Cell::from(
                 run.worker_host
@@ -498,7 +525,11 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
 
     if rows.is_empty() {
         rows.push(Row::new(vec![
+            Cell::from(""),
             Cell::from("(none)"),
+            Cell::from(""),
+            Cell::from(""),
+            Cell::from(""),
             Cell::from(""),
             Cell::from(""),
             Cell::from(""),
@@ -508,6 +539,88 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
     }
 
     rows
+}
+
+fn compact_session_id(session_id: Option<&str>) -> String {
+    session_id
+        .map(|value| value.chars().take(8).collect::<String>())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn status_dot(
+    last_event: Option<&str>,
+    last_activity: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Span<'static> {
+    Span::styled(
+        "●",
+        Style::default().fg(status_color(last_event, last_activity, now)),
+    )
+}
+
+fn status_color(
+    last_event: Option<&str>,
+    last_activity: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Color {
+    if last_event.is_none() || is_stale_session(last_activity, now) {
+        return Color::Red;
+    }
+
+    let normalized = last_event
+        .map(|event| event.trim().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if is_failure_event(&normalized) {
+        Color::Red
+    } else if is_turn_completed_event(&normalized) {
+        Color::Magenta
+    } else if normalized.contains("token_count") {
+        Color::Yellow
+    } else if normalized.contains("task_started")
+        || normalized.contains("tool_call")
+        || normalized.contains("item/tool/call")
+    {
+        Color::Green
+    } else {
+        Color::Blue
+    }
+}
+
+fn is_failure_event(normalized_event: &str) -> bool {
+    normalized_event.contains("failed")
+        || normalized_event.contains("error")
+        || normalized_event.contains("cancelled")
+        || normalized_event.contains("canceled")
+}
+
+fn is_turn_completed_event(normalized_event: &str) -> bool {
+    normalized_event.contains("turn_completed")
+        || normalized_event.contains("turn/completed")
+        || (normalized_event.contains("turn") && normalized_event.contains("completed"))
+}
+
+fn is_stale_session(last_activity: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    let Some(last_activity) = last_activity else {
+        return true;
+    };
+
+    (now - last_activity).num_milliseconds() > STALE_ACTIVITY_THRESHOLD_MS
+}
+
+fn truncate_for_cell(value: &str, max_chars: usize) -> String {
+    let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.chars().count() <= max_chars {
+        return normalized;
+    }
+
+    let mut out = String::new();
+    for ch in normalized.chars().take(max_chars.saturating_sub(1)) {
+        out.push(ch);
+    }
+    out.push('…');
+    out
 }
 
 fn retry_rows(snapshot: &OrchestratorSnapshot) -> Vec<Row<'static>> {
@@ -837,6 +950,65 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("secondary: 34% used")),
             "expected secondary usage summary, got: {summary:?}"
+        );
+    }
+
+    #[test]
+    fn compact_session_id_truncates_to_first_eight_chars() {
+        assert_eq!(
+            compact_session_id(Some("1234567890abcdef")),
+            "12345678".to_string()
+        );
+        assert_eq!(compact_session_id(None), "-".to_string());
+    }
+
+    #[test]
+    fn status_color_respects_event_mapping_and_staleness() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 22, 15, 0, 0)
+            .single()
+            .expect("valid fixture timestamp");
+        let fresh = Utc
+            .with_ymd_and_hms(2026, 3, 22, 14, 59, 30)
+            .single()
+            .expect("valid fixture timestamp");
+        let stale = Utc
+            .with_ymd_and_hms(2026, 3, 22, 14, 55, 0)
+            .single()
+            .expect("valid fixture timestamp");
+
+        assert_eq!(
+            status_color(Some("codex/event/task_started"), Some(fresh), now),
+            Color::Green
+        );
+        assert_eq!(
+            status_color(Some("codex/event/token_count"), Some(fresh), now),
+            Color::Yellow
+        );
+        assert_eq!(
+            status_color(Some("turn_completed"), Some(fresh), now),
+            Color::Magenta
+        );
+        assert_eq!(
+            status_color(Some("codex/event/turn/completed"), Some(fresh), now),
+            Color::Magenta
+        );
+        assert_eq!(
+            status_color(Some("codex/event/tool_call_failed"), Some(fresh), now),
+            Color::Red
+        );
+        assert_eq!(
+            status_color(Some("startup_failed"), Some(fresh), now),
+            Color::Red
+        );
+        assert_eq!(
+            status_color(Some("notification"), Some(fresh), now),
+            Color::Blue
+        );
+        assert_eq!(status_color(None, Some(fresh), now), Color::Red);
+        assert_eq!(
+            status_color(Some("turn_completed"), Some(stale), now),
+            Color::Red
         );
     }
 

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -397,7 +397,7 @@ fn test_logs_root_writes_startup_logs_to_file_and_suppresses_stdout_logs() {
 }
 
 #[test]
-fn test_without_logs_root_keeps_stdout_only_behavior() {
+fn test_without_logs_root_suppresses_stdout_logs_when_tui_defaults_on() {
     let run_dir = tempfile::tempdir().expect("temp dir should be created");
     let missing_workflow = run_dir.path().join("missing-workflow.md");
 
@@ -414,8 +414,43 @@ fn test_without_logs_root_keeps_stdout_only_behavior() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
+        !stdout.contains("starting CLI bootstrap"),
+        "stdout should suppress startup logs when TUI is enabled by default; got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\"phase\":\"startup\""),
+        "stdout should suppress startup JSON fields when TUI is enabled by default; got: {stdout}"
+    );
+
+    let log_file_path = run_dir.path().join("log").join("symphony.log");
+    assert!(
+        !log_file_path.exists(),
+        "no log file should be created when --logs-root is omitted, found {}",
+        log_file_path.display()
+    );
+}
+
+#[test]
+fn test_without_logs_root_no_tui_streams_stdout_logs() {
+    let run_dir = tempfile::tempdir().expect("temp dir should be created");
+    let missing_workflow = run_dir.path().join("missing-workflow.md");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_symphony"))
+        .current_dir(run_dir.path())
+        .arg(&missing_workflow)
+        .arg("--no-tui")
+        .output()
+        .expect("symphony binary should execute");
+
+    assert!(
+        !output.status.success(),
+        "missing workflow path should still fail startup"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
         stdout.contains("starting CLI bootstrap"),
-        "stdout should still include startup logs when --logs-root is omitted; got: {stdout}"
+        "stdout should include startup logs when --no-tui is set and --logs-root is omitted; got: {stdout}"
     );
 
     let log_file_path = run_dir.path().join("log").join("symphony.log");

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -283,6 +283,9 @@ fn test_orchestrator_snapshot_serializes() {
                     turn_count: 3,
                     last_activity_at: Some(Utc::now()),
                     total_tokens: 120,
+                    last_event: None,
+                    last_event_message: None,
+                    session_id: None,
                 },
             );
             m.insert(
@@ -291,6 +294,9 @@ fn test_orchestrator_snapshot_serializes() {
                     turn_count: 1,
                     last_activity_at: Some(Utc::now()),
                     total_tokens: 40,
+                    last_event: None,
+                    last_event_message: None,
+                    session_id: None,
                 },
             );
             m

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -86,6 +86,9 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                     turn_count: 2,
                     last_activity_at: Some(started_at),
                     total_tokens: 200,
+                    last_event: Some("codex/event/task_started".to_string()),
+                    last_event_message: Some("running cargo test".to_string()),
+                    session_id: Some("session-12345678".to_string()),
                 },
             );
             sessions

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -790,6 +790,21 @@ fn test_streamed_event_updates_activity_before_worker_completion() {
             .contains_key("issue-stream-activity"),
         "worker should not be retried while streamed activity is within stall timeout"
     );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-stream-activity")
+        .expect("running session snapshot should include stream activity issue");
+    assert_eq!(session.last_event.as_deref(), Some("session_started"));
+    assert_eq!(
+        session.last_event_message.as_deref(),
+        Some("session thread-s")
+    );
+    assert_eq!(
+        session.session_id.as_deref(),
+        Some("thread-stream-1-turn-1")
+    );
 }
 
 #[test]
@@ -854,6 +869,93 @@ fn test_streamed_events_keep_refreshing_stall_detection_window() {
             .retry_attempts
             .contains_key("issue-stream-window"),
         "stalled retry should remain unscheduled when streamed activity continues"
+    );
+}
+
+#[test]
+fn test_streamed_notification_records_event_method_and_message() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let now_ms = 3_000_000;
+    orchestrator.state_mut().running.insert(
+        "issue-notification".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-notification".to_string(),
+            issue_identifier: "SIM-STREAM-3".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-notification".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            linear_state: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        "issue-notification",
+        &AgentEvent::Notification {
+            timestamp: utc_ms(now_ms - 3_000),
+            codex_app_server_pid: Some("3333".to_string()),
+            message:
+                r#"{"method":"codex/event/task_started","params":{"message":"running cargo test"}}"#
+                    .to_string(),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-notification")
+        .expect("running session snapshot should include notification issue");
+    assert_eq!(
+        session.last_event.as_deref(),
+        Some("codex/event/task_started")
+    );
+    assert_eq!(
+        session.last_event_message.as_deref(),
+        Some("running cargo test")
+    );
+}
+
+#[test]
+fn test_streamed_tool_call_completed_uses_completed_summary() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let now_ms = 3_500_000;
+    orchestrator.state_mut().running.insert(
+        "issue-tool-call".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-tool-call".to_string(),
+            issue_identifier: "SIM-STREAM-TOOL".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-tool-call".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            linear_state: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        "issue-tool-call",
+        &AgentEvent::ToolCallCompleted {
+            timestamp: utc_ms(now_ms - 1_000),
+            codex_app_server_pid: Some("4444".to_string()),
+            tool_name: "cargo test".to_string(),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-tool-call")
+        .expect("running session snapshot should include tool call issue");
+    assert_eq!(session.last_event.as_deref(), Some("tool_call_completed"));
+    assert_eq!(
+        session.last_event_message.as_deref(),
+        Some("completed cargo test")
     );
 }
 


### PR DESCRIPTION
## Summary
- enable Symphony TUI by default for standard CLI runs
- add a new `--no-tui` flag to explicitly disable the TUI and keep stdout logging behavior
- keep `--tui` accepted as a hidden backward-compatible no-op
- update Symphony CLI integration tests and docs (`README.md`, `AGENTS.md`) for the new defaults

## Validation
- `cd apps/symphony && cargo test parse_cli_ -- --nocapture`
- `cd apps/symphony && cargo test test_without_logs_root_ -- --nocapture`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`

## Ticket
- Closes KAT-899

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR flips the Symphony CLI's TUI mode from opt-in (`--tui`) to opt-out (`--no-tui`), making the Ratatui terminal dashboard the default experience for local runs while suppressing stdout logs when TUI is active. Documentation in `README.md` and `AGENTS.md` is updated consistently, and integration tests are revised to assert the new default behavior.

**Key changes:**
- `tui: bool` in `Cli` gains `default_value_t = true` and `hide = true`, turning it into a hidden legacy no-op
- New `no_tui: bool` field added; `parse_cli_from` normalizes both flags so `--no-tui` wins when both are present
- `init_tracing` already used `std::io::sink()` when `tui_enabled = true`, so log suppression worked without additional changes
- Integration tests updated: one renamed test verifies stdout suppression under default TUI; a new test verifies `--no-tui` restores stdout JSON log streaming
- **Breaking for non-interactive environments**: any script running `symphony` without `--no-tui` in a non-TTY context will now hit `tui::validate_terminal_for_tui()` and exit with an error; the docs note this but existing automation may need updates
- `no_tui` is the only private field in `Cli` — all other fields are `pub`. In Rust this prevents external struct-literal construction of `Cli` anywhere outside `main.rs`, which is a subtle API break worth resolving before merge

<h3>Confidence Score: 3/5</h3>

- Logic is correct and tests are solid, but the private `no_tui` field silently breaks external `Cli` struct construction and the `default_value_t = true` + `SetTrue` combination on a bool flag is an unusual Clap pattern worth validating
- The core flag-inversion logic in `parse_cli_from` is correct and well-tested. However, `no_tui` being the sole private field in a struct with otherwise all-`pub` fields is an API break that could cause compilation failures in any external code constructing `Cli` directly. Additionally, combining `default_value_t = true` with Clap v4's implicit `SetTrue` action on a `bool` field is non-standard — it works correctly here but may produce unexpected behavior with future Clap versions or emit warnings. These two issues lower confidence despite the otherwise clean implementation.
- apps/symphony/src/main.rs — private `no_tui` field and `default_value_t = true` on hidden bool flag

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/main.rs | Core logic change: `tui` field gains `default_value_t = true` (TUI on by default), new hidden `--tui` backward-compat flag, new `no_tui` private field. Post-processing in `parse_cli_from` normalizes flags correctly. Private `no_tui` field creates an API break for any external struct-literal construction of `Cli`. |
| apps/symphony/tests/cli_tests.rs | Existing test renamed and tightened to verify stdout suppression under default-on TUI; new `test_without_logs_root_no_tui_streams_stdout_logs` test verifies `--no-tui` restores stdout logging. Coverage is thorough and correct. |
| apps/symphony/README.md | Docs updated to reflect TUI default-on and `--no-tui` opt-out. Legacy compatibility note added outside the table (minor inconsistency). No functional concerns. |
| apps/symphony/AGENTS.md | Reference docs updated consistently with README: command signature, flag table, and logging section all updated to reflect new default-on TUI behavior. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI invoked] --> B[Cli::try_parse_from]
    B --> C{--no-tui passed?}
    C -- yes --> D[cli.tui = false]
    C -- no --> E[cli.tui = true\ndefault_value_t]
    D --> F[init_tracing\ntui_enabled=false\nwrites to stdout]
    E --> G[init_tracing\ntui_enabled=true\nwrites to sink]
    F --> H[execute_cli]
    G --> H
    H --> I{workflow file exists?}
    I -- no --> J[Err: workflow not found\nprinted to stderr]
    I -- yes --> K[startup_validate]
    K --> L[start_orchestrator]
    L --> M{cli.tui?}
    M -- true --> N[tui::validate_terminal_for_tui]
    N -- fail --> O[Err: tui preflight failed]
    N -- ok --> P[spawn TUI task\nsuppress startup banner]
    M -- false --> Q[print_startup_banner\nto stdout]
    P --> R[run_runtime_until_shutdown]
    Q --> R
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/main.rs
Line: 44-45

Comment:
**Private field breaks external `Cli` struct literals**

`no_tui` is the only private field in the `Cli` struct — all others (`workflow_path`, `port`, `logs_root`, `tui`) are `pub`. In Rust, any private field in a struct prevents external code from constructing the struct via a struct literal (`Cli { ..., tui: false }`). If any code outside this module (integration tests, other crates) was previously constructing `Cli` directly, it will now fail to compile.

The field should either be made `pub` to match the rest of the struct, or if the intent is to hide it permanently, that should be confirmed. Making it `pub` is safe because normalization still happens in `parse_cli_from`, and `no_tui = true` with `tui = true` (the inconsistency that can only arise from direct construction) would just be confusing, not harmful.

```suggestion
    /// Disable the live terminal dashboard (Ratatui)
    #[arg(long)]
    pub no_tui: bool,
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/main.rs
Line: 39-41

Comment:
**`default_value_t = true` on `SetTrue` bool flag may confuse Clap**

Using `default_value_t = true` on a `bool` field that Clap v4 automatically assigns `ArgAction::SetTrue` to is unusual. Clap's `SetTrue` action starts from a stored default, and setting it to `true` means the flag is effectively permanently `true` and can never be set back to `false` by passing `--tui`. While this is the intended "no-op" behavior, the interaction between `default_value_t = true` and `SetTrue` could produce a deprecation warning or confusing `[default: true]` in debug help output depending on the Clap version.

A clearer alternative that achieves the same no-op intent would be to omit `default_value_t = true` and simply rely on the post-processing in `parse_cli_from` — the field starting as `false` and never being checked directly (only `no_tui` is read) would achieve the same result without the unusual Clap attribute combination.

```suggestion
    /// Legacy compatibility flag. TUI is now enabled by default.
    #[arg(long, hide = true)]
    pub tui: bool,
```

With this change, update `parse_cli_from` accordingly:
```rust
pub fn parse_cli_from<I, T>(args: I) -> Result<Cli, clap::Error>
where
    I: IntoIterator<Item = T>,
    T: Into<OsString> + Clone,
{
    let mut cli = Cli::try_parse_from(args)?;
    // TUI is on unless --no-tui is passed; --tui is a no-op legacy flag
    cli.tui = !cli.no_tui;
    Ok(cli)
}
```
And update the related unit tests to reflect `tui` defaults to `true` via the logic, not the field default.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): default TUI on and add -..."](https://github.com/gannonh/kata/commit/dce2421e66ada50b05afc77ed6009e7c57ab0ccb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25986202)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->