### PR TITLE
feat(symphony): live agent tool activity stream in TUI and dashboard

### DIFF
--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -514,6 +514,12 @@ pub struct WorkerSessionInfo {
     pub last_activity_ms: Option<i64>,
     #[serde(default)]
     pub session_tokens: SessionTokenUsage,
+    /// Name of the tool currently executing (set on tool_start, cleared on tool_end).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_tool_name: Option<String>,
+    /// Short preview of the arguments for the currently executing tool.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_tool_args_preview: Option<String>,
 }
 
 // ── LiveSession (spec §4.1.6) ─────────────────────────────────────────
@@ -642,6 +648,12 @@ pub struct RunningSessionSnapshot {
     pub last_event_message: Option<String>,
     #[serde(default)]
     pub session_id: Option<String>,
+    /// Name of the tool currently executing (set on tool_start, cleared on tool_end).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_tool_name: Option<String>,
+    /// Short preview of the arguments for the currently executing tool.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_tool_args_preview: Option<String>,
 }
 
 /// Polling state for the snapshot.

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -331,6 +331,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
             <th>Identifier</th>
             <th>Linear State</th>
             <th>Status</th>
+            <th>Activity</th>
             <th>Attempt</th>
             <th>Turn</th>
             <th>Last Activity</th>
@@ -342,7 +343,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
           </tr>
         </thead>
         <tbody id="running-table-body">
-          <tr><td class="muted" colspan="11">Loading...</td></tr>
+          <tr><td class="muted" colspan="12">Loading...</td></tr>
         </tbody>
       </table>
     </div>
