### PR TITLE
[symphony/KAT-912] KAT-912: rename Symphony pi backend to kata-cli with aliases

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -16,7 +16,7 @@ for distributing agent sessions across multiple machines.
 - A Linear personal API key (`LINEAR_API_KEY`)
 - Agent runtime binary reachable on `PATH`:
   - Codex backend: `codex app-server`
-  - Pi backend: `kata --mode rpc`
+  - Kata CLI backend (`kata-cli` / `kata` / `pi`): `kata --mode rpc`
 
 Build the release binary:
 
@@ -125,7 +125,7 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | `agent.max_concurrent_agents`          | u32                | `10`     | Global cap on simultaneously running agent sessions.                                                                           |
 | `agent.max_turns`                      | u32                | `20`     | Maximum prompt turns per session attempt before the worker run ends.                                                           |
 | `agent.max_retry_backoff_ms`           | u64                | `300000` | Maximum exponential back-off delay (ms) between retries.                                                                       |
-| `agent.backend`                        | string             | `"codex"`| Runtime backend: `"codex"` (Codex app-server) or `"pi"` (Kata RPC).                                                           |
+| `agent.backend`                        | string             | `"codex"`| Runtime backend: `"codex"` (Codex app-server) or `"kata-cli"` (aliases: `"kata"`, `"pi"`) for Kata RPC.                   |
 | `agent.max_concurrent_agents_by_state` | map\<string, u32\> | `{}`     | Per-Linear-state concurrency caps. Keys are lowercased state names; zero or negative values are silently ignored (spec §17.1). |
 
 #### `codex` section
@@ -140,16 +140,16 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | `codex.read_timeout_ms`     | u64                | `5000`                    | Timeout waiting for Codex process output (ms).                                                                           |
 | `codex.stall_timeout_ms`    | u64                | `300000`                  | Time before a non-progressing session is considered stalled (5 min default).                                             |
 
-#### `pi_agent` section
+#### `kata_agent` section (`pi_agent` alias)
 
-| Field                           | Type               | Default  | Description                                                                                               |
-| ------------------------------- | ------------------ | -------- | --------------------------------------------------------------------------------------------------------- |
-| `pi_agent.command`              | string or string[] | `["kata"]` | Pi agent executable and base args. Symphony appends `--mode rpc --cwd <workspace>`.                    |
-| `pi_agent.model`                | string             | _(none)_ | Optional model override passed as `--model`.                                                             |
-| `pi_agent.no_session`           | bool               | `true`   | Pass `--no-session` to disable persistent session storage.                                               |
-| `pi_agent.append_system_prompt` | string             | _(none)_ | Optional path passed via `--append-system-prompt`.                                                       |
-| `pi_agent.read_timeout_ms`      | u64                | `5000`   | Timeout waiting for pi agent process output (ms).                                                        |
-| `pi_agent.stall_timeout_ms`     | u64                | `300000` | Time before a non-progressing pi session is considered stalled (5 min default).                         |
+| Field                             | Type               | Default  | Description                                                                                               |
+| --------------------------------- | ------------------ | -------- | --------------------------------------------------------------------------------------------------------- |
+| `kata_agent.command` (`pi_agent.command`)              | string or string[] | `["kata"]` | Kata CLI executable and base args. Symphony appends `--mode rpc --cwd <workspace>`.                    |
+| `kata_agent.model` (`pi_agent.model`)                  | string             | _(none)_ | Optional model override passed as `--model`.                                                             |
+| `kata_agent.no_session` (`pi_agent.no_session`)        | bool               | `true`   | Pass `--no-session` to disable persistent session storage.                                               |
+| `kata_agent.append_system_prompt` (`pi_agent.append_system_prompt`) | string             | _(none)_ | Optional path passed via `--append-system-prompt`.                                                       |
+| `kata_agent.read_timeout_ms` (`pi_agent.read_timeout_ms`)      | u64                | `5000`   | Timeout waiting for Kata CLI process output (ms).                                                        |
+| `kata_agent.stall_timeout_ms` (`pi_agent.stall_timeout_ms`)     | u64                | `300000` | Time before a non-progressing Kata CLI session is considered stalled (5 min default).                   |
 
 #### `hooks` section
 
