### PR TITLE
KAT-897: Auto-detect available HTTP port when configured port is in use

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -27,7 +27,7 @@ cargo build --release
 ## Running
 
 ```sh
-symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
+symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--no-tui]
 ```
 
 ### CLI Flag Reference
@@ -37,7 +37,7 @@ symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
 | `WORKFLOW.md` (positional)                                              | path | `WORKFLOW.md` | Path to the WORKFLOW.md configuration file                                                                                           |
 | `--port PORT`                                                           | u16  | `8080`        | Bind the HTTP dashboard and API on this port. Overrides `server.port` in the workflow file.                                         |
 | `--logs-root PATH`                                                      | path | _(none)_      | Directory root for agent log files.                                                                                                  |
-| `--tui`                                                                 | flag | `false`       | Render a Ratatui terminal dashboard. When enabled with no `--logs-root`, stdout logs are suppressed to avoid corrupting the TUI.   |
+| `--no-tui`                                                              | flag | `false`       | Disable the Ratatui terminal dashboard. Without this flag, TUI is enabled by default and stdout logs are suppressed unless logs write to files. |
 
 ### Exit Codes
 
@@ -61,8 +61,8 @@ Default level is `info`.
 
 When `--logs-root` is set, logs write to rotating files under
 `<logs-root>/log/symphony.log` and stdout shows only the startup banner.
-Without `--logs-root`, logs stream to stdout as structured JSON unless `--tui`
-is enabled.
+Without `--logs-root`, stdout logs are suppressed while the default TUI is
+active. Pass `--no-tui` to stream structured JSON logs to stdout instead.
 
 ---
 

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -17,7 +17,7 @@ Headless orchestrator that polls a Linear project for candidate issues and dispa
 - **Rotating log files** — structured JSON logs to disk with rotation via `--logs-root`
 - **SSH worker pools** — distribute sessions across remote machines
 - **HTTP dashboard + JSON API** — live session table with turn/activity/session-token observability, retry queue, polling stats
-- **Terminal dashboard (`--tui`)** — Ratatui observability view for local runs
+- **Terminal dashboard (default-on)** — Ratatui observability view for local runs; disable with `--no-tui`
 
 <details>
 <summary>HTTP Dashboard</summary>
@@ -86,7 +86,7 @@ Press Ctrl+C to stop.
 ## CLI Flags
 
 ```
-symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
+symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--no-tui]
 ```
 
 | Flag | Default | Description |
@@ -94,7 +94,9 @@ symphony [WORKFLOW.md] [--port PORT] [--logs-root PATH] [--tui]
 | `WORKFLOW.md` (positional) | `WORKFLOW.md` | Path to the workflow configuration file |
 | `--port PORT` | `8080` | HTTP dashboard and API port. Overrides `server.port` in config |
 | `--logs-root PATH` | *(none)* | Directory for rotating log files. Suppresses stdout log streaming |
-| `--tui` | `false` | Render the Ratatui terminal dashboard. When enabled without `--logs-root`, stdout logs are suppressed to keep the TUI clean |
+| `--no-tui` | `false` | Disable the Ratatui terminal dashboard. Without this flag, TUI is enabled by default |
+
+Legacy compatibility: `--tui` is still accepted as a no-op.
 
 ### Log verbosity
 
@@ -106,7 +108,7 @@ RUST_LOG=debug symphony WORKFLOW.md                   # verbose
 RUST_LOG=symphony=trace,info symphony WORKFLOW.md     # trace symphony, info everything else
 ```
 
-When `--logs-root` is set, logs write to rotating files under `<logs-root>/log/symphony.log` and stdout shows only the startup banner. Without `--logs-root`, logs stream to stdout as structured JSON unless `--tui` is enabled.
+When `--logs-root` is set, logs write to rotating files under `<logs-root>/log/symphony.log` and stdout shows only the startup banner. Without `--logs-root`, stdout logs are suppressed while the default TUI is active; pass `--no-tui` to stream structured JSON logs to stdout instead.
 
 ## Multiple Workflows
 

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -534,6 +534,12 @@ pub struct RunningSessionSnapshot {
     pub last_activity_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub total_tokens: u64,
+    #[serde(default)]
+    pub last_event: Option<String>,
+    #[serde(default)]
+    pub last_event_message: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 /// Polling state for the snapshot.

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -14,6 +14,8 @@ use crate::domain::{
 };
 use crate::orchestrator::{RefreshSender, SnapshotHandle};
 
+pub const HTTP_PORT_RETRY_LIMIT: u16 = 10;
+
 // ── Traits for testability ─────────────────────────────────────────────
 
 pub trait SnapshotSource: Send + Sync {
@@ -152,18 +154,65 @@ pub fn build_router(state: HttpServerState) -> Router {
 
 pub async fn start_http_server(
     state: HttpServerState,
-    port: u16,
+    listener: TcpListener,
     host: &str,
+    configured_port: u16,
+    bound_port: u16,
 ) -> std::io::Result<()> {
-    let bind_addr = format!("{host}:{port}");
-    let listener = TcpListener::bind(&bind_addr).await?;
     tracing::info!(
         event = "http_server_started",
         host = host,
-        port,
+        configured_port,
+        port = bound_port,
         "HTTP observability server started"
     );
     axum::serve(listener, build_router(state)).await
+}
+
+pub async fn bind_http_listener_with_fallback(
+    host: &str,
+    configured_port: u16,
+    max_port_offset: u16,
+) -> std::io::Result<(TcpListener, u16)> {
+    let mut attempt_port = configured_port;
+    let max_port = configured_port.saturating_add(max_port_offset);
+
+    loop {
+        let bind_addr = format!("{host}:{attempt_port}");
+        match TcpListener::bind(&bind_addr).await {
+            Ok(listener) => {
+                let bound_port = listener.local_addr()?.port();
+                if attempt_port != configured_port {
+                    tracing::warn!(
+                        event = "http_server_port_auto_incremented",
+                        host = host,
+                        configured_port,
+                        bound_port,
+                        retries = attempt_port.saturating_sub(configured_port),
+                        "Configured HTTP port was in use; bound the next available port"
+                    );
+                }
+                return Ok((listener, bound_port));
+            }
+            Err(err)
+                if configured_port != 0
+                    && err.kind() == std::io::ErrorKind::AddrInUse
+                    && attempt_port < max_port =>
+            {
+                tracing::warn!(
+                    event = "http_server_port_in_use_retry",
+                    host = host,
+                    configured_port,
+                    attempted_port = attempt_port,
+                    next_port = attempt_port + 1,
+                    max_port,
+                    "Configured HTTP port is in use; retrying on next port"
+                );
+                attempt_port += 1;
+            }
+            Err(err) => return Err(err),
+        }
+    }
 }
 
 // ── Route Handlers ─────────────────────────────────────────────────────
@@ -722,4 +771,82 @@ fn looks_like_issue_identifier(candidate: &str) -> bool {
         && prefix.chars().all(|c| c.is_ascii_uppercase())
         && !number.is_empty()
         && number.chars().all(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener as StdTcpListener;
+
+    fn reserve_contiguous_ports(range_width: u16) -> (u16, Vec<StdTcpListener>) {
+        for _ in 0..256 {
+            let first = StdTcpListener::bind(("127.0.0.1", 0))
+                .expect("should bind a seed loopback port for test");
+            let base = first
+                .local_addr()
+                .expect("seed listener should expose local addr")
+                .port();
+
+            if u16::MAX - base < range_width {
+                continue;
+            }
+
+            let mut listeners = vec![first];
+            let mut all_reserved = true;
+            for offset in 1..=range_width {
+                match StdTcpListener::bind(("127.0.0.1", base + offset)) {
+                    Ok(listener) => listeners.push(listener),
+                    Err(_) => {
+                        all_reserved = false;
+                        break;
+                    }
+                }
+            }
+
+            if all_reserved {
+                return (base, listeners);
+            }
+        }
+
+        panic!("failed to reserve contiguous loopback ports for test");
+    }
+
+    #[tokio::test]
+    async fn bind_http_listener_with_fallback_increments_when_configured_port_is_in_use() {
+        // Reserve a full contiguous range first so we know retries are possible,
+        // then keep only the first port occupied.
+        let (configured_port, mut listeners) = reserve_contiguous_ports(HTTP_PORT_RETRY_LIMIT);
+        let occupied = listeners.remove(0);
+        drop(listeners);
+
+        let (listener, bound_port) =
+            bind_http_listener_with_fallback("127.0.0.1", configured_port, HTTP_PORT_RETRY_LIMIT)
+                .await
+                .expect("fallback bind should find an available nearby port");
+
+        assert!(
+            bound_port > configured_port,
+            "bound port should move forward when configured port is taken: configured={configured_port}, bound={bound_port}"
+        );
+        assert!(
+            bound_port <= configured_port.saturating_add(HTTP_PORT_RETRY_LIMIT),
+            "bound port should remain within retry cap: configured={configured_port}, bound={bound_port}"
+        );
+
+        drop(occupied);
+        drop(listener);
+    }
+
+    #[tokio::test]
+    async fn bind_http_listener_with_fallback_errors_after_retry_cap_is_exhausted() {
+        let (configured_port, listeners) = reserve_contiguous_ports(HTTP_PORT_RETRY_LIMIT);
+
+        let err =
+            bind_http_listener_with_fallback("127.0.0.1", configured_port, HTTP_PORT_RETRY_LIMIT)
+                .await
+                .expect_err("binding should fail when configured port and +10 range are occupied");
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+
+        drop(listeners);
+    }
 }

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -174,6 +174,12 @@ pub async fn bind_http_listener_with_fallback(
     configured_port: u16,
     max_port_offset: u16,
 ) -> std::io::Result<(TcpListener, u16)> {
+    if configured_port == 0 {
+        let listener = TcpListener::bind(format!("{host}:0")).await?;
+        let bound_port = listener.local_addr()?.port();
+        return Ok((listener, bound_port));
+    }
+
     let mut attempt_port = configured_port;
     let max_port = configured_port.saturating_add(max_port_offset);
 
@@ -194,11 +200,7 @@ pub async fn bind_http_listener_with_fallback(
                 }
                 return Ok((listener, bound_port));
             }
-            Err(err)
-                if configured_port != 0
-                    && err.kind() == std::io::ErrorKind::AddrInUse
-                    && attempt_port < max_port =>
-            {
+            Err(err) if err.kind() == std::io::ErrorKind::AddrInUse && attempt_port < max_port => {
                 tracing::warn!(
                     event = "http_server_port_in_use_retry",
                     host = host,
@@ -813,28 +815,53 @@ mod tests {
 
     #[tokio::test]
     async fn bind_http_listener_with_fallback_increments_when_configured_port_is_in_use() {
-        // Reserve a full contiguous range first so we know retries are possible,
-        // then keep only the first port occupied.
-        let (configured_port, mut listeners) = reserve_contiguous_ports(HTTP_PORT_RETRY_LIMIT);
-        let occupied = listeners.remove(0);
-        drop(listeners);
+        const MAX_TEST_ATTEMPTS: usize = 5;
 
-        let (listener, bound_port) =
-            bind_http_listener_with_fallback("127.0.0.1", configured_port, HTTP_PORT_RETRY_LIMIT)
-                .await
-                .expect("fallback bind should find an available nearby port");
+        for attempt in 1..=MAX_TEST_ATTEMPTS {
+            // Reserve a full contiguous range first so retries are possible, then keep
+            // only the configured port occupied while releasing fallback candidates.
+            let (configured_port, mut listeners) = reserve_contiguous_ports(HTTP_PORT_RETRY_LIMIT);
+            let occupied = listeners.remove(0);
+            drop(listeners);
 
-        assert!(
-            bound_port > configured_port,
-            "bound port should move forward when configured port is taken: configured={configured_port}, bound={bound_port}"
+            match bind_http_listener_with_fallback(
+                "127.0.0.1",
+                configured_port,
+                HTTP_PORT_RETRY_LIMIT,
+            )
+            .await
+            {
+                Ok((listener, bound_port)) => {
+                    assert!(
+                        bound_port > configured_port,
+                        "bound port should move forward when configured port is taken: configured={configured_port}, bound={bound_port}"
+                    );
+                    assert!(
+                        bound_port <= configured_port.saturating_add(HTTP_PORT_RETRY_LIMIT),
+                        "bound port should remain within retry cap: configured={configured_port}, bound={bound_port}"
+                    );
+                    drop(occupied);
+                    drop(listener);
+                    return;
+                }
+                Err(err)
+                    if err.kind() == std::io::ErrorKind::AddrInUse
+                        && attempt < MAX_TEST_ATTEMPTS =>
+                {
+                    drop(occupied);
+                }
+                Err(err) => {
+                    drop(occupied);
+                    panic!(
+                        "fallback bind should find an available nearby port (attempt {attempt}/{MAX_TEST_ATTEMPTS}): {err}"
+                    );
+                }
+            }
+        }
+
+        panic!(
+            "fallback bind should find an available nearby port after {MAX_TEST_ATTEMPTS} attempts"
         );
-        assert!(
-            bound_port <= configured_port.saturating_add(HTTP_PORT_RETRY_LIMIT),
-            "bound port should remain within retry cap: configured={configured_port}, bound={bound_port}"
-        );
-
-        drop(occupied);
-        drop(listener);
     }
 
     #[tokio::test]

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 
 use clap::Parser;
 use symphony::domain::{Issue, ServiceConfig};
-use symphony::http_server::{start_http_server, HttpServerState};
+use symphony::http_server::{
+    bind_http_listener_with_fallback, start_http_server, HttpServerState, HTTP_PORT_RETRY_LIMIT,
+};
 use symphony::linear::adapter::{LinearAdapter, TrackerAdapter};
 use symphony::linear::client::LinearClient;
 use symphony::logging;
@@ -15,6 +17,7 @@ use symphony::orchestrator::{Orchestrator, OrchestratorPort};
 use symphony::tui;
 use symphony::workflow_store::WorkflowStore;
 use symphony::{config, error};
+use tokio::net::TcpListener;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
 
@@ -61,6 +64,14 @@ struct StartupContext {
 pub(crate) struct HttpBinding {
     pub(crate) host: String,
     pub(crate) port: u16,
+}
+
+struct PreparedHttpServer {
+    host: String,
+    configured_port: u16,
+    bound_port: u16,
+    banner_binding: HttpBinding,
+    listener: TcpListener,
 }
 
 struct LinearOrchestratorPort {
@@ -189,13 +200,20 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
 
     fn start_orchestrator(&mut self, workflow_path: &Path, cli: &Cli) -> Result<(), String> {
         let context = self.take_or_load_validated_context(workflow_path)?;
-        let http_binding = effective_http_binding(&context.effective_config, cli);
+        let prepared_http_server =
+            prepare_http_server_binding(effective_http_binding(&context.effective_config, cli))?;
         if cli.tui {
             tui::validate_terminal_for_tui()
                 .map_err(|err| format!("tui preflight failed: {err}"))?;
         }
         if !cli.tui {
-            print_startup_banner(cli, &context.effective_config, http_binding.as_ref());
+            print_startup_banner(
+                cli,
+                &context.effective_config,
+                prepared_http_server
+                    .as_ref()
+                    .map(|server| &server.banner_binding),
+            );
         }
 
         let workflow_store = Arc::new(context.workflow_store);
@@ -228,20 +246,21 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             phase = "startup",
             stage = "runtime_init",
             workflow_path = %workflow_path.display(),
-            http_enabled = http_binding.is_some(),
-            http_host = http_binding.as_ref().map(|binding| binding.host.as_str()).unwrap_or("n/a"),
-            http_port = http_binding.as_ref().map(|binding| binding.port),
+            http_enabled = prepared_http_server.is_some(),
+            http_host = prepared_http_server.as_ref().map(|server| server.host.as_str()).unwrap_or("n/a"),
+            http_port = prepared_http_server.as_ref().map(|server| server.bound_port),
             logs_root_configured = cli.logs_root.is_some(),
             tui_enabled = cli.tui,
 
             "constructed orchestrator runtime"
         );
 
-        if let Some(binding) = &http_binding {
+        if let Some(server) = &prepared_http_server {
             tracing::info!(
                 event = "http_server_enabled",
-                host = %binding.host,
-                port = binding.port,
+                host = %server.host,
+                configured_port = server.configured_port,
+                port = server.bound_port,
                 "HTTP server binding enabled at startup"
             );
         } else {
@@ -256,7 +275,7 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             &mut orchestrator,
             &mut tracker_port,
             workflow_path,
-            http_binding,
+            prepared_http_server,
             http_state,
             tui_exit,
         );
@@ -308,6 +327,46 @@ pub(crate) fn effective_http_binding(config: &ServiceConfig, cli: &Cli) -> Optio
         host: config.server.host.clone(),
         port,
     })
+}
+
+fn startup_banner_binding(configured_binding: &HttpBinding, bound_port: u16) -> HttpBinding {
+    HttpBinding {
+        host: configured_binding.host.clone(),
+        port: if configured_binding.port == 0 {
+            0
+        } else {
+            bound_port
+        },
+    }
+}
+
+fn prepare_http_server_binding(
+    configured_binding: Option<HttpBinding>,
+) -> Result<Option<PreparedHttpServer>, String> {
+    let Some(configured_binding) = configured_binding else {
+        return Ok(None);
+    };
+
+    let host = configured_binding.host.clone();
+    let configured_port = configured_binding.port;
+    let runtime = tokio::runtime::Handle::try_current()
+        .map_err(|err| format!("missing tokio runtime for HTTP server bind: {err}"))?;
+    let (listener, bound_port) = tokio::task::block_in_place(|| {
+        runtime.block_on(bind_http_listener_with_fallback(
+            &host,
+            configured_port,
+            HTTP_PORT_RETRY_LIMIT,
+        ))
+    })
+    .map_err(|err| err.to_string())?;
+
+    Ok(Some(PreparedHttpServer {
+        host,
+        configured_port,
+        bound_port,
+        banner_binding: startup_banner_binding(&configured_binding, bound_port),
+        listener,
+    }))
 }
 
 fn format_polling_interval(interval_ms: u64) -> String {
@@ -451,7 +510,7 @@ fn run_runtime_until_shutdown(
     orchestrator: &mut Orchestrator,
     port: &mut dyn OrchestratorPort,
     workflow_path: &Path,
-    http_binding: Option<HttpBinding>,
+    prepared_http_server: Option<PreparedHttpServer>,
     http_state: HttpServerState,
     mut tui_exit: Option<tokio::sync::watch::Receiver<Option<tui::TuiExitReason>>>,
 ) -> Result<(), String> {
@@ -464,13 +523,19 @@ fn run_runtime_until_shutdown(
                 phase = "runtime",
                 stage = "start",
                 workflow_path = %workflow_path.display(),
-                http_enabled = http_binding.is_some(),
+                http_enabled = prepared_http_server.is_some(),
                 "starting orchestrator runtime"
             );
 
             let http_future = async {
-                if let Some(binding) = http_binding {
-                    start_http_server(http_state, binding.port, &binding.host)
+                if let Some(server) = prepared_http_server {
+                    start_http_server(
+                        http_state,
+                        server.listener,
+                        &server.host,
+                        server.configured_port,
+                        server.bound_port,
+                    )
                         .await
                         .map_err(|err| format!("http server failed: {err}"))
                 } else {
@@ -676,5 +741,28 @@ mod tests {
         let cli =
             parse_cli_from(["symphony", "WORKFLOW.md", "--tui", "--no-tui"]).expect("cli parse");
         assert!(!cli.tui);
+    }
+
+    #[test]
+    fn startup_banner_binding_uses_bound_port_when_configured_port_changes() {
+        let configured = HttpBinding {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+        };
+
+        let banner_binding = startup_banner_binding(&configured, 8081);
+        assert_eq!(banner_binding.host, "127.0.0.1");
+        assert_eq!(banner_binding.port, 8081);
+    }
+
+    #[test]
+    fn startup_banner_binding_keeps_ephemeral_marker_for_zero_port() {
+        let configured = HttpBinding {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+        };
+
+        let banner_binding = startup_banner_binding(&configured, 43123);
+        assert_eq!(banner_binding.port, 0);
     }
 }

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 
 use clap::Parser;
 use symphony::domain::{Issue, ServiceConfig};
-use symphony::http_server::{start_http_server, HttpServerState};
+use symphony::http_server::{
+    bind_http_listener_with_fallback, start_http_server, HttpServerState, HTTP_PORT_RETRY_LIMIT,
+};
 use symphony::linear::adapter::{LinearAdapter, TrackerAdapter};
 use symphony::linear::client::LinearClient;
 use symphony::logging;
@@ -15,6 +17,7 @@ use symphony::orchestrator::{Orchestrator, OrchestratorPort};
 use symphony::tui;
 use symphony::workflow_store::WorkflowStore;
 use symphony::{config, error};
+use tokio::net::TcpListener;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
 
@@ -57,6 +60,14 @@ struct StartupContext {
 pub(crate) struct HttpBinding {
     pub(crate) host: String,
     pub(crate) port: u16,
+}
+
+struct PreparedHttpServer {
+    host: String,
+    configured_port: u16,
+    bound_port: u16,
+    banner_binding: HttpBinding,
+    listener: TcpListener,
 }
 
 struct LinearOrchestratorPort {
@@ -185,13 +196,20 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
 
     fn start_orchestrator(&mut self, workflow_path: &Path, cli: &Cli) -> Result<(), String> {
         let context = self.take_or_load_validated_context(workflow_path)?;
-        let http_binding = effective_http_binding(&context.effective_config, cli);
+        let prepared_http_server =
+            prepare_http_server_binding(effective_http_binding(&context.effective_config, cli))?;
         if cli.tui {
             tui::validate_terminal_for_tui()
                 .map_err(|err| format!("tui preflight failed: {err}"))?;
         }
         if !cli.tui {
-            print_startup_banner(cli, &context.effective_config, http_binding.as_ref());
+            print_startup_banner(
+                cli,
+                &context.effective_config,
+                prepared_http_server
+                    .as_ref()
+                    .map(|server| &server.banner_binding),
+            );
         }
 
         let workflow_store = Arc::new(context.workflow_store);
@@ -224,20 +242,21 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             phase = "startup",
             stage = "runtime_init",
             workflow_path = %workflow_path.display(),
-            http_enabled = http_binding.is_some(),
-            http_host = http_binding.as_ref().map(|binding| binding.host.as_str()).unwrap_or("n/a"),
-            http_port = http_binding.as_ref().map(|binding| binding.port),
+            http_enabled = prepared_http_server.is_some(),
+            http_host = prepared_http_server.as_ref().map(|server| server.host.as_str()).unwrap_or("n/a"),
+            http_port = prepared_http_server.as_ref().map(|server| server.bound_port),
             logs_root_configured = cli.logs_root.is_some(),
             tui_enabled = cli.tui,
 
             "constructed orchestrator runtime"
         );
 
-        if let Some(binding) = &http_binding {
+        if let Some(server) = &prepared_http_server {
             tracing::info!(
                 event = "http_server_enabled",
-                host = %binding.host,
-                port = binding.port,
+                host = %server.host,
+                configured_port = server.configured_port,
+                port = server.bound_port,
                 "HTTP server binding enabled at startup"
             );
         } else {
@@ -252,7 +271,7 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             &mut orchestrator,
             &mut tracker_port,
             workflow_path,
-            http_binding,
+            prepared_http_server,
             http_state,
             tui_exit,
         );
@@ -301,6 +320,46 @@ pub(crate) fn effective_http_binding(config: &ServiceConfig, cli: &Cli) -> Optio
         host: config.server.host.clone(),
         port,
     })
+}
+
+fn startup_banner_binding(configured_binding: &HttpBinding, bound_port: u16) -> HttpBinding {
+    HttpBinding {
+        host: configured_binding.host.clone(),
+        port: if configured_binding.port == 0 {
+            0
+        } else {
+            bound_port
+        },
+    }
+}
+
+fn prepare_http_server_binding(
+    configured_binding: Option<HttpBinding>,
+) -> Result<Option<PreparedHttpServer>, String> {
+    let Some(configured_binding) = configured_binding else {
+        return Ok(None);
+    };
+
+    let host = configured_binding.host.clone();
+    let configured_port = configured_binding.port;
+    let runtime = tokio::runtime::Handle::try_current()
+        .map_err(|err| format!("missing tokio runtime for HTTP server bind: {err}"))?;
+    let (listener, bound_port) = tokio::task::block_in_place(|| {
+        runtime.block_on(bind_http_listener_with_fallback(
+            &host,
+            configured_port,
+            HTTP_PORT_RETRY_LIMIT,
+        ))
+    })
+    .map_err(|err| err.to_string())?;
+
+    Ok(Some(PreparedHttpServer {
+        host,
+        configured_port,
+        bound_port,
+        banner_binding: startup_banner_binding(&configured_binding, bound_port),
+        listener,
+    }))
 }
 
 fn format_polling_interval(interval_ms: u64) -> String {
@@ -444,7 +503,7 @@ fn run_runtime_until_shutdown(
     orchestrator: &mut Orchestrator,
     port: &mut dyn OrchestratorPort,
     workflow_path: &Path,
-    http_binding: Option<HttpBinding>,
+    prepared_http_server: Option<PreparedHttpServer>,
     http_state: HttpServerState,
     mut tui_exit: Option<tokio::sync::watch::Receiver<Option<tui::TuiExitReason>>>,
 ) -> Result<(), String> {
@@ -457,13 +516,19 @@ fn run_runtime_until_shutdown(
                 phase = "runtime",
                 stage = "start",
                 workflow_path = %workflow_path.display(),
-                http_enabled = http_binding.is_some(),
+                http_enabled = prepared_http_server.is_some(),
                 "starting orchestrator runtime"
             );
 
             let http_future = async {
-                if let Some(binding) = http_binding {
-                    start_http_server(http_state, binding.port, &binding.host)
+                if let Some(server) = prepared_http_server {
+                    start_http_server(
+                        http_state,
+                        server.listener,
+                        &server.host,
+                        server.configured_port,
+                        server.bound_port,
+                    )
                         .await
                         .map_err(|err| format!("http server failed: {err}"))
                 } else {
@@ -656,5 +721,28 @@ mod tests {
     fn parse_cli_defaults_tui_to_false() {
         let cli = parse_cli_from(["symphony", "WORKFLOW.md"]).expect("cli parse");
         assert!(!cli.tui);
+    }
+
+    #[test]
+    fn startup_banner_binding_uses_bound_port_when_configured_port_changes() {
+        let configured = HttpBinding {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+        };
+
+        let banner_binding = startup_banner_binding(&configured, 8081);
+        assert_eq!(banner_binding.host, "127.0.0.1");
+        assert_eq!(banner_binding.port, 8081);
+    }
+
+    #[test]
+    fn startup_banner_binding_keeps_ephemeral_marker_for_zero_port() {
+        let configured = HttpBinding {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+        };
+
+        let banner_binding = startup_banner_binding(&configured, 43123);
+        assert_eq!(banner_binding.port, 0);
     }
 }

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -36,9 +36,13 @@ pub struct Cli {
     #[arg(long)]
     pub logs_root: Option<String>,
 
-    /// Render a live terminal dashboard (Ratatui)
-    #[arg(long)]
+    /// Legacy compatibility flag. TUI is now enabled by default.
+    #[arg(long, hide = true)]
     pub tui: bool,
+
+    /// Disable the live terminal dashboard (Ratatui)
+    #[arg(long)]
+    pub no_tui: bool,
 }
 
 pub trait BootstrapDeps {
@@ -288,7 +292,10 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    Cli::try_parse_from(args)
+    let mut cli = Cli::try_parse_from(args)?;
+    // TUI is enabled by default; --no-tui is the explicit opt-out.
+    cli.tui = !cli.no_tui;
+    Ok(cli)
 }
 
 pub fn resolve_workflow_path(cli: &Cli) -> PathBuf {
@@ -653,8 +660,21 @@ mod tests {
     }
 
     #[test]
-    fn parse_cli_defaults_tui_to_false() {
+    fn parse_cli_defaults_tui_to_true() {
         let cli = parse_cli_from(["symphony", "WORKFLOW.md"]).expect("cli parse");
+        assert!(cli.tui);
+    }
+
+    #[test]
+    fn parse_cli_accepts_no_tui_flag() {
+        let cli = parse_cli_from(["symphony", "WORKFLOW.md", "--no-tui"]).expect("cli parse");
+        assert!(!cli.tui);
+    }
+
+    #[test]
+    fn parse_cli_no_tui_wins_when_both_flags_are_present() {
+        let cli =
+            parse_cli_from(["symphony", "WORKFLOW.md", "--tui", "--no-tui"]).expect("cli parse");
         assert!(!cli.tui);
     }
 }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -600,6 +600,9 @@ struct RunningSessionStats {
     turn_count: u32,
     last_activity_at: Option<DateTime<Utc>>,
     total_tokens: u64,
+    last_event: Option<String>,
+    last_event_message: Option<String>,
+    session_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1261,11 +1264,15 @@ impl Orchestrator {
                 .insert(issue_id.to_string(), session_id.to_string());
         }
 
+        let (last_event, last_event_message) = event_summary(event);
         let session_stats = self
             .running_session_stats
             .entry(issue_id.to_string())
             .or_default();
         session_stats.last_activity_at = Some(event_time);
+        session_stats.last_event = Some(last_event);
+        session_stats.last_event_message = last_event_message;
+        session_stats.session_id = self.worker_session_ids.get(issue_id).cloned();
 
         if let Some(run_attempt) = self.state.running.get_mut(issue_id) {
             match event {
@@ -1490,6 +1497,9 @@ impl Orchestrator {
                 turn_count: 0,
                 last_activity_at: Some(Utc::now()),
                 total_tokens: 0,
+                last_event: None,
+                last_event_message: None,
+                session_id: None,
             });
         self.state.retry_attempts.remove(&issue.id);
 
@@ -1765,6 +1775,11 @@ impl Orchestrator {
                             .and_then(|s| s.last_activity_at)
                             .or(Some(run_attempt.started_at)),
                         total_tokens: stats.map(|s| s.total_tokens).unwrap_or(0),
+                        last_event: stats.and_then(|s| s.last_event.clone()),
+                        last_event_message: stats.and_then(|s| s.last_event_message.clone()),
+                        session_id: stats
+                            .and_then(|s| s.session_id.clone())
+                            .or_else(|| self.worker_session_ids.get(issue_id).cloned()),
                     },
                 )
             })
@@ -2039,6 +2054,9 @@ impl Orchestrator {
                 turn_count: 0,
                 last_activity_at: Some(Utc::now()),
                 total_tokens: 0,
+                last_event: None,
+                last_event_message: None,
+                session_id: None,
             },
         );
         self.state.retry_attempts.remove(&issue.id);
@@ -2426,6 +2444,289 @@ fn event_name(event: &AgentEvent) -> &'static str {
     }
 }
 
+fn event_summary(event: &AgentEvent) -> (String, Option<String>) {
+    let (name, message) = match event {
+        AgentEvent::SessionStarted { session_id, .. } => (
+            event_name(event).to_string(),
+            Some(format!("session {}", compact_session_id(session_id))),
+        ),
+        AgentEvent::StartupFailed { error, .. } => {
+            (event_name(event).to_string(), Some(error.clone()))
+        }
+        AgentEvent::TurnCompleted { message, .. } => (
+            event_name(event).to_string(),
+            Some(
+                message
+                    .clone()
+                    .unwrap_or_else(|| "turn completed".to_string()),
+            ),
+        ),
+        AgentEvent::TurnFailed { error, .. } => {
+            (event_name(event).to_string(), Some(error.clone()))
+        }
+        AgentEvent::TurnCancelled { .. } => (
+            event_name(event).to_string(),
+            Some("turn cancelled".to_string()),
+        ),
+        AgentEvent::TurnEndedWithError { error, .. } => {
+            (event_name(event).to_string(), Some(error.clone()))
+        }
+        AgentEvent::TurnInputRequired { prompt, .. } => (
+            event_name(event).to_string(),
+            prompt
+                .clone()
+                .or_else(|| Some("input required".to_string())),
+        ),
+        AgentEvent::ApprovalAutoApproved { tool_call, .. } => (
+            event_name(event).to_string(),
+            Some(format!("auto-approved {tool_call}")),
+        ),
+        AgentEvent::ApprovalRequired { method, .. } => (
+            event_name(event).to_string(),
+            Some(format!("approval required: {method}")),
+        ),
+        AgentEvent::ToolCallCompleted { tool_name, .. } => (
+            event_name(event).to_string(),
+            Some(format!("completed {tool_name}")),
+        ),
+        AgentEvent::ToolCallFailed { tool_name, .. } => {
+            let message = tool_name
+                .as_ref()
+                .map(|name| format!("tool {name} failed"))
+                .unwrap_or_else(|| "tool call failed".to_string());
+            (event_name(event).to_string(), Some(message))
+        }
+        AgentEvent::ToolInputAutoAnswered { .. } => (
+            event_name(event).to_string(),
+            Some("tool input auto-answered".to_string()),
+        ),
+        AgentEvent::UnsupportedToolCall { tool_name, .. } => (
+            event_name(event).to_string(),
+            Some(format!("unsupported tool {tool_name}")),
+        ),
+        AgentEvent::Notification { message, .. } => notification_event_summary(message),
+        AgentEvent::OtherMessage { raw, .. } => other_message_summary(raw),
+        AgentEvent::Malformed {
+            parse_error,
+            raw_text,
+            ..
+        } => (
+            event_name(event).to_string(),
+            Some(format!(
+                "malformed event: {parse_error}; {}",
+                normalize_whitespace(raw_text)
+            )),
+        ),
+    };
+
+    (
+        name,
+        message
+            .as_deref()
+            .map(|value| truncate_for_summary(value, 160))
+            .filter(|value| !value.is_empty()),
+    )
+}
+
+fn notification_event_summary(message: &str) -> (String, Option<String>) {
+    let fallback_message = normalize_whitespace(message);
+    let parsed = match serde_json::from_str::<serde_json::Value>(message) {
+        Ok(parsed) => parsed,
+        Err(_) => {
+            return (
+                "notification".to_string(),
+                (!fallback_message.is_empty()).then_some(fallback_message),
+            )
+        }
+    };
+
+    let name = parsed
+        .get("method")
+        .and_then(|method| method.as_str())
+        .unwrap_or("notification")
+        .to_string();
+    let mut summary = summarize_notification_payload(&name, &parsed);
+    if summary.is_none() && !fallback_message.is_empty() {
+        summary = Some(fallback_message);
+    }
+
+    (name, summary)
+}
+
+fn summarize_notification_payload(name: &str, payload: &serde_json::Value) -> Option<String> {
+    if name.contains("token_count") {
+        let input = first_u64_at_paths(
+            payload,
+            &[
+                &["params", "tokenUsage", "total", "input_tokens"],
+                &["params", "tokenUsage", "total", "inputTokens"],
+                &[
+                    "params",
+                    "msg",
+                    "payload",
+                    "info",
+                    "total_token_usage",
+                    "input_tokens",
+                ],
+            ],
+        );
+        let output = first_u64_at_paths(
+            payload,
+            &[
+                &["params", "tokenUsage", "total", "output_tokens"],
+                &["params", "tokenUsage", "total", "outputTokens"],
+                &[
+                    "params",
+                    "msg",
+                    "payload",
+                    "info",
+                    "total_token_usage",
+                    "output_tokens",
+                ],
+            ],
+        );
+        let total = first_u64_at_paths(
+            payload,
+            &[
+                &["params", "tokenUsage", "total", "total_tokens"],
+                &["params", "tokenUsage", "total", "totalTokens"],
+                &[
+                    "params",
+                    "msg",
+                    "payload",
+                    "info",
+                    "total_token_usage",
+                    "total_tokens",
+                ],
+            ],
+        );
+
+        let mut pieces = Vec::new();
+        if let Some(value) = input {
+            pieces.push(format!("in {value}"));
+        }
+        if let Some(value) = output {
+            pieces.push(format!("out {value}"));
+        }
+        if let Some(value) = total {
+            pieces.push(format!("total {value}"));
+        }
+        if !pieces.is_empty() {
+            return Some(format!("tokens {}", pieces.join(" / ")));
+        }
+    }
+
+    payload
+        .get("params")
+        .and_then(find_preferred_text)
+        .or_else(|| find_preferred_text(payload))
+}
+
+fn other_message_summary(raw: &serde_json::Value) -> (String, Option<String>) {
+    let name = raw
+        .get("method")
+        .and_then(|method| method.as_str())
+        .unwrap_or("other_message")
+        .to_string();
+    let summary = raw
+        .get("params")
+        .and_then(find_preferred_text)
+        .or_else(|| find_preferred_text(raw));
+    (name, summary)
+}
+
+fn find_preferred_text(value: &serde_json::Value) -> Option<String> {
+    const MAX_TEXT_SEARCH_DEPTH: usize = 5;
+    find_preferred_text_with_depth(value, MAX_TEXT_SEARCH_DEPTH)
+}
+
+fn find_preferred_text_with_depth(value: &serde_json::Value, depth: usize) -> Option<String> {
+    if depth == 0 {
+        return None;
+    }
+
+    match value {
+        serde_json::Value::String(text) => {
+            let normalized = normalize_whitespace(text);
+            if normalized.is_empty() {
+                None
+            } else {
+                Some(normalized)
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for key in [
+                "summary",
+                "message",
+                "text",
+                "title",
+                "command",
+                "tool_name",
+                "toolName",
+                "name",
+            ] {
+                if let Some(found) = map
+                    .get(key)
+                    .and_then(|candidate| find_preferred_text_with_depth(candidate, depth - 1))
+                {
+                    return Some(found);
+                }
+            }
+
+            map.values()
+                .find_map(|candidate| find_preferred_text_with_depth(candidate, depth - 1))
+        }
+        serde_json::Value::Array(items) => items
+            .iter()
+            .find_map(|candidate| find_preferred_text_with_depth(candidate, depth - 1)),
+        _ => None,
+    }
+}
+
+fn first_u64_at_paths(value: &serde_json::Value, paths: &[&[&str]]) -> Option<u64> {
+    paths
+        .iter()
+        .find_map(|path| value_at_path(value, path).and_then(integer_like))
+}
+
+fn value_at_path<'a>(value: &'a serde_json::Value, path: &[&str]) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+fn integer_like(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::Number(number) => number.as_u64(),
+        serde_json::Value::String(text) => text.trim().parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+fn compact_session_id(session_id: &str) -> String {
+    session_id.chars().take(8).collect()
+}
+
+fn normalize_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_for_summary(value: &str, max_chars: usize) -> String {
+    let normalized = normalize_whitespace(value);
+    if normalized.chars().count() <= max_chars {
+        return normalized;
+    }
+
+    let mut out = String::new();
+    for ch in normalized.chars().take(max_chars.saturating_sub(1)) {
+        out.push(ch);
+    }
+    out.push('…');
+    out
+}
+
 fn normalize_issue_state(state_name: &str) -> String {
     state_name.trim().to_ascii_lowercase()
 }
@@ -2457,4 +2758,29 @@ fn issue_identifier_sort_key(issue: &Issue) -> (&str, &str) {
 
 pub fn rate_limit_info(data: serde_json::Value) -> RateLimitInfo {
     RateLimitInfo { data }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn find_preferred_text_stops_searching_past_depth_limit() {
+        let nested = json!({
+            "level_1": {
+                "level_2": {
+                    "level_3": {
+                        "level_4": {
+                            "level_5": {
+                                "message": "too deep"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        assert_eq!(find_preferred_text(&nested), None);
+    }
 }

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -10,8 +10,8 @@ use crossterm::terminal::{
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, List, ListItem, Paragraph, Row, Table, Wrap};
 use ratatui::{Frame, Terminal};
 use tokio::sync::watch;
@@ -26,6 +26,7 @@ const SPARKLINE_WINDOW_MS: i64 = 10 * 60 * 1_000;
 const SPARKLINE_BUCKETS: usize = 24;
 const SPARKLINE_BUCKET_MS: i64 = SPARKLINE_WINDOW_MS / SPARKLINE_BUCKETS as i64;
 const SPARKLINE_BLOCKS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+const STALE_ACTIVITY_THRESHOLD_MS: i64 = 120_000;
 
 #[derive(Debug, Default)]
 struct ThroughputTracker {
@@ -392,9 +393,13 @@ fn draw_dashboard(
     frame.render_widget(Paragraph::new(summary_lines), sections[0]);
 
     let running_header = Row::new(vec![
+        Cell::from(""),
         Cell::from("ID"),
+        Cell::from("Session"),
         Cell::from("State"),
         Cell::from("Turn"),
+        Cell::from("Last Event"),
+        Cell::from("Message"),
         Cell::from("Last Activity"),
         Cell::from("Tokens"),
         Cell::from("Host"),
@@ -404,9 +409,13 @@ fn draw_dashboard(
     let running_table = Table::new(
         running_rows,
         [
+            Constraint::Length(2),
+            Constraint::Length(10),
             Constraint::Length(12),
             Constraint::Length(14),
             Constraint::Length(8),
+            Constraint::Length(24),
+            Constraint::Min(16),
             Constraint::Length(14),
             Constraint::Length(12),
             Constraint::Length(10),
@@ -476,16 +485,34 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
             .and_then(|m| m.last_activity_at.as_ref().cloned())
             .or(Some(run.started_at));
         let total_tokens = metrics.map(|m| m.total_tokens).unwrap_or(0);
+        let last_event = metrics.and_then(|m| m.last_event.as_deref());
+        let last_event_message = metrics.and_then(|m| m.last_event_message.as_deref());
+        let session_id = metrics.and_then(|m| m.session_id.as_deref());
+        let stale = is_stale_session(last_activity, now);
         let state = run
             .linear_state
             .as_deref()
             .unwrap_or(run.status.as_str())
             .to_string();
+        let last_activity_text = format_age(last_activity, now);
+        let last_activity_cell = if stale {
+            Cell::from(Span::styled(
+                last_activity_text,
+                Style::default().fg(Color::Red),
+            ))
+        } else {
+            Cell::from(last_activity_text)
+        };
+
         rows.push(Row::new(vec![
+            Cell::from(status_dot(last_event, last_activity, now)),
             Cell::from(run.issue_identifier.clone()),
+            Cell::from(compact_session_id(session_id)),
             Cell::from(state),
             Cell::from(turn_count.to_string()),
-            Cell::from(format_age(last_activity, now)),
+            Cell::from(truncate_for_cell(last_event.unwrap_or("-"), 32)),
+            Cell::from(truncate_for_cell(last_event_message.unwrap_or("-"), 60)),
+            last_activity_cell,
             Cell::from(format_tokens(total_tokens)),
             Cell::from(
                 run.worker_host
@@ -498,7 +525,11 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
 
     if rows.is_empty() {
         rows.push(Row::new(vec![
+            Cell::from(""),
             Cell::from("(none)"),
+            Cell::from(""),
+            Cell::from(""),
+            Cell::from(""),
             Cell::from(""),
             Cell::from(""),
             Cell::from(""),
@@ -508,6 +539,88 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
     }
 
     rows
+}
+
+fn compact_session_id(session_id: Option<&str>) -> String {
+    session_id
+        .map(|value| value.chars().take(8).collect::<String>())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn status_dot(
+    last_event: Option<&str>,
+    last_activity: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Span<'static> {
+    Span::styled(
+        "●",
+        Style::default().fg(status_color(last_event, last_activity, now)),
+    )
+}
+
+fn status_color(
+    last_event: Option<&str>,
+    last_activity: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Color {
+    if last_event.is_none() || is_stale_session(last_activity, now) {
+        return Color::Red;
+    }
+
+    let normalized = last_event
+        .map(|event| event.trim().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if is_failure_event(&normalized) {
+        Color::Red
+    } else if is_turn_completed_event(&normalized) {
+        Color::Magenta
+    } else if normalized.contains("token_count") {
+        Color::Yellow
+    } else if normalized.contains("task_started")
+        || normalized.contains("tool_call")
+        || normalized.contains("item/tool/call")
+    {
+        Color::Green
+    } else {
+        Color::Blue
+    }
+}
+
+fn is_failure_event(normalized_event: &str) -> bool {
+    normalized_event.contains("failed")
+        || normalized_event.contains("error")
+        || normalized_event.contains("cancelled")
+        || normalized_event.contains("canceled")
+}
+
+fn is_turn_completed_event(normalized_event: &str) -> bool {
+    normalized_event.contains("turn_completed")
+        || normalized_event.contains("turn/completed")
+        || (normalized_event.contains("turn") && normalized_event.contains("completed"))
+}
+
+fn is_stale_session(last_activity: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    let Some(last_activity) = last_activity else {
+        return true;
+    };
+
+    (now - last_activity).num_milliseconds() > STALE_ACTIVITY_THRESHOLD_MS
+}
+
+fn truncate_for_cell(value: &str, max_chars: usize) -> String {
+    let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.chars().count() <= max_chars {
+        return normalized;
+    }
+
+    let mut out = String::new();
+    for ch in normalized.chars().take(max_chars.saturating_sub(1)) {
+        out.push(ch);
+    }
+    out.push('…');
+    out
 }
 
 fn retry_rows(snapshot: &OrchestratorSnapshot) -> Vec<Row<'static>> {
@@ -837,6 +950,65 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("secondary: 34% used")),
             "expected secondary usage summary, got: {summary:?}"
+        );
+    }
+
+    #[test]
+    fn compact_session_id_truncates_to_first_eight_chars() {
+        assert_eq!(
+            compact_session_id(Some("1234567890abcdef")),
+            "12345678".to_string()
+        );
+        assert_eq!(compact_session_id(None), "-".to_string());
+    }
+
+    #[test]
+    fn status_color_respects_event_mapping_and_staleness() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 22, 15, 0, 0)
+            .single()
+            .expect("valid fixture timestamp");
+        let fresh = Utc
+            .with_ymd_and_hms(2026, 3, 22, 14, 59, 30)
+            .single()
+            .expect("valid fixture timestamp");
+        let stale = Utc
+            .with_ymd_and_hms(2026, 3, 22, 14, 55, 0)
+            .single()
+            .expect("valid fixture timestamp");
+
+        assert_eq!(
+            status_color(Some("codex/event/task_started"), Some(fresh), now),
+            Color::Green
+        );
+        assert_eq!(
+            status_color(Some("codex/event/token_count"), Some(fresh), now),
+            Color::Yellow
+        );
+        assert_eq!(
+            status_color(Some("turn_completed"), Some(fresh), now),
+            Color::Magenta
+        );
+        assert_eq!(
+            status_color(Some("codex/event/turn/completed"), Some(fresh), now),
+            Color::Magenta
+        );
+        assert_eq!(
+            status_color(Some("codex/event/tool_call_failed"), Some(fresh), now),
+            Color::Red
+        );
+        assert_eq!(
+            status_color(Some("startup_failed"), Some(fresh), now),
+            Color::Red
+        );
+        assert_eq!(
+            status_color(Some("notification"), Some(fresh), now),
+            Color::Blue
+        );
+        assert_eq!(status_color(None, Some(fresh), now), Color::Red);
+        assert_eq!(
+            status_color(Some("turn_completed"), Some(stale), now),
+            Color::Red
         );
     }
 

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -397,7 +397,7 @@ fn test_logs_root_writes_startup_logs_to_file_and_suppresses_stdout_logs() {
 }
 
 #[test]
-fn test_without_logs_root_keeps_stdout_only_behavior() {
+fn test_without_logs_root_suppresses_stdout_logs_when_tui_defaults_on() {
     let run_dir = tempfile::tempdir().expect("temp dir should be created");
     let missing_workflow = run_dir.path().join("missing-workflow.md");
 
@@ -414,8 +414,43 @@ fn test_without_logs_root_keeps_stdout_only_behavior() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
+        !stdout.contains("starting CLI bootstrap"),
+        "stdout should suppress startup logs when TUI is enabled by default; got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\"phase\":\"startup\""),
+        "stdout should suppress startup JSON fields when TUI is enabled by default; got: {stdout}"
+    );
+
+    let log_file_path = run_dir.path().join("log").join("symphony.log");
+    assert!(
+        !log_file_path.exists(),
+        "no log file should be created when --logs-root is omitted, found {}",
+        log_file_path.display()
+    );
+}
+
+#[test]
+fn test_without_logs_root_no_tui_streams_stdout_logs() {
+    let run_dir = tempfile::tempdir().expect("temp dir should be created");
+    let missing_workflow = run_dir.path().join("missing-workflow.md");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_symphony"))
+        .current_dir(run_dir.path())
+        .arg(&missing_workflow)
+        .arg("--no-tui")
+        .output()
+        .expect("symphony binary should execute");
+
+    assert!(
+        !output.status.success(),
+        "missing workflow path should still fail startup"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
         stdout.contains("starting CLI bootstrap"),
-        "stdout should still include startup logs when --logs-root is omitted; got: {stdout}"
+        "stdout should include startup logs when --no-tui is set and --logs-root is omitted; got: {stdout}"
     );
 
     let log_file_path = run_dir.path().join("log").join("symphony.log");

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -283,6 +283,9 @@ fn test_orchestrator_snapshot_serializes() {
                     turn_count: 3,
                     last_activity_at: Some(Utc::now()),
                     total_tokens: 120,
+                    last_event: None,
+                    last_event_message: None,
+                    session_id: None,
                 },
             );
             m.insert(
@@ -291,6 +294,9 @@ fn test_orchestrator_snapshot_serializes() {
                     turn_count: 1,
                     last_activity_at: Some(Utc::now()),
                     total_tokens: 40,
+                    last_event: None,
+                    last_event_message: None,
+                    session_id: None,
                 },
             );
             m

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -86,6 +86,9 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                     turn_count: 2,
                     last_activity_at: Some(started_at),
                     total_tokens: 200,
+                    last_event: Some("codex/event/task_started".to_string()),
+                    last_event_message: Some("running cargo test".to_string()),
+                    session_id: Some("session-12345678".to_string()),
                 },
             );
             sessions

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -790,6 +790,21 @@ fn test_streamed_event_updates_activity_before_worker_completion() {
             .contains_key("issue-stream-activity"),
         "worker should not be retried while streamed activity is within stall timeout"
     );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-stream-activity")
+        .expect("running session snapshot should include stream activity issue");
+    assert_eq!(session.last_event.as_deref(), Some("session_started"));
+    assert_eq!(
+        session.last_event_message.as_deref(),
+        Some("session thread-s")
+    );
+    assert_eq!(
+        session.session_id.as_deref(),
+        Some("thread-stream-1-turn-1")
+    );
 }
 
 #[test]
@@ -854,6 +869,93 @@ fn test_streamed_events_keep_refreshing_stall_detection_window() {
             .retry_attempts
             .contains_key("issue-stream-window"),
         "stalled retry should remain unscheduled when streamed activity continues"
+    );
+}
+
+#[test]
+fn test_streamed_notification_records_event_method_and_message() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let now_ms = 3_000_000;
+    orchestrator.state_mut().running.insert(
+        "issue-notification".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-notification".to_string(),
+            issue_identifier: "SIM-STREAM-3".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-notification".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            linear_state: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        "issue-notification",
+        &AgentEvent::Notification {
+            timestamp: utc_ms(now_ms - 3_000),
+            codex_app_server_pid: Some("3333".to_string()),
+            message:
+                r#"{"method":"codex/event/task_started","params":{"message":"running cargo test"}}"#
+                    .to_string(),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-notification")
+        .expect("running session snapshot should include notification issue");
+    assert_eq!(
+        session.last_event.as_deref(),
+        Some("codex/event/task_started")
+    );
+    assert_eq!(
+        session.last_event_message.as_deref(),
+        Some("running cargo test")
+    );
+}
+
+#[test]
+fn test_streamed_tool_call_completed_uses_completed_summary() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let now_ms = 3_500_000;
+    orchestrator.state_mut().running.insert(
+        "issue-tool-call".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-tool-call".to_string(),
+            issue_identifier: "SIM-STREAM-TOOL".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-tool-call".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            linear_state: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        "issue-tool-call",
+        &AgentEvent::ToolCallCompleted {
+            timestamp: utc_ms(now_ms - 1_000),
+            codex_app_server_pid: Some("4444".to_string()),
+            tool_name: "cargo test".to_string(),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session = snapshot
+        .running_sessions
+        .get("issue-tool-call")
+        .expect("running session snapshot should include tool call issue");
+    assert_eq!(session.last_event.as_deref(), Some("tool_call_completed"));
+    assert_eq!(
+        session.last_event_message.as_deref(),
+        Some("completed cargo test")
     );
 }
 


### PR DESCRIPTION
## Summary
- add HTTP bind fallback logic that retries on `EADDRINUSE` from the configured port through configured `+10`
- pre-bind the HTTP listener during startup so startup banner and logs report the actual bound port
- keep ephemeral (`--port 0`) banner behavior while still logging the actual bound socket port
- add regression tests for successful fallback and retry-cap exhaustion

## Validation
- `cd apps/symphony && cargo test`
- runtime check: with `--port 18080` occupied, startup retries and binds `18081`, banner/logs show `18081`
- runtime check: with `18080..18090` occupied, startup retries through `18090` and exits with addr-in-use

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic HTTP port fallback logic to the `symphony` app: when the configured port is `EADDRINUSE`, the server retries on successive ports up to `configured_port + 10`, pre-binds the listener during startup so the actual bound port is reflected in both the banner and structured logs, and preserves the existing `--port 0` ephemeral-port display behaviour.

**Key changes:**
- `bind_http_listener_with_fallback` in `http_server.rs` — new async helper that loops from the configured port up to `configured_port + HTTP_PORT_RETRY_LIMIT (10)`, emitting structured `warn` events on each retry and returning the bound `TcpListener` plus the resolved port.
- `start_http_server` signature change — now accepts a pre-bound `TcpListener` instead of binding internally, eliminating the TOCTOU gap between logging and binding.
- `PreparedHttpServer` struct and `prepare_http_server_binding` in `main.rs` — synchronously pre-binds the listener at startup via `block_in_place` so the banner always shows the true port; correctly treats `port == 0` as ephemeral and keeps the `<ephemeral>` placeholder.
- Two integration-style tokio tests for fallback success and retry-cap exhaustion, plus two unit tests for `startup_banner_binding`.

<h3>Confidence Score: 4/5</h3>

- PR is safe to merge; changes are well-scoped and backed by tests with only minor style observations.
- The fallback logic is correct: the retry guard (`attempt_port < max_port`) guarantees the loop terminates and exhausts exactly `max_port_offset + 1` ports before surfacing the error; the `saturating_add` on `max_port` prevents `u16` overflow; the `block_in_place` pattern is consistent with the existing codebase; and the ephemeral-port (`port == 0`) fast-path is handled correctly throughout. Two minor style observations (loop-invariant guard, test race window) have no impact on correctness or production behaviour.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/http_server.rs | Adds `bind_http_listener_with_fallback` with port-increment loop and `HTTP_PORT_RETRY_LIMIT` constant; refactors `start_http_server` to accept a pre-bound `TcpListener`; adds two tokio tests with a contiguous-port reservation helper. Logic is sound; minor style notes on loop-invariant guard and test race window. |
| apps/symphony/src/main.rs | Introduces `PreparedHttpServer` struct and `prepare_http_server_binding` helper that pre-binds the listener at startup using `block_in_place`; updates `run_runtime_until_shutdown` and logging to use bound port; adds unit tests for `startup_banner_binding`. Consistent with existing `block_in_place` usage in the codebase. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[startup: prepare_http_server_binding] --> B{configured_binding?}
    B -- None --> C[HTTP disabled\nreturn Ok None]
    B -- Some --> D[block_in_place:\nbind_http_listener_with_fallback]
    D --> E{TcpListener::bind\nattempt_port}
    E -- Ok --> F[return listener\n+ bound_port]
    E -- Err EADDRINUSE\nconfigured_port!=0\nattempt_port < max_port --> G[warn: port in use\nattempt_port += 1]
    G --> E
    E -- Err other\nor attempt_port >= max_port --> H[return Err\nAddrInUse / other]
    F --> I[PreparedHttpServer\nhost, configured_port,\nbound_port, banner_binding, listener]
    I --> J[print_startup_banner\nshows bound_port\nexcept port==0 → ephemeral]
    I --> K[run_runtime_until_shutdown:\nstart_http_server\naxum::serve on pre-bound listener]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 820-840

Comment:
**Potential test flakiness after port release**

In `bind_http_listener_with_fallback_increments_when_configured_port_is_in_use`, after `drop(listeners)` the ports `base+1` through `base+10` are immediately released back to the OS. There is a brief race window between that `drop` and the awaited `bind_http_listener_with_fallback` call during which another process (or a concurrent test) could grab `base+1`. If that happens, the fallback would land on `base+2` (or further), and the assertions would still pass — but if every port up to `base+10` gets taken, the function would return `Err` and the `expect` unwrap would panic, making the test a flaky failure.

A common mitigation is to hold `occupied` (already done) **and** keep one additional "sentinel" listener on `base+1` so the fallback is forced to a known-free slot, then drop only the sentinel just before calling `bind_http_listener_with_fallback`. That said, the current approach is standard for this style of test and is only a risk on exceptionally loaded CI hosts.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 197-212

Comment:
**`configured_port != 0` check is loop-invariant**

`configured_port` is a function parameter that never changes, so the guard `configured_port != 0` is re-evaluated on every iteration even though it will always produce the same value. Moving it to a one-time check before the loop (or using a separate early-return path) makes the intent clearer and avoids re-evaluating a constant condition:

```rust
if configured_port == 0 {
    // ephemeral bind — no fallback
    let listener = TcpListener::bind(format!("{host}:0")).await?;
    let bound_port = listener.local_addr()?.port();
    return Ok((listener, bound_port));
}

let mut attempt_port = configured_port;
let max_port = configured_port.saturating_add(max_port_offset);

loop {
    ...
    Err(err)
        if err.kind() == std::io::ErrorKind::AddrInUse
            && attempt_port < max_port =>
    { ... }
    ...
}
```
This is a style concern only; correctness is unaffected.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(symphony): retry HTTP port bind when..."](https://github.com/gannonh/kata/commit/9b9f7406c9acd163ccff9b6ba4ed47938550b9a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25986399)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->