### PR TITLE
fix(cli): call initTheme() before mode routing in cli.ts

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -7,6 +7,7 @@ import {
   createAgentSession,
   InteractiveMode,
   runPrintMode,
+  initTheme,
 } from '@mariozechner/pi-coding-agent'
 import { readFileSync } from 'node:fs'
 import { agentDir, sessionsDir, authFilePath } from './app-paths.js'
@@ -133,6 +134,13 @@ if (!hasConfiguredPackages && !globalPackages.includes(MCP_ADAPTER_PACKAGE)) {
   settingsManager.setPackages([...globalPackages, MCP_ADAPTER_PACKAGE])
 }
 await settingsManager.flush()
+
+// ---------------------------------------------------------------------------
+// Theme — must be initialized before any extension or MCP adapter accesses it.
+// pi-coding-agent's main() does this internally, but cli.ts bypasses main().
+// No file watcher needed for non-interactive (print/RPC) modes.
+// ---------------------------------------------------------------------------
+initTheme(settingsManager.getTheme(), !isPrintMode && !isRpcMode)
 
 // ---------------------------------------------------------------------------
 // Package commands: install, remove, uninstall, update, list


### PR DESCRIPTION
## Summary

Fixes KAT-915: Kata CLI RPC mode fails with "Theme not initialized. Call initTheme() first." because `cli.ts` bypasses pi-coding-agent's `main()` which normally calls `initTheme()`.

## Changes

- Import `initTheme` from `@mariozechner/pi-coding-agent`
- Call `initTheme(settingsManager.getTheme(), ...)` after settings are ready, before any mode routing or extension loading
- File watcher enabled only for interactive mode (disabled for print/RPC)

## Verification

- `npx tsc --noEmit` — clean
- `bun test src/` — all tests pass
- Manual: `node dist/cli.js --mode rpc` starts without theme initialization error; MCP reports `0/2 servers` (lazy connect) instead of crashing

Closes KAT-915

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a targeted one-line fix that resolves KAT-915: `cli.ts` bypasses `pi-coding-agent`'s `main()` entrypoint (which normally calls `initTheme()`), so the theme was never initialized when entering RPC or print mode directly. The fix imports `initTheme` and calls it immediately after `settingsManager.flush()`, before session creation or mode routing, which is the correct place in the startup sequence.

**Key changes:**
- `initTheme` is added to the import from `@mariozechner/pi-coding-agent` (line 10)
- `initTheme(settingsManager.getTheme(), !isPrintMode && !isRpcMode)` is called at line 143, after all settings are ready and flushed, but before any extension/MCP adapter or session creation runs
- The second argument correctly disables the theme file-watcher for non-interactive (print/RPC) modes
- `bun test` and `npx tsc --noEmit` are reported as clean in the PR description

**Minor concern:** `initTheme` is reached even for package management subcommands (`kata install`, `kata remove`, etc.) because the early-exit block for those commands comes *after* line 143. Since `isPrintMode` and `isRpcMode` are both `false` in that case, the file watcher is started and then immediately discarded when the process calls `process.exit(0)` at line 257. This is harmless but wasteful.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the fix is minimal, correctly placed, and directly addresses the stated crash.
- The change is a single call insertion that fixes a clear initialization ordering bug. TypeScript type-checking and the test suite are reported as passing. The only concern is a minor efficiency issue where the theme file-watcher is unnecessarily started for `kata install`/`kata remove`/etc. subcommands before they `process.exit(0)`, which does not affect correctness.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/cli.ts | Adds `initTheme` import and a single call after settings flush, correctly fixing the "Theme not initialized" crash in RPC/print modes. Minor: the file watcher is unnecessarily started for package management subcommands that exit before ever using the theme. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as cli.ts
    participant SM as SettingsManager
    participant PI as pi-coding-agent

    CLI->>SM: SettingsManager.create(agentDir)
    CLI->>SM: configure defaults (model, thinking, quiet, changelog, packages)
    CLI->>SM: flush()
    Note over CLI,PI: NEW: initTheme() called here (before any extension or mode routing)
    CLI->>PI: initTheme(settingsManager.getTheme(), watcherEnabled)
    Note right of PI: watcherEnabled = !isPrintMode && !isRpcMode

    alt Package command (install/remove/update/list)
        CLI->>CLI: handle command → process.exit(0)
    else RPC Mode
        CLI->>PI: createAgentSession(...)
        CLI->>PI: runRpcMode(session)
    else Print Mode
        CLI->>PI: createAgentSession(...)
        CLI->>PI: runPrintMode(session, ...)
        CLI->>CLI: process.exit(0)
    else Interactive Mode
        CLI->>PI: createAgentSession(...)
        CLI->>PI: new InteractiveMode(session).run()
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/cli.ts
Line: 143

Comment:
**File watcher started unnecessarily for package commands**

`initTheme` is called with the file-watcher enabled (`!isPrintMode && !isRpcMode` evaluates to `true`) for package management subcommands like `kata install`, `kata remove`, etc. Those commands exit early via `process.exit(0)` at line 257 without ever touching the theme, so a watcher is started and then immediately discarded. Consider also excluding the package-command path from the watcher, or moving the `initTheme` call to below the package-command early-exit block.

```suggestion
initTheme(settingsManager.getTheme(), !isPrintMode && !isRpcMode && !(rawCommand && (PACKAGE_COMMANDS as readonly string[]).includes(rawCommand)))
```

Note: this is a minor inefficiency rather than a correctness problem, since `process.exit` cleans up file handles.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): call initTheme() before mode r..."](https://github.com/gannonh/kata/commit/ead00dbd82cc958ef9351b9f6f54889d89f54632) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26351341)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->