### PR TITLE
KAT-832: [S05] Project-level MCP server configuration

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -368,7 +368,7 @@ Merge rules:
 - `settings`: shallow-merged, project-local wins on collisions
 - `imports`: concatenated (`global` then `project-local`)
 
-On first use of a project's local MCP config, Kata asks for one-time confirmation before trusting and loading it.
+On first use of a project's local MCP config, Kata asks for confirmation before trusting and loading it. If the project's `mcp.json` content changes later, Kata asks again.
 
 ### Importing existing configs
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -353,6 +353,23 @@ mcp({ connect: "linear" })
 
 OAuth servers (Linear, etc.) open a browser window for authorization on first connect. Tokens are cached for subsequent sessions.
 
+### Project-local MCP config
+
+Kata also supports project-local MCP config at `<project-root>/.kata-cli/mcp.json`.
+
+At startup, Kata merges:
+
+- global `~/.kata-cli/agent/mcp.json`
+- project-local `<cwd>/.kata-cli/mcp.json`
+
+Merge rules:
+
+- `mcpServers`: merged by server name, project-local wins on collisions
+- `settings`: shallow-merged, project-local wins on collisions
+- `imports`: concatenated (`global` then `project-local`)
+
+On first use of a project's local MCP config, Kata asks for one-time confirmation before trusting and loading it.
+
 ### Importing existing configs
 
 Pull in MCP configs from other tools:

--- a/apps/cli/src/loader.ts
+++ b/apps/cli/src/loader.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "url";
 import { dirname, resolve, join } from "path";
 import { existsSync, readFileSync } from "fs";
 import { agentDir, appRoot } from "./app-paths.js";
+import { resolveEffectiveMcpConfigPath } from "./mcp-config.js";
 
 // pkg/ is a shim directory: contains kata's piConfig (package.json) and pi's
 // theme assets (dist/modes/interactive/theme/) without a src/ directory.
@@ -109,11 +110,16 @@ process.env.KATA_BUNDLED_EXTENSION_PATHS = [
   join(agentDir, "extensions", "get-secrets-from-user.ts"),
 ].join(":");
 
-// KATA_MCP_CONFIG_PATH — absolute path to Kata's MCP config file.
+// KATA_MCP_CONFIG_PATH — absolute path to the effective MCP config file.
+// If <cwd>/.kata-cli/mcp.json exists and is approved for this project, we merge it
+// with ~/.kata-cli/agent/mcp.json (project wins collisions) and point the adapter
+// at the merged file. Otherwise we fall back to ~/.kata-cli/agent/mcp.json.
 // pi-mcp-adapter reads --mcp-config from process.argv directly (before session_start fires).
-// We inject it here so the adapter uses ~/.kata-cli/agent/mcp.json instead of the
-// default ~/.pi/agent/mcp.json.
-const mcpConfigPath = join(agentDir, "mcp.json");
+const { configPath: mcpConfigPath } = await resolveEffectiveMcpConfigPath({
+  agentDir,
+  appRoot,
+  cwd: process.cwd(),
+});
 process.env.KATA_MCP_CONFIG_PATH = mcpConfigPath;
 const hasMcpConfigArg = process.argv.some(
   (arg) => arg === "--mcp-config" || arg.startsWith("--mcp-config="),

--- a/apps/cli/src/mcp-config.ts
+++ b/apps/cli/src/mcp-config.ts
@@ -1,13 +1,19 @@
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 
 type JsonObject = Record<string, unknown>;
-type ProjectMcpConsent = "approved" | "denied";
+type ProjectMcpConsentStatus = "approved" | "denied";
 
 const PROJECT_MCP_CONSENT_VERSION = 1;
 const PROJECT_MCP_CONSENT_FILE = "project-mcp-consent.json";
 const EFFECTIVE_MCP_CONFIG_FILE = "mcp.effective.json";
+
+interface ProjectMcpConsent {
+  status: ProjectMcpConsentStatus;
+  hash?: string;
+}
 
 interface ProjectMcpConsentStore {
   version: number;
@@ -73,13 +79,16 @@ export async function resolveEffectiveMcpConfigPath(
     loadMcpConfig(globalConfigPath, "global", stderr, false) ?? {};
   const projectConfig = loadMcpConfig(projectConfigPath, "project", stderr, true);
   if (!projectConfig) return fallback;
+  const projectConfigHash = hashObject(projectConfig);
 
   const consentPath = join(options.appRoot, PROJECT_MCP_CONSENT_FILE);
   const consentStore = loadProjectMcpConsentStore(consentPath, stderr);
   const consentKey = resolve(projectConfigPath);
   let consent = consentStore.projects[consentKey];
+  const consentMatchesProjectConfig =
+    consent?.status === "approved" && consent.hash === projectConfigHash;
 
-  if (!consent) {
+  if (!consentMatchesProjectConfig && consent?.status !== "denied") {
     let approved: boolean | null = null;
     if (options.confirmProjectMcpUse) {
       approved = await options.confirmProjectMcpUse(projectConfigPath);
@@ -87,7 +96,7 @@ export async function resolveEffectiveMcpConfigPath(
       options.isInteractive ??
       Boolean(process.stdin.isTTY && process.stdout.isTTY)
     ) {
-      approved = await promptForProjectMcpUse(projectConfigPath);
+      approved = await promptForProjectMcpUse(projectConfigPath, stderr);
     }
 
     if (approved === null) {
@@ -97,12 +106,14 @@ export async function resolveEffectiveMcpConfigPath(
       return fallback;
     }
 
-    consent = approved ? "approved" : "denied";
+    consent = approved
+      ? { status: "approved", hash: projectConfigHash }
+      : { status: "denied" };
     consentStore.projects[consentKey] = consent;
     saveProjectMcpConsentStore(consentPath, consentStore, stderr);
   }
 
-  if (consent !== "approved") {
+  if (consent?.status !== "approved" || consent.hash !== projectConfigHash) {
     return fallback;
   }
 
@@ -164,7 +175,17 @@ function loadProjectMcpConsentStore(
     const normalizedProjects: Record<string, ProjectMcpConsent> = {};
     for (const [key, value] of Object.entries(projects)) {
       if (value === "approved" || value === "denied") {
-        normalizedProjects[key] = value;
+        normalizedProjects[key] = { status: value };
+        continue;
+      }
+
+      const consent = asObject(value);
+      if (consent.status === "approved" || consent.status === "denied") {
+        const normalizedConsent: ProjectMcpConsent = { status: consent.status };
+        if (typeof consent.hash === "string") {
+          normalizedConsent.hash = consent.hash;
+        }
+        normalizedProjects[key] = normalizedConsent;
       }
     }
 
@@ -200,11 +221,14 @@ function saveProjectMcpConsentStore(
   }
 }
 
-async function promptForProjectMcpUse(projectConfigPath: string): Promise<boolean> {
-  process.stderr.write(
+async function promptForProjectMcpUse(
+  projectConfigPath: string,
+  stderr: Pick<NodeJS.WriteStream, "write"> = process.stderr,
+): Promise<boolean> {
+  stderr.write(
     `[kata] Project-local MCP config detected: ${projectConfigPath}\n`,
   );
-  process.stderr.write(
+  stderr.write(
     "[kata] Trust this file before Kata starts MCP servers from this project.\n",
   );
 
@@ -253,4 +277,10 @@ function writeIfChanged(path: string, nextContent: string): void {
     }
   }
   writeFileSync(path, nextContent, "utf-8");
+}
+
+function hashObject(value: JsonObject): string {
+  return createHash("sha256")
+    .update(JSON.stringify(value))
+    .digest("hex");
 }

--- a/apps/cli/src/mcp-config.ts
+++ b/apps/cli/src/mcp-config.ts
@@ -108,12 +108,9 @@ export async function resolveEffectiveMcpConfigPath(
 
   const effectiveConfigPath = join(options.agentDir, EFFECTIVE_MCP_CONFIG_FILE);
   const effectiveConfig = mergeMcpConfigs(globalConfig, projectConfig);
+  const serializedEffectiveConfig = `${JSON.stringify(effectiveConfig, null, 2)}\n`;
   try {
-    writeFileSync(
-      effectiveConfigPath,
-      `${JSON.stringify(effectiveConfig, null, 2)}\n`,
-      "utf-8",
-    );
+    writeIfChanged(effectiveConfigPath, serializedEffectiveConfig);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     stderr.write(
@@ -244,4 +241,16 @@ function asObject(value: unknown): JsonObject {
 
 function isObject(value: unknown): value is JsonObject {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function writeIfChanged(path: string, nextContent: string): void {
+  if (existsSync(path)) {
+    try {
+      const currentContent = readFileSync(path, "utf-8");
+      if (currentContent === nextContent) return;
+    } catch {
+      // Fall through and overwrite unreadable/invalid content.
+    }
+  }
+  writeFileSync(path, nextContent, "utf-8");
 }

--- a/apps/cli/src/mcp-config.ts
+++ b/apps/cli/src/mcp-config.ts
@@ -1,0 +1,247 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+
+type JsonObject = Record<string, unknown>;
+type ProjectMcpConsent = "approved" | "denied";
+
+const PROJECT_MCP_CONSENT_VERSION = 1;
+const PROJECT_MCP_CONSENT_FILE = "project-mcp-consent.json";
+const EFFECTIVE_MCP_CONFIG_FILE = "mcp.effective.json";
+
+interface ProjectMcpConsentStore {
+  version: number;
+  projects: Record<string, ProjectMcpConsent>;
+}
+
+export interface McpConfig extends JsonObject {
+  imports?: string[];
+  settings?: JsonObject;
+  mcpServers?: JsonObject;
+}
+
+export interface ResolveEffectiveMcpConfigPathOptions {
+  agentDir: string;
+  appRoot: string;
+  cwd: string;
+  confirmProjectMcpUse?: (projectConfigPath: string) => Promise<boolean>;
+  isInteractive?: boolean;
+  stderr?: Pick<NodeJS.WriteStream, "write">;
+}
+
+export interface EffectiveMcpConfigResolution {
+  configPath: string;
+  usedProjectConfig: boolean;
+  projectConfigPath: string | null;
+}
+
+export function mergeMcpConfigs(
+  globalConfig: McpConfig,
+  projectConfig: McpConfig,
+): McpConfig {
+  const globalObject = asObject(globalConfig);
+  const projectObject = asObject(projectConfig);
+  const globalSettings = asObject(globalObject.settings);
+  const projectSettings = asObject(projectObject.settings);
+  const globalServers = asObject(globalObject.mcpServers);
+  const projectServers = asObject(projectObject.mcpServers);
+
+  return {
+    ...globalObject,
+    ...projectObject,
+    imports: [...asStringArray(globalObject.imports), ...asStringArray(projectObject.imports)],
+    settings: { ...globalSettings, ...projectSettings },
+    mcpServers: { ...globalServers, ...projectServers },
+  };
+}
+
+export async function resolveEffectiveMcpConfigPath(
+  options: ResolveEffectiveMcpConfigPathOptions,
+): Promise<EffectiveMcpConfigResolution> {
+  const stderr = options.stderr ?? process.stderr;
+  const globalConfigPath = join(options.agentDir, "mcp.json");
+  const projectConfigPath = join(options.cwd, ".kata-cli", "mcp.json");
+  const fallback: EffectiveMcpConfigResolution = {
+    configPath: globalConfigPath,
+    usedProjectConfig: false,
+    projectConfigPath: null,
+  };
+
+  if (!existsSync(projectConfigPath)) return fallback;
+
+  const globalConfig =
+    loadMcpConfig(globalConfigPath, "global", stderr, false) ?? {};
+  const projectConfig = loadMcpConfig(projectConfigPath, "project", stderr, true);
+  if (!projectConfig) return fallback;
+
+  const consentPath = join(options.appRoot, PROJECT_MCP_CONSENT_FILE);
+  const consentStore = loadProjectMcpConsentStore(consentPath, stderr);
+  const consentKey = resolve(projectConfigPath);
+  let consent = consentStore.projects[consentKey];
+
+  if (!consent) {
+    let approved: boolean | null = null;
+    if (options.confirmProjectMcpUse) {
+      approved = await options.confirmProjectMcpUse(projectConfigPath);
+    } else if (
+      options.isInteractive ??
+      Boolean(process.stdin.isTTY && process.stdout.isTTY)
+    ) {
+      approved = await promptForProjectMcpUse(projectConfigPath);
+    }
+
+    if (approved === null) {
+      stderr.write(
+        `[kata] Project-local MCP config found at ${projectConfigPath}, but confirmation requires an interactive TTY. Using global MCP config.\n`,
+      );
+      return fallback;
+    }
+
+    consent = approved ? "approved" : "denied";
+    consentStore.projects[consentKey] = consent;
+    saveProjectMcpConsentStore(consentPath, consentStore, stderr);
+  }
+
+  if (consent !== "approved") {
+    return fallback;
+  }
+
+  const effectiveConfigPath = join(options.agentDir, EFFECTIVE_MCP_CONFIG_FILE);
+  const effectiveConfig = mergeMcpConfigs(globalConfig, projectConfig);
+  try {
+    writeFileSync(
+      effectiveConfigPath,
+      `${JSON.stringify(effectiveConfig, null, 2)}\n`,
+      "utf-8",
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stderr.write(
+      `[kata] Failed to write effective MCP config (${effectiveConfigPath}): ${message}. Using global MCP config.\n`,
+    );
+    return fallback;
+  }
+
+  return {
+    configPath: effectiveConfigPath,
+    usedProjectConfig: true,
+    projectConfigPath,
+  };
+}
+
+function loadMcpConfig(
+  path: string,
+  scope: "global" | "project",
+  stderr: Pick<NodeJS.WriteStream, "write">,
+  strict: boolean,
+): McpConfig | null {
+  if (!existsSync(path)) {
+    return strict ? null : {};
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    if (!isObject(parsed)) {
+      throw new Error("expected top-level JSON object");
+    }
+    return parsed as McpConfig;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stderr.write(`[kata] Invalid ${scope} MCP config at ${path}: ${message}\n`);
+    return strict ? null : {};
+  }
+}
+
+function loadProjectMcpConsentStore(
+  path: string,
+  stderr: Pick<NodeJS.WriteStream, "write">,
+): ProjectMcpConsentStore {
+  if (!existsSync(path)) {
+    return emptyProjectMcpConsentStore();
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    const parsedObject = asObject(parsed);
+    const projects = asObject(parsedObject.projects);
+    const normalizedProjects: Record<string, ProjectMcpConsent> = {};
+    for (const [key, value] of Object.entries(projects)) {
+      if (value === "approved" || value === "denied") {
+        normalizedProjects[key] = value;
+      }
+    }
+
+    return {
+      version:
+        typeof parsedObject.version === "number"
+          ? parsedObject.version
+          : PROJECT_MCP_CONSENT_VERSION,
+      projects: normalizedProjects,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stderr.write(
+      `[kata] Invalid project MCP consent store at ${path}: ${message}. Resetting consent state.\n`,
+    );
+    return emptyProjectMcpConsentStore();
+  }
+}
+
+function saveProjectMcpConsentStore(
+  path: string,
+  store: ProjectMcpConsentStore,
+  stderr: Pick<NodeJS.WriteStream, "write">,
+): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stderr.write(
+      `[kata] Failed to persist project MCP consent store at ${path}: ${message}\n`,
+    );
+  }
+}
+
+async function promptForProjectMcpUse(projectConfigPath: string): Promise<boolean> {
+  process.stderr.write(
+    `[kata] Project-local MCP config detected: ${projectConfigPath}\n`,
+  );
+  process.stderr.write(
+    "[kata] Trust this file before Kata starts MCP servers from this project.\n",
+  );
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    const answer = await rl.question(
+      "[kata] Use project-local MCP config for this project? (y/N): ",
+    );
+    return /^(y|yes)$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}
+
+function emptyProjectMcpConsentStore(): ProjectMcpConsentStore {
+  return {
+    version: PROJECT_MCP_CONSENT_VERSION,
+    projects: {},
+  };
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function asObject(value: unknown): JsonObject {
+  return isObject(value) ? value : {};
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/cli/src/mcp-config.ts
+++ b/apps/cli/src/mcp-config.ts
@@ -121,6 +121,7 @@ export async function resolveEffectiveMcpConfigPath(
   const effectiveConfig = mergeMcpConfigs(globalConfig, projectConfig);
   const serializedEffectiveConfig = `${JSON.stringify(effectiveConfig, null, 2)}\n`;
   try {
+    mkdirSync(dirname(effectiveConfigPath), { recursive: true });
     writeIfChanged(effectiveConfigPath, serializedEffectiveConfig);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/apps/cli/src/tests/mcp-config.test.ts
+++ b/apps/cli/src/tests/mcp-config.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -177,7 +178,72 @@ test("resolveEffectiveMcpConfigPath merges approved project config and persists 
     const consent = JSON.parse(readFileSync(consentPath, "utf-8"));
     assert.equal(consent.version, 1);
     const expectedConsentKey = resolve(join(projectMcpDir, "mcp.json"));
-    assert.equal(consent.projects[expectedConsentKey], "approved");
+    const expectedConsentHash = createHash("sha256")
+      .update(
+        JSON.stringify(
+          JSON.parse(readFileSync(join(projectMcpDir, "mcp.json"), "utf-8")),
+        ),
+      )
+      .digest("hex");
+    assert.deepEqual(consent.projects[expectedConsentKey], {
+      status: "approved",
+      hash: expectedConsentHash,
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveEffectiveMcpConfigPath requires reconfirmation after approved project config changes", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-reconfirm-"));
+  const agentDir = join(tmp, "agent");
+  const appRoot = join(tmp, ".kata-cli");
+  const cwd = join(tmp, "project");
+  const projectMcpDir = join(cwd, ".kata-cli");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(projectMcpDir, { recursive: true });
+
+  writeFileSync(
+    join(agentDir, "mcp.json"),
+    JSON.stringify({ imports: [], settings: {}, mcpServers: {} }, null, 2),
+  );
+  const projectConfigPath = join(projectMcpDir, "mcp.json");
+  writeFileSync(
+    projectConfigPath,
+    JSON.stringify({ imports: ["cursor"], settings: {}, mcpServers: {} }, null, 2),
+  );
+
+  let promptCount = 0;
+  const confirm = async () => {
+    promptCount += 1;
+    return true;
+  };
+
+  try {
+    const first = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      confirmProjectMcpUse: confirm,
+      isInteractive: false,
+    });
+    assert.equal(first.usedProjectConfig, true);
+    assert.equal(promptCount, 1);
+
+    writeFileSync(
+      projectConfigPath,
+      JSON.stringify({ imports: ["cursor", "vscode"], settings: {}, mcpServers: {} }, null, 2),
+    );
+
+    const second = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      confirmProjectMcpUse: confirm,
+      isInteractive: false,
+    });
+    assert.equal(second.usedProjectConfig, true);
+    assert.equal(promptCount, 2);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/apps/cli/src/tests/mcp-config.test.ts
+++ b/apps/cli/src/tests/mcp-config.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { mergeMcpConfigs, resolveEffectiveMcpConfigPath } from "../mcp-config.ts";
 
@@ -63,6 +63,52 @@ test("resolveEffectiveMcpConfigPath returns global config when no project config
     assert.equal(result.configPath, globalPath);
     assert.equal(result.usedProjectConfig, false);
     assert.equal(result.projectConfigPath, null);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveEffectiveMcpConfigPath merges approved project config when global config is missing", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-no-global-"));
+  const agentDir = join(tmp, "agent");
+  const appRoot = join(tmp, ".kata-cli");
+  const cwd = join(tmp, "project");
+  const projectMcpDir = join(cwd, ".kata-cli");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(projectMcpDir, { recursive: true });
+
+  writeFileSync(
+    join(projectMcpDir, "mcp.json"),
+    JSON.stringify(
+      {
+        imports: ["cursor"],
+        settings: { projectFlag: true },
+        mcpServers: {
+          projectOnly: { command: "node", args: ["x"] },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  try {
+    const result = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      confirmProjectMcpUse: async () => true,
+      isInteractive: false,
+    });
+
+    assert.equal(result.usedProjectConfig, true);
+    assert.equal(result.configPath, join(agentDir, "mcp.effective.json"));
+    assert.equal(result.projectConfigPath, join(projectMcpDir, "mcp.json"));
+
+    const merged = JSON.parse(readFileSync(result.configPath, "utf-8"));
+    assert.deepEqual(merged.imports, ["cursor"]);
+    assert.equal(merged.settings.projectFlag, true);
+    assert.ok(merged.mcpServers.projectOnly, "project-only server preserved");
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
@@ -130,7 +176,8 @@ test("resolveEffectiveMcpConfigPath merges approved project config and persists 
     assert.ok(existsSync(consentPath), "consent file persisted after approval");
     const consent = JSON.parse(readFileSync(consentPath, "utf-8"));
     assert.equal(consent.version, 1);
-    assert.equal(consent.projects[join(projectMcpDir, "mcp.json")], "approved");
+    const expectedConsentKey = resolve(join(projectMcpDir, "mcp.json"));
+    assert.equal(consent.projects[expectedConsentKey], "approved");
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
@@ -201,6 +248,112 @@ test("resolveEffectiveMcpConfigPath skips project config in non-interactive mode
     assert.equal(result.usedProjectConfig, false);
     assert.equal(result.configPath, join(agentDir, "mcp.json"));
     assert.equal(existsSync(join(appRoot, "project-mcp-consent.json")), false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveEffectiveMcpConfigPath falls back to global config when project config is invalid JSON", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-invalid-project-"));
+  const agentDir = join(tmp, "agent");
+  const appRoot = join(tmp, ".kata-cli");
+  const cwd = join(tmp, "project");
+  const projectMcpDir = join(cwd, ".kata-cli");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(projectMcpDir, { recursive: true });
+
+  const globalPath = join(agentDir, "mcp.json");
+  writeFileSync(globalPath, JSON.stringify({ imports: [], settings: {}, mcpServers: {} }, null, 2));
+  writeFileSync(join(projectMcpDir, "mcp.json"), "{ invalid json", "utf-8");
+
+  try {
+    const result = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      isInteractive: false,
+    });
+    assert.equal(result.usedProjectConfig, false);
+    assert.equal(result.configPath, globalPath);
+    assert.equal(result.projectConfigPath, null);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveEffectiveMcpConfigPath falls back to global config when writing effective file fails", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-write-fail-"));
+  const agentDir = join(tmp, "agent");
+  const appRoot = join(tmp, ".kata-cli");
+  const cwd = join(tmp, "project");
+  const projectMcpDir = join(cwd, ".kata-cli");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(projectMcpDir, { recursive: true });
+
+  const globalPath = join(agentDir, "mcp.json");
+  writeFileSync(globalPath, JSON.stringify({ imports: [], settings: {}, mcpServers: {} }, null, 2));
+  writeFileSync(
+    join(projectMcpDir, "mcp.json"),
+    JSON.stringify({ imports: ["cursor"], settings: {}, mcpServers: {} }, null, 2),
+  );
+  mkdirSync(join(agentDir, "mcp.effective.json"), { recursive: true });
+
+  try {
+    const result = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      confirmProjectMcpUse: async () => true,
+      isInteractive: false,
+    });
+    assert.equal(result.usedProjectConfig, false);
+    assert.equal(result.configPath, globalPath);
+    assert.equal(result.projectConfigPath, null);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveEffectiveMcpConfigPath does not rewrite unchanged effective config", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-no-rewrite-"));
+  const agentDir = join(tmp, "agent");
+  const appRoot = join(tmp, ".kata-cli");
+  const cwd = join(tmp, "project");
+  const projectMcpDir = join(cwd, ".kata-cli");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(projectMcpDir, { recursive: true });
+
+  writeFileSync(
+    join(agentDir, "mcp.json"),
+    JSON.stringify({ imports: ["claude-code"], settings: {}, mcpServers: {} }, null, 2),
+  );
+  writeFileSync(
+    join(projectMcpDir, "mcp.json"),
+    JSON.stringify({ imports: ["cursor"], settings: {}, mcpServers: {} }, null, 2),
+  );
+
+  try {
+    const first = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      confirmProjectMcpUse: async () => true,
+      isInteractive: false,
+    });
+    const before = statSync(first.configPath).mtimeMs;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+
+    const second = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      isInteractive: false,
+    });
+    const after = statSync(second.configPath).mtimeMs;
+
+    assert.equal(second.usedProjectConfig, true);
+    assert.equal(first.configPath, second.configPath);
+    assert.equal(after, before);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/apps/cli/src/tests/mcp-config.test.ts
+++ b/apps/cli/src/tests/mcp-config.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { mergeMcpConfigs, resolveEffectiveMcpConfigPath } from "../mcp-config.ts";
+
+test("mergeMcpConfigs applies project precedence and concatenates imports", () => {
+  const merged = mergeMcpConfigs(
+    {
+      imports: ["claude-code"],
+      settings: { toolPrefix: "server", idleTimeout: 10, globalOnly: true },
+      mcpServers: {
+        globalOnly: { command: "node", args: ["a"] },
+        shared: { command: "node", args: ["global"] },
+      },
+      topLevel: "global",
+    },
+    {
+      imports: ["cursor", "vscode"],
+      settings: { idleTimeout: 30, projectOnly: true },
+      mcpServers: {
+        shared: { command: "node", args: ["project"] },
+        projectOnly: { command: "node", args: ["b"] },
+      },
+      topLevel: "project",
+    },
+  );
+
+  assert.deepEqual(merged.imports, ["claude-code", "cursor", "vscode"]);
+  assert.deepEqual(merged.settings, {
+    toolPrefix: "server",
+    idleTimeout: 30,
+    globalOnly: true,
+    projectOnly: true,
+  });
+  assert.deepEqual(merged.mcpServers, {
+    globalOnly: { command: "node", args: ["a"] },
+    shared: { command: "node", args: ["project"] },
+    projectOnly: { command: "node", args: ["b"] },
+  });
+  assert.equal(merged.topLevel, "project");
+});
+
+test("resolveEffectiveMcpConfigPath returns global config when no project config exists", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-resolve-"));
+  const agentDir = join(tmp, "agent");
+  const appRoot = join(tmp, ".kata-cli");
+  const cwd = join(tmp, "project");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(cwd, { recursive: true });
+
+  const globalPath = join(agentDir, "mcp.json");
+  writeFileSync(globalPath, JSON.stringify({ imports: [], settings: {}, mcpServers: {} }, null, 2));
+
+  try {
+    const result = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      isInteractive: false,
+    });
+    assert.equal(result.configPath, globalPath);
+    assert.equal(result.usedProjectConfig, false);
+    assert.equal(result.projectConfigPath, null);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveEffectiveMcpConfigPath merges approved project config and persists consent", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-approved-"));
+  const agentDir = join(tmp, "agent");
+  const appRoot = join(tmp, ".kata-cli");
+  const cwd = join(tmp, "project");
+  const projectMcpDir = join(cwd, ".kata-cli");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(projectMcpDir, { recursive: true });
+
+  writeFileSync(
+    join(agentDir, "mcp.json"),
+    JSON.stringify(
+      {
+        imports: ["claude-code"],
+        settings: { idleTimeout: 10 },
+        mcpServers: { shared: { command: "node", args: ["global"] } },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    join(projectMcpDir, "mcp.json"),
+    JSON.stringify(
+      {
+        imports: ["cursor"],
+        settings: { idleTimeout: 45, projectFlag: true },
+        mcpServers: {
+          shared: { command: "node", args: ["project"] },
+          projectOnly: { command: "node", args: ["x"] },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  try {
+    const result = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      confirmProjectMcpUse: async () => true,
+      isInteractive: false,
+    });
+
+    assert.equal(result.usedProjectConfig, true);
+    assert.equal(result.projectConfigPath, join(projectMcpDir, "mcp.json"));
+    assert.equal(result.configPath, join(agentDir, "mcp.effective.json"));
+    assert.ok(existsSync(result.configPath), "effective config file is written");
+
+    const merged = JSON.parse(readFileSync(result.configPath, "utf-8"));
+    assert.deepEqual(merged.imports, ["claude-code", "cursor"]);
+    assert.equal(merged.settings.idleTimeout, 45);
+    assert.equal(merged.settings.projectFlag, true);
+    assert.deepEqual(merged.mcpServers.shared.args, ["project"]);
+    assert.ok(merged.mcpServers.projectOnly, "project-only server preserved");
+
+    const consentPath = join(appRoot, "project-mcp-consent.json");
+    assert.ok(existsSync(consentPath), "consent file persisted after approval");
+    const consent = JSON.parse(readFileSync(consentPath, "utf-8"));
+    assert.equal(consent.version, 1);
+    assert.equal(consent.projects[join(projectMcpDir, "mcp.json")], "approved");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveEffectiveMcpConfigPath stores denied decision and keeps global config", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-denied-"));
+  const agentDir = join(tmp, "agent");
+  const appRoot = join(tmp, ".kata-cli");
+  const cwd = join(tmp, "project");
+  const projectMcpDir = join(cwd, ".kata-cli");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(projectMcpDir, { recursive: true });
+
+  const globalPath = join(agentDir, "mcp.json");
+  writeFileSync(globalPath, JSON.stringify({ imports: [], settings: {}, mcpServers: {} }, null, 2));
+  writeFileSync(
+    join(projectMcpDir, "mcp.json"),
+    JSON.stringify({ imports: ["cursor"], settings: {}, mcpServers: {} }, null, 2),
+  );
+
+  try {
+    const first = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      confirmProjectMcpUse: async () => false,
+      isInteractive: false,
+    });
+    assert.equal(first.configPath, globalPath);
+    assert.equal(first.usedProjectConfig, false);
+
+    const second = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      isInteractive: false,
+    });
+    assert.equal(second.configPath, globalPath);
+    assert.equal(second.usedProjectConfig, false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveEffectiveMcpConfigPath skips project config in non-interactive mode before consent", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-non-tty-"));
+  const agentDir = join(tmp, "agent");
+  const appRoot = join(tmp, ".kata-cli");
+  const cwd = join(tmp, "project");
+  const projectMcpDir = join(cwd, ".kata-cli");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(projectMcpDir, { recursive: true });
+
+  writeFileSync(join(agentDir, "mcp.json"), JSON.stringify({ imports: [], settings: {}, mcpServers: {} }, null, 2));
+  writeFileSync(
+    join(projectMcpDir, "mcp.json"),
+    JSON.stringify({ imports: ["cursor"], settings: {}, mcpServers: {} }, null, 2),
+  );
+
+  try {
+    const result = await resolveEffectiveMcpConfigPath({
+      agentDir,
+      appRoot,
+      cwd,
+      isInteractive: false,
+    });
+    assert.equal(result.usedProjectConfig, false);
+    assert.equal(result.configPath, join(agentDir, "mcp.json"));
+    assert.equal(existsSync(join(appRoot, "project-mcp-consent.json")), false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/apps/cli/src/tests/mcp-config.test.ts
+++ b/apps/cli/src/tests/mcp-config.test.ts
@@ -69,13 +69,12 @@ test("resolveEffectiveMcpConfigPath returns global config when no project config
   }
 });
 
-test("resolveEffectiveMcpConfigPath merges approved project config when global config is missing", async () => {
+test("resolveEffectiveMcpConfigPath merges approved project config on first run when agentDir is missing", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "kata-mcp-no-global-"));
   const agentDir = join(tmp, "agent");
   const appRoot = join(tmp, ".kata-cli");
   const cwd = join(tmp, "project");
   const projectMcpDir = join(cwd, ".kata-cli");
-  mkdirSync(agentDir, { recursive: true });
   mkdirSync(projectMcpDir, { recursive: true });
 
   writeFileSync(
@@ -94,6 +93,8 @@ test("resolveEffectiveMcpConfigPath merges approved project config when global c
   );
 
   try {
+    assert.equal(existsSync(agentDir), false);
+
     const result = await resolveEffectiveMcpConfigPath({
       agentDir,
       appRoot,
@@ -105,6 +106,7 @@ test("resolveEffectiveMcpConfigPath merges approved project config when global c
     assert.equal(result.usedProjectConfig, true);
     assert.equal(result.configPath, join(agentDir, "mcp.effective.json"));
     assert.equal(result.projectConfigPath, join(projectMcpDir, "mcp.json"));
+    assert.equal(existsSync(agentDir), true);
 
     const merged = JSON.parse(readFileSync(result.configPath, "utf-8"));
     assert.deepEqual(merged.imports, ["cursor"]);


### PR DESCRIPTION
## Summary
- add startup MCP resolver to merge global `~/.kata-cli/agent/mcp.json` with project-local `<cwd>/.kata-cli/mcp.json`
- enforce merge semantics: `mcpServers` and `settings` are project-preferred, `imports` are concatenated
- add one-time per-project consent persisted at `~/.kata-cli/project-mcp-consent.json`; approved projects use merged `~/.kata-cli/agent/mcp.effective.json`
- wire loader startup to inject resolved effective config path into `--mcp-config`
- document project-local MCP behavior in CLI README

## Validation
- `cd apps/cli && npx tsc`
- `cd apps/cli && node --import ./src/resources/extensions/kata/tests/resolve-ts.mjs --experimental-strip-types --test 'src/resources/extensions/kata/tests/*.test.ts' 'src/tests/*.test.ts'`
- pre-push gate: `turbo run lint typecheck test --affected` (hook)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now resolves an "effective" MCP config by merging a project-local config (when approved) with the global config; project values take precedence.
  * User consent for using project configs is recorded; interactive approval is requested when appropriate, non-interactive runs fall back to the global config.
  * Resolved effective config is persisted so the CLI consistently uses the merged result.

* **Tests**
  * Added tests for merging behavior, consent persistence, fallback paths, and idempotent effective-config writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds project-level MCP server configuration support to the Kata CLI. At startup, `loader.ts` now calls the new `resolveEffectiveMcpConfigPath` function in `mcp-config.ts`, which merges `~/.kata-cli/agent/mcp.json` (global) with `<cwd>/.kata-cli/mcp.json` (project-local) when the latter exists and has been consented to by the user. The merged result is written to `~/.kata-cli/agent/mcp.effective.json` and injected into `--mcp-config`, falling back to the global config if no project config is found, consent is denied, or the session is non-interactive.

**Key findings:**

- **Consent is path-based, not content-based** — once a project's `mcp.json` path is approved, any future modifications to the file are automatically trusted without re-prompting. Given that the consent flow's purpose is to protect against untrusted MCP server definitions, storing a SHA-256 hash of the approved content alongside the consent status would meaningfully close this gap.
- `promptForProjectMcpUse` writes directly to `process.stderr` instead of using the injectable `stderr` parameter that the rest of the module uses, creating an inconsistency in the abstraction.
- `apps/cli/src/resources/AGENTS.md` still documents `KATA_MCP_CONFIG_PATH` as pointing to `mcp.json` — it now needs to reflect that it can also point to `mcp.effective.json`.
- The merge semantics (project wins `mcpServers`/`settings`, imports concatenated) are correctly implemented and well-tested; the fallback-on-error behavior at each step is robust.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with caution — the consent mechanism has a meaningful security gap that should be addressed before the feature is considered production-hardened.
- The implementation is well-structured with good error handling and fallback logic throughout. The main concern lowering the score is that consent is bound only to the file path, not its content — a project's `mcp.json` can be silently modified after initial approval and Kata will load the new servers without prompting the user. For a security-gating mechanism, this is a notable gap. The stale AGENTS.md doc and `stderr` inconsistency are minor style issues.
- apps/cli/src/mcp-config.ts — specifically the consent persistence logic (lines 77–103) and the `promptForProjectMcpUse` function (lines 206–227).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/mcp-config.ts | New module implementing MCP config merge logic and project-level consent flow; consent is path-based rather than content-based, meaning a modified `mcp.json` is silently trusted after initial approval — a meaningful security gap. |
| apps/cli/src/loader.ts | Wires `resolveEffectiveMcpConfigPath` into the startup sequence; change is minimal and correct — falls back to global config if resolution fails. |
| apps/cli/src/tests/mcp-config.test.ts | Good coverage of the happy path (approval/denial/non-interactive); missing a test for re-approval when the file content changes after initial consent. |
| apps/cli/README.md | Adds project-local MCP config documentation; accurate and consistent with the implementation. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant L as loader.ts
    participant R as resolveEffectiveMcpConfigPath
    participant FS as Filesystem
    participant U as User (TTY prompt)

    L->>R: resolveEffectiveMcpConfigPath({ agentDir, appRoot, cwd })
    R->>FS: existsSync(<cwd>/.kata-cli/mcp.json)
    alt No project config
        R-->>L: { configPath: ~/.kata-cli/agent/mcp.json }
    else Project config exists
        R->>FS: loadMcpConfig(globalConfigPath)
        R->>FS: loadMcpConfig(projectConfigPath)
        R->>FS: loadProjectMcpConsentStore(~/.kata-cli/project-mcp-consent.json)
        alt Consent already recorded
            note over R: use stored "approved"/"denied"
        else No consent yet
            alt confirmProjectMcpUse callback provided
                R->>U: confirmProjectMcpUse(projectConfigPath)
                U-->>R: true / false
            else Interactive TTY
                R->>U: promptForProjectMcpUse()
                U-->>R: y/N answer
            else Non-interactive, no callback
                R-->>L: fallback (global config) — no consent persisted
            end
            R->>FS: saveProjectMcpConsentStore("approved"/"denied")
        end
        alt consent === "approved"
            R->>R: mergeMcpConfigs(global, project)
            R->>FS: writeFileSync(~/.kata-cli/agent/mcp.effective.json)
            R-->>L: { configPath: mcp.effective.json, usedProjectConfig: true }
        else consent === "denied"
            R-->>L: fallback (global config)
        end
    end
    L->>L: process.env.KATA_MCP_CONFIG_PATH = configPath
    L->>L: process.argv.push("--mcp-config", configPath)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/cli/src/resources/AGENTS.md`, line 69 ([link](https://github.com/gannonh/kata/blob/7c0a53ea128cbd239caa8d55ea9859ad854bee2e/apps/cli/src/resources/AGENTS.md#L69)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`KATA_MCP_CONFIG_PATH` description is now stale**

   After this PR, `KATA_MCP_CONFIG_PATH` can point to `~/.kata-cli/agent/mcp.effective.json` instead of `mcp.json` when a project-local config is approved. The table entry should be updated to reflect the new semantics:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/AGENTS.md
   Line: 69

   Comment:
   **`KATA_MCP_CONFIG_PATH` description is now stale**

   After this PR, `KATA_MCP_CONFIG_PATH` can point to `~/.kata-cli/agent/mcp.effective.json` instead of `mcp.json` when a project-local config is approved. The table entry should be updated to reflect the new semantics:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/mcp-config.ts
Line: 77-103

Comment:
**Consent is path-based, not content-based — modified configs are silently trusted**

The consent store persists a "yes/no for this path" decision. Once `~/.kata-cli/project-mcp-consent.json` records `"approved"` for a path, _any future content_ of that file is automatically trusted — including modifications introduced by post-install scripts, `git pull`, or compromised tooling — without prompting the user again.

Since the whole point of the consent flow is to protect against untrusted MCP server definitions, consider storing a SHA-256 hash of the file alongside the `"approved"` status and invalidating consent when the hash changes:

```ts
interface ProjectMcpConsent {
  status: "approved" | "denied";
  hash: string; // sha256 hex of the approved file content
}
```

Then in `resolveEffectiveMcpConfigPath`, compare the stored hash against `crypto.createHash('sha256').update(rawContent).digest('hex')` before treating the existing consent as valid. This ensures the user is only asked once per unique content, not just once per path.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/mcp-config.ts
Line: 206-227

Comment:
**`promptForProjectMcpUse` bypasses the injectable `stderr` abstraction**

Every other message in `resolveEffectiveMcpConfigPath` is written through `options.stderr` (which defaults to `process.stderr` but can be substituted in tests). `promptForProjectMcpUse`, however, calls `process.stderr.write` directly, making it impossible to capture these particular lines in tests or redirected contexts.

```suggestion
async function promptForProjectMcpUse(
  projectConfigPath: string,
  stderr: Pick<NodeJS.WriteStream, "write"> = process.stderr,
): Promise<boolean> {
  stderr.write(
    `[kata] Project-local MCP config detected: ${projectConfigPath}\n`,
  );
  stderr.write(
    "[kata] Trust this file before Kata starts MCP servers from this project.\n",
  );
```

And update the call site in `resolveEffectiveMcpConfigPath` to pass `stderr`:

```ts
approved = await promptForProjectMcpUse(projectConfigPath, stderr);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/AGENTS.md
Line: 69

Comment:
**`KATA_MCP_CONFIG_PATH` description is now stale**

After this PR, `KATA_MCP_CONFIG_PATH` can point to `~/.kata-cli/agent/mcp.effective.json` instead of `mcp.json` when a project-local config is approved. The table entry should be updated to reflect the new semantics:

```suggestion
| `KATA_MCP_CONFIG_PATH`         | Absolute path to the effective MCP config (`mcp.json` or `mcp.effective.json` when a project-local config is merged) |
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): support project-level MCP con..."](https://github.com/gannonh/kata/commit/7c0a53ea128cbd239caa8d55ea9859ad854bee2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26120338)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->