### PR TITLE
KAT-913: enforce deterministic workpad comment reuse

### DIFF
--- a/apps/symphony/WORKFLOW-cli.md
+++ b/apps/symphony/WORKFLOW-cli.md
@@ -327,7 +327,12 @@ Use one persistent workpad comment and include task-level progress:
 0. Before ANY other action, read `.codex/skills/linear/SKILL.md` and keep it in context.
 1. Fetch the issue by explicit ticket ID.
 2. Route by state.
-3. Ensure one active unresolved `## Codex Workpad` comment exists and reuse it.
+3. Ensure workpad reuse is deterministic:
+   - list comments before creating anything,
+   - match `## Codex Workpad` heading candidates,
+   - reuse the most recently updated active/unresolved candidate when one exists,
+   - create exactly one new workpad only when no active candidate exists,
+   - persist that chosen comment ID for all further updates.
 4. Check if a PR already exists for the current branch and whether it is closed/merged.
    - If closed/merged, create a fresh branch from `origin/{{ workspace.base_branch }}` and restart.
 

--- a/apps/symphony/WORKFLOW-cli.md
+++ b/apps/symphony/WORKFLOW-cli.md
@@ -329,9 +329,9 @@ Use one persistent workpad comment and include task-level progress:
 2. Route by state.
 3. Ensure workpad reuse is deterministic:
    - list comments before creating anything,
-   - match `## Codex Workpad` heading candidates,
+   - match `## Codex Workpad` heading candidates (case-sensitive, at the start of a markdown heading line),
    - reuse the most recently updated active/unresolved candidate when one exists,
-   - create exactly one new workpad only when no active candidate exists,
+   - create exactly one new workpad when no active candidate exists (even if resolved/archived workpads exist),
    - persist that chosen comment ID for all further updates.
 4. Check if a PR already exists for the current branch and whether it is closed/merged.
    - If closed/merged, create a fresh branch from `origin/{{ workspace.base_branch }}` and restart.

--- a/apps/symphony/WORKFLOW-symphony.md
+++ b/apps/symphony/WORKFLOW-symphony.md
@@ -281,11 +281,13 @@ Todo -> In Progress -> Agent Review (auto, address bot feedback) -> Human Review
 ## Step 1: Start/continue execution (Todo or In Progress)
 
 1. Find or create a single persistent scratchpad comment for the issue:
-    - Search existing comments for a marker header: `## Codex Workpad`.
-    - Ignore resolved comments while searching; only active/unresolved comments are eligible to be reused as the live workpad.
-    - If found, reuse that comment; do not create a new workpad comment.
-    - If not found, create one workpad comment and use it for all updates.
-    - Persist the workpad comment ID and only write progress updates to that ID.
+    - List comments first; never create a new workpad before reading the existing comment list.
+    - Match candidates by marker header: `## Codex Workpad` (case-sensitive) at the start of a markdown heading line.
+    - Treat only active/unresolved comments as reusable live candidates.
+    - Deterministic selection rule when multiple active candidates exist: reuse the most recently updated candidate and keep its comment ID fixed for the run.
+    - Do **not** create a new workpad if any active candidate exists.
+    - If no active candidate exists but resolved/archived workpads exist, create exactly one new workpad comment.
+    - Persist the chosen workpad comment ID immediately and use only that ID for all subsequent updates in this run.
 2. If arriving from `Todo`, do not delay on additional status transitions: the issue should already be `In Progress` before this step begins.
 3. Immediately reconcile the workpad before new edits:
     - Check off items that are already done.

--- a/apps/symphony/docker/WORKFLOW-docker.md
+++ b/apps/symphony/docker/WORKFLOW-docker.md
@@ -278,11 +278,13 @@ Todo -> In Progress -> Agent Review (auto, address bot feedback) -> Human Review
 ## Step 1: Start/continue execution (Todo or In Progress)
 
 1. Find or create a single persistent scratchpad comment for the issue:
-    - Search existing comments for a marker header: `## Codex Workpad`.
-    - Ignore resolved comments while searching; only active/unresolved comments are eligible to be reused as the live workpad.
-    - If found, reuse that comment; do not create a new workpad comment.
-    - If not found, create one workpad comment and use it for all updates.
-    - Persist the workpad comment ID and only write progress updates to that ID.
+    - List comments first; never create a new workpad before reading the existing comment list.
+    - Match candidates by marker header: `## Codex Workpad` (case-sensitive) at the start of a markdown heading line.
+    - Treat only active/unresolved comments as reusable live candidates.
+    - Deterministic selection rule when multiple active candidates exist: reuse the most recently updated candidate and keep its comment ID fixed for the run.
+    - Do **not** create a new workpad if any active candidate exists.
+    - If no active candidate exists but resolved/archived workpads exist, create exactly one new workpad comment.
+    - Persist the chosen workpad comment ID immediately and use only that ID for all subsequent updates in this run.
 2. If arriving from `Todo`, do not delay on additional status transitions: the issue should already be `In Progress` before this step begins.
 3. Immediately reconcile the workpad before new edits:
     - Check off items that are already done.

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -502,11 +502,13 @@ mutation AttachURL($issueId: String!, $url: String!, $title: String) {
 ## Step 1: Start/continue execution (Todo or In Progress)
 
 1. Find or create a single persistent scratchpad comment for the issue:
-    - Search existing comments for a marker header: `## Codex Workpad`.
-    - Ignore resolved comments while searching; only active/unresolved comments are eligible to be reused as the live workpad.
-    - If found, reuse that comment; do not create a new workpad comment.
-    - If not found, create one workpad comment and use it for all updates.
-    - Persist the workpad comment ID and only write progress updates to that ID.
+    - List comments first; never create a new workpad before reading the existing comment list.
+    - Match candidates by marker header: `## Codex Workpad` (case-sensitive) at the start of a markdown heading line.
+    - Treat only active/unresolved comments as reusable live candidates.
+    - Deterministic selection rule when multiple active candidates exist: reuse the most recently updated candidate and keep its comment ID fixed for the run.
+    - Do **not** create a new workpad if any active candidate exists.
+    - If no active candidate exists but resolved/archived workpads exist, create exactly one new workpad comment.
+    - Persist the chosen workpad comment ID immediately and use only that ID for all subsequent updates in this run.
 2. If arriving from `Todo`, do not delay on additional status transitions: the issue should already be `In Progress` before this step begins.
 3. Immediately reconcile the workpad before new edits:
     - Check off items that are already done.


### PR DESCRIPTION
## Summary
- harden Symphony workflow instructions to make workpad reuse deterministic
- require listing comments first and matching `## Codex Workpad` heading candidates
- require reusing the most recently updated active/unresolved workpad, and never creating a new one when an active candidate exists

## Files
- apps/symphony/WORKFLOW-symphony.md
- apps/symphony/docs/WORKFLOW-REFERENCE.md
- apps/symphony/docker/WORKFLOW-docker.md
- apps/symphony/WORKFLOW-cli.md

## Validation
- cd apps/symphony && cargo fmt --check
- cd apps/symphony && cargo clippy -- -D warnings
- cd apps/symphony && cargo test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the workpad comment reuse logic across all four Symphony workflow files (`WORKFLOW-symphony.md`, `WORKFLOW-docker.md`, `WORKFLOW-REFERENCE.md`, `WORKFLOW-cli.md`) to make the selection algorithm deterministic. The key changes enforce: (1) always listing existing comments before creating anything, (2) case-sensitive matching of the `## Codex Workpad` heading at the start of a markdown heading line, (3) a tie-breaking rule that selects the most recently updated active/unresolved candidate when multiple exist, (4) a hard prohibition on creating a new workpad when any active candidate is already present, and (5) immediate persistence of the chosen comment ID for the entire run.

- Three of the four files (`WORKFLOW-symphony.md`, `WORKFLOW-docker.md`, `WORKFLOW-REFERENCE.md`) receive identical, complete updates and are internally consistent.
- `WORKFLOW-cli.md` receives a condensed update in Step 0 that is missing two matching qualifiers present in the sibling files — `(case-sensitive)` and "at the start of a markdown heading line" — which could cause an agent following only the CLI file to match a heading it shouldn't (e.g. a case variant or an embedded substring). The CLI version also omits the explicit guard clarifying that resolved/archived workpads must not be reused.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor follow-up recommended to tighten the CLI workflow matching rule.
- Three of the four files are updated with full, consistent, and well-specified rules. The fourth (`WORKFLOW-cli.md`) is functionally correct for the common path but omits precision qualifiers that could matter in edge cases (case variants, embedded headings, resolved-workpad reuse). These are documentation/instruction files with no runtime code impact, so the risk is low but the inconsistency is worth fixing before it confuses an agent following only the CLI workflow.
- apps/symphony/WORKFLOW-cli.md — the condensed Step 0 rule is missing case-sensitivity and line-anchor qualifiers present in all three sibling files.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/WORKFLOW-cli.md | Step 0 workpad rules updated but missing the `(case-sensitive)` qualifier, the "at the start of a markdown heading line" anchor, and the explicit "resolved/archived workpads exist" guard present in all three sibling files — leaving the CLI workflow subtly less precise. |
| apps/symphony/WORKFLOW-symphony.md | Step 1 workpad instructions fully updated with all deterministic selection rules: list-first, case-sensitive heading match, most-recently-updated tie-break, hard prohibition on creating when an active candidate exists, and immediate ID persistence. No issues found. |
| apps/symphony/docker/WORKFLOW-docker.md | Step 1 workpad instructions updated identically to WORKFLOW-symphony.md; all deterministic reuse rules are present and consistent. No issues found. |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Step 1 workpad instructions updated identically to WORKFLOW-symphony.md and WORKFLOW-docker.md; all deterministic reuse rules are present and consistent. No issues found. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start workflow run] --> B[List all existing comments]
    B --> C{Any comments with\n'## Codex Workpad'\nheading?}
    C -- No comments at all --> G[Create exactly one\nnew workpad comment]
    C -- Only resolved/archived\ncandidates found --> G
    C -- One or more active/\nunresolved candidates --> D[Select most recently\nupdated active candidate]
    D --> E[Persist chosen\ncomment ID]
    G --> E
    E --> F[Use only that ID\nfor all subsequent updates]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/WORKFLOW-cli.md
