### PR TITLE
fix(symphony): support non-root Docker worker user isolation

### DIFF
--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -198,7 +198,7 @@ workspace:
     env:
       - CARGO_HOME=/usr/local/cargo
     volumes:
-      - ~/.ssh:/root/.ssh:ro
+      - ~/.ssh:/home/node/.ssh:ro
 
 agent:
   max_concurrent_agents: 3
@@ -250,14 +250,15 @@ docker compose up -d --build
 ### Custom worker images and setup scripts
 
 - Base worker image is `docker/Dockerfile.worker`.
+- Default worker runtime user is non-root (`node`, home `/home/node`).
 - `workspace.docker.image` selects the base image tag.
 - `workspace.docker.setup` points to a setup script; Symphony caches a derived image based on setup script content hash.
 - Bundled setup scripts live in `docker/setups/` (`rust.sh`, `python.sh`, `go.sh`, `bun.sh`).
 
 ### Docker auth modes
 
-- `codex_auth: auto` uses `OPENAI_API_KEY` when set, otherwise mounts `~/.codex/auth.json`.
-- `codex_auth: mount` requires `~/.codex/auth.json`.
+- `codex_auth: auto` uses `OPENAI_API_KEY` when set, otherwise stages host `~/.codex/auth.json` and installs it into the container user's `$HOME/.codex/auth.json`.
+- `codex_auth: mount` requires host `~/.codex/auth.json` and installs it into the container user's `$HOME/.codex/auth.json`.
 - `codex_auth: env` requires `OPENAI_API_KEY`.
 
 ## Dashboard

--- a/apps/symphony/docker/Dockerfile.worker
+++ b/apps/symphony/docker/Dockerfile.worker
@@ -16,4 +16,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 RUN npm install -g @openai/codex@${CODEX_VERSION}
 
+RUN mkdir -p /workspace && chown -R node:node /workspace
+
+ENV HOME=/home/node
 WORKDIR /workspace
+USER node

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -126,6 +126,7 @@ workspace:
   # If omitted, these defaults are applied automatically.
   docker:
     # Base image used for worker containers.
+    # Bundled worker image defaults to non-root user `node` (home `/home/node`).
     # Default: symphony-worker:latest
     image: symphony-worker:latest
 
@@ -134,8 +135,8 @@ workspace:
     # setup: docker/setups/rust.sh
 
     # Codex auth mode inside the worker container:
-    #   - auto  (default): OPENAI_API_KEY if set, else mount ~/.codex/auth.json
-    #   - mount: force mount ~/.codex/auth.json
+    #   - auto  (default): OPENAI_API_KEY if set, else stage host ~/.codex/auth.json and install to $HOME/.codex/auth.json in-container
+    #   - mount: force host ~/.codex/auth.json -> $HOME/.codex/auth.json in-container
     #   - env:   force OPENAI_API_KEY
     # codex_auth: auto
 
@@ -145,7 +146,7 @@ workspace:
 
     # Extra bind mounts passed at `docker run` time.
     # volumes:
-    #   - ~/.ssh:/root/.ssh:ro
+    #   - ~/.ssh:/home/node/.ssh:ro
 
 # ─── Hooks ────────────────────────────────────────────────────────────────────
 # Shell commands run at workspace lifecycle events. All hooks receive these

--- a/apps/symphony/src/docker.rs
+++ b/apps/symphony/src/docker.rs
@@ -371,7 +371,7 @@ fn derived_image_dockerfile(base_image: &str, base_image_user: &str) -> String {
 SHELL [\"/bin/sh\", \"-lc\"]\n\
 USER {ROOT_USER}\n\
 COPY setup.sh {SETUP_SCRIPT_PATH}\n\
-RUN chmod +x {SETUP_SCRIPT_PATH} && {SETUP_SCRIPT_PATH} && rm -f {SETUP_SCRIPT_PATH}\n\
+RUN export HOME=/root && chmod +x {SETUP_SCRIPT_PATH} && {SETUP_SCRIPT_PATH} && rm -f {SETUP_SCRIPT_PATH}\n\
 USER {base_image_user}\n"
     )
 }
@@ -573,7 +573,7 @@ mod tests {
         let dockerfile = derived_image_dockerfile("symphony-worker:latest", "node");
         assert!(dockerfile.contains("FROM symphony-worker:latest"));
         assert!(dockerfile.contains("USER root"));
-        assert!(dockerfile.contains("RUN chmod +x /tmp/symphony-setup.sh"));
+        assert!(dockerfile.contains("RUN export HOME=/root && chmod +x /tmp/symphony-setup.sh"));
         assert!(dockerfile.contains("USER node"));
     }
 

--- a/apps/symphony/src/docker.rs
+++ b/apps/symphony/src/docker.rs
@@ -478,6 +478,9 @@ home_dir=\"${{SYMPHONY_RUNTIME_HOME:-}}\"\n\
 if [ -z \"$home_dir\" ] && [ -n \"$runtime_uid\" ]; then\n\
   home_dir=\"$(getent passwd \"$runtime_uid\" | cut -d: -f6 2>/dev/null || true)\"\n\
 fi\n\
+if [ -z \"$home_dir\" ] && [ -n \"$runtime_uid\" ]; then\n\
+  home_dir=\"$(grep \"^[^:]*:[^:]*:${{runtime_uid}}:\" /etc/passwd | cut -d: -f6 2>/dev/null || true)\"\n\
+fi\n\
 if [ -z \"$home_dir\" ]; then\n\
   home_dir=\"${{HOME:-}}\"\n\
 fi\n\

--- a/apps/symphony/src/docker.rs
+++ b/apps/symphony/src/docker.rs
@@ -7,6 +7,9 @@ use crate::domain::{DockerCodexAuth, DockerConfig, Issue};
 use crate::error::{Result, SymphonyError};
 
 pub type DockerAuthArgs = (Vec<(String, String)>, Vec<String>);
