### PR TITLE
KAT-901: post-patch verification + docs parity for TUI/dashboard

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -463,8 +463,8 @@ Core Rust modules:
 | --- | --- | --- |
 | CLI/runtime entrypoint | `src/main.rs` | CLI parsing, startup validation, tracing setup, runtime wiring |
 | Orchestrator loop | `src/orchestrator.rs` | Poll/dispatch loop, retries, worker lifecycle, state snapshots |
-| HTTP dashboard/API | `src/http_server.rs` | `/`, `/api/v1/state`, `/api/v1/:issue_identifier`, refresh endpoint |
-| Terminal dashboard | `src/tui.rs` | Ratatui renderer, keyboard handling, live snapshot display |
+| HTTP dashboard/API | `src/http_server.rs` | `/`, `/api/v1/state`, `/api/v1/:issue_identifier`, refresh endpoint, dashboard Linear project link card |
+| Terminal dashboard | `src/tui.rs` | Ratatui renderer with throughput sparkline, color-coded status dots, keyboard handling, and live snapshot display |
 | Workflow/config parser | `src/workflow.rs`, `src/config.rs` | Front-matter parsing, env/tilde resolution, typed config defaults |
 | Domain model | `src/domain.rs` | Shared runtime/config structs (`RunAttempt`, snapshots, worker/session info) |
 | Tracker adapter/client | `src/linear/adapter.rs`, `src/linear/client.rs` | Linear GraphQL fetch/update operations and issue normalization |
@@ -476,7 +476,7 @@ Core Rust modules:
 
 ## Testing
 
