### PR TITLE
docs(symphony): add pi_agent config to WORKFLOW-symphony.md

### DIFF
--- a/apps/symphony/WORKFLOW-symphony.md
+++ b/apps/symphony/WORKFLOW-symphony.md
@@ -33,10 +33,6 @@ agent:
   max_concurrent_agents: 3
   max_turns: 20
   backend: codex              # "codex" (legacy) or "pi" (Kata CLI, recommended for new setups)
-pi_agent:
-  command: kata
-  model: anthropic/claude-sonnet-4-6
-  stall_timeout_ms: 900000
 codex:
   command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
   stall_timeout_ms: 900000
@@ -44,6 +40,10 @@ codex:
   thread_sandbox: danger-full-access
   turn_sandbox_policy:
     type: dangerFullAccess
+pi_agent:
+  command: kata
+  model: anthropic/claude-sonnet-4-6
+  stall_timeout_ms: 900000
 server:
   port: 8080
   host: "127.0.0.1"

--- a/apps/symphony/WORKFLOW-symphony.md
+++ b/apps/symphony/WORKFLOW-symphony.md
@@ -32,6 +32,11 @@ hooks:
 agent:
   max_concurrent_agents: 3
   max_turns: 20
+  backend: codex              # "codex" (legacy) or "pi" (Kata CLI, recommended for new setups)
+pi_agent:
+  command: kata
+  model: anthropic/claude-sonnet-4-6
+  stall_timeout_ms: 900000
 codex:
   command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
   stall_timeout_ms: 900000


### PR DESCRIPTION
Add pi_agent section and agent.backend field to WORKFLOW-symphony.md, the only Symphony doc file that was missing pi-agent backend configuration after KAT-902.

## Changes
- Added `agent.backend: codex` with comment explaining both options
- Added `pi_agent` section with `command`, `model`, and `stall_timeout_ms`

All other Symphony docs (README.md, AGENTS.md, WORKFLOW-REFERENCE.md, WORKFLOW-cli.md) were already updated as part of KAT-902.

Closes KAT-911

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the KAT-902 follow-up (KAT-911) by adding the missing `agent.backend` field and `pi_agent` configuration block to `WORKFLOW-symphony.md` — the only Symphony example workflow file that was not updated in the original KAT-902 pass. The change is documentation-only and has no functional impact on compiled code.

**Key changes:**
- Added `agent.backend: codex` with an inline comment explaining both `codex` (legacy) and `pi` (recommended) options.
- Added a `pi_agent:` section with `command: kata`, `model: anthropic/claude-sonnet-4-6`, and `stall_timeout_ms: 900000`, consistent with values documented in `AGENTS.md` and `docs/WORKFLOW-REFERENCE.md`.
- **Minor style note:** The `pi_agent` section is inserted before the existing `codex:` section, which is the reverse of the ordering used in `WORKFLOW-REFERENCE.md` (`codex` → `pi_agent`). This has no functional impact but is a slight consistency gap with the reference doc.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure documentation change to a workflow template file with no impact on compiled code.
- The added `agent.backend` and `pi_agent` values are consistent with the canonical reference in `AGENTS.md` and `docs/WORKFLOW-REFERENCE.md`. The only finding is a minor section-ordering difference from the reference doc, which does not affect runtime behavior.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/WORKFLOW-symphony.md | Adds `agent.backend: codex` and a `pi_agent` section to the frontmatter config; values are consistent with AGENTS.md and WORKFLOW-REFERENCE.md, with one minor ordering difference (pi_agent placed before codex rather than after). |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Symphony Workflow Config\nWORKFLOW-symphony.md"] --> B{"agent.backend"}
    B -->|codex - current default| C["codex: section\ncommand, stall_timeout_ms,\napproval_policy, thread_sandbox"]
    B -->|pi - recommended for new| D["pi_agent: section\ncommand: kata\nmodel: anthropic/claude-sonnet-4-6\nstall_timeout_ms: 900000"]
    C --> E["Codex App-Server Process"]
    D --> F["Kata CLI in RPC mode\n--mode rpc --cwd workspace"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/WORKFLOW-symphony.md
Line: 35-39

Comment:
**Section order differs from reference doc**

The added `pi_agent:` section is placed *before* `codex:` in this file, but `WORKFLOW-REFERENCE.md` documents the canonical ordering as `agent` → `codex` → `pi_agent` (lines 204–260). While YAML key order is irrelevant to parsing, keeping the same order as the reference doc would make this example easier to compare and cross-reference.

```suggestion
  backend: codex              # "codex" (legacy) or "pi" (Kata CLI, recommended for new setups)
codex:
  command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
  stall_timeout_ms: 900000
  approval_policy: never
  thread_sandbox: danger-full-access
  turn_sandbox_policy:
    type: dangerFullAccess
pi_agent:
  command: kata
  model: anthropic/claude-sonnet-4-6
  stall_timeout_ms: 900000
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(symphony): add pi\_agent config and ..."](https://github.com/gannonh/kata/commit/e3ac9006c603a650f7bc786dc806cd75c39c934d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26176409)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->