@@ -458,7 +459,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }});
 
       if (rows.length === 0) {{
-        return '<tr><td class="muted" colspan="11">No running sessions.</td></tr>';
+        return '<tr><td class="muted" colspan="12">No running sessions.</td></tr>';
       }}
 
       return rows.map(function(entry) {{
@@ -485,10 +486,14 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         const tokenOutput = Number(sessionTokens.output_tokens ?? 0);
         const tokenTotal = Number(sessionTokens.total_tokens ?? 0);
         const tokenLabel = tokenInput + ' / ' + tokenOutput + ' / ' + tokenTotal;
+        const toolName = sessionInfo.current_tool_name || '';
+        const toolArgs = sessionInfo.current_tool_args_preview || '';
+        const activityLabel = toolName ? 'tool: ' + toolName + (toolArgs ? ' (' + toolArgs + ')' : '') : '-';
         return '<tr>' +
           '<td class="mono">' + escapeHtml(run.issue_identifier || '-') + '</td>' +
           '<td>' + escapeHtml(run.linear_state || '-') + '</td>' +
           '<td>' + escapeHtml(run.status || '-') + '</td>' +
+          '<td class="mono">' + escapeHtml(activityLabel) + '</td>' +
           '<td>' + escapeHtml(attempt) + '</td>' +
           '<td class="mono">' + escapeHtml(turnLabel) + '</td>' +
           '<td class="' + escapeHtml(lastActivityClass) + '">' + escapeHtml(lastActivityLabel) + '</td>' +

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1074,6 +1074,10 @@ struct RunningSessionStats {
     last_event: Option<String>,
     last_event_message: Option<String>,
     session_id: Option<String>,
+    /// Name of the tool currently executing (set on tool_start, cleared on tool_end).
+    current_tool_name: Option<String>,
+    /// Short preview of arguments for the currently executing tool.
+    current_tool_args_preview: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1687,6 +1691,8 @@ impl Orchestrator {
                 stall_timeout_ms,
                 last_activity_ms,
                 session_tokens: SessionTokenUsage::default(),
+                current_tool_name: None,
+                current_tool_args_preview: None,
             });
         if info.max_turns == 0 {
             info.max_turns = max_turns;
@@ -1740,6 +1746,28 @@ impl Orchestrator {
         session_stats.last_event = Some(last_event);
         session_stats.last_event_message = last_event_message;
         session_stats.session_id = self.worker_session_ids.get(issue_id).cloned();
+
+        // Track current tool activity from events.
+        let tool_activity = extract_tool_activity(event);
+        match tool_activity {
+            ToolActivity::Started { name, args_preview } => {
+                session_stats.current_tool_name = Some(name.clone());
+                session_stats.current_tool_args_preview = args_preview.clone();
+                if let Some(info) = self.worker_session_info.get_mut(issue_id) {
+                    info.current_tool_name = Some(name);
+                    info.current_tool_args_preview = args_preview;
+                }
+            }
+            ToolActivity::Ended => {
+                session_stats.current_tool_name = None;
+                session_stats.current_tool_args_preview = None;
+                if let Some(info) = self.worker_session_info.get_mut(issue_id) {
+                    info.current_tool_name = None;
+                    info.current_tool_args_preview = None;
+                }
+            }
+            ToolActivity::None => {}
+        }
 
         if let Some(run_attempt) = self.state.running.get_mut(issue_id) {
             match event {
@@ -1972,6 +2000,8 @@ impl Orchestrator {
                 last_event: None,
                 last_event_message: None,
                 session_id: None,
+                current_tool_name: None,
+                current_tool_args_preview: None,
             });
         self.state.retry_attempts.remove(&issue.id);
 
@@ -2318,6 +2348,9 @@ impl Orchestrator {
                         last_event: stats.and_then(|s| s.last_event.clone()),
                         last_event_message: stats.and_then(|s| s.last_event_message.clone()),
                         session_id: stats.and_then(|s| s.session_id.clone()),
+                        current_tool_name: stats.and_then(|s| s.current_tool_name.clone()),
+                        current_tool_args_preview: stats
+                            .and_then(|s| s.current_tool_args_preview.clone()),
                     },
                 )
             })
@@ -2579,6 +2612,8 @@ impl Orchestrator {
                 last_event: None,
                 last_event_message: None,
                 session_id: None,
+                current_tool_name: None,
+                current_tool_args_preview: None,
             },
         );
         self.state.retry_attempts.remove(&issue.id);
@@ -3274,6 +3309,110 @@ pub fn rate_limit_info(data: serde_json::Value) -> RateLimitInfo {
     RateLimitInfo { data }
 }
 
+// ── Tool activity extraction ──────────────────────────────────────────
+
+/// Represents the current tool activity state derived from an agent event.
+enum ToolActivity {
+    /// A tool started executing.
+    Started {
+        name: String,
+        args_preview: Option<String>,
+    },
+    /// A tool finished executing.
+    Ended,
+    /// Event is unrelated to tool activity.
+    None,
+}
+
+/// Maximum length for the tool args preview string.
+const TOOL_ARGS_PREVIEW_MAX_LEN: usize = 120;
+
+/// Extract tool activity information from an agent event.
+///
+/// Handles both Codex backend events (ToolCallCompleted/Failed) and
+/// pi-agent RPC events (Notification messages with tool_start/tool_end prefixes).
+fn extract_tool_activity(event: &AgentEvent) -> ToolActivity {
+    match event {
+        // Codex backend: tool calls complete in a single event (no start/end separation).
+        // We don't set "started" for these since they arrive post-completion.
+        AgentEvent::ToolCallCompleted { .. }
+        | AgentEvent::ToolCallFailed { .. }
+        | AgentEvent::UnsupportedToolCall { .. } => ToolActivity::Ended,
+
+        // Pi-agent RPC: tool execution events arrive as Notification messages.
+        AgentEvent::Notification { message, .. } => parse_tool_notification(message),
+
+        _ => ToolActivity::None,
+    }
+}
+
+/// Parse a pi-agent notification message for tool activity.
+///
+/// Messages follow the format:
+/// - `"tool_start: <name> <args_json>"` — tool began executing
+/// - `"tool_end: <name>"` — tool finished successfully
+/// - `"tool_error: <name>"` — tool finished with error
+fn parse_tool_notification(message: &str) -> ToolActivity {
+    if let Some(rest) = message.strip_prefix("tool_start: ") {
+        let (name, args) = match rest.find(' ') {
+            Some(pos) => (&rest[..pos], Some(&rest[pos + 1..])),
+            None => (rest, None),
+        };
+        let args_preview = args.map(|a| {
+            let preview = build_tool_args_preview(a);
+            truncate_for_display(&preview, TOOL_ARGS_PREVIEW_MAX_LEN)
+        });
+        ToolActivity::Started {
+            name: name.to_string(),
+            args_preview,
+        }
+    } else if message.starts_with("tool_end: ") || message.starts_with("tool_error: ") {
+        ToolActivity::Ended
+    } else {
+        ToolActivity::None
+    }
+}
+
+/// Build a human-readable preview of tool arguments from a JSON string.
+///
+/// For common tools, extracts the most meaningful argument:
+/// - `bash`: shows the command
+/// - `read`/`write`/`edit`: shows the path
+/// - `browser_navigate`: shows the URL
+/// - Others: shows a compact summary of top-level keys
+fn build_tool_args_preview(args_json: &str) -> String {
+    let parsed: serde_json::Value = match serde_json::from_str(args_json) {
+        Ok(v) => v,
+        Err(_) => return args_json.to_string(),
+    };
+
+    let obj = match parsed.as_object() {
+        Some(o) => o,
+        None => return args_json.to_string(),
+    };
+
+    // Extract the most meaningful field for common tools
+    if let Some(cmd) = obj.get("command").and_then(|v| v.as_str()) {
+        return cmd.to_string();
+    }
+    if let Some(path) = obj.get("path").and_then(|v| v.as_str()) {
+        return path.to_string();
+    }
+    if let Some(url) = obj.get("url").and_then(|v| v.as_str()) {
+        return url.to_string();
+    }
+    if let Some(query) = obj.get("query").and_then(|v| v.as_str()) {
+        return query.to_string();
+    }
+
+    // Fallback: show keys
+    let keys: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+    if keys.is_empty() {
+        return "{}".to_string();
+    }
+    keys.join(", ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3296,5 +3435,76 @@ mod tests {
         });
 
         assert_eq!(find_preferred_text(&nested), None);
+    }
+
+    #[test]
+    fn parse_tool_notification_start_with_args() {
+        let msg = r#"tool_start: bash {"command":"cargo test","timeout":60}"#;
+        match parse_tool_notification(msg) {
+            ToolActivity::Started { name, args_preview } => {
+                assert_eq!(name, "bash");
+                assert_eq!(args_preview.unwrap(), "cargo test");
+            }
+            other => panic!("expected Started, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn parse_tool_notification_start_no_args() {
+        match parse_tool_notification("tool_start: read") {
+            ToolActivity::Started { name, args_preview } => {
+                assert_eq!(name, "read");
+                assert!(args_preview.is_none());
+            }
+            other => panic!("expected Started, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn parse_tool_notification_end() {
+        assert!(matches!(
+            parse_tool_notification("tool_end: bash"),
+            ToolActivity::Ended
+        ));
+    }
+
+    #[test]
+    fn parse_tool_notification_error() {
+        assert!(matches!(
+            parse_tool_notification("tool_error: bash"),
+            ToolActivity::Ended
+        ));
+    }
+
+    #[test]
+    fn parse_tool_notification_unrelated() {
+        assert!(matches!(
+            parse_tool_notification("some other message"),
+            ToolActivity::None
+        ));
+    }
+
+    #[test]
+    fn build_tool_args_preview_extracts_command() {
+        let preview = build_tool_args_preview(r#"{"command":"cargo test --release"}"#);
+        assert_eq!(preview, "cargo test --release");
+    }
+
+    #[test]
+    fn build_tool_args_preview_extracts_path() {
+        let preview = build_tool_args_preview(r#"{"path":"src/main.rs","offset":10}"#);
+        assert_eq!(preview, "src/main.rs");
+    }
+
+    #[test]
+    fn build_tool_args_preview_fallback_to_keys() {
+        let preview = build_tool_args_preview("{\"selector\":\"btn\",\"text\":\"click\"}");
+        assert_eq!(preview, "selector, text");
+    }
+
+    #[test]
+    fn build_tool_args_preview_invalid_json() {
+        let preview = build_tool_args_preview("not json");
+        assert_eq!(preview, "not json");
     }
 }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -3337,7 +3337,11 @@ fn extract_tool_activity(event: &AgentEvent) -> ToolActivity {
         // We don't set "started" for these since they arrive post-completion.
         AgentEvent::ToolCallCompleted { .. }
         | AgentEvent::ToolCallFailed { .. }
-        | AgentEvent::UnsupportedToolCall { .. } => ToolActivity::Ended,
+        | AgentEvent::UnsupportedToolCall { .. }
+        | AgentEvent::TurnCompleted { .. }
+        | AgentEvent::TurnFailed { .. }
+        | AgentEvent::TurnCancelled { .. }
+        | AgentEvent::TurnEndedWithError { .. } => ToolActivity::Ended,
 
         // Pi-agent RPC: tool execution events arrive as Notification messages.
         AgentEvent::Notification { message, .. } => parse_tool_notification(message),
@@ -3383,7 +3387,7 @@ fn parse_tool_notification(message: &str) -> ToolActivity {
 fn build_tool_args_preview(args_json: &str) -> String {
     let parsed: serde_json::Value = match serde_json::from_str(args_json) {
         Ok(v) => v,
-        Err(_) => return args_json.to_string(),
+        Err(_) => return args_json.chars().filter(|c| !c.is_control()).collect(),
     };
 
     let obj = match parsed.as_object() {
@@ -3506,5 +3510,37 @@ mod tests {
     fn build_tool_args_preview_invalid_json() {
         let preview = build_tool_args_preview("not json");
         assert_eq!(preview, "not json");
+    }
+
+    #[test]
+    fn build_tool_args_preview_strips_control_chars_on_invalid_json() {
+        let preview = build_tool_args_preview("bad\x00json\nwith\tcontrol");
+        assert_eq!(preview, "badjsonwithcontrol"); // all control chars stripped
+    }
+
+    #[test]
+    fn extract_tool_activity_clears_on_turn_completed() {
+        let event = AgentEvent::TurnCompleted {
+            timestamp: chrono::Utc::now(),
+            codex_app_server_pid: None,
+            turn_id: "t1".to_string(),
+            message: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            rate_limits: None,
+        };
+        assert!(matches!(extract_tool_activity(&event), ToolActivity::Ended));
+    }
+
+    #[test]
+    fn extract_tool_activity_clears_on_turn_failed() {
+        let event = AgentEvent::TurnFailed {
+            timestamp: chrono::Utc::now(),
+            codex_app_server_pid: None,
+            turn_id: "t1".to_string(),
+            error: "crash".to_string(),
+        };
+        assert!(matches!(extract_tool_activity(&event), ToolActivity::Ended));
     }
 }

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -548,6 +548,8 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
         let last_event = metrics.and_then(|m| m.last_event.as_deref());
         let last_event_message = metrics.and_then(|m| m.last_event_message.as_deref());
         let session_id = metrics.and_then(|m| m.session_id.as_deref());
+        let current_tool_name = metrics.and_then(|m| m.current_tool_name.as_deref());
+        let current_tool_args = metrics.and_then(|m| m.current_tool_args_preview.as_deref());
         let stale = is_stale_session(last_activity, now);
         let state = run
             .linear_state
@@ -575,7 +577,7 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
                 LAST_EVENT_COLUMN_WIDTH as usize,
             )),
             Cell::from(truncate_for_display(
-                last_event_message.unwrap_or("-"),
+                &format_activity_message(current_tool_name, current_tool_args, last_event_message),
                 MESSAGE_COLUMN_TRUNCATE_WIDTH,
             )),
             last_activity_cell,
@@ -614,6 +616,22 @@ fn compact_session_id(session_id: Option<&str>) -> String {
         .map(compact_session_id_value)
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| "-".to_string())
+}
+
+/// Format the activity message for display, preferring current tool info when available.
+fn format_activity_message(
+    current_tool_name: Option<&str>,
+    current_tool_args: Option<&str>,
+    fallback_message: Option<&str>,
+) -> String {
+    if let Some(tool) = current_tool_name {
+        match current_tool_args {
+            Some(args) if !args.is_empty() => format!("tool: {tool} ({args})"),
+            _ => format!("tool: {tool}"),
+        }
+    } else {
+        fallback_message.unwrap_or("-").to_string()
+    }
 }
 
 fn status_dot(
@@ -1054,6 +1072,8 @@ mod tests {
                 last_event: Some(long_event.to_string()),
                 last_event_message: Some("message".to_string()),
                 session_id: Some("1234567890abcdef".to_string()),
+                current_tool_name: None,
+                current_tool_args_preview: None,
             },
         );
 

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -294,6 +294,8 @@ fn test_orchestrator_snapshot_serializes() {
                     last_event: None,
                     last_event_message: None,
                     session_id: None,
+                    current_tool_name: None,
+                    current_tool_args_preview: None,
                 },
             );
             m.insert(
@@ -305,6 +307,8 @@ fn test_orchestrator_snapshot_serializes() {
                     last_event: None,
                     last_event_message: None,
                     session_id: None,
+                    current_tool_name: None,
+                    current_tool_args_preview: None,
                 },
             );
             m

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -90,6 +90,8 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                     last_event: Some("codex/event/task_started".to_string()),
                     last_event_message: Some("running cargo test".to_string()),
                     session_id: Some("session-12345678".to_string()),
+                    current_tool_name: None,
+                    current_tool_args_preview: None,
                 },
             );
             sessions
@@ -106,6 +108,8 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                     output_tokens: 12,
                     total_tokens: 47,
                 },
+                current_tool_name: None,
+                current_tool_args_preview: None,
             },
         )]),
         claimed: BTreeSet::from(["issue-123".to_string()]),


