### PR TITLE
CLI v0.6.0

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.0
+
+### Features
+
+- **Project-level MCP server configuration** — Projects can now define local MCP servers in `<project>/.kata-cli/mcp.json`. On startup, Kata merges global and project-local configs: `mcpServers` and `settings` are project-preferred, `imports` are concatenated. First use per project requires one-time consent, persisted at `~/.kata-cli/project-mcp-consent.json`. The resolved config is written to `~/.kata-cli/agent/mcp.effective.json`.
+- **RPC mode and cwd override** — Kata CLI now supports `--mode rpc` and `--cwd` arguments, enabling embedding as a backend for Symphony's pi-agent runtime.
+
 ## 0.5.2
 
 ### Features

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## CLI v0.6.0

### Features

- **Project-level MCP server configuration** — Projects can now define local MCP servers in `<project>/.kata-cli/mcp.json`. On startup, Kata merges global and project-local configs: `mcpServers` and `settings` are project-preferred, `imports` are concatenated. First use per project requires one-time consent, persisted at `~/.kata-cli/project-mcp-consent.json`. The resolved config is written to `~/.kata-cli/agent/mcp.effective.json`.
- **RPC mode and cwd override** — Kata CLI now supports `--mode rpc` and `--cwd` arguments, enabling embedding as a backend for Symphony's pi-agent runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CLI package version to `0.6.0`.
  * This release bumps the CLI version number to reflect the latest maintenance update; no user-facing behavior or configuration changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR releases CLI v0.6.0 by bumping the `package.json` version from `0.5.2` to `0.6.0` and adding the corresponding `CHANGELOG.md` entry. The two documented features — project-level MCP server configuration and `--mode rpc`/`--cwd` support — are described accurately and consistently with the repository's existing changelog style. No source code is modified in this PR; the underlying implementation was already landed before this version release commit.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure version bump and changelog update with no logic changes.
- Only two files are touched: the changelog receives a well-formatted v0.6.0 entry consistent with prior entries, and package.json receives a single version field update from 0.5.2 to 0.6.0. There is no risk of regression, no dependency changes, and no source code modifications.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/CHANGELOG.md | Added v0.6.0 section documenting two new features: project-level MCP server configuration and RPC mode/cwd override. Format and style are consistent with all prior entries. |
| apps/cli/package.json | Version bumped from 0.5.2 to 0.6.0. No other fields changed; bump is consistent with the new feature scope described in the changelog. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Kata CLI startup] --> B{Project has\n.kata-cli/mcp.json?}
    B -- No --> C[Use global\n~/.kata-cli/agent/mcp.json]
    B -- Yes --> D{First use\nfor this project?}
    D -- Yes --> E[Prompt for\none-time consent]
    E -- Granted --> F[Persist consent to\n~/.kata-cli/project-mcp-consent.json]
    E -- Denied --> C
    F --> G[Merge configs]
    D -- Already consented --> G
    G --> H["mcpServers: project-preferred\nsettings: project-preferred\nimports: concatenated"]
    C --> I[Write resolved config\n~/.kata-cli/agent/mcp.effective.json]
    H --> I
    I --> J[Agent session starts\nwith effective MCP config]
```

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump cli to 0.6.0"](https://github.com/gannonh/kata/commit/6f90c903f36584d8e6ff6d718040351ccdf28294) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26206892)</sub>

<!-- /greptile_comment -->