### PR TITLE
feat(symphony): per-state model selection for kata-cli workers

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -145,7 +145,8 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | Field                             | Type               | Default  | Description                                                                                               |
 | --------------------------------- | ------------------ | -------- | --------------------------------------------------------------------------------------------------------- |
 | `kata_agent.command` (`pi_agent.command`)              | string or string[] | `["kata"]` | Kata CLI executable and base args. Symphony appends `--mode rpc --cwd <workspace>`.                    |
-| `kata_agent.model` (`pi_agent.model`)                  | string             | _(none)_ | Optional model override passed as `--model`.                                                             |
+| `kata_agent.model` (`pi_agent.model`)                  | string             | _(none)_ | Optional default model override passed as `--model`.                                                     |
+| `kata_agent.model_by_state` (`pi_agent.model_by_state`) | map<string, string> | `{}`    | Optional per-Linear-state model overrides. Keys are lowercased state names; falls back to `model`.      |
 | `kata_agent.no_session` (`pi_agent.no_session`)        | bool               | `true`   | Pass `--no-session` to disable persistent session storage.                                               |
 | `kata_agent.append_system_prompt` (`pi_agent.append_system_prompt`) | string             | _(none)_ | Optional path passed via `--append-system-prompt`.                                                       |
 | `kata_agent.read_timeout_ms` (`pi_agent.read_timeout_ms`)      | u64                | `5000`   | Timeout waiting for Kata CLI process output (ms).                                                        |

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -238,6 +238,7 @@ struct RawCodexConfig {
 struct RawPiAgentConfig {
     command: Option<Value>,
     model: Option<String>,
+    model_by_state: Option<HashMap<String, String>>,
     no_session: Option<bool>,
     append_system_prompt: Option<String>,
     read_timeout_ms: Option<u64>,
@@ -778,6 +779,18 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         .map(|value| resolve_env(&value))
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
+    let pi_agent_model_by_state: HashMap<String, String> = selected_agent_config
+        .model_by_state
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(state, model)| {
+            (
+                state.trim().to_lowercase(),
+                resolve_env(&model).trim().to_string(),
+            )
+        })
+        .filter(|(state, model)| !state.is_empty() && !model.is_empty())
+        .collect();
     let pi_agent_append_system_prompt = selected_agent_config
         .append_system_prompt
         .map(|value| resolve_env(&value))
@@ -786,6 +799,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let pi_agent = PiAgentConfig {
         command: pi_agent_command,
         model: pi_agent_model,
+        model_by_state: pi_agent_model_by_state,
         no_session: selected_agent_config
             .no_session
             .unwrap_or(defaults.pi_agent.no_session),

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -375,8 +375,10 @@ pub enum AgentBackend {
 pub struct PiAgentConfig {
     /// Command and arguments to launch pi-agent.
     pub command: Vec<String>,
-    /// Optional model identifier passed via `--model`.
+    /// Optional default model identifier passed via `--model`.
     pub model: Option<String>,
+    /// Optional per-Linear-state model overrides (lowercased state names).
+    pub model_by_state: HashMap<String, String>,
     /// Whether to pass `--no-session`.
     pub no_session: bool,
     /// Optional file path passed via `--append-system-prompt`.
@@ -392,6 +394,7 @@ impl Default for PiAgentConfig {
         Self {
             command: vec!["kata".to_string()],
             model: None,
+            model_by_state: HashMap::new(),
             no_session: true,
             append_system_prompt: None,
             read_timeout_ms: 5_000,
@@ -467,6 +470,9 @@ pub struct RunAttempt {
     pub error: Option<String>,
     #[serde(default)]
     pub worker_host: Option<String>,
+    /// Effective model selected for this run attempt (backend-dependent).
+    #[serde(default)]
+    pub model: Option<String>,
     /// Linear issue state at dispatch time (e.g. "In Progress", "Agent Review").
     #[serde(default)]
     pub linear_state: Option<String>,

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -403,6 +403,20 @@ impl Default for PiAgentConfig {
     }
 }
 
+impl PiAgentConfig {
+    /// Resolve the effective model for a Linear issue state.
+    ///
+    /// Looks up a lowercase/trimmed state key in `model_by_state` first,
+    /// then falls back to the default `model`.
+    pub fn model_for_state(&self, issue_state: &str) -> Option<String> {
+        let state_key = issue_state.trim().to_lowercase();
+        self.model_by_state
+            .get(&state_key)
+            .cloned()
+            .or_else(|| self.model.clone())
+    }
+}
+
 /// Hooks configuration (spec §5.3.4).
 #[derive(Debug, Clone)]
 pub struct HooksConfig {

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -336,12 +336,13 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
             <th>Last Activity</th>
             <th>Elapsed</th>
             <th>Tokens</th>
+            <th>Model</th>
             <th>Workspace</th>
             <th>Worker host</th>
           </tr>
         </thead>
         <tbody id="running-table-body">
-          <tr><td class="muted" colspan="10">Loading...</td></tr>
+          <tr><td class="muted" colspan="11">Loading...</td></tr>
         </tbody>
       </table>
     </div>
@@ -457,7 +458,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }});
 
       if (rows.length === 0) {{
-        return '<tr><td class="muted" colspan="10">No running sessions.</td></tr>';
+        return '<tr><td class="muted" colspan="11">No running sessions.</td></tr>';
       }}
 
       return rows.map(function(entry) {{
@@ -493,6 +494,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
           '<td class="' + escapeHtml(lastActivityClass) + '">' + escapeHtml(lastActivityLabel) + '</td>' +
           '<td class="mono">' + escapeHtml(elapsed) + '</td>' +
           '<td class="mono">' + escapeHtml(tokenLabel) + '</td>' +
+          '<td class="mono">' + escapeHtml(run.model || '-') + '</td>' +
           '<td class="mono">' + escapeHtml(run.workspace_path || '-') + '</td>' +
           '<td>' + escapeHtml(run.worker_host || 'local') + '</td>' +
           '</tr>';

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -107,6 +107,16 @@ fn backend_stall_timeout_ms(config: &ServiceConfig, backend: AgentBackend) -> i6
     timeout.min(i64::MAX as u64) as i64
 }
 
+fn effective_pi_model_for_issue(config: &ServiceConfig, issue: &Issue) -> Option<String> {
+    let state_key = issue.state.trim().to_lowercase();
+    config
+        .pi_agent
+        .model_by_state
+        .get(&state_key)
+        .cloned()
+        .or_else(|| config.pi_agent.model.clone())
+}
+
 fn should_continue_issue_in_session(issue: &Issue, tracker_config: &TrackerConfig) -> bool {
     issue.assigned_to_worker
         && is_active_state(&issue.state, tracker_config)
@@ -1958,6 +1968,11 @@ impl Orchestrator {
                 status: "running".to_string(),
                 error: None,
                 worker_host: prior_worker_host.clone(),
+                model: if self.config.agent_backend == AgentBackend::KataCli {
+                    effective_pi_model_for_issue(&self.config, issue)
+                } else {
+                    None
+                },
                 linear_state: Some(issue.state.clone()),
             },
         );
@@ -2586,6 +2601,11 @@ impl Orchestrator {
             status: "scheduled".to_string(),
             error: None,
             worker_host,
+            model: if self.config.agent_backend == AgentBackend::KataCli {
+                effective_pi_model_for_issue(&self.config, issue)
+            } else {
+                None
+            },
             linear_state: Some(issue.state.clone()),
         };
 

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -108,13 +108,7 @@ fn backend_stall_timeout_ms(config: &ServiceConfig, backend: AgentBackend) -> i6
 }
 
 fn effective_pi_model_for_issue(config: &ServiceConfig, issue: &Issue) -> Option<String> {
-    let state_key = issue.state.trim().to_lowercase();
-    config
-        .pi_agent
-        .model_by_state
-        .get(&state_key)
-        .cloned()
-        .or_else(|| config.pi_agent.model.clone())
+    config.pi_agent.model_for_state(&issue.state)
 }
 
 fn should_continue_issue_in_session(issue: &Issue, tracker_config: &TrackerConfig) -> bool {

--- a/apps/symphony/src/pi_agent/rpc_bridge.rs
+++ b/apps/symphony/src/pi_agent/rpc_bridge.rs
@@ -60,15 +60,6 @@ fn next_command_id(prefix: &str) -> String {
     format!("{prefix}-{}-{n}", Utc::now().timestamp_millis())
 }
 
-fn resolve_model_for_state(config: &PiAgentConfig, issue_state: &str) -> Option<String> {
-    let state_key = issue_state.trim().to_lowercase();
-    config
-        .model_by_state
-        .get(&state_key)
-        .cloned()
-        .or_else(|| config.model.clone())
-}
-
 fn build_command_parts(
     config: &PiAgentConfig,
     workspace_path: &str,
@@ -89,7 +80,7 @@ fn build_command_parts(
     if config.no_session {
         parts.push("--no-session".to_string());
     }
-    if let Some(model) = resolve_model_for_state(config, issue_state) {
+    if let Some(model) = config.model_for_state(issue_state) {
         parts.push("--model".to_string());
         parts.push(model);
     }
@@ -749,12 +740,12 @@ fn expand_path_no_symlinks(path: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_command_parts, resolve_model_for_state};
+    use super::build_command_parts;
     use crate::domain::PiAgentConfig;
     use std::collections::HashMap;
 
     #[test]
-    fn resolve_model_for_state_prefers_state_override_then_default() {
+    fn pi_agent_config_model_for_state_prefers_state_override_then_default() {
         let mut config = PiAgentConfig {
             model: Some("anthropic/claude-opus-4-6".to_string()),
             ..PiAgentConfig::default()
@@ -765,11 +756,11 @@ mod tests {
         )]);
 
         assert_eq!(
-            resolve_model_for_state(&config, "Agent Review").as_deref(),
+            config.model_for_state("Agent Review").as_deref(),
             Some("anthropic/claude-sonnet-4-6")
         );
         assert_eq!(
-            resolve_model_for_state(&config, "In Progress").as_deref(),
+            config.model_for_state("In Progress").as_deref(),
             Some("anthropic/claude-opus-4-6")
         );
     }

--- a/apps/symphony/src/pi_agent/rpc_bridge.rs
+++ b/apps/symphony/src/pi_agent/rpc_bridge.rs
@@ -60,7 +60,20 @@ fn next_command_id(prefix: &str) -> String {
     format!("{prefix}-{}-{n}", Utc::now().timestamp_millis())
 }
 
-fn build_command_parts(config: &PiAgentConfig, workspace_path: &str) -> Result<Vec<String>> {
+fn resolve_model_for_state(config: &PiAgentConfig, issue_state: &str) -> Option<String> {
+    let state_key = issue_state.trim().to_lowercase();
+    config
+        .model_by_state
+        .get(&state_key)
+        .cloned()
+        .or_else(|| config.model.clone())
+}
+
+fn build_command_parts(
+    config: &PiAgentConfig,
+    workspace_path: &str,
+    issue_state: &str,
+) -> Result<Vec<String>> {
     if config.command.is_empty() {
         return Err(SymphonyError::PiAgentError(
             "pi_agent.command cannot be empty".to_string(),
@@ -76,9 +89,9 @@ fn build_command_parts(config: &PiAgentConfig, workspace_path: &str) -> Result<V
     if config.no_session {
         parts.push("--no-session".to_string());
     }
-    if let Some(model) = config.model.as_deref() {
+    if let Some(model) = resolve_model_for_state(config, issue_state) {
         parts.push("--model".to_string());
-        parts.push(model.to_string());
+        parts.push(model);
     }
     if let Some(path) = config.append_system_prompt.as_deref() {
         parts.push("--append-system-prompt".to_string());
@@ -325,10 +338,10 @@ pub async fn start_session(
     container_id: Option<&str>,
 ) -> Result<SessionHandle> {
     let command_parts = match (container_id, worker_host) {
-        (Some(_), _) => build_command_parts(config, "/workspace")?,
+        (Some(_), _) => build_command_parts(config, "/workspace", &issue.state)?,
         _ => {
             let workspace_for_args = workspace_path.to_string_lossy().to_string();
-            build_command_parts(config, &workspace_for_args)?
+            build_command_parts(config, &workspace_for_args, &issue.state)?
         }
     };
 
@@ -732,4 +745,50 @@ fn expand_path_no_symlinks(path: &Path) -> PathBuf {
         }
     }
     normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_command_parts, resolve_model_for_state};
+    use crate::domain::PiAgentConfig;
+    use std::collections::HashMap;
+
+    #[test]
+    fn resolve_model_for_state_prefers_state_override_then_default() {
+        let mut config = PiAgentConfig {
+            model: Some("anthropic/claude-opus-4-6".to_string()),
+            ..PiAgentConfig::default()
+        };
+        config.model_by_state = HashMap::from([(
+            "agent review".to_string(),
+            "anthropic/claude-sonnet-4-6".to_string(),
+        )]);
+
+        assert_eq!(
+            resolve_model_for_state(&config, "Agent Review").as_deref(),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+        assert_eq!(
+            resolve_model_for_state(&config, "In Progress").as_deref(),
+            Some("anthropic/claude-opus-4-6")
+        );
+    }
+
+    #[test]
+    fn build_command_parts_uses_state_selected_model() {
+        let mut config = PiAgentConfig {
+            command: vec!["kata".to_string()],
+            model: Some("anthropic/claude-opus-4-6".to_string()),
+            ..PiAgentConfig::default()
+        };
+        config.model_by_state = HashMap::from([(
+            "merging".to_string(),
+            "anthropic/claude-sonnet-4-6".to_string(),
+        )]);
+
+        let parts = build_command_parts(&config, "/tmp/workspace", "Merging")
+            .expect("command should build");
+        let joined = parts.join(" ");
+        assert!(joined.contains("--model anthropic/claude-sonnet-4-6"));
+    }
 }

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -407,6 +407,7 @@ fn draw_dashboard(
         Cell::from("Message"),
         Cell::from("Last Activity"),
         Cell::from("Tokens"),
+        Cell::from("Model"),
         Cell::from("Host"),
     ])
     .style(Style::default().add_modifier(Modifier::BOLD));
@@ -423,6 +424,7 @@ fn draw_dashboard(
             Constraint::Min(16),
             Constraint::Length(14),
             Constraint::Length(12),
+            Constraint::Length(20),
             Constraint::Length(10),
         ],
     )
@@ -525,6 +527,7 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
             )),
             last_activity_cell,
             Cell::from(format_tokens(total_tokens)),
+            Cell::from(run.model.clone().unwrap_or_else(|| "-".to_string())),
             Cell::from(
                 run.worker_host
                     .as_deref()
@@ -538,6 +541,7 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
         rows.push(Row::new(vec![
             Cell::from(""),
             Cell::from("(none)"),
+            Cell::from(""),
             Cell::from(""),
             Cell::from(""),
             Cell::from(""),
@@ -983,6 +987,7 @@ mod tests {
                 status: "running".to_string(),
                 error: None,
                 worker_host: None,
+                model: None,
                 linear_state: Some("Agent Review".to_string()),
             },
         );

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -424,7 +424,7 @@ fn draw_dashboard(
             Constraint::Min(16),
             Constraint::Length(14),
             Constraint::Length(12),
-            Constraint::Length(20),
+            Constraint::Min(20),
             Constraint::Length(10),
         ],
     )

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -184,6 +184,7 @@ fn test_run_attempt_construction_and_serialization() {
         status: "running".into(),
         error: None,
         worker_host: None,
+        model: None,
         linear_state: None,
     };
     let json = serde_json::to_string(&ra).unwrap();
@@ -260,6 +261,7 @@ fn test_orchestrator_snapshot_serializes() {
                     status: "running".into(),
                     error: None,
                     worker_host: None,
+                    model: None,
                     linear_state: None,
                 },
             );
@@ -275,6 +277,7 @@ fn test_orchestrator_snapshot_serializes() {
                     status: "running".into(),
                     error: None,
                     worker_host: None,
+                    model: None,
                     linear_state: None,
                 },
             );

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -73,6 +73,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                     status: "running".to_string(),
                     error: None,
                     worker_host: Some("worker-a".to_string()),
+                    model: None,
                     linear_state: None,
                 },
             );

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -321,6 +321,7 @@ fn test_startup_terminal_cleanup_clears_runtime_bookkeeping_without_completed_in
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: Some("In Progress".to_string()),
         },
     );
@@ -821,6 +822,7 @@ fn test_stall_detection_schedules_forced_retry() {
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: None,
         },
     );
@@ -872,6 +874,7 @@ fn test_streamed_event_updates_activity_before_worker_completion() {
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: None,
         },
     );
@@ -935,6 +938,7 @@ fn test_streamed_events_keep_refreshing_stall_detection_window() {
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: None,
         },
     );
@@ -999,6 +1003,7 @@ fn test_streamed_notification_records_event_method_and_message() {
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: None,
         },
     );
@@ -1045,6 +1050,7 @@ fn test_streamed_tool_call_completed_uses_completed_summary() {
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: None,
         },
     );
@@ -1086,6 +1092,7 @@ fn test_streamed_turn_completed_events_update_token_totals_in_real_time() {
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: None,
         },
     );
@@ -1220,6 +1227,7 @@ fn test_late_streamed_event_after_completion_is_ignored() {
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: None,
         },
     );