@@ -471,7 +471,7 @@ symphony WORKFLOW.md
 Symphony connects via `ssh -T [-F config] -p <port> <host> bash -lc '<command>'`.
 The command string is POSIX single-quote-escaped. The remote host must have
 `bash` available and the configured runtime binary on its `PATH`
-(`codex.command` for codex backend, `pi_agent.command` for pi backend).
+(`codex.command` for codex backend, `kata_agent.command` / `pi_agent.command` for Kata CLI backend).
 
 ### Docker Isolation Lifecycle
 

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -233,9 +233,9 @@ codex:
   turn_sandbox_policy:
     type: dangerFullAccess
 
-# ─── Pi Agent (Kata RPC) ──────────────────────────────────────────────────────
-# Configures Kata RPC runtime (used when `agent.backend: pi`).
-pi_agent:
+# ─── Kata Agent (Kata RPC) ────────────────────────────────────────────────────
+# Configures Kata RPC runtime (used when `agent.backend: kata-cli`; aliases: kata, pi).
+kata_agent:  # alias: pi_agent
   # Command used to launch Kata RPC. Can be a string or list.
   # Symphony appends --mode rpc --cwd <workspace> automatically.
   # Default parser value: `kata`

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -433,11 +433,20 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let raw_worker: RawWorkerConfig = extract_section(&normalized, "worker")?;
     let raw_agent: RawAgentConfig = extract_section(&normalized, "agent")?;
     let raw_codex: RawCodexConfig = extract_section(&normalized, "codex")?;
+    let raw_kata_agent: RawPiAgentConfig = extract_section(&normalized, "kata_agent")?;
     let raw_pi_agent: RawPiAgentConfig = extract_section(&normalized, "pi_agent")?;
     let raw_hooks: RawHooksConfig = extract_section(&normalized, "hooks")?;
     let raw_server: RawServerConfig = extract_section(&normalized, "server")?;
 
     let defaults = ServiceConfig::default();
+    let has_kata_agent_section = normalized.get("kata_agent").is_some();
+    let has_pi_agent_section = normalized.get("pi_agent").is_some();
+
+    if has_kata_agent_section && has_pi_agent_section {
+        return Err(SymphonyError::InvalidWorkflowConfig(
+            "config must set only one of 'kata_agent' or 'pi_agent'".to_string(),
+        ));
+    }
 
     // ── TrackerConfig ─────────────────────────────────────────────────────
     // Resolve $VAR references in api_key; on empty result try LINEAR_API_KEY
@@ -753,17 +762,23 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
             .unwrap_or(defaults.codex.stall_timeout_ms),
     };
 