### PR DESCRIPTION
## Summary

Show what each agent is currently doing (tool name + args preview) in the TUI running sessions table and web dashboard.

## Changes

### Domain ()
- Added `current_tool_name` and `current_tool_args_preview` fields to `WorkerSessionInfo` and `RunningSessionSnapshot`
- Fields are `Option<String>`, serialized to JSON when present (skip_serializing_if none)

### Orchestrator (`orchestrator.rs`)
- New `ToolActivity` enum and `extract_tool_activity()` function that parses tool events from both backends:
  - Pi-agent RPC: parses `tool_start: <name> <args>` / `tool_end: <name>` / `tool_error: <name>` notification messages
  - Codex: clears tool activity on `ToolCallCompleted`/`ToolCallFailed`/`UnsupportedToolCall` events
- `build_tool_args_preview()` extracts meaningful arg previews (command for bash, path for read/write, URL for navigate, fallback to key names)
- `ingest_agent_event()` now updates both `RunningSessionStats` and `WorkerSessionInfo` with current tool state

### TUI (`tui.rs`)
- Message column now shows `tool: bash (cargo test)` when a tool is executing
- Falls back to previous `last_event_message` when no tool is active

### HTTP Dashboard (`http_server.rs`)
- New "Activity" column in running sessions table
- Shows `tool: <name> (<args_preview>)` or `-` when idle