@@ -1319,6 +1327,7 @@ fn test_snapshot_exposes_running_and_retry_diagnostics() {
             status: "failed".to_string(),
             error: Some("worker failed".to_string()),
             worker_host: Some("worker-a".to_string()),
+            model: None,
             linear_state: None,
         },
     );
@@ -1395,6 +1404,7 @@ fn test_worker_completion_schedules_continuation_retry_with_session_context() {
             status: "running".to_string(),
             error: None,
             worker_host: Some("worker-b".to_string()),
+            model: None,
             linear_state: None,
         },
     );
@@ -1486,6 +1496,7 @@ fn test_worker_completion_without_continuation_does_not_queue_retry() {
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: None,
         },
     );
@@ -1538,6 +1549,7 @@ fn test_worker_failure_preserves_attempt_and_backoff_cap() {
             status: "running".to_string(),
             error: None,
             worker_host: Some("worker-c".to_string()),
+            model: None,
             linear_state: None,
         },
     );
@@ -1923,6 +1935,7 @@ fn test_reconcile_non_active_state_stops_run_without_cleanup() {
         status: "running".to_string(),
         error: None,
         worker_host: None,
+        model: None,
         linear_state: None,
     };
     orchestrator
@@ -2040,6 +2053,7 @@ fn test_terminal_state_cleanup_removes_workspace_when_enabled() {
         status: "running".to_string(),
         error: None,
         worker_host: None,
+        model: None,
         linear_state: None,
     };
     orchestrator
@@ -2089,6 +2103,7 @@ fn test_terminal_state_cleanup_preserves_workspace_when_disabled() {
         status: "running".to_string(),
         error: None,
         worker_host: None,
+        model: None,
         linear_state: None,
     };
     orchestrator
@@ -2147,6 +2162,7 @@ fn test_terminal_state_cleanup_runs_before_remove_hook() {
         status: "running".to_string(),
         error: None,
         worker_host: None,
+        model: None,
         linear_state: None,
     };
     orchestrator
@@ -2207,6 +2223,7 @@ fn test_terminal_state_cleanup_defers_until_worker_completion() {
             status: "running".to_string(),
             error: None,
             worker_host: None,
+            model: None,
             linear_state: None,
         },
     );
@@ -2361,6 +2378,7 @@ fn test_terminal_state_cleanup_removes_worktree_checkout_when_enabled() {
         status: "running".to_string(),
         error: None,
         worker_host: None,
+        model: None,
         linear_state: None,
     };
     orchestrator
@@ -2419,6 +2437,7 @@ fn test_terminal_state_cleanup_failure_is_non_fatal() {
         status: "running".to_string(),
         error: None,
         worker_host: None,
+        model: None,
         linear_state: None,
     };
     orchestrator

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -170,6 +170,7 @@ fn test_config_defaults() {
     assert_eq!(config.agent_backend, AgentBackend::Codex);
     assert_eq!(config.pi_agent.command, vec!["kata".to_string()]);
     assert_eq!(config.pi_agent.model, None);
+    assert!(config.pi_agent.model_by_state.is_empty());
     assert!(config.pi_agent.no_session);
     assert_eq!(config.pi_agent.append_system_prompt, None);
     assert_eq!(config.pi_agent.read_timeout_ms, 5_000);
@@ -198,6 +199,7 @@ kata_agent:
         config.pi_agent.model.as_deref(),
         Some("anthropic/claude-sonnet-4-6")
     );
+    assert!(config.pi_agent.model_by_state.is_empty());
     assert!(!config.pi_agent.no_session);
     assert_eq!(
         config.pi_agent.append_system_prompt.as_deref(),
@@ -205,6 +207,45 @@ kata_agent:
     );
     assert_eq!(config.pi_agent.read_timeout_ms, 1200);
     assert_eq!(config.pi_agent.stall_timeout_ms, 90_000);
+}
+
+#[test]
+fn test_pi_agent_model_by_state_normalizes_keys() {
+    let yaml_str = r#"
+agent:
+  backend: kata-cli
+pi_agent:
+  command: kata
+  model: anthropic/claude-opus-4-6
+  model_by_state:
+    Agent Review: anthropic/claude-sonnet-4-6
+    MERGING: anthropic/claude-sonnet-4-6
+    "  ": ignored
+"#;
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("model_by_state config should parse");
+
+    assert_eq!(
+        config
+            .pi_agent
+            .model_by_state
+            .get("agent review")
+            .map(String::as_str),
+        Some("anthropic/claude-sonnet-4-6")
+    );
+    assert_eq!(
+        config
+            .pi_agent
+            .model_by_state
+            .get("merging")
+            .map(String::as_str),
+        Some("anthropic/claude-sonnet-4-6")
+    );
+    assert!(!config.pi_agent.model_by_state.contains_key("Agent Review"));
+    assert!(
+        !config.pi_agent.model_by_state.contains_key(""),
+        "blank state keys should be ignored"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `pi_agent.model_by_state` support with lowercase-key normalization and fallback to `pi_agent.model`
- resolve kata worker `--model` from the current Linear issue state at session start
- track/render the effective model on running attempts in TUI and dashboard

## Testing
- `cd apps/symphony && cargo build`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `cd apps/symphony && cargo fmt --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-Linear-state model selection for kata-cli workers in Symphony. When an issue enters a new state (e.g. "Agent Review", "Merging"), the orchestrator can now resolve a dedicated model override from `pi_agent.model_by_state` rather than always using the global `pi_agent.model` fallback. The resolved model is stamped onto `RunAttempt` for display in the TUI and HTTP dashboard, and is also independently resolved at CLI spawn time via `rpc_bridge.rs`.

Key changes:
- `PiAgentConfig` gains a `model_by_state: HashMap<String, String>` field; keys are normalised to lowercase at config-parse time, with blank keys and values filtered out.
- `RunAttempt` gains an optional `model` field (serde-defaulted) used by both TUI and dashboard rendering.
- Two new helper functions — `effective_pi_model_for_issue` (`orchestrator.rs`) and `resolve_model_for_state` (`rpc_bridge.rs`) — implement the same lookup logic independently; centralising this onto a `PiAgentConfig` method would eliminate the duplication.
- TUI "Model" column uses `Constraint::Length(20)`, which may clip longer model identifiers; `Constraint::Min(20)` would be safer.
- Test coverage is solid: new unit tests in `rpc_bridge.rs` and `workflow_config_tests.rs` exercise state-based resolution and key normalisation.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the feature is well-tested with no critical bugs, and the two style issues found are minor.
- The implementation is correct and well-covered by tests. The only concerns are non-critical: duplicate model-resolution logic between orchestrator.rs and rpc_bridge.rs (divergence risk, not a current bug), and a TUI column width that may clip long model names. No data-loss, security, or correctness issues were found.
- apps/symphony/src/orchestrator.rs and apps/symphony/src/pi_agent/rpc_bridge.rs — both define equivalent model-resolution logic that should ideally be consolidated onto PiAgentConfig.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/domain.rs | Adds `model_by_state` field to `PiAgentConfig` (with `HashMap::new()` default) and `model` field to `RunAttempt` (optional, serde-defaulted). Clean struct changes with correct Default impl. |
| apps/symphony/src/config.rs | Parses `model_by_state` from raw config, normalises keys to lowercase, strips whitespace, filters blank entries, and resolves env vars — all correct and consistent with how `model` is handled. |
| apps/symphony/src/orchestrator.rs | Adds `effective_pi_model_for_issue` and stamps `model` onto both scheduled and running `RunAttempt`s. Logic is correct but duplicates `resolve_model_for_state` in `rpc_bridge.rs`; risk of future divergence between displayed and actual model. |
| apps/symphony/src/pi_agent/rpc_bridge.rs | Introduces `resolve_model_for_state` and threads `issue_state` through `build_command_parts`; correctly selects the per-state model (or falls back to default) before appending `--model` to the CLI invocation. New unit tests cover both the resolver and command builder. |
| apps/symphony/src/tui.rs | Adds a "Model" column to the running-sessions table. `Constraint::Length(20)` may clip longer model identifiers; consider `Constraint::Min(20)` to allow the column to expand when terminal width allows. |
| apps/symphony/src/http_server.rs | Adds a "Model" `<th>` column and corresponding `<td>` cell in the dashboard HTML; correctly bumps both `colspan` values from 10 to 11. |
| apps/symphony/tests/workflow_config_tests.rs | Adds `test_pi_agent_model_by_state_normalizes_keys` covering key lowercasing, multi-case input, and blank-key filtering. Existing tests updated for new `model_by_state` field assertions. |
| apps/symphony/AGENTS.md | Documentation updated to describe the new `model_by_state` config field and clarify `model` as a default fallback. Accurate and complete. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Issue dispatched / session started] --> B{AgentBackend == KataCli?}
    B -- No --> C[model = None]
    B -- Yes --> D[effective_pi_model_for_issue\norchestrator.rs]
    D --> E{model_by_state\ncontains lowercase state?}
    E -- Yes --> F[Use per-state model]
    E -- No --> G{pi_agent.model set?}
    G -- Yes --> H[Use default model]
    G -- No --> I[model = None]
    F --> J[Stamp model on RunAttempt\nshown in TUI + Dashboard]
    H --> J
    I --> J
    C --> J

    J --> K[start_session called in rpc_bridge.rs]
    K --> L[resolve_model_for_state\nrpc_bridge.rs]
    L --> M{model_by_state\ncontains lowercase state?}
    M -- Yes --> N[Append --model per-state-value to CLI args]
    M -- No --> O{config.model set?}
    O -- Yes --> P[Append --model default-value to CLI args]
    O -- No --> Q[No --model flag passed]
    N --> R[kata CLI spawned]
    P --> R
    Q --> R
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/tui.rs
Line: 427

Comment:
**Model column width may truncate common model names**

`Constraint::Length(20)` allocates exactly 20 characters for the model column. Several typical model identifiers are longer than this — for example `anthropic/claude-opus-4-6` is 23 characters and would be silently clipped. Consider using `Constraint::Min(20)` to allow the column to grow when the terminal is wide enough, or increasing the fixed length:

```suggestion
            Constraint::Min(20),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 110-118

Comment:
**Duplicate model-resolution logic**

`effective_pi_model_for_issue` here and `resolve_model_for_state` in `rpc_bridge.rs` (line 63) are functionally identical — both lowercase the state key, look it up in `model_by_state`, and fall back to `model`. Having two separate copies means a future change to one (e.g. a different normalisation strategy) may silently diverge from the other, causing the model displayed in the TUI/dashboard to differ from the model actually passed to the CLI.

Consider lifting the logic into a method directly on `PiAgentConfig` (e.g. `model_for_state(&self, state: &str) -> Option<String>`) so both `orchestrator.rs` and `rpc_bridge.rs` share a single implementation and can never drift apart.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): select kata worker model..."](https://github.com/gannonh/kata/commit/f61a97cdfb84d545d8c893fb3e0bb84368c20666) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26209251)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring different AI models for specific workflow states.
  * Dashboard and TUI now display the model used for each running session.
  * System automatically selects the appropriate model based on the current issue state.

* **Tests**
  * Updated test fixtures and added new tests for state-based model selection and configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->