-    // ── PiAgentConfig ───────────────────────────────────────────────────
-    let pi_agent_command = match raw_pi_agent.command {
+    // ── Kata/Pi agent config ───────────────────────────────────────────
+    let selected_agent_config = if has_kata_agent_section {
+        raw_kata_agent
+    } else {
+        raw_pi_agent
+    };
+
+    let pi_agent_command = match selected_agent_config.command {
         Some(val) => parse_pi_agent_command(val)?,
         None => defaults.pi_agent.command.clone(),
     };
-    let pi_agent_model = raw_pi_agent
+    let pi_agent_model = selected_agent_config
         .model
         .map(|value| resolve_env(&value))
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    let pi_agent_append_system_prompt = raw_pi_agent
+    let pi_agent_append_system_prompt = selected_agent_config
         .append_system_prompt
         .map(|value| resolve_env(&value))
         .map(|value| value.trim().to_string())
@@ -771,14 +786,14 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let pi_agent = PiAgentConfig {
         command: pi_agent_command,
         model: pi_agent_model,
-        no_session: raw_pi_agent
+        no_session: selected_agent_config
             .no_session
             .unwrap_or(defaults.pi_agent.no_session),
         append_system_prompt: pi_agent_append_system_prompt,
-        read_timeout_ms: raw_pi_agent
+        read_timeout_ms: selected_agent_config
             .read_timeout_ms
             .unwrap_or(defaults.pi_agent.read_timeout_ms),
-        stall_timeout_ms: raw_pi_agent
+        stall_timeout_ms: selected_agent_config
             .stall_timeout_ms
             .unwrap_or(defaults.pi_agent.stall_timeout_ms),
     };
@@ -790,10 +805,10 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         .map(|value| value.trim().to_ascii_lowercase())
         .filter(|value| !value.is_empty())
         .map(|value| match value.as_str() {
-            "pi" => Ok(AgentBackend::Pi),
+            "kata-cli" | "kata" | "pi" => Ok(AgentBackend::KataCli),
             "codex" => Ok(AgentBackend::Codex),
             other => Err(SymphonyError::InvalidWorkflowConfig(format!(
-                "agent.backend must be 'pi' or 'codex' (got '{other}')"
+                "agent.backend must be 'kata-cli' (aliases: 'kata', 'pi') or 'codex' (got '{other}')"
             ))),
         })
         .transpose()?
@@ -876,9 +891,9 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
             "codex.command is required when agent.backend is 'codex'".to_string(),
         ));
     }
