### PR TITLE
CLI v0.5.1

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.1
+
+### Features
+
+- **Package commands** — `kata install`, `kata remove`, `kata update`, and `kata list` now work as CLI subcommands. Previously, running `kata update` (as shown in the package update notification) did nothing because Kata bypasses pi's `main()` which handled these commands.
+- **`kata` bin alias** — added `kata` as a bin entry alongside `kata-cli`, so global installs register both commands. The update notification message ("Run `kata update`") now matches the actual CLI command.
+
 ## 0.5.0
 
 ### Features

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,
@@ -11,6 +11,7 @@
   },
   "type": "module",
   "bin": {
+    "kata": "dist/loader.js",
     "kata-cli": "dist/loader.js"
   },
   "files": [

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -152,7 +152,12 @@ if (rawCommand && (PACKAGE_COMMANDS as readonly string[]).includes(rawCommand)) 
     } else if (arg.startsWith('-')) {
       // unknown flag, ignore
     } else {
-      source = arg
+      if (source === undefined) {
+        source = arg
+      } else {
+        console.error(`Error: unexpected argument '${arg}' — only one package source is accepted`)
+        process.exit(1)
+      }
     }
   }
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -3,6 +3,7 @@ import {
   ModelRegistry,
   SettingsManager,
   SessionManager,
+  DefaultPackageManager,
   createAgentSession,
   InteractiveMode,
   runPrintMode,
@@ -123,6 +124,116 @@ if (!hasConfiguredPackages && !globalPackages.includes(MCP_ADAPTER_PACKAGE)) {
   settingsManager.setPackages([...globalPackages, MCP_ADAPTER_PACKAGE])
 }
 await settingsManager.flush()
+
+// ---------------------------------------------------------------------------
+// Package commands: install, remove, uninstall, update, list
+// ---------------------------------------------------------------------------
+
+const PACKAGE_COMMANDS = ['install', 'remove', 'uninstall', 'update', 'list'] as const
+type PackageCommand = 'install' | 'remove' | 'update' | 'list'
+
+const rawArgs = process.argv.slice(2)
+const rawCommand = rawArgs[0]
+
+if (rawCommand && (PACKAGE_COMMANDS as readonly string[]).includes(rawCommand)) {
+  const command: PackageCommand = rawCommand === 'uninstall' ? 'remove' : rawCommand as PackageCommand
+  const rest = rawArgs.slice(1)
+
+  // Parse flags — skip known flag-value pairs injected by loader.ts
+  let local = false
+  let help = false
+  let source: string | undefined
+  for (let j = 0; j < rest.length; j++) {
+    const arg = rest[j]
+    if (arg === '-h' || arg === '--help') help = true
+    else if (arg === '-l' || arg === '--local') local = true
+    else if (arg === '--mcp-config' || arg === '--model' || arg === '--mode' || arg === '--tools' || arg === '--append-system-prompt' || arg === '--extension') {
+      j++ // skip the value
+    } else if (arg.startsWith('-')) {
+      // unknown flag, ignore
+    } else {
+      source = arg
+    }
+  }
+
+  if (help) {
+    const name = 'kata'
+    switch (command) {
+      case 'install':
+        console.log(`Usage: ${name} install <source> [-l]\n\nInstall a package and add it to settings.\n  -l, --local    Install project-locally`)
+        break
+      case 'remove':
+        console.log(`Usage: ${name} remove <source> [-l]\n\nRemove a package.\n  -l, --local    Remove from project settings`)
+        break
+      case 'update':
+        console.log(`Usage: ${name} update [source]\n\nUpdate installed packages.\nIf <source> is provided, only that package is updated.`)
+        break
+      case 'list':
+        console.log(`Usage: ${name} list\n\nList installed packages.`)
+        break
+    }
+    process.exit(0)
+  }
+
+  const packageManager = new DefaultPackageManager({
+    cwd: process.cwd(),
+    agentDir,
+    settingsManager,
+  })
+
+  try {
+    switch (command) {
+      case 'install': {
+        if (!source) { console.error('Error: source is required'); process.exit(1) }
+        await packageManager.install(source, { local })
+        console.log(`Installed ${source}`)
+        break
+      }
+      case 'remove': {
+        if (!source) { console.error('Error: source is required'); process.exit(1) }
+        await packageManager.remove(source, { local })
+        console.log(`Removed ${source}`)
+        break
+      }
+      case 'update':
+        await packageManager.update(source)
+        console.log(source ? `Updated ${source}` : 'Updated packages')
+        break
+      case 'list': {
+        const gs = settingsManager.getGlobalSettings()
+        const ps = settingsManager.getProjectSettings()
+        const gp = (gs.packages ?? []).map((p: string | { source: string }) => typeof p === 'string' ? p : p.source)
+        const pp = (ps.packages ?? []).map((p: string | { source: string }) => typeof p === 'string' ? p : p.source)
+        if (gp.length > 0) {
+          console.log('User packages:')
+          for (const p of gp) {
+            console.log(`  ${p}`)
+            const path = packageManager.getInstalledPath(p, 'user')
+            if (path) console.log(`    ${path}`)
+          }
+        }
+        if (pp.length > 0) {
+          if (gp.length > 0) console.log()
+          console.log('Project packages:')
+          for (const p of pp) {
+            console.log(`  ${p}`)
+            const path = packageManager.getInstalledPath(p, 'project')
+            if (path) console.log(`    ${path}`)
+          }
+        }
+        if (gp.length === 0 && pp.length === 0) {
+          console.log('No packages installed.')
+        }
+        break
+      }
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    console.error(`Error: ${message}`)
+    process.exit(1)
+  }
+  process.exit(0)
+}
 
 const sessionManager = SessionManager.create(process.cwd(), sessionsDir)
 


### PR DESCRIPTION
## CLI v0.5.1

### Features

- **Package commands** — `kata install`, `kata remove`, `kata update`, and `kata list` now work as CLI subcommands. Previously, running `kata update` (as shown in the package update notification) did nothing because Kata bypasses pi's `main()` which handled these commands.
- **`kata` bin alias** — added `kata` as a bin entry alongside `kata-cli`, so global installs register both commands. The update notification message ("Run `kata update`") now matches the actual CLI command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `kata` CLI alias for the existing executable.
  * Added package management subcommands: `install`, `remove` (alias `uninstall`), `update`, and `list`.
  * `list` shows installed packages with their resolved paths; subcommands support help and a local scope option and report success or error.

* **Chores**
  * Bumped package version to 0.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR (v0.5.1) adds `kata install`, `kata remove`, `kata update`, and `kata list` as first-class CLI subcommands, and registers a `kata` bin alias in `package.json` alongside the existing `kata-cli` entry. Both changes are a clean fix for a real gap — previously the update notification's suggested command (`kata update`) was a no-op because the underlying `pi` framework's package handling was bypassed.

Key findings:
- **Wizard interrupts package commands** — `runWizardIfNeeded` runs before the package command check. On a fresh install with no optional API keys stored, a simple `kata install <pkg>` will trigger the interactive API key setup wizard before performing the install.
- **Silent arg discard on multiple positional args** — the source argument parser overwrites `source` on every positional arg, so `kata install pkg1 pkg2` silently installs only `pkg2`.
- The flag-skipping logic in the package arg parser correctly handles loader-injected flags like `--mcp-config`, `--model`, `--mode`, and `--extension`.
- The `uninstall` → `remove` alias is correctly implemented and the help text reflects it.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with low risk — the two bugs are UX-level rather than data-destroying, but the wizard interrupt could be confusing on first run.
- The core feature (package subcommands) is sound and the flag handling is correct. The two issues — wizard running before package commands, and silent multi-arg discard — are real bugs but neither causes data loss or security exposure. The bin alias addition in package.json is straightforward and correct.
- apps/cli/src/cli.ts — the ordering of the wizard call relative to the package command guard, and the positional argument parsing loop

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/cli.ts | Adds package subcommands (install, remove, update, list) with inline argument parsing; two bugs: wizard runs before the package-command guard, and multiple positional args silently discard all but the last. |
| apps/cli/package.json | Bumps version to 0.5.1 and registers `kata` as a second bin alias pointing to the same `dist/loader.js` entry point as `kata-cli`. |
| apps/cli/CHANGELOG.md | Changelog entry for v0.5.1 accurately documents the two new features (package commands and `kata` bin alias). |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant L as loader.ts
    participant C as cli.ts

    U->>L: kata install foo
    L->>L: Set env vars (PI_PACKAGE_DIR, KATA_MCP_CONFIG_PATH, etc.)
    L->>L: Inject --mcp-config into process.argv
    L->>C: import cli.js

    C->>C: parseCliFlags() → isPrintMode=false
    C->>C: AuthStorage.create() + loadStoredEnvKeys()
    Note over C: ⚠️ Wizard runs BEFORE package command check
    C->>U: runWizardIfNeeded() — may prompt for API keys
    C->>C: SettingsManager.create() + set defaults
    C->>C: settingsManager.flush()

    C->>C: rawCommand = 'install' → matches PACKAGE_COMMANDS
    C->>C: Parse rest args → source='foo'
    C->>C: new DefaultPackageManager(...)
    C->>C: packageManager.install('foo', {local:false})
    C->>U: "Installed foo"
    C->>C: process.exit(0)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/cli/src/cli.ts`, line 73-75 ([link](https://github.com/gannonh/kata/blob/613da4ddc0ede53a99bb3ab18b0b488227edc1a0/apps/cli/src/cli.ts#L73-L75)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Interactive wizard runs before package command check**

   `runWizardIfNeeded` is called at line 74, but the package command detection doesn't happen until line 138. On a fresh install where optional API keys haven't been configured yet, running `kata install <pkg>` or `kata list` will first interrupt the user with the interactive API key setup wizard before executing the package command.

   Since package management commands don't require any of the optional API keys, the wizard call (and the settings initialization / flush block above it) should be guarded or the package command detection should happen earlier in the file — before the wizard is invoked.

   Minimal fix: detect the package command early and skip the wizard:

   ```typescript
   const rawArgs = process.argv.slice(2)
   const rawCommand = rawArgs[0]
   const isPackageCommand = rawCommand !== undefined && (['install', 'remove', 'uninstall', 'update', 'list'] as string[]).includes(rawCommand)

   // Skip interactive wizard in print/json mode — subagents can't do TTY prompts
   if (!isPrintMode && !isPackageCommand) {
     await runWizardIfNeeded(authStorage)
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/cli.ts
   Line: 73-75

   Comment:
   **Interactive wizard runs before package command check**

   `runWizardIfNeeded` is called at line 74, but the package command detection doesn't happen until line 138. On a fresh install where optional API keys haven't been configured yet, running `kata install <pkg>` or `kata list` will first interrupt the user with the interactive API key setup wizard before executing the package command.

   Since package management commands don't require any of the optional API keys, the wizard call (and the settings initialization / flush block above it) should be guarded or the package command detection should happen earlier in the file — before the wizard is invoked.

   Minimal fix: detect the package command early and skip the wizard:

   ```typescript
   const rawArgs = process.argv.slice(2)
   const rawCommand = rawArgs[0]
   const isPackageCommand = rawCommand !== undefined && (['install', 'remove', 'uninstall', 'update', 'list'] as string[]).includes(rawCommand)

   // Skip interactive wizard in print/json mode — subagents can't do TTY prompts
   if (!isPrintMode && !isPackageCommand) {
     await runWizardIfNeeded(authStorage)
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/cli.ts
Line: 73-75

Comment:
**Interactive wizard runs before package command check**

`runWizardIfNeeded` is called at line 74, but the package command detection doesn't happen until line 138. On a fresh install where optional API keys haven't been configured yet, running `kata install <pkg>` or `kata list` will first interrupt the user with the interactive API key setup wizard before executing the package command.

Since package management commands don't require any of the optional API keys, the wizard call (and the settings initialization / flush block above it) should be guarded or the package command detection should happen earlier in the file — before the wizard is invoked.

Minimal fix: detect the package command early and skip the wizard:

```typescript
const rawArgs = process.argv.slice(2)
const rawCommand = rawArgs[0]
const isPackageCommand = rawCommand !== undefined && (['install', 'remove', 'uninstall', 'update', 'list'] as string[]).includes(rawCommand)

// Skip interactive wizard in print/json mode — subagents can't do TTY prompts
if (!isPrintMode && !isPackageCommand) {
  await runWizardIfNeeded(authStorage)
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/cli.ts
Line: 153-156

Comment:
**Multiple positional args silently drop all but the last**

The loop assigns `source = arg` on every positional argument it encounters. When the user passes more than one positional argument — e.g. `kata install pkg1 pkg2` — `source` is silently overwritten: `pkg1` is ignored and only `pkg2` is installed. The user gets no indication that their intent wasn't fulfilled.

The `update` command has the same issue: `kata update pkg1 pkg2` would silently update only `pkg2`.

Consider either rejecting extra positional args or setting `source` only once:

```typescript
} else {
  if (source === undefined) {
    source = arg
  } else {
    console.error(`Error: unexpected argument '${arg}' — only one package source is accepted`)
    process.exit(1)
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump cli to 0.5.1"](https://github.com/gannonh/kata/commit/613da4ddc0ede53a99bb3ab18b0b488227edc1a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26048761)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->