Line: 330-335

Comment:
**Workpad matching rule less precise than sibling workflows**

The CLI step 0 matching rule omits two qualifiers that are present in all three sibling files (`WORKFLOW-symphony.md`, `WORKFLOW-docker.md`, `WORKFLOW-REFERENCE.md`):

1. **Case-sensitivity** — the other files specify `## Codex Workpad` **(case-sensitive)**; the CLI rule only says `match ## Codex Workpad heading candidates`, leaving the matcher ambiguous about whether `## codex workpad` or `## CODEX WORKPAD` would be treated as a valid candidate.
2. **Position anchor** — the other files specify "at the start of a markdown heading line", which prevents a `## Codex Workpad` substring deeper inside a comment body from being mistakenly matched as a workpad header.

Without these two constraints the CLI workflow could produce a different matching result than the three other workflows for the same comment data.

Suggested update to align with the sibling files:

```suggestion
3. Ensure workpad reuse is deterministic:
   - list comments before creating anything,
   - match `## Codex Workpad` heading candidates (case-sensitive, at the start of a markdown heading line),
   - reuse the most recently updated active/unresolved candidate when one exists,
   - create exactly one new workpad only when no active candidate exists,
   - persist that chosen comment ID for all further updates.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/WORKFLOW-cli.md
Line: 334

Comment:
**Missing "resolved/archived workpads exist" sub-condition**

The three sibling workflow files distinguish the case where no active candidate exists but resolved/archived workpads do exist:

> *"If no active candidate exists **but resolved/archived workpads exist**, create exactly one new workpad comment."*

The CLI version currently reads: *"create exactly one new workpad only when no active candidate exists"* — which is semantically close, but it omits the explicit guard that prevents reusing a resolved/archived workpad. An agent following only the CLI file could potentially interpret the absence of this clause as permission to reuse a resolved comment instead of creating a fresh one.

Consider aligning with the phrasing used in the other files:
```suggestion
   - create exactly one new workpad when no active candidate exists (even if resolved/archived workpads exist),
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(symphony): enforce deterministic wo..."](https://github.com/gannonh/kata/commit/c33b6d9fd6d4f927e5f161b0321bb31d45cabf8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26205315)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->