### PR TITLE
feat: store slice/task plans in Linear issue descriptions

### DIFF
--- a/apps/cli/src/resources/KATA-WORKFLOW.md
+++ b/apps/cli/src/resources/KATA-WORKFLOW.md
@@ -833,8 +833,9 @@ Auto-mode runs fresh context windows in a loop until the slice is complete. Each
 3. If `phase: "blocked"`, surface `blockers[]` to the user and stop.
 4. If `phase: "executing"` or `phase: "verifying"`:
    - Get `activeTask.id` and `activeTask.title` from the result.
-   - Call `kata_read_document` with the task plan title (e.g. `T01-PLAN`) to load the contract.
-   - If no plan doc exists (null result), the planning phase did not complete correctly. Stop and surface the error.
+   - Load the task issue via `linear_get_issue(<task-uuid>)` and use `issue.description` as the task plan contract.
+   - Backward-compatible fallback: if task `description` is empty, call `kata_read_document` with the task plan title (e.g. `T01-PLAN`).
+   - If both description and fallback plan doc are empty, planning did not complete correctly. Stop and surface the error.
 
 ### During execution
 
@@ -844,10 +845,10 @@ Auto-mode runs fresh context windows in a loop until the slice is complete. Each
 
 ### At the end of every session (before context window closes)
 
-1. **Write the task summary** — call `kata_write_document` with the task summary content.
+1. **Write the task summary** — post an issue comment on the task via `linear_add_comment`.
 2. **Advance the task state** — call `kata_update_issue_state` with `phase: "done"`.
 3. If this was the last task in the slice:
-   - Write the slice summary via `kata_write_document`.
+   - Write the slice summary as a comment on the slice issue via `linear_add_comment`.
    - Advance the slice issue via `kata_update_issue_state(sliceIssueId, { phase: "done" })`.
 
 **Never finish a session without writing the summary and advancing the issue state.**
@@ -877,9 +878,11 @@ All Kata-specific tools use the `kata_` prefix.
 
 | Tool                    | Description                                                                                       |
 | ----------------------- | ------------------------------------------------------------------------------------------------- |
-| `kata_write_document`   | Write (upsert) a Kata artifact as a LinearDocument. Takes `title` and `content`.                  |
-| `kata_read_document`    | Read a Kata artifact document by title. Returns document with content, or `null` if not found.    |
+| `kata_write_document`   | Write (upsert) a Kata artifact as a LinearDocument. Use for milestone/project artifacts (`ROADMAP`, `CONTEXT`, `DECISIONS`, `PROJECT`, `REQUIREMENTS`, milestone summaries). |
+| `kata_read_document`    | Read a Kata artifact document by title. Returns document with content, or `null` if not found. Use as fallback for legacy slice/task plan docs when issue descriptions are empty. |
 | `kata_list_documents`   | List all Kata artifact documents in the attachment scope.                                         |
+
+> Slice plans (`Sxx-PLAN`) and task plans (`Txx-PLAN`) should now live in issue descriptions, not LinearDocuments. Slice/task summaries should be issue comments (`linear_add_comment`).
 
 ### Entity Creation
 

--- a/apps/cli/src/resources/extensions/kata/linear-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-backend.ts
@@ -546,7 +546,7 @@ export class LinearBackend implements KataBackend {
     return {
       backendRules: HARD_RULE,
       backendOps,
-      backendMustComplete: `**You MUST write the ${sid} plan into the slice issue description before finishing.**\n\n${REFERENCE}`
+      backendMustComplete: `**You MUST write the ${sid} plan into the slice issue description before finishing.**\n\n${REFERENCE}`,
     };
   }
 