+const ROOT_USER: &str = "root";
+const SETUP_SCRIPT_PATH: &str = "/tmp/symphony-setup.sh";
+const CODEX_AUTH_STAGING_PATH: &str = "/tmp/symphony-codex-auth.json";
 
 /// Check if Docker daemon is reachable.
 pub async fn is_docker_available() -> bool {
@@ -106,9 +109,8 @@ async fn build_derived_image(base_image: &str, setup_content: &str, tag: &str) -
     let dockerfile_path = build_dir.join("Dockerfile");
     let setup_path = build_dir.join("setup.sh");
 
-    let dockerfile = format!(
-        "FROM {base_image}\nSHELL [\"/bin/sh\", \"-lc\"]\nCOPY setup.sh /tmp/symphony-setup.sh\nRUN chmod +x /tmp/symphony-setup.sh && /tmp/symphony-setup.sh && rm -f /tmp/symphony-setup.sh\n"
-    );
+    let base_image_user = image_default_user(base_image).await?;
+    let dockerfile = derived_image_dockerfile(base_image, &base_image_user);
     std::fs::write(&dockerfile_path, dockerfile).map_err(SymphonyError::Io)?;
     std::fs::write(&setup_path, setup_content).map_err(SymphonyError::Io)?;
 
@@ -193,6 +195,14 @@ pub async fn start_container(
                 "docker run succeeded but did not return a container id".to_string(),
             ));
         }
+
+        if !auth_mounts.is_empty() {
+            if let Err(err) = install_mounted_codex_auth(&container_id).await {
+                let _ = stop_container(&container_id).await;
+                return Err(err);
+            }
+        }
+
         Ok(container_id)
     } else {
         let details = command_output_summary(&output.stdout, &output.stderr, output.status.code());
@@ -263,7 +273,7 @@ pub fn resolve_codex_auth(auth_mode: DockerCodexAuth) -> Result<DockerAuthArgs> 
     let auth_json = codex_auth_json_path();
     let auth_mount = auth_json
         .as_ref()
-        .map(|path| format!("{}:/root/.codex/auth.json:ro", path.display()));
+        .map(|path| format!("{}:{CODEX_AUTH_STAGING_PATH}:ro", path.display()));
 
     match auth_mode {
         DockerCodexAuth::Auto => {
@@ -283,7 +293,7 @@ pub fn resolve_codex_auth(auth_mode: DockerCodexAuth) -> Result<DockerAuthArgs> 
                 Ok((vec![], vec![mount]))
             } else {
                 Err(SymphonyError::DockerAuthError(
-                    "docker codex_auth=mount requires ~/.codex/auth.json".to_string(),
+                    "docker codex_auth=mount requires host ~/.codex/auth.json".to_string(),
                 ))
             }
         }
@@ -303,6 +313,110 @@ fn codex_auth_json_path() -> Option<PathBuf> {
     let home = std::env::var("HOME").ok()?;
     let path = Path::new(&home).join(".codex").join("auth.json");
     path.exists().then_some(path)
+}
+
+async fn image_default_user(image: &str) -> Result<String> {
+    if let Ok(user) = inspect_image_default_user(image).await {
+        if user.is_empty() {
+            return Ok(ROOT_USER.to_string());
+        }
+        return Ok(user);
+    }
+
+    let pull_output = Command::new("docker")
+        .args(["pull", image])
+        .output()
+        .await
+        .map_err(map_docker_io_error)?;
+    if !pull_output.status.success() {
+        let details = command_output_summary(
+            &pull_output.stdout,
+            &pull_output.stderr,
+            pull_output.status.code(),
+        );
+        return Err(SymphonyError::DockerImageBuildFailed(format!(
+            "failed to inspect base image '{image}' user and pull fallback failed: {details}"
+        )));
+    }
+
+    let user = inspect_image_default_user(image).await?;
+    if user.is_empty() {
+        Ok(ROOT_USER.to_string())
+    } else {
+        Ok(user)
+    }
+}
+
+async fn inspect_image_default_user(image: &str) -> Result<String> {
+    let output = Command::new("docker")
+        .args(["image", "inspect", "--format", "{{.Config.User}}", image])
+        .output()
+        .await
+        .map_err(map_docker_io_error)?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        let details = command_output_summary(&output.stdout, &output.stderr, output.status.code());
+        Err(SymphonyError::DockerImageBuildFailed(format!(
+            "failed to inspect base image '{image}' user: {details}"
+        )))
+    }
+}
+
+fn derived_image_dockerfile(base_image: &str, base_image_user: &str) -> String {
+    format!(
+        "FROM {base_image}\n\
+SHELL [\"/bin/sh\", \"-lc\"]\n\
+USER {ROOT_USER}\n\
+COPY setup.sh {SETUP_SCRIPT_PATH}\n\
+RUN chmod +x {SETUP_SCRIPT_PATH} && {SETUP_SCRIPT_PATH} && rm -f {SETUP_SCRIPT_PATH}\n\
+USER {base_image_user}\n"
+    )
+}
+
+async fn install_mounted_codex_auth(container_id: &str) -> Result<()> {
+    let script = codex_auth_install_script();
+    let output = Command::new("docker")
+        .arg("exec")
+        .arg("-i")
+        .arg(container_id)
+        .arg("sh")
+        .arg("-lc")
+        .arg(script)
+        .output()
+        .await
+        .map_err(map_docker_io_error)?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let details = command_output_summary(&output.stdout, &output.stderr, output.status.code());
+        Err(SymphonyError::DockerAuthError(format!(
+            "failed to install mounted Codex auth in container home: {details}"
+        )))
+    }
+}
+
+fn codex_auth_install_script() -> String {
+    format!(
+        "set -eu\n\
+auth_src=\"{CODEX_AUTH_STAGING_PATH}\"\n\
+home_dir=\"${{HOME:-}}\"\n\
+if [ -z \"$home_dir\" ]; then\n\
+  home_dir=\"$(getent passwd \"$(id -u)\" | cut -d: -f6 2>/dev/null || true)\"\n\
+fi\n\
+if [ -z \"$home_dir\" ]; then\n\
+  home_dir=\"$(cd && pwd)\"\n\
+fi\n\
+if [ -z \"$home_dir\" ]; then\n\
+  echo \"failed to resolve container home directory\" >&2\n\
+  exit 1\n\
+fi\n\
+mkdir -p \"$home_dir/.codex\"\n\
+cp \"$auth_src\" \"$home_dir/.codex/auth.json\"\n\
+chmod 600 \"$home_dir/.codex/auth.json\""
+    )
 }
 
 fn create_build_dir() -> Result<PathBuf> {
@@ -367,5 +481,23 @@ mod tests {
             summary.contains("https://[REDACTED]@github.com/org/repo"),
             "expected redacted URL in summary, got: {summary}"
         );
+    }
+
+    #[test]
+    fn test_derived_image_dockerfile_runs_setup_as_root_then_restores_user() {
+        let dockerfile = derived_image_dockerfile("symphony-worker:latest", "node");
+        assert!(dockerfile.contains("FROM symphony-worker:latest"));
+        assert!(dockerfile.contains("USER root"));
+        assert!(dockerfile.contains("RUN chmod +x /tmp/symphony-setup.sh"));
+        assert!(dockerfile.contains("USER node"));
+    }
+
+    #[test]
+    fn test_codex_auth_install_script_uses_dynamic_home_path() {
+        let script = codex_auth_install_script();
+        assert!(script.contains("${HOME:-}"));
+        assert!(script.contains("getent passwd"));
+        assert!(script.contains(".codex/auth.json"));
+        assert!(!script.contains("/root/.codex/auth.json"));
     }
 }

--- a/apps/symphony/src/docker.rs
+++ b/apps/symphony/src/docker.rs
@@ -8,6 +8,7 @@ use crate::error::{Result, SymphonyError};
 
 pub type DockerAuthArgs = (Vec<(String, String)>, Vec<String>);
 const ROOT_USER: &str = "root";
+const ROOT_UID: &str = "0";
 const SETUP_SCRIPT_PATH: &str = "/tmp/symphony-setup.sh";
 const CODEX_AUTH_STAGING_PATH: &str = "/tmp/symphony-codex-auth.json";
 
@@ -376,10 +377,24 @@ USER {base_image_user}\n"
 }
 
 async fn install_mounted_codex_auth(container_id: &str) -> Result<()> {
+    let identity = container_identity(container_id).await?;
     let script = codex_auth_install_script();
-    let output = Command::new("docker")
+    let mut command = Command::new("docker");
+    command
         .arg("exec")
         .arg("-i")
+        .arg("-u")
+        .arg(ROOT_UID)
+        .arg("-e")
+        .arg(format!("SYMPHONY_RUNTIME_UID={}", identity.uid))
+        .arg("-e")
+        .arg(format!("SYMPHONY_RUNTIME_GID={}", identity.gid));
+    if let Some(home) = identity.home {
+        command
+            .arg("-e")
+            .arg(format!("SYMPHONY_RUNTIME_HOME={home}"));
+    }
+    let output = command
         .arg(container_id)
         .arg("sh")
         .arg("-lc")
@@ -398,13 +413,73 @@ async fn install_mounted_codex_auth(container_id: &str) -> Result<()> {
     }
 }
 
+#[derive(Debug)]
+struct ContainerIdentity {
+    uid: String,
+    gid: String,
+    home: Option<String>,
+}
+
+async fn container_identity(container_id: &str) -> Result<ContainerIdentity> {
+    let output = exec_in_container(
+        container_id,
+        "printf 'uid=%s\\ngid=%s\\nhome=%s\\n' \"$(id -u)\" \"$(id -g)\" \"${HOME:-}\"",
+    )
+    .await
+    .map_err(|err| {
+        SymphonyError::DockerAuthError(format!(
+            "failed to resolve runtime user identity before auth install: {err}"
+        ))
+    })?;
+
+    let mut uid: Option<String> = None;
+    let mut gid: Option<String> = None;
+    let mut home: Option<String> = None;
+
+    for line in output.lines() {
+        if let Some(value) = line.strip_prefix("uid=") {
+            uid = Some(value.to_string());
+        } else if let Some(value) = line.strip_prefix("gid=") {
+            gid = Some(value.to_string());
+        } else if let Some(value) = line.strip_prefix("home=") {
+            home = Some(value.to_string());
+        }
+    }
+
+    let uid = uid
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            SymphonyError::DockerAuthError(
+                "failed to resolve runtime uid before auth install".to_string(),
+            )
+        })?;
+    let gid = gid
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            SymphonyError::DockerAuthError(
+                "failed to resolve runtime gid before auth install".to_string(),
+            )
+        })?;
+
+    Ok(ContainerIdentity {
+        uid,
+        gid,
+        home: home.filter(|value| !value.trim().is_empty()),
+    })
+}
+
 fn codex_auth_install_script() -> String {
     format!(
         "set -eu\n\
 auth_src=\"{CODEX_AUTH_STAGING_PATH}\"\n\
-home_dir=\"${{HOME:-}}\"\n\
+runtime_uid=\"${{SYMPHONY_RUNTIME_UID:-}}\"\n\
+runtime_gid=\"${{SYMPHONY_RUNTIME_GID:-}}\"\n\
+home_dir=\"${{SYMPHONY_RUNTIME_HOME:-}}\"\n\
+if [ -z \"$home_dir\" ] && [ -n \"$runtime_uid\" ]; then\n\
+  home_dir=\"$(getent passwd \"$runtime_uid\" | cut -d: -f6 2>/dev/null || true)\"\n\
+fi\n\
 if [ -z \"$home_dir\" ]; then\n\
-  home_dir=\"$(getent passwd \"$(id -u)\" | cut -d: -f6 2>/dev/null || true)\"\n\
+  home_dir=\"${{HOME:-}}\"\n\
 fi\n\
 if [ -z \"$home_dir\" ]; then\n\
   home_dir=\"$(cd && pwd)\"\n\
@@ -415,6 +490,13 @@ if [ -z \"$home_dir\" ]; then\n\
 fi\n\
 mkdir -p \"$home_dir/.codex\"\n\
 cp \"$auth_src\" \"$home_dir/.codex/auth.json\"\n\
+if [ -n \"$runtime_uid\" ]; then\n\
+  if [ -n \"$runtime_gid\" ]; then\n\
+    chown \"$runtime_uid:$runtime_gid\" \"$home_dir/.codex\" \"$home_dir/.codex/auth.json\"\n\
+  else\n\
+    chown \"$runtime_uid\" \"$home_dir/.codex\" \"$home_dir/.codex/auth.json\"\n\
+  fi\n\
+fi\n\
 chmod 600 \"$home_dir/.codex/auth.json\""
     )
 }
@@ -495,6 +577,9 @@ mod tests {
     #[test]
     fn test_codex_auth_install_script_uses_dynamic_home_path() {
         let script = codex_auth_install_script();
+        assert!(script.contains("SYMPHONY_RUNTIME_UID"));
+        assert!(script.contains("SYMPHONY_RUNTIME_HOME"));
+        assert!(script.contains("chown \"$runtime_uid:$runtime_gid\""));
         assert!(script.contains("${HOME:-}"));
         assert!(script.contains("getent passwd"));
         assert!(script.contains(".codex/auth.json"));

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -258,7 +258,7 @@ pub struct DockerConfig {
     pub codex_auth: DockerCodexAuth,
     /// Additional environment variables passed to the container.
     pub env: Vec<String>,
-    /// Additional volume mounts (e.g. "~/.ssh:/root/.ssh:ro").
+    /// Additional volume mounts (e.g. "~/.ssh:/home/node/.ssh:ro").
     pub volumes: Vec<String>,
 }
 

--- a/apps/symphony/tests/docker_integration_tests.rs
+++ b/apps/symphony/tests/docker_integration_tests.rs
@@ -3,6 +3,7 @@
 
 use chrono::Utc;
 use serial_test::serial;
+use std::os::unix::fs::PermissionsExt;
 use tempfile::tempdir;
 use tokio::process::Command;
 
@@ -223,7 +224,13 @@ async fn test_mount_auth_installs_in_non_root_home() {
     let home = tempdir().expect("temp home should create");
     let codex_dir = home.path().join(".codex");
     std::fs::create_dir_all(&codex_dir).expect("codex dir should create");
-    std::fs::write(codex_dir.join("auth.json"), "{}").expect("auth file should create");
+    let auth_path = codex_dir.join("auth.json");
+    std::fs::write(&auth_path, "{}").expect("auth file should create");
+    let mut permissions = std::fs::metadata(&auth_path)
+        .expect("auth file metadata should exist")
+        .permissions();
+    permissions.set_mode(0o600);
+    std::fs::set_permissions(&auth_path, permissions).expect("auth file permissions should update");
     std::env::set_var("HOME", home.path());
 
     let issue = make_issue(unique_identifier("KAT-903-mount"));

--- a/apps/symphony/tests/docker_integration_tests.rs
+++ b/apps/symphony/tests/docker_integration_tests.rs
@@ -3,6 +3,7 @@
 
 use chrono::Utc;
 use serial_test::serial;
+use tempfile::tempdir;
 use tokio::process::Command;
 
 use symphony::docker;
@@ -37,6 +38,46 @@ fn make_issue(identifier: String) -> Issue {
         created_at: Some(Utc::now()),
         updated_at: Some(Utc::now()),
     }
+}
+
+fn non_root_worker_dockerfile() -> &'static str {
+    r#"
+FROM alpine:3.20
+RUN adduser -D -u 10001 symphony
+ENV HOME=/home/symphony
+WORKDIR /workspace
+USER symphony
+"#
+}
+
+async fn build_image(tag: &str, dockerfile: &str) {
+    let dir = tempdir().expect("tempdir should create");
+    let dockerfile_path = dir.path().join("Dockerfile");
+    std::fs::write(&dockerfile_path, dockerfile).expect("Dockerfile write should succeed");
+
+    let output = Command::new("docker")
+        .arg("build")
+        .arg("-t")
+        .arg(tag)
+        .arg("-f")
+        .arg(dockerfile_path.as_os_str())
+        .arg(dir.path().as_os_str())
+        .output()
+        .await
+        .expect("docker build should run");
+
+    assert!(
+        output.status.success(),
+        "docker build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+async fn remove_image(tag: &str) {
+    let _ = Command::new("docker")
+        .args(["rmi", "-f", tag])
+        .output()
+        .await;
 }
 
 #[tokio::test]
@@ -162,4 +203,187 @@ async fn test_auth_resolution_auto() {
     } else {
         std::env::remove_var("OPENAI_API_KEY");
     }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_mount_auth_installs_in_non_root_home() {
+    if !docker_tests_enabled() {
+        return;
+    }
+
+    if !docker::is_docker_available().await {
+        return;
+    }
+
+    let tag = unique_identifier("kat-903-non-root-mount");
+    build_image(&tag, non_root_worker_dockerfile()).await;
+
+    let previous_home = std::env::var("HOME").ok();
+    let home = tempdir().expect("temp home should create");
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).expect("codex dir should create");
+    std::fs::write(codex_dir.join("auth.json"), "{}").expect("auth file should create");
+    std::env::set_var("HOME", home.path());
+
+    let issue = make_issue(unique_identifier("KAT-903-mount"));
+    let docker_config = DockerConfig {
+        codex_auth: DockerCodexAuth::Mount,
+        ..DockerConfig::default()
+    };
+
+    let container_id = docker::start_container(&tag, &issue, &docker_config, &[])
+        .await
+        .expect("container should start");
+
+    let uid = docker::exec_in_container(&container_id, "id -u")
+        .await
+        .expect("id lookup should succeed");
+    assert_ne!(uid.trim(), "0", "worker container should run as non-root");
+
+    let auth_present = docker::exec_in_container(
+        &container_id,
+        "test -f \"$HOME/.codex/auth.json\" && echo present",
+    )
+    .await
+    .expect("auth file probe should succeed");
+    assert_eq!(auth_present.trim(), "present");
+
+    docker::stop_container(&container_id)
+        .await
+        .expect("container should stop");
+
+    if let Some(value) = previous_home {
+        std::env::set_var("HOME", value);
+    } else {
+        std::env::remove_var("HOME");
+    }
+
+    remove_image(&tag).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_env_auth_mode_works_in_non_root_container() {
+    if !docker_tests_enabled() {
+        return;
+    }
+
+    if !docker::is_docker_available().await {
+        return;
+    }
+
+    let tag = unique_identifier("kat-903-non-root-env");
+    build_image(&tag, non_root_worker_dockerfile()).await;
+
+    let previous_api_key = std::env::var("OPENAI_API_KEY").ok();
+    std::env::set_var("OPENAI_API_KEY", "sk-test-env-mode");
+
+    let issue = make_issue(unique_identifier("KAT-903-env"));
+    let docker_config = DockerConfig {
+        codex_auth: DockerCodexAuth::Env,
+        ..DockerConfig::default()
+    };
+
+    let container_id = docker::start_container(&tag, &issue, &docker_config, &[])
+        .await
+        .expect("container should start");
+
+    let uid = docker::exec_in_container(&container_id, "id -u")
+        .await
+        .expect("id lookup should succeed");
+    assert_ne!(uid.trim(), "0", "worker container should run as non-root");
+
+    let api_key = docker::exec_in_container(&container_id, "printenv OPENAI_API_KEY")
+        .await
+        .expect("OPENAI_API_KEY should be present");
+    assert_eq!(api_key.trim(), "sk-test-env-mode");
+
+    docker::stop_container(&container_id)
+        .await
+        .expect("container should stop");
+
+    if let Some(value) = previous_api_key {
+        std::env::set_var("OPENAI_API_KEY", value);
+    } else {
+        std::env::remove_var("OPENAI_API_KEY");
+    }
+
+    remove_image(&tag).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_setup_script_runs_as_root_and_restores_non_root_default_user() {
+    if !docker_tests_enabled() {
+        return;
+    }
+
+    if !docker::is_docker_available().await {
+        return;
+    }
+
+    let base_tag = unique_identifier("kat-903-setup-base");
+    build_image(&base_tag, non_root_worker_dockerfile()).await;
+
+    let setup_dir = tempdir().expect("setup tempdir should create");
+    let setup_script = setup_dir.path().join("setup.sh");
+    std::fs::write(
+        &setup_script,
+        "#!/bin/sh\nset -eu\nif [ \"$(id -u)\" -ne 0 ]; then echo \"setup must run as root\" >&2; exit 1; fi\ntouch /tmp/kat-903-setup-ran\n",
+    )
+    .expect("setup script write should succeed");
+
+    let derived_image = docker::resolve_image(
+        &base_tag,
+        Some(
+            setup_script
+                .to_str()
+                .expect("setup path should be valid UTF-8"),
+        ),
+    )
+    .await
+    .expect("derived image should build");
+
+    let previous_api_key = std::env::var("OPENAI_API_KEY").ok();
+    std::env::set_var("OPENAI_API_KEY", "sk-test-setup");
+
+    let issue = make_issue(unique_identifier("KAT-903-setup"));
+    let docker_config = DockerConfig {
+        codex_auth: DockerCodexAuth::Env,
+        ..DockerConfig::default()
+    };
+    let container_id = docker::start_container(&derived_image, &issue, &docker_config, &[])
+        .await
+        .expect("container should start");
+
+    let uid = docker::exec_in_container(&container_id, "id -u")
+        .await
+        .expect("id lookup should succeed");
+    assert_ne!(
+        uid.trim(),
+        "0",
+        "derived image should restore non-root user"
+    );
+
+    let setup_marker = docker::exec_in_container(
+        &container_id,
+        "test -f /tmp/kat-903-setup-ran && echo present",
+    )
+    .await
+    .expect("setup marker check should succeed");
+    assert_eq!(setup_marker.trim(), "present");
+
+    docker::stop_container(&container_id)
+        .await
+        .expect("container should stop");
+
+    if let Some(value) = previous_api_key {
+        std::env::set_var("OPENAI_API_KEY", value);
+    } else {
+        std::env::remove_var("OPENAI_API_KEY");
+    }
+
+    remove_image(&derived_image).await;
+    remove_image(&base_tag).await;
 }

--- a/apps/symphony/tests/docker_integration_tests.rs
+++ b/apps/symphony/tests/docker_integration_tests.rs
@@ -45,6 +45,7 @@ fn non_root_worker_dockerfile() -> &'static str {
     r#"
 FROM alpine:3.20
 RUN adduser -D -u 10001 symphony
+RUN mkdir -p /workspace && chown symphony:symphony /workspace
 ENV HOME=/home/symphony
 WORKDIR /workspace
 USER symphony
@@ -74,11 +75,50 @@ async fn build_image(tag: &str, dockerfile: &str) {
     );
 }
 
-async fn remove_image(tag: &str) {
-    let _ = Command::new("docker")
+fn remove_image_sync(tag: &str) {
+    let _ = std::process::Command::new("docker")
         .args(["rmi", "-f", tag])
-        .output()
-        .await;
+        .output();
+}
+
+struct ImageCleanupGuard {
+    tag: String,
+}
+
+impl ImageCleanupGuard {
+    fn new(tag: impl Into<String>) -> Self {
+        Self { tag: tag.into() }
+    }
+}
+
+impl Drop for ImageCleanupGuard {
+    fn drop(&mut self) {
+        remove_image_sync(&self.tag);
+    }
+}
+
+struct EnvRestoreGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvRestoreGuard {
+    fn capture(key: &'static str) -> Self {
+        Self {
+            key,
+            previous: std::env::var(key).ok(),
+        }
+    }
+}
+
+impl Drop for EnvRestoreGuard {
+    fn drop(&mut self) {
+        if let Some(value) = &self.previous {
+            std::env::set_var(self.key, value);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
 }
 
 #[tokio::test]
@@ -219,8 +259,9 @@ async fn test_mount_auth_installs_in_non_root_home() {
 
     let tag = unique_identifier("kat-903-non-root-mount");
     build_image(&tag, non_root_worker_dockerfile()).await;
+    let _image_cleanup = ImageCleanupGuard::new(tag.clone());
 
-    let previous_home = std::env::var("HOME").ok();
+    let _home_restore = EnvRestoreGuard::capture("HOME");
     let home = tempdir().expect("temp home should create");
     let codex_dir = home.path().join(".codex");
     std::fs::create_dir_all(&codex_dir).expect("codex dir should create");
@@ -259,14 +300,6 @@ async fn test_mount_auth_installs_in_non_root_home() {
     docker::stop_container(&container_id)
         .await
         .expect("container should stop");
-
-    if let Some(value) = previous_home {
-        std::env::set_var("HOME", value);
-    } else {
-        std::env::remove_var("HOME");
-    }
-
-    remove_image(&tag).await;
 }
 
 #[tokio::test]
@@ -282,8 +315,9 @@ async fn test_env_auth_mode_works_in_non_root_container() {
 
     let tag = unique_identifier("kat-903-non-root-env");
     build_image(&tag, non_root_worker_dockerfile()).await;
+    let _image_cleanup = ImageCleanupGuard::new(tag.clone());
 
-    let previous_api_key = std::env::var("OPENAI_API_KEY").ok();
+    let _api_key_restore = EnvRestoreGuard::capture("OPENAI_API_KEY");
     std::env::set_var("OPENAI_API_KEY", "sk-test-env-mode");
 
     let issue = make_issue(unique_identifier("KAT-903-env"));
@@ -309,14 +343,6 @@ async fn test_env_auth_mode_works_in_non_root_container() {
     docker::stop_container(&container_id)
         .await
         .expect("container should stop");
-
-    if let Some(value) = previous_api_key {
-        std::env::set_var("OPENAI_API_KEY", value);
-    } else {
-        std::env::remove_var("OPENAI_API_KEY");
-    }
-
-    remove_image(&tag).await;
 }
 
 #[tokio::test]
@@ -332,6 +358,7 @@ async fn test_setup_script_runs_as_root_and_restores_non_root_default_user() {
 
     let base_tag = unique_identifier("kat-903-setup-base");
     build_image(&base_tag, non_root_worker_dockerfile()).await;
+    let _base_image_cleanup = ImageCleanupGuard::new(base_tag.clone());
 
     let setup_dir = tempdir().expect("setup tempdir should create");
     let setup_script = setup_dir.path().join("setup.sh");
@@ -351,8 +378,9 @@ async fn test_setup_script_runs_as_root_and_restores_non_root_default_user() {
     )
     .await
     .expect("derived image should build");
+    let _derived_image_cleanup = ImageCleanupGuard::new(derived_image.clone());
 
-    let previous_api_key = std::env::var("OPENAI_API_KEY").ok();
+    let _api_key_restore = EnvRestoreGuard::capture("OPENAI_API_KEY");
     std::env::set_var("OPENAI_API_KEY", "sk-test-setup");
 
     let issue = make_issue(unique_identifier("KAT-903-setup"));
@@ -384,13 +412,4 @@ async fn test_setup_script_runs_as_root_and_restores_non_root_default_user() {
     docker::stop_container(&container_id)
         .await
         .expect("container should stop");
-
-    if let Some(value) = previous_api_key {
-        std::env::set_var("OPENAI_API_KEY", value);
-    } else {
-        std::env::remove_var("OPENAI_API_KEY");
-    }
-
-    remove_image(&derived_image).await;
-    remove_image(&base_tag).await;
 }

--- a/apps/symphony/tests/docker_tests.rs
+++ b/apps/symphony/tests/docker_tests.rs
@@ -87,9 +87,27 @@ fn test_resolve_codex_auth_auto_with_auth_json() {
     let (env_vars, volumes) = resolve_codex_auth(DockerCodexAuth::Auto).unwrap();
     assert!(env_vars.is_empty());
     assert_eq!(volumes.len(), 1);
-    assert!(volumes[0].contains(".codex/auth.json:/root/.codex/auth.json:ro"));
+    assert!(volumes[0].contains(".codex/auth.json:/tmp/symphony-codex-auth.json:ro"));
 
     restore_env("OPENAI_API_KEY", prev_api_key);
+    restore_env("HOME", prev_home);
+}
+
+#[test]
+#[serial]
+fn test_resolve_codex_auth_mount_with_auth_json() {
+    let prev_home = std::env::var("HOME").ok();
+    let home = tempdir().unwrap();
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    std::fs::write(codex_dir.join("auth.json"), "{}").unwrap();
+    std::env::set_var("HOME", home.path());
+
+    let (env_vars, volumes) = resolve_codex_auth(DockerCodexAuth::Mount).unwrap();
+    assert!(env_vars.is_empty());
+    assert_eq!(volumes.len(), 1);
+    assert!(volumes[0].contains(".codex/auth.json:/tmp/symphony-codex-auth.json:ro"));
+
     restore_env("HOME", prev_home);
 }
 

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -398,7 +398,7 @@ workspace:
       - FOO=bar
       - BAR=baz
     volumes:
-      - ~/.ssh:/root/.ssh:ro
+      - ~/.ssh:/home/node/.ssh:ro
 "#;
     let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
     let config = from_workflow(&raw).expect("full docker config should parse");
@@ -412,7 +412,7 @@ workspace:
         vec!["FOO=bar".to_string(), "BAR=baz".to_string()]
     );
     assert_eq!(docker.volumes.len(), 1);
-    assert!(docker.volumes[0].contains(".ssh:/root/.ssh:ro"));
+    assert!(docker.volumes[0].contains(".ssh:/home/node/.ssh:ro"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- run the Symphony Docker worker image as a dedicated non-root user (`node`) by default
- remove hardcoded `/root` auth mount assumptions by staging host auth and installing it into `$HOME/.codex/auth.json` inside the container
- preserve setup-script layering by forcing setup `RUN` steps as root and restoring the base image default user afterward
- update Docker docs/examples and parser tests to reflect non-root mount paths
- add Docker integration tests that validate mount auth mode, env auth mode, and setup-script build behavior under non-root execution

## Validation
- `cd apps/symphony && cargo build`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `cd apps/symphony && SYMPHONY_DOCKER_TESTS=1 cargo test --test docker_integration_tests test_mount_auth_installs_in_non_root_home -- --exact --nocapture`
- `cd apps/symphony && SYMPHONY_DOCKER_TESTS=1 cargo test --test docker_integration_tests test_env_auth_mode_works_in_non_root_container -- --exact --nocapture`
- `cd apps/symphony && SYMPHONY_DOCKER_TESTS=1 cargo test --test docker_integration_tests test_setup_script_runs_as_root_and_restores_non_root_default_user -- --exact --nocapture`

## Linear
- KAT-903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker worker containers now run as non-root users by default
  * Automatic detection and preservation of base image's default user configuration
  * Enhanced Codex authentication file handling for non-root environments
  * Setup scripts can execute with elevated privileges while reverting to non-root runtime

* **Tests**
  * Added integration test coverage for non-root container operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens Docker worker isolation by running containers as a dedicated non-root `node` user, replacing the previous hardcoded `/root` path assumptions with dynamic home-directory resolution. The key changes are: the bundled `Dockerfile.worker` now ends with `USER node`; `resolve_codex_auth` stages the host auth file at `/tmp/symphony-codex-auth.json` instead of directly mounting it into a hardcoded root path; a new `install_mounted_codex_auth` step runs a shell script inside the just-started container to locate `$HOME` at runtime and copy the file there with `chmod 600`; and the derived-image Dockerfile generator wraps setup scripts in `USER root` / `USER <original_user>` so setup always runs as root regardless of the base image's default user. New integration tests validate all three auth modes under a non-root Alpine-based image.

Key points from the review:

- **Cache invalidation gap (P1):** `derived_image_tag` hashes only `base_image + setup_content`, not the Dockerfile template. Existing cached derived images built before this PR don't include the `USER root` / `USER <original_user>` directives and will be served from cache unchanged, leaving users on the old behavior until they manually remove those Docker images.
- **`getent` not available on Alpine (P2):** The home-directory fallback chain in `codex_auth_install_script` calls `getent passwd`, which is absent on Alpine (musl libc). The `|| true` silences the error but the next fallback (`cd && pwd`) also depends on `$HOME` being set by the login shell — a direct `/etc/passwd` parse would be a more portable intermediate step.
- **Test image `/workspace` is root-owned (P2):** `non_root_worker_dockerfile()` sets `WORKDIR /workspace` before `USER symphony`, leaving the directory root-owned, unlike the real `Dockerfile.worker` which explicitly `chown`s it. Tests pass because they don't write there, but it's inconsistent and could mislead users.
- **No cleanup on panic in integration tests (P2):** If any assertion fails between `build_image` and `remove_image`, the test images and mutated env vars are not cleaned up.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with the understanding that existing users with cached derived images will need to manually purge them to get the non-root user restoration behavior.
- The implementation is correct for new setups and well-tested. The P1 cache-key issue means upgrading users could silently continue using stale derived images built without the new USER directives, but this does not cause data loss or a security regression — it just delays the benefit of this PR for existing caches. All other issues are minor style/robustness concerns.
- apps/symphony/src/docker.rs — the derived_image_tag cache key and the codex_auth_install_script fallback chain warrant close attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/docker.rs | Core implementation for non-root user support: adds staging-based auth installation, derived-image Dockerfile generation with root/restore pattern, and dynamic home-dir resolution. Cache key does not include the Dockerfile template version, risking stale derived images for existing users. |
| apps/symphony/docker/Dockerfile.worker | Correctly adds /workspace chown, ENV HOME, and USER node as the final step to switch the bundled worker image to a non-root runtime user. |
| apps/symphony/tests/docker_integration_tests.rs | Good coverage for mount-auth, env-auth, and setup-script scenarios under a non-root container user. Minor issues: test helper image leaves /workspace root-owned (unlike the real worker), and no cleanup guard on assertion failure leaves images behind. |
| apps/symphony/tests/docker_tests.rs | Updated unit tests correctly verify that the staging mount path changed from /root/.codex/auth.json to /tmp/symphony-codex-auth.json; new test_resolve_codex_auth_mount_with_auth_json is a valid addition. |
| apps/symphony/src/domain.rs | Trivial doc-comment update reflecting the new /home/node volume mount example. No logic changes. |
| apps/symphony/tests/workflow_config_tests.rs | Parser test YAML and assertion updated from /root/.ssh to /home/node/.ssh to match new default user home. Straightforward change. |
| apps/symphony/README.md | Documentation updated to reflect non-root default user and staging-based auth installation semantics. Accurate and consistent with the implementation. |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Reference docs updated with non-root user note and corrected volume mount example. No issues. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[start_container called] --> B[resolve_codex_auth]
    B --> C{auth mode?}

    C -->|Mount or Auto without env var| D[Stage host credentials file as read-only bind mount at /tmp staging path]
    D --> E[docker run -d with staging mount and sleep infinity]
    E --> F[install_mounted_codex_auth]
    F --> G{HOME resolution inside container}
    G -->|HOME env set| H[Use HOME env var]
    G -->|HOME empty| I[Try getent passwd lookup]
    G -->|getent missing| J[Fall back to cd and pwd]
    H --> K[mkdir -p HOME/.codex]
    I --> K
    J --> K
    K --> L[cp staging file to HOME/.codex/auth.json]
    L --> M[chmod 600]
    M --> N[Return container_id]

    C -->|Env mode| O[Inject API key as environment variable]
    O --> P[docker run -d with env var and sleep infinity]
    P --> N

    Q[resolve_image called with setup script] --> R[inspect_image_default_user]
    R -->|user found| S[derived_image_dockerfile]
    R -->|image not local| T[docker pull then inspect]
    T --> S
    S --> U["Dockerfile: FROM base, USER root, RUN setup, USER original_user"]
    U --> V[docker build derived image with versioned tag]
    V --> W[Return derived tag]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/src/docker.rs`, line 42-48 ([link](https://github.com/gannonh/kata/blob/e9aadc426417ee34832878524aec877281aaa5f6/apps/symphony/src/docker.rs#L42-L48)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Derived-image cache key doesn't include Dockerfile template version**

   `derived_image_tag` hashes only `base_image + setup_content`, so any existing cached image built with the *old* Dockerfile template (no `USER root` / `USER <original_user>` directives) will be served from cache unchanged after this upgrade. Users with pre-existing derived images won't get the non-root user restoration until they manually purge those Docker images.

   The fix is to include a template-version salt in the hash:

   ```rust
   let tag = derived_image_tag(base_image, &setup_content);
   ```

   Consider something like:

   ```rust
   // Bump this constant whenever the derived Dockerfile template changes.
   const DOCKERFILE_TEMPLATE_VERSION: &str = "v2"; // v1 was the pre-non-root-user template

   pub fn derived_image_tag(base_image: &str, setup_content: &str) -> String {
       // include template version in hash input so stale caches are invalidated
       let versioned = format!("{DOCKERFILE_TEMPLATE_VERSION}\0{base_image}\0{setup_content}");
       // ... hash versioned ...
   }
   ```

   Without this, the cache check at line 42 will hit on an old image and return before `build_derived_image` (which uses the new template) is ever called.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/docker.rs
   Line: 42-48

   Comment:
   **Derived-image cache key doesn't include Dockerfile template version**

   `derived_image_tag` hashes only `base_image + setup_content`, so any existing cached image built with the *old* Dockerfile template (no `USER root` / `USER <original_user>` directives) will be served from cache unchanged after this upgrade. Users with pre-existing derived images won't get the non-root user restoration until they manually purge those Docker images.

   The fix is to include a template-version salt in the hash:

   ```rust
   let tag = derived_image_tag(base_image, &setup_content);
   ```

   Consider something like:

   ```rust
   // Bump this constant whenever the derived Dockerfile template changes.
   const DOCKERFILE_TEMPLATE_VERSION: &str = "v2"; // v1 was the pre-non-root-user template

   pub fn derived_image_tag(base_image: &str, setup_content: &str) -> String {
       // include template version in hash input so stale caches are invalidated
       let versioned = format!("{DOCKERFILE_TEMPLATE_VERSION}\0{base_image}\0{setup_content}");
       // ... hash versioned ...
   }
   ```

   Without this, the cache check at line 42 will hit on an old image and return before `build_derived_image` (which uses the new template) is ever called.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/docker.rs
Line: 42-48

Comment:
**Derived-image cache key doesn't include Dockerfile template version**

`derived_image_tag` hashes only `base_image + setup_content`, so any existing cached image built with the *old* Dockerfile template (no `USER root` / `USER <original_user>` directives) will be served from cache unchanged after this upgrade. Users with pre-existing derived images won't get the non-root user restoration until they manually purge those Docker images.

The fix is to include a template-version salt in the hash:

```rust
let tag = derived_image_tag(base_image, &setup_content);
```

Consider something like:

```rust
// Bump this constant whenever the derived Dockerfile template changes.
const DOCKERFILE_TEMPLATE_VERSION: &str = "v2"; // v1 was the pre-non-root-user template

pub fn derived_image_tag(base_image: &str, setup_content: &str) -> String {
    // include template version in hash input so stale caches are invalidated
    let versioned = format!("{DOCKERFILE_TEMPLATE_VERSION}\0{base_image}\0{setup_content}");
    // ... hash versioned ...
}
```

Without this, the cache check at line 42 will hit on an old image and return before `build_derived_image` (which uses the new template) is ever called.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/tests/docker_integration_tests.rs
Line: 43-51

Comment:
**Test image `/workspace` is root-owned, unlike the real worker image**

`WORKDIR /workspace` runs before `USER symphony`, so the directory is created and owned by root. The real `Dockerfile.worker` explicitly does `RUN mkdir -p /workspace && chown -R node:node /workspace` to give the non-root user write access.

This inconsistency means any test that tries to write to `/workspace` inside this image would fail with a permission error, even though the same operation works in production. It could also mislead users who copy this as a reference for building their own images.

```suggestion
fn non_root_worker_dockerfile() -> &'static str {
    r#"
FROM alpine:3.20
RUN adduser -D -u 10001 symphony
RUN mkdir -p /workspace && chown symphony:symphony /workspace
ENV HOME=/home/symphony
WORKDIR /workspace
USER symphony
"#
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/tests/docker_integration_tests.rs
Line: 210-263

Comment:
**No cleanup on panic — test images may be left behind on assertion failure**

If any assertion between `build_image` and `remove_image` panics (e.g. `assert_ne!(uid.trim(), "0", ...)` fails), `remove_image(&tag)` is never reached and the image persists in the local Docker registry. The `HOME` env-var also wouldn't be restored.

This pattern repeats in all three new integration tests (`test_mount_auth_installs_in_non_root_home`, `test_env_auth_mode_works_in_non_root_container`, `test_setup_script_runs_as_root_and_restores_non_root_default_user`).

A simple mitigation is a `defer`-style RAII guard or wrapping the test body in a closure and catching panics, similar to what some test suites do:

```rust
// at the top of each test
let _cleanup = scopeguard::defer(|| {
    let rt = tokio::runtime::Handle::current();
    rt.block_on(remove_image(&tag));
    if let Some(ref val) = previous_home { std::env::set_var("HOME", val); }
    else { std::env::remove_var("HOME"); }
});
```

Even without a crate, structuring the test to call cleanup regardless (via `tokio::select!` or an explicit teardown step) would make this more robust.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/docker.rs
Line: 401-419

Comment:
**`getent` unavailable on Alpine Linux silently degrades to `cd && pwd`**

The `getent` command is part of glibc tools and is not present on Alpine Linux (musl libc). The `2>/dev/null || true` suppresses the error correctly, so the fallback chain continues to `cd && pwd`. That third fallback works in most scenarios, but only because a login shell (`sh -l`) sources `/etc/profile` which sets `$HOME` — the same value the first fallback (`${HOME:-}`) already checks.

In practice, any Alpine-based custom image built *without* an `ENV HOME=...` directive (unlike both `Dockerfile.worker` and `non_root_worker_dockerfile`) would fall through all three fallbacks and exit with "failed to resolve container home directory".

Consider adding a direct `/etc/passwd` parse as a portable middle step that works on Alpine:

```
if [ -z "$home_dir" ]; then
  uid="$(id -u)"
  home_dir="$(grep "^[^:]*:[^:]*:${uid}:" /etc/passwd | cut -d: -f6 2>/dev/null || true)"
fi
```

This works on any POSIX system with a standard `/etc/passwd` and doesn't depend on `getent`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(symphony): support non-root Docker w..."](https://github.com/gannonh/kata/commit/e9aadc426417ee34832878524aec877281aaa5f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26088574)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->