### PR TITLE
Migrate Symphony agent runtime to Kata RPC pi-agent backend

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -255,10 +255,10 @@ const sessionManager = SessionManager.create(process.cwd(), sessionsDir)
 // Resource loader — read --append-system-prompt before reload
 // ---------------------------------------------------------------------------
 
-// Skip resource syncing in print mode — subagent processes inherit the
+// Skip resource syncing in print/rpc mode — child processes inherit the
 // already-synced ~/.kata-cli/agent/ from the parent. Running initResources()
-// concurrently from multiple subagents causes ENOENT race conditions.
-if (!isPrintMode) {
+// concurrently from multiple workers causes ENOENT race conditions.
+if (!isPrintMode && !isRpcMode) {
   initResources(agentDir)
 }
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -18,11 +18,12 @@ import { loadStoredEnvKeys, runWizardIfNeeded } from './wizard.js'
 // ---------------------------------------------------------------------------
 
 interface CliFlags {
-  mode?: 'json' | 'text'
+  mode?: 'json' | 'text' | 'rpc'
   print?: boolean
   noSession?: boolean
   model?: string
   tools?: string
+  cwd?: string
   appendSystemPrompt?: string
   messages: string[]
 }
@@ -34,7 +35,7 @@ function parseCliFlags(argv: string[]): CliFlags {
     const arg = argv[i]
     if (arg === '--mode' && i + 1 < argv.length) {
       const val = argv[++i]
-      if (val === 'json' || val === 'text') result.mode = val
+      if (val === 'json' || val === 'text' || val === 'rpc') result.mode = val
     } else if (arg === '-p' || arg === '--print') {
       result.print = true
     } else if (arg === '--no-session') {
@@ -45,6 +46,8 @@ function parseCliFlags(argv: string[]): CliFlags {
       result.tools = argv[++i]
     } else if (arg === '--append-system-prompt' && i + 1 < argv.length) {
       result.appendSystemPrompt = argv[++i]
+    } else if (arg === '--cwd' && i + 1 < argv.length) {
+      result.cwd = argv[++i]
     } else if (arg === '--extension' && i + 1 < argv.length) {
       i++ // handled by loader.ts
     } else if (arg === '--no-extensions') {
@@ -61,6 +64,12 @@ function parseCliFlags(argv: string[]): CliFlags {
 
 const cliFlags = parseCliFlags(process.argv.slice(2))
 const isPrintMode = cliFlags.mode === 'json' || cliFlags.mode === 'text' || cliFlags.print
+const isRpcMode = cliFlags.mode === 'rpc'
+
+// Apply --cwd before any path-dependent initialization.
+if (cliFlags.cwd) {
+  process.chdir(cliFlags.cwd)
+}
 
 // ---------------------------------------------------------------------------
 // Auth, model registry, settings
@@ -70,7 +79,7 @@ const authStorage = AuthStorage.create(authFilePath)
 loadStoredEnvKeys(authStorage)
 
 // Skip interactive wizard in print/json mode — subagents can't do TTY prompts
-if (!isPrintMode) {
+if (!isPrintMode && !isRpcMode) {
   await runWizardIfNeeded(authStorage)
 }
 
@@ -147,7 +156,7 @@ if (rawCommand && (PACKAGE_COMMANDS as readonly string[]).includes(rawCommand)) 
     const arg = rest[j]
     if (arg === '-h' || arg === '--help') help = true
     else if (arg === '-l' || arg === '--local') local = true
-    else if (arg === '--mcp-config' || arg === '--model' || arg === '--mode' || arg === '--tools' || arg === '--append-system-prompt' || arg === '--extension') {
+    else if (arg === '--mcp-config' || arg === '--model' || arg === '--mode' || arg === '--tools' || arg === '--append-system-prompt' || arg === '--extension' || arg === '--cwd') {
       j++ // skip the value
     } else if (arg.startsWith('-')) {
       // unknown flag, ignore
@@ -300,7 +309,28 @@ if (extensionsResult.errors.length > 0) {
 // Mode routing
 // ---------------------------------------------------------------------------
 
-if (isPrintMode) {
+if (cliFlags.mode === 'rpc') {
+  // Apply --model override if provided
+  if (cliFlags.model) {
+    const match = modelRegistry.getAll().find(
+      (m) => `${m.provider}/${m.id}` === cliFlags.model || m.id === cliFlags.model
+    )
+    if (match) {
+      await session.setModel(match)
+    }
+  }
+
+  // Apply --tools override if provided
+  if (cliFlags.tools) {
+    const toolNames = cliFlags.tools.split(',').map((t: string) => t.trim()).filter(Boolean)
+    if (toolNames.length > 0) {
+      session.setActiveToolsByName(toolNames)
+    }
+  }
+
+  const { runRpcMode } = await import('@mariozechner/pi-coding-agent')
+  await runRpcMode(session)
+} else if (isPrintMode) {
   if (cliFlags.messages.length === 0) {
     process.stderr.write('[kata] --print/--mode requires a message argument\n')
     process.exit(2)

--- a/apps/cli/src/tests/app-smoke.test.ts
+++ b/apps/cli/src/tests/app-smoke.test.ts
@@ -516,6 +516,42 @@ test("cli.ts injects mcp-config flag into extension runtime", () => {
   );
 });
 
+test("cli.ts supports rpc mode and cwd override for Symphony RPC embedding", () => {
+  const cliSrc = readFileSync(join(projectRoot, "src", "cli.ts"), "utf-8");
+  assert.ok(
+    cliSrc.includes("val === 'json' || val === 'text' || val === 'rpc'"),
+    "cli.ts accepts --mode rpc in parseCliFlags",
+  );
+  assert.ok(
+    cliSrc.includes("arg === '--cwd' && i + 1 < argv.length"),
+    "cli.ts parses --cwd flag",
+  );
+  assert.ok(
+    cliSrc.includes("if (cliFlags.cwd)"),
+    "cli.ts applies cwd override",
+  );
+  assert.ok(
+    cliSrc.includes("process.chdir(cliFlags.cwd)"),
+    "cli.ts calls process.chdir for --cwd",
+  );
+});
+
+test("cli.ts routes --mode rpc through runRpcMode", () => {
+  const cliSrc = readFileSync(join(projectRoot, "src", "cli.ts"), "utf-8");
+  assert.ok(
+    cliSrc.includes("if (cliFlags.mode === 'rpc')"),
+    "cli.ts has explicit rpc mode branch",
+  );
+  assert.ok(
+    cliSrc.includes("const { runRpcMode } = await import('@mariozechner/pi-coding-agent')"),
+    "cli.ts lazily imports runRpcMode",
+  );
+  assert.ok(
+    cliSrc.includes("await runRpcMode(session)"),
+    "cli.ts invokes runRpcMode(session)",
+  );
+});
+
 test("loader.ts injects --mcp-config into process.argv", () => {
   const loaderSrc = readFileSync(join(projectRoot, "src", "loader.ts"), "utf-8");
   assert.ok(

--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -1,11 +1,12 @@
 # Symphony
 
 Symphony is a headless orchestrator that polls a Linear project for candidate
-issues and dispatches each one to a Codex agent session running in an isolated
-workspace. It tracks concurrency limits, retries failures with exponential
-back-off, reconciles issue state on each poll cycle, and optionally exposes a
-live HTTP dashboard and JSON API for observability. SSH remote worker pools are
-supported for distributing agent sessions across multiple machines.
+issues and dispatches each one to an agent session running in an isolated
+workspace. It supports both Codex app-server and Kata RPC (`agent.backend`),
+tracks concurrency limits, retries failures with exponential back-off,
+reconciles issue state on each poll cycle, and optionally exposes a live HTTP
+dashboard and JSON API for observability. SSH remote worker pools are supported
+for distributing agent sessions across multiple machines.
 
 ---
 
@@ -13,7 +14,9 @@ supported for distributing agent sessions across multiple machines.
 
 - **Rust stable toolchain** (install via [rustup](https://rustup.rs/))
 - A Linear personal API key (`LINEAR_API_KEY`)
-- A Codex binary reachable on `PATH` (default command: `codex app-server`)
+- Agent runtime binary reachable on `PATH`:
+  - Codex backend: `codex app-server`
+  - Pi backend: `kata --mode rpc`
 
 Build the release binary:
 
@@ -120,8 +123,9 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | Field                                  | Type               | Default  | Description                                                                                                                    |
 | -------------------------------------- | ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `agent.max_concurrent_agents`          | u32                | `10`     | Global cap on simultaneously running agent sessions.                                                                           |
-| `agent.max_turns`                      | u32                | `20`     | Maximum Codex turns per session before the run is considered stalled.                                                          |
+| `agent.max_turns`                      | u32                | `20`     | Maximum prompt turns per session attempt before the worker run ends.                                                           |
 | `agent.max_retry_backoff_ms`           | u64                | `300000` | Maximum exponential back-off delay (ms) between retries.                                                                       |
+| `agent.backend`                        | string             | `"codex"`| Runtime backend: `"codex"` (Codex app-server) or `"pi"` (Kata RPC).                                                           |
 | `agent.max_concurrent_agents_by_state` | map\<string, u32\> | `{}`     | Per-Linear-state concurrency caps. Keys are lowercased state names; zero or negative values are silently ignored (spec §17.1). |
 
 #### `codex` section
@@ -136,13 +140,24 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | `codex.read_timeout_ms`     | u64                | `5000`                    | Timeout waiting for Codex process output (ms).                                                                           |
 | `codex.stall_timeout_ms`    | u64                | `300000`                  | Time before a non-progressing session is considered stalled (5 min default).                                             |
 
+#### `pi_agent` section
+
+| Field                           | Type               | Default  | Description                                                                                               |
+| ------------------------------- | ------------------ | -------- | --------------------------------------------------------------------------------------------------------- |
+| `pi_agent.command`              | string or string[] | `["kata"]` | Pi agent executable and base args. Symphony appends `--mode rpc --cwd <workspace>`.                    |
+| `pi_agent.model`                | string             | _(none)_ | Optional model override passed as `--model`.                                                             |
+| `pi_agent.no_session`           | bool               | `true`   | Pass `--no-session` to disable persistent session storage.                                               |
+| `pi_agent.append_system_prompt` | string             | _(none)_ | Optional path passed via `--append-system-prompt`.                                                       |
+| `pi_agent.read_timeout_ms`      | u64                | `5000`   | Timeout waiting for pi agent process output (ms).                                                        |
+| `pi_agent.stall_timeout_ms`     | u64                | `300000` | Time before a non-progressing pi session is considered stalled (5 min default).                         |
+
 #### `hooks` section
 
 | Field                 | Type   | Default  | Description                                                          |
 | --------------------- | ------ | -------- | -------------------------------------------------------------------- |
 | `hooks.after_create`  | string | _(none)_ | Shell command run after the workspace is created.                    |
-| `hooks.before_run`    | string | _(none)_ | Shell command run before the Codex session starts.                   |
-| `hooks.after_run`     | string | _(none)_ | Shell command run after the Codex session ends (success or failure). |
+| `hooks.before_run`    | string | _(none)_ | Shell command run before the agent session starts.                   |
+| `hooks.after_run`     | string | _(none)_ | Shell command run after the agent session ends (success or failure). |
 | `hooks.before_remove` | string | _(none)_ | Shell command run before the workspace is removed.                   |
 | `hooks.timeout_ms`    | u64    | `60000`  | Timeout for each hook invocation (ms).                               |
 
@@ -455,8 +470,8 @@ symphony WORKFLOW.md
 
 Symphony connects via `ssh -T [-F config] -p <port> <host> bash -lc '<command>'`.
 The command string is POSIX single-quote-escaped. The remote host must have
-`bash` available and the Codex binary on its `PATH` (or accessible via the
-configured `codex.command`).
+`bash` available and the configured runtime binary on its `PATH`
+(`codex.command` for codex backend, `pi_agent.command` for pi backend).
 
 ### Docker Isolation Lifecycle
 
@@ -467,7 +482,8 @@ When `workspace.isolation: docker` is selected:
    `workspace.docker.setup` is configured.
 3. A per-issue container is started via `docker run --rm -d`.
 4. Repository bootstrap and hooks execute inside the container (`docker exec`).
-5. Codex app-server runs via `docker exec -i <container> sh -lc 'cd /workspace && <codex.command>'`.
+5. Agent runtime runs via `docker exec -i <container> sh -lc 'cd /workspace && <runtime command>'`
+   where runtime command is backend-dependent (`<codex.command>` or Kata RPC).
 6. Container is removed via `docker rm -f` after session completion.
 
 ---
@@ -488,6 +504,9 @@ Core Rust modules:
 | Docker runtime helpers | `src/docker.rs` | Docker availability checks, image resolution/build cache, container lifecycle, auth resolution |
 | Workspace + git bootstrap | `src/workspace.rs` | clone/worktree bootstrapping, branch naming, hooks |
 | Codex app-server bridge | `src/codex/app_server.rs` | Session subprocess lifecycle, turn streaming, tool execution |
+| Pi RPC bridge | `src/pi_agent/rpc_bridge.rs` | Kata RPC subprocess lifecycle, turn streaming, token stats integration |
+| Pi protocol types | `src/pi_agent/protocol.rs` | Pi RPC command/response/event serde models |
+| Pi token accounting | `src/pi_agent/token_accounting.rs` | Cumulative token stats to per-turn delta tracking |
 | SSH helpers | `src/ssh.rs` | Remote target parsing, command escaping, host selection helpers |
 
 ---

--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -2036,6 +2036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2175,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
+ "shell-words",
  "tempfile",
  "thiserror",
  "tokio",

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -55,6 +55,7 @@ ratatui = "0.29"
 # Regex for sanitization
 regex = "1"
 dotenvy = "0.15.7"
+shell-words = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -183,11 +183,16 @@ agent:
   max_concurrent_agents: 1
 
   # Maximum turns (Codex interactions) per session before the run is
-  # considered stalled. Each turn is one request/response cycle.
+  # considered complete for a single worker attempt.
   max_turns: 20
 
   # Maximum exponential back-off delay (ms) between retries on failure.
   # max_retry_backoff_ms: 300000
+
+  # Runtime backend for worker sessions.
+  #   - codex (default): launch `codex app-server`
+  #   - pi: launch Kata CLI in RPC mode
+  # backend: codex
 
   # Per-state concurrency caps. Keys are lowercased state names.
   # Limits how many agents can work on issues in a specific state simultaneously.
@@ -197,7 +202,7 @@ agent:
   #   merging: 1
 
 # ─── Codex ────────────────────────────────────────────────────────────────────
-# Configures the Codex app-server process that runs inside each agent session.
+# Configures the Codex app-server process (used when `agent.backend: codex`).
 codex:
   # Command to start Codex. Can be a string (whitespace-split) or list.
   # Default parser value: `codex app-server`.
@@ -227,6 +232,31 @@ codex:
   # Default parser value: unset.
   turn_sandbox_policy:
     type: dangerFullAccess
+
+# ─── Pi Agent (Kata RPC) ──────────────────────────────────────────────────────
+# Configures Kata RPC runtime (used when `agent.backend: pi`).
+pi_agent:
+  # Command used to launch Kata RPC. Can be a string or list.
+  # Symphony appends --mode rpc --cwd <workspace> automatically.
+  # Default parser value: `kata`
+  # command: kata
+
+  # Optional model override passed via `--model`.
+  # model: anthropic/claude-sonnet-4-6
+
+  # Whether to pass `--no-session` to Kata (default: true).
+  # no_session: true
+
+  # Optional file path passed via `--append-system-prompt`.
+  # append_system_prompt: /absolute/path/to/prompt.md
+
+  # Timeout waiting for stdout lines in milliseconds.
+  # Default parser value: 5000.
+  # read_timeout_ms: 5000
+
+  # Time (ms) before a non-progressing session is considered stalled.
+  # Default parser value: 300000.
+  # stall_timeout_ms: 300000
 
 # ─── Worker (SSH) ─────────────────────────────────────────────────────────────
 # Distribute agent sessions across remote SSH hosts.

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -11,9 +11,9 @@ use serde::Deserialize;
 use serde_yaml::{Mapping, Value};
 
 use crate::domain::{
-    AgentConfig, ApiKey, CodexConfig, DockerCodexAuth, DockerConfig, HooksConfig, PollingConfig,
-    ServerConfig, ServiceConfig, TrackerConfig, WorkerConfig, WorkspaceConfig, WorkspaceIsolation,
-    WorkspaceRepoStrategy,
+    AgentBackend, AgentConfig, ApiKey, CodexConfig, DockerCodexAuth, DockerConfig, HooksConfig,
+    PiAgentConfig, PollingConfig, ServerConfig, ServiceConfig, TrackerConfig, WorkerConfig,
+    WorkspaceConfig, WorkspaceIsolation, WorkspaceRepoStrategy,
 };
 use crate::error::{Result, SymphonyError};
 use crate::repo_url::repo_is_remote;
@@ -211,6 +211,7 @@ struct RawWorkerConfig {
 #[derive(Deserialize, Default)]
 #[serde(default)]
 struct RawAgentConfig {
+    backend: Option<String>,
     max_concurrent_agents: Option<u32>,
     max_turns: Option<u32>,
     max_retry_backoff_ms: Option<u64>,
@@ -228,6 +229,17 @@ struct RawCodexConfig {
     thread_sandbox: Option<String>,
     turn_sandbox_policy: Option<Value>,
     turn_timeout_ms: Option<u64>,
+    read_timeout_ms: Option<u64>,
+    stall_timeout_ms: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct RawPiAgentConfig {
+    command: Option<Value>,
+    model: Option<String>,
+    no_session: Option<bool>,
+    append_system_prompt: Option<String>,
     read_timeout_ms: Option<u64>,
     stall_timeout_ms: Option<u64>,
 }
@@ -288,7 +300,7 @@ fn yaml_to_json(val: Value) -> Result<serde_json::Value> {
 /// Accepts either a whitespace-split string (`"codex app-server"`) or an
 /// explicit list (`["codex", "app-server"]`).  Returns `InvalidWorkflowConfig`
 /// for any other shape.
-fn parse_codex_command(val: Value) -> Result<Vec<String>> {
+fn parse_command_value(val: Value, field_name: &str) -> Result<Vec<String>> {
     match val {
         Value::String(s) if s.is_empty() => Ok(vec![]),
         Value::String(s) => Ok(s.split_whitespace().map(|p| p.to_string()).collect()),
@@ -297,14 +309,18 @@ fn parse_codex_command(val: Value) -> Result<Vec<String>> {
             .map(|v| match v {
                 Value::String(s) => Ok(s),
                 other => Err(SymphonyError::InvalidWorkflowConfig(format!(
-                    "codex.command list elements must be strings, got: {other:?}"
+                    "{field_name} list elements must be strings, got: {other:?}"
                 ))),
             })
             .collect(),
         other => Err(SymphonyError::InvalidWorkflowConfig(format!(
-            "codex.command must be a string or list of strings, got: {other:?}"
+            "{field_name} must be a string or list of strings, got: {other:?}"
         ))),
     }
+}
+
+fn parse_codex_command(val: Value) -> Result<Vec<String>> {
+    parse_command_value(val, "codex.command")
 }
 
 fn parse_workspace_git_strategy(value: &str) -> Result<WorkspaceRepoStrategy> {
@@ -394,6 +410,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let raw_worker: RawWorkerConfig = extract_section(&normalized, "worker")?;
     let raw_agent: RawAgentConfig = extract_section(&normalized, "agent")?;
     let raw_codex: RawCodexConfig = extract_section(&normalized, "codex")?;
+    let raw_pi_agent: RawPiAgentConfig = extract_section(&normalized, "pi_agent")?;
     let raw_hooks: RawHooksConfig = extract_section(&normalized, "hooks")?;
     let raw_server: RawServerConfig = extract_section(&normalized, "server")?;
 
@@ -713,6 +730,52 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
             .unwrap_or(defaults.codex.stall_timeout_ms),
     };
 
+    // ── PiAgentConfig ───────────────────────────────────────────────────
+    let pi_agent_command = match raw_pi_agent.command {
+        Some(val) => parse_command_value(val, "pi_agent.command")?,
+        None => defaults.pi_agent.command.clone(),
+    };
+    let pi_agent_model = raw_pi_agent
+        .model
+        .map(|value| resolve_env(&value))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let pi_agent_append_system_prompt = raw_pi_agent
+        .append_system_prompt
+        .map(|value| resolve_env(&value))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let pi_agent = PiAgentConfig {
+        command: pi_agent_command,
+        model: pi_agent_model,
+        no_session: raw_pi_agent
+            .no_session
+            .unwrap_or(defaults.pi_agent.no_session),
+        append_system_prompt: pi_agent_append_system_prompt,
+        read_timeout_ms: raw_pi_agent
+            .read_timeout_ms
+            .unwrap_or(defaults.pi_agent.read_timeout_ms),
+        stall_timeout_ms: raw_pi_agent
+            .stall_timeout_ms
+            .unwrap_or(defaults.pi_agent.stall_timeout_ms),
+    };
+
+    // ── AgentBackend ───────────────────────────────────────────────────
+    let agent_backend = raw_agent
+        .backend
+        .map(|value| resolve_env(&value))
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .map(|value| match value.as_str() {
+            "pi" => Ok(AgentBackend::Pi),
+            "codex" => Ok(AgentBackend::Codex),
+            other => Err(SymphonyError::InvalidWorkflowConfig(format!(
+                "agent.backend must be 'pi' or 'codex' (got '{other}')"
+            ))),
+        })
+        .transpose()?
+        .unwrap_or(defaults.agent_backend);
+
     // ── HooksConfig ───────────────────────────────────────────────────────
     let hooks = HooksConfig {
         after_create: raw_hooks.after_create,
@@ -735,6 +798,8 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         worker,
         agent,
         codex,
+        pi_agent,
+        agent_backend,
         hooks,
         server,
     })
@@ -782,10 +847,15 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
         }
     }
 
-    // codex.command must be non-empty
-    if config.codex.command.is_empty() {
+    // backend-specific command requirements
+    if config.agent_backend == AgentBackend::Codex && config.codex.command.is_empty() {
         return Err(SymphonyError::InvalidWorkflowConfig(
-            "codex.command is required".to_string(),
+            "codex.command is required when agent.backend is 'codex'".to_string(),
+        ));
+    }
+    if config.agent_backend == AgentBackend::Pi && config.pi_agent.command.is_empty() {
+        return Err(SymphonyError::InvalidWorkflowConfig(
+            "pi_agent.command is required when agent.backend is 'pi'".to_string(),
         ));
     }
 

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -323,6 +323,29 @@ fn parse_codex_command(val: Value) -> Result<Vec<String>> {
     parse_command_value(val, "codex.command")
 }
 
+fn parse_pi_agent_command(val: Value) -> Result<Vec<String>> {
+    match val {
+        Value::String(s) if s.is_empty() => Ok(vec![]),
+        Value::String(s) => shell_words::split(&s).map_err(|err| {
+            SymphonyError::InvalidWorkflowConfig(format!(
+                "pi_agent.command string could not be parsed: {err}"
+            ))
+        }),
+        Value::Sequence(seq) => seq
+            .into_iter()
+            .map(|v| match v {
+                Value::String(s) => Ok(s),
+                other => Err(SymphonyError::InvalidWorkflowConfig(format!(
+                    "pi_agent.command list elements must be strings, got: {other:?}"
+                ))),
+            })
+            .collect(),
+        other => Err(SymphonyError::InvalidWorkflowConfig(format!(
+            "pi_agent.command must be a string or list of strings, got: {other:?}"
+        ))),
+    }
+}
+
 fn parse_workspace_git_strategy(value: &str) -> Result<WorkspaceRepoStrategy> {
     match value {
         "clone-local" => Ok(WorkspaceRepoStrategy::CloneLocal),
@@ -732,7 +755,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
 
     // ── PiAgentConfig ───────────────────────────────────────────────────
     let pi_agent_command = match raw_pi_agent.command {
-        Some(val) => parse_command_value(val, "pi_agent.command")?,
+        Some(val) => parse_pi_agent_command(val)?,
         None => defaults.pi_agent.command.clone(),
     };
     let pi_agent_model = raw_pi_agent
@@ -984,6 +1007,31 @@ mod tests {
         let val = Value::String(String::new());
         let cmd = parse_codex_command(val).unwrap();
         assert!(cmd.is_empty());
+    }
+
+    #[test]
+    fn parse_pi_agent_command_string_shell_words() {
+        let val = Value::String(
+            "\"/tmp/kata cli/kata\" --mode rpc --model \"anthropic/claude sonnet\"".to_string(),
+        );
+        let cmd = parse_pi_agent_command(val).unwrap();
+        assert_eq!(
+            cmd,
+            vec![
+                "/tmp/kata cli/kata",
+                "--mode",
+                "rpc",
+                "--model",
+                "anthropic/claude sonnet",
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_pi_agent_command_list() {
+        let val: Value = serde_yaml::from_str("- kata\n- --mode\n- rpc").unwrap();
+        let cmd = parse_pi_agent_command(val).unwrap();
+        assert_eq!(cmd, vec!["kata", "--mode", "rpc"]);
     }
 
     #[test]

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -124,6 +124,8 @@ pub struct ServiceConfig {
     pub worker: WorkerConfig,
     pub agent: AgentConfig,
     pub codex: CodexConfig,
+    pub pi_agent: PiAgentConfig,
+    pub agent_backend: AgentBackend,
     pub hooks: HooksConfig,
     pub server: ServerConfig,
 }
@@ -354,6 +356,44 @@ impl Default for CodexConfig {
             thread_sandbox: "workspace-write".to_string(),
             turn_sandbox_policy: None,
             turn_timeout_ms: 3_600_000,
+            read_timeout_ms: 5_000,
+            stall_timeout_ms: 300_000,
+        }
+    }
+}
+
+/// Which runtime backend to use for agent sessions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AgentBackend {
+    Pi,
+    #[default]
+    Codex,
+}
+
+/// Pi-agent (Kata RPC) runtime configuration.
+#[derive(Debug, Clone)]
+pub struct PiAgentConfig {
+    /// Command and arguments to launch pi-agent.
+    pub command: Vec<String>,
+    /// Optional model identifier passed via `--model`.
+    pub model: Option<String>,
+    /// Whether to pass `--no-session`.
+    pub no_session: bool,
+    /// Optional file path passed via `--append-system-prompt`.
+    pub append_system_prompt: Option<String>,
+    /// Timeout for stdout reads.
+    pub read_timeout_ms: u64,
+    /// Timeout for stalled sessions (no activity).
+    pub stall_timeout_ms: u64,
+}
+
+impl Default for PiAgentConfig {
+    fn default() -> Self {
+        Self {
+            command: vec!["kata".to_string()],
+            model: None,
+            no_session: true,
+            append_system_prompt: None,
             read_timeout_ms: 5_000,
             stall_timeout_ms: 300_000,
         }

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -490,6 +490,8 @@ pub struct WorkerSessionInfo {
     pub turn_count: u32,
     #[serde(default)]
     pub max_turns: u32,
+    #[serde(skip)]
+    pub stall_timeout_ms: i64,
     #[serde(default)]
     pub last_activity_ms: Option<i64>,
     #[serde(default)]

--- a/apps/symphony/src/error.rs
+++ b/apps/symphony/src/error.rs
@@ -88,6 +88,9 @@ pub enum SymphonyError {
     #[error("codex turn input required")]
     TurnInputRequired,
 
+    #[error("pi-agent error: {0}")]
+    PiAgentError(String),
+
     // ── SSH ────────────────────────────────────────────────────────────
     #[error("ssh launch failed: {0}")]
     SshLaunchFailed(String),

--- a/apps/symphony/src/lib.rs
+++ b/apps/symphony/src/lib.rs
@@ -17,6 +17,7 @@ pub mod codex;
 pub mod http_server;
 pub mod logging;
 pub mod orchestrator;
+pub mod pi_agent;
 mod session_summary;
 pub mod tui;
 

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -9,12 +9,14 @@ use std::time::Duration;
 use crate::codex::app_server;
 use crate::config;
 use crate::domain::{
-    AgentEvent, CodexConfig, CodexTotals, CompletedEntry, HooksConfig, Issue, OrchestratorSnapshot,
-    OrchestratorState, PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetryEntry,
-    RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot, ServiceConfig, SessionTokenUsage,
-    TrackerConfig, WorkerSessionInfo, WorkspaceConfig, WorkspaceIsolation,
+    AgentBackend, AgentEvent, CodexConfig, CodexTotals, CompletedEntry, HooksConfig, Issue,
+    OrchestratorSnapshot, OrchestratorState, PiAgentConfig, PollingSnapshot, RateLimitInfo,
+    RefreshRequestOutcome, RetryEntry, RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot,
+    ServiceConfig, SessionTokenUsage, TrackerConfig, WorkerSessionInfo, WorkspaceConfig,
+    WorkspaceIsolation,
 };
 use crate::error::{Result, SymphonyError};
+use crate::pi_agent::rpc_bridge;
 use crate::session_summary::{compact_session_id, normalize_whitespace, truncate_for_display};
 use crate::ssh::{self, WorkerHostSelection};
 use crate::workflow_store::WorkflowStore;
@@ -28,6 +30,8 @@ struct WorkerTaskConfig {
     workspace: WorkspaceConfig,
     hooks: HooksConfig,
     codex: CodexConfig,
+    pi_agent: PiAgentConfig,
+    agent_backend: AgentBackend,
     max_turns: u32,
     tracker: TrackerConfig,
     prompt_template: String,
@@ -52,22 +56,28 @@ struct SessionTurnLoopFailure {
     metrics: Option<TurnMetrics>,
 }
 
-fn accumulate_turn_metrics(metrics: &mut Option<TurnMetrics>, turn: &app_server::TurnResult) {
+fn accumulate_turn_metrics(
+    metrics: &mut Option<TurnMetrics>,
+    input_tokens: u64,
+    output_tokens: u64,
+    total_tokens: u64,
+    rate_limits: Option<serde_json::Value>,
+) {
     match metrics {
         Some(total) => {
-            total.input_tokens = total.input_tokens.saturating_add(turn.input_tokens);
-            total.output_tokens = total.output_tokens.saturating_add(turn.output_tokens);
-            total.total_tokens = total.total_tokens.saturating_add(turn.total_tokens);
-            if let Some(rate_limits) = turn.rate_limits.clone() {
+            total.input_tokens = total.input_tokens.saturating_add(input_tokens);
+            total.output_tokens = total.output_tokens.saturating_add(output_tokens);
+            total.total_tokens = total.total_tokens.saturating_add(total_tokens);
+            if let Some(rate_limits) = rate_limits {
                 total.rate_limits = Some(rate_limits);
             }
         }
         None => {
             *metrics = Some(TurnMetrics {
-                input_tokens: turn.input_tokens,
-                output_tokens: turn.output_tokens,
-                total_tokens: turn.total_tokens,
-                rate_limits: turn.rate_limits.clone(),
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                rate_limits,
             });
         }
     }
@@ -157,7 +167,107 @@ where
 
         match run_result {
             Ok(turn_result) => {
-                accumulate_turn_metrics(&mut metrics, &turn_result);
+                accumulate_turn_metrics(
+                    &mut metrics,
+                    turn_result.input_tokens,
+                    turn_result.output_tokens,
+                    turn_result.total_tokens,
+                    turn_result.rate_limits.clone(),
+                );
+            }
+            Err(err) => {
+                return Err(SessionTurnLoopFailure {
+                    error: err,
+                    events: observed_events,
+                    metrics,
+                });
+            }
+        }
+
+        if turn_number >= capped_max_turns {
+            break;
+        }
+
+        match check_issue_still_active(&current_issue, &issue_state_client, tracker_config).await {
+            IssueCheck::Continue(refreshed) => {
+                current_issue = refreshed;
+                turn_number = turn_number.saturating_add(1);
+            }
+            IssueCheck::Done(_refreshed) => {
+                schedule_continuation = false;
+                break;
+            }
+            IssueCheck::Error(err) => {
+                let event = AgentEvent::Notification {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: None,
+                    message: format!(
+                        "inter-turn issue refresh failed for {} ({}): {}",
+                        current_issue.identifier, current_issue.id, err
+                    ),
+                };
+                stream_event(event.clone());
+                observed_events.push(event);
+                tracing::warn!(
+                    issue_id = %current_issue.id,
+                    issue_identifier = %current_issue.identifier,
+                    error = %err,
+                    "failed to refresh issue state between worker turns; ending session-level turn loop"
+                );
+                break;
+            }
+        }
+    }
+
+    Ok(SessionTurnLoopSuccess {
+        events: observed_events,
+        metrics,
+        schedule_continuation,
+    })
+}
+
+async fn run_pi_turns_in_session<EventCallback>(
+    session: &mut rpc_bridge::SessionHandle,
+    issue: &Issue,
+    initial_prompt: String,
+    max_turns: u32,
+    tracker_config: &TrackerConfig,
+    mut stream_event: EventCallback,
+) -> std::result::Result<SessionTurnLoopSuccess, SessionTurnLoopFailure>
+where
+    EventCallback: FnMut(AgentEvent) + Send,
+{
+    let capped_max_turns = max_turns.max(1);
+    let mut turn_number: u32 = 1;
+    let mut current_issue = issue.clone();
+    let issue_state_client = crate::linear::client::LinearClient::new(tracker_config.clone());
+    let mut observed_events: Vec<AgentEvent> = Vec::new();
+    let mut metrics: Option<TurnMetrics> = None;
+    let mut schedule_continuation = true;
+    let mut initial_prompt = Some(initial_prompt);
+
+    loop {
+        let prompt = if turn_number == 1 {
+            initial_prompt.take().unwrap_or_default()
+        } else {
+            prompt_builder::render_continuation_prompt(turn_number, capped_max_turns)
+        };
+
+        let run_result = rpc_bridge::run_turn(session, &prompt, |event| {
+            stream_event(event.clone());
+            observed_events.push(event);
+        })
+        .await;
+
+        match run_result {
+            Ok(turn_result) => {
+                accumulate_turn_metrics(
+                    &mut metrics,
+                    turn_result.input_tokens,
+                    turn_result.output_tokens,
+                    turn_result.total_tokens,
+                    turn_result.rate_limits.clone(),
+                );
             }
             Err(err) => {
                 return Err(SessionTurnLoopFailure {
@@ -325,59 +435,116 @@ async fn run_worker_task(
                 )
                 .map_err(|err| format!("prompt rendering failed: {err}"))?;
 
-                let mut session = app_server::start_session(
-                    &config.codex,
-                    issue,
-                    Path::new("/workspace"),
-                    Path::new("/"),
-                    None,
-                    Some(&container_id),
-                )
-                .await
-                .map_err(|err| format!("codex session start failed: {err}"))?;
+                let loop_result = match config.agent_backend {
+                    AgentBackend::Codex => {
+                        let mut session = app_server::start_session(
+                            &config.codex,
+                            issue,
+                            Path::new("/workspace"),
+                            Path::new("/"),
+                            None,
+                            Some(&container_id),
+                        )
+                        .await
+                        .map_err(|err| format!("codex session start failed: {err}"))?;
 
-                tracing::info!(
-                    event = "worker_started",
-                    issue_id = %issue.id,
-                    issue_identifier = %issue.identifier,
-                    session_id = %session.session_id,
-                    workspace_path = "/workspace",
-                    container_id = %container_id,
-                    "docker worker attempt started"
-                );
+                        tracing::info!(
+                            event = "worker_started",
+                            backend = "codex",
+                            issue_id = %issue.id,
+                            issue_identifier = %issue.identifier,
+                            session_id = %session.session_id,
+                            workspace_path = "/workspace",
+                            container_id = %container_id,
+                            "docker worker attempt started"
+                        );
 
-                let linear_client =
-                    crate::linear::client::LinearClient::new(config.tracker.clone());
-                let graphql_executor = move |query: String, vars: serde_json::Value| {
-                    let client = linear_client.clone();
-                    async move { client.graphql_raw(&query, vars).await }
-                };
+                        let linear_client =
+                            crate::linear::client::LinearClient::new(config.tracker.clone());
+                        let graphql_executor = move |query: String, vars: serde_json::Value| {
+                            let client = linear_client.clone();
+                            async move { client.graphql_raw(&query, vars).await }
+                        };
 
-                let loop_result = run_codex_turns_in_session(
-                    &mut session,
-                    issue,
-                    prompt,
-                    config.max_turns,
-                    &config.tracker,
-                    graphql_executor,
-                    {
-                        let event_tx = config.event_tx.clone();
-                        let issue_id = issue.id.clone();
-                        move |event| {
-                            let _ = event_tx.send((issue_id.clone(), event));
+                        let loop_result = run_codex_turns_in_session(
+                            &mut session,
+                            issue,
+                            prompt.clone(),
+                            config.max_turns,
+                            &config.tracker,
+                            graphql_executor,
+                            {
+                                let event_tx = config.event_tx.clone();
+                                let issue_id = issue.id.clone();
+                                move |event| {
+                                    let _ = event_tx.send((issue_id.clone(), event));
+                                }
+                            },
+                        )
+                        .await;
+
+                        if let Err(err) = app_server::stop_session(session).await {
+                            tracing::warn!(
+                                issue_id = %issue.id,
+                                issue_identifier = %issue.identifier,
+                                error = %err,
+                                "failed to stop codex session cleanly"
+                            );
                         }
-                    },
-                )
-                .await;
 
-                if let Err(err) = app_server::stop_session(session).await {
-                    tracing::warn!(
-                        issue_id = %issue.id,
-                        issue_identifier = %issue.identifier,
-                        error = %err,
-                        "failed to stop codex session cleanly"
-                    );
-                }
+                        loop_result
+                    }
+                    AgentBackend::Pi => {
+                        let mut session = rpc_bridge::start_session(
+                            &config.pi_agent,
+                            issue,
+                            Path::new("/workspace"),
+                            Path::new("/"),
+                            None,
+                            Some(&container_id),
+                        )
+                        .await
+                        .map_err(|err| format!("pi session start failed: {err}"))?;
+
+                        tracing::info!(
+                            event = "worker_started",
+                            backend = "pi",
+                            issue_id = %issue.id,
+                            issue_identifier = %issue.identifier,
+                            session_id = %session.session_id,
+                            workspace_path = "/workspace",
+                            container_id = %container_id,
+                            "docker worker attempt started"
+                        );
+
+                        let loop_result = run_pi_turns_in_session(
+                            &mut session,
+                            issue,
+                            prompt,
+                            config.max_turns,
+                            &config.tracker,
+                            {
+                                let event_tx = config.event_tx.clone();
+                                let issue_id = issue.id.clone();
+                                move |event| {
+                                    let _ = event_tx.send((issue_id.clone(), event));
+                                }
+                            },
+                        )
+                        .await;
+
+                        if let Err(err) = rpc_bridge::stop_session(session).await {
+                            tracing::warn!(
+                                issue_id = %issue.id,
+                                issue_identifier = %issue.identifier,
+                                error = %err,
+                                "failed to stop pi session cleanly"
+                            );
+                        }
+
+                        loop_result
+                    }
+                };
 
                 if let Some(hook) = &config.hooks.after_run {
                     if let Err(err) = workspace::run_hook_in_container(
@@ -513,79 +680,150 @@ async fn run_worker_task(
         }
     };
 
-    // 4. Start Codex session
     let workspace_root = Path::new(&config.workspace.root);
-    let mut session = match app_server::start_session(
-        &config.codex,
-        issue,
-        workspace_path,
-        workspace_root,
-        worker_host,
-        None,
-    )
-    .await
-    {
-        Ok(session) => session,
-        Err(err) => {
-            tracing::error!(
-                event = "worker_session_start_failed",
+    let loop_result = match config.agent_backend {
+        AgentBackend::Codex => {
+            let mut session = match app_server::start_session(
+                &config.codex,
+                issue,
+                workspace_path,
+                workspace_root,
+                worker_host,
+                None,
+            )
+            .await
+            {
+                Ok(session) => session,
+                Err(err) => {
+                    tracing::error!(
+                        event = "worker_session_start_failed",
+                        issue_id = %issue_id,
+                        issue_identifier = %issue.identifier,
+                        error = %err,
+                        "codex session start failed"
+                    );
+                    return WorkerResult {
+                        issue_id,
+                        completion: WorkerCompletion::Failed {
+                            error: format!("codex session start failed: {err}"),
+                        },
+                        events: vec![],
+                        metrics: None,
+                    };
+                }
+            };
+
+            tracing::info!(
+                event = "worker_started",
+                backend = "codex",
                 issue_id = %issue_id,
                 issue_identifier = %issue.identifier,
-                error = %err,
-                "codex session start failed"
+                session_id = %session.session_id,
+                workspace_path = %workspace_info.path,
+                "worker attempt started"
             );
-            return WorkerResult {
-                issue_id,
-                completion: WorkerCompletion::Failed {
-                    error: format!("codex session start failed: {err}"),
-                },
-                events: vec![],
-                metrics: None,
+
+            let linear_client = crate::linear::client::LinearClient::new(config.tracker.clone());
+            let graphql_executor = move |query: String, vars: serde_json::Value| {
+                let client = linear_client.clone();
+                async move { client.graphql_raw(&query, vars).await }
             };
+
+            let loop_result = run_codex_turns_in_session(
+                &mut session,
+                issue,
+                prompt.clone(),
+                config.max_turns,
+                &config.tracker,
+                graphql_executor,
+                {
+                    let event_tx = config.event_tx.clone();
+                    let issue_id = issue.id.clone();
+                    move |event| {
+                        let _ = event_tx.send((issue_id.clone(), event));
+                    }
+                },
+            )
+            .await;
+
+            if let Err(err) = app_server::stop_session(session).await {
+                tracing::warn!(
+                    issue_id = %issue_id,
+                    error = %err,
+                    "failed to stop codex session cleanly"
+                );
+            }
+
+            loop_result
+        }
+        AgentBackend::Pi => {
+            let mut session = match rpc_bridge::start_session(
+                &config.pi_agent,
+                issue,
+                workspace_path,
+                workspace_root,
+                worker_host,
+                None,
+            )
+            .await
+            {
+                Ok(session) => session,
+                Err(err) => {
+                    tracing::error!(
+                        event = "worker_session_start_failed",
+                        issue_id = %issue_id,
+                        issue_identifier = %issue.identifier,
+                        error = %err,
+                        "pi session start failed"
+                    );
+                    return WorkerResult {
+                        issue_id,
+                        completion: WorkerCompletion::Failed {
+                            error: format!("pi session start failed: {err}"),
+                        },
+                        events: vec![],
+                        metrics: None,
+                    };
+                }
+            };
+
+            tracing::info!(
+                event = "worker_started",
+                backend = "pi",
+                issue_id = %issue_id,
+                issue_identifier = %issue.identifier,
+                session_id = %session.session_id,
+                workspace_path = %workspace_info.path,
+                "worker attempt started"
+            );
+
+            let loop_result = run_pi_turns_in_session(
+                &mut session,
+                issue,
+                prompt,
+                config.max_turns,
+                &config.tracker,
+                {
+                    let event_tx = config.event_tx.clone();
+                    let issue_id = issue.id.clone();
+                    move |event| {
+                        let _ = event_tx.send((issue_id.clone(), event));
+                    }
+                },
+            )
+            .await;
+
+            if let Err(err) = rpc_bridge::stop_session(session).await {
+                tracing::warn!(
+                    issue_id = %issue_id,
+                    error = %err,
+                    "failed to stop pi session cleanly"
+                );
+            }
+
+            loop_result
         }
     };
-
-    tracing::info!(
-        event = "worker_started",
-        issue_id = %issue_id,
-        issue_identifier = %issue.identifier,
-        session_id = %session.session_id,
-        workspace_path = %workspace_info.path,
-        "worker attempt started"
-    );
-
-    // 5. Run up to max_turns within the same session.
-    let linear_client = crate::linear::client::LinearClient::new(config.tracker.clone());
-    let graphql_executor = move |query: String, vars: serde_json::Value| {
-        let client = linear_client.clone();
-        async move { client.graphql_raw(&query, vars).await }
-    };
-
-    let loop_result = run_codex_turns_in_session(
-        &mut session,
-        issue,
-        prompt,
-        config.max_turns,
-        &config.tracker,
-        graphql_executor,
-        {
-            let event_tx = config.event_tx.clone();
-            let issue_id = issue.id.clone();
-            move |event| {
-                let _ = event_tx.send((issue_id.clone(), event));
-            }
-        },
-    )
-    .await;
-
-    // 6. Stop session
-    if let Err(err) = app_server::stop_session(session).await {
-        tracing::warn!(
-            issue_id = %issue_id,
-            error = %err,
-            "failed to stop codex session cleanly"
-        );
-    }
 
     // 7. After-run hook
     let _ = workspace::run_after_run_hook_for_issue(workspace_path, &config.hooks, issue);
@@ -980,8 +1218,11 @@ impl Orchestrator {
                 self.refresh_runtime_config();
 
                 let now_ms = Utc::now().timestamp_millis();
-                let stall_timeout_ms =
-                    self.config.codex.stall_timeout_ms.min(i64::MAX as u64) as i64;
+                let backend_stall_timeout = match self.config.agent_backend {
+                    AgentBackend::Pi => self.config.pi_agent.stall_timeout_ms,
+                    AgentBackend::Codex => self.config.codex.stall_timeout_ms,
+                };
+                let stall_timeout_ms = backend_stall_timeout.min(i64::MAX as u64) as i64;
 
                 self.detect_stalled_workers(now_ms, stall_timeout_ms);
 
@@ -1096,6 +1337,8 @@ impl Orchestrator {
                 workspace: self.config.workspace.clone(),
                 hooks: self.config.hooks.clone(),
                 codex: self.config.codex.clone(),
+                pi_agent: self.config.pi_agent.clone(),
+                agent_backend: self.config.agent_backend,
                 max_turns: self.config.agent.max_turns,
                 tracker: self.config.tracker.clone(),
                 prompt_template: self.prompt_template.clone(),
@@ -1757,48 +2000,119 @@ impl Orchestrator {
             }
         };
 
-        let mut session = match app_server::start_session(
-            &self.config.codex,
-            issue,
-            workspace_path,
-            Path::new(&self.config.workspace.root),
-            prior_worker_host.as_deref(),
-            None,
-        )
-        .await
-        {
-            Ok(session) => session,
-            Err(err) => {
-                self.handle_worker_completion(
-                    &issue.id,
-                    WorkerCompletion::Failed {
-                        error: err.to_string(),
-                    },
-                    Utc::now().timestamp_millis(),
+        let loop_result = match self.config.agent_backend {
+            AgentBackend::Codex => {
+                let mut session = match app_server::start_session(
+                    &self.config.codex,
+                    issue,
+                    workspace_path,
+                    Path::new(&self.config.workspace.root),
+                    prior_worker_host.as_deref(),
+                    None,
+                )
+                .await
+                {
+                    Ok(session) => session,
+                    Err(err) => {
+                        self.handle_worker_completion(
+                            &issue.id,
+                            WorkerCompletion::Failed {
+                                error: err.to_string(),
+                            },
+                            Utc::now().timestamp_millis(),
+                        );
+                        return Err(err);
+                    }
+                };
+
+                tracing::info!(
+                    event = "worker_started",
+                    backend = "codex",
+                    issue_id = %issue.id,
+                    issue_identifier = %issue.identifier,
+                    session_id = %session.session_id,
+                    workspace_path = %workspace_info.path,
+                    "worker attempt started"
                 );
-                return Err(err);
+
+                let loop_result = run_codex_turns_in_session(
+                    &mut session,
+                    issue,
+                    prompt.clone(),
+                    self.config.agent.max_turns,
+                    &self.config.tracker,
+                    graphql_executor.clone(),
+                    |_event| {},
+                )
+                .await;
+
+                if let Err(err) = app_server::stop_session(session).await {
+                    tracing::warn!(
+                        issue_id = %issue.id,
+                        issue_identifier = %issue.identifier,
+                        error = %err,
+                        "failed to stop codex session cleanly"
+                    );
+                }
+
+                loop_result
+            }
+            AgentBackend::Pi => {
+                let mut session = match rpc_bridge::start_session(
+                    &self.config.pi_agent,
+                    issue,
+                    workspace_path,
+                    Path::new(&self.config.workspace.root),
+                    prior_worker_host.as_deref(),
+                    None,
+                )
+                .await
+                {
+                    Ok(session) => session,
+                    Err(err) => {
+                        self.handle_worker_completion(
+                            &issue.id,
+                            WorkerCompletion::Failed {
+                                error: err.to_string(),
+                            },
+                            Utc::now().timestamp_millis(),
+                        );
+                        return Err(err);
+                    }
+                };
+
+                tracing::info!(
+                    event = "worker_started",
+                    backend = "pi",
+                    issue_id = %issue.id,
+                    issue_identifier = %issue.identifier,
+                    session_id = %session.session_id,
+                    workspace_path = %workspace_info.path,
+                    "worker attempt started"
+                );
+
+                let loop_result = run_pi_turns_in_session(
+                    &mut session,
+                    issue,
+                    prompt,
+                    self.config.agent.max_turns,
+                    &self.config.tracker,
+                    |_event| {},
+                )
+                .await;
+
+                if let Err(err) = rpc_bridge::stop_session(session).await {
+                    tracing::warn!(
+                        issue_id = %issue.id,
+                        issue_identifier = %issue.identifier,
+                        error = %err,
+                        "failed to stop pi session cleanly"
+                    );
+                }
+
+                loop_result
             }
         };
-
-        tracing::info!(
-            event = "worker_started",
-            issue_id = %issue.id,
-            issue_identifier = %issue.identifier,
-            session_id = %session.session_id,
-            workspace_path = %workspace_info.path,
-            "worker attempt started"
-        );
-
-        let loop_result = run_codex_turns_in_session(
-            &mut session,
-            issue,
-            prompt,
-            self.config.agent.max_turns,
-            &self.config.tracker,
-            graphql_executor,
-            |_event| {},
-        )
-        .await;
 
         let observed_events = match &loop_result {
             Ok(success) => &success.events,
@@ -1807,15 +2121,6 @@ impl Orchestrator {
 
         for event in observed_events {
             self.ingest_agent_event(&issue.id, event);
-        }
-
-        if let Err(err) = app_server::stop_session(session).await {
-            tracing::warn!(
-                issue_id = %issue.id,
-                issue_identifier = %issue.identifier,
-                error = %err,
-                "failed to stop codex session cleanly"
-            );
         }
 
         let _ = workspace::run_after_run_hook_for_issue(workspace_path, &self.config.hooks, issue);

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -99,6 +99,14 @@ fn is_active_state(state_name: &str, tracker_config: &TrackerConfig) -> bool {
         .any(|state| normalize_issue_state(state) == normalized)
 }
 
+fn backend_stall_timeout_ms(config: &ServiceConfig, backend: AgentBackend) -> i64 {
+    let timeout = match backend {
+        AgentBackend::Pi => config.pi_agent.stall_timeout_ms,
+        AgentBackend::Codex => config.codex.stall_timeout_ms,
+    };
+    timeout.min(i64::MAX as u64) as i64
+}
+
 fn should_continue_issue_in_session(issue: &Issue, tracker_config: &TrackerConfig) -> bool {
     issue.assigned_to_worker
         && is_active_state(&issue.state, tracker_config)
@@ -1218,11 +1226,8 @@ impl Orchestrator {
                 self.refresh_runtime_config();
 
                 let now_ms = Utc::now().timestamp_millis();
-                let backend_stall_timeout = match self.config.agent_backend {
-                    AgentBackend::Pi => self.config.pi_agent.stall_timeout_ms,
-                    AgentBackend::Codex => self.config.codex.stall_timeout_ms,
-                };
-                let stall_timeout_ms = backend_stall_timeout.min(i64::MAX as u64) as i64;
+                let stall_timeout_ms =
+                    backend_stall_timeout_ms(&self.config, self.config.agent_backend);
 
                 self.detect_stalled_workers(now_ms, stall_timeout_ms);
 
@@ -1680,6 +1685,7 @@ impl Orchestrator {
 
     fn ensure_worker_session_info(&mut self, issue_id: &str) -> &mut WorkerSessionInfo {
         let max_turns = self.config.agent.max_turns.max(1);
+        let stall_timeout_ms = backend_stall_timeout_ms(&self.config, self.config.agent_backend);
         let last_activity_ms = self.worker_last_activity_ms.get(issue_id).copied();
         let info = self
             .worker_session_info
@@ -1687,11 +1693,15 @@ impl Orchestrator {
             .or_insert(WorkerSessionInfo {
                 turn_count: 1,
                 max_turns,
+                stall_timeout_ms,
                 last_activity_ms,
                 session_tokens: SessionTokenUsage::default(),
             });
         if info.max_turns == 0 {
             info.max_turns = max_turns;
+        }
+        if info.stall_timeout_ms <= 0 {
+            info.stall_timeout_ms = stall_timeout_ms;
         }
         if info.turn_count == 0 {
             info.turn_count = 1;
@@ -2151,16 +2161,21 @@ impl Orchestrator {
     }
 
     pub fn detect_stalled_workers(&mut self, now_ms: i64, stall_timeout_ms: i64) {
-        if stall_timeout_ms <= 0 {
-            return;
-        }
-
         let running_issue_ids: Vec<String> = self.state.running.keys().cloned().collect();
 
         for issue_id in running_issue_ids {
             let Some(run_attempt) = self.state.running.get(&issue_id).cloned() else {
                 continue;
             };
+            let per_session_stall_timeout_ms = self
+                .worker_session_info
+                .get(&issue_id)
+                .map(|info| info.stall_timeout_ms)
+                .filter(|timeout| *timeout > 0)
+                .unwrap_or(stall_timeout_ms);
+            if per_session_stall_timeout_ms <= 0 {
+                continue;
+            }
 
             let last_activity_ms = self
                 .worker_last_activity_ms
@@ -2169,7 +2184,7 @@ impl Orchestrator {
                 .unwrap_or_else(|| run_attempt.started_at.timestamp_millis());
 
             let elapsed_ms = now_ms.saturating_sub(last_activity_ms);
-            if elapsed_ms <= stall_timeout_ms {
+            if elapsed_ms <= per_session_stall_timeout_ms {
                 continue;
             }
 
@@ -2181,7 +2196,7 @@ impl Orchestrator {
                 issue_identifier = %run_attempt.issue_identifier,
                 session_id = session_id.as_deref().unwrap_or("n/a"),
                 elapsed_ms,
-                stall_timeout_ms,
+                stall_timeout_ms = per_session_stall_timeout_ms,
                 "detected stalled worker; scheduling failure retry"
             );
 
@@ -2195,7 +2210,7 @@ impl Orchestrator {
             self.handle_worker_completion(
                 &issue_id,
                 WorkerCompletion::Failed {
-                    error: format!("stalled for {elapsed_ms}ms without codex activity"),
+                    error: format!("stalled for {elapsed_ms}ms without agent activity"),
                 },
                 now_ms,
             );

--- a/apps/symphony/src/pi_agent/mod.rs
+++ b/apps/symphony/src/pi_agent/mod.rs
@@ -1,0 +1,5 @@
+//! Pi-coding-agent RPC bridge and protocol helpers.
+
+pub mod protocol;
+pub mod rpc_bridge;
+pub mod token_accounting;

--- a/apps/symphony/src/pi_agent/protocol.rs
+++ b/apps/symphony/src/pi_agent/protocol.rs
@@ -1,0 +1,232 @@
+//! Pi RPC protocol types used by Symphony.
+//!
+//! This module intentionally models only the subset of the protocol used by
+//! Symphony's non-interactive worker runtime.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A command sent to a pi RPC process over stdin.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+pub enum RpcCommand {
+    #[serde(rename = "prompt")]
+    Prompt {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        message: String,
+    },
+    #[serde(rename = "abort")]
+    Abort {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+    #[serde(rename = "get_state")]
+    GetState {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+    #[serde(rename = "get_session_stats")]
+    GetSessionStats {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+}
+
+/// A command response emitted by pi RPC on stdout.
+#[derive(Debug, Deserialize)]
+pub struct RpcResponse {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(rename = "type")]
+    #[serde(default)]
+    pub type_: String,
+    pub command: String,
+    pub success: bool,
+    #[serde(default)]
+    pub data: Option<Value>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Cumulative token counters returned from `get_session_stats`.
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+pub struct SessionTokens {
+    #[serde(default)]
+    pub input: u64,
+    #[serde(default)]
+    pub output: u64,
+    #[serde(default, rename = "cacheRead")]
+    pub cache_read: u64,
+    #[serde(default, rename = "cacheWrite")]
+    pub cache_write: u64,
+    #[serde(default)]
+    pub total: u64,
+}
+
+/// Session stats payload returned by `get_session_stats`.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct SessionStats {
+    #[serde(default)]
+    pub session_id: String,
+    #[serde(default)]
+    pub user_messages: u64,
+    #[serde(default)]
+    pub assistant_messages: u64,
+    #[serde(default)]
+    pub tool_calls: u64,
+    #[serde(default)]
+    pub total_messages: u64,
+    #[serde(default)]
+    pub tokens: SessionTokens,
+    #[serde(default)]
+    pub cost: f64,
+}
+
+/// A parsed stdout line from pi RPC.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum RpcOutputLine {
+    #[serde(rename = "response")]
+    Response(RpcResponse),
+
+    #[serde(rename = "agent_start")]
+    AgentStart,
+    #[serde(rename = "agent_end")]
+    AgentEnd {
+        #[serde(default)]
+        messages: Value,
+    },
+
+    #[serde(rename = "turn_start")]
+    TurnStart,
+    #[serde(rename = "turn_end")]
+    TurnEnd {
+        #[serde(default)]
+        message: Value,
+    },
+
+    #[serde(rename = "message_start")]
+    MessageStart {
+        #[serde(default)]
+        message: Value,
+    },
+    #[serde(rename = "message_update")]
+    MessageUpdate {
+        #[serde(default)]
+        message: Value,
+    },
+    #[serde(rename = "message_end")]
+    MessageEnd {
+        #[serde(default)]
+        message: Value,
+    },
+
+    #[serde(rename = "tool_execution_start")]
+    ToolExecutionStart {
+        #[serde(default, rename = "toolCallId")]
+        tool_call_id: Option<String>,
+        #[serde(default, rename = "toolName")]
+        tool_name: Option<String>,
+        #[serde(default)]
+        args: Value,
+    },
+    #[serde(rename = "tool_execution_update")]
+    ToolExecutionUpdate {
+        #[serde(default, rename = "toolCallId")]
+        tool_call_id: Option<String>,
+        #[serde(default, rename = "toolName")]
+        tool_name: Option<String>,
+    },
+    #[serde(rename = "tool_execution_end")]
+    ToolExecutionEnd {
+        #[serde(default, rename = "toolCallId")]
+        tool_call_id: Option<String>,
+        #[serde(default, rename = "toolName")]
+        tool_name: Option<String>,
+        #[serde(default, rename = "isError")]
+        is_error: bool,
+    },
+
+    #[serde(rename = "auto_compaction_start")]
+    AutoCompactionStart {
+        #[serde(default)]
+        reason: Option<String>,
+    },
+    #[serde(rename = "auto_compaction_end")]
+    AutoCompactionEnd {
+        #[serde(default)]
+        aborted: bool,
+    },
+
+    #[serde(rename = "auto_retry_start")]
+    AutoRetryStart {
+        #[serde(default)]
+        attempt: u32,
+        #[serde(default)]
+        max_attempts: u32,
+        #[serde(default)]
+        delay_ms: u64,
+        #[serde(default)]
+        error_message: Option<String>,
+    },
+    #[serde(rename = "auto_retry_end")]
+    AutoRetryEnd {
+        #[serde(default)]
+        success: bool,
+    },
+
+    #[serde(rename = "extension_ui_request")]
+    ExtensionUIRequest {
+        id: String,
+        method: String,
+        #[serde(default, flatten)]
+        extra: Value,
+    },
+
+    #[serde(rename = "extension_error")]
+    ExtensionError {
+        #[serde(default)]
+        extension_path: Option<String>,
+        #[serde(default)]
+        error: Option<String>,
+    },
+}
+
+/// Response payload for extension UI requests in non-interactive mode.
+#[derive(Debug, Serialize)]
+pub struct ExtensionUIResponse {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancelled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirmed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+impl ExtensionUIResponse {
+    /// Cancel interactive prompts such as select/input/editor.
+    pub fn cancel(id: String) -> Self {
+        Self {
+            type_: "extension_ui_response".to_string(),
+            id,
+            cancelled: Some(true),
+            confirmed: None,
+            value: None,
+        }
+    }
+
+    /// Reject interactive confirmations.
+    pub fn reject(id: String) -> Self {
+        Self {
+            type_: "extension_ui_response".to_string(),
+            id,
+            cancelled: None,
+            confirmed: Some(false),
+            value: None,
+        }
+    }
+}

--- a/apps/symphony/src/pi_agent/rpc_bridge.rs
+++ b/apps/symphony/src/pi_agent/rpc_bridge.rs
@@ -457,7 +457,7 @@ pub async fn run_turn(
     let session_started = AgentEvent::SessionStarted {
         timestamp: Utc::now(),
         codex_app_server_pid: handle.pid.clone(),
-        session_id: format!("{}-{turn_id}", handle.session_id),
+        session_id: handle.session_id.clone(),
     };
     event_callback(session_started.clone());
     let mut events = vec![session_started];

--- a/apps/symphony/src/pi_agent/rpc_bridge.rs
+++ b/apps/symphony/src/pi_agent/rpc_bridge.rs
@@ -463,10 +463,10 @@ pub async fn run_turn(
     let mut events = vec![session_started];
 
     let mut output_text: Option<String> = None;
-    let read_timeout_ms = handle.stall_timeout_ms.max(handle.read_timeout_ms);
+    let turn_line_timeout_ms = handle.stall_timeout_ms.max(handle.read_timeout_ms);
 
     loop {
-        let line = read_line(&mut handle.stdout_reader, read_timeout_ms).await?;
+        let line = read_line(&mut handle.stdout_reader, turn_line_timeout_ms).await?;
         let Some(parsed) = parse_output_line(&line) else {
             continue;
         };

--- a/apps/symphony/src/pi_agent/rpc_bridge.rs
+++ b/apps/symphony/src/pi_agent/rpc_bridge.rs
@@ -1,0 +1,735 @@
+//! Pi RPC bridge — subprocess lifecycle, JSON-line I/O, and turn management.
+//!
+//! This module launches `kata --mode rpc` (or a compatible pi-agent command)
+//! and drives prompt turns over stdin/stdout JSON lines.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use chrono::Utc;
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use crate::domain::{AgentEvent, Issue, PiAgentConfig};
+use crate::error::{Result, SymphonyError};
+use crate::path_safety;
+use crate::pi_agent::protocol::{
+    ExtensionUIResponse, RpcCommand, RpcOutputLine, RpcResponse, SessionStats,
+};
+use crate::pi_agent::token_accounting::{TokenDelta, TokenTracker};
+use crate::ssh::{self, SshRunner};
+
+const HANDSHAKE_TIMEOUT_MS: u64 = 30_000;
+const MAX_STREAM_LOG_BYTES: usize = 1_000;
+const SHUTDOWN_GRACE_MS: u64 = 3_000;
+
+static COMMAND_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Opaque handle to a running pi-agent subprocess session.
+pub struct SessionHandle {
+    /// Stable session ID reported by pi-agent.
+    pub session_id: String,
+
+    child: tokio::process::Child,
+    stdin: tokio::process::ChildStdin,
+    stdout_reader: BufReader<tokio::process::ChildStdout>,
+    pid: Option<String>,
+
+    issue_id: String,
+    issue_identifier: String,
+    read_timeout_ms: u64,
+    stall_timeout_ms: u64,
+    token_tracker: TokenTracker,
+}
+
+/// Outcome of one completed prompt turn.
+#[derive(Debug)]
+pub struct TurnResult {
+    pub events: Vec<AgentEvent>,
+    pub output_text: Option<String>,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    pub rate_limits: Option<Value>,
+}
+
+fn next_command_id(prefix: &str) -> String {
+    let n = COMMAND_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{}-{n}", Utc::now().timestamp_millis())
+}
+
+fn build_command_parts(config: &PiAgentConfig, workspace_path: &str) -> Result<Vec<String>> {
+    if config.command.is_empty() {
+        return Err(SymphonyError::PiAgentError(
+            "pi_agent.command cannot be empty".to_string(),
+        ));
+    }
+
+    let mut parts = config.command.clone();
+    parts.push("--mode".to_string());
+    parts.push("rpc".to_string());
+    parts.push("--cwd".to_string());
+    parts.push(workspace_path.to_string());
+
+    if config.no_session {
+        parts.push("--no-session".to_string());
+    }
+    if let Some(model) = config.model.as_deref() {
+        parts.push("--model".to_string());
+        parts.push(model.to_string());
+    }
+    if let Some(path) = config.append_system_prompt.as_deref() {
+        parts.push("--append-system-prompt".to_string());
+        parts.push(path.to_string());
+    }
+
+    Ok(parts)
+}
+
+fn shell_join(parts: &[String]) -> String {
+    parts
+        .iter()
+        .map(|part| ssh::shell_escape(part))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+async fn send_command(stdin: &mut tokio::process::ChildStdin, command: &RpcCommand) -> Result<()> {
+    let mut line = serde_json::to_string(command).map_err(|err| {
+        SymphonyError::PiAgentError(format!("failed to serialize command: {err}"))
+    })?;
+    line.push('\n');
+    stdin
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|err| SymphonyError::PiAgentError(format!("failed to write stdin: {err}")))?;
+    stdin
+        .flush()
+        .await
+        .map_err(|err| SymphonyError::PiAgentError(format!("failed to flush stdin: {err}")))?;
+    Ok(())
+}
+
+async fn read_line(
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    timeout_ms: u64,
+) -> Result<String> {
+    let mut line = String::new();
+    let read_fut = reader.read_line(&mut line);
+    match tokio::time::timeout(Duration::from_millis(timeout_ms), read_fut).await {
+        Ok(Ok(0)) => Err(SymphonyError::PiAgentError(
+            "pi-agent stdout closed unexpectedly".to_string(),
+        )),
+        Ok(Ok(_)) => Ok(line),
+        Ok(Err(err)) => Err(SymphonyError::PiAgentError(format!(
+            "failed to read pi-agent stdout: {err}"
+        ))),
+        Err(_) => Err(SymphonyError::PiAgentError(format!(
+            "pi-agent read timed out after {timeout_ms}ms"
+        ))),
+    }
+}
+
+fn parse_output_line(line: &str) -> Option<RpcOutputLine> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    match serde_json::from_str::<RpcOutputLine>(trimmed) {
+        Ok(parsed) => Some(parsed),
+        Err(err) => {
+            let preview = if trimmed.len() > MAX_STREAM_LOG_BYTES {
+                &trimmed[..MAX_STREAM_LOG_BYTES]
+            } else {
+                trimmed
+            };
+            tracing::debug!(
+                error = %err,
+                line = %preview,
+                "ignoring non-protocol stdout line from pi-agent"
+            );
+            None
+        }
+    }
+}
+
+fn extract_session_id(response: &RpcResponse) -> Option<String> {
+    let data = response.data.as_ref()?;
+
+    data.get("sessionId")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            data.get("session_id")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+        .or_else(|| {
+            data.get("session")
+                .and_then(|session| session.get("id"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+}
+
+async fn maybe_respond_extension_ui(
+    stdin: &mut tokio::process::ChildStdin,
+    id: String,
+    method: String,
+) {
+    let response = match method.as_str() {
+        "notify" | "setStatus" | "setWidget" | "setTitle" | "set_editor_text" => return,
+        "confirm" => ExtensionUIResponse::reject(id),
+        _ => ExtensionUIResponse::cancel(id),
+    };
+
+    if let Ok(mut line) = serde_json::to_string(&response) {
+        line.push('\n');
+        let _ = stdin.write_all(line.as_bytes()).await;
+        let _ = stdin.flush().await;
+    }
+}
+
+fn maybe_extract_text(message: &Value) -> Option<String> {
+    let content = message.get("content")?.as_array()?;
+    for item in content {
+        if item.get("type").and_then(Value::as_str) == Some("text") {
+            if let Some(text) = item.get("text").and_then(Value::as_str) {
+                return Some(text.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn decode_session_stats(data: Value) -> Result<SessionStats> {
+    if let Ok(stats) = serde_json::from_value::<SessionStats>(data.clone()) {
+        return Ok(stats);
+    }
+
+    if let Some(stats_val) = data.get("stats") {
+        return serde_json::from_value::<SessionStats>(stats_val.clone()).map_err(|err| {
+            SymphonyError::PiAgentError(format!("failed to parse stats payload: {err}"))
+        });
+    }
+
+    Err(SymphonyError::PiAgentError(
+        "stats response missing parseable payload".to_string(),
+    ))
+}
+
+async fn read_stats_response(
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    stdin: &mut tokio::process::ChildStdin,
+    timeout_ms: u64,
+) -> Result<SessionStats> {
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms.max(5_000));
+
+    loop {
+        let remaining_ms = deadline
+            .saturating_duration_since(tokio::time::Instant::now())
+            .as_millis() as u64;
+        if remaining_ms == 0 {
+            return Err(SymphonyError::PiAgentError(
+                "timed out waiting for get_session_stats response".to_string(),
+            ));
+        }
+
+        let line = read_line(reader, remaining_ms.min(2_000)).await?;
+        let Some(parsed) = parse_output_line(&line) else {
+            continue;
+        };
+
+        match parsed {
+            RpcOutputLine::Response(response)
+                if response.command == "get_session_stats"
+                    || response.command == "getSessionStats" =>
+            {
+                if !response.success {
+                    return Err(SymphonyError::PiAgentError(
+                        response
+                            .error
+                            .unwrap_or_else(|| "get_session_stats failed".to_string()),
+                    ));
+                }
+                let data = response.data.ok_or_else(|| {
+                    SymphonyError::PiAgentError(
+                        "get_session_stats response missing `data`".to_string(),
+                    )
+                })?;
+                return decode_session_stats(data);
+            }
+            RpcOutputLine::ExtensionUIRequest { id, method, .. } => {
+                maybe_respond_extension_ui(stdin, id, method).await;
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn wait_for_handshake(
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    stdin: &mut tokio::process::ChildStdin,
+    timeout_ms: u64,
+) -> Result<String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
+
+    loop {
+        let remaining_ms = deadline
+            .saturating_duration_since(tokio::time::Instant::now())
+            .as_millis() as u64;
+        if remaining_ms == 0 {
+            return Err(SymphonyError::PiAgentError(
+                "timed out waiting for get_state response".to_string(),
+            ));
+        }
+
+        let line = read_line(reader, remaining_ms.min(2_000)).await?;
+        let Some(parsed) = parse_output_line(&line) else {
+            continue;
+        };
+
+        match parsed {
+            RpcOutputLine::Response(response)
+                if response.command == "get_state" || response.command == "getState" =>
+            {
+                if !response.success {
+                    return Err(SymphonyError::PiAgentError(
+                        response
+                            .error
+                            .unwrap_or_else(|| "get_state failed".to_string()),
+                    ));
+                }
+                return Ok(
+                    extract_session_id(&response).unwrap_or_else(|| next_command_id("pi-session"))
+                );
+            }
+            RpcOutputLine::ExtensionUIRequest { id, method, .. } => {
+                maybe_respond_extension_ui(stdin, id, method).await;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Start a pi-agent session process for an issue.
+pub async fn start_session(
+    config: &PiAgentConfig,
+    issue: &Issue,
+    workspace_path: &Path,
+    workspace_root: &Path,
+    worker_host: Option<&str>,
+    container_id: Option<&str>,
+) -> Result<SessionHandle> {
+    let command_parts = match (container_id, worker_host) {
+        (Some(_), _) => build_command_parts(config, "/workspace")?,
+        _ => {
+            let workspace_for_args = workspace_path.to_string_lossy().to_string();
+            build_command_parts(config, &workspace_for_args)?
+        }
+    };
+
+    let (workspace_str, mut child) = match (container_id, worker_host) {
+        (Some(container_id), _) => {
+            let workspace_str = workspace_path.to_string_lossy().to_string();
+            let remote_cmd = format!(
+                "cd {} && {}",
+                ssh::shell_escape(&workspace_str),
+                shell_join(&command_parts)
+            );
+
+            let child = crate::docker::exec_command(container_id, &remote_cmd)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .map_err(|err| {
+                    SymphonyError::PiAgentError(format!("docker spawn failed: {err}"))
+                })?;
+
+            (workspace_str, child)
+        }
+        (None, Some(host)) => {
+            let workspace_str =
+                crate::ssh::validate_remote_workspace_cwd(&workspace_path.to_string_lossy())?;
+            let remote_cmd = format!(
+                "cd {} && {}",
+                ssh::shell_escape(&workspace_str),
+                shell_join(&command_parts)
+            );
+            let child = SshRunner::start_process(host, &remote_cmd).await?;
+            (workspace_str, child)
+        }
+        (None, None) => {
+            let canonical_workspace = validate_workspace_cwd(workspace_path, workspace_root)?;
+            let workspace_str = canonical_workspace.to_string_lossy().to_string();
+            let program = command_parts
+                .first()
+                .cloned()
+                .ok_or_else(|| SymphonyError::PiAgentError("empty pi-agent command".to_string()))?;
+
+            let child = tokio::process::Command::new(program)
+                .args(command_parts.iter().skip(1))
+                .current_dir(&canonical_workspace)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .map_err(|err| SymphonyError::PiAgentError(format!("spawn failed: {err}")))?;
+
+            (workspace_str, child)
+        }
+    };
+
+    let pid = child.id().map(|p| p.to_string());
+    let mut stdin = child.stdin.take().ok_or_else(|| {
+        SymphonyError::PiAgentError("failed to capture pi-agent stdin".to_string())
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        SymphonyError::PiAgentError("failed to capture pi-agent stdout".to_string())
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        SymphonyError::PiAgentError("failed to capture pi-agent stderr".to_string())
+    })?;
+
+    tokio::spawn(drain_stderr(stderr));
+    let mut stdout_reader = BufReader::new(stdout);
+
+    let get_state_id = next_command_id("get-state");
+    send_command(
+        &mut stdin,
+        &RpcCommand::GetState {
+            id: Some(get_state_id),
+        },
+    )
+    .await?;
+
+    let session_id =
+        match wait_for_handshake(&mut stdout_reader, &mut stdin, HANDSHAKE_TIMEOUT_MS).await {
+            Ok(session_id) => session_id,
+            Err(err) => {
+                let _ = child.kill().await;
+                return Err(err);
+            }
+        };
+
+    tracing::info!(
+        issue_id = %issue.id,
+        issue_identifier = %issue.identifier,
+        workspace = %workspace_str,
+        session_id = %session_id,
+        "pi-agent session started"
+    );
+
+    Ok(SessionHandle {
+        session_id,
+        child,
+        stdin,
+        stdout_reader,
+        pid,
+        issue_id: issue.id.clone(),
+        issue_identifier: issue.identifier.clone(),
+        read_timeout_ms: config.read_timeout_ms,
+        stall_timeout_ms: config.stall_timeout_ms,
+        token_tracker: TokenTracker::new(),
+    })
+}
+
+/// Run one prompt turn and stream mapped events until `agent_end`.
+pub async fn run_turn(
+    handle: &mut SessionHandle,
+    prompt: &str,
+    mut event_callback: impl FnMut(AgentEvent) + Send,
+) -> Result<TurnResult> {
+    let turn_id = next_command_id("prompt");
+    send_command(
+        &mut handle.stdin,
+        &RpcCommand::Prompt {
+            id: Some(turn_id.clone()),
+            message: prompt.to_string(),
+        },
+    )
+    .await?;
+
+    let session_started = AgentEvent::SessionStarted {
+        timestamp: Utc::now(),
+        codex_app_server_pid: handle.pid.clone(),
+        session_id: format!("{}-{turn_id}", handle.session_id),
+    };
+    event_callback(session_started.clone());
+    let mut events = vec![session_started];
+
+    let mut output_text: Option<String> = None;
+    let read_timeout_ms = handle.stall_timeout_ms.max(handle.read_timeout_ms);
+
+    loop {
+        let line = read_line(&mut handle.stdout_reader, read_timeout_ms).await?;
+        let Some(parsed) = parse_output_line(&line) else {
+            continue;
+        };
+
+        match parsed {
+            RpcOutputLine::AgentEnd { .. } => break,
+            RpcOutputLine::Response(response) if response.command == "prompt" => {
+                if !response.success {
+                    let err = response
+                        .error
+                        .unwrap_or_else(|| "prompt command failed".to_string());
+                    let failed = AgentEvent::TurnFailed {
+                        timestamp: Utc::now(),
+                        codex_app_server_pid: handle.pid.clone(),
+                        turn_id: turn_id.clone(),
+                        error: err.clone(),
+                    };
+                    event_callback(failed.clone());
+                    events.push(failed);
+                    return Err(SymphonyError::TurnFailed(err));
+                }
+            }
+            RpcOutputLine::ToolExecutionStart {
+                tool_name, args, ..
+            } => {
+                let name = tool_name.unwrap_or_else(|| "unknown".to_string());
+                let payload = serde_json::to_string(&args).unwrap_or_else(|_| "{}".to_string());
+                let event = AgentEvent::Notification {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: handle.pid.clone(),
+                    message: format!("tool_start: {name} {payload}"),
+                };
+                event_callback(event.clone());
+                events.push(event);
+            }
+            RpcOutputLine::ToolExecutionEnd {
+                tool_name,
+                is_error,
+                ..
+            } => {
+                let name = tool_name.unwrap_or_else(|| "unknown".to_string());
+                let event = AgentEvent::Notification {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: handle.pid.clone(),
+                    message: if is_error {
+                        format!("tool_error: {name}")
+                    } else {
+                        format!("tool_end: {name}")
+                    },
+                };
+                event_callback(event.clone());
+                events.push(event);
+            }
+            RpcOutputLine::AutoCompactionStart { reason } => {
+                let event = AgentEvent::Notification {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: handle.pid.clone(),
+                    message: format!(
+                        "auto_compaction_start: {}",
+                        reason.unwrap_or_else(|| "unknown".to_string())
+                    ),
+                };
+                event_callback(event.clone());
+                events.push(event);
+            }
+            RpcOutputLine::AutoCompactionEnd { aborted } => {
+                let event = AgentEvent::Notification {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: handle.pid.clone(),
+                    message: format!("auto_compaction_end: aborted={aborted}"),
+                };
+                event_callback(event.clone());
+                events.push(event);
+            }
+            RpcOutputLine::AutoRetryStart {
+                attempt,
+                error_message,
+                ..
+            } => {
+                let event = AgentEvent::Notification {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: handle.pid.clone(),
+                    message: format!(
+                        "auto_retry_start: attempt={attempt} error={}",
+                        error_message.unwrap_or_default()
+                    ),
+                };
+                event_callback(event.clone());
+                events.push(event);
+            }
+            RpcOutputLine::AutoRetryEnd { success } => {
+                let event = AgentEvent::Notification {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: handle.pid.clone(),
+                    message: format!("auto_retry_end: success={success}"),
+                };
+                event_callback(event.clone());
+                events.push(event);
+            }
+            RpcOutputLine::ExtensionError {
+                error: Some(error_text),
+                ..
+            } => {
+                let event = AgentEvent::Notification {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: handle.pid.clone(),
+                    message: format!("extension_error: {error_text}"),
+                };
+                event_callback(event.clone());
+                events.push(event);
+            }
+            RpcOutputLine::ExtensionUIRequest { id, method, .. } => {
+                maybe_respond_extension_ui(&mut handle.stdin, id, method).await;
+            }
+            RpcOutputLine::MessageUpdate { message } | RpcOutputLine::MessageEnd { message } => {
+                if let Some(text) = maybe_extract_text(&message) {
+                    output_text = Some(text);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let stats_id = next_command_id("stats");
+    send_command(
+        &mut handle.stdin,
+        &RpcCommand::GetSessionStats { id: Some(stats_id) },
+    )
+    .await?;
+
+    let token_delta = match read_stats_response(
+        &mut handle.stdout_reader,
+        &mut handle.stdin,
+        handle.read_timeout_ms,
+    )
+    .await
+    {
+        Ok(stats) => {
+            handle
+                .token_tracker
+                .update(stats.tokens.input, stats.tokens.output, stats.tokens.total)
+        }
+        Err(err) => {
+            tracing::warn!(
+                issue_id = %handle.issue_id,
+                issue_identifier = %handle.issue_identifier,
+                error = %err,
+                "failed to read get_session_stats; reporting zero token delta"
+            );
+            TokenDelta::default()
+        }
+    };
+
+    let completed = AgentEvent::TurnCompleted {
+        timestamp: Utc::now(),
+        codex_app_server_pid: handle.pid.clone(),
+        turn_id: turn_id.clone(),
+        message: output_text.clone(),
+        input_tokens: token_delta.input_tokens,
+        output_tokens: token_delta.output_tokens,
+        total_tokens: token_delta.total_tokens,
+        rate_limits: None,
+    };
+    event_callback(completed.clone());
+    events.push(completed);
+
+    Ok(TurnResult {
+        events,
+        output_text,
+        input_tokens: token_delta.input_tokens,
+        output_tokens: token_delta.output_tokens,
+        total_tokens: token_delta.total_tokens,
+        rate_limits: None,
+    })
+}
+
+/// Stop a pi-agent session process.
+pub async fn stop_session(mut handle: SessionHandle) -> Result<()> {
+    let _ = send_command(&mut handle.stdin, &RpcCommand::Abort { id: None }).await;
+    drop(handle.stdin);
+
+    match tokio::time::timeout(
+        Duration::from_millis(SHUTDOWN_GRACE_MS),
+        handle.child.wait(),
+    )
+    .await
+    {
+        Ok(Ok(_status)) => Ok(()),
+        _ => {
+            let _ = handle.child.kill().await;
+            Ok(())
+        }
+    }
+}
+
+async fn drain_stderr(stderr: tokio::process::ChildStderr) {
+    let mut reader = BufReader::new(stderr);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break,
+            Ok(_) => {
+                let text = line.trim_end_matches(['\n', '\r']);
+                if !text.is_empty() {
+                    tracing::debug!(stream = "pi-agent-stderr", line = %text);
+                }
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// Validate that `workspace_path` is a legitimate subdirectory of `workspace_root`.
+fn validate_workspace_cwd(workspace_path: &Path, workspace_root: &Path) -> Result<PathBuf> {
+    let canonical_workspace = path_safety::canonicalize(workspace_path)?;
+    let canonical_root = path_safety::canonicalize(workspace_root)?;
+
+    let expanded_workspace = expand_path_no_symlinks(workspace_path);
+    let expanded_root = expand_path_no_symlinks(workspace_root);
+
+    if canonical_workspace == canonical_root {
+        return Err(SymphonyError::InvalidWorkspaceCwd(format!(
+            "workspace is the workspace root: {}",
+            canonical_workspace.display()
+        )));
+    }
+
+    if canonical_workspace.starts_with(&canonical_root) {
+        return Ok(canonical_workspace);
+    }
+
+    if expanded_workspace.starts_with(&expanded_root) && expanded_workspace != expanded_root {
+        return Err(SymphonyError::InvalidWorkspaceCwd(format!(
+            "symlink escape: {} resolves outside workspace root {}",
+            workspace_path.display(),
+            canonical_root.display()
+        )));
+    }
+
+    Err(SymphonyError::InvalidWorkspaceCwd(format!(
+        "workspace {} is outside root {}",
+        canonical_workspace.display(),
+        canonical_root.display()
+    )))
+}
+
+fn expand_path_no_symlinks(path: &Path) -> PathBuf {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_default().join(path)
+    };
+
+    let mut normalized = PathBuf::new();
+    for component in abs.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::CurDir => {}
+            c => normalized.push(c),
+        }
+    }
+    normalized
+}

--- a/apps/symphony/src/pi_agent/token_accounting.rs
+++ b/apps/symphony/src/pi_agent/token_accounting.rs
@@ -1,0 +1,39 @@
+//! Token accounting for pi-agent sessions.
+//!
+//! pi RPC reports cumulative totals via `get_session_stats`; this tracker
+//! converts those totals into per-turn deltas.
+
+/// Incremental token usage for one prompt turn.
+#[derive(Debug, Clone, Default)]
+pub struct TokenDelta {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+}
+
+/// Tracks last-seen cumulative token counts.
+#[derive(Debug, Clone, Default)]
+pub struct TokenTracker {
+    last_input: u64,
+    last_output: u64,
+    last_total: u64,
+}
+
+impl TokenTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Update with cumulative totals and return the incremental delta.
+    pub fn update(&mut self, input: u64, output: u64, total: u64) -> TokenDelta {
+        let delta = TokenDelta {
+            input_tokens: input.saturating_sub(self.last_input),
+            output_tokens: output.saturating_sub(self.last_output),
+            total_tokens: total.saturating_sub(self.last_total),
+        };
+        self.last_input = input;
+        self.last_output = output;
+        self.last_total = total;
+        delta
+    }
+}

--- a/apps/symphony/tests/codex_tests.rs
+++ b/apps/symphony/tests/codex_tests.rs
@@ -428,7 +428,7 @@ fn make_codex_config(script_path: &Path) -> CodexConfig {
     CodexConfig {
         command: vec![script_path.to_str().unwrap().to_string()],
         turn_timeout_ms: 10_000,
-        read_timeout_ms: 5_000,
+        read_timeout_ms: 20_000,
         ..Default::default()
     }
 }
@@ -935,7 +935,7 @@ fn make_auto_approve_config(script_path: &Path) -> CodexConfig {
         command: vec![script_path.to_str().unwrap().to_string()],
         approval_policy: serde_json::json!("never"),
         turn_timeout_ms: 10_000,
-        read_timeout_ms: 5_000,
+        read_timeout_ms: 20_000,
         ..Default::default()
     }
 }

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -110,6 +110,8 @@ fn test_service_config_defaults_match_spec() {
         worker: WorkerConfig::default(),
         agent: AgentConfig::default(),
         codex: CodexConfig::default(),
+        pi_agent: PiAgentConfig::default(),
+        agent_backend: AgentBackend::default(),
         hooks: HooksConfig::default(),
         server: ServerConfig::default(),
     };
@@ -126,6 +128,9 @@ fn test_service_config_defaults_match_spec() {
     assert_eq!(cfg.codex.turn_timeout_ms, 3_600_000);
     assert_eq!(cfg.codex.read_timeout_ms, 5_000);
     assert_eq!(cfg.codex.stall_timeout_ms, 300_000);
+    assert_eq!(cfg.pi_agent.read_timeout_ms, 5_000);
+    assert_eq!(cfg.pi_agent.stall_timeout_ms, 300_000);
+    assert_eq!(cfg.agent_backend, AgentBackend::Codex);
 
     // Hooks §5.3.4
     assert_eq!(cfg.hooks.timeout_ms, 60_000);

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -98,6 +98,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
             WorkerSessionInfo {
                 turn_count: 3,
                 max_turns: 20,
+                stall_timeout_ms: 0,
                 last_activity_ms: Some(started_at.timestamp_millis() + 70_000),
                 session_tokens: SessionTokenUsage {
                     input_tokens: 35,

--- a/apps/symphony/tests/pi_agent_tests.rs
+++ b/apps/symphony/tests/pi_agent_tests.rs
@@ -1,0 +1,251 @@
+//! Tests for pi-agent protocol serde and token accounting.
+
+use serde_json::json;
+use std::path::Path;
+use symphony::pi_agent::protocol::{
+    ExtensionUIResponse, RpcCommand, RpcOutputLine, SessionStats, SessionTokens,
+};
+use symphony::pi_agent::rpc_bridge;
+use symphony::pi_agent::token_accounting::TokenTracker;
+use symphony::{domain::Issue, domain::PiAgentConfig};
+
+#[test]
+fn serialize_prompt_command() {
+    let cmd = RpcCommand::Prompt {
+        id: Some("cmd-1".to_string()),
+        message: "hello world".to_string(),
+    };
+    let json = serde_json::to_value(cmd).expect("serialize prompt command");
+    assert_eq!(
+        json,
+        json!({
+            "type": "prompt",
+            "id": "cmd-1",
+            "message": "hello world"
+        })
+    );
+}
+
+#[test]
+fn serialize_get_state_command() {
+    let cmd = RpcCommand::GetState {
+        id: Some("state-1".to_string()),
+    };
+    let json = serde_json::to_value(cmd).expect("serialize get_state command");
+    assert_eq!(
+        json,
+        json!({
+            "type": "get_state",
+            "id": "state-1"
+        })
+    );
+}
+
+#[test]
+fn parse_prompt_response_line() {
+    let parsed: RpcOutputLine = serde_json::from_value(json!({
+        "type": "response",
+        "id": "prompt-1",
+        "command": "prompt",
+        "success": true,
+        "data": { "ok": true }
+    }))
+    .expect("parse response line");
+
+    match parsed {
+        RpcOutputLine::Response(r) => {
+            assert_eq!(r.id.as_deref(), Some("prompt-1"));
+            assert_eq!(r.command, "prompt");
+            assert!(r.success);
+        }
+        other => panic!("expected response variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_tool_execution_start_event() {
+    let parsed: RpcOutputLine = serde_json::from_value(json!({
+        "type": "tool_execution_start",
+        "toolCallId": "call-1",
+        "toolName": "bash",
+        "args": {"command": "ls -la"}
+    }))
+    .expect("parse tool_execution_start");
+
+    match parsed {
+        RpcOutputLine::ToolExecutionStart {
+            tool_call_id,
+            tool_name,
+            args,
+        } => {
+            assert_eq!(tool_call_id.as_deref(), Some("call-1"));
+            assert_eq!(tool_name.as_deref(), Some("bash"));
+            assert_eq!(args["command"], "ls -la");
+        }
+        other => panic!("expected tool_execution_start variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn extension_ui_response_helpers() {
+    let cancel = ExtensionUIResponse::cancel("req-1".to_string());
+    assert_eq!(cancel.type_, "extension_ui_response");
+    assert_eq!(cancel.id, "req-1");
+    assert_eq!(cancel.cancelled, Some(true));
+    assert_eq!(cancel.confirmed, None);
+
+    let reject = ExtensionUIResponse::reject("req-2".to_string());
+    assert_eq!(reject.id, "req-2");
+    assert_eq!(reject.cancelled, None);
+    assert_eq!(reject.confirmed, Some(false));
+}
+
+#[test]
+fn parse_session_stats_payload() {
+    let stats: SessionStats = serde_json::from_value(json!({
+        "session_id": "session-1",
+        "user_messages": 2,
+        "assistant_messages": 3,
+        "tool_calls": 1,
+        "total_messages": 5,
+        "tokens": {
+            "input": 100,
+            "output": 40,
+            "cacheRead": 5,
+            "cacheWrite": 2,
+            "total": 140
+        },
+        "cost": 0.12
+    }))
+    .expect("parse session stats");
+
+    assert_eq!(stats.session_id, "session-1");
+    assert_eq!(
+        stats.tokens,
+        SessionTokens {
+            input: 100,
+            output: 40,
+            cache_read: 5,
+            cache_write: 2,
+            total: 140
+        }
+    );
+}
+
+#[test]
+fn token_tracker_computes_deltas() {
+    let mut tracker = TokenTracker::new();
+    let d1 = tracker.update(100, 40, 140);
+    assert_eq!(d1.input_tokens, 100);
+    assert_eq!(d1.output_tokens, 40);
+    assert_eq!(d1.total_tokens, 140);
+
+    let d2 = tracker.update(160, 75, 235);
+    assert_eq!(d2.input_tokens, 60);
+    assert_eq!(d2.output_tokens, 35);
+    assert_eq!(d2.total_tokens, 95);
+}
+
+#[test]
+fn token_tracker_clamps_negative_deltas_to_zero() {
+    let mut tracker = TokenTracker::new();
+    let _ = tracker.update(100, 50, 150);
+    let d = tracker.update(90, 45, 135);
+    assert_eq!(d.input_tokens, 0);
+    assert_eq!(d.output_tokens, 0);
+    assert_eq!(d.total_tokens, 0);
+}
+
+fn write_script(dir: &Path, name: &str, content: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, content).expect("write script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod script");
+    }
+    path
+}
+
+fn make_test_issue() -> Issue {
+    Issue {
+        id: "issue-test-1".to_string(),
+        identifier: "TST-1".to_string(),
+        title: "Test Issue".to_string(),
+        description: None,
+        priority: None,
+        state: "In Progress".to_string(),
+        branch_name: None,
+        url: None,
+        assignee_id: None,
+        labels: vec![],
+        blocked_by: vec![],
+        assigned_to_worker: true,
+        created_at: None,
+        updated_at: None,
+    }
+}
+
+const SCRIPT_BASIC_RPC: &str = r#"#!/bin/bash
+set -euo pipefail
+
+read -r line # get_state
+echo '{"type":"response","command":"get_state","success":true,"data":{"sessionId":"sess-123"}}'
+
+while read -r line; do
+  if [[ "$line" == *'"type":"prompt"'* ]]; then
+    echo '{"type":"response","command":"prompt","success":true}'
+    echo '{"type":"tool_execution_start","toolName":"bash","args":{"command":"echo hi"}}'
+    echo '{"type":"message_end","message":{"content":[{"type":"text","text":"done"}]}}'
+    echo '{"type":"agent_end","messages":[]}'
+  elif [[ "$line" == *'"type":"get_session_stats"'* ]]; then
+    echo '{"type":"response","command":"get_session_stats","success":true,"data":{"session_id":"sess-123","tokens":{"input":10,"output":4,"total":14}}}'
+  elif [[ "$line" == *'"type":"abort"'* ]]; then
+    exit 0
+  fi
+done
+"#;
+
+#[tokio::test]
+async fn rpc_bridge_start_turn_stop_smoke() {
+    let scripts_dir = tempfile::tempdir().expect("scripts dir");
+    let root_dir = tempfile::tempdir().expect("root dir");
+    let workspace = root_dir.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let script_path = write_script(scripts_dir.path(), "fake-kata.sh", SCRIPT_BASIC_RPC);
+    let config = PiAgentConfig {
+        command: vec![script_path.to_string_lossy().to_string()],
+        read_timeout_ms: 5_000,
+        stall_timeout_ms: 10_000,
+        ..PiAgentConfig::default()
+    };
+
+    let issue = make_test_issue();
+
+    let mut handle =
+        rpc_bridge::start_session(&config, &issue, &workspace, root_dir.path(), None, None)
+            .await
+            .expect("start_session succeeds");
+
+    let mut events = Vec::new();
+    let turn = rpc_bridge::run_turn(&mut handle, "hello", |event| events.push(event))
+        .await
+        .expect("run_turn succeeds");
+
+    assert_eq!(turn.output_text.as_deref(), Some("done"));
+    assert_eq!(turn.input_tokens, 10);
+    assert_eq!(turn.output_tokens, 4);
+    assert_eq!(turn.total_tokens, 14);
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, symphony::domain::AgentEvent::TurnCompleted { .. })),
+        "TurnCompleted event should be emitted"
+    );
+
+    rpc_bridge::stop_session(handle)
+        .await
+        .expect("stop_session succeeds");
+}

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -182,7 +182,7 @@ fn test_agent_backend_pi_with_pi_agent_config() {
 agent:
   backend: pi
 pi_agent:
-  command: "kata --mode rpc"
+  command: "kata"
   model: "anthropic/claude-sonnet-4-6"
   no_session: false
   append_system_prompt: "/tmp/system.md"
@@ -193,10 +193,7 @@ pi_agent:
     let config = from_workflow(&raw).expect("pi backend config should parse");
 
     assert_eq!(config.agent_backend, AgentBackend::Pi);
-    assert_eq!(
-        config.pi_agent.command,
-        vec!["kata".to_string(), "--mode".to_string(), "rpc".to_string()]
-    );
+    assert_eq!(config.pi_agent.command, vec!["kata".to_string()]);
     assert_eq!(
         config.pi_agent.model.as_deref(),
         Some("anthropic/claude-sonnet-4-6")

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -11,7 +11,7 @@ use tempfile::NamedTempFile;
 
 use symphony::config::{from_workflow, validate};
 use symphony::domain::{
-    CodexConfig, DockerCodexAuth, ServiceConfig, TrackerConfig, WorkspaceConfig,
+    AgentBackend, CodexConfig, DockerCodexAuth, ServiceConfig, TrackerConfig, WorkspaceConfig,
     WorkspaceIsolation, WorkspaceRepoStrategy,
 };
 use symphony::error::SymphonyError;
@@ -167,6 +167,61 @@ fn test_config_defaults() {
     assert_eq!(config.workspace.clone_branch, None);
     assert_eq!(config.workspace.base_branch.as_deref(), Some("main"));
     assert!(!config.workspace.cleanup_on_done);
+    assert_eq!(config.agent_backend, AgentBackend::Codex);
+    assert_eq!(config.pi_agent.command, vec!["kata".to_string()]);
+    assert_eq!(config.pi_agent.model, None);
+    assert!(config.pi_agent.no_session);
+    assert_eq!(config.pi_agent.append_system_prompt, None);
+    assert_eq!(config.pi_agent.read_timeout_ms, 5_000);
+    assert_eq!(config.pi_agent.stall_timeout_ms, 300_000);
+}
+
+#[test]
+fn test_agent_backend_pi_with_pi_agent_config() {
+    let yaml_str = r#"
+agent:
+  backend: pi
+pi_agent:
+  command: "kata --mode rpc"
+  model: "anthropic/claude-sonnet-4-6"
+  no_session: false
+  append_system_prompt: "/tmp/system.md"
+  read_timeout_ms: 1200
+  stall_timeout_ms: 90000
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("pi backend config should parse");
+
+    assert_eq!(config.agent_backend, AgentBackend::Pi);
+    assert_eq!(
+        config.pi_agent.command,
+        vec!["kata".to_string(), "--mode".to_string(), "rpc".to_string()]
+    );
+    assert_eq!(
+        config.pi_agent.model.as_deref(),
+        Some("anthropic/claude-sonnet-4-6")
+    );
+    assert!(!config.pi_agent.no_session);
+    assert_eq!(
+        config.pi_agent.append_system_prompt.as_deref(),
+        Some("/tmp/system.md")
+    );
+    assert_eq!(config.pi_agent.read_timeout_ms, 1200);
+    assert_eq!(config.pi_agent.stall_timeout_ms, 90_000);
+}
+
+#[test]
+fn test_agent_backend_invalid_value_errors() {
+    let yaml_str = r#"
+agent:
+  backend: unknown
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let err = from_workflow(&raw).expect_err("unknown backend should fail");
+    assert!(
+        err.to_string().contains("agent.backend"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- migrate Symphony agent execution to support a new `pi` backend that launches Kata CLI in RPC mode (`kata --mode rpc`) while keeping codex as a transition backend
- add `src/pi_agent` protocol, token accounting, and RPC bridge plumbing and wire backend-aware dispatch into worker task/attempt orchestration
- add config/domain support for `agent.backend` and `pi_agent` settings, plus docs and tests for the new runtime path
- update Kata CLI argument handling so `--mode rpc` and `--cwd` are supported for embedding/runtime launches

## Testing
- cd apps/cli && bun test src/tests/app-smoke.test.ts -t "cli.ts supports rpc mode and cwd override|cli.ts routes --mode rpc through runRpcMode"
- cd apps/symphony && cargo test --test pi_agent_tests
- cd apps/symphony && cargo test --test workflow_config_tests test_config_defaults
- cd apps/symphony && cargo test --test workflow_config_tests agent_backend
- cd apps/symphony && cargo test --test orchestrator_tests
- cd apps/symphony && cargo fmt --check
- cd apps/symphony && cargo clippy -- -D warnings
- cd apps/symphony && cargo test
- cd apps/symphony && cargo build

## Linear
Closes KAT-902


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--cwd` option and `--mode rpc` to the CLI
  * Introduced a selectable pi-agent backend with configurable command, model, and timeout settings
  * New non-interactive RPC execution path (start/stop sessions, run turns, token accounting)

* **Behavior Changes**
  * Interactive wizard is skipped in print/json and rpc non-interactive modes

* **Tests**
  * Added CLI smoke tests and protocol/integration tests for pi-agent and config parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new `pi` agent backend for Symphony that launches Kata CLI in RPC mode (`kata --mode rpc`), alongside the existing Codex app-server backend. The changes include a full Rust `pi_agent` module (protocol serde, RPC bridge subprocess management, token delta accounting), backend-aware dispatch in the orchestrator across all three worker paths (local, SSH, and Docker), a new `agent.backend` / `pi_agent` config section, and `--mode rpc` / `--cwd` flag support in the Kata CLI.

Key changes:
- **`apps/symphony/src/pi_agent/`** — New module with `protocol.rs` (pi RPC serde models), `rpc_bridge.rs` (subprocess lifecycle, JSON-line I/O, turn streaming, workspace path safety), and `token_accounting.rs` (cumulative-to-delta token conversion)
- **`apps/symphony/src/orchestrator.rs`** — All three worker code paths now `match config.agent_backend` to dispatch to either `run_codex_turns_in_session` or the new `run_pi_turns_in_session`; stall timeout also switches per backend
- **`apps/symphony/src/config.rs` / `domain.rs`** — `AgentBackend` enum, `PiAgentConfig` struct, YAML parsing, and validation gated on active backend
- **`apps/cli/src/cli.ts`** — `--mode rpc` and `--cwd` flags; RPC mode skips the interactive wizard and lazily imports `runRpcMode`
- **Tests** — Protocol serde, token-delta math, an end-to-end bash-script smoke test for the RPC bridge, and config-parsing tests

<h3>Confidence Score: 3/5</h3>

- The core logic is sound and well-tested, but three issues in `rpc_bridge.rs` and one misleading test configuration warrant attention before merging to production.
- The architecture is clean and mirrors the existing Codex path closely. The pi_agent module is well-structured with good test coverage. However: (1) a test configures `pi_agent.command: "kata --mode rpc"` which models an incorrect pattern that would cause duplicate `--mode rpc` flags at runtime; (2) the stats request uses a 5-second total deadline that can silently produce zero token deltas if the agent emits buffered output after `agent_end`; (3) `rate_limits` is hardcoded `None` with no comment, creating a silent observability gap. None of these are crashes, but (1) is a test quality issue that could mislead users and (2) can cause incorrect token accounting in production.
- `apps/symphony/src/pi_agent/rpc_bridge.rs` (stats timeout + rate_limits gap) and `apps/symphony/tests/workflow_config_tests.rs` (misleading command example)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/pi_agent/rpc_bridge.rs | New RPC bridge for the pi backend — subprocess lifecycle, JSON-line I/O, handshake, turn streaming, and workspace path validation. Three issues flagged: misleading `read_timeout_ms` variable shadowing, stats request deadline too short (can silently zero out token accounting), and `rate_limits` is hardcoded `None`. |
| apps/symphony/src/pi_agent/protocol.rs | Serde models for the pi RPC protocol (commands, responses, events). Clean, well-structured, only models the subset needed for Symphony's non-interactive runtime. No issues found. |
| apps/symphony/src/orchestrator.rs | Adds backend-aware dispatch for both Codex and Pi sessions in all three worker paths (docker, SSH/local, and inline). `accumulate_turn_metrics` is refactored to accept raw values. Stall timeout correctly switches on `agent_backend`. No logical issues; duplication is structural. |
| apps/symphony/src/config.rs | Config parsing extended with `pi_agent` section and `agent.backend` field. `parse_codex_command` is generalized into `parse_command_value`. Validation correctly gates on active backend. No issues found. |
| apps/symphony/src/domain.rs | Adds `AgentBackend` enum (default `Codex`) and `PiAgentConfig` with sensible defaults matching documentation. `ServiceConfig` extended with two new fields. |
| apps/symphony/tests/workflow_config_tests.rs | New tests for `agent_backend` parsing and pi_agent config. Key issue: `test_agent_backend_pi_with_pi_agent_config` uses `command: "kata --mode rpc"` which would produce a duplicate `--mode rpc` flag at runtime since Symphony always appends it automatically. |
| apps/symphony/tests/pi_agent_tests.rs | Comprehensive unit and integration tests for protocol serde, token tracking, and an end-to-end smoke test using a fake bash script as the kata subprocess. Covers happy path and edge cases (negative token deltas). |
| apps/cli/src/cli.ts | Adds `--mode rpc` and `--cwd` flag support, skips interactive wizard in RPC mode, and lazily imports `runRpcMode` from `@mariozechner/pi-coding-agent`. Logic is clean and isolated. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Orchestrator
    participant rpc_bridge
    participant KataProcess as kata --mode rpc
    participant TokenTracker

    Orchestrator->>rpc_bridge: start_session(PiAgentConfig, issue, workspace)
    rpc_bridge->>KataProcess: spawn subprocess
    rpc_bridge->>KataProcess: stdin: {"type":"get_state"}
    KataProcess-->>rpc_bridge: stdout: {"type":"response","command":"get_state","data":{"sessionId":"..."}}
    rpc_bridge-->>Orchestrator: SessionHandle{session_id}

    loop up to max_turns
        Orchestrator->>rpc_bridge: run_turn(handle, prompt)
        rpc_bridge->>KataProcess: stdin: {"type":"prompt","message":"..."}
        KataProcess-->>rpc_bridge: stdout: tool_execution_start / message_end / agent_end events
        rpc_bridge->>KataProcess: stdin: {"type":"get_session_stats"}
        KataProcess-->>rpc_bridge: stdout: {"command":"get_session_stats","data":{tokens}}
        rpc_bridge->>TokenTracker: update(cumulative) → delta
        rpc_bridge-->>Orchestrator: TurnResult{input_tokens, output_tokens, total_tokens}
        Orchestrator->>Orchestrator: accumulate_turn_metrics
    end

    Orchestrator->>rpc_bridge: stop_session(handle)
    rpc_bridge->>KataProcess: stdin: {"type":"abort"}
    rpc_bridge->>KataProcess: wait (3s grace) / kill
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/symphony/src/pi_agent/rpc_bridge.rs`, line 886-898 ([link](https://github.com/gannonh/kata/blob/a09d9d224e283aed2f707eca0155dd061e5c5af5/apps/symphony/src/pi_agent/rpc_bridge.rs#L886-L898)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`rate_limits` always `None` for the pi backend**

   `TurnResult.rate_limits` and the emitted `TurnCompleted` event both hardcode `rate_limits: None`. The Codex path propagates real rate-limit headers into `TurnMetrics`, which feeds the orchestrator's observability layer. The pi backend silently drops this field, so any rate-limit diagnostics in the dashboard or metrics will always show zero/absent for pi-backend sessions.

   If the pi-agent `get_session_stats` payload includes rate-limit data (or if the protocol adds it later), this would need to be wired through. At a minimum, adding a `// TODO: pi protocol does not yet expose rate-limit headers` comment would make the intentional omission clear.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/pi_agent/rpc_bridge.rs
   Line: 886-898

   Comment:
   **`rate_limits` always `None` for the pi backend**

   `TurnResult.rate_limits` and the emitted `TurnCompleted` event both hardcode `rate_limits: None`. The Codex path propagates real rate-limit headers into `TurnMetrics`, which feeds the orchestrator's observability layer. The pi backend silently drops this field, so any rate-limit diagnostics in the dashboard or metrics will always show zero/absent for pi-backend sessions.

   If the pi-agent `get_session_stats` payload includes rate-limit data (or if the protocol adds it later), this would need to be wired through. At a minimum, adding a `// TODO: pi protocol does not yet expose rate-limit headers` comment would make the intentional omission clear.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/symphony/src/pi_agent/rpc_bridge.rs`, line 855-858 ([link](https://github.com/gannonh/kata/blob/a09d9d224e283aed2f707eca0155dd061e5c5af5/apps/symphony/src/pi_agent/rpc_bridge.rs#L855-L858)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stats request uses `read_timeout_ms` (5 s), not stall timeout**

   After `agent_end`, Symphony sends `get_session_stats` and calls `read_stats_response` with `handle.read_timeout_ms` (default 5 000 ms). Inside that function, each individual `read_line` is capped at 2 000 ms, but the total deadline is only `max(5_000, read_timeout_ms)`.

   If the pi-agent emits a burst of intermediate output lines between `agent_end` and the stats response — each taking up to 2 000 ms to arrive — the 5-second deadline could expire before the stats line is reached, causing `token_delta` to silently fall back to zero.

   Consider using `handle.stall_timeout_ms` (or a dedicated `stats_timeout_ms`) for the stats request so that token accounting is as reliable as the turn itself.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/pi_agent/rpc_bridge.rs
   Line: 855-858

   Comment:
   **Stats request uses `read_timeout_ms` (5 s), not stall timeout**

   After `agent_end`, Symphony sends `get_session_stats` and calls `read_stats_response` with `handle.read_timeout_ms` (default 5 000 ms). Inside that function, each individual `read_line` is capped at 2 000 ms, but the total deadline is only `max(5_000, read_timeout_ms)`.

   If the pi-agent emits a burst of intermediate output lines between `agent_end` and the stats response — each taking up to 2 000 ms to arrive — the 5-second deadline could expire before the stats line is reached, causing `token_delta` to silently fall back to zero.

   Consider using `handle.stall_timeout_ms` (or a dedicated `stats_timeout_ms`) for the stats request so that token accounting is as reliable as the turn itself.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/tests/workflow_config_tests.rs
Line: 197-205

Comment:
**Test command duplicates `--mode rpc` flag**

The test configures `pi_agent.command: "kata --mode rpc"`, which — combined with `build_command_parts` in `rpc_bridge.rs` always appending `--mode rpc --cwd <workspace>` — would produce the following runtime invocation:

```
kata --mode rpc --mode rpc --cwd <workspace>
```

`parseCliFlags` in `cli.ts` silently accepts duplicate `--mode` flags (last one wins), so it won't crash, but the test models an incorrect configuration pattern. The documentation correctly shows `kata` as the default; this test should match that convention to avoid misleading users who treat tests as configuration examples.

```suggestion
pi_agent:
  command: "kata"
  model: "anthropic/claude-sonnet-4-6"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/pi_agent/rpc_bridge.rs
Line: 719-724

Comment:
**`read_timeout_ms` shadowed with stall timeout value**

The local `read_timeout_ms` is assigned `stall_timeout_ms.max(read_timeout_ms)`, effectively making every individual line-read in the turn loop use the stall timeout (300 s by default) rather than the short read timeout (5 s). The variable name is misleading because `read_timeout_ms` now carries the stall semantics.

This is intentional (each `.read_line` call becomes the stall boundary), but the naming conflicts with the same field on `SessionHandle`. Consider renaming the local to `turn_line_timeout_ms` to clarify intent and avoid shadowing:

```suggestion
    let turn_line_timeout_ms = handle.stall_timeout_ms.max(handle.read_timeout_ms);

    loop {
        let line = read_line(&mut handle.stdout_reader, turn_line_timeout_ms).await?;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/pi_agent/rpc_bridge.rs
Line: 886-898

Comment:
**`rate_limits` always `None` for the pi backend**

`TurnResult.rate_limits` and the emitted `TurnCompleted` event both hardcode `rate_limits: None`. The Codex path propagates real rate-limit headers into `TurnMetrics`, which feeds the orchestrator's observability layer. The pi backend silently drops this field, so any rate-limit diagnostics in the dashboard or metrics will always show zero/absent for pi-backend sessions.

If the pi-agent `get_session_stats` payload includes rate-limit data (or if the protocol adds it later), this would need to be wired through. At a minimum, adding a `// TODO: pi protocol does not yet expose rate-limit headers` comment would make the intentional omission clear.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/pi_agent/rpc_bridge.rs
Line: 855-858

Comment:
**Stats request uses `read_timeout_ms` (5 s), not stall timeout**

After `agent_end`, Symphony sends `get_session_stats` and calls `read_stats_response` with `handle.read_timeout_ms` (default 5 000 ms). Inside that function, each individual `read_line` is capped at 2 000 ms, but the total deadline is only `max(5_000, read_timeout_ms)`.

If the pi-agent emits a burst of intermediate output lines between `agent_end` and the stats response — each taking up to 2 000 ms to arrive — the 5-second deadline could expire before the stats line is reached, causing `token_delta` to silently fall back to zero.

Consider using `handle.stall_timeout_ms` (or a dedicated `stats_timeout_ms`) for the stats request so that token accounting is as reliable as the turn itself.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(symphony): increase codex harness r..."](https://github.com/gannonh/kata/commit/a09d9d224e283aed2f707eca0155dd061e5c5af5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26123350)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->