-    if config.agent_backend == AgentBackend::Pi && config.pi_agent.command.is_empty() {
+    if config.agent_backend == AgentBackend::KataCli && config.pi_agent.command.is_empty() {
         return Err(SymphonyError::InvalidWorkflowConfig(
-            "pi_agent.command is required when agent.backend is 'pi'".to_string(),
+            "kata_agent.command (alias: pi_agent.command) is required when agent.backend is 'kata-cli' (aliases: 'kata', 'pi')".to_string(),
         ));
     }
 

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -365,7 +365,7 @@ impl Default for CodexConfig {
 /// Which runtime backend to use for agent sessions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AgentBackend {
-    Pi,
+    KataCli,
     #[default]
     Codex,
 }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -101,7 +101,7 @@ fn is_active_state(state_name: &str, tracker_config: &TrackerConfig) -> bool {
 
 fn backend_stall_timeout_ms(config: &ServiceConfig, backend: AgentBackend) -> i64 {
     let timeout = match backend {
-        AgentBackend::Pi => config.pi_agent.stall_timeout_ms,
+        AgentBackend::KataCli => config.pi_agent.stall_timeout_ms,
         AgentBackend::Codex => config.codex.stall_timeout_ms,
     };
     timeout.min(i64::MAX as u64) as i64
@@ -502,7 +502,7 @@ async fn run_worker_task(
 
                         loop_result
                     }
-                    AgentBackend::Pi => {
+                    AgentBackend::KataCli => {
                         let mut session = rpc_bridge::start_session(
                             &config.pi_agent,
                             issue,
@@ -516,7 +516,7 @@ async fn run_worker_task(
 
                         tracing::info!(
                             event = "worker_started",
-                            backend = "pi",
+                            backend = "kata-cli",
                             issue_id = %issue.id,
                             issue_identifier = %issue.identifier,
                             session_id = %session.session_id,
@@ -764,7 +764,7 @@ async fn run_worker_task(
 
             loop_result
         }
-        AgentBackend::Pi => {
+        AgentBackend::KataCli => {
             let mut session = match rpc_bridge::start_session(
                 &config.pi_agent,
                 issue,
@@ -797,7 +797,7 @@ async fn run_worker_task(
 
             tracing::info!(
                 event = "worker_started",
-                backend = "pi",
+                backend = "kata-cli",
                 issue_id = %issue_id,
                 issue_identifier = %issue.identifier,
                 session_id = %session.session_id,
@@ -2067,7 +2067,7 @@ impl Orchestrator {
 
                 loop_result
             }
-            AgentBackend::Pi => {
+            AgentBackend::KataCli => {
                 let mut session = match rpc_bridge::start_session(
                     &self.config.pi_agent,
                     issue,
@@ -2093,7 +2093,7 @@ impl Orchestrator {
 
                 tracing::info!(
                     event = "worker_started",
-                    backend = "pi",
+                    backend = "kata-cli",
                     issue_id = %issue.id,
                     issue_identifier = %issue.identifier,
                     session_id = %session.session_id,

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -177,11 +177,11 @@ fn test_config_defaults() {
 }
 
 #[test]
-fn test_agent_backend_pi_with_pi_agent_config() {
+fn test_agent_backend_kata_cli_with_kata_agent_config() {
     let yaml_str = r#"
 agent:
-  backend: pi
-pi_agent:
+  backend: kata-cli
+kata_agent:
   command: "kata"
   model: "anthropic/claude-sonnet-4-6"
   no_session: false
@@ -190,9 +190,9 @@ pi_agent:
   stall_timeout_ms: 90000
 "#;
     let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
-    let config = from_workflow(&raw).expect("pi backend config should parse");
+    let config = from_workflow(&raw).expect("kata-cli backend config should parse");
 
-    assert_eq!(config.agent_backend, AgentBackend::Pi);
+    assert_eq!(config.agent_backend, AgentBackend::KataCli);
     assert_eq!(config.pi_agent.command, vec!["kata".to_string()]);
     assert_eq!(
         config.pi_agent.model.as_deref(),
@@ -205,6 +205,49 @@ pi_agent:
     );
     assert_eq!(config.pi_agent.read_timeout_ms, 1200);
     assert_eq!(config.pi_agent.stall_timeout_ms, 90_000);
+}
+
+#[test]
+fn test_agent_backend_aliases_map_to_kata_cli() {
+    for backend in ["kata-cli", "kata", "pi"] {
+        let yaml_str = format!("agent:\n  backend: {backend}\nkata_agent:\n  command: kata\n");
+        let raw: serde_yaml::Value = serde_yaml::from_str(&yaml_str).unwrap();
+        let config = from_workflow(&raw).expect("backend alias should parse");
+        assert_eq!(config.agent_backend, AgentBackend::KataCli);
+    }
+}
+
+#[test]
+fn test_pi_agent_section_still_supported_as_alias() {
+    let yaml_str = r#"
+agent:
+  backend: kata
+pi_agent:
+  command: "kata"
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("pi_agent alias section should parse");
+    assert_eq!(config.agent_backend, AgentBackend::KataCli);
+    assert_eq!(config.pi_agent.command, vec!["kata".to_string()]);
+}
+
+#[test]
+fn test_kata_agent_and_pi_agent_sections_conflict() {
+    let yaml_str = r#"
+agent:
+  backend: kata-cli
+kata_agent:
+  command: "kata"
+pi_agent:
+  command: "kata"
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let err = from_workflow(&raw).expect_err("dual agent sections should fail");
+    assert!(
+        err.to_string()
+            .contains("only one of 'kata_agent' or 'pi_agent'"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What Changed
See slice plan: 912: (no slice plan found)

## Must-Haves
- See slice plan

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the Symphony "Pi" backend to `kata-cli` throughout the codebase, adding `"kata"` and `"pi"` as accepted aliases for both the `agent.backend` config key and the YAML config section (`kata_agent` / `pi_agent`). The change is backward-compatible: existing configs using `backend: pi` or a `pi_agent:` section continue to work without modification.

**Key changes:**
- `AgentBackend::Pi` enum variant renamed to `AgentBackend::KataCli` in `domain.rs`
- Config parser (`config.rs`) now deserializes both `kata_agent` and `pi_agent` sections, picks the one that is present (or errors if both are set), and maps `"kata-cli"` / `"kata"` / `"pi"` backend strings to `AgentBackend::KataCli`
- Tracing log `backend = "pi"` fields updated to `"kata-cli"` in `orchestrator.rs`
- Four new tests added covering aliases, the alias section, and the conflict guard
- `AGENTS.md` and `WORKFLOW-REFERENCE.md` updated to document the new canonical name and aliases

**Notable observation:** The internal struct `PiAgentConfig`, the `pi_agent` field on `ServiceConfig`, and local variable names like `pi_agent_command` were intentionally left unchanged. While this works correctly, it creates a split where `AgentBackend::KataCli` drives `config.pi_agent` of type `PiAgentConfig`, which may confuse future contributors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; all changes are backward-compatible renames with no functional logic alterations.
- The change is a well-scoped rename with explicit alias support for the old names. The conflict guard prevents ambiguous configs. All three alias strings (`kata-cli`, `kata`, `pi`) and both YAML section names are tested. The only concerns are a naming inconsistency between the renamed enum variant and the unchanged internal structs (style, not a bug), and a slightly thin assertion set in the `pi_agent` alias backward-compat test.
- apps/symphony/src/domain.rs — internal struct and field names still use the old `Pi`/`pi_agent` naming while the enum variant has moved to `KataCli`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/config.rs | Adds `kata_agent` section deserialization alongside legacy `pi_agent`, with a mutual-exclusion guard and a selection shim. The conflict check, alias mapping, and validation message updates are all correct. Local variable names still use the `pi_agent_` prefix (style inconsistency, not a bug). |
| apps/symphony/src/domain.rs | Renames `AgentBackend::Pi` to `AgentBackend::KataCli`, but leaves `PiAgentConfig`, its doc-comment, and the `pi_agent` field name unchanged — creating a naming inconsistency between the enum variant and the structs it drives. |
| apps/symphony/src/orchestrator.rs | Mechanical rename of `AgentBackend::Pi` → `AgentBackend::KataCli` in all `match` arms and `backend = "pi"` tracing fields → `"kata-cli"`. No logic changes; looks correct. |
| apps/symphony/tests/workflow_config_tests.rs | Good new coverage for alias backend strings and conflict detection. The `pi_agent` alias section test only asserts one field, leaving other fields unverified for the backward-compat path. |
| apps/symphony/AGENTS.md | Documentation updated to reflect new `kata_agent` / `kata-cli` naming with `pi_agent` / `pi` aliases. Changes are accurate and consistent with code changes. |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Workflow reference updated to replace `pi_agent` with `kata_agent` (with alias comment). Consistent with implementation. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["YAML config loaded"] --> B["normalize_keys()"]
    B --> C{"detect sections"}
    C --> D{"kata_agent AND pi_agent\nboth present?"}
    D -- Yes --> E["❌ InvalidWorkflowConfig\n'only one of kata_agent or pi_agent'"]
    D -- No --> F{"kata_agent section present?"}
    F -- Yes --> G["use raw_kata_agent"]
    F -- No --> H["use raw_pi_agent (legacy alias)"]
    G --> I["build PiAgentConfig\nstored as config.pi_agent"]
    H --> I
    I --> J{"agent.backend value?"}
    J -- "'kata-cli' | 'kata' | 'pi'" --> K["AgentBackend::KataCli"]
    J -- "'codex'" --> L["AgentBackend::Codex"]
    J -- other --> M["❌ InvalidWorkflowConfig"]
    K --> N["validate(): pi_agent.command must not be empty"]
    L --> O["validate(): codex.command must not be empty"]
    N --> P["ValidatedServiceConfig"]
    O --> P
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/src/domain.rs`, line 373-388 ([link](https://github.com/gannonh/kata/blob/f87e4d71c0802a5708660865e09b8e4288505680/apps/symphony/src/domain.rs#L373-L388)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale internal naming after enum rename**

   The enum variant was renamed to `AgentBackend::KataCli`, but the associated struct (`PiAgentConfig`), the doc-comment on line 373 (`"Pi-agent (Kata RPC) runtime configuration"`), and the field name `pi_agent` on `ServiceConfig` were all left with the old `Pi`/`pi_` prefix. This creates a misleading split: the public-facing identifier says `KataCli`, but every internal reference still says `pi`.

   While this is intentional to avoid a larger refactor, it would be worth either:
   - Adding a `// TODO: rename PiAgentConfig → KataAgentConfig once Pi branding is fully retired` comment, or
   - Completing the rename now by also updating `PiAgentConfig`, the `pi_agent` field in `ServiceConfig`, and the local variable names in `config.rs` (`pi_agent_command`, `pi_agent_model`, etc.).

   As-is, a future developer matching `AgentBackend::KataCli` in `orchestrator.rs` will find it drives `config.pi_agent` of type `PiAgentConfig`, which is confusing.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/domain.rs
   Line: 373-388

   Comment:
   **Stale internal naming after enum rename**

   The enum variant was renamed to `AgentBackend::KataCli`, but the associated struct (`PiAgentConfig`), the doc-comment on line 373 (`"Pi-agent (Kata RPC) runtime configuration"`), and the field name `pi_agent` on `ServiceConfig` were all left with the old `Pi`/`pi_` prefix. This creates a misleading split: the public-facing identifier says `KataCli`, but every internal reference still says `pi`.

   While this is intentional to avoid a larger refactor, it would be worth either:
   - Adding a `// TODO: rename PiAgentConfig → KataAgentConfig once Pi branding is fully retired` comment, or
   - Completing the rename now by also updating `PiAgentConfig`, the `pi_agent` field in `ServiceConfig`, and the local variable names in `config.rs` (`pi_agent_command`, `pi_agent_model`, etc.).

   As-is, a future developer matching `AgentBackend::KataCli` in `orchestrator.rs` will find it drives `config.pi_agent` of type `PiAgentConfig`, which is confusing.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/domain.rs
Line: 373-388

Comment:
**Stale internal naming after enum rename**

The enum variant was renamed to `AgentBackend::KataCli`, but the associated struct (`PiAgentConfig`), the doc-comment on line 373 (`"Pi-agent (Kata RPC) runtime configuration"`), and the field name `pi_agent` on `ServiceConfig` were all left with the old `Pi`/`pi_` prefix. This creates a misleading split: the public-facing identifier says `KataCli`, but every internal reference still says `pi`.

While this is intentional to avoid a larger refactor, it would be worth either:
- Adding a `// TODO: rename PiAgentConfig → KataAgentConfig once Pi branding is fully retired` comment, or
- Completing the rename now by also updating `PiAgentConfig`, the `pi_agent` field in `ServiceConfig`, and the local variable names in `config.rs` (`pi_agent_command`, `pi_agent_model`, etc.).

As-is, a future developer matching `AgentBackend::KataCli` in `orchestrator.rs` will find it drives `config.pi_agent` of type `PiAgentConfig`, which is confusing.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/tests/workflow_config_tests.rs
Line: 220-231

Comment:
**Alias section test only verifies `command`, not all fields**

`test_pi_agent_section_still_supported_as_alias` confirms the `pi_agent` alias section is accepted and sets `pi_agent.command`, but it does not verify that the remaining fields (`model`, `no_session`, `append_system_prompt`, `read_timeout_ms`, `stall_timeout_ms`) are also correctly forwarded from the `pi_agent` section.

The new `selected_agent_config` selection path (`has_kata_agent_section ? raw_kata_agent : raw_pi_agent`) is exercised for `raw_pi_agent` in this test, but only one field is asserted. A full-field assertion (similar to `test_agent_backend_kata_cli_with_kata_agent_config`) would provide stronger coverage that the alias path doesn't silently drop any configuration.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): rename pi backend to kat..."](https://github.com/gannonh/kata/commit/f87e4d71c0802a5708660865e09b8e4288505680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26184323)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->