-Run the full test suite (280+ tests):
+Run the full test suite (321 tests):
 
 ```sh
 cargo test

--- a/apps/symphony/CHANGELOG.md
+++ b/apps/symphony/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.0.1 — TUI/dashboard polish + post-patch verification
+
+### Runtime and UX
+
+- **TUI default-on behavior** — terminal dashboard is enabled by default; `--no-tui` is the explicit opt-out. Legacy `--tui` remains accepted as a no-op for compatibility.
+- **Throughput sparkline** — TUI summary now includes a compact throughput graph for recent token rate changes.
+- **Color-coded status dots** — running-session state indicators use event/staleness-aware colors for faster scanability.
+- **Linear project URL visibility** — TUI summary and HTTP dashboard both surface the configured Linear project link.
+- **Session-only completed list** — startup terminal-issue discovery no longer pollutes the per-session completed issues list.
+- **Startup banner consistency** — banner version line is emitted from the crate package version.
+
+### Verification and docs
+
+- **Quality gate rerun** — validated with `cargo test`, `cargo clippy -- -D warnings`, and `cargo build --release`.
+- **Documentation sync** — refreshed README, AGENTS architecture notes, and WORKFLOW reference to match current CLI/TUI/dashboard behavior.
+
 ## 1.0.0 — MVP Release
 
 First public release. Symphony is a headless orchestrator that polls Linear for issues, dispatches parallel agent sessions, and manages the full ticket lifecycle autonomously.

--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -2148,7 +2148,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphony"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symphony"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Symphony orchestrator — polls Linear, dispatches Codex agent sessions"
 license = "MIT"

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -16,8 +16,8 @@ Headless orchestrator that polls a Linear project for candidate issues and dispa
 - **Workspace cleanup** — auto-remove workspaces when issues reach terminal state
 - **Rotating log files** — structured JSON logs to disk with rotation via `--logs-root`
 - **SSH worker pools** — distribute sessions across remote machines
-- **HTTP dashboard + JSON API** — live session table with turn/activity/session-token observability, retry queue, polling stats
-- **Terminal dashboard (default-on)** — Ratatui observability view for local runs; disable with `--no-tui`
+- **HTTP dashboard + JSON API** — live session table with turn/activity/session-token observability, retry queue, polling stats, and a Linear project link in the summary panel
+- **Terminal dashboard (default-on)** — Ratatui observability view with throughput sparkline, color-coded session status dots, and Linear project URL; disable with `--no-tui`
 
 <details>
 <summary>HTTP Dashboard</summary>
@@ -229,6 +229,7 @@ The HTTP dashboard at `localhost:<port>` shows:
 - **Completed issues** — ticket identifier, title, completion date
 - **Polling stats** — last poll time, poll count, interval
 - **Rate limits** — Codex API rate limit data
+- **Linear project link** — direct link card to the configured Linear project
 
 Auto-refreshes every 2 seconds. JSON API at `/api/v1/state` and `/api/v1/{ISSUE-ID}`.
 
@@ -238,7 +239,7 @@ Auto-refreshes every 2 seconds. JSON API at `/api/v1/state` and `/api/v1/{ISSUE-
 # Build
 cargo build
 
-# Test (290 tests)
+# Test (321 tests)
 cargo test
 
 # Lint

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -73,7 +73,7 @@ cp docs/WORKFLOW-REFERENCE.md WORKFLOW.md
 On startup, Symphony prints a summary banner:
 
 ```
-Symphony v1.0.0
+Symphony v1.0.1
 Dashboard: http://127.0.0.1:8080
 Logs: stdout
 Project: 89d4761fddf0

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -5,11 +5,10 @@
 #
 # This file serves two purposes:
 #   1. YAML front-matter: parsed by Symphony as runtime configuration
-#   2. Markdown body: rendered as the Jinja2 prompt template for each agent session
+#   2. Markdown body: rendered as the Liquid prompt template for each agent session
 #
-# Symphony watches this file for changes. When `workspace.cleanup_on_done` is
-# false (default), a restart is needed for config changes to take effect.
-# See KAT-815 for dynamic reload support.
+# Symphony watches this file for changes and applies config updates without
+# requiring a process restart.
 #
 # Environment variable indirection: any string value starting with `$` followed
 # by a bare identifier (no `/`, spaces, or `:`) is resolved from the process


### PR DESCRIPTION
## Summary
- run full post-patch verification for Symphony (tests, clippy, release build)
- verify TUI/dashboard behaviors landed in KAT-893..KAT-900 (default-on TUI, `--no-tui` opt-out, sparkline, status colors, Linear project links, session-scoped completed list, startup banner version wiring)
- update Symphony docs to match current behavior and add `1.0.1` changelog section

## Validation
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `cd apps/symphony && cargo build --release`
- pre-push gate: `turbo run lint typecheck test --affected`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation-only update that syncs Symphony's `README.md`, `AGENTS.md`, `CHANGELOG.md`, and `WORKFLOW-REFERENCE.md` with the TUI/dashboard behaviors shipped in KAT-893..KAT-900. All 321 tests pass and the quality gate (clippy + release build) is clean.

Key documentation changes:
- **CHANGELOG.md** — adds a `1.0.1` entry covering default-on TUI, throughput sparkline, color-coded status dots, Linear project URL visibility, session-scoped completed list, and startup banner version wiring. However, `Cargo.toml` still declares `version = "1.0.0"`, so the startup banner (which reads the crate version) will still display `1.0.0` rather than the `1.0.1` advertised in the changelog.
- **README.md** — updates HTTP and TUI dashboard feature descriptions; corrects test count from 290 → 321.
- **AGENTS.md** — expands module-table entries for `http_server.rs` and `tui.rs`; updates test count from "280+" → 321.
- **docs/WORKFLOW-REFERENCE.md** — corrects template engine name from "Jinja2" to "Liquid" and removes the stale hot-reload caveat (KAT-815 reference), reflecting that live config reload now works without a restart.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — documentation-only changes with one actionable follow-up needed.
- All changes are in markdown documentation files with no runtime impact. The one issue — `Cargo.toml` version still at `1.0.0` while CHANGELOG documents `1.0.1` — creates a visible inconsistency in the startup banner but does not break any functionality.
- apps/symphony/CHANGELOG.md — the 1.0.1 version entry should be paired with a Cargo.toml version bump.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/CHANGELOG.md | Adds a 1.0.1 changelog entry documenting TUI/dashboard improvements, but Cargo.toml still declares version 1.0.0, creating a mismatch with the startup banner that reads from the crate version. |
| apps/symphony/README.md | Updates HTTP and TUI dashboard feature descriptions to mention the Linear project link card, throughput sparkline, and color-coded dots; corrects test count from 290 to 321. |
| apps/symphony/AGENTS.md | Expands module-table descriptions for http_server.rs and tui.rs; updates test suite count from "280+" to "321 tests". |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Corrects template engine name from "Jinja2" to "Liquid" and removes the outdated hot-reload caveat (KAT-815 reference), reflecting that live config reload now works without a restart. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Symphony startup] --> B{TUI enabled? default: true}
    B -->|yes| C[Ratatui TUI dashboard\nsparkline + color dots + Linear URL]
    B -->|no via --no-tui| D[Stdout-only mode]
    A --> E[HTTP dashboard at localhost:port]
    E --> F[Live session table\nToken summary\nRetry queue\nCompleted issues\nLinear project link card]
    A --> G[Startup banner\nversion read from Cargo.toml]
    G -.->|mismatch| H[CHANGELOG says 1.0.1\nCargo.toml still 1.0.0]
    style H fill:#ffcccc,stroke:#cc0000
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/CHANGELOG.md
Line: 3

Comment:
**CHANGELOG version not reflected in Cargo.toml**

The changelog documents a `1.0.1` release, but `apps/symphony/Cargo.toml` still declares `version = "1.0.0"`. The PR description also calls out "Startup banner consistency — banner version line is emitted from the crate package version", which means the startup banner will continue to display `1.0.0` until the `Cargo.toml` version is bumped to match. Users reading the CHANGELOG expecting to see `1.0.1` in the running process will be confused.

Consider bumping `Cargo.toml`:

```
version = "1.0.1"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(symphony): sync post-patch verifica..."](https://github.com/gannonh/kata/commit/05ca49c95d22193775624be9a1c1bdf1d2501f2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25992684)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->