### PR TITLE
KAT-900: keep dashboard completed list session-scoped

### DIFF
--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -945,7 +945,7 @@ impl Orchestrator {
         let terminal_issues = port.startup_terminal_issues(&self.config.tracker.terminal_states)?;
 
         for issue in terminal_issues {
-            self.mark_issue_terminal(&issue, None);
+            self.mark_issue_terminal(&issue, None, false);
         }
 
         Ok(())
@@ -1866,7 +1866,7 @@ impl Orchestrator {
 
             let normalized_state = normalize_issue_state(&issue.state);
             if terminal_states.contains(&normalized_state) {
-                self.mark_issue_terminal(&issue, None);
+                self.mark_issue_terminal(&issue, None, true);
                 continue;
             }
 
@@ -2154,7 +2154,11 @@ impl Orchestrator {
                             state = %hidden_state,
                             "retry issue became terminal before active-candidate visibility; marking terminal"
                         );
-                        self.mark_issue_terminal(&hidden_issue, retry.workspace_path.as_deref());
+                        self.mark_issue_terminal(
+                            &hidden_issue,
+                            retry.workspace_path.as_deref(),
+                            true,
+                        );
                         continue;
                     }
                 }
@@ -2171,7 +2175,7 @@ impl Orchestrator {
 
             let normalized_state = normalize_issue_state(&issue.state);
             if self.terminal_state_set().contains(&normalized_state) {
-                self.mark_issue_terminal(&issue, retry.workspace_path.as_deref());
+                self.mark_issue_terminal(&issue, retry.workspace_path.as_deref(), true);
                 continue;
             }
 
@@ -2259,7 +2263,12 @@ impl Orchestrator {
             .to_string()
     }
 
-    fn mark_issue_terminal(&mut self, issue: &Issue, workspace_path_hint: Option<&str>) {
+    fn mark_issue_terminal(
+        &mut self,
+        issue: &Issue,
+        workspace_path_hint: Option<&str>,
+        include_in_completed: bool,
+    ) {
         let issue_id = issue.id.as_str();
 
         if self.config.workspace.cleanup_on_done {
@@ -2298,15 +2307,19 @@ impl Orchestrator {
             }
         }
 
-        self.state.completed.insert(
-            issue_id.to_string(),
-            CompletedEntry {
-                issue_id: issue_id.to_string(),
-                identifier: issue.identifier.clone(),
-                title: issue.title.clone(),
-                completed_at: None,
-            },
-        );
+        if include_in_completed {
+            self.state.completed.insert(
+                issue_id.to_string(),
+                CompletedEntry {
+                    issue_id: issue_id.to_string(),
+                    identifier: issue.identifier.clone(),
+                    title: issue.title.clone(),
+                    completed_at: None,
+                },
+            );
+        } else {
+            self.state.completed.remove(issue_id);
+        }
         self.state.running.remove(issue_id);
         self.state.claimed.remove(issue_id);
         self.state.retry_attempts.remove(issue_id);

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -946,7 +946,7 @@ impl Orchestrator {
         let terminal_issues = port.startup_terminal_issues(&self.config.tracker.terminal_states)?;
 
         for issue in terminal_issues {
-            self.mark_issue_terminal(&issue, None);
+            self.mark_issue_terminal(&issue, None, false);
         }
 
         Ok(())
@@ -1865,7 +1865,7 @@ impl Orchestrator {
 
             let normalized_state = normalize_issue_state(&issue.state);
             if terminal_states.contains(&normalized_state) {
-                self.mark_issue_terminal(&issue, None);
+                self.mark_issue_terminal(&issue, None, true);
                 continue;
             }
 
@@ -2153,7 +2153,11 @@ impl Orchestrator {
                             state = %hidden_state,
                             "retry issue became terminal before active-candidate visibility; marking terminal"
                         );
-                        self.mark_issue_terminal(&hidden_issue, retry.workspace_path.as_deref());
+                        self.mark_issue_terminal(
+                            &hidden_issue,
+                            retry.workspace_path.as_deref(),
+                            true,
+                        );
                         continue;
                     }
                 }
@@ -2170,7 +2174,7 @@ impl Orchestrator {
 
             let normalized_state = normalize_issue_state(&issue.state);
             if self.terminal_state_set().contains(&normalized_state) {
-                self.mark_issue_terminal(&issue, retry.workspace_path.as_deref());
+                self.mark_issue_terminal(&issue, retry.workspace_path.as_deref(), true);
                 continue;
             }
 
@@ -2258,7 +2262,12 @@ impl Orchestrator {
             .to_string()
     }
 
-    fn mark_issue_terminal(&mut self, issue: &Issue, workspace_path_hint: Option<&str>) {
+    fn mark_issue_terminal(
+        &mut self,
+        issue: &Issue,
+        workspace_path_hint: Option<&str>,
+        include_in_completed: bool,
+    ) {
         let issue_id = issue.id.as_str();
 
         if self.config.workspace.cleanup_on_done {
@@ -2297,15 +2306,19 @@ impl Orchestrator {
             }
         }
 
-        self.state.completed.insert(
-            issue_id.to_string(),
-            CompletedEntry {
-                issue_id: issue_id.to_string(),
-                identifier: issue.identifier.clone(),
-                title: issue.title.clone(),
-                completed_at: None,
-            },
-        );
+        if include_in_completed {
+            self.state.completed.insert(
+                issue_id.to_string(),
+                CompletedEntry {
+                    issue_id: issue_id.to_string(),
+                    identifier: issue.identifier.clone(),
+                    title: issue.title.clone(),
+                    completed_at: None,
+                },
+            );
+        } else {
+            self.state.completed.remove(issue_id);
+        }
         self.state.running.remove(issue_id);
         self.state.claimed.remove(issue_id);
         self.state.retry_attempts.remove(issue_id);

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -340,6 +340,15 @@ fn test_startup_terminal_cleanup_clears_runtime_bookkeeping_without_completed_in
             workspace_path: Some("/tmp/workspace-closed".to_string()),
         },
     );
+    orchestrator.state_mut().completed.insert(
+        "issue-closed".to_string(),
+        symphony::domain::CompletedEntry {
+            issue_id: "issue-closed".to_string(),
+            identifier: "SIM-10".to_string(),
+            title: "Issue SIM-10".to_string(),
+            completed_at: Some(Utc::now()),
+        },
+    );
 
     let result = orchestrator.startup_cleanup(&mut port);
     assert!(

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -280,7 +280,7 @@ fn utc_ms(ms: i64) -> chrono::DateTime<Utc> {
 }
 
 #[test]
-fn test_reconcile_startup_terminal_cleanup_marks_terminal_issues_completed() {
+fn test_reconcile_startup_terminal_cleanup_excludes_terminal_issues_from_completed() {
     let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let mut port = FakePort {
         terminal_issues: vec![issue("issue-closed", "SIM-10", "Done", Some(1), 0)],
@@ -295,8 +295,76 @@ fn test_reconcile_startup_terminal_cleanup_marks_terminal_issues_completed() {
 
     let completed = &orchestrator.state().completed;
     assert!(
-        completed.contains_key("issue-closed"),
-        "startup cleanup must mark terminal tracker issues as completed before first dispatch"
+        !completed.contains_key("issue-closed"),
+        "startup cleanup should not include pre-existing terminal issues in session completed list"
+    );
+}
+
+#[test]
+fn test_startup_terminal_cleanup_clears_runtime_bookkeeping_without_completed_insert() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let mut port = FakePort {
+        terminal_issues: vec![issue("issue-closed", "SIM-10", "Done", Some(1), 0)],
+        ..FakePort::default()
+    };
+
+    orchestrator.state_mut().running.insert(
+        "issue-closed".to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: "issue-closed".to_string(),
+            issue_identifier: "SIM-10".to_string(),
+            issue_title: Some("Issue SIM-10".to_string()),
+            attempt: Some(2),
+            workspace_path: "/tmp/workspace-closed".to_string(),
+            started_at: Utc::now(),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            linear_state: Some("In Progress".to_string()),
+        },
+    );
+    orchestrator
+        .state_mut()
+        .claimed
+        .insert("issue-closed".to_string());
+    orchestrator.state_mut().retry_attempts.insert(
+        "issue-closed".to_string(),
+        symphony::domain::RetryEntry {
+            issue_id: "issue-closed".to_string(),
+            identifier: "SIM-10".to_string(),
+            attempt: 2,
+            due_at_ms: 42_000,
+            timer_handle: Some("timer-1".to_string()),
+            error: Some("retry pending".to_string()),
+            worker_host: None,
+            workspace_path: Some("/tmp/workspace-closed".to_string()),
+        },
+    );
+
+    let result = orchestrator.startup_cleanup(&mut port);
+    assert!(
+        result.is_ok(),
+        "startup cleanup should run without transport errors: {result:?}"
+    );
+
+    assert!(
+        !orchestrator.state().running.contains_key("issue-closed"),
+        "startup terminal cleanup should clear running bookkeeping"
+    );
+    assert!(
+        !orchestrator.state().claimed.contains("issue-closed"),
+        "startup terminal cleanup should clear claimed bookkeeping"
+    );
+    assert!(
+        !orchestrator
+            .state()
+            .retry_attempts
+            .contains_key("issue-closed"),
+        "startup terminal cleanup should clear retry bookkeeping"
+    );
+    assert!(
+        !orchestrator.state().completed.contains_key("issue-closed"),
+        "startup terminal cleanup should still avoid completed session entries"
     );
 }
 


### PR DESCRIPTION
## Summary
- prevent startup terminal cleanup from adding issues to orchestrator completed list
- keep runtime terminal transitions (reconcile/retry) adding to completed
- add startup tests proving terminal startup issues are excluded while running/claimed/retry bookkeeping is still cleared

## Validation
- cd apps/symphony && cargo test
- cd apps/symphony && cargo clippy -- -D warnings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes the orchestrator's `completed` list to the current session by preventing `startup_cleanup` from inserting pre-existing terminal issues into it. A new `include_in_completed: bool` parameter is added to `mark_issue_terminal`; all runtime call-sites (reconcile, retry) pass `true` and retain their existing behaviour, while `startup_cleanup` passes `false`, which also defensively removes any stale entry that might already be present.

- `mark_issue_terminal` gains `include_in_completed: bool`; all non-startup callers updated to `true`, startup caller set to `false`.
- When `false`, the method calls `self.state.completed.remove(issue_id)` instead of insert — a defensive no-op at startup since the map is empty, but ensures clean state.
- All other bookkeeping (running, claimed, retry_attempts, worker maps) is cleared unconditionally, preserving correct tracking regardless of the flag.
- The previously-passing test asserting terminal issues *were* added on startup is inverted and renamed; a new second test pre-populates running/claimed/retry maps and confirms they are all cleared while `completed` remains empty.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; the logic change is small, well-reasoned, and the existing + new test suite covers all critical paths.
- The diff is minimal (one new boolean flag propagated to four call-sites), the invariant that all non-startup paths pass `true` is straightforward to verify, and the existing retry/reconcile integration tests confirm the runtime behaviour is unchanged. The only gap is a minor branch in the test coverage for the defensive `completed.remove` path, which does not affect production correctness.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Adds `include_in_completed: bool` parameter to `mark_issue_terminal`; startup cleanup passes `false` (excluding pre-existing terminal issues from the session-scoped completed list and defensively removing them), while all runtime reconcile/retry call-sites pass `true` preserving existing behaviour. |
| apps/symphony/tests/orchestrator_tests.rs | Renames the inverted startup test, adds a comprehensive second test that pre-populates running/claimed/retry bookkeeping and confirms all are cleared while completed stays empty. Existing tests (e.g. the continuation-retry test at line 703) continue to validate the `true` path. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[mark_issue_terminal called] --> B{include_in_completed?}
    B -- true\nruntime reconcile / retry --> C[state.completed.insert]
    B -- false\nstartup_cleanup --> D[state.completed.remove\ndefensive no-op at startup]
    C --> E[Clear bookkeeping\nrunning / claimed / retry_attempts\nrunning_issue_states / tokens / workers]
    D --> E
    E --> F[Done]

    subgraph Callers
        G[startup_cleanup] -->|false| A
        H[reconcile_running_issues] -->|true| A
        I[retry loop – hidden issue terminal] -->|true| A
        J[retry loop – visible issue terminal] -->|true| A
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/tests/orchestrator_tests.rs
Line: 304-369

Comment:
**Test gap: `else` branch (`completed.remove`) is not exercised**

The new test correctly verifies that a fresh orchestrator does not gain a `completed` entry after startup cleanup, but it never pre-populates `state.completed` before calling `startup_cleanup`. That means the `else { self.state.completed.remove(issue_id); }` branch in `mark_issue_terminal` is never exercised — it silently stays a no-op throughout.

While in practice `completed` is always empty at startup, the intent of that defensive removal is specifically to guard against a stale entry surviving from a prior session or an earlier call. Adding a small variant where the entry is pre-seeded would fully cover that path:

```rust
// in addition to the existing test:
orchestrator
    .state_mut()
    .completed
    .insert("issue-closed".to_string(), CompletedEntry { /* ... */ });

let _ = orchestrator.startup_cleanup(&mut port);

assert!(
    !orchestrator.state().completed.contains_key("issue-closed"),
    "startup cleanup must evict a stale completed entry, not just skip insertion"
);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(symphony): keep startup terminal iss..."](https://github.com/gannonh/kata/commit/a4223cc13c3361b11c49a8e68eaef012161959a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25988393)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->