--- a/apps/cli/src/resources/extensions/kata/linear-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-backend.ts
@@ -540,7 +540,8 @@ export class LinearBackend implements KataBackend {
 
     const dependencySummaries = [
       `- Check the roadmap for \`depends:[]\` on this slice.`,
-      `- For each dependency, call \`kata_read_document("Sxx-SUMMARY", { issueId: "<dependency-slice-issue-uuid>" })\`. Get slice issue UUIDs from \`kata_list_slices\`.`,
+      `- For each dependency, call \`linear_get_issue("<dependency-slice-issue-uuid>")\` and inspect issue.comments for summary evidence (primary path).`,
+      `- Backward-compatible fallback: if no summary comment is present, call \`kata_read_document("Sxx-SUMMARY", { issueId: "<dependency-slice-issue-uuid>" })\`. Get slice issue UUIDs from \`kata_list_slices\`.`,
     ].join("\n");
 
     const inlinedContext = [
@@ -613,7 +614,8 @@ export class LinearBackend implements KataBackend {
 
     const dependencySummaries = [
       `- Check the roadmap for \`depends:[]\` on this slice.`,
-      `- For each dependency, call \`kata_read_document("Sxx-SUMMARY", { issueId: "<dependency-slice-issue-uuid>" })\`. Get slice issue UUIDs from \`kata_list_slices\`.`,
+      `- For each dependency, call \`linear_get_issue("<dependency-slice-issue-uuid>")\` and inspect issue.comments for summary evidence (primary path).`,
+      `- Backward-compatible fallback: if no summary comment is present, call \`kata_read_document("Sxx-SUMMARY", { issueId: "<dependency-slice-issue-uuid>" })\`. Get slice issue UUIDs from \`kata_list_slices\`.`,
     ].join("\n");
 
     const inlinedContext = [

--- a/apps/cli/src/resources/extensions/kata/linear-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-backend.ts
@@ -35,7 +35,7 @@ import { resolveGitRoot, ensureGitRepo } from "./git-utils.js";
 
 // ─── Prompt Constants ─────────────────────────────────────────────────────────
 
-const HARD_RULE = `Hard rule: In Linear mode, never use bash/read/find/rg/git to locate workflow artifacts. Use only kata_read_document/kata_write_document for plan and summary artifacts. Scope rules — milestone-level docs (M001-ROADMAP, M001-CONTEXT, M001-RESEARCH, M001-SUMMARY, PROJECT, REQUIREMENTS, DECISIONS) use { projectId }. Slice-level docs (S01-PLAN, S01-RESEARCH, S01-SUMMARY, S01-UAT, S01-REPLAN, S01-ASSESSMENT) and task-level docs (T01-PLAN, T01-SUMMARY) BOTH use { issueId } scoped to the slice issue — this prevents collisions when multiple milestones have their own S01, S02, etc.`;
+const HARD_RULE = `Hard rule: In Linear mode, never use bash/read/find/rg/git to locate workflow artifacts. Milestone-level artifacts (M001-ROADMAP, M001-CONTEXT, M001-RESEARCH, M001-SUMMARY, PROJECT, REQUIREMENTS, DECISIONS) are LinearDocuments via kata_read_document/kata_write_document with { projectId }. Slice/task plans live in issue descriptions (slice issue + task sub-issue), read/write them via linear_get_issue / linear_update_issue or kata_create_slice / kata_create_task description fields. Backward compatibility: if a slice/task plan description is empty, fall back to legacy S01-PLAN/T01-PLAN docs via kata_read_document. Slice/task summaries are issue comments via linear_add_comment.`;
 
 const REFERENCE = `**Reference:** Consult \`KATA-WORKFLOW.md\` (injected into your system prompt) for full operation steps, entity conventions, artifact storage format, and phase transition rules.`;
 
@@ -524,12 +524,13 @@ export class LinearBackend implements KataBackend {
   private _buildPlanSliceOps(sid: string): OpsBlock {
     const backendOps = [
       `10. Idempotency check:`,
-      `    - Call \`kata_read_document("${sid}-PLAN", { issueId: "<slice-issue-uuid>" })\`. If it exists, review rather than rewrite.`,
+      `    - Call \`linear_get_issue\` for the slice issue UUID. If issue.description already contains a valid ${sid} plan, review/update rather than rewrite.`,
+      `    - Backward-compatible fallback: if description is empty, call \`kata_read_document("${sid}-PLAN", { issueId: "<slice-issue-uuid>" })\` and adapt/migrate content.`,
       `    - Call \`kata_list_tasks\` for the slice issue. If tasks exist, do NOT create duplicates.`,
-      `11. Write the slice plan (scoped to slice issue): \`kata_write_document("${sid}-PLAN", content, { issueId: "<slice-issue-uuid>" })\``,
+      `11. Write the slice plan into slice issue description: \`linear_update_issue({ id: "<slice-issue-uuid>", description: content })\``,
       `    - Decompose into 1-7 tasks, each fitting one context window.`,
       `    - Each task: title, must-haves (truths, artifacts, key links), steps.`,
-      `    - Slice docs MUST use { issueId } scoped to the slice issue, NOT { projectId }. This prevents S01-PLAN collisions across milestones.`,
+      `    - Slice plan source of truth is the slice issue description.`,
       `12. **Self-audit the plan before continuing.** Walk through each check — if any fail, fix the plan before moving on:`,
       `    - **Completion semantics:** If every task were completed exactly as written, the slice goal/demo should actually be true at the claimed proof level.`,
       `    - **Requirement coverage:** Every must-have in the slice maps to at least one task. No must-have is orphaned.`,
@@ -537,15 +538,15 @@ export class LinearBackend implements KataBackend {
       `    - **Dependency correctness:** Task ordering is consistent. No task references work from a later task.`,
       `    - **Scope sanity:** Target 2-5 steps and 3-8 files per task. 10+ steps or 12+ files: must split.`,
       `13. Create task sub-issues: call \`kata_create_task\` for each task (T01, T02, ...).`,
-      `    - Write individual task plans: \`kata_write_document("T01-PLAN", content, { issueId: "<slice-issue-uuid>" })\` for each task.`,
-      `    - Task docs MUST use { issueId } scoped to the slice issue, NOT { projectId }. This prevents T01-PLAN collisions across slices.`,
+      `    - Pass each task plan as task issue \`description\` in \`kata_create_task\` (primary path).`,
+      `    - If a task already exists, update task issue description via \`linear_update_issue\` so issue.description remains canonical.`,
       `14. Advance the slice to executing: \`kata_update_issue_state({ issueId: "<slice-uuid>", phase: "executing" })\``,
     ].join("\n");
 
     return {
       backendRules: HARD_RULE,
       backendOps,
-      backendMustComplete: `**You MUST write the \`${sid}-PLAN\` document before finishing.**\n\n${REFERENCE}`,
+      backendMustComplete: `**You MUST write the ${sid} plan into the slice issue description before finishing.**\n\n${REFERENCE}`
     };
   }
 
@@ -597,14 +598,14 @@ export class LinearBackend implements KataBackend {
   ): OpsBlock & { backingArtifacts: string } {
     const backingArtifacts = [
       `## Backing Source Artifacts`,
-      `- Task plan: \`${tid}-PLAN\` (scoped to slice issue)`,
-      `- Slice plan: \`${sid}-PLAN\` (scoped to slice issue)`,
+      `- Task plan: task issue description (legacy fallback: ${tid}-PLAN document)`,
+      `- Slice plan: slice issue description (legacy fallback: ${sid}-PLAN document)`,
       `- Prior task summaries: call \`kata_list_tasks\` then read each completed task's summary`,
     ].join("\n");
 
     const backendOps = [
       `13. Read the task summary template: \`kata_read_document("task-summary-template")\` or use the standard task-summary format.`,
-      `14. Write the task summary (scoped to slice issue): \`kata_write_document("${tid}-SUMMARY", content, { issueId: "<slice-issue-uuid>" })\``,
+      `14. Write the task summary as a comment on the task issue: \`linear_add_comment({ issueId: "<task-uuid>", body: content })\``,
       `   - Include: what shipped (one-liner), what happened, deviations, files modified, verification result.`,
       `15. Commit your work:`,
       `   - Stage all changed files: \`git add -A\``,
@@ -619,7 +620,7 @@ export class LinearBackend implements KataBackend {
       backingArtifacts,
       backendRules: HARD_RULE,
       backendOps,
-      backendMustComplete: `**You MUST write the \`${tid}-SUMMARY\` document AND advance the task to done before finishing.**\n\n${REFERENCE}`,
+      backendMustComplete: `**You MUST post a task summary comment AND advance the task to done before finishing.**\n\n${REFERENCE}`,
     };
   }
 
@@ -639,31 +640,32 @@ export class LinearBackend implements KataBackend {
       DISCOVER_PROJECT_DOCS,
       DISCOVER_SLICE_DOCS,
       ``,
-      `3. Read the task plan (scoped to the slice issue, NOT the project):`,
-      `   - Call \`kata_read_document("${tid}-PLAN", { issueId: "<slice-issue-uuid>" })\` — **required**. If null, stop: task plan is missing.`,
-      `   - Get the slice issue UUID from \`kata_derive_state\` → \`activeSlice\` or from \`kata_list_slices\`.`,
-      `   - Treat the returned content as the authoritative execution steps.`,
+      `3. Read the task issue and load task plan from issue description (primary path):`,
+      `   - Call \`kata_list_tasks\` to resolve the active task UUID from ${tid}.`,
+      `   - Call \`linear_get_issue("<task-uuid>")\` — **required**. Use issue.description as the authoritative task plan.`,
+      `   - Backward-compatible fallback: if description is empty, call \`kata_read_document("${tid}-PLAN", { issueId: "<slice-issue-uuid>" })\`. If both are empty, stop: task plan is missing.`,
     ].join("\n");
 
     const slicePlanExcerpt = [
       `## Slice Plan Excerpt`,
       ``,
-      `Read the slice plan for goal, demo, and verification criteria:`,
-      `- Call \`kata_read_document("${sid}-PLAN", { issueId: "<slice-issue-uuid>" })\``,
+      `Read the slice issue for goal, demo, and verification criteria from issue description (primary path):`,
+      `- Call \`linear_get_issue("<slice-issue-uuid>")\` and use issue.description as slice plan`,
+      `- Backward-compatible fallback: if description is empty, call \`kata_read_document("${sid}-PLAN", { issueId: "<slice-issue-uuid>" })\``,
     ].join("\n");
 
     const resumeSection = [
       `## Resume Check`,
       ``,
       `Check for partial progress:`,
-      `- Call \`kata_read_document("${tid}-SUMMARY", { issueId: "<slice-issue-uuid>" })\`. If it exists with partial content, resume from where it left off.`,
+      `- Read existing task issue comments for partial progress; if partial summary exists, resume from it.`,
     ].join("\n");
 
     const carryForwardSection = [
       `## Carry-Forward from Prior Tasks`,
       ``,
       `- Call \`kata_list_tasks\` with the slice issue UUID.`,
-      `- For each completed prior task, call \`kata_read_document("Txx-SUMMARY", { issueId: "<slice-issue-uuid>" })\` to understand what's already built.`,
+      `- For each completed prior task, inspect the task issue (description + comments) to understand what is already built.`,
     ].join("\n");
 
     const ops = this._buildExecuteTaskOps(sid, tid);
@@ -692,7 +694,8 @@ export class LinearBackend implements KataBackend {
   ): OpsBlock {
     const backendOps = [
       `5. Read the slice-summary and UAT templates (if available via \`kata_read_document\`), or use the standard formats.`,
-      `6. Write the slice summary (scoped to slice issue): \`kata_write_document("${sid}-SUMMARY", content, { issueId: "<slice-issue-uuid>" })\``,
+      `6. Write the slice summary as a comment on the slice issue: \`linear_add_comment({ issueId: "<slice-issue-uuid>", body: content })\``,
+
       `   - Synthesize work across all tasks: what was built, key decisions, key files, patterns established.`,
       `   - Fill the requirement-related sections explicitly.`,
       `7. Write the UAT script (scoped to slice issue): \`kata_write_document("${sid}-UAT", content, { issueId: "<slice-issue-uuid>" })\``,
@@ -709,7 +712,7 @@ export class LinearBackend implements KataBackend {
     return {
       backendRules: HARD_RULE,
       backendOps,
-      backendMustComplete: `**You MUST write the \`${sid}-SUMMARY\` document AND advance the slice to done before finishing.**\n\n${REFERENCE}`,
+      backendMustComplete: `**You MUST post a slice summary comment AND advance the slice to done before finishing.**\n\n${REFERENCE}`,
     };
   }
 
@@ -729,14 +732,15 @@ export class LinearBackend implements KataBackend {
       ``,
       `3. Read required context:`,
       `   - Call \`kata_read_document("${mid}-ROADMAP")\` — **required**. Needed for success criteria and boundary map.`,
-      `   - Call \`kata_read_document("${sid}-PLAN", { issueId: "<slice-issue-uuid>" })\` — **required**. Needed for slice must-haves and verification criteria.`,
+      `   - Call \`linear_get_issue("<slice-issue-uuid>")\` — **required**. Use issue.description as slice must-have contract.`,
+      `   - Backward-compatible fallback: if description is empty, call \`kata_read_document("${sid}-PLAN", { issueId: "<slice-issue-uuid>" })\`.`,
       ``,
       `4. Read optional context:`,
       `   - \`kata_read_document("REQUIREMENTS")\``,
       ``,
-      `5. Collect all task summaries (scoped to slice issue):`,
+      `5. Collect all task execution outcomes:`,
       `   - Call \`kata_list_tasks\` with the slice issue UUID.`,
-      `   - For each task, call \`kata_read_document("Txx-SUMMARY", { issueId: "<slice-issue-uuid>" })\`.`,
+      `   - For each task, inspect the task issue (description + comments) for execution outcomes and summary evidence.`,
     ].join("\n");
 
     const ops = this._buildCompleteSliceOps(mid, sid, sTitle);
@@ -790,9 +794,11 @@ export class LinearBackend implements KataBackend {
       `3. Read required context:`,
       `   - Call \`kata_read_document("${mid}-ROADMAP")\` — **required**.`,
       ``,
-      `4. Read all slice summaries (scoped to each slice issue):`,
+      `4. Read all slice outcomes from slice issues:`,
       `   - Call \`kata_list_slices\` to enumerate all slices in this milestone.`,
-      `   - For each slice, call \`kata_read_document("Sxx-SUMMARY", { issueId: "<slice-issue-uuid>" })\`.`,
+      `   - For each slice, call \`linear_get_issue("<slice-issue-uuid>")\` and inspect description/comments for summary evidence (legacy fallback: \`Sxx-SUMMARY\` doc).`,
+      `   - If a legacy summary doc exists, call \`kata_read_document("Sxx-SUMMARY", { issueId: "<slice-issue-uuid>" })\` as supplemental context.`,
+
       ``,
       `5. Read optional context:`,
       `   - \`kata_read_document("REQUIREMENTS")\``,
@@ -823,7 +829,8 @@ export class LinearBackend implements KataBackend {
       `   - Read task summaries to find which task discovered the blocker.`,
       `4. Write the replan (scoped to slice issue): \`kata_write_document("${sid}-REPLAN", content, { issueId: "<slice-issue-uuid>" })\``,
       `   - Describe the blocker, its impact, and the revised task decomposition.`,
-      `5. Rewrite the slice plan (scoped to slice issue): \`kata_write_document("${sid}-PLAN", content, { issueId: "<slice-issue-uuid>" })\``,
+      `5. Rewrite the slice plan in slice issue description: \`linear_update_issue({ id: "<slice-issue-uuid>", description: content })\``,
+
       `   - Keep all \`[x]\` tasks exactly as they were`,
       `   - Update the \`[ ]\` tasks to address the blocker`,
       `   - Create new task sub-issues if needed via \`kata_create_task\``,
@@ -848,7 +855,9 @@ export class LinearBackend implements KataBackend {
       ``,
       `2. Read required context:`,
       `   - Call \`kata_read_document("${mid}-ROADMAP")\` — **required**.`,
-      `   - Call \`kata_read_document("${sid}-PLAN", { issueId: "<slice-issue-uuid>" })\` — **required**.`,
+      `   - Call \`linear_get_issue("<slice-issue-uuid>")\` — **required**. Use issue.description as current slice plan.`,
+      `   - Backward-compatible fallback: if description is empty, call \`kata_read_document("${sid}-PLAN", { issueId: "<slice-issue-uuid>" })\`.`,
+
       ``,
       `3. Read optional context:`,
       `   - \`kata_read_document("DECISIONS")\``,
@@ -901,7 +910,9 @@ export class LinearBackend implements KataBackend {
       ``,
       `2. Read required context:`,
       `   - Call \`kata_read_document("${mid}-ROADMAP")\` — **required**.`,
-      `   - Call \`kata_read_document("${completedSliceId}-SUMMARY", { issueId: "<completed-slice-issue-uuid>" })\` — **required**. Get the slice issue UUID from \`kata_list_slices\`.`,
+      `   - Call \`linear_get_issue("<completed-slice-issue-uuid>")\` — **required**. Read description/comments for completed slice summary evidence. Get the slice issue UUID from \`kata_list_slices\`.`,
+      `   - Backward-compatible fallback: if comments/description are insufficient, call \`kata_read_document("${completedSliceId}-SUMMARY", { issueId: "<completed-slice-issue-uuid>" })\`.`,
+
       ``,
       `3. Read optional context:`,
       `   - \`kata_read_document("PROJECT")\``,
@@ -947,7 +958,8 @@ export class LinearBackend implements KataBackend {
       `   - Call \`kata_read_document("${sliceId}-UAT", { issueId: "<slice-issue-uuid>" })\` — **required**. Contains the test script. Get the slice issue UUID from \`kata_list_slices\`.`,
       ``,
       `3. Read optional context:`,
-      `   - \`kata_read_document("${sliceId}-SUMMARY", { issueId: "<slice-issue-uuid>" })\``,
+      `   - Read slice issue comments/description for summary evidence (legacy fallback: \`kata_read_document("${sliceId}-SUMMARY", { issueId: "<slice-issue-uuid>" })\`)`,
+
       `   - \`kata_read_document("PROJECT")\``,
     ].join("\n");
 

--- a/apps/cli/src/resources/extensions/kata/linear-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-backend.ts
@@ -27,7 +27,7 @@ import {
   listKataDocuments,
 } from "../linear/linear-documents.js";
 import { listKataSlices, parseKataEntityTitle } from "../linear/linear-entities.js";
-import type { DocumentAttachment } from "../linear/linear-types.js";
+import type { DocumentAttachment, LinearComment } from "../linear/linear-types.js";
 import { ensureGitignore } from "./gitignore.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { buildSkillDiscoveryVars } from "./preferences.js";
@@ -106,12 +106,68 @@ export class LinearBackend implements KataBackend {
     return { projectId: this.config.projectId };
   }
 
+  private parseIssueArtifactName(name: string): { unitId: string; kind: "PLAN" | "SUMMARY" } | null {
+    const match = /^([ST]\d+)-(PLAN|SUMMARY)$/i.exec(name.trim());
+    if (!match) return null;
+    return { unitId: match[1].toUpperCase(), kind: match[2].toUpperCase() as "PLAN" | "SUMMARY" };
+  }
+
+  private async listIssueComments(issueId: string): Promise<LinearComment[]> {
+    const data = await this.client.graphql<{
+      issue: { comments: { nodes: LinearComment[] } | null } | null;
+    }>(`
+      query KataIssueComments($id: String!) {
+        issue(id: $id) {
+          comments(first: 50) {
+            nodes {
+              id
+              body
+              createdAt
+              updatedAt
+              url
+            }
+          }
+        }
+      }
+    `, { id: issueId });
+
+    return data.issue?.comments?.nodes ?? [];
+  }
+
+  private pickLatestSummaryComment(name: string, comments: LinearComment[]): string | null {
+    if (comments.length === 0) return null;
+    const marker = `<!-- KATA:${name.toUpperCase()} -->`;
+
+    const tagged = comments
+      .filter((c) => c.body.includes(marker))
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+    if (tagged.length > 0) return tagged[0].body;
+
+    const fallback = comments
+      .filter((c) => c.body.includes(name))
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+    if (fallback.length > 0) return fallback[0].body;
+
+    return null;
+  }
+
   async readDocument(name: string, scope?: DocumentScope): Promise<string | null> {
-    const doc = await readKataDocument(
-      this.client,
-      name,
-      this.resolveAttachment(scope),
-    );
+    const attachment = this.resolveAttachment(scope);
+    const issueArtifact = this.parseIssueArtifactName(name);
+
+    if (issueArtifact && "issueId" in attachment) {
+      const issue = await this.client.getIssue(attachment.issueId);
+      if (issueArtifact.kind === "PLAN") {
+        const description = issue?.description?.trim();
+        if (description) return description;
+      } else {
+        const comments = await this.listIssueComments(attachment.issueId);
+        const summary = this.pickLatestSummaryComment(name, comments);
+        if (summary) return summary;
+      }
+    }
+
+    const doc = await readKataDocument(this.client, name, attachment);
     return doc?.content ?? null;
   }
 
@@ -606,6 +662,8 @@ export class LinearBackend implements KataBackend {
     const backendOps = [
       `13. Read the task summary template: \`kata_read_document("task-summary-template")\` or use the standard task-summary format.`,
       `14. Write the task summary as a comment on the task issue: \`linear_add_comment({ issueId: "<task-uuid>", body: content })\``,
+      `   - Prefix summary with marker: \`<!-- KATA:${tid}-SUMMARY -->\` so retries can detect existing summary comments.`,
+      `   - Before posting, call \`linear_get_issue("<task-uuid>")\` and inspect issue.comments; if marker already exists, DO NOT post a duplicate.`,
       `   - Include: what shipped (one-liner), what happened, deviations, files modified, verification result.`,
       `15. Commit your work:`,
       `   - Stage all changed files: \`git add -A\``,
@@ -695,7 +753,8 @@ export class LinearBackend implements KataBackend {
     const backendOps = [
       `5. Read the slice-summary and UAT templates (if available via \`kata_read_document\`), or use the standard formats.`,
       `6. Write the slice summary as a comment on the slice issue: \`linear_add_comment({ issueId: "<slice-issue-uuid>", body: content })\``,
-
+      `   - Prefix summary with marker: \`<!-- KATA:${sid}-SUMMARY -->\` so retries can detect existing summary comments.`,
+      `   - Before posting, call \`linear_get_issue("<slice-issue-uuid>")\` and inspect issue.comments; if marker already exists, DO NOT post a duplicate.`,
       `   - Synthesize work across all tasks: what was built, key decisions, key files, patterns established.`,
       `   - Fill the requirement-related sections explicitly.`,
       `7. Write the UAT script (scoped to slice issue): \`kata_write_document("${sid}-UAT", content, { issueId: "<slice-issue-uuid>" })\``,
@@ -706,13 +765,14 @@ export class LinearBackend implements KataBackend {
       `   - Stage all changed files: \`git add -A\``,
       `   - Commit with message: \`feat(${sid}): complete slice — ${sTitle}\``,
       `   - Do NOT push.`,
-      `10. Advance the slice to done: \`kata_update_issue_state({ issueId: "<slice-uuid>", phase: "done" })\``,
+      `10. Do NOT advance the slice to done directly — slice completion is orchestrator-owned after summarizing.`,
+      `    - Post the slice summary comment and leave state transition handoff to the orchestrator path.`,
     ].join("\n");
 
     return {
       backendRules: HARD_RULE,
       backendOps,
-      backendMustComplete: `**You MUST post a slice summary comment AND advance the slice to done before finishing.**\n\n${REFERENCE}`,
+      backendMustComplete: `**You MUST post a slice summary comment (with marker) before finishing. Do NOT advance the slice to done directly.**\n\n${REFERENCE}`,
     };
   }
 

--- a/apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts
@@ -344,9 +344,10 @@ describe("LinearBackend complete slice prompt", () => {
     assert.match(p, /S01-PLAN/i);
   });
 
-  it("references kata_update_issue_state", async () => {
+  it("does not advance slice directly to done", async () => {
     const p = await b.buildPrompt("summarizing", makeState({ phase: "summarizing" }));
-    assert.match(p, /kata_update_issue_state/);
+    assert.doesNotMatch(p, /kata_update_issue_state\(\{ issueId: "<slice-uuid>", phase: "done" \}\)/);
+    assert.match(p, /Do NOT advance the slice to done directly/i);
   });
 
   it("references kata_list_tasks", async () => {
@@ -362,6 +363,7 @@ describe("LinearBackend complete slice prompt", () => {
   it("writes slice summary via linear_add_comment", async () => {
     const p = await b.buildPrompt("summarizing", makeState({ phase: "summarizing" }));
     assert.match(p, /linear_add_comment\(\{ issueId: "<slice-issue-uuid>", body: content \}\)/);
+    assert.match(p, /<!-- KATA:S01-SUMMARY -->/);
   });
 });
 

--- a/apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts
@@ -239,7 +239,12 @@ describe("LinearBackend execute task prompt", () => {
     assert.match(p, /KATA-WORKFLOW\.md/);
   });
 
-  it("reads T01-PLAN", async () => {
+  it("uses task issue description as primary task plan source", async () => {
+    const p = await b.buildPrompt("executing", makeState());
+    assert.match(p, /linear_get_issue\("<task-uuid>"\)/i);
+  });
+
+  it("keeps T01-PLAN fallback for backward compatibility", async () => {
     const p = await b.buildPrompt("executing", makeState());
     assert.match(p, /T01-PLAN/i);
   });
@@ -295,6 +300,12 @@ describe("LinearBackend plan slice prompt", () => {
     assert.match(p, /kata_create_task/);
   });
 
+  it("writes slice plan via linear_update_issue description", async () => {
+    const state = makeState({ phase: "planning", activeSlice: { id: "S02", title: "Second Slice" } });
+    const p = await b.buildPrompt("planning", state);
+    assert.match(p, /linear_update_issue\(\{ id: "<slice-issue-uuid>", description: content \}\)/);
+  });
+
   it("references kata_update_issue_state", async () => {
     const state = makeState({ phase: "planning", activeSlice: { id: "S02", title: "Second Slice" } });
     const p = await b.buildPrompt("planning", state);
@@ -346,6 +357,11 @@ describe("LinearBackend complete slice prompt", () => {
   it("writes UAT", async () => {
     const p = await b.buildPrompt("summarizing", makeState({ phase: "summarizing" }));
     assert.match(p, /S01-UAT/);
+  });
+
+  it("writes slice summary via linear_add_comment", async () => {
+    const p = await b.buildPrompt("summarizing", makeState({ phase: "summarizing" }));
+    assert.match(p, /linear_add_comment\(\{ issueId: "<slice-issue-uuid>", body: content \}\)/);
   });
 });
 

--- a/apps/cli/src/resources/extensions/linear/linear-client.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-client.ts
@@ -24,6 +24,7 @@ import type {
   LinearWorkflowState,
   LinearUser,
   LinearPageInfo,
+  LinearComment,
   ProjectCreateInput,
   ProjectUpdateInput,
   MilestoneCreateInput,

--- a/apps/cli/src/resources/extensions/linear/linear-tools.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-tools.ts
@@ -582,7 +582,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       milestoneId: Type.Optional(Type.String({ description: "Linear ProjectMilestone UUID to attach this slice to" })),
       sliceLabelId: Type.Optional(Type.String({ description: "Label UUID for kata:slice (from kata_ensure_labels)" })),
       taskLabelId: Type.Optional(Type.String({ description: "Label UUID for kata:task (from kata_ensure_labels); used to complete the KataLabelSet" })),
-      description: Type.Optional(Type.String({ description: "Slice description (markdown)" })),
+      description: Type.Optional(Type.String({ description: "Slice description (markdown). Use this for the canonical Sxx plan content." })),
       initialPhase: Type.Optional(
         Type.Union(
           [
@@ -640,7 +640,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
       sliceIssueId: Type.String({ description: "Linear issue UUID of the parent slice issue" }),
       sliceLabelId: Type.Optional(Type.String({ description: "Label UUID for kata:slice (from kata_ensure_labels); used to complete the KataLabelSet" })),
       taskLabelId: Type.Optional(Type.String({ description: "Label UUID for kata:task (from kata_ensure_labels)" })),
-      description: Type.Optional(Type.String({ description: "Task description (markdown)" })),
+      description: Type.Optional(Type.String({ description: "Task description (markdown). Use this for the canonical Txx plan content." })),
       initialPhase: Type.Optional(
         Type.Union(
           [

--- a/apps/cli/src/resources/extensions/linear/linear-types.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-types.ts
@@ -113,6 +113,14 @@ export interface LinearDocument {
   updatedAt: string;
 }
 
+export interface LinearComment {
+  id: string;
+  body: string;
+  createdAt: string;
+  updatedAt?: string;
+  url: string;
+}
+
 /**
  * Discriminated union for document attachment targets.
  * A document attaches to exactly one: a project or an issue.

--- a/apps/symphony/docs/WORKFLOW-cli.md
+++ b/apps/symphony/docs/WORKFLOW-cli.md
@@ -192,9 +192,10 @@ This workflow is for Kata CLI planned execution and dispatches a **slice issue**
 Before implementation starts, load context in this exact order:
 
 1. Child issues (`issue.children`) to discover task list and ordering.
-2. Slice issue documents (`issue.documents`) to read slice-scoped docs (`S0N-PLAN`, `S0N-RESEARCH`, `T0N-PLAN`, `T0N-SUMMARY`). Slice and task docs are attached to the slice issue, not the project — this prevents ID collisions across milestones.
-3. Project documents (`project.documents`) to read project-scoped docs (`PROJECT`, `REQUIREMENTS`, `DECISIONS`, `M00N-CONTEXT`, `M00N-ROADMAP`).
-4. Milestone context via `issue.projectMilestone` to get the milestone name, then find `M00N-CONTEXT` and `M00N-ROADMAP` in the project documents (milestone docs are attached to the project, not the milestone entity).
+2. Slice issue + child task issue descriptions to read plans (`S0N-PLAN` in slice description, `T0N-PLAN` in task description). Use slice/task documents only as backward-compatible fallback when descriptions are empty.
+3. Slice issue documents (`issue.documents`) for remaining slice-scoped docs (`S0N-RESEARCH`, `S0N-UAT`, optional legacy summaries/plans).
+4. Project documents (`project.documents`) to read project-scoped docs (`PROJECT`, `REQUIREMENTS`, `DECISIONS`, `M00N-CONTEXT`, `M00N-ROADMAP`).
+5. Milestone context via `issue.projectMilestone` to get the milestone name, then find `M00N-CONTEXT` and `M00N-ROADMAP` in the project documents (milestone docs are attached to the project, not the milestone entity).
 
 Preferred query patterns:
 


### PR DESCRIPTION
## Summary
- make Linear-mode prompts treat slice/task issue descriptions as canonical plan storage
- switch task/slice summary instructions to issue comments (`linear_add_comment`) with legacy doc fallback
- update workflow docs and linear-backend tests for description-first behavior

## Validation
- `cd apps/cli && npx tsc`
- `cd apps/cli && node --import ./src/resources/extensions/kata/tests/resolve-ts.mjs --experimental-strip-types --test 'src/resources/extensions/kata/tests/linear-backend.test.ts'`
- `cd apps/cli && node --import ./src/resources/extensions/kata/tests/resolve-ts.mjs --experimental-strip-types --test 'src/resources/extensions/kata/tests/*.test.ts' 'src/tests/*.test.ts'`

Closes KAT-939


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plans are now stored in issue descriptions and summaries are posted as issue comments for clearer in-app visibility.
* **Bug Fixes**
  * Legacy document fallbacks preserved so existing plans/summaries remain accessible when issue-based content is missing.
* **Tests**
  * Added/updated tests to verify issue-based plan retrieval, writing, and comment-based summaries.
* **Documentation**
  * Clarified tool descriptions to indicate issue descriptions are the canonical place for slice/task plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates Kata's Linear-mode workflow from `LinearDocument` storage to issue-native storage: slice and task **plans** now live in issue `description` fields (written via `linear_update_issue` / `kata_create_task`), while slice and task **summaries** are now posted as issue comments via `linear_add_comment`. All existing `kata_read_document`/`kata_write_document` references for `Sxx-PLAN` and `Txx-PLAN` are demoted to backward-compatible fallbacks when descriptions are empty, and the workflow documentation and Linear tool descriptions are updated consistently.

- **Plan storage change**: slice/task plans written to `issue.description` via `linear_update_issue` (primary) with `kata_write_document` legacy fallback.
- **Summary storage change**: slice and task summaries posted as issue comments via `linear_add_comment` (primary) — removes the need for scoped `Txx-SUMMARY`/`Sxx-SUMMARY` LinearDocuments.
- **Backward compatibility**: every read site now checks `issue.description` (or comments) first and falls back to the legacy `kata_read_document` call when descriptions are empty.
- **P1 gap**: `dependencySummaries` in `_buildPlanSlicePrompt` was not updated — it still instructs the agent to call `kata_read_document("Sxx-SUMMARY")` for dependent-slice context, which will return `null` for any slice summarised under the new comment-based workflow, silently dropping dependency context during planning.
- **Test coverage**: new tests added for the primary `linear_update_issue`/`linear_add_comment`/`linear_get_issue` paths; a test verifying `linear_add_comment` in the execute-task summary path is missing.

<h3>Confidence Score: 3/5</h3>

- One concrete logic gap (dependency summaries not migrated) could cause the agent to plan slices without dependency context in new-style projects; fix before merge.
- The overall migration is well-structured and the backward-compatibility strategy is sound, but the `dependencySummaries` section in `_buildPlanSlicePrompt` was not updated alongside the rest of the plan-slice prompt. For any project that has completed slices under the new workflow, `kata_read_document("Sxx-SUMMARY")` will silently return null, and the AI agent will plan subsequent slices without the context of what dependent slices actually built. This directly affects the primary planning path.
- `apps/cli/src/resources/extensions/kata/linear-backend.ts` — specifically the `dependencySummaries` constant in `_buildPlanSlicePrompt`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/linear-backend.ts | Core prompt-building logic migrated from LinearDocument storage to issue descriptions/comments. One P1 logic gap: `dependencySummaries` in `_buildPlanSlicePrompt` still calls `kata_read_document("Sxx-SUMMARY")` for dependency context, which will return null for slices summarised under the new comment-based workflow. |
| apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts | New tests added for primary plan-via-description and summary-via-comment paths; backward-compatibility fallback also tested. Missing a test verifying `linear_add_comment` usage in the execute-task summary path. |
| apps/cli/src/resources/extensions/linear/linear-tools.ts | Minimal, correct change: updated tool description strings for `kata_create_slice` and `kata_create_task` to indicate the `description` field is the canonical plan storage location. |
| apps/cli/src/resources/KATA-WORKFLOW.md | Workflow docs updated to reflect description-first plan storage and comment-based summary writing, with clear backward-compatibility notes. Consistent with code changes. |
| apps/symphony/docs/WORKFLOW-cli.md | Context-loading order correctly updated to prioritise issue descriptions/comments for plans, with slice documents retained as legacy fallback. Step numbering updated from 4 → 5 items. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant Linear

    note over Agent,Linear: Plan Slice (new)
    Agent->>Linear: linear_get_issue(sliceUUID)
    Linear-->>Agent: issue.description (plan, if exists)
    alt description empty (legacy fallback)
        Agent->>Linear: kata_read_document("Sxx-PLAN", {issueId})
        Linear-->>Agent: legacy plan doc or null
    end
    Agent->>Linear: linear_update_issue({id, description: planContent})

    note over Agent,Linear: Create Tasks (new)
    Agent->>Linear: kata_create_task({description: taskPlanContent})

    note over Agent,Linear: Execute Task (new)
    Agent->>Linear: linear_get_issue(taskUUID)
    Linear-->>Agent: issue.description (task plan)
    alt description empty (legacy fallback)
        Agent->>Linear: kata_read_document("Txx-PLAN", {issueId})
    end
    Agent->>Linear: linear_add_comment({issueId: taskUUID, body: taskSummary})

    note over Agent,Linear: Complete Slice (new)
    Agent->>Linear: linear_get_issue(sliceUUID)
    Linear-->>Agent: issue.description + comments
    Agent->>Linear: linear_add_comment({issueId: sliceUUID, body: sliceSummary})

    note over Agent,Linear: ⚠️ Plan Slice — dependency check (NOT updated)
    Agent->>Linear: kata_read_document("Sxx-SUMMARY", {issueId})
    Linear-->>Agent: null (if summary was written as comment)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/cli/src/resources/extensions/kata/linear-backend.ts`, line 558-561 ([link](https://github.com/gannonh/kata/blob/1559933c8633faeca2ccc5fc740fa189206ffdff/apps/cli/src/resources/extensions/kata/linear-backend.ts#L558-L561)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Dependency summaries not updated for new comment-based storage**

   `dependencySummaries` still instructs the agent to call `kata_read_document("Sxx-SUMMARY", ...)` to retrieve context for dependent slices. However, after this PR, slice summaries are now written as issue comments via `linear_add_comment` — not as `LinearDocument` entries. For any slice that was summarised using the **new** workflow, `kata_read_document("Sxx-SUMMARY")` will return `null`, silently dropping the dependency context when planning a slice.

   This section needs the same treatment as the `complete-milestone` prompt (lines ~794-797), which was updated to check `linear_get_issue` + description/comments first with a legacy doc fallback:

   ```typescript
   const dependencySummaries = [
     `- Check the roadmap for \`depends:[]\` on this slice.`,
     `- For each dependency, call \`linear_get_issue("<dependency-slice-issue-uuid>")\` and inspect description/comments for summary evidence (legacy fallback: \`kata_read_document("Sxx-SUMMARY", { issueId: "<dependency-slice-issue-uuid>" })\`). Get slice issue UUIDs from \`kata_list_slices\`.`,
   ].join("\n");
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/extensions/kata/linear-backend.ts
   Line: 558-561

   Comment:
   **Dependency summaries not updated for new comment-based storage**

   `dependencySummaries` still instructs the agent to call `kata_read_document("Sxx-SUMMARY", ...)` to retrieve context for dependent slices. However, after this PR, slice summaries are now written as issue comments via `linear_add_comment` — not as `LinearDocument` entries. For any slice that was summarised using the **new** workflow, `kata_read_document("Sxx-SUMMARY")` will return `null`, silently dropping the dependency context when planning a slice.

   This section needs the same treatment as the `complete-milestone` prompt (lines ~794-797), which was updated to check `linear_get_issue` + description/comments first with a legacy doc fallback:

   ```typescript
   const dependencySummaries = [
     `- Check the roadmap for \`depends:[]\` on this slice.`,
     `- For each dependency, call \`linear_get_issue("<dependency-slice-issue-uuid>")\` and inspect description/comments for summary evidence (legacy fallback: \`kata_read_document("Sxx-SUMMARY", { issueId: "<dependency-slice-issue-uuid>" })\`). Get slice issue UUIDs from \`kata_list_slices\`.`,
   ].join("\n");
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts`, line 242-265 ([link](https://github.com/gannonh/kata/blob/1559933c8633faeca2ccc5fc740fa189206ffdff/apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts#L242-L265)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing test for task summary via `linear_add_comment`**

   The execute-task ops were updated to write the task summary as an issue comment (`linear_add_comment({ issueId: "<task-uuid>", body: content })`), mirroring the new slice summary tests added for the `summarizing` phase. However, there is no corresponding test in the `execute task prompt` suite that verifies this new behaviour. The existing tests only check for `linear_get_issue` (plan loading) and the legacy `T01-PLAN` fallback. Consider adding:

   ```typescript
   it("writes task summary via linear_add_comment", async () => {
     const p = await b.buildPrompt("executing", makeState());
     assert.match(p, /linear_add_comment\(\{ issueId: "<task-uuid>", body: content \}\)/);
   });
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts
   Line: 242-265

   Comment:
   **Missing test for task summary via `linear_add_comment`**

   The execute-task ops were updated to write the task summary as an issue comment (`linear_add_comment({ issueId: "<task-uuid>", body: content })`), mirroring the new slice summary tests added for the `summarizing` phase. However, there is no corresponding test in the `execute task prompt` suite that verifies this new behaviour. The existing tests only check for `linear_get_issue` (plan loading) and the legacy `T01-PLAN` fallback. Consider adding:

   ```typescript
   it("writes task summary via linear_add_comment", async () => {
     const p = await b.buildPrompt("executing", makeState());
     assert.match(p, /linear_add_comment\(\{ issueId: "<task-uuid>", body: content \}\)/);
   });
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/linear-backend.ts
Line: 558-561

Comment:
**Dependency summaries not updated for new comment-based storage**

`dependencySummaries` still instructs the agent to call `kata_read_document("Sxx-SUMMARY", ...)` to retrieve context for dependent slices. However, after this PR, slice summaries are now written as issue comments via `linear_add_comment` — not as `LinearDocument` entries. For any slice that was summarised using the **new** workflow, `kata_read_document("Sxx-SUMMARY")` will return `null`, silently dropping the dependency context when planning a slice.

This section needs the same treatment as the `complete-milestone` prompt (lines ~794-797), which was updated to check `linear_get_issue` + description/comments first with a legacy doc fallback:

```typescript
const dependencySummaries = [
  `- Check the roadmap for \`depends:[]\` on this slice.`,
  `- For each dependency, call \`linear_get_issue("<dependency-slice-issue-uuid>")\` and inspect description/comments for summary evidence (legacy fallback: \`kata_read_document("Sxx-SUMMARY", { issueId: "<dependency-slice-issue-uuid>" })\`). Get slice issue UUIDs from \`kata_list_slices\`.`,
].join("\n");
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/tests/linear-backend.test.ts
Line: 242-265

Comment:
**Missing test for task summary via `linear_add_comment`**

The execute-task ops were updated to write the task summary as an issue comment (`linear_add_comment({ issueId: "<task-uuid>", body: content })`), mirroring the new slice summary tests added for the `summarizing` phase. However, there is no corresponding test in the `execute task prompt` suite that verifies this new behaviour. The existing tests only check for `linear_get_issue` (plan loading) and the legacy `T01-PLAN` fallback. Consider adding:

```typescript
it("writes task summary via linear_add_comment", async () => {
  const p = await b.buildPrompt("executing", makeState());
  assert.match(p, /linear_add_comment\(\{ issueId: "<task-uuid>", body: content \}\)/);
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/linear-backend.ts
Line: 546-551

Comment:
**Trailing comma inconsistency in return object**

The `backendMustComplete` property is missing a trailing comma, which is inconsistent with every other `OpsBlock` return in this file (e.g. `_buildCompleteSliceOps`, `_buildExecuteTaskOps`). While not a runtime error, it stands out against the file's established style.

```suggestion
    return {
      backendRules: HARD_RULE,
      backendOps,
      backendMustComplete: `**You MUST write the ${sid} plan into the slice issue description before finishing.**\n\n${REFERENCE}`,
    };
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(kata): move linear slice/task plans..."](https://github.com/gannonh/kata/commit/1559933c8633faeca2ccc5fc740fa189206ffdff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26383698)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->