### API (`/api/v1/state`)
- `current_tool_name` and `current_tool_args_preview` exposed in both `running_session_info` and `running_sessions` objects

## Tests
- 8 new unit tests for `parse_tool_notification` and `build_tool_args_preview`
- All 381 existing tests pass
- Zero clippy warnings

Closes KAT-926

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Activity column to the dashboard's running-sessions table showing the active tool and a short preview of its arguments (formatted like "tool: name (args)"), falling back to "-" when none.
  * Sessions now surface per-session active-tool state for improved real-time monitoring.

* **Tests**
  * Updated snapshots and unit tests to cover the new activity fields and preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds live tool-activity visibility to the Symphony TUI and HTTP dashboard by propagating `current_tool_name` / `current_tool_args_preview` through the domain model, orchestrator event loop, and both display layers. The implementation is clean and well-tested for the happy path.

**Key changes:**
- `WorkerSessionInfo` and `RunningSessionSnapshot` gain two new optional fields, correctly guarded with `skip_serializing_if = "Option::is_none"`
- `extract_tool_activity` + `parse_tool_notification` + `build_tool_args_preview` form a small, focused parsing pipeline in `orchestrator.rs`
- The TUI `format_activity_message` helper correctly prefers live tool info and falls back gracefully
- The dashboard adds an Activity column with proper `escapeHtml` sanitization

**Issues found:**
- **P1 – Stale tool state after abnormal turn end**: `TurnCompleted`, `TurnFailed`, `TurnCancelled`, and `TurnEndedWithError` do not clear `current_tool_name`. If a pi-agent session crashes mid-tool without emitting `tool_end`, the last tool will remain displayed indefinitely for that session. Adding these events to the `ToolActivity::Ended` arm of `extract_tool_activity` would close the gap.
- **P2 – Raw args fallback on JSON parse failure**: When `args_json` is not valid JSON, the unprocessed string is returned directly. While `truncate_for_display` eventually normalizes whitespace, there is no early sanitization of control characters in this path.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with the stale-tool-state edge case addressed before wider rollout
- The feature is well-scoped and cleanly implemented. The P1 issue (stale tool state on abnormal turn end) is a UX correctness bug rather than a data-loss or security risk — it would show incorrect activity info in the display but does not corrupt any persisted state. All 381 existing tests pass and 8 new unit tests cover the critical parsing logic. The fix is a one-line addition to `extract_tool_activity`.
- apps/symphony/src/orchestrator.rs — specifically `extract_tool_activity` (lines 3334–3346) needs turn-terminal events added to the `Ended` arm

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Core logic for tool activity tracking. `extract_tool_activity` correctly handles Codex backend events and pi-agent notifications, but does not clear tool state on turn-level terminal events (`TurnCompleted`, `TurnFailed`, `TurnCancelled`, `TurnEndedWithError`), risking stale tool activity display after abnormal session termination. `build_tool_args_preview` and `parse_tool_notification` are well-tested and correct for the happy path. |
| apps/symphony/src/domain.rs | Adds `current_tool_name` and `current_tool_args_preview` as `Option<String>` fields to `WorkerSessionInfo` and `RunningSessionSnapshot`. Clean implementation with correct `skip_serializing_if` annotations and doc comments. |
| apps/symphony/src/http_server.rs | Adds an Activity column to the running sessions HTML table. `activityLabel` is correctly sanitized via `escapeHtml` before insertion into the DOM. `colspan` values are updated consistently from 11 to 12. |
| apps/symphony/src/tui.rs | Introduces `format_activity_message` helper that correctly prefers live tool info over `last_event_message`, with a clean `-` fallback. No issues found. |
| apps/symphony/tests/domain_tests.rs | Fixture structs updated with the two new `None` fields. Straightforward test maintenance change. |
| apps/symphony/tests/http_server_tests.rs | Fixture structs updated with the two new `None` fields. No new HTTP-level tests for the Activity column, but existing fixture coverage is maintained. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Pi-Agent / Codex
    participant Orch as Orchestrator (ingest_agent_event)
    participant Stats as RunningSessionStats
    participant Info as WorkerSessionInfo
    participant TUI as TUI / Dashboard

    Agent->>Orch: Notification("tool_start: bash {\"command\":\"cargo test\"}")
    Orch->>Orch: extract_tool_activity() → ToolActivity::Started
    Orch->>Stats: current_tool_name = Some("bash")\ncurrent_tool_args_preview = Some("cargo test")
    Orch->>Info: current_tool_name = Some("bash")\ncurrent_tool_args_preview = Some("cargo test")
    TUI->>Stats: poll snapshot
    Stats-->>TUI: current_tool_name="bash", args="cargo test"
    TUI->>TUI: format_activity_message() → "tool: bash (cargo test)"

    Agent->>Orch: Notification("tool_end: bash")
    Orch->>Orch: extract_tool_activity() → ToolActivity::Ended
    Orch->>Stats: current_tool_name = None\ncurrent_tool_args_preview = None
    Orch->>Info: current_tool_name = None\ncurrent_tool_args_preview = None
    TUI->>Stats: poll snapshot
    Stats-->>TUI: current_tool_name=None
    TUI->>TUI: format_activity_message() → last_event_message fallback

    Agent->>Orch: ToolCallCompleted (Codex backend)
    Orch->>Orch: extract_tool_activity() → ToolActivity::Ended
    Orch->>Stats: current_tool_name = None
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 3334-3346

Comment:
**Stale tool activity not cleared on turn termination**

`TurnCompleted`, `TurnFailed`, `TurnCancelled`, and `TurnEndedWithError` all fall through to `ToolActivity::None`, meaning they do **not** clear the current tool state. For the pi-agent backend, if a session crashes mid-tool without sending a `tool_end` notification, the `current_tool_name` will remain set in both `RunningSessionStats` and `WorkerSessionInfo` for the entire remaining lifetime of the running session. The dashboard and TUI would then continue to show `tool: bash (some command)` even after the turn has finished or the session is in an error state.

Consider adding these events to return `ToolActivity::Ended` so the display is cleared on any turn boundary:

```rust
fn extract_tool_activity(event: &AgentEvent) -> ToolActivity {
    match event {
        AgentEvent::ToolCallCompleted { .. }
        | AgentEvent::ToolCallFailed { .. }
        | AgentEvent::UnsupportedToolCall { .. }
        | AgentEvent::TurnCompleted { .. }
        | AgentEvent::TurnFailed { .. }
        | AgentEvent::TurnCancelled { .. }
        | AgentEvent::TurnEndedWithError { .. } => ToolActivity::Ended,

        AgentEvent::Notification { message, .. } => parse_tool_notification(message),

        _ => ToolActivity::None,
    }
}
```

This is especially important for `TurnFailed` and `TurnCancelled` where normal `tool_end` cleanup may never have been sent.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 3383-3392

Comment:
**Raw args returned on JSON parse failure may produce noisy output**

When `args_json` is not valid JSON (e.g. the pi-agent emits a non-JSON arg string), the function returns the raw string directly. After `truncate_for_display` this is capped at 120 chars, so it won't overflow, but it could include embedded newlines or control characters that render strangely in the TUI. `truncate_for_display` already calls `normalize_whitespace`, so this is handled for the final output — but it's worth noting that the raw fallback path bypasses any sanitization until that point.

Consider at minimum stripping or escaping non-printable characters here rather than relying on the caller's `truncate_for_display` call:

```rust
Err(_) => return args_json.chars().filter(|c| !c.is_control()).collect(),
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): live agent tool activity..."](https://github.com/gannonh/kata/commit/4e92084a3bbd0de861b63dbaa5c204e23a439977) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26357541)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->