### PR TITLE
CLI v0.7.0

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.7.0
+
+### Features
+
+- **`/kata plan` command** — New interactive command for ad-hoc planning decoupled from execution. Plan milestone roadmaps, plan specific slices, or plan the next pending slice without being forced into the sequential execute-after-plan flow.
+- **`/kata discuss` Linear mode support** — Fixed `/kata discuss` which was broken in Linear mode. Now uses the backend abstraction instead of file-based state derivation.
+
+### Fixes
+
+- **RPC mode theme initialization** — `initTheme()` is now called before mode routing in `cli.ts`, fixing "Theme not initialized" errors when MCP adapter connects in RPC mode (KAT-915).
+
 ## 0.6.0
 
 ### Features

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## CLI v0.7.0

### Features

- **`/kata plan` command** — New interactive command for ad-hoc planning decoupled from execution. Plan milestone roadmaps, plan specific slices, or plan the next pending slice without being forced into the sequential execute-after-plan flow.
- **`/kata discuss` Linear mode support** — Fixed `/kata discuss` which was broken in Linear mode. Now uses the backend abstraction instead of file-based state derivation.

### Fixes

- **RPC mode theme initialization** — `initTheme()` is now called before mode routing in `cli.ts`, fixing "Theme not initialized" errors when MCP adapter connects in RPC mode (KAT-915).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a version bump for `@kata-sh/cli` from `0.6.0` to `0.7.0`, paired with a matching `CHANGELOG.md` entry. The actual feature and fix implementations (the `/kata plan` command, the `/kata discuss` Linear mode repair, and the RPC-mode theme initialization fix) are captured in the changelog entry and are not part of this diff — this PR is purely the release metadata update.

- `package.json`: `version` field updated from `"0.6.0"` to `"0.7.0"` — correct and consistent.
- `CHANGELOG.md`: New `## 0.7.0` section added at the top with proper `### Features` and `### Fixes` sub-sections — one minor categorization issue noted (the `/kata discuss` fix is listed under `### Features` rather than `### Fixes`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — changes are limited to version metadata and changelog documentation with no runtime code affected.
- Only two files changed: a version field in `package.json` and a changelog section in `CHANGELOG.md`. No logic, dependencies, or runtime behaviour is modified. The sole issue found is a minor categorization inconsistency in the changelog.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/CHANGELOG.md | New `## 0.7.0` section prepended correctly; minor inconsistency where the `/kata discuss` fix is categorized under `### Features` instead of `### Fixes`. |
| apps/cli/package.json | Single-field version bump from `0.6.0` to `0.7.0`; no other changes, consistent with the changelog entry. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant CLI as @kata-sh/cli (npm)
    participant User as End User

    Dev->>CLI: Bump version 0.6.0 → 0.7.0 (package.json)
    Dev->>CLI: Update CHANGELOG.md (## 0.7.0 entry)
    CLI-->>User: /kata plan command (new interactive planning)
    CLI-->>User: /kata discuss Linear mode (fixed)
    CLI-->>User: RPC mode theme init fix (initTheme before routing)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/CHANGELOG.md
Line: 8

Comment:
**Fix categorized as Feature in CHANGELOG**

The second bullet under `### Features` describes a bug fix ("Fixed `/kata discuss` which was broken in Linear mode"), but it is categorized under `### Features` rather than `### Fixes`. The `### Fixes` section already exists in this entry (for the RPC mode theme initialization), so this entry would fit more accurately there.

```suggestion
- **`/kata discuss` Linear mode support** — Fixed `/kata discuss` which was broken in Linear mode. Now uses the backend abstraction instead of file-based state derivation.
```
(Move this line from `### Features` to `### Fixes`.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump cli to 0.7.0"](https://github.com/gannonh/kata/commit/5ec2920c90335456241a3165bd1a49b16198a240) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26353537)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump for CLI package (0.6.0 → 0.7.0)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->