### PR TITLE
[KAT-618] S04: Live Refresh + Combined Retrieval

### DIFF
--- a/apps/context/package.json
+++ b/apps/context/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.8.0",
+    "chokidar": "^5.0.0",
     "commander": "^14.0.3",
     "sqlite-vec": "^0.1.7",
     "tree-sitter": "^0.25.0",

--- a/apps/context/skill/SKILL.md
+++ b/apps/context/skill/SKILL.md
@@ -459,6 +459,97 @@ kata-context find "app" --limit 5 --json
 9. **Use `remember` for durable knowledge.** Persist decisions, patterns, and learnings. They survive across sessions and are searchable via `recall`.
 10. **Memory has a git audit trail.** Every `remember`, `forget`, and `consolidate` creates a git commit in the project repo. Use `git log` to see memory mutation history.
 
+## Watch Mode
+
+### `kata-context watch [path]`
+
+Monitor source files and automatically re-index on changes.
+
+```bash
+# Start watching (human-readable events)
+kata-context watch .
+
+# JSON event stream (NDJSON)
+kata-context watch . --json
+
+# Custom debounce window
+kata-context watch . --debounce 500
+
+# Quiet mode (no event output, background operation)
+kata-context watch . --quiet
+```
+
+**Options:**
+- `--debounce <ms>` — Debounce window in milliseconds (default: 300)
+- `--json` — Output events as NDJSON (one JSON object per line)
+- `--quiet` — Suppress event output
+
+**Events emitted:**
+- `start` — Watcher initialized and ready
+- `change` — File changes detected (includes file list)
+- `reindex-start` — Incremental re-indexing triggered
+- `reindex-done` — Re-indexing completed (includes duration)
+- `error` — Error during watch/reindex (includes error code)
+
+**Error codes:** `WATCH_INIT_FAILED`, `WATCH_REINDEX_FAILED`, `WATCH_PROVIDER_ERROR`
+
+Stop with `Ctrl+C` (SIGINT) — the watcher shuts down cleanly.
+
+## Combined Retrieval
+
+### `kata-context get "<query>" [--budget N]`
+
+Get an integrated context bundle assembled from structural, semantic, and memory retrieval within a token budget.
+
+```bash
+# Default budget (4000 tokens)
+kata-context get "implement rate limiting"
+
+# Custom budget
+kata-context get "authentication handler" --budget 8000
+
+# Filter by symbol kind
+kata-context get "error handling" --kind function
+
+# JSON output with full diagnostics
+kata-context get "implement rate limiting" --json
+
+# Quiet mode (raw content only)
+kata-context get "implement rate limiting" --quiet
+```
+
+**Options:**
+- `--budget <tokens>` — Token budget for results (default: 4000)
+- `--kind <kind>` — Filter by symbol kind (function, class, etc.)
+- `--json` — Full JSON output including diagnostics envelope
+- `--quiet` — Raw content blocks only
+
+**How it works:**
+1. Runs structural (FTS + graph), semantic (vector search), and memory (recall) strategies in parallel
+2. Deduplicates overlapping results by symbol ID
+3. Reranks with configurable weights (structural 0.4, semantic 0.3, recency 0.15, memory 0.15)
+4. Assembles results within the token budget (greedy fill from top-ranked)
+5. Returns items with provenance labels (structural/semantic/memory)
+
+**JSON output includes a diagnostics envelope:**
+```json
+{
+  "items": [...],
+  "diagnostics": {
+    "perStrategy": {
+      "structural": { "status": "ok", "hits": 5, "timeMs": 12 },
+      "semantic": { "status": "ok", "hits": 3, "timeMs": 145 },
+      "memory": { "status": "skipped", "hits": 0, "timeMs": 0 }
+    },
+    "budgetUsed": 3800,
+    "budgetTotal": 4000,
+    "totalTimeMs": 158
+  }
+}
+```
+
+**Degraded modes:** If semantic fails (no API key), structural + memory results are still returned. If memory store is empty, it's skipped. Per-strategy status in diagnostics shows what happened.
+
 ## Troubleshooting
 
 | Error | Cause | Fix |
@@ -474,6 +565,11 @@ kata-context find "app" --limit 5 --json
 | `MEMORY_RECALL_MISSING_KEY` | `OPENAI_API_KEY` not set for recall | Set the environment variable |
 | `MEMORY_FILE_NOT_FOUND` | Memory ID doesn't exist | Check the ID with `recall` or list memories |
 | `MEMORY_CONSOLIDATE_TOO_FEW` | Need at least 2 IDs to consolidate | Provide 2+ memory IDs |
+| `WATCH_INIT_FAILED` | Watcher couldn't start | Check path exists and permissions |
+| `WATCH_REINDEX_FAILED` | Re-index failed during watch | Check disk space and DB access |
+| `WATCH_PROVIDER_ERROR` | API provider error during re-index | Check API keys and connectivity |
+| Empty `get` results | No matching data | Run `index` first, check `OPENAI_API_KEY` for semantic results |
+| Budget too small | Budget can't fit any results | Increase `--budget` value |
 
 ## Exit Codes
 

--- a/apps/context/src/cli.ts
+++ b/apps/context/src/cli.ts
@@ -46,6 +46,9 @@ import {
 import { MemoryStore, MemoryError } from "./memory/index.js";
 import { recallMemories } from "./memory/recall.js";
 import { consolidateMemories } from "./memory/consolidate.js";
+import { createWatcher } from "./watcher/index.js";
+import { combinedRetrieval } from "./retrieval/combined.js";
+import type { CombinedRetrievalResult } from "./retrieval/types.js";
 
 // ── Version ──
 
@@ -1191,6 +1194,178 @@ program
       }
       if (outputOpts.json) {
         console.log(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+      } else {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      process.exit(1);
+    }
+  });
+
+// ── Watch command ──
+
+program
+  .command("watch")
+  .description("Watch for file changes and trigger incremental re-indexing")
+  .argument("[path]", "Project root path", ".")
+  .option("--debounce <ms>", "Debounce window in milliseconds", "300")
+  .action(async (pathArg: string, cmdOpts: Record<string, string>) => {
+    const outputOpts = getOutputOptions(program);
+    const rootPath = resolve(pathArg);
+    const config = loadConfig(rootPath);
+    const debounceMs = parseInt(cmdOpts.debounce ?? "300", 10);
+
+    const watcher = createWatcher(rootPath, config, { debounceMs });
+
+    watcher.on((event) => {
+      if (outputOpts.quiet) return; // suppress in quiet mode
+
+      if (outputOpts.json) {
+        console.log(JSON.stringify(event));
+      } else {
+        const ts = event.timestamp.replace("T", " ").replace(/\.\d+Z$/, "");
+        switch (event.type) {
+          case "start":
+            console.log(`[${ts}] Watching ${rootPath}`);
+            break;
+          case "change":
+            console.log(`[${ts}] Changed: ${event.files?.join(", ")}`);
+            break;
+          case "reindex-start":
+            console.log(`[${ts}] Re-indexing ${event.files?.length ?? 0} files...`);
+            break;
+          case "reindex-done":
+            console.log(`[${ts}] Re-index done (${event.durationMs}ms)`);
+            break;
+          case "error":
+            console.error(`[${ts}] Error [${event.errorCode}]: ${event.error}`);
+            break;
+        }
+      }
+    });
+
+    // Handle SIGINT/SIGTERM for graceful shutdown
+    const shutdown = async () => {
+      await watcher.stop();
+      process.exit(0);
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+
+    try {
+      await watcher.start();
+      // Keep process alive — watcher is persistent
+    } catch (err) {
+      if (outputOpts.json) {
+        console.log(JSON.stringify({ error: true, message: err instanceof Error ? err.message : String(err) }));
+      } else {
+        console.error(`Watch failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      process.exit(1);
+    }
+  });
+
+// ── Get command (combined retrieval) ──
+
+program
+  .command("get")
+  .description("Get combined context bundle from structural, semantic, and memory retrieval")
+  .argument("<query>", "Natural language task description")
+  .option("--budget <tokens>", "Token budget for the result", "4000")
+  .option("--kind <kind>", "Filter by symbol kind")
+  .action(async (query: string, cmdOpts: Record<string, string>) => {
+    const outputOpts = getOutputOptions(program);
+    const rootPath = resolve(".");
+    const config = loadConfig(rootPath);
+    const dbPath = getDbPath(program, rootPath);
+    const budget = parseInt(cmdOpts.budget ?? "4000", 10);
+
+    if (!existsSync(dbPath)) {
+      if (outputOpts.json) {
+        console.log(JSON.stringify({ error: true, message: "No index found. Run `kata context index` first." }));
+      } else {
+        console.error("No index found. Run `kata context index` first.");
+      }
+      process.exit(1);
+    }
+
+    const store = new GraphStore(dbPath);
+    let memoryStore: MemoryStore | undefined;
+    try {
+      memoryStore = new MemoryStore(rootPath);
+    } catch {
+      // Memory store optional
+    }
+
+    try {
+      const result: CombinedRetrievalResult = await combinedRetrieval({
+        query,
+        store,
+        memoryStore,
+        config,
+        options: {
+          budget,
+          kinds: cmdOpts.kind ? [cmdOpts.kind] : undefined,
+        },
+      });
+
+      if (outputOpts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (outputOpts.quiet) {
+        // Quiet: raw content blocks only
+        for (const item of result.items) {
+          console.log(item.content);
+        }
+      } else {
+        // Human-readable: sections grouped by provenance
+        const grouped = new Map<string, typeof result.items>();
+        for (const item of result.items) {
+          const group = grouped.get(item.provenance) ?? [];
+          group.push(item);
+          grouped.set(item.provenance, group);
+        }
+
+        const provenanceOrder = ["structural", "semantic", "memory"];
+        const labels: Record<string, string> = {
+          structural: "Structural",
+          semantic: "Semantic",
+          memory: "Memory",
+        };
+
+        for (const prov of provenanceOrder) {
+          const items = grouped.get(prov);
+          if (!items || items.length === 0) continue;
+
+          console.log(formatHeader(`${labels[prov]} (${items.length} items)`));
+          for (const item of items) {
+            console.log(`  ${item.source}`);
+            const preview = item.content.split("\n").slice(0, 3).join("\n    ");
+            console.log(`    ${preview}`);
+            console.log();
+          }
+        }
+
+        // Diagnostics summary
+        const d = result.diagnostics;
+        console.log(formatHeader("Diagnostics"));
+        console.log(
+          formatKeyValue([
+            ["Budget", `${d.budgetUsed}/${d.budgetTotal} tokens`],
+            ["Time", `${d.totalTimeMs}ms`],
+            [
+              "Strategies",
+              Object.entries(d.perStrategy)
+                .map(([k, v]) => `${k}: ${v.status} (${v.hits} hits, ${v.timeMs}ms)`)
+                .join(", "),
+            ],
+          ]),
+        );
+      }
+
+      store.close();
+    } catch (err) {
+      store.close();
+      if (outputOpts.json) {
+        console.log(JSON.stringify({ error: true, message: err instanceof Error ? err.message : String(err) }));
       } else {
         console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
       }

--- a/apps/context/src/cli.ts
+++ b/apps/context/src/cli.ts
@@ -1208,11 +1208,13 @@ program
   .description("Watch for file changes and trigger incremental re-indexing")
   .argument("[path]", "Project root path", ".")
   .option("--debounce <ms>", "Debounce window in milliseconds", "300")
-  .action(async (pathArg: string, cmdOpts: Record<string, string>) => {
-    const outputOpts = getOutputOptions(program);
+  .option("--json", "Output structured JSON")
+  .option("--quiet", "Suppress all output")
+  .action(async (pathArg: string, _opts: Record<string, string>, cmd: Command) => {
+    const outputOpts = getOutputOptions(cmd);
     const rootPath = resolve(pathArg);
     const config = loadConfig(rootPath);
-    const debounceMs = parseInt(cmdOpts.debounce ?? "300", 10);
+    const debounceMs = parseInt((cmd.opts() as Record<string, string>).debounce ?? "300", 10);
 
     const watcher = createWatcher(rootPath, config, { debounceMs });
 
@@ -1245,6 +1247,8 @@ program
 
     // Handle SIGINT/SIGTERM for graceful shutdown
     const shutdown = async () => {
+      process.off("SIGINT", shutdown);
+      process.off("SIGTERM", shutdown);
       await watcher.stop();
       process.exit(0);
     };
@@ -1272,12 +1276,15 @@ program
   .argument("<query>", "Natural language task description")
   .option("--budget <tokens>", "Token budget for the result", "4000")
   .option("--kind <kind>", "Filter by symbol kind")
-  .action(async (query: string, cmdOpts: Record<string, string>) => {
-    const outputOpts = getOutputOptions(program);
+  .option("--json", "Output structured JSON")
+  .option("--quiet", "Minimal output (content only)")
+  .action(async (query: string, _opts: Record<string, string>, cmd: Command) => {
+    const outputOpts = getOutputOptions(cmd);
     const rootPath = resolve(".");
     const config = loadConfig(rootPath);
     const dbPath = getDbPath(program, rootPath);
-    const budget = parseInt(cmdOpts.budget ?? "4000", 10);
+    const cmdOptsTyped = cmd.opts() as Record<string, string>;
+    const budget = parseInt(cmdOptsTyped.budget ?? "4000", 10);
 
     if (!existsSync(dbPath)) {
       if (outputOpts.json) {
@@ -1304,7 +1311,7 @@ program
         config,
         options: {
           budget,
-          kinds: cmdOpts.kind ? [cmdOpts.kind] : undefined,
+          kinds: cmdOptsTyped.kind ? [cmdOptsTyped.kind as SymbolKind] : undefined,
         },
       });
 
@@ -1360,16 +1367,15 @@ program
           ]),
         );
       }
-
-      store.close();
     } catch (err) {
-      store.close();
       if (outputOpts.json) {
         console.log(JSON.stringify({ error: true, message: err instanceof Error ? err.message : String(err) }));
       } else {
         console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
       }
       process.exit(1);
+    } finally {
+      store.close();
     }
   });
 

--- a/apps/context/src/retrieval/budget.ts
+++ b/apps/context/src/retrieval/budget.ts
@@ -1,0 +1,49 @@
+/**
+ * Token budget assembler — greedily fills from ranked items.
+ *
+ * Slice: S04 — T03
+ */
+
+import type { RetrievalItem } from "./types.js";
+
+export interface BudgetAssemblyResult {
+  items: RetrievalItem[];
+  budgetUsed: number;
+  budgetTotal: number;
+}
+
+/**
+ * Estimate tokens for a string: ceil(chars / 4).
+ */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Greedily fill items within a token budget.
+ * Items should already be sorted by score (highest first).
+ */
+export function assembleBudget(
+  rankedItems: RetrievalItem[],
+  budgetTokens: number,
+): BudgetAssemblyResult {
+  const selected: RetrievalItem[] = [];
+  let used = 0;
+
+  for (const item of rankedItems) {
+    const tokens = item.estimatedTokens || estimateTokens(item.content);
+    if (used + tokens > budgetTokens && selected.length > 0) {
+      // Don't exceed budget (but always include at least one item)
+      continue;
+    }
+    selected.push({ ...item, estimatedTokens: tokens });
+    used += tokens;
+    if (used >= budgetTokens) break;
+  }
+
+  return {
+    items: selected,
+    budgetUsed: used,
+    budgetTotal: budgetTokens,
+  };
+}

--- a/apps/context/src/retrieval/combined.ts
+++ b/apps/context/src/retrieval/combined.ts
@@ -10,7 +10,7 @@ import type { GraphStore } from "../graph/store.js";
 import type { Config } from "../types.js";
 import type { MemoryStore } from "../memory/store.js";
 import type { EmbeddingProvider } from "../semantic/contracts.js";
-import { dependents, dependencies, resolveSymbol } from "../graph/queries.js";
+import { dependents } from "../graph/queries.js";
 import { semanticSearch } from "../search/semantic.js";
 import { recallMemories } from "../memory/recall.js";
 import { rerankResults } from "./reranker.js";

--- a/apps/context/src/retrieval/combined.ts
+++ b/apps/context/src/retrieval/combined.ts
@@ -24,6 +24,7 @@ import type {
   RetrievalDiagnostics,
 } from "./types.js";
 import { DEFAULT_RANKING_WEIGHTS } from "./types.js";
+import type { SymbolKind } from "../types.js";
 
 const DEFAULT_BUDGET = 4000;
 const DEFAULT_TOP_K = 20;
@@ -49,10 +50,12 @@ export async function combinedRetrieval(
   const topK = options?.topK ?? DEFAULT_TOP_K;
   const weights = { ...DEFAULT_RANKING_WEIGHTS, ...options?.weights };
 
+  const kinds = options?.kinds && options.kinds.length > 0 ? options.kinds : undefined;
+
   // Run all three strategies in parallel
   const [structuralResult, semanticResult, memoryResult] = await Promise.allSettled([
-    runStructural(query, store, topK),
-    runSemantic(query, store, config, topK, embeddingProvider),
+    runStructural(query, store, topK, kinds),
+    runSemantic(query, store, config, topK, embeddingProvider, kinds),
     runMemory(query, memoryStore, embeddingProvider, store, topK),
   ]);
 
@@ -112,12 +115,25 @@ async function runStructural(
   query: string,
   store: GraphStore,
   topK: number,
+  kinds?: SymbolKind[],
 ): Promise<StrategyResult> {
   const start = performance.now();
   const items: RetrievalItem[] = [];
 
-  // FTS match query to find relevant symbols
-  const matches = store.ftsSearch(query, { limit: topK });
+  // FTS match query to find relevant symbols; apply kind filter when provided
+  // ftsSearch accepts a single kind — run once per kind when filtering, or unfiltered otherwise
+  let matches;
+  if (kinds && kinds.length === 1) {
+    matches = store.ftsSearch(query, { limit: topK, kind: kinds[0] });
+  } else {
+    matches = store.ftsSearch(query, { limit: topK });
+  }
+
+  // Post-filter when multiple kinds are requested
+  if (kinds && kinds.length > 1) {
+    const kindSet = new Set<string>(kinds);
+    matches = matches.filter((s) => kindSet.has(s.kind));
+  }
 
   for (const sym of matches) {
     items.push({
@@ -127,6 +143,7 @@ async function runStructural(
       provenance: "structural",
       score: 1.0, // raw score, reranker will normalize
       estimatedTokens: estimateTokens(sym.source),
+      kind: sym.kind,
     });
 
     // Also include direct dependents/dependencies for context
@@ -141,6 +158,7 @@ async function runStructural(
             provenance: "structural",
             score: 0.5,
             estimatedTokens: estimateTokens(dep.symbol.source),
+            kind: dep.symbol.kind,
           });
         }
       }
@@ -156,29 +174,34 @@ async function runSemantic(
   config: Config,
   topK: number,
   provider?: EmbeddingProvider,
+  kinds?: SymbolKind[],
 ): Promise<StrategyResult> {
   const start = performance.now();
 
-  try {
-    const results = await semanticSearch(query, store, config, {
-      topK,
-      provider,
-    });
+  // Semantic search may fail (no API key, empty index) — let errors propagate
+  // so extractDiagnostic() records status: "failed" correctly.
+  const results = await semanticSearch(query, store, config, {
+    topK,
+    provider,
+  });
 
-    const items: RetrievalItem[] = results.map((r) => ({
-      id: r.symbol.id,
-      content: r.symbol.source,
-      source: `${r.symbol.filePath}:${r.symbol.lineStart}-${r.symbol.lineEnd}`,
-      provenance: "semantic" as const,
-      score: r.score,
-      estimatedTokens: estimateTokens(r.symbol.source),
-    }));
-
-    return { items, timeMs: Math.round(performance.now() - start) };
-  } catch (err: unknown) {
-    // Semantic may fail (no API key, empty index) — that's ok
-    throw err;
+  let filtered = results;
+  if (kinds && kinds.length > 0) {
+    const kindSet = new Set<string>(kinds);
+    filtered = results.filter((r) => kindSet.has(r.symbol.kind));
   }
+
+  const items: RetrievalItem[] = filtered.map((r) => ({
+    id: r.symbol.id,
+    content: r.symbol.source,
+    source: `${r.symbol.filePath}:${r.symbol.lineStart}-${r.symbol.lineEnd}`,
+    provenance: "semantic" as const,
+    score: r.score,
+    estimatedTokens: estimateTokens(r.symbol.source),
+    kind: r.symbol.kind,
+  }));
+
+  return { items, timeMs: Math.round(performance.now() - start) };
 }
 
 async function runMemory(
@@ -194,29 +217,27 @@ async function runMemory(
     return { items: [], timeMs: 0 };
   }
 
-  try {
-    const results = await recallMemories({
-      query,
-      store: memoryStore,
-      embeddingProvider: provider,
-      graphStore,
-      topK,
-    });
+  // Let unexpected errors from recallMemories propagate so extractDiagnostic()
+  // can record status: "failed". The only silent-skip is when memoryStore is
+  // absent (handled above).
+  const results = await recallMemories({
+    query,
+    store: memoryStore,
+    embeddingProvider: provider,
+    graphStore,
+    topK,
+  });
 
-    const items: RetrievalItem[] = results.map((r) => ({
-      id: r.memory.id,
-      content: r.memory.content,
-      source: `memory:${r.memory.id}`,
-      provenance: "memory" as const,
-      score: r.similarity,
-      estimatedTokens: estimateTokens(r.memory.content),
-    }));
+  const items: RetrievalItem[] = results.map((r) => ({
+    id: r.memory.id,
+    content: r.memory.content,
+    source: `memory:${r.memory.id}`,
+    provenance: "memory" as const,
+    score: r.similarity,
+    estimatedTokens: estimateTokens(r.memory.content),
+  }));
 
-    return { items, timeMs: Math.round(performance.now() - start) };
-  } catch {
-    // Memory may fail (empty store, no provider) — that's ok
-    return { items: [], timeMs: Math.round(performance.now() - start) };
-  }
+  return { items, timeMs: Math.round(performance.now() - start) };
 }
 
 // ── Helpers ──

--- a/apps/context/src/retrieval/combined.ts
+++ b/apps/context/src/retrieval/combined.ts
@@ -1,0 +1,251 @@
+/**
+ * Combined retrieval orchestrator — runs structural, semantic, and memory
+ * strategies in parallel, deduplicates, reranks, and assembles a budgeted
+ * context bundle.
+ *
+ * Slice: S04 — T03
+ */
+
+import type { GraphStore } from "../graph/store.js";
+import type { Config } from "../types.js";
+import type { MemoryStore } from "../memory/store.js";
+import type { EmbeddingProvider } from "../semantic/contracts.js";
+import { dependents, dependencies, resolveSymbol } from "../graph/queries.js";
+import { semanticSearch } from "../search/semantic.js";
+import { recallMemories } from "../memory/recall.js";
+import { rerankResults } from "./reranker.js";
+import { assembleBudget, estimateTokens } from "./budget.js";
+import type {
+  CombinedRetrievalResult,
+  CombinedRetrievalOptions,
+  RetrievalItem,
+  RetrievalStrategy,
+  StrategyDiagnostic,
+  RetrievalDiagnostics,
+} from "./types.js";
+import { DEFAULT_RANKING_WEIGHTS } from "./types.js";
+
+const DEFAULT_BUDGET = 4000;
+const DEFAULT_TOP_K = 20;
+
+export interface CombinedRetrievalInput {
+  query: string;
+  store: GraphStore;
+  memoryStore?: MemoryStore;
+  config: Config;
+  embeddingProvider?: EmbeddingProvider;
+  options?: CombinedRetrievalOptions;
+}
+
+/**
+ * Run combined retrieval: structural + semantic + memory in parallel.
+ */
+export async function combinedRetrieval(
+  input: CombinedRetrievalInput,
+): Promise<CombinedRetrievalResult> {
+  const totalStart = performance.now();
+  const { query, store, memoryStore, config, embeddingProvider, options } = input;
+  const budget = options?.budget ?? DEFAULT_BUDGET;
+  const topK = options?.topK ?? DEFAULT_TOP_K;
+  const weights = { ...DEFAULT_RANKING_WEIGHTS, ...options?.weights };
+
+  // Run all three strategies in parallel
+  const [structuralResult, semanticResult, memoryResult] = await Promise.allSettled([
+    runStructural(query, store, topK),
+    runSemantic(query, store, config, topK, embeddingProvider),
+    runMemory(query, memoryStore, embeddingProvider, store, topK),
+  ]);
+
+  // Collect items and diagnostics
+  const allItems: RetrievalItem[] = [];
+  const perStrategy: Record<RetrievalStrategy, StrategyDiagnostic> = {
+    structural: extractDiagnostic(structuralResult),
+    semantic: extractDiagnostic(semanticResult),
+    memory: extractDiagnostic(memoryResult),
+  };
+
+  if (structuralResult.status === "fulfilled") {
+    allItems.push(...structuralResult.value.items);
+    perStrategy.structural.hits = structuralResult.value.items.length;
+  }
+  if (semanticResult.status === "fulfilled") {
+    allItems.push(...semanticResult.value.items);
+    perStrategy.semantic.hits = semanticResult.value.items.length;
+  }
+  if (memoryResult.status === "fulfilled") {
+    allItems.push(...memoryResult.value.items);
+    perStrategy.memory.hits = memoryResult.value.items.length;
+  }
+
+  // Deduplicate by ID (keep highest-scoring)
+  const deduped = deduplicateById(allItems);
+
+  // Rerank
+  const reranked = rerankResults(deduped, weights);
+
+  // Budget assembly
+  const assembled = assembleBudget(reranked, budget);
+
+  const totalTimeMs = Math.round(performance.now() - totalStart);
+
+  const diagnostics: RetrievalDiagnostics = {
+    perStrategy,
+    budgetUsed: assembled.budgetUsed,
+    budgetTotal: assembled.budgetTotal,
+    totalTimeMs,
+  };
+
+  return {
+    items: assembled.items,
+    diagnostics,
+  };
+}
+
+// ── Strategy runners ──
+
+interface StrategyResult {
+  items: RetrievalItem[];
+  timeMs: number;
+}
+
+async function runStructural(
+  query: string,
+  store: GraphStore,
+  topK: number,
+): Promise<StrategyResult> {
+  const start = performance.now();
+  const items: RetrievalItem[] = [];
+
+  // FTS match query to find relevant symbols
+  const matches = store.ftsSearch(query, { limit: topK });
+
+  for (const sym of matches) {
+    items.push({
+      id: sym.id,
+      content: sym.source,
+      source: `${sym.filePath}:${sym.lineStart}-${sym.lineEnd}`,
+      provenance: "structural",
+      score: 1.0, // raw score, reranker will normalize
+      estimatedTokens: estimateTokens(sym.source),
+    });
+
+    // Also include direct dependents/dependencies for context
+    const deps = dependents(store, sym.name);
+    if (deps) {
+      for (const dep of deps.related.slice(0, 3)) {
+        if (!items.some((i) => i.id === dep.symbol.id)) {
+          items.push({
+            id: dep.symbol.id,
+            content: dep.symbol.source,
+            source: `${dep.symbol.filePath}:${dep.symbol.lineStart}-${dep.symbol.lineEnd}`,
+            provenance: "structural",
+            score: 0.5,
+            estimatedTokens: estimateTokens(dep.symbol.source),
+          });
+        }
+      }
+    }
+  }
+
+  return { items: items.slice(0, topK), timeMs: Math.round(performance.now() - start) };
+}
+
+async function runSemantic(
+  query: string,
+  store: GraphStore,
+  config: Config,
+  topK: number,
+  provider?: EmbeddingProvider,
+): Promise<StrategyResult> {
+  const start = performance.now();
+
+  try {
+    const results = await semanticSearch(query, store, config, {
+      topK,
+      provider,
+    });
+
+    const items: RetrievalItem[] = results.map((r) => ({
+      id: r.symbol.id,
+      content: r.symbol.source,
+      source: `${r.symbol.filePath}:${r.symbol.lineStart}-${r.symbol.lineEnd}`,
+      provenance: "semantic" as const,
+      score: r.score,
+      estimatedTokens: estimateTokens(r.symbol.source),
+    }));
+
+    return { items, timeMs: Math.round(performance.now() - start) };
+  } catch (err: unknown) {
+    // Semantic may fail (no API key, empty index) — that's ok
+    throw err;
+  }
+}
+
+async function runMemory(
+  query: string,
+  memoryStore?: MemoryStore,
+  provider?: EmbeddingProvider,
+  graphStore?: GraphStore,
+  topK?: number,
+): Promise<StrategyResult> {
+  const start = performance.now();
+
+  if (!memoryStore) {
+    return { items: [], timeMs: 0 };
+  }
+
+  try {
+    const results = await recallMemories({
+      query,
+      store: memoryStore,
+      embeddingProvider: provider,
+      graphStore,
+      topK,
+    });
+
+    const items: RetrievalItem[] = results.map((r) => ({
+      id: r.memory.id,
+      content: r.memory.content,
+      source: `memory:${r.memory.id}`,
+      provenance: "memory" as const,
+      score: r.similarity,
+      estimatedTokens: estimateTokens(r.memory.content),
+    }));
+
+    return { items, timeMs: Math.round(performance.now() - start) };
+  } catch {
+    // Memory may fail (empty store, no provider) — that's ok
+    return { items: [], timeMs: Math.round(performance.now() - start) };
+  }
+}
+
+// ── Helpers ──
+
+function extractDiagnostic(
+  result: PromiseSettledResult<StrategyResult>,
+): StrategyDiagnostic {
+  if (result.status === "fulfilled") {
+    return {
+      status: result.value.items.length === 0 && result.value.timeMs === 0 ? "skipped" : "ok",
+      hits: result.value.items.length,
+      timeMs: result.value.timeMs,
+    };
+  }
+  return {
+    status: "failed",
+    hits: 0,
+    timeMs: 0,
+    error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+  };
+}
+
+function deduplicateById(items: RetrievalItem[]): RetrievalItem[] {
+  const seen = new Map<string, RetrievalItem>();
+  for (const item of items) {
+    const existing = seen.get(item.id);
+    if (!existing || item.score > existing.score) {
+      seen.set(item.id, item);
+    }
+  }
+  return [...seen.values()];
+}

--- a/apps/context/src/retrieval/reranker.ts
+++ b/apps/context/src/retrieval/reranker.ts
@@ -7,13 +7,6 @@
 import type { RetrievalItem, RankingWeights } from "./types.js";
 import { DEFAULT_RANKING_WEIGHTS } from "./types.js";
 
-interface ScoredCandidate {
-  item: RetrievalItem;
-  rawScore: number;
-  /** File modification recency score 0-1 (not used here, placeholder) */
-  recencyScore: number;
-}
-
 /**
  * Rerank retrieval items using configurable per-strategy weights.
  *

--- a/apps/context/src/retrieval/reranker.ts
+++ b/apps/context/src/retrieval/reranker.ts
@@ -1,0 +1,73 @@
+/**
+ * Multi-strategy reranker — normalizes per-strategy scores and applies weights.
+ *
+ * Slice: S04 — T03
+ */
+
+import type { RetrievalItem, RankingWeights } from "./types.js";
+import { DEFAULT_RANKING_WEIGHTS } from "./types.js";
+
+interface ScoredCandidate {
+  item: RetrievalItem;
+  rawScore: number;
+  /** File modification recency score 0-1 (not used here, placeholder) */
+  recencyScore: number;
+}
+
+/**
+ * Rerank retrieval items using configurable per-strategy weights.
+ *
+ * Normalizes raw scores within each strategy to 0-1, then applies
+ * weighted combination: structural*w1 + semantic*w2 + recency*w3 + memory*w4.
+ */
+export function rerankResults(
+  items: RetrievalItem[],
+  weights?: Partial<RankingWeights>,
+): RetrievalItem[] {
+  if (items.length === 0) return [];
+
+  const w: RankingWeights = { ...DEFAULT_RANKING_WEIGHTS, ...weights };
+
+  // Group by strategy and find min/max for normalization
+  const byStrategy = new Map<string, RetrievalItem[]>();
+  for (const item of items) {
+    const group = byStrategy.get(item.provenance) ?? [];
+    group.push(item);
+    byStrategy.set(item.provenance, group);
+  }
+
+  // Normalize scores per strategy to 0-1
+  const normalized = new Map<string, number>(); // item.id -> normalized score
+  for (const [, group] of byStrategy) {
+    const scores = group.map((i) => i.score);
+    const min = Math.min(...scores);
+    const max = Math.max(...scores);
+    const range = max - min;
+    for (const item of group) {
+      normalized.set(item.id, range > 0 ? (item.score - min) / range : 1.0);
+    }
+  }
+
+  // Compute combined scores
+  const combined: Array<{ item: RetrievalItem; combinedScore: number }> = [];
+  for (const item of items) {
+    const normScore = normalized.get(item.id) ?? 0;
+    const strategyWeight =
+      item.provenance === "structural"
+        ? w.structural
+        : item.provenance === "semantic"
+          ? w.semantic
+          : w.memory;
+
+    // Recency weight is applied uniformly (no file mtime data here)
+    const combinedScore = normScore * strategyWeight + w.recency * 0.5;
+    combined.push({ item, combinedScore });
+  }
+
+  combined.sort((a, b) => b.combinedScore - a.combinedScore);
+
+  return combined.map(({ item, combinedScore }) => ({
+    ...item,
+    score: combinedScore,
+  }));
+}

--- a/apps/context/src/retrieval/reranker.ts
+++ b/apps/context/src/retrieval/reranker.ts
@@ -52,8 +52,9 @@ export function rerankResults(
           ? w.semantic
           : w.memory;
 
-    // Recency weight is applied uniformly (no file mtime data here)
-    const combinedScore = normScore * strategyWeight + w.recency * 0.5;
+    // Note: recency weight is omitted until per-item mtime data is available.
+    // Adding a flat constant for every item would not differentiate rankings.
+    const combinedScore = normScore * strategyWeight;
     combined.push({ item, combinedScore });
   }
 

--- a/apps/context/src/retrieval/types.ts
+++ b/apps/context/src/retrieval/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Combined retrieval type definitions for S04.
+ *
+ * Defines the result model, diagnostics envelope, and options
+ * for the multi-strategy retrieval orchestrator.
+ */
+
+// ── Retrieval strategy ──
+
+export type RetrievalStrategy = "structural" | "semantic" | "memory";
+
+// ── Retrieval item ──
+
+export interface RetrievalItem {
+  /** Unique ID (symbol ID or memory ID) */
+  id: string;
+  /** Content text (source code or memory content) */
+  content: string;
+  /** Source location (e.g. "src/foo.ts:10-25") */
+  source: string;
+  /** Which strategy produced this item */
+  provenance: RetrievalStrategy;
+  /** Combined score after reranking */
+  score: number;
+  /** Estimated token count */
+  estimatedTokens: number;
+}
+
+// ── Strategy status ──
+
+export type StrategyStatus = "ok" | "skipped" | "failed";
+
+export interface StrategyDiagnostic {
+  status: StrategyStatus;
+  hits: number;
+  timeMs: number;
+  error?: string;
+}
+
+// ── Diagnostics envelope ──
+
+export interface RetrievalDiagnostics {
+  perStrategy: Record<RetrievalStrategy, StrategyDiagnostic>;
+  budgetUsed: number;
+  budgetTotal: number;
+  totalTimeMs: number;
+}
+
+// ── Combined result ──
+
+export interface CombinedRetrievalResult {
+  items: RetrievalItem[];
+  diagnostics: RetrievalDiagnostics;
+}
+
+// ── Options ──
+
+export interface RankingWeights {
+  structural: number;
+  semantic: number;
+  recency: number;
+  memory: number;
+}
+
+export const DEFAULT_RANKING_WEIGHTS: RankingWeights = {
+  structural: 0.4,
+  semantic: 0.3,
+  recency: 0.15,
+  memory: 0.15,
+};
+
+export interface CombinedRetrievalOptions {
+  /** Token budget (default: 4000) */
+  budget?: number;
+  /** Max results per strategy before dedup (default: 20) */
+  topK?: number;
+  /** Custom ranking weights */
+  weights?: Partial<RankingWeights>;
+  /** Filter by symbol kind */
+  kinds?: string[];
+}

--- a/apps/context/src/retrieval/types.ts
+++ b/apps/context/src/retrieval/types.ts
@@ -5,6 +5,8 @@
  * for the multi-strategy retrieval orchestrator.
  */
 
+import type { SymbolKind } from "../types.js";
+
 // ── Retrieval strategy ──
 
 export type RetrievalStrategy = "structural" | "semantic" | "memory";
@@ -24,6 +26,8 @@ export interface RetrievalItem {
   score: number;
   /** Estimated token count */
   estimatedTokens: number;
+  /** Symbol kind for structural/semantic items — used for kind filtering */
+  kind?: SymbolKind;
 }
 
 // ── Strategy status ──
@@ -77,5 +81,5 @@ export interface CombinedRetrievalOptions {
   /** Custom ranking weights */
   weights?: Partial<RankingWeights>;
   /** Filter by symbol kind */
-  kinds?: string[];
+  kinds?: SymbolKind[];
 }

--- a/apps/context/src/watcher/index.ts
+++ b/apps/context/src/watcher/index.ts
@@ -48,6 +48,8 @@ export function createWatcher(
   let fsWatcher: FSWatcher | null = null;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let pendingFiles: Set<string> = new Set();
+  /** Files that arrived while a reindex was in progress; processed after current run completes. */
+  let queuedDuringReindex: Set<string> = new Set();
   let reindexing = false;
 
   function emit(event: WatcherEvent): void {
@@ -57,7 +59,11 @@ export function createWatcher(
   }
 
   async function triggerReindex(files: string[]): Promise<void> {
-    if (reindexing) return;
+    if (reindexing) {
+      // Queue these files for a follow-up pass after the current reindex finishes.
+      for (const f of files) queuedDuringReindex.add(f);
+      return;
+    }
     reindexing = true;
 
     emit({
@@ -68,7 +74,9 @@ export function createWatcher(
 
     const start = performance.now();
     try {
-      indexProject(resolve(rootDir), { config });
+      // Force a full re-index so that uncommitted (dirty) file changes on disk
+      // are always picked up, not just committed-history changes.
+      indexProject(resolve(rootDir), { config, full: true });
       const durationMs = Math.round(performance.now() - start);
       emit({
         type: "reindex-done",
@@ -88,6 +96,12 @@ export function createWatcher(
       });
     } finally {
       reindexing = false;
+      // If new files accumulated while we were indexing, schedule another pass.
+      if (queuedDuringReindex.size > 0) {
+        const nextFiles = [...queuedDuringReindex];
+        queuedDuringReindex = new Set();
+        void triggerReindex(nextFiles);
+      }
     }
   }
 
@@ -153,6 +167,7 @@ export function createWatcher(
         debounceTimer = null;
       }
       pendingFiles.clear();
+      queuedDuringReindex.clear();
       if (fsWatcher) {
         await fsWatcher.close();
         fsWatcher = null;

--- a/apps/context/src/watcher/index.ts
+++ b/apps/context/src/watcher/index.ts
@@ -1,0 +1,165 @@
+/**
+ * File watcher — monitors source files and triggers incremental re-indexing.
+ *
+ * Slice: S04 — Live Refresh + Combined Retrieval
+ * Task: T02
+ */
+
+import { watch as chokidarWatch, type FSWatcher } from "chokidar";
+import { resolve, relative } from "node:path";
+import { indexProject } from "../indexer.js";
+import type { Config } from "../types.js";
+import type {
+  Watcher,
+  WatcherOptions,
+  WatcherEvent,
+  WatcherEventHandler,
+} from "./types.js";
+
+/** Default debounce window in ms */
+const DEFAULT_DEBOUNCE_MS = 300;
+
+/** Paths always ignored to prevent self-trigger loops */
+const ALWAYS_IGNORED = [
+  "**/.kata/index/**",
+  "**/.kata/memory/**",
+  "**/node_modules/**",
+  "**/.git/**",
+];
+
+export { type Watcher, type WatcherOptions, type WatcherEvent } from "./types.js";
+
+/**
+ * Create a file watcher that triggers incremental re-indexing on change.
+ */
+export function createWatcher(
+  rootDir: string,
+  config: Config,
+  options?: WatcherOptions,
+): Watcher {
+  const debounceMs = options?.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const extraIgnored = options?.ignorePaths ?? [];
+  const ignored = [...ALWAYS_IGNORED, ...config.excludes.map(e => `**/${e}/**`), ...extraIgnored];
+
+  const handlers: WatcherEventHandler[] = [];
+  let fsWatcher: FSWatcher | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingFiles: Set<string> = new Set();
+  let reindexing = false;
+
+  function emit(event: WatcherEvent): void {
+    for (const h of handlers) {
+      try { h(event); } catch { /* swallow handler errors */ }
+    }
+  }
+
+  async function triggerReindex(files: string[]): Promise<void> {
+    if (reindexing) return;
+    reindexing = true;
+
+    emit({
+      type: "reindex-start",
+      timestamp: new Date().toISOString(),
+      files,
+    });
+
+    const start = performance.now();
+    try {
+      indexProject(resolve(rootDir), { config });
+      const durationMs = Math.round(performance.now() - start);
+      emit({
+        type: "reindex-done",
+        timestamp: new Date().toISOString(),
+        files,
+        durationMs,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Determine error code
+      const isProviderError = message.includes("API") || message.includes("key") || message.includes("provider");
+      emit({
+        type: "error",
+        timestamp: new Date().toISOString(),
+        error: message,
+        errorCode: isProviderError ? "WATCH_PROVIDER_ERROR" : "WATCH_REINDEX_FAILED",
+      });
+    } finally {
+      reindexing = false;
+    }
+  }
+
+  function onFileChange(filePath: string): void {
+    const rel = relative(rootDir, filePath);
+    pendingFiles.add(rel);
+
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      const files = [...pendingFiles];
+      pendingFiles = new Set();
+      debounceTimer = null;
+
+      emit({
+        type: "change",
+        timestamp: new Date().toISOString(),
+        files,
+      });
+
+      triggerReindex(files);
+    }, debounceMs);
+  }
+
+  const watcher: Watcher = {
+    async start(): Promise<void> {
+      try {
+        fsWatcher = chokidarWatch(rootDir, {
+          ignored,
+          persistent: true,
+          ignoreInitial: true,
+          awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 50 },
+        });
+
+        fsWatcher.on("change", onFileChange);
+        fsWatcher.on("add", onFileChange);
+        fsWatcher.on("unlink", onFileChange);
+
+        // Wait for ready event
+        await new Promise<void>((res, rej) => {
+          fsWatcher!.on("ready", res);
+          fsWatcher!.on("error", rej);
+        });
+
+        emit({
+          type: "start",
+          timestamp: new Date().toISOString(),
+        });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        emit({
+          type: "error",
+          timestamp: new Date().toISOString(),
+          error: message,
+          errorCode: "WATCH_INIT_FAILED",
+        });
+        throw err;
+      }
+    },
+
+    async stop(): Promise<void> {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      pendingFiles.clear();
+      if (fsWatcher) {
+        await fsWatcher.close();
+        fsWatcher = null;
+      }
+    },
+
+    on(handler: WatcherEventHandler): void {
+      handlers.push(handler);
+    },
+  };
+
+  return watcher;
+}

--- a/apps/context/src/watcher/index.ts
+++ b/apps/context/src/watcher/index.ts
@@ -21,10 +21,9 @@ const DEFAULT_DEBOUNCE_MS = 300;
 
 /** Paths always ignored to prevent self-trigger loops */
 const ALWAYS_IGNORED = [
-  "**/.kata/index/**",
-  "**/.kata/memory/**",
-  "**/node_modules/**",
-  "**/.git/**",
+  /(^|[/\\])\.kata[/\\]/,
+  /(^|[/\\])node_modules[/\\]/,
+  /(^|[/\\])\.git[/\\]/,
 ];
 
 export { type Watcher, type WatcherOptions, type WatcherEvent } from "./types.js";
@@ -39,7 +38,11 @@ export function createWatcher(
 ): Watcher {
   const debounceMs = options?.debounceMs ?? DEFAULT_DEBOUNCE_MS;
   const extraIgnored = options?.ignorePaths ?? [];
-  const ignored = [...ALWAYS_IGNORED, ...config.excludes.map(e => `**/${e}/**`), ...extraIgnored];
+  const ignored: Array<RegExp | string> = [
+    ...ALWAYS_IGNORED,
+    ...config.excludes.map(e => `**/${e}/**`),
+    ...extraIgnored,
+  ];
 
   const handlers: WatcherEventHandler[] = [];
   let fsWatcher: FSWatcher | null = null;

--- a/apps/context/src/watcher/types.ts
+++ b/apps/context/src/watcher/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Watcher type definitions for S04 — Live Refresh.
+ *
+ * Defines the event model, options, and interface for the
+ * chokidar-based file watcher that triggers incremental re-indexing.
+ */
+
+// ── Watcher event types ──
+
+export type WatcherEventType =
+  | "start"
+  | "change"
+  | "reindex-start"
+  | "reindex-done"
+  | "error";
+
+export interface WatcherEvent {
+  type: WatcherEventType;
+  timestamp: string;
+  files?: string[];
+  error?: string;
+  errorCode?: WatcherErrorCode;
+  /** Duration of the reindex in ms (only for reindex-done) */
+  durationMs?: number;
+}
+
+export type WatcherErrorCode =
+  | "WATCH_INIT_FAILED"
+  | "WATCH_REINDEX_FAILED"
+  | "WATCH_PROVIDER_ERROR";
+
+// ── Watcher options ──
+
+export interface WatcherOptions {
+  /** Debounce window in ms (default: 300) */
+  debounceMs?: number;
+  /** Additional paths to ignore (merged with defaults) */
+  ignorePaths?: string[];
+}
+
+// ── Watcher interface ──
+
+export type WatcherEventHandler = (event: WatcherEvent) => void;
+
+export interface Watcher {
+  /** Start watching for file changes */
+  start(): Promise<void>;
+  /** Stop watching and clean up resources */
+  stop(): Promise<void>;
+  /** Register an event handler */
+  on(handler: WatcherEventHandler): void;
+}

--- a/apps/context/test/cli/watch-get-commands.test.ts
+++ b/apps/context/test/cli/watch-get-commands.test.ts
@@ -1,0 +1,59 @@
+/**
+ * CLI command registration tests for watch + get — S04/T01
+ */
+
+import { describe, it, expect } from "vitest";
+import { program } from "../../src/cli.js";
+
+describe("CLI command registration", () => {
+  it("watch command is registered", () => {
+    const watchCmd = program.commands.find((c) => c.name() === "watch");
+    expect(watchCmd).toBeDefined();
+    expect(watchCmd!.description()).toContain("Watch");
+  });
+
+  it("get command is registered", () => {
+    const getCmd = program.commands.find((c) => c.name() === "get");
+    expect(getCmd).toBeDefined();
+    expect(getCmd!.description()).toContain("combined");
+  });
+
+  it("get command has --budget option", () => {
+    const getCmd = program.commands.find((c) => c.name() === "get");
+    expect(getCmd).toBeDefined();
+    const budgetOpt = getCmd!.options.find(
+      (o) => o.long === "--budget",
+    );
+    expect(budgetOpt).toBeDefined();
+  });
+
+  it("get command has --kind option", () => {
+    const getCmd = program.commands.find((c) => c.name() === "get");
+    expect(getCmd).toBeDefined();
+    const kindOpt = getCmd!.options.find(
+      (o) => o.long === "--kind",
+    );
+    expect(kindOpt).toBeDefined();
+  });
+
+  it("watch command has --debounce option", () => {
+    const watchCmd = program.commands.find((c) => c.name() === "watch");
+    expect(watchCmd).toBeDefined();
+    const debounceOpt = watchCmd!.options.find(
+      (o) => o.long === "--debounce",
+    );
+    expect(debounceOpt).toBeDefined();
+  });
+
+  it("all original commands still registered", () => {
+    const expectedCmds = [
+      "index", "status", "graph", "grep", "search", "find",
+      "remember", "recall", "forget", "consolidate",
+      "watch", "get",
+    ];
+    const cmdNames = program.commands.map((c) => c.name());
+    for (const name of expectedCmds) {
+      expect(cmdNames).toContain(name);
+    }
+  });
+});

--- a/apps/context/test/retrieval/combined-retrieval.test.ts
+++ b/apps/context/test/retrieval/combined-retrieval.test.ts
@@ -2,15 +2,26 @@
  * Combined retrieval contract tests — S04/T01
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { rerankResults } from "../../src/retrieval/reranker.js";
 import { assembleBudget, estimateTokens } from "../../src/retrieval/budget.js";
+import { combinedRetrieval } from "../../src/retrieval/combined.js";
 import type {
   RetrievalItem,
   CombinedRetrievalResult,
+  CombinedRetrievalInput,
   RetrievalDiagnostics,
 } from "../../src/retrieval/types.js";
 import { DEFAULT_RANKING_WEIGHTS } from "../../src/retrieval/types.js";
+
+// Top-level mocks required by combinedRetrieval orchestrator tests
+vi.mock("../../src/graph/queries.js", () => ({
+  dependents: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../../src/search/semantic.js", () => ({
+  semanticSearch: vi.fn().mockRejectedValue(new Error("no vector index")),
+}));
 
 // ── Helper factories ──
 
@@ -153,5 +164,104 @@ describe("Retrieval Types", () => {
     expect(result.diagnostics.perStrategy.structural.status).toBe("ok");
     expect(result.diagnostics.perStrategy.semantic.status).toBe("skipped");
     expect(result.diagnostics.perStrategy.memory.status).toBe("failed");
+  });
+});
+
+describe("combinedRetrieval orchestrator", () => {
+  const SHARED_ID = "shared-sym";
+
+  function makeSymbol(id: string, source = "function foo() {}") {
+    return {
+      id,
+      name: "foo",
+      kind: "function" as import("../../src/types.js").SymbolKind,
+      filePath: "src/foo.ts",
+      lineStart: 1,
+      lineEnd: 3,
+      source,
+      signature: "function foo()",
+      docstring: null,
+      exported: true,
+      summary: null,
+      lastIndexedAt: new Date().toISOString(),
+      gitSha: null,
+    };
+  }
+
+  function makeStoreMock(symId = "struct-1") {
+    return {
+      ftsSearch: vi.fn().mockReturnValue([makeSymbol(symId)]),
+      close: vi.fn(),
+    };
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("aggregates structural hits, skips missing memoryStore, reports failed semantic", async () => {
+    const store = makeStoreMock("struct-1");
+    const { dependents } = await import("../../src/graph/queries.js");
+    vi.mocked(dependents).mockReturnValue(null);
+
+    // semanticSearch is already mocked at module top to reject — no override needed
+
+    const input: CombinedRetrievalInput = {
+      query: "foo function",
+      store: store as unknown as import("../../src/graph/store.js").GraphStore,
+      // memoryStore intentionally absent → strategy should be "skipped"
+      config: { rootDir: "/tmp", excludes: [], extensions: [] } as unknown as import("../../src/types.js").Config,
+      options: { budget: 4000, topK: 10 },
+    };
+
+    const result = await combinedRetrieval(input);
+
+    // Structural produced at least one hit
+    expect(result.diagnostics.perStrategy.structural.status).toBe("ok");
+    expect(result.diagnostics.perStrategy.structural.hits).toBeGreaterThan(0);
+
+    // Memory was skipped (no store)
+    expect(result.diagnostics.perStrategy.memory.status).toBe("skipped");
+
+    // Semantic failed
+    expect(result.diagnostics.perStrategy.semantic.status).toBe("failed");
+    expect(result.diagnostics.perStrategy.semantic.error).toBeTruthy();
+
+    // Budget fields are populated
+    expect(result.diagnostics.budgetTotal).toBe(4000);
+    expect(result.diagnostics.budgetUsed).toBeGreaterThanOrEqual(0);
+    expect(result.diagnostics.totalTimeMs).toBeGreaterThanOrEqual(0);
+
+    // Items array reflects deduplication (all from structural here)
+    expect(result.items.length).toBeGreaterThan(0);
+  });
+
+  it("deduplicates items across strategies keeping highest score", async () => {
+    const store = makeStoreMock(SHARED_ID);
+    const { dependents } = await import("../../src/graph/queries.js");
+    vi.mocked(dependents).mockReturnValue(null);
+
+    // Override semantic to return the same ID with a higher score
+    const { semanticSearch } = await import("../../src/search/semantic.js");
+    vi.mocked(semanticSearch).mockResolvedValue([
+      {
+        symbol: makeSymbol(SHARED_ID, "function shared() {}") as any,
+        score: 0.9,
+        distance: 0.1,
+      },
+    ]);
+
+    const input: CombinedRetrievalInput = {
+      query: "shared",
+      store: store as unknown as import("../../src/graph/store.js").GraphStore,
+      config: { rootDir: "/tmp", excludes: [], extensions: [] } as unknown as import("../../src/types.js").Config,
+      options: { budget: 4000 },
+    };
+
+    const result = await combinedRetrieval(input);
+
+    // Should only appear once after dedup
+    const occurrences = result.items.filter((i) => i.id === SHARED_ID);
+    expect(occurrences).toHaveLength(1);
   });
 });

--- a/apps/context/test/retrieval/combined-retrieval.test.ts
+++ b/apps/context/test/retrieval/combined-retrieval.test.ts
@@ -5,11 +5,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { rerankResults } from "../../src/retrieval/reranker.js";
 import { assembleBudget, estimateTokens } from "../../src/retrieval/budget.js";
-import { combinedRetrieval } from "../../src/retrieval/combined.js";
+import { combinedRetrieval, type CombinedRetrievalInput } from "../../src/retrieval/combined.js";
 import type {
   RetrievalItem,
   CombinedRetrievalResult,
-  CombinedRetrievalInput,
   RetrievalDiagnostics,
 } from "../../src/retrieval/types.js";
 import { DEFAULT_RANKING_WEIGHTS } from "../../src/retrieval/types.js";

--- a/apps/context/test/retrieval/combined-retrieval.test.ts
+++ b/apps/context/test/retrieval/combined-retrieval.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Combined retrieval contract tests — S04/T01
+ */
+
+import { describe, it, expect } from "vitest";
+import { rerankResults } from "../../src/retrieval/reranker.js";
+import { assembleBudget, estimateTokens } from "../../src/retrieval/budget.js";
+import type {
+  RetrievalItem,
+  CombinedRetrievalResult,
+  RetrievalDiagnostics,
+} from "../../src/retrieval/types.js";
+import { DEFAULT_RANKING_WEIGHTS } from "../../src/retrieval/types.js";
+
+// ── Helper factories ──
+
+function makeItem(overrides: Partial<RetrievalItem> = {}): RetrievalItem {
+  return {
+    id: "sym-1",
+    content: "function foo() { return 1; }",
+    source: "src/foo.ts:1-3",
+    provenance: "structural",
+    score: 1.0,
+    estimatedTokens: 7,
+    ...overrides,
+  };
+}
+
+describe("Reranker", () => {
+  it("returns empty array for empty input", () => {
+    expect(rerankResults([])).toEqual([]);
+  });
+
+  it("preserves all items", () => {
+    const items = [
+      makeItem({ id: "a", provenance: "structural", score: 1.0 }),
+      makeItem({ id: "b", provenance: "semantic", score: 0.8 }),
+      makeItem({ id: "c", provenance: "memory", score: 0.6 }),
+    ];
+    const result = rerankResults(items);
+    expect(result).toHaveLength(3);
+  });
+
+  it("applies ranking weights", () => {
+    const items = [
+      makeItem({ id: "a", provenance: "structural", score: 0.5 }),
+      makeItem({ id: "b", provenance: "semantic", score: 1.0 }),
+    ];
+    // With default weights (structural 0.4 > semantic 0.3),
+    // a structural item with same normalized score should rank higher
+    const result = rerankResults(items);
+    expect(result).toHaveLength(2);
+    // All items have scores assigned
+    for (const item of result) {
+      expect(item.score).toBeGreaterThan(0);
+    }
+  });
+
+  it("accepts custom weights", () => {
+    const items = [
+      makeItem({ id: "a", provenance: "structural", score: 1.0 }),
+      makeItem({ id: "b", provenance: "semantic", score: 1.0 }),
+    ];
+    const result = rerankResults(items, { structural: 0.1, semantic: 0.9 });
+    expect(result).toHaveLength(2);
+    // Semantic should rank higher with boosted weight
+    expect(result[0]!.id).toBe("b");
+  });
+
+  it("includes provenance labels on output", () => {
+    const items = [
+      makeItem({ id: "a", provenance: "structural" }),
+      makeItem({ id: "b", provenance: "semantic" }),
+      makeItem({ id: "c", provenance: "memory" }),
+    ];
+    const result = rerankResults(items);
+    const provenances = new Set(result.map((r) => r.provenance));
+    expect(provenances.has("structural")).toBe(true);
+    expect(provenances.has("semantic")).toBe(true);
+    expect(provenances.has("memory")).toBe(true);
+  });
+});
+
+describe("Budget Assembly", () => {
+  it("estimateTokens uses chars/4", () => {
+    expect(estimateTokens("abcd")).toBe(1);
+    expect(estimateTokens("abcde")).toBe(2);
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it("respects budget limit", () => {
+    const items = [
+      makeItem({ id: "a", content: "a".repeat(400), estimatedTokens: 100 }),
+      makeItem({ id: "b", content: "b".repeat(400), estimatedTokens: 100 }),
+      makeItem({ id: "c", content: "c".repeat(400), estimatedTokens: 100 }),
+    ];
+    const result = assembleBudget(items, 200);
+    expect(result.budgetUsed).toBeLessThanOrEqual(200);
+    expect(result.budgetTotal).toBe(200);
+    expect(result.items.length).toBeLessThanOrEqual(2);
+  });
+
+  it("includes at least one item even if over budget", () => {
+    const items = [makeItem({ id: "a", content: "a".repeat(1000), estimatedTokens: 250 })];
+    const result = assembleBudget(items, 10);
+    expect(result.items).toHaveLength(1);
+  });
+
+  it("returns empty for empty input", () => {
+    const result = assembleBudget([], 1000);
+    expect(result.items).toHaveLength(0);
+    expect(result.budgetUsed).toBe(0);
+  });
+
+  it("fills greedily from top-ranked", () => {
+    const items = [
+      makeItem({ id: "a", content: "a".repeat(100), estimatedTokens: 25, score: 1.0 }),
+      makeItem({ id: "b", content: "b".repeat(100), estimatedTokens: 25, score: 0.5 }),
+      makeItem({ id: "c", content: "c".repeat(100), estimatedTokens: 25, score: 0.3 }),
+    ];
+    const result = assembleBudget(items, 50);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0]!.id).toBe("a");
+    expect(result.items[1]!.id).toBe("b");
+  });
+});
+
+describe("Retrieval Types", () => {
+  it("DEFAULT_RANKING_WEIGHTS sums to 1.0", () => {
+    const sum =
+      DEFAULT_RANKING_WEIGHTS.structural +
+      DEFAULT_RANKING_WEIGHTS.semantic +
+      DEFAULT_RANKING_WEIGHTS.recency +
+      DEFAULT_RANKING_WEIGHTS.memory;
+    expect(sum).toBe(1.0);
+  });
+
+  it("CombinedRetrievalResult shape is correct", () => {
+    const result: CombinedRetrievalResult = {
+      items: [makeItem()],
+      diagnostics: {
+        perStrategy: {
+          structural: { status: "ok", hits: 1, timeMs: 10 },
+          semantic: { status: "skipped", hits: 0, timeMs: 0 },
+          memory: { status: "failed", hits: 0, timeMs: 0, error: "no store" },
+        },
+        budgetUsed: 7,
+        budgetTotal: 4000,
+        totalTimeMs: 15,
+      },
+    };
+    expect(result.items).toHaveLength(1);
+    expect(result.diagnostics.perStrategy.structural.status).toBe("ok");
+    expect(result.diagnostics.perStrategy.semantic.status).toBe("skipped");
+    expect(result.diagnostics.perStrategy.memory.status).toBe("failed");
+  });
+});

--- a/apps/context/test/watcher/watcher.test.ts
+++ b/apps/context/test/watcher/watcher.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Watcher contract tests — S04/T01
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createWatcher } from "../../src/watcher/index.js";
+import { loadConfig } from "../../src/config.js";
+import type { WatcherEvent } from "../../src/watcher/types.js";
+
+describe("Watcher", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "kata-watcher-test-"));
+    // Create .kata/index dir so it's a valid project root
+    mkdirSync(join(tmpDir, ".kata", "index"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("createWatcher returns a Watcher interface", () => {
+    const config = loadConfig(tmpDir);
+    const watcher = createWatcher(tmpDir, config);
+    expect(watcher).toBeDefined();
+    expect(typeof watcher.start).toBe("function");
+    expect(typeof watcher.stop).toBe("function");
+    expect(typeof watcher.on).toBe("function");
+  });
+
+  it("emits start event on start()", async () => {
+    const config = loadConfig(tmpDir);
+    const watcher = createWatcher(tmpDir, config, { debounceMs: 50 });
+    const events: WatcherEvent[] = [];
+    watcher.on((e) => events.push(e));
+
+    await watcher.start();
+    await watcher.stop();
+
+    expect(events.some((e) => e.type === "start")).toBe(true);
+  });
+
+  it("stops cleanly without errors", async () => {
+    const config = loadConfig(tmpDir);
+    const watcher = createWatcher(tmpDir, config, { debounceMs: 50 });
+    await watcher.start();
+    await watcher.stop();
+    // No error thrown = pass
+  });
+
+  it("debounces rapid changes", async () => {
+    const config = loadConfig(tmpDir);
+    const watcher = createWatcher(tmpDir, config, { debounceMs: 100 });
+    const events: WatcherEvent[] = [];
+    watcher.on((e) => events.push(e));
+
+    await watcher.start();
+
+    // Simulate rapid file changes
+    const testFile = join(tmpDir, "test.ts");
+    writeFileSync(testFile, "const a = 1;");
+    await new Promise((r) => setTimeout(r, 20));
+    writeFileSync(testFile, "const a = 2;");
+    await new Promise((r) => setTimeout(r, 20));
+    writeFileSync(testFile, "const a = 3;");
+
+    // Wait for debounce + processing
+    await new Promise((r) => setTimeout(r, 500));
+    await watcher.stop();
+
+    // Should have coalesced into a small number of change events
+    const changeEvents = events.filter((e) => e.type === "change");
+    expect(changeEvents.length).toBeLessThanOrEqual(2);
+  });
+
+  it("ignores .kata/ path changes", async () => {
+    const config = loadConfig(tmpDir);
+    const watcher = createWatcher(tmpDir, config, { debounceMs: 50 });
+    const events: WatcherEvent[] = [];
+    watcher.on((e) => events.push(e));
+
+    await watcher.start();
+
+    // Write to .kata/index — should be ignored
+    writeFileSync(join(tmpDir, ".kata", "index", "test.db"), "data");
+    await new Promise((r) => setTimeout(r, 200));
+
+    await watcher.stop();
+
+    const changeEvents = events.filter((e) => e.type === "change");
+    const hasKataPath = changeEvents.some((e) =>
+      e.files?.some((f) => f.includes(".kata/")),
+    );
+    expect(hasKataPath).toBe(false);
+  });
+
+  it("event has correct shape", async () => {
+    const config = loadConfig(tmpDir);
+    const watcher = createWatcher(tmpDir, config, { debounceMs: 50 });
+    const events: WatcherEvent[] = [];
+    watcher.on((e) => events.push(e));
+
+    await watcher.start();
+    await watcher.stop();
+
+    const startEvent = events.find((e) => e.type === "start");
+    expect(startEvent).toBeDefined();
+    expect(startEvent!.timestamp).toBeDefined();
+    expect(typeof startEvent!.timestamp).toBe("string");
+  });
+});

--- a/apps/context/test/watcher/watcher.test.ts
+++ b/apps/context/test/watcher/watcher.test.ts
@@ -92,8 +92,9 @@ describe("Watcher", () => {
     await watcher.stop();
 
     const changeEvents = events.filter((e) => e.type === "change");
+    // Normalize to forward slashes for cross-platform compatibility
     const hasKataPath = changeEvents.some((e) =>
-      e.files?.some((f) => f.includes(".kata/")),
+      e.files?.some((f) => f.replace(/\\/g, "/").includes(".kata/")),
     );
     expect(hasKataPath).toBe(false);
   });

--- a/bun.lock
+++ b/bun.lock
@@ -88,8 +88,9 @@
     },
     "apps/cli": {
       "name": "@kata-sh/cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
+        "kata": "dist/loader.js",
         "kata-cli": "dist/loader.js",
       },
       "dependencies": {
@@ -112,6 +113,7 @@
       },
       "dependencies": {
         "better-sqlite3": "^12.8.0",
+        "chokidar": "^5.0.0",
         "commander": "^14.0.3",
         "sqlite-vec": "^0.1.7",
         "tree-sitter": "^0.25.0",


### PR DESCRIPTION
Closes KAT-618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `watch` CLI command to monitor files for changes and perform incremental reindexing with configurable debouncing.
  * Added `get` CLI command to retrieve combined results from multiple retrieval strategies with diagnostics reporting (budget usage, timing, per-strategy performance).
  * Implemented token budget management for result selection and multi-strategy result reranking with configurable weights.
  * Support for `--quiet`, `--json`, `--budget`, and `--kind` options for output customization and filtering.

* **Tests**
  * Added test coverage for new CLI commands and retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new CLI commands to `apps/context`: `watch` (live file monitoring with incremental reindexing via chokidar) and `get` (combined structural + semantic + memory retrieval with token-budget management and diagnostics reporting). The implementation is well-structured with clean type definitions, parallel strategy execution via `Promise.allSettled`, and solid unit/integration test coverage.

Key issues found:

- **`--json`/`--quiet` flags broken on `watch` and `get`**: Both commands call `getOutputOptions(program)` (root program) instead of receiving the subcommand's `Command` object. Neither command registers `--json` or `--quiet` as local options, so passing them after the subcommand name (as documented in `SKILL.md`) will result in a Commander "unknown option" error.
- **`kinds` filter is silently ignored**: The `--kind` CLI option is wired up and passed into `CombinedRetrievalOptions.kinds`, but `combinedRetrieval` never applies it to filter results.
- **File changes during reindex are dropped**: When `reindexing === true`, the debounce callback calls `triggerReindex` which immediately returns, discarding the pending file list with no follow-up reindex scheduled after completion.
- **`runSemantic` has a no-op try-catch** that catches only to immediately re-throw, with a misleading comment implying errors are handled gracefully.
- **Memory failures silently report as `ok` in diagnostics**: The `runMemory` catch block returns `{ items: [], timeMs: <non-zero> }`, which `extractDiagnostic` classifies as `status: "ok"` (0 hits) rather than `"failed"`, hiding errors from operators.
- **Recency weight is a flat constant**: The formula `normScore * strategyWeight + w.recency * 0.5` adds the same `0.075` bonus to every item — it doesn't differentiate ranking at all until file mtime data is plumbed in.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — documented CLI flags (`--json`, `--quiet`) don't work on the new commands, and the `--kind` filter option is silently ignored.
- Two of the four new features have functional correctness issues: the output-mode flags fail when used as documented, and the kinds filter is a no-op. The watcher also has a data-loss edge case (changes dropped mid-reindex). The retrieval and budget logic itself is sound and well-tested.
- `apps/context/src/cli.ts` (option registration), `apps/context/src/retrieval/combined.ts` (kinds filter, memory error reporting), and `apps/context/src/watcher/index.ts` (dropped-changes race condition).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/context/src/cli.ts | Adds `watch` and `get` CLI commands; both commands incorrectly call `getOutputOptions(program)` with the root program instead of the subcommand `cmd` object, and neither registers `--json`/`--quiet` locally, causing those flags to fail when passed after the subcommand name. |
| apps/context/src/watcher/index.ts | Implements chokidar-based file watcher with debouncing and incremental reindexing; file changes that arrive while a reindex is in progress are silently dropped with no follow-up reindex scheduled. |
| apps/context/src/retrieval/combined.ts | Orchestrates parallel structural/semantic/memory retrieval; the `kinds` filter option is accepted and passed from CLI but never applied, and `runSemantic` contains a no-op try-catch that re-throws immediately. Memory failures are also misreported as "ok" in diagnostics. |
| apps/context/src/retrieval/reranker.ts | Multi-strategy score normalizer and reranker; the recency weight is applied as a flat constant (w.recency × 0.5) added uniformly to all items, so it does not differentiate ranking at all. |
| apps/context/src/retrieval/budget.ts | Greedy token-budget assembler; logic is correct — always includes at least one item, then continues trying smaller items to fill remaining budget space. |
| apps/context/test/retrieval/combined-retrieval.test.ts | Good unit coverage for reranker, budget assembler, and type shapes; all boundary conditions (empty input, over-budget single item, custom weights) are exercised. |
| apps/context/test/watcher/watcher.test.ts | Integration tests for the watcher using a real tmp directory; covers start/stop, debounce coalescing, and `.kata/` path exclusion, but does not test the dropped-changes-during-reindex scenario. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI
    participant Watcher
    participant Chokidar
    participant Indexer
    participant CombinedRetrieval
    participant Structural
    participant Semantic
    participant Memory
    participant Budget

    Note over CLI,Chokidar: watch command
    CLI->>Watcher: createWatcher(rootDir, config)
    CLI->>Watcher: watcher.start()
    Watcher->>Chokidar: watch(rootDir, { ignored, persistent })
    Chokidar-->>Watcher: ready
    Watcher-->>CLI: emit("start")

    Chokidar->>Watcher: change/add/unlink(filePath)
    Watcher->>Watcher: debounce(300ms)
    Watcher-->>CLI: emit("change", files)
    Watcher->>Indexer: indexProject(rootDir, { config })
    Watcher-->>CLI: emit("reindex-done", durationMs)

    Note over CLI,Budget: get command
    CLI->>CombinedRetrieval: combinedRetrieval({ query, store, memoryStore, config, options })
    par Parallel strategies
        CombinedRetrieval->>Structural: runStructural(query, store, topK)
        CombinedRetrieval->>Semantic: runSemantic(query, store, config, topK)
        CombinedRetrieval->>Memory: runMemory(query, memoryStore, topK)
    end
    Structural-->>CombinedRetrieval: { items[], timeMs }
    Semantic-->>CombinedRetrieval: { items[], timeMs } or rejected
    Memory-->>CombinedRetrieval: { items[], timeMs }
    CombinedRetrieval->>CombinedRetrieval: deduplicateById(allItems)
    CombinedRetrieval->>CombinedRetrieval: rerankResults(deduped, weights)
    CombinedRetrieval->>Budget: assembleBudget(reranked, budget)
    Budget-->>CombinedRetrieval: { items[], budgetUsed, budgetTotal }
    CombinedRetrieval-->>CLI: CombinedRetrievalResult { items, diagnostics }
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/context/src/retrieval/combined.ts
Line: 153-182

Comment:
**Useless try-catch in `runSemantic`**

The try-catch block inside `runSemantic` catches `err` only to immediately re-throw it. This is dead code and the comment `// Semantic may fail (no API key, empty index) — that's ok` is misleading since the error is not actually handled here — it propagates to `Promise.allSettled` just as it would without the try-catch. Remove the try-catch wrapper and return directly:

```suggestion
async function runSemantic(
  query: string,
  store: GraphStore,
  config: Config,
  topK: number,
  provider?: EmbeddingProvider,
): Promise<StrategyResult> {
  const start = performance.now();

  const results = await semanticSearch(query, store, config, {
    topK,
    provider,
  });

  const items: RetrievalItem[] = results.map((r) => ({
    id: r.symbol.id,
    content: r.symbol.source,
    source: `${r.symbol.filePath}:${r.symbol.lineStart}-${r.symbol.lineEnd}`,
    provenance: "semantic" as const,
    score: r.score,
    estimatedTokens: estimateTokens(r.symbol.source),
  }));

  return { items, timeMs: Math.round(performance.now() - start) };
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/retrieval/combined.ts
Line: 43-57

Comment:
**`kinds` filter option is accepted but never applied**

`CombinedRetrievalOptions.kinds` is declared in the type, documented in `SKILL.md`, and passed from the CLI (`--kind` flag), but `combinedRetrieval` never uses it to filter results. The option silently has no effect.

After deduplication and before reranking, you'd need to apply the filter:

```typescript
// Filter by kind if requested
const kinds = options?.kinds;
const filtered = kinds && kinds.length > 0
  ? deduped.filter(item => /* match item kind */ ...)
  : deduped;

const reranked = rerankResults(filtered, weights);
```

Note that `RetrievalItem` doesn't currently carry a `kind` field, so either the field needs to be added, or the filtering should happen inside the strategy runners where the symbol kind is available (e.g. pass `kinds` into `runStructural`/`runSemantic`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/watcher/index.ts
Line: 59-92

Comment:
**File changes that arrive during an active reindex are silently dropped**

When `reindexing === true`, any call to `triggerReindex` returns immediately on line 60. Meanwhile the debounce timer can fire, `pendingFiles` is cleared, and the collected file list is passed into `triggerReindex` — which no-ops and never schedules another run.

In practice, any file saved while indexing is in progress is ignored: no `reindex-start`/`reindex-done` event fires for it and no follow-up index pass happens.

A simple fix is to reschedule after the reindex completes if new files accumulated:

```typescript
async function triggerReindex(files: string[]): Promise<void> {
  if (reindexing) return;
  reindexing = true;
  // ... existing logic ...
  } finally {
    reindexing = false;
    // If new files arrived while we were indexing, schedule another pass
    if (pendingFiles.size > 0) {
      const queued = [...pendingFiles];
      pendingFiles = new Set();
      triggerReindex(queued);
    }
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/cli.ts
Line: 1201-1220

Comment:
**`--json` and `--quiet` flags cannot be passed after the subcommand name for `watch` and `get`**

Both `watch` and `get` action callbacks use the 2-argument form `(pathArg/query, cmdOpts)`, so they never receive the subcommand `Command` object. They then call `getOutputOptions(program)`, reading from the root program's parsed options.

In Commander.js, `--json` passed after the subcommand name (e.g. `kata-context watch . --json`) is dispatched to the subcommand's option parser. Since `--json` is not registered on the `watch` or `get` subcommands, Commander will throw "error: unknown option '--json'".

Global options (registered on the root `program`) are only parsed when placed *before* the subcommand name: `kata-context --json watch .`.

The SKILL.md documentation however shows the canonical usage as `kata-context watch . --json`, which will not work.

Fix: register `--json` and `--quiet` directly on each subcommand, or change the action signatures to accept the 3-argument form and pass `cmd` to `getOutputOptions`:

```typescript
.action(async (pathArg: string, cmdOpts: Record<string, string>, cmd: Command) => {
    const outputOpts = getOutputOptions(cmd);
```

And add `.option("--json", ...)` and `.option("--quiet", ...)` to both `watch` and `get` command definitions.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/retrieval/reranker.ts
Line: 55-57

Comment:
**Recency weight adds a flat constant instead of differentiating items**

The formula `normScore * strategyWeight + w.recency * 0.5` adds the same constant `0.075` (= 0.15 × 0.5) to every item regardless of provenance or actual file recency. Since all items receive the same recency bonus, it doesn't affect relative ranking at all — it simply shifts all scores up by 0.075.

The `DEFAULT_RANKING_WEIGHTS` are documented as summing to 1.0, but with this formula the recency factor is never used in a differentiating way. Consider either removing the recency addend until file modification timestamps are available, or applying the unused weight to the strategy weight so the effective strategy weights are proportionally scaled:

```suggestion
    // Recency weight is applied uniformly (no file mtime data here)
    const combinedScore = normScore * (strategyWeight + w.recency / 3);
```

Or simply omit the recency term until mtime data is plumbed in.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/context/src/retrieval/combined.ts
Line: 216-219

Comment:
**Memory failure silently reported as "ok" in diagnostics**

When `recallMemories` throws inside `runMemory`, the catch block returns `{ items: [], timeMs: <non-zero> }`. In `extractDiagnostic`, the condition for `"skipped"` is `items.length === 0 && timeMs === 0`. Since `timeMs > 0` here, the strategy shows as `status: "ok"` with 0 hits, hiding the fact that it actually failed.

This is inconsistent with `runSemantic`, which lets errors propagate so they appear as `status: "failed"` in diagnostics.

Consider re-throwing from the catch so `Promise.allSettled` records the rejection:

```suggestion
  } catch (err) {
    // Re-throw so extractDiagnostic can record status: "failed"
    throw err;
  }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(context): use regex patterns for cho..."](https://github.com/gannonh/kata/commit/5d8276af391e7b28267f2c8119c4035c3540a480) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26223849)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->