### PR TITLE
KAT-831: add doctor environment and provider diagnostics

### DIFF
--- a/apps/cli/src/resources/extensions/kata/doctor-environment.ts
+++ b/apps/cli/src/resources/extensions/kata/doctor-environment.ts
@@ -108,7 +108,8 @@ async function detectGitVersion(): Promise<string | null> {
 async function detectDiskFreeBytes(basePath: string): Promise<number | null> {
   try {
     const fsStats = await statfs(basePath);
-    return fsStats.bavail * fsStats.bsize;
+    const blockSize = fsStats.frsize > 0 ? fsStats.frsize : fsStats.bsize;
+    return fsStats.bavail * blockSize;
   } catch {
     return null;
   }

--- a/apps/cli/src/resources/extensions/kata/doctor-environment.ts
+++ b/apps/cli/src/resources/extensions/kata/doctor-environment.ts
@@ -1,0 +1,298 @@
+import { execFile } from "node:child_process";
+import { statfs } from "node:fs/promises";
+import os from "node:os";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type EnvironmentCheckStatus = "pass" | "warn" | "fail" | "info";
+
+export interface EnvironmentCheck {
+  id: string;
+  label: string;
+  status: EnvironmentCheckStatus;
+  message: string;
+}
+
+export interface EnvironmentCheckResult {
+  ok: boolean;
+  checkedAt: string;
+  nodeVersion: string;
+  minNodeVersion: string;
+  gitVersion: string | null;
+  minGitVersion: string;
+  diskFreeBytes: number | null;
+  os: string;
+  shell: string | null;
+  checks: EnvironmentCheck[];
+}
+
+export interface RunEnvironmentChecksOptions {
+  basePath?: string;
+  minNodeVersion?: string;
+  minGitVersion?: string;
+  diskWarnBytes?: number;
+  diskFailBytes?: number;
+  env?: NodeJS.ProcessEnv;
+  overrides?: Partial<{
+    checkedAt: string;
+    nodeVersion: string;
+    gitVersion: string | null;
+    diskFreeBytes: number | null;
+    platform: NodeJS.Platform;
+    osRelease: string;
+    shell: string | null;
+  }>;
+}
+
+const DEFAULT_MIN_NODE_VERSION = "20.6.0";
+const DEFAULT_MIN_GIT_VERSION = "2.25.0";
+const DEFAULT_DISK_WARN_BYTES = 5 * 1024 * 1024 * 1024; // 5 GB
+const DEFAULT_DISK_FAIL_BYTES = 512 * 1024 * 1024; // 512 MB
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function parseVersion(input: string): ParsedVersion | null {
+  const match = input.trim().match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+  };
+}
+
+function compareVersions(a: ParsedVersion, b: ParsedVersion): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+function normalizeNodeVersion(version: string): string {
+  return version.startsWith("v") ? version.slice(1) : version;
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "unknown";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  if (unit === 0) return `${Math.round(value)} ${units[unit]}`;
+  return `${value.toFixed(1)} ${units[unit]}`;
+}
+
+function formatStatus(status: EnvironmentCheckStatus): string {
+  return status.toUpperCase();
+}
+
+async function detectGitVersion(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["--version"], {
+      encoding: "utf-8",
+    });
+    const match = stdout.trim().match(/(\d+\.\d+\.\d+)/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function detectDiskFreeBytes(basePath: string): Promise<number | null> {
+  try {
+    const fsStats = await statfs(basePath);
+    return fsStats.bavail * fsStats.bsize;
+  } catch {
+    return null;
+  }
+}
+
+export async function runEnvironmentChecks(
+  options: RunEnvironmentChecksOptions = {},
+): Promise<EnvironmentCheckResult> {
+  const env = options.env ?? process.env;
+  const checkedAt = options.overrides?.checkedAt ?? new Date().toISOString();
+  const nodeVersion = normalizeNodeVersion(
+    options.overrides?.nodeVersion ?? process.versions.node,
+  );
+  const minNodeVersion = options.minNodeVersion ?? DEFAULT_MIN_NODE_VERSION;
+  const minGitVersion = options.minGitVersion ?? DEFAULT_MIN_GIT_VERSION;
+  const diskWarnBytes = options.diskWarnBytes ?? DEFAULT_DISK_WARN_BYTES;
+  const diskFailBytes = options.diskFailBytes ?? DEFAULT_DISK_FAIL_BYTES;
+  const basePath = options.basePath ?? process.cwd();
+  const platform = options.overrides?.platform ?? process.platform;
+  const osRelease = options.overrides?.osRelease ?? os.release();
+  const shell =
+    options.overrides?.shell ??
+    (platform === "win32" ? env.COMSPEC ?? env.SHELL ?? null : env.SHELL ?? null);
+
+  const gitVersion =
+    options.overrides?.gitVersion !== undefined
+      ? options.overrides.gitVersion
+      : await detectGitVersion();
+  const diskFreeBytes =
+    options.overrides?.diskFreeBytes !== undefined
+      ? options.overrides.diskFreeBytes
+      : await detectDiskFreeBytes(basePath);
+
+  const checks: EnvironmentCheck[] = [];
+
+  const parsedNode = parseVersion(nodeVersion);
+  const parsedNodeMin = parseVersion(minNodeVersion);
+  if (!parsedNode || !parsedNodeMin) {
+    checks.push({
+      id: "node_version",
+      label: "Node.js",
+      status: "warn",
+      message: `Could not parse Node.js version check (${nodeVersion} vs >=${minNodeVersion})`,
+    });
+  } else if (compareVersions(parsedNode, parsedNodeMin) < 0) {
+    checks.push({
+      id: "node_version",
+      label: "Node.js",
+      status: "fail",
+      message: `${nodeVersion} is below required >=${minNodeVersion}`,
+    });
+  } else {
+    checks.push({
+      id: "node_version",
+      label: "Node.js",
+      status: "pass",
+      message: `${nodeVersion} (required >=${minNodeVersion})`,
+    });
+  }
+
+  if (!gitVersion) {
+    checks.push({
+      id: "git_version",
+      label: "Git",
+      status: "fail",
+      message: "git executable not found in PATH",
+    });
+  } else {
+    const parsedGit = parseVersion(gitVersion);
+    const parsedGitMin = parseVersion(minGitVersion);
+    if (!parsedGit || !parsedGitMin) {
+      checks.push({
+        id: "git_version",
+        label: "Git",
+        status: "warn",
+        message: `Found git ${gitVersion}, but could not validate minimum >=${minGitVersion}`,
+      });
+    } else if (compareVersions(parsedGit, parsedGitMin) < 0) {
+      checks.push({
+        id: "git_version",
+        label: "Git",
+        status: "warn",
+        message: `${gitVersion} is below recommended >=${minGitVersion}`,
+      });
+    } else {
+      checks.push({
+        id: "git_version",
+        label: "Git",
+        status: "pass",
+        message: `${gitVersion} (recommended >=${minGitVersion})`,
+      });
+    }
+  }
+
+  if (diskFreeBytes === null) {
+    checks.push({
+      id: "disk_space",
+      label: "Disk space",
+      status: "warn",
+      message: `Could not read free disk space for ${basePath}`,
+    });
+  } else if (diskFreeBytes <= diskFailBytes) {
+    checks.push({
+      id: "disk_space",
+      label: "Disk space",
+      status: "fail",
+      message: `${formatBytes(diskFreeBytes)} free (critical, <= ${formatBytes(diskFailBytes)})`,
+    });
+  } else if (diskFreeBytes <= diskWarnBytes) {
+    checks.push({
+      id: "disk_space",
+      label: "Disk space",
+      status: "warn",
+      message: `${formatBytes(diskFreeBytes)} free (low, <= ${formatBytes(diskWarnBytes)})`,
+    });
+  } else {
+    checks.push({
+      id: "disk_space",
+      label: "Disk space",
+      status: "pass",
+      message: `${formatBytes(diskFreeBytes)} free`,
+    });
+  }
+
+  if (platform === "darwin" || platform === "linux" || platform === "win32") {
+    checks.push({
+      id: "os",
+      label: "Operating system",
+      status: "pass",
+      message: `${platform} ${osRelease}`,
+    });
+  } else {
+    checks.push({
+      id: "os",
+      label: "Operating system",
+      status: "warn",
+      message: `${platform} ${osRelease} (unverified platform)`,
+    });
+  }
+
+  if (shell && shell.trim().length > 0) {
+    checks.push({
+      id: "shell",
+      label: "Shell",
+      status: "pass",
+      message: shell,
+    });
+  } else {
+    checks.push({
+      id: "shell",
+      label: "Shell",
+      status: "warn",
+      message: "No shell detected from SHELL/COMSPEC",
+    });
+  }
+
+  const ok = !checks.some((check) => check.status === "fail");
+  return {
+    ok,
+    checkedAt,
+    nodeVersion,
+    minNodeVersion,
+    gitVersion,
+    minGitVersion,
+    diskFreeBytes,
+    os: `${platform} ${osRelease}`,
+    shell,
+    checks,
+  };
+}
+
+export function formatEnvironmentReport(result: EnvironmentCheckResult): string {
+  const passCount = result.checks.filter((check) => check.status === "pass").length;
+  const warnCount = result.checks.filter((check) => check.status === "warn").length;
+  const failCount = result.checks.filter((check) => check.status === "fail").length;
+  const infoCount = result.checks.filter((check) => check.status === "info").length;
+
+  const lines: string[] = [];
+  lines.push("Environment diagnostics:");
+  lines.push(
+    `Summary: ${passCount} pass, ${warnCount} warn, ${failCount} fail${infoCount > 0 ? `, ${infoCount} info` : ""}`,
+  );
+  for (const check of result.checks) {
+    lines.push(`- ${check.label}: ${formatStatus(check.status)} - ${check.message}`);
+  }
+  return lines.join("\n");
+}

--- a/apps/cli/src/resources/extensions/kata/doctor-providers.ts
+++ b/apps/cli/src/resources/extensions/kata/doctor-providers.ts
@@ -1,0 +1,324 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const defaultAgentDir = join(process.env.HOME ?? homedir(), ".kata-cli", "agent");
+const defaultAuthPath = join(defaultAgentDir, "auth.json");
+
+export type ProviderCheckStatus = "pass" | "warn" | "fail" | "info";
+
+export interface ProviderCheck {
+  id: string;
+  label: string;
+  status: ProviderCheckStatus;
+  message: string;
+}
+
+export interface ProviderStatus {
+  provider: string;
+  kind: "llm" | "tool";
+  configured: boolean;
+  hasEnvCredential: boolean;
+  hasStoredCredential: boolean;
+  modelCount: number;
+}
+
+export interface ProviderCheckResult {
+  ok: boolean;
+  checkedAt: string;
+  availableModels: number;
+  defaultModel: string | null;
+  checks: ProviderCheck[];
+  providers: ProviderStatus[];
+}
+
+interface KnownProvider {
+  id: string;
+  label: string;
+  kind: "llm" | "tool";
+  envVar?: string;
+  authKey?: string;
+}
+
+interface ModelDescriptor {
+  provider: string;
+  id: string;
+}
+
+export interface RunProviderChecksOptions {
+  env?: NodeJS.ProcessEnv;
+  authPath?: string;
+  overrides?: Partial<{
+    checkedAt: string;
+    authProviders: string[];
+    models: ModelDescriptor[];
+    defaultProvider: string | null;
+    defaultModel: string | null;
+  }>;
+}
+
+const LLM_PROVIDERS: KnownProvider[] = [
+  { id: "anthropic", label: "Anthropic", kind: "llm", envVar: "ANTHROPIC_API_KEY" },
+  { id: "openai", label: "OpenAI", kind: "llm", envVar: "OPENAI_API_KEY" },
+  { id: "google", label: "Google", kind: "llm", envVar: "GOOGLE_API_KEY" },
+  { id: "xai", label: "xAI", kind: "llm", envVar: "XAI_API_KEY" },
+  { id: "groq", label: "Groq", kind: "llm", envVar: "GROQ_API_KEY" },
+];
+
+const TOOL_PROVIDERS: KnownProvider[] = [
+  { id: "brave", label: "Brave Search", kind: "tool", envVar: "BRAVE_API_KEY", authKey: "brave" },
+  { id: "tavily", label: "Tavily Search", kind: "tool", envVar: "TAVILY_API_KEY" },
+  { id: "linear", label: "Linear", kind: "tool", envVar: "LINEAR_API_KEY", authKey: "linear" },
+  { id: "context7", label: "Context7", kind: "tool", envVar: "CONTEXT7_API_KEY", authKey: "context7" },
+  { id: "jina", label: "Jina", kind: "tool", envVar: "JINA_API_KEY", authKey: "jina" },
+];
+
+function safeTrim(value: string | undefined): string {
+  return (value ?? "").trim();
+}
+
+function hasEnvCredential(env: NodeJS.ProcessEnv, envVar?: string): boolean {
+  if (!envVar) return false;
+  return safeTrim(env[envVar]).length > 0;
+}
+
+function readAuthSnapshot(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function hasStoredCredential(
+  snapshot: Record<string, unknown>,
+  provider: string,
+): boolean {
+  const value = snapshot[provider];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (typeof record.key === "string" && record.key.trim().length > 0) return true;
+  if (typeof record.accessToken === "string" && record.accessToken.trim().length > 0) return true;
+  if (typeof record.access_token === "string" && record.access_token.trim().length > 0) return true;
+  return Object.keys(record).length > 0;
+}
+
+function buildModelCounts(models: ModelDescriptor[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const model of models) {
+    if (!model.provider) continue;
+    counts.set(model.provider, (counts.get(model.provider) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function formatStatus(status: ProviderCheckStatus): string {
+  return status.toUpperCase();
+}
+
+async function loadModelRuntime(
+  authPath: string,
+): Promise<{
+  models: ModelDescriptor[];
+  defaultProvider: string | null;
+  defaultModel: string | null;
+  loadError: string | null;
+}> {
+  try {
+    const pi = await import("@mariozechner/pi-coding-agent");
+    const authStorage = pi.AuthStorage.create(authPath);
+    const registry = new pi.ModelRegistry(authStorage);
+    const settings = pi.SettingsManager.create(defaultAgentDir);
+    const models = registry.getAll().map((model: { provider: string; id: string }) => ({
+      provider: model.provider,
+      id: model.id,
+    }));
+    return {
+      models,
+      defaultProvider: settings.getDefaultProvider() ?? null,
+      defaultModel: settings.getDefaultModel() ?? null,
+      loadError: null,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      models: [],
+      defaultProvider: null,
+      defaultModel: null,
+      loadError: message,
+    };
+  }
+}
+
+export async function runProviderChecks(
+  options: RunProviderChecksOptions = {},
+): Promise<ProviderCheckResult> {
+  const env = options.env ?? process.env;
+  const authPath = options.authPath ?? defaultAuthPath;
+  const checkedAt = options.overrides?.checkedAt ?? new Date().toISOString();
+  const authSnapshot = readAuthSnapshot(authPath);
+  const authProviders = new Set(
+    options.overrides?.authProviders ??
+      Object.keys(authSnapshot).filter((provider) =>
+        hasStoredCredential(authSnapshot, provider),
+      ),
+  );
+
+  const runtime =
+    options.overrides?.models &&
+    options.overrides.defaultProvider !== undefined &&
+    options.overrides.defaultModel !== undefined
+      ? {
+          models: options.overrides.models,
+          defaultProvider: options.overrides.defaultProvider,
+          defaultModel: options.overrides.defaultModel,
+          loadError: null,
+        }
+      : await loadModelRuntime(authPath);
+
+  const models = options.overrides?.models ?? runtime.models;
+  const defaultProvider =
+    options.overrides?.defaultProvider ?? runtime.defaultProvider;
+  const defaultModel = options.overrides?.defaultModel ?? runtime.defaultModel;
+  const modelCounts = buildModelCounts(models);
+
+  const checks: ProviderCheck[] = [];
+  const providers: ProviderStatus[] = [];
+
+  if (runtime.loadError) {
+    checks.push({
+      id: "model_registry_unavailable",
+      label: "Model registry",
+      status: "warn",
+      message: `Could not load model registry: ${runtime.loadError}`,
+    });
+  }
+
+  if (models.length === 0) {
+    checks.push({
+      id: "model_inventory_empty",
+      label: "Model inventory",
+      status: "warn",
+      message: "No models are currently available. Run /login and /model to configure one.",
+    });
+  } else {
+    checks.push({
+      id: "model_inventory",
+      label: "Model inventory",
+      status: "pass",
+      message: `${models.length} model(s) available`,
+    });
+  }
+
+  if (defaultProvider && defaultModel) {
+    const exists = models.some(
+      (model) => model.provider === defaultProvider && model.id === defaultModel,
+    );
+    checks.push({
+      id: "default_model",
+      label: "Default model",
+      status: exists ? "pass" : "warn",
+      message: exists
+        ? `${defaultProvider}/${defaultModel} is available`
+        : `${defaultProvider}/${defaultModel} is configured but missing from registry`,
+    });
+  } else {
+    checks.push({
+      id: "default_model",
+      label: "Default model",
+      status: "warn",
+      message: "No default model configured",
+    });
+  }
+
+  for (const provider of LLM_PROVIDERS) {
+    const envConfigured = hasEnvCredential(env, provider.envVar);
+    const storedConfigured = authProviders.has(provider.authKey ?? provider.id);
+    const configured = envConfigured || storedConfigured;
+    const modelCount = modelCounts.get(provider.id) ?? 0;
+
+    let status: ProviderCheckStatus;
+    let message: string;
+    if (configured && modelCount > 0) {
+      status = "pass";
+      message = `Credentials detected; ${modelCount} model(s) available`;
+    } else if (configured && modelCount === 0) {
+      status = "warn";
+      message = "Credentials detected but no models available";
+    } else if (!configured && modelCount > 0) {
+      status = "info";
+      message = `${modelCount} model(s) visible but no direct API key/auth entry detected`;
+    } else {
+      status = "info";
+      message = `No credentials detected (${provider.envVar ?? "no env var"})`;
+    }
+
+    checks.push({
+      id: `${provider.id}_provider`,
+      label: provider.label,
+      status,
+      message,
+    });
+    providers.push({
+      provider: provider.id,
+      kind: provider.kind,
+      configured,
+      hasEnvCredential: envConfigured,
+      hasStoredCredential: storedConfigured,
+      modelCount,
+    });
+  }
+
+  for (const provider of TOOL_PROVIDERS) {
+    const envConfigured = hasEnvCredential(env, provider.envVar);
+    const storedConfigured = authProviders.has(provider.authKey ?? provider.id);
+    const configured = envConfigured || storedConfigured;
+    checks.push({
+      id: `${provider.id}_tool_provider`,
+      label: provider.label,
+      status: configured ? "pass" : "info",
+      message: configured
+        ? "API credential detected"
+        : `API credential not configured (${provider.envVar ?? "no env var"})`,
+    });
+    providers.push({
+      provider: provider.id,
+      kind: provider.kind,
+      configured,
+      hasEnvCredential: envConfigured,
+      hasStoredCredential: storedConfigured,
+      modelCount: 0,
+    });
+  }
+
+  const ok = !checks.some((check) => check.status === "fail");
+  return {
+    ok,
+    checkedAt,
+    availableModels: models.length,
+    defaultModel:
+      defaultProvider && defaultModel ? `${defaultProvider}/${defaultModel}` : null,
+    checks,
+    providers,
+  };
+}
+
+export function formatProviderReport(result: ProviderCheckResult): string {
+  const passCount = result.checks.filter((check) => check.status === "pass").length;
+  const warnCount = result.checks.filter((check) => check.status === "warn").length;
+  const failCount = result.checks.filter((check) => check.status === "fail").length;
+  const infoCount = result.checks.filter((check) => check.status === "info").length;
+
+  const lines: string[] = [];
+  lines.push("Provider diagnostics:");
+  lines.push(
+    `Summary: ${passCount} pass, ${warnCount} warn, ${failCount} fail, ${infoCount} info`,
+  );
+  for (const check of result.checks) {
+    lines.push(`- ${check.label}: ${formatStatus(check.status)} - ${check.message}`);
+  }
+  return lines.join("\n");
+}

--- a/apps/cli/src/resources/extensions/kata/doctor-providers.ts
+++ b/apps/cli/src/resources/extensions/kata/doctor-providers.ts
@@ -1,9 +1,14 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
-const defaultAgentDir = join(process.env.HOME ?? homedir(), ".kata-cli", "agent");
-const defaultAuthPath = join(defaultAgentDir, "auth.json");
+function getDefaultAgentDir(): string {
+  return join(process.env.HOME ?? homedir(), ".kata-cli", "agent");
+}
+
+function getDefaultAuthPath(): string {
+  return join(getDefaultAgentDir(), "auth.json");
+}
 
 export type ProviderCheckStatus = "pass" | "warn" | "fail" | "info";
 
@@ -103,7 +108,7 @@ function hasStoredCredential(
   if (typeof record.key === "string" && record.key.trim().length > 0) return true;
   if (typeof record.accessToken === "string" && record.accessToken.trim().length > 0) return true;
   if (typeof record.access_token === "string" && record.access_token.trim().length > 0) return true;
-  return Object.keys(record).length > 0;
+  return false;
 }
 
 function buildModelCounts(models: ModelDescriptor[]): Map<string, number> {
@@ -121,6 +126,7 @@ function formatStatus(status: ProviderCheckStatus): string {
 
 async function loadModelRuntime(
   authPath: string,
+  agentDir: string,
 ): Promise<{
   models: ModelDescriptor[];
   defaultProvider: string | null;
@@ -131,7 +137,7 @@ async function loadModelRuntime(
     const pi = await import("@mariozechner/pi-coding-agent");
     const authStorage = pi.AuthStorage.create(authPath);
     const registry = new pi.ModelRegistry(authStorage);
-    const settings = pi.SettingsManager.create(defaultAgentDir);
+    const settings = pi.SettingsManager.create(agentDir);
     const models = registry.getAll().map((model: { provider: string; id: string }) => ({
       provider: model.provider,
       id: model.id,
@@ -157,7 +163,8 @@ export async function runProviderChecks(
   options: RunProviderChecksOptions = {},
 ): Promise<ProviderCheckResult> {
   const env = options.env ?? process.env;
-  const authPath = options.authPath ?? defaultAuthPath;
+  const authPath = options.authPath ?? getDefaultAuthPath();
+  const agentDir = dirname(authPath);
   const checkedAt = options.overrides?.checkedAt ?? new Date().toISOString();
   const authSnapshot = readAuthSnapshot(authPath);
   const authProviders = new Set(
@@ -177,7 +184,7 @@ export async function runProviderChecks(
           defaultModel: options.overrides.defaultModel,
           loadError: null,
         }
-      : await loadModelRuntime(authPath);
+      : await loadModelRuntime(authPath, agentDir);
 
   const models = options.overrides?.models ?? runtime.models;
   const defaultProvider =

--- a/apps/cli/src/resources/extensions/kata/doctor-providers.ts
+++ b/apps/cli/src/resources/extensions/kata/doctor-providers.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 function getDefaultAgentDir(): string {
-  return join(process.env.HOME ?? homedir(), ".kata-cli", "agent");
+  return process.env.KATA_CODING_AGENT_DIR?.trim() || join(process.env.HOME ?? homedir(), ".kata-cli", "agent");
 }
 
 function getDefaultAuthPath(): string {
@@ -42,6 +42,7 @@ interface KnownProvider {
   label: string;
   kind: "llm" | "tool";
   envVar?: string;
+  fallbackEnvVar?: string;
   authKey?: string;
 }
 
@@ -63,28 +64,34 @@ export interface RunProviderChecksOptions {
 }
 
 const LLM_PROVIDERS: KnownProvider[] = [
-  { id: "anthropic", label: "Anthropic", kind: "llm", envVar: "ANTHROPIC_API_KEY" },
-  { id: "openai", label: "OpenAI", kind: "llm", envVar: "OPENAI_API_KEY" },
-  { id: "google", label: "Google", kind: "llm", envVar: "GOOGLE_API_KEY" },
-  { id: "xai", label: "xAI", kind: "llm", envVar: "XAI_API_KEY" },
-  { id: "groq", label: "Groq", kind: "llm", envVar: "GROQ_API_KEY" },
+  { id: "anthropic", label: "Anthropic", kind: "llm", envVar: "KATA_ANTHROPIC_API_KEY", fallbackEnvVar: "ANTHROPIC_API_KEY" },
+  { id: "openai", label: "OpenAI", kind: "llm", envVar: "KATA_OPENAI_API_KEY", fallbackEnvVar: "OPENAI_API_KEY" },
+  { id: "google", label: "Google", kind: "llm", envVar: "KATA_GOOGLE_API_KEY", fallbackEnvVar: "GOOGLE_API_KEY" },
+  { id: "xai", label: "xAI", kind: "llm", envVar: "KATA_XAI_API_KEY", fallbackEnvVar: "XAI_API_KEY" },
+  { id: "groq", label: "Groq", kind: "llm", envVar: "KATA_GROQ_API_KEY", fallbackEnvVar: "GROQ_API_KEY" },
 ];
 
 const TOOL_PROVIDERS: KnownProvider[] = [
-  { id: "brave", label: "Brave Search", kind: "tool", envVar: "BRAVE_API_KEY", authKey: "brave" },
-  { id: "tavily", label: "Tavily Search", kind: "tool", envVar: "TAVILY_API_KEY" },
-  { id: "linear", label: "Linear", kind: "tool", envVar: "LINEAR_API_KEY", authKey: "linear" },
-  { id: "context7", label: "Context7", kind: "tool", envVar: "CONTEXT7_API_KEY", authKey: "context7" },
-  { id: "jina", label: "Jina", kind: "tool", envVar: "JINA_API_KEY", authKey: "jina" },
+  { id: "brave", label: "Brave Search", kind: "tool", envVar: "KATA_BRAVE_API_KEY", fallbackEnvVar: "BRAVE_API_KEY", authKey: "brave" },
+  { id: "tavily", label: "Tavily Search", kind: "tool", envVar: "KATA_TAVILY_API_KEY", fallbackEnvVar: "TAVILY_API_KEY" },
+  { id: "linear", label: "Linear", kind: "tool", envVar: "KATA_LINEAR_API_KEY", fallbackEnvVar: "LINEAR_API_KEY", authKey: "linear" },
+  { id: "context7", label: "Context7", kind: "tool", envVar: "KATA_CONTEXT7_API_KEY", fallbackEnvVar: "CONTEXT7_API_KEY", authKey: "context7" },
+  { id: "jina", label: "Jina", kind: "tool", envVar: "KATA_JINA_API_KEY", fallbackEnvVar: "JINA_API_KEY", authKey: "jina" },
 ];
 
 function safeTrim(value: string | undefined): string {
   return (value ?? "").trim();
 }
 
-function hasEnvCredential(env: NodeJS.ProcessEnv, envVar?: string): boolean {
-  if (!envVar) return false;
-  return safeTrim(env[envVar]).length > 0;
+function hasEnvCredential(
+  env: NodeJS.ProcessEnv,
+  envVar?: string,
+  fallbackEnvVar?: string,
+): boolean {
+  if (!envVar && !fallbackEnvVar) return false;
+  if (envVar && safeTrim(env[envVar]).length > 0) return true;
+  if (fallbackEnvVar && safeTrim(env[fallbackEnvVar]).length > 0) return true;
+  return false;
 }
 
 function readAuthSnapshot(path: string): Record<string, unknown> {
@@ -242,7 +249,11 @@ export async function runProviderChecks(
   }
 
   for (const provider of LLM_PROVIDERS) {
-    const envConfigured = hasEnvCredential(env, provider.envVar);
+    const envConfigured = hasEnvCredential(
+      env,
+      provider.envVar,
+      provider.fallbackEnvVar,
+    );
     const storedConfigured = authProviders.has(provider.authKey ?? provider.id);
     const configured = envConfigured || storedConfigured;
     const modelCount = modelCounts.get(provider.id) ?? 0;
@@ -280,7 +291,11 @@ export async function runProviderChecks(
   }
 
   for (const provider of TOOL_PROVIDERS) {
-    const envConfigured = hasEnvCredential(env, provider.envVar);
+    const envConfigured = hasEnvCredential(
+      env,
+      provider.envVar,
+      provider.fallbackEnvVar,
+    );
     const storedConfigured = authProviders.has(provider.authKey ?? provider.id);
     const configured = envConfigured || storedConfigured;
     checks.push({

--- a/apps/cli/src/resources/extensions/kata/doctor.ts
+++ b/apps/cli/src/resources/extensions/kata/doctor.ts
@@ -379,8 +379,15 @@ export function formatDoctorReport(
   });
   const summary = summarizeDoctorIssues(scopedIssues);
   const maxIssues = options?.maxIssues ?? 12;
+  const hasBlockingFailures =
+    summary.errors > 0 || !report.environment.ok || !report.providers.ok;
   const lines: string[] = [];
-  lines.push(options?.title ?? (summary.errors > 0 ? "Kata doctor found blocking issues." : "Kata doctor report."));
+  lines.push(
+    options?.title ??
+      (hasBlockingFailures
+        ? "Kata doctor found blocking issues."
+        : "Kata doctor report."),
+  );
   lines.push(`Scope: ${options?.scope ?? "all milestones"}`);
   lines.push(`Issues: ${summary.total} total · ${summary.errors} error(s) · ${summary.warnings} warning(s) · ${summary.fixable} fixable`);
 

--- a/apps/cli/src/resources/extensions/kata/doctor.ts
+++ b/apps/cli/src/resources/extensions/kata/doctor.ts
@@ -5,6 +5,8 @@ import { loadFile, parsePlan, parseRoadmap, parseSummary, saveFile, parseTaskPla
 import { resolveMilestoneFile, resolveMilestonePath, resolveSliceFile, resolveSlicePath, resolveTaskFile, resolveTaskFiles, resolveTasksDir, milestonesDir, kataRoot, relMilestoneFile, relSliceFile, relTaskFile, relSlicePath, relKataRootFile, resolveKataRootFile } from "./paths.js";
 import { deriveState, isMilestoneComplete } from "./state.js";
 import { loadEffectiveKataPreferences, type KataPreferences } from "./preferences.js";
+import { formatEnvironmentReport, runEnvironmentChecks, type EnvironmentCheckResult } from "./doctor-environment.js";
+import { formatProviderReport, runProviderChecks, type ProviderCheckResult } from "./doctor-providers.js";
 
 export type DoctorSeverity = "info" | "warning" | "error";
 export type DoctorIssueCode =
@@ -39,6 +41,8 @@ export interface DoctorReport {
   basePath: string;
   issues: DoctorIssue[];
   fixesApplied: string[];
+  environment: EnvironmentCheckResult;
+  providers: ProviderCheckResult;
 }
 
 export interface DoctorSummary {
@@ -404,6 +408,11 @@ export function formatDoctorReport(
     if (report.fixesApplied.length > maxIssues) lines.push(`- ...and ${report.fixesApplied.length - maxIssues} more`);
   }
 
+  lines.push("");
+  lines.push(formatEnvironmentReport(report.environment));
+  lines.push("");
+  lines.push(formatProviderReport(report.providers));
+
   return lines.join("\n");
 }
 
@@ -419,6 +428,10 @@ export async function runKataDoctor(basePath: string, options?: { fix?: boolean;
   const issues: DoctorIssue[] = [];
   const fixesApplied: string[] = [];
   const fix = options?.fix === true;
+  const [environment, providers] = await Promise.all([
+    runEnvironmentChecks({ basePath }),
+    runProviderChecks(),
+  ]);
 
   const prefs = loadEffectiveKataPreferences();
   if (prefs) {
@@ -438,7 +451,17 @@ export async function runKataDoctor(basePath: string, options?: { fix?: boolean;
 
   const milestonesPath = milestonesDir(basePath);
   if (!existsSync(milestonesPath)) {
-    return { ok: issues.every(issue => issue.severity !== "error"), basePath, issues, fixesApplied };
+    return {
+      ok:
+        issues.every(issue => issue.severity !== "error") &&
+        environment.ok &&
+        providers.ok,
+      basePath,
+      issues,
+      fixesApplied,
+      environment,
+      providers,
+    };
   }
 
   const requirementsPath = resolveKataRootFile(basePath, "REQUIREMENTS");
@@ -674,10 +697,14 @@ export async function runKataDoctor(basePath: string, options?: { fix?: boolean;
   }
 
   return {
-    ok: issues.every(issue => issue.severity !== "error"),
+    ok:
+      issues.every(issue => issue.severity !== "error") &&
+      environment.ok &&
+      providers.ok,
     basePath,
     issues,
     fixesApplied,
+    environment,
+    providers,
   };
 }
-

--- a/apps/cli/src/resources/extensions/kata/tests/doctor-environment.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/doctor-environment.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  formatEnvironmentReport,
+  runEnvironmentChecks,
+} from "../doctor-environment.ts";
+
+describe("runEnvironmentChecks", () => {
+  it("returns pass statuses for a healthy environment snapshot", async () => {
+    const result = await runEnvironmentChecks({
+      minNodeVersion: "20.6.0",
+      minGitVersion: "2.25.0",
+      diskWarnBytes: 1_000,
+      diskFailBytes: 500,
+      overrides: {
+        checkedAt: "2026-03-23T00:00:00.000Z",
+        nodeVersion: "v22.1.0",
+        gitVersion: "2.48.0",
+        diskFreeBytes: 5_000,
+        platform: "linux",
+        osRelease: "6.8.0",
+        shell: "/bin/zsh",
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "node_version" && check.status === "pass",
+      ),
+      true,
+    );
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "git_version" && check.status === "pass",
+      ),
+      true,
+    );
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "disk_space" && check.status === "pass",
+      ),
+      true,
+    );
+  });
+
+  it("flags failing and warning checks in degraded conditions", async () => {
+    const result = await runEnvironmentChecks({
+      minNodeVersion: "20.6.0",
+      minGitVersion: "2.25.0",
+      diskWarnBytes: 2_000,
+      diskFailBytes: 1_000,
+      overrides: {
+        checkedAt: "2026-03-23T00:00:00.000Z",
+        nodeVersion: "v18.19.0",
+        gitVersion: null,
+        diskFreeBytes: 100,
+        platform: "linux",
+        osRelease: "6.8.0",
+        shell: null,
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "node_version" && check.status === "fail",
+      ),
+      true,
+    );
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "git_version" && check.status === "fail",
+      ),
+      true,
+    );
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "disk_space" && check.status === "fail",
+      ),
+      true,
+    );
+
+    const formatted = formatEnvironmentReport(result);
+    assert.equal(formatted.includes("Environment diagnostics:"), true);
+    assert.equal(formatted.includes("Node.js: FAIL"), true);
+    assert.equal(formatted.includes("Git: FAIL"), true);
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import { formatProviderReport, runProviderChecks } from "../doctor-providers.ts";
@@ -67,5 +69,96 @@ describe("runProviderChecks", () => {
     const formatted = formatProviderReport(result);
     assert.equal(formatted.includes("Provider diagnostics:"), true);
     assert.equal(formatted.includes("OpenAI: WARN"), true);
+  });
+
+  it("ignores non-secret metadata in auth snapshots", async () => {
+    const tempDir = mkdtempSync(join(process.cwd(), ".tmp-doctor-provider-auth-"));
+    const authPath = join(tempDir, "auth.json");
+    writeFileSync(
+      authPath,
+      JSON.stringify({
+        anthropic: {
+          expiresAt: "2027-01-01T00:00:00.000Z",
+          metadata: "present",
+        },
+      }),
+      "utf-8",
+    );
+
+    try {
+      const result = await runProviderChecks({
+        authPath,
+        env: {},
+        overrides: {
+          checkedAt: "2026-03-23T00:00:00.000Z",
+          models: [],
+          defaultProvider: null,
+          defaultModel: null,
+        },
+      });
+
+      const anthropic = result.providers.find((provider) => provider.provider === "anthropic");
+      assert.ok(anthropic);
+      assert.equal(anthropic.hasStoredCredential, false);
+      assert.equal(
+        result.checks.some(
+          (check) => check.id === "anthropic_provider" && check.status === "info",
+        ),
+        true,
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves default auth path from current HOME at check time", async () => {
+    const originalHome = process.env.HOME;
+    const baseline = await runProviderChecks({
+      env: {},
+      overrides: {
+        checkedAt: "2026-03-23T00:00:00.000Z",
+        models: [],
+        defaultProvider: null,
+        defaultModel: null,
+      },
+    });
+
+    const target = baseline.providers.find((provider) => !provider.hasStoredCredential);
+    assert.ok(
+      target,
+      "expected at least one provider without stored credentials to validate HOME path resolution",
+    );
+
+    const tempHome = mkdtempSync(join(process.cwd(), ".tmp-doctor-provider-home-"));
+    const tempAgentDir = join(tempHome, ".kata-cli", "agent");
+    mkdirSync(tempAgentDir, { recursive: true });
+    writeFileSync(
+      join(tempAgentDir, "auth.json"),
+      JSON.stringify({
+        [target.provider]: {
+          key: "test-key",
+        },
+      }),
+      "utf-8",
+    );
+
+    try {
+      process.env.HOME = tempHome;
+      const result = await runProviderChecks({
+        env: {},
+        overrides: {
+          checkedAt: "2026-03-23T00:00:00.000Z",
+          models: [],
+          defaultProvider: null,
+          defaultModel: null,
+        },
+      });
+      const provider = result.providers.find((item) => item.provider === target.provider);
+      assert.ok(provider);
+      assert.equal(provider.hasStoredCredential, true);
+    } finally {
+      process.env.HOME = originalHome;
+      rmSync(tempHome, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
@@ -38,6 +38,28 @@ describe("runProviderChecks", () => {
     );
   });
 
+  it("recognizes KATA-prefixed provider environment aliases", async () => {
+    const result = await runProviderChecks({
+      env: {
+        KATA_ANTHROPIC_API_KEY: "test-key",
+      },
+      overrides: {
+        checkedAt: "2026-03-23T00:00:00.000Z",
+        authProviders: [],
+        models: [{ provider: "anthropic", id: "claude-sonnet-4-6" }],
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+      },
+    });
+
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "anthropic_provider" && check.status === "pass",
+      ),
+      true,
+    );
+  });
+
   it("warns when credentials exist but no models are available", async () => {
     const result = await runProviderChecks({
       env: {
@@ -113,21 +135,7 @@ describe("runProviderChecks", () => {
 
   it("resolves default auth path from current HOME at check time", async () => {
     const originalHome = process.env.HOME;
-    const baseline = await runProviderChecks({
-      env: {},
-      overrides: {
-        checkedAt: "2026-03-23T00:00:00.000Z",
-        models: [],
-        defaultProvider: null,
-        defaultModel: null,
-      },
-    });
-
-    const target = baseline.providers.find((provider) => !provider.hasStoredCredential);
-    assert.ok(
-      target,
-      "expected at least one provider without stored credentials to validate HOME path resolution",
-    );
+    const targetProvider = "anthropic";
 
     const tempHome = mkdtempSync(join(process.cwd(), ".tmp-doctor-provider-home-"));
     const tempAgentDir = join(tempHome, ".kata-cli", "agent");
@@ -135,7 +143,7 @@ describe("runProviderChecks", () => {
     writeFileSync(
       join(tempAgentDir, "auth.json"),
       JSON.stringify({
-        [target.provider]: {
+        [targetProvider]: {
           key: "test-key",
         },
       }),
@@ -153,12 +161,50 @@ describe("runProviderChecks", () => {
           defaultModel: null,
         },
       });
-      const provider = result.providers.find((item) => item.provider === target.provider);
+      const provider = result.providers.find((item) => item.provider === targetProvider);
       assert.ok(provider);
       assert.equal(provider.hasStoredCredential, true);
     } finally {
       process.env.HOME = originalHome;
       rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves default auth path from KATA_CODING_AGENT_DIR when set", async () => {
+    const originalAgentDir = process.env.KATA_CODING_AGENT_DIR;
+    const targetProvider = "openai";
+
+    const tempRoot = mkdtempSync(join(process.cwd(), ".tmp-doctor-provider-agent-dir-"));
+    const tempAgentDir = join(tempRoot, "agent");
+    mkdirSync(tempAgentDir, { recursive: true });
+    writeFileSync(
+      join(tempAgentDir, "auth.json"),
+      JSON.stringify({
+        [targetProvider]: {
+          key: "test-key",
+        },
+      }),
+      "utf-8",
+    );
+
+    try {
+      process.env.KATA_CODING_AGENT_DIR = tempAgentDir;
+      const result = await runProviderChecks({
+        env: {},
+        overrides: {
+          checkedAt: "2026-03-23T00:00:00.000Z",
+          models: [],
+          defaultProvider: null,
+          defaultModel: null,
+        },
+      });
+
+      const provider = result.providers.find((item) => item.provider === targetProvider);
+      assert.ok(provider);
+      assert.equal(provider.hasStoredCredential, true);
+    } finally {
+      process.env.KATA_CODING_AGENT_DIR = originalAgentDir;
+      rmSync(tempRoot, { recursive: true, force: true });
     }
   });
 });

--- a/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { formatProviderReport, runProviderChecks } from "../doctor-providers.ts";
+
+describe("runProviderChecks", () => {
+  it("reports configured provider models as pass", async () => {
+    const result = await runProviderChecks({
+      env: {
+        ANTHROPIC_API_KEY: "test-key",
+        BRAVE_API_KEY: "test-brave",
+      },
+      overrides: {
+        checkedAt: "2026-03-23T00:00:00.000Z",
+        authProviders: ["anthropic", "brave"],
+        models: [{ provider: "anthropic", id: "claude-sonnet-4-6" }],
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.availableModels, 1);
+    assert.equal(result.defaultModel, "anthropic/claude-sonnet-4-6");
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "anthropic_provider" && check.status === "pass",
+      ),
+      true,
+    );
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "default_model" && check.status === "pass",
+      ),
+      true,
+    );
+  });
+
+  it("warns when credentials exist but no models are available", async () => {
+    const result = await runProviderChecks({
+      env: {
+        OPENAI_API_KEY: "test-key",
+      },
+      overrides: {
+        checkedAt: "2026-03-23T00:00:00.000Z",
+        authProviders: ["openai"],
+        models: [],
+        defaultProvider: null,
+        defaultModel: null,
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "openai_provider" && check.status === "warn",
+      ),
+      true,
+    );
+    assert.equal(
+      result.checks.some(
+        (check) => check.id === "model_inventory_empty" && check.status === "warn",
+      ),
+      true,
+    );
+
+    const formatted = formatProviderReport(result);
+    assert.equal(formatted.includes("Provider diagnostics:"), true);
+    assert.equal(formatted.includes("OpenAI: WARN"), true);
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/doctor.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/doctor.test.ts
@@ -148,6 +148,55 @@ async function main(): Promise<void> {
     );
   }
 
+  console.log("\n=== doctor formatting reflects diagnostic failures in header ===");
+  {
+    const text = formatDoctorReport({
+      ok: false,
+      basePath: tmpBase,
+      issues: [],
+      fixesApplied: [],
+      environment: {
+        ok: false,
+        checkedAt: "2026-03-23T00:00:00.000Z",
+        nodeVersion: "18.0.0",
+        minNodeVersion: "20.6.0",
+        gitVersion: "2.45.0",
+        minGitVersion: "2.25.0",
+        diskFreeBytes: 10_000,
+        os: "linux",
+        shell: "/bin/zsh",
+        checks: [
+          {
+            id: "node_version",
+            label: "Node.js",
+            status: "fail",
+            message: "18.0.0 is below required >=20.6.0",
+          },
+        ],
+      },
+      providers: {
+        ok: true,
+        checkedAt: "2026-03-23T00:00:00.000Z",
+        availableModels: 1,
+        defaultModel: "anthropic/claude-sonnet-4-6",
+        checks: [
+          {
+            id: "model_inventory",
+            label: "Model inventory",
+            status: "pass",
+            message: "1 model(s) available",
+          },
+        ],
+        providers: [],
+      },
+    });
+
+    assert(
+      text.includes("Kata doctor found blocking issues."),
+      "header reflects diagnostic failures even when issue list is empty",
+    );
+  }
+
   console.log("\n=== doctor default scope ===");
   {
     const scope = await selectDoctorScope(tmpBase);

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -198,7 +198,7 @@ workspace:
     env:
       - CARGO_HOME=/usr/local/cargo
     volumes:
-      - ~/.ssh:/root/.ssh:ro
+      - ~/.ssh:/home/node/.ssh:ro
 
 agent:
   max_concurrent_agents: 3
@@ -250,14 +250,15 @@ docker compose up -d --build
 ### Custom worker images and setup scripts
 
 - Base worker image is `docker/Dockerfile.worker`.
+- Default worker runtime user is non-root (`node`, home `/home/node`).
 - `workspace.docker.image` selects the base image tag.
 - `workspace.docker.setup` points to a setup script; Symphony caches a derived image based on setup script content hash.
 - Bundled setup scripts live in `docker/setups/` (`rust.sh`, `python.sh`, `go.sh`, `bun.sh`).
 
 ### Docker auth modes
 
-- `codex_auth: auto` uses `OPENAI_API_KEY` when set, otherwise mounts `~/.codex/auth.json`.
-- `codex_auth: mount` requires `~/.codex/auth.json`.
+- `codex_auth: auto` uses `OPENAI_API_KEY` when set, otherwise stages host `~/.codex/auth.json` and installs it into the container user's `$HOME/.codex/auth.json`.
+- `codex_auth: mount` requires host `~/.codex/auth.json` and installs it into the container user's `$HOME/.codex/auth.json`.
 - `codex_auth: env` requires `OPENAI_API_KEY`.
 
 ## Dashboard

--- a/apps/symphony/docker/Dockerfile.worker
+++ b/apps/symphony/docker/Dockerfile.worker
@@ -16,4 +16,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 RUN npm install -g @openai/codex@${CODEX_VERSION}
 
+RUN mkdir -p /workspace && chown -R node:node /workspace
+
+ENV HOME=/home/node
 WORKDIR /workspace
+USER node

--- a/apps/symphony/docker/setups/go.sh
+++ b/apps/symphony/docker/setups/go.sh
@@ -19,20 +19,30 @@ esac
 
 GO_TARBALL="${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
 GO_URL="https://go.dev/dl/${GO_TARBALL}"
-GO_SHA_URL="${GO_URL}.sha256"
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 TARBALL_PATH="${TMP_DIR}/${GO_TARBALL}"
-SHA_PATH="${TMP_DIR}/${GO_TARBALL}.sha256"
 
+# Download tarball
 curl -fsSL "$GO_URL" -o "$TARBALL_PATH"
-curl -fsSL "$GO_SHA_URL" -o "$SHA_PATH"
 
-GO_SHA256=$(tr -d '\n\r[:space:]' < "$SHA_PATH")
+# Fetch checksum from Go's JSON release API.
+# The per-file .sha256 URLs on go.dev return HTML redirects, not checksums.
+# The JSON API provides checksums for all files in each release.
+GO_SHA256=$(curl -fsSL "https://go.dev/dl/?mode=json" \
+  | node -e "
+    const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+    const rel = data.find(r => r.version === '${GO_VERSION}');
+    if (!rel) { process.exit(1); }
+    const file = rel.files.find(f => f.filename === '${GO_TARBALL}');
+    if (!file) { process.exit(1); }
+    process.stdout.write(file.sha256);
+  " 2>/dev/null)
+
 if [[ -z "$GO_SHA256" ]]; then
-  echo "Failed to read Go SHA256 checksum from ${GO_SHA_URL}" >&2
+  echo "Failed to fetch SHA256 checksum for ${GO_TARBALL} from go.dev JSON API" >&2
   exit 1
 fi
 

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -126,6 +126,7 @@ workspace:
   # If omitted, these defaults are applied automatically.
   docker:
     # Base image used for worker containers.
+    # Bundled worker image defaults to non-root user `node` (home `/home/node`).
     # Default: symphony-worker:latest
     image: symphony-worker:latest
 
@@ -134,8 +135,8 @@ workspace:
     # setup: docker/setups/rust.sh
 
     # Codex auth mode inside the worker container:
-    #   - auto  (default): OPENAI_API_KEY if set, else mount ~/.codex/auth.json
-    #   - mount: force mount ~/.codex/auth.json
+    #   - auto  (default): OPENAI_API_KEY if set, else stage host ~/.codex/auth.json and install to $HOME/.codex/auth.json in-container
+    #   - mount: force host ~/.codex/auth.json -> $HOME/.codex/auth.json in-container
     #   - env:   force OPENAI_API_KEY
     # codex_auth: auto
 
@@ -145,7 +146,7 @@ workspace:
 
     # Extra bind mounts passed at `docker run` time.
     # volumes:
-    #   - ~/.ssh:/root/.ssh:ro
+    #   - ~/.ssh:/home/node/.ssh:ro
 
 # ─── Hooks ────────────────────────────────────────────────────────────────────
 # Shell commands run at workspace lifecycle events. All hooks receive these

--- a/apps/symphony/src/docker.rs
+++ b/apps/symphony/src/docker.rs
@@ -7,6 +7,10 @@ use crate::domain::{DockerCodexAuth, DockerConfig, Issue};
 use crate::error::{Result, SymphonyError};
 
 pub type DockerAuthArgs = (Vec<(String, String)>, Vec<String>);
+const ROOT_USER: &str = "root";
+const ROOT_UID: &str = "0";
+const SETUP_SCRIPT_PATH: &str = "/tmp/symphony-setup.sh";
+const CODEX_AUTH_STAGING_PATH: &str = "/tmp/symphony-codex-auth.json";
 
 /// Check if Docker daemon is reachable.
 pub async fn is_docker_available() -> bool {
@@ -106,9 +110,8 @@ async fn build_derived_image(base_image: &str, setup_content: &str, tag: &str) -
     let dockerfile_path = build_dir.join("Dockerfile");
     let setup_path = build_dir.join("setup.sh");
 
-    let dockerfile = format!(
-        "FROM {base_image}\nSHELL [\"/bin/sh\", \"-lc\"]\nCOPY setup.sh /tmp/symphony-setup.sh\nRUN chmod +x /tmp/symphony-setup.sh && /tmp/symphony-setup.sh && rm -f /tmp/symphony-setup.sh\n"
-    );
+    let base_image_user = image_default_user(base_image).await?;
+    let dockerfile = derived_image_dockerfile(base_image, &base_image_user);
     std::fs::write(&dockerfile_path, dockerfile).map_err(SymphonyError::Io)?;
     std::fs::write(&setup_path, setup_content).map_err(SymphonyError::Io)?;
 
@@ -193,6 +196,14 @@ pub async fn start_container(
                 "docker run succeeded but did not return a container id".to_string(),
             ));
         }
+
+        if !auth_mounts.is_empty() {
+            if let Err(err) = install_mounted_codex_auth(&container_id).await {
+                let _ = stop_container(&container_id).await;
+                return Err(err);
+            }
+        }
+
         Ok(container_id)
     } else {
         let details = command_output_summary(&output.stdout, &output.stderr, output.status.code());
@@ -263,7 +274,7 @@ pub fn resolve_codex_auth(auth_mode: DockerCodexAuth) -> Result<DockerAuthArgs> 
     let auth_json = codex_auth_json_path();
     let auth_mount = auth_json
         .as_ref()
-        .map(|path| format!("{}:/root/.codex/auth.json:ro", path.display()));
+        .map(|path| format!("{}:{CODEX_AUTH_STAGING_PATH}:ro", path.display()));
 
     match auth_mode {
         DockerCodexAuth::Auto => {
@@ -283,7 +294,7 @@ pub fn resolve_codex_auth(auth_mode: DockerCodexAuth) -> Result<DockerAuthArgs> 
                 Ok((vec![], vec![mount]))
             } else {
                 Err(SymphonyError::DockerAuthError(
-                    "docker codex_auth=mount requires ~/.codex/auth.json".to_string(),
+                    "docker codex_auth=mount requires host ~/.codex/auth.json".to_string(),
                 ))
             }
         }
@@ -303,6 +314,194 @@ fn codex_auth_json_path() -> Option<PathBuf> {
     let home = std::env::var("HOME").ok()?;
     let path = Path::new(&home).join(".codex").join("auth.json");
     path.exists().then_some(path)
+}
+
+async fn image_default_user(image: &str) -> Result<String> {
+    if let Ok(user) = inspect_image_default_user(image).await {
+        if user.is_empty() {
+            return Ok(ROOT_USER.to_string());
+        }
+        return Ok(user);
+    }
+
+    let pull_output = Command::new("docker")
+        .args(["pull", image])
+        .output()
+        .await
+        .map_err(map_docker_io_error)?;
+    if !pull_output.status.success() {
+        let details = command_output_summary(
+            &pull_output.stdout,
+            &pull_output.stderr,
+            pull_output.status.code(),
+        );
+        return Err(SymphonyError::DockerImageBuildFailed(format!(
+            "failed to inspect base image '{image}' user and pull fallback failed: {details}"
+        )));
+    }
+
+    let user = inspect_image_default_user(image).await?;
+    if user.is_empty() {
+        Ok(ROOT_USER.to_string())
+    } else {
+        Ok(user)
+    }
+}
+
+async fn inspect_image_default_user(image: &str) -> Result<String> {
+    let output = Command::new("docker")
+        .args(["image", "inspect", "--format", "{{.Config.User}}", image])
+        .output()
+        .await
+        .map_err(map_docker_io_error)?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        let details = command_output_summary(&output.stdout, &output.stderr, output.status.code());
+        Err(SymphonyError::DockerImageBuildFailed(format!(
+            "failed to inspect base image '{image}' user: {details}"
+        )))
+    }
+}
+
+fn derived_image_dockerfile(base_image: &str, base_image_user: &str) -> String {
+    format!(
+        "FROM {base_image}\n\
+SHELL [\"/bin/sh\", \"-lc\"]\n\
+USER {ROOT_USER}\n\
+COPY setup.sh {SETUP_SCRIPT_PATH}\n\
+RUN export HOME=/root && chmod +x {SETUP_SCRIPT_PATH} && {SETUP_SCRIPT_PATH} && rm -f {SETUP_SCRIPT_PATH}\n\
+USER {base_image_user}\n"
+    )
+}
+
+async fn install_mounted_codex_auth(container_id: &str) -> Result<()> {
+    let identity = container_identity(container_id).await?;
+    let script = codex_auth_install_script();
+    let mut command = Command::new("docker");
+    command
+        .arg("exec")
+        .arg("-i")
+        .arg("-u")
+        .arg(ROOT_UID)
+        .arg("-e")
+        .arg(format!("SYMPHONY_RUNTIME_UID={}", identity.uid))
+        .arg("-e")
+        .arg(format!("SYMPHONY_RUNTIME_GID={}", identity.gid));
+    if let Some(home) = identity.home {
+        command
+            .arg("-e")
+            .arg(format!("SYMPHONY_RUNTIME_HOME={home}"));
+    }
+    let output = command
+        .arg(container_id)
+        .arg("sh")
+        .arg("-lc")
+        .arg(script)
+        .output()
+        .await
+        .map_err(map_docker_io_error)?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let details = command_output_summary(&output.stdout, &output.stderr, output.status.code());
+        Err(SymphonyError::DockerAuthError(format!(
+            "failed to install mounted Codex auth in container home: {details}"
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct ContainerIdentity {
+    uid: String,
+    gid: String,
+    home: Option<String>,
+}
+
+async fn container_identity(container_id: &str) -> Result<ContainerIdentity> {
+    let output = exec_in_container(
+        container_id,
+        "printf 'uid=%s\\ngid=%s\\nhome=%s\\n' \"$(id -u)\" \"$(id -g)\" \"${HOME:-}\"",
+    )
+    .await
+    .map_err(|err| {
+        SymphonyError::DockerAuthError(format!(
+            "failed to resolve runtime user identity before auth install: {err}"
+        ))
+    })?;
+
+    let mut uid: Option<String> = None;
+    let mut gid: Option<String> = None;
+    let mut home: Option<String> = None;
+
+    for line in output.lines() {
+        if let Some(value) = line.strip_prefix("uid=") {
+            uid = Some(value.to_string());
+        } else if let Some(value) = line.strip_prefix("gid=") {
+            gid = Some(value.to_string());
+        } else if let Some(value) = line.strip_prefix("home=") {
+            home = Some(value.to_string());
+        }
+    }
+
+    let uid = uid
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            SymphonyError::DockerAuthError(
+                "failed to resolve runtime uid before auth install".to_string(),
+            )
+        })?;
+    let gid = gid
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            SymphonyError::DockerAuthError(
+                "failed to resolve runtime gid before auth install".to_string(),
+            )
+        })?;
+
+    Ok(ContainerIdentity {
+        uid,
+        gid,
+        home: home.filter(|value| !value.trim().is_empty()),
+    })
+}
+
+fn codex_auth_install_script() -> String {
+    format!(
+        "set -eu\n\
+auth_src=\"{CODEX_AUTH_STAGING_PATH}\"\n\
+runtime_uid=\"${{SYMPHONY_RUNTIME_UID:-}}\"\n\
+runtime_gid=\"${{SYMPHONY_RUNTIME_GID:-}}\"\n\
+home_dir=\"${{SYMPHONY_RUNTIME_HOME:-}}\"\n\
+if [ -z \"$home_dir\" ] && [ -n \"$runtime_uid\" ]; then\n\
+  home_dir=\"$(getent passwd \"$runtime_uid\" | cut -d: -f6 2>/dev/null || true)\"\n\
+fi\n\
+if [ -z \"$home_dir\" ] && [ -n \"$runtime_uid\" ]; then\n\
+  home_dir=\"$(grep \"^[^:]*:[^:]*:${{runtime_uid}}:\" /etc/passwd | cut -d: -f6 2>/dev/null || true)\"\n\
+fi\n\
+if [ -z \"$home_dir\" ]; then\n\
+  home_dir=\"${{HOME:-}}\"\n\
+fi\n\
+if [ -z \"$home_dir\" ]; then\n\
+  home_dir=\"$(cd && pwd)\"\n\
+fi\n\
+if [ -z \"$home_dir\" ]; then\n\
+  echo \"failed to resolve container home directory\" >&2\n\
+  exit 1\n\
+fi\n\
+mkdir -p \"$home_dir/.codex\"\n\
+cp \"$auth_src\" \"$home_dir/.codex/auth.json\"\n\
+if [ -n \"$runtime_uid\" ]; then\n\
+  if [ -n \"$runtime_gid\" ]; then\n\
+    chown \"$runtime_uid:$runtime_gid\" \"$home_dir/.codex\" \"$home_dir/.codex/auth.json\"\n\
+  else\n\
+    chown \"$runtime_uid\" \"$home_dir/.codex\" \"$home_dir/.codex/auth.json\"\n\
+  fi\n\
+fi\n\
+chmod 600 \"$home_dir/.codex/auth.json\""
+    )
 }
 
 fn create_build_dir() -> Result<PathBuf> {
@@ -367,5 +566,26 @@ mod tests {
             summary.contains("https://[REDACTED]@github.com/org/repo"),
             "expected redacted URL in summary, got: {summary}"
         );
+    }
+
+    #[test]
+    fn test_derived_image_dockerfile_runs_setup_as_root_then_restores_user() {
+        let dockerfile = derived_image_dockerfile("symphony-worker:latest", "node");
+        assert!(dockerfile.contains("FROM symphony-worker:latest"));
+        assert!(dockerfile.contains("USER root"));
+        assert!(dockerfile.contains("RUN export HOME=/root && chmod +x /tmp/symphony-setup.sh"));
+        assert!(dockerfile.contains("USER node"));
+    }
+
+    #[test]
+    fn test_codex_auth_install_script_uses_dynamic_home_path() {
+        let script = codex_auth_install_script();
+        assert!(script.contains("SYMPHONY_RUNTIME_UID"));
+        assert!(script.contains("SYMPHONY_RUNTIME_HOME"));
+        assert!(script.contains("chown \"$runtime_uid:$runtime_gid\""));
+        assert!(script.contains("${HOME:-}"));
+        assert!(script.contains("getent passwd"));
+        assert!(script.contains(".codex/auth.json"));
+        assert!(!script.contains("/root/.codex/auth.json"));
     }
 }

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -258,7 +258,7 @@ pub struct DockerConfig {
     pub codex_auth: DockerCodexAuth,
     /// Additional environment variables passed to the container.
     pub env: Vec<String>,
-    /// Additional volume mounts (e.g. "~/.ssh:/root/.ssh:ro").
+    /// Additional volume mounts (e.g. "~/.ssh:/home/node/.ssh:ro").
     pub volumes: Vec<String>,
 }
 

--- a/apps/symphony/tests/docker_integration_tests.rs
+++ b/apps/symphony/tests/docker_integration_tests.rs
@@ -3,6 +3,8 @@
 
 use chrono::Utc;
 use serial_test::serial;
+use std::os::unix::fs::PermissionsExt;
+use tempfile::tempdir;
 use tokio::process::Command;
 
 use symphony::docker;
@@ -36,6 +38,86 @@ fn make_issue(identifier: String) -> Issue {
         assigned_to_worker: true,
         created_at: Some(Utc::now()),
         updated_at: Some(Utc::now()),
+    }
+}
+
+fn non_root_worker_dockerfile() -> &'static str {
+    r#"
+FROM alpine:3.20
+RUN adduser -D -u 10001 symphony
+RUN mkdir -p /workspace && chown symphony:symphony /workspace
+ENV HOME=/home/symphony
+WORKDIR /workspace
+USER symphony
+"#
+}
+
+async fn build_image(tag: &str, dockerfile: &str) {
+    let dir = tempdir().expect("tempdir should create");
+    let dockerfile_path = dir.path().join("Dockerfile");
+    std::fs::write(&dockerfile_path, dockerfile).expect("Dockerfile write should succeed");
+
+    let output = Command::new("docker")
+        .arg("build")
+        .arg("-t")
+        .arg(tag)
+        .arg("-f")
+        .arg(dockerfile_path.as_os_str())
+        .arg(dir.path().as_os_str())
+        .output()
+        .await
+        .expect("docker build should run");
+
+    assert!(
+        output.status.success(),
+        "docker build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn remove_image_sync(tag: &str) {
+    let _ = std::process::Command::new("docker")
+        .args(["rmi", "-f", tag])
+        .output();
+}
+
+struct ImageCleanupGuard {
+    tag: String,
+}
+
+impl ImageCleanupGuard {
+    fn new(tag: impl Into<String>) -> Self {
+        Self { tag: tag.into() }
+    }
+}
+
+impl Drop for ImageCleanupGuard {
+    fn drop(&mut self) {
+        remove_image_sync(&self.tag);
+    }
+}
+
+struct EnvRestoreGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvRestoreGuard {
+    fn capture(key: &'static str) -> Self {
+        Self {
+            key,
+            previous: std::env::var(key).ok(),
+        }
+    }
+}
+
+impl Drop for EnvRestoreGuard {
+    fn drop(&mut self) {
+        if let Some(value) = &self.previous {
+            std::env::set_var(self.key, value);
+        } else {
+            std::env::remove_var(self.key);
+        }
     }
 }
 
@@ -162,4 +244,172 @@ async fn test_auth_resolution_auto() {
     } else {
         std::env::remove_var("OPENAI_API_KEY");
     }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_mount_auth_installs_in_non_root_home() {
+    if !docker_tests_enabled() {
+        return;
+    }
+
+    if !docker::is_docker_available().await {
+        return;
+    }
+
+    let tag = unique_identifier("kat-903-non-root-mount");
+    build_image(&tag, non_root_worker_dockerfile()).await;
+    let _image_cleanup = ImageCleanupGuard::new(tag.clone());
+
+    let _home_restore = EnvRestoreGuard::capture("HOME");
+    let home = tempdir().expect("temp home should create");
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).expect("codex dir should create");
+    let auth_path = codex_dir.join("auth.json");
+    std::fs::write(&auth_path, "{}").expect("auth file should create");
+    let mut permissions = std::fs::metadata(&auth_path)
+        .expect("auth file metadata should exist")
+        .permissions();
+    permissions.set_mode(0o600);
+    std::fs::set_permissions(&auth_path, permissions).expect("auth file permissions should update");
+    std::env::set_var("HOME", home.path());
+
+    let issue = make_issue(unique_identifier("KAT-903-mount"));
+    let docker_config = DockerConfig {
+        codex_auth: DockerCodexAuth::Mount,
+        ..DockerConfig::default()
+    };
+
+    let container_id = docker::start_container(&tag, &issue, &docker_config, &[])
+        .await
+        .expect("container should start");
+
+    let uid = docker::exec_in_container(&container_id, "id -u")
+        .await
+        .expect("id lookup should succeed");
+    assert_ne!(uid.trim(), "0", "worker container should run as non-root");
+
+    let auth_present = docker::exec_in_container(
+        &container_id,
+        "test -f \"$HOME/.codex/auth.json\" && echo present",
+    )
+    .await
+    .expect("auth file probe should succeed");
+    assert_eq!(auth_present.trim(), "present");
+
+    docker::stop_container(&container_id)
+        .await
+        .expect("container should stop");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_env_auth_mode_works_in_non_root_container() {
+    if !docker_tests_enabled() {
+        return;
+    }
+
+    if !docker::is_docker_available().await {
+        return;
+    }
+
+    let tag = unique_identifier("kat-903-non-root-env");
+    build_image(&tag, non_root_worker_dockerfile()).await;
+    let _image_cleanup = ImageCleanupGuard::new(tag.clone());
+
+    let _api_key_restore = EnvRestoreGuard::capture("OPENAI_API_KEY");
+    std::env::set_var("OPENAI_API_KEY", "sk-test-env-mode");
+
+    let issue = make_issue(unique_identifier("KAT-903-env"));
+    let docker_config = DockerConfig {
+        codex_auth: DockerCodexAuth::Env,
+        ..DockerConfig::default()
+    };
+
+    let container_id = docker::start_container(&tag, &issue, &docker_config, &[])
+        .await
+        .expect("container should start");
+
+    let uid = docker::exec_in_container(&container_id, "id -u")
+        .await
+        .expect("id lookup should succeed");
+    assert_ne!(uid.trim(), "0", "worker container should run as non-root");
+
+    let api_key = docker::exec_in_container(&container_id, "printenv OPENAI_API_KEY")
+        .await
+        .expect("OPENAI_API_KEY should be present");
+    assert_eq!(api_key.trim(), "sk-test-env-mode");
+
+    docker::stop_container(&container_id)
+        .await
+        .expect("container should stop");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_setup_script_runs_as_root_and_restores_non_root_default_user() {
+    if !docker_tests_enabled() {
+        return;
+    }
+
+    if !docker::is_docker_available().await {
+        return;
+    }
+
+    let base_tag = unique_identifier("kat-903-setup-base");
+    build_image(&base_tag, non_root_worker_dockerfile()).await;
+    let _base_image_cleanup = ImageCleanupGuard::new(base_tag.clone());
+
+    let setup_dir = tempdir().expect("setup tempdir should create");
+    let setup_script = setup_dir.path().join("setup.sh");
+    std::fs::write(
+        &setup_script,
+        "#!/bin/sh\nset -eu\nif [ \"$(id -u)\" -ne 0 ]; then echo \"setup must run as root\" >&2; exit 1; fi\ntouch /tmp/kat-903-setup-ran\n",
+    )
+    .expect("setup script write should succeed");
+
+    let derived_image = docker::resolve_image(
+        &base_tag,
+        Some(
+            setup_script
+                .to_str()
+                .expect("setup path should be valid UTF-8"),
+        ),
+    )
+    .await
+    .expect("derived image should build");
+    let _derived_image_cleanup = ImageCleanupGuard::new(derived_image.clone());
+
+    let _api_key_restore = EnvRestoreGuard::capture("OPENAI_API_KEY");
+    std::env::set_var("OPENAI_API_KEY", "sk-test-setup");
+
+    let issue = make_issue(unique_identifier("KAT-903-setup"));
+    let docker_config = DockerConfig {
+        codex_auth: DockerCodexAuth::Env,
+        ..DockerConfig::default()
+    };
+    let container_id = docker::start_container(&derived_image, &issue, &docker_config, &[])
+        .await
+        .expect("container should start");
+
+    let uid = docker::exec_in_container(&container_id, "id -u")
+        .await
+        .expect("id lookup should succeed");
+    assert_ne!(
+        uid.trim(),
+        "0",
+        "derived image should restore non-root user"
+    );
+
+    let setup_marker = docker::exec_in_container(
+        &container_id,
+        "test -f /tmp/kat-903-setup-ran && echo present",
+    )
+    .await
+    .expect("setup marker check should succeed");
+    assert_eq!(setup_marker.trim(), "present");
+
+    docker::stop_container(&container_id)
+        .await
+        .expect("container should stop");
 }

--- a/apps/symphony/tests/docker_tests.rs
+++ b/apps/symphony/tests/docker_tests.rs
@@ -87,9 +87,27 @@ fn test_resolve_codex_auth_auto_with_auth_json() {
     let (env_vars, volumes) = resolve_codex_auth(DockerCodexAuth::Auto).unwrap();
     assert!(env_vars.is_empty());
     assert_eq!(volumes.len(), 1);
-    assert!(volumes[0].contains(".codex/auth.json:/root/.codex/auth.json:ro"));
+    assert!(volumes[0].contains(".codex/auth.json:/tmp/symphony-codex-auth.json:ro"));
 
     restore_env("OPENAI_API_KEY", prev_api_key);
+    restore_env("HOME", prev_home);
+}
+
+#[test]
+#[serial]
+fn test_resolve_codex_auth_mount_with_auth_json() {
+    let prev_home = std::env::var("HOME").ok();
+    let home = tempdir().unwrap();
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    std::fs::write(codex_dir.join("auth.json"), "{}").unwrap();
+    std::env::set_var("HOME", home.path());
+
+    let (env_vars, volumes) = resolve_codex_auth(DockerCodexAuth::Mount).unwrap();
+    assert!(env_vars.is_empty());
+    assert_eq!(volumes.len(), 1);
+    assert!(volumes[0].contains(".codex/auth.json:/tmp/symphony-codex-auth.json:ro"));
+
     restore_env("HOME", prev_home);
 }
 

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -398,7 +398,7 @@ workspace:
       - FOO=bar
       - BAR=baz
     volumes:
-      - ~/.ssh:/root/.ssh:ro
+      - ~/.ssh:/home/node/.ssh:ro
 "#;
     let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
     let config = from_workflow(&raw).expect("full docker config should parse");
@@ -412,7 +412,7 @@ workspace:
         vec!["FOO=bar".to_string(), "BAR=baz".to_string()]
     );
     assert_eq!(docker.volumes.len(), 1);
-    assert!(docker.volumes[0].contains(".ssh:/root/.ssh:ro"));
+    assert!(docker.volumes[0].contains(".ssh:/home/node/.ssh:ro"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `doctor-environment.ts` with Node, disk space, git, OS, and shell diagnostics
- add `doctor-providers.ts` with API credential and model-availability diagnostics
- integrate both reports into `runKataDoctor`/`formatDoctorReport`
- add tests for the new environment/provider diagnostic modules

## Validation
- `cd apps/cli && npx tsc`
- `cd apps/cli && node --import ./src/resources/extensions/kata/tests/resolve-ts.mjs --experimental-strip-types --test 'src/resources/extensions/kata/tests/*.test.ts' 'src/tests/*.test.ts'`
- pre-push hook: `turbo run lint typecheck test --affected`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new diagnostic modules — `doctor-environment.ts` and `doctor-providers.ts` — that check Node.js/git versions, disk space, OS/shell info, and API credential/model availability respectively, then integrates both into the existing `/doctor` command report. The integration in `doctor.ts` is clean (parallel `Promise.all`, correct `ok` propagation, formatted output appended to the report), and the override-injection pattern used throughout makes the new modules hermetic and testable.

Key findings:
- **`hasStoredCredential` false positive** (`doctor-providers.ts:106`): the final `return Object.keys(record).length > 0` catches any object with unrecognized keys (e.g. `{ expiry: "..." }`), incorrectly reporting stored credentials and misleading users running `/doctor`.
- **Incorrect disk-free calculation** (`doctor-environment.ts:111`): `fsStats.bavail * fsStats.bsize` should use `frsize` (the fundamental block size) rather than `bsize` (the advisory I/O hint); these differ on ZFS and some network file systems.
- **`SettingsManager` ignores custom `authPath`** (`doctor-providers.ts:134`): the agent settings (default provider/model) are always read from the module-level `defaultAgentDir`, creating an inconsistency when a custom `authPath` is supplied — the registry and settings can diverge.
- **Module-level path eagerly captures `HOME`** (`doctor-providers.ts:5-6`): `defaultAuthPath` is frozen at import time, which can cause issues in environments where `HOME` is not yet populated or where the path needs to vary.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — two of the three logic bugs directly affect the correctness of diagnostic output shown to users.
- The `hasStoredCredential` false positive can mislead users into believing a provider is configured when it is not (or vice versa, masking a misconfiguration). The `bsize` vs `frsize` issue can produce silently wrong free-space figures. The `SettingsManager` always reading from a hardcoded path means the default-model check can be stale or wrong for non-default deployments. These are not theoretical edge cases — they affect the core diagnostic output of the new feature.
- `apps/cli/src/resources/extensions/kata/doctor-providers.ts` requires the most attention (two logic bugs + the module-level init issue). `apps/cli/src/resources/extensions/kata/doctor-environment.ts` has one incorrect field reference (`bsize` → `frsize`).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/doctor-environment.ts | New module providing Node.js, git, disk space, OS, and shell diagnostics. Well-structured with testable overrides, but uses `bsize` instead of `frsize` for disk-free calculation, which can be inaccurate on some filesystems. |
| apps/cli/src/resources/extensions/kata/doctor-providers.ts | New module providing API credential and model-availability diagnostics. Contains two logic issues: `hasStoredCredential` has a catch-all fallback that can produce false positives, and `SettingsManager` is hardcoded to the global default directory instead of using the provided `authPath`. Module-level path initialization may also cause issues in certain environments. |
| apps/cli/src/resources/extensions/kata/doctor.ts | Integrates the new environment and provider check results into the doctor report. The integration is clean — both checks are run concurrently with `Promise.all`, the `ok` flag is correctly propagated, and both reports are appended to the formatted output. |
| apps/cli/src/resources/extensions/kata/tests/doctor-environment.test.ts | Tests cover healthy and degraded environment snapshots using override injection. Coverage is light (2 test cases) but the override pattern makes the tests hermetic. |
| apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts | Tests cover a configured provider and the credentials-but-no-models warning case. Like the environment tests, coverage is minimal but the override injection pattern keeps them deterministic. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/doctor command"] --> B["runKataDoctor(basePath)"]
    B --> C["Promise.all(...)"]
    C --> D["runEnvironmentChecks()"]
    C --> E["runProviderChecks()"]

    D --> D1["Check Node.js version"]
    D --> D2["Detect git version\n(execFileAsync)"]
    D --> D3["Detect disk free\n(statfs · bavail × bsize ⚠)"]
    D --> D4["Check OS platform"]
    D --> D5["Detect shell\n(env.SHELL / COMSPEC)"]
    D1 & D2 & D3 & D4 & D5 --> D6["EnvironmentCheckResult\n{ ok, checks[] }"]

    E --> E1["readAuthSnapshot\n(auth.json)"]
    E --> E2["loadModelRuntime\n(pi.ModelRegistry)"]
    E1 --> E3["hasStoredCredential\n⚠ catch-all false positive"]
    E2 --> E4["pi.SettingsManager\n⚠ always defaultAgentDir"]
    E3 & E4 --> E5["ProviderCheckResult\n{ ok, checks[], providers[] }"]

    D6 --> F["DoctorReport\n{ ok, issues[], environment, providers }"]
    E5 --> F
    F --> G["formatDoctorReport()\n→ text output to user"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/doctor-providers.ts
Line: 106

Comment:
**`hasStoredCredential` catch-all causes false positives**

The final `return Object.keys(record).length > 0` returns `true` for any object that has *any* keys — not just recognized credential fields. This means an entry in `auth.json` like `{ "anthropic": { "expiry": "2025-01-01", "metadata": "foo" } }` (no actual key/token) would be reported as "Credentials detected" in the `/doctor` output, misleading the user.

Only the three explicitly checked fields (`key`, `accessToken`, `access_token`) represent actual credentials. The catch-all should be removed:

```suggestion
  return Object.keys(record).length > 0;
```

Consider replacing the fallback with `return false` so only the known credential fields are treated as valid:

```ts
function hasStoredCredential(
  snapshot: Record<string, unknown>,
  provider: string,
): boolean {
  const value = snapshot[provider];
  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
  const record = value as Record<string, unknown>;
  if (typeof record.key === "string" && record.key.trim().length > 0) return true;
  if (typeof record.accessToken === "string" && record.accessToken.trim().length > 0) return true;
  if (typeof record.access_token === "string" && record.access_token.trim().length > 0) return true;
  return false;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/doctor-environment.ts
Line: 111

Comment:
**`bsize` should be `frsize` for accurate disk-free calculation**

`statfs.bsize` is the *preferred I/O transfer block size* (an advisory hint), while `statfs.frsize` is the *fundamental file system block size* — the actual unit used for allocation. Free disk space is formally defined as `bavail * frsize`.

On most Linux/macOS systems these happen to be identical (both 4096), but on some file systems (e.g. ZFS, certain network file systems) they differ, which would produce an incorrect free-space figure.

```suggestion
    return fsStats.bavail * fsStats.frsize;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/doctor-providers.ts
Line: 134

Comment:
**`SettingsManager` ignores the custom `authPath` parameter**

`loadModelRuntime` accepts `authPath` and correctly passes it to `pi.AuthStorage.create(authPath)`, but `pi.SettingsManager.create(defaultAgentDir)` is hardcoded to the module-level `defaultAgentDir`. This means the default-provider/model settings will always be read from `~/.kata-cli/agent/` even when a custom `authPath` points to a different directory.

The two data sources — the model registry and the settings — can therefore diverge for non-default deployments (e.g. CI environments, multi-user setups, tests that pass a custom `authPath` in production code paths).

```suggestion
    const settings = pi.SettingsManager.create(join(authPath, ".."));
```

(or derive the agent directory from `authPath` however `SettingsManager` expects it).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/doctor-providers.ts
Line: 5-6

Comment:
**Module-level path eagerly captures `HOME` at import time**

`defaultAgentDir` and `defaultAuthPath` are computed once when the module is first imported. If `process.env.HOME` is not yet set at that point (e.g., certain CI contexts or edge-case shell configurations), `homedir()` is used as a fallback, but the computed path is then frozen for the lifetime of the process.

Consider computing these lazily inside `runProviderChecks` (or deferring to the call site) so the path reflects the environment at the time of the actual check rather than at module load time:

```ts
function getDefaultAuthPath(): string {
  return join(process.env.HOME ?? homedir(), ".kata-cli", "agent", "auth.json");
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(kata): add doctor environment and p..."](https://github.com/gannonh/kata/commit/f9384f606ea1d0ede175312868eb3194082106e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26075034)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive environment diagnostics to the CLI doctor command, checking Node.js, Git, disk space, and OS details.
  * Added provider diagnostics to the CLI doctor command, validating LLM and tool provider credentials and available models.

* **Bug Fixes**
  * Docker containers now properly support non-root user execution with correct auth file handling.
  * Updated Docker Go installation to use API-based checksum retrieval for improved reliability.

* **Configuration**
  * Normalized Docker volume mount paths to use `/home/node` instead of `/root`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->