### PR TITLE
feat(symphony): issue dependency ordering [KAT-927]

### DIFF
--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -48,6 +48,16 @@ pub struct BlockerRef {
     pub state: Option<String>,
 }
 
+/// A blocked issue entry for the orchestrator snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockedIssueEntry {
+    pub issue_id: String,
+    pub identifier: String,
+    pub title: String,
+    pub state: String,
+    pub blocker_identifiers: Vec<String>,
+}
+
 // ── ApiKey ─────────────────────────────────────────────────────────────
 
 /// A redacted API-key value.
@@ -684,6 +694,8 @@ pub struct OrchestratorSnapshot {
     pub claimed: BTreeSet<String>,
     pub retry_queue: Vec<RetrySnapshotEntry>,
     pub completed: Vec<CompletedEntry>,
+    #[serde(default)]
+    pub blocked: Vec<BlockedIssueEntry>,
     pub codex_totals: CodexTotals,
     pub codex_rate_limits: Option<RateLimitInfo>,
     pub polling: PollingSnapshot,

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -110,6 +110,7 @@ struct StateResponse {
     running_session_info: std::collections::BTreeMap<String, WorkerSessionInfo>,
     claimed: std::collections::BTreeSet<String>,
     retry_queue: Vec<RetrySnapshotEntry>,
+    blocked: Vec<crate::domain::BlockedIssueEntry>,
     completed: Vec<crate::domain::CompletedEntry>,
     codex_totals: CodexTotals,
     codex_rate_limits: Option<serde_json::Value>,
@@ -369,6 +370,23 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     </div>
   </section>
 
+  <section class="card section" id="blocked-section" style="display:none">
+    <h2 style="color:#e6a817">Blocked issues</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Title</th>
+            <th>State</th>
+            <th>Blocked by</th>
+          </tr>
+        </thead>
+        <tbody id="blocked-table-body"></tbody>
+      </table>
+    </div>
+  </section>
+
   <section class="card section">
     <h2>Completed issues</h2>
     <ul id="completed-list" class="list">
@@ -603,6 +621,21 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
           state.running_session_info || {{}}
         );
         document.getElementById('retry-table-body').innerHTML = renderRetryTable(retryQueue);
+
+        const blocked = state.blocked || [];
+        const blockedSection = document.getElementById('blocked-section');
+        if (blocked.length > 0) {{
+          blockedSection.style.display = '';
+          document.getElementById('blocked-table-body').innerHTML = blocked.map(function(entry) {{
+            return '<tr><td>' + escapeHtml(entry.identifier) + '</td>'
+              + '<td>' + escapeHtml(entry.title || '') + '</td>'
+              + '<td>' + escapeHtml(entry.state || '') + '</td>'
+              + '<td>' + escapeHtml((entry.blocker_identifiers || []).join(', ')) + '</td></tr>';
+          }}).join('');
+        }} else {{
+          blockedSection.style.display = 'none';
+        }}
+
         document.getElementById('completed-list').innerHTML = renderCompleted(completed);
         document.getElementById('token-input').textContent = state.codex_totals?.input_tokens ?? 0;
         document.getElementById('token-output').textContent = state.codex_totals?.output_tokens ?? 0;
@@ -636,6 +669,7 @@ async fn get_state(State(state): State<HttpServerState>) -> impl IntoResponse {
         running_session_info: snapshot.running_session_info,
         claimed: snapshot.claimed,
         retry_queue: snapshot.retry_queue,
+        blocked: snapshot.blocked,
         completed: snapshot.completed,
         codex_totals: snapshot.codex_totals,
         codex_rate_limits: snapshot.codex_rate_limits.map(|r| r.data),

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1117,6 +1117,8 @@ pub struct Orchestrator {
     worker_session_info: HashMap<String, WorkerSessionInfo>,
     worker_session_ids: HashMap<String, String>,
     running_session_stats: HashMap<String, RunningSessionStats>,
+    /// Blocked issues from the latest dispatch phase.
+    blocked_issues: Vec<crate::domain::BlockedIssueEntry>,
     pending_terminal_cleanup: HashMap<String, PendingTerminalCleanup>,
     /// Normalized running issue state cache used for per-state slot accounting.
     running_issue_states: HashMap<String, String>,
@@ -1192,6 +1194,7 @@ impl Orchestrator {
             worker_session_info: HashMap::new(),
             worker_session_ids: HashMap::new(),
             running_session_stats: HashMap::new(),
+            blocked_issues: Vec::new(),
             pending_terminal_cleanup: HashMap::new(),
             running_issue_states: HashMap::new(),
             next_retry_token: 0,
@@ -1485,10 +1488,14 @@ impl Orchestrator {
         tracing::info!(phase = "dispatch", "starting orchestrator tick phase");
 
         let candidates = port.fetch_candidate_issues()?;
+        let sorted_candidates = self.sort_issues_for_dispatch(candidates);
+        let candidate_ids: std::collections::HashSet<String> =
+            sorted_candidates.iter().map(|i| i.id.clone()).collect();
         let mut dispatched_issue_ids = vec![];
         let mut dispatched_issues = vec![];
+        let mut blocked_entries: Vec<crate::domain::BlockedIssueEntry> = vec![];
 
-        for candidate in self.sort_issues_for_dispatch(candidates) {
+        for candidate in &sorted_candidates {
             if self.available_slots() == 0 {
                 tracing::debug!(
                     phase = "dispatch",
@@ -1498,7 +1505,7 @@ impl Orchestrator {
                 break;
             }
 
-            if !self.should_dispatch_issue(&candidate) {
+            if !self.should_dispatch_issue(candidate) {
                 tracing::debug!(
                     phase = "dispatch",
                     reason = "blocked",
@@ -1506,6 +1513,20 @@ impl Orchestrator {
                     issue_identifier = %candidate.identifier,
                     "candidate rejected before refresh"
                 );
+                continue;
+            }
+
+            // Check dependency blockers (applies to all active states)
+            let (dep_blocked, blocker_ids) =
+                self.is_blocked_by_dependency(candidate, &sorted_candidates, &candidate_ids);
+            if dep_blocked {
+                blocked_entries.push(crate::domain::BlockedIssueEntry {
+                    issue_id: candidate.id.clone(),
+                    identifier: candidate.identifier.clone(),
+                    title: candidate.title.clone(),
+                    state: candidate.state.clone(),
+                    blocker_identifiers: blocker_ids,
+                });
                 continue;
             }
 
@@ -1554,6 +1575,9 @@ impl Orchestrator {
                 worker_host,
             });
         }
+
+        // Store blocked issues for snapshot visibility
+        self.blocked_issues = blocked_entries;
 
         Ok(TickResult {
             dispatched_issue_ids,
@@ -2397,6 +2421,7 @@ impl Orchestrator {
             linear_project_url: self.config.tracker.linear_project_url(),
             running,
             running_sessions,
+            blocked: self.blocked_issues.clone(),
             running_session_info,
             claimed,
             retry_queue,
@@ -2523,9 +2548,8 @@ impl Orchestrator {
             return false;
         }
 
-        if self.todo_issue_blocked_by_non_terminal(issue) {
-            return false;
-        }
+        // NOTE: blocker checks are done at the dispatch loop level via
+        // is_blocked_by_dependency() which needs access to all candidates.
 
         if self.state.claimed.contains(&issue.id) || self.state.running.contains_key(&issue.id) {
             return false;
@@ -2538,20 +2562,98 @@ impl Orchestrator {
         true
     }
 
-    fn todo_issue_blocked_by_non_terminal(&self, issue: &Issue) -> bool {
-        if normalize_issue_state(&issue.state) != "todo" {
-            return false;
+    /// Returns `true` if the issue has at least one non-terminal blocker,
+    /// meaning it should not be dispatched. Applies to **all** active states
+    /// (not just Todo).
+    ///
+    /// Cross-project blockers (state = None) are treated as **non-blocking**
+    /// with a warning, since Symphony cannot resolve them.
+    ///
+    /// When `candidate_ids` is provided, direct circular dependencies (A↔B)
+    /// are detected: if this issue blocks a candidate that also blocks this
+    /// issue, both are considered blocked and a warning is logged.
+    fn is_blocked_by_dependency(
+        &self,
+        issue: &Issue,
+        all_issues: &[Issue],
+        candidate_ids: &std::collections::HashSet<String>,
+    ) -> (bool, Vec<String>) {
+        if issue.blocked_by.is_empty() {
+            return (false, vec![]);
         }
 
         let terminal_states = self.terminal_state_set();
+        let mut blocking_identifiers: Vec<String> = Vec::new();
 
-        issue.blocked_by.iter().any(|blocker| {
-            blocker
-                .state
-                .as_ref()
-                .map(|state| !terminal_states.contains(&normalize_issue_state(state)))
-                .unwrap_or(true)
-        })
+        for blocker in &issue.blocked_by {
+            let blocker_state = match &blocker.state {
+                Some(s) => s,
+                None => {
+                    // Cross-project blocker — unknown state, treat as non-blocking
+                    let blocker_id = blocker.identifier.as_deref().unwrap_or("unknown");
+                    tracing::warn!(
+                        event = "cross_project_blocker_ignored",
+                        issue_id = %issue.id,
+                        issue_identifier = %issue.identifier,
+                        blocker_identifier = %blocker_id,
+                        "blocker has no state info (cross-project?); treating as non-blocking"
+                    );
+                    continue;
+                }
+            };
+
+            if terminal_states.contains(&normalize_issue_state(blocker_state)) {
+                continue; // blocker resolved
+            }
+
+            // Non-terminal blocker — this issue is blocked
+            let blocker_id = blocker
+                .identifier
+                .as_deref()
+                .unwrap_or("unknown")
+                .to_string();
+            blocking_identifiers.push(blocker_id);
+        }
+
+        // Check for direct circular dependencies (A↔B)
+        if !blocking_identifiers.is_empty() {
+            for blocker in &issue.blocked_by {
+                if let Some(blocker_issue_id) = &blocker.id {
+                    if candidate_ids.contains(blocker_issue_id) {
+                        // Check if the blocker also has this issue as a blocker
+                        if let Some(blocker_issue) =
+                            all_issues.iter().find(|i| i.id == *blocker_issue_id)
+                        {
+                            let reverse_blocked = blocker_issue
+                                .blocked_by
+                                .iter()
+                                .any(|b| b.id.as_deref() == Some(&issue.id));
+                            if reverse_blocked {
+                                tracing::warn!(
+                                    event = "circular_dependency_detected",
+                                    issue_a = %issue.identifier,
+                                    issue_b = %blocker_issue.identifier,
+                                    "circular dependency detected; both issues will be blocked"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let blocked = !blocking_identifiers.is_empty();
+        if blocked {
+            tracing::info!(
+                event = "dispatch_blocked_by_dependency",
+                issue_id = %issue.id,
+                issue_identifier = %issue.identifier,
+                blocker_identifiers = ?blocking_identifiers,
+                "issue blocked by non-terminal dependencies; skipping dispatch"
+            );
+        }
+
+        (blocked, blocking_identifiers)
     }
 
     fn available_slots(&self) -> u32 {

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1495,6 +1495,33 @@ impl Orchestrator {
         let mut dispatched_issues = vec![];
         let mut blocked_entries: Vec<crate::domain::BlockedIssueEntry> = vec![];
 
+        // First pass: identify all dependency-blocked candidates so the blocked list
+        // is complete regardless of slot availability. Without this, candidates that
+        // happen to appear after slot exhaustion would be silently omitted from the
+        // blocked_issues list, making the dashboard/TUI under-report blocked work.
+        for candidate in &sorted_candidates {
+            if !self.should_dispatch_issue(candidate) {
+                continue;
+            }
+            let (dep_blocked, blocker_ids) =
+                self.is_blocked_by_dependency(candidate, &sorted_candidates, &candidate_ids);
+            if dep_blocked {
+                blocked_entries.push(crate::domain::BlockedIssueEntry {
+                    issue_id: candidate.id.clone(),
+                    identifier: candidate.identifier.clone(),
+                    title: candidate.title.clone(),
+                    state: candidate.state.clone(),
+                    blocker_identifiers: blocker_ids,
+                });
+            }
+        }
+
+        // Second pass: dispatch non-blocked candidates until slots are exhausted.
+        let blocked_ids: std::collections::HashSet<&str> = blocked_entries
+            .iter()
+            .map(|e| e.issue_id.as_str())
+            .collect();
+
         for candidate in &sorted_candidates {
             if self.available_slots() == 0 {
                 tracing::debug!(
@@ -1516,17 +1543,8 @@ impl Orchestrator {
                 continue;
             }
 
-            // Check dependency blockers (applies to all active states)
-            let (dep_blocked, blocker_ids) =
-                self.is_blocked_by_dependency(candidate, &sorted_candidates, &candidate_ids);
-            if dep_blocked {
-                blocked_entries.push(crate::domain::BlockedIssueEntry {
-                    issue_id: candidate.id.clone(),
-                    identifier: candidate.identifier.clone(),
-                    title: candidate.title.clone(),
-                    state: candidate.state.clone(),
-                    blocker_identifiers: blocker_ids,
-                });
+            // Skip dependency-blocked candidates (already collected above)
+            if blocked_ids.contains(candidate.id.as_str()) {
                 continue;
             }
 
@@ -2570,8 +2588,9 @@ impl Orchestrator {
     /// with a warning, since Symphony cannot resolve them.
     ///
     /// When `candidate_ids` is provided, direct circular dependencies (A↔B)
-    /// are detected: if this issue blocks a candidate that also blocks this
-    /// issue, both are considered blocked and a warning is logged.
+    /// are detected and a warning is logged for observability. Note that the
+    /// circular detection itself does not cause blocking — both issues are
+    /// already blocked individually by the non-terminal blocker check above.
     fn is_blocked_by_dependency(
         &self,
         issue: &Issue,
@@ -2615,12 +2634,15 @@ impl Orchestrator {
             blocking_identifiers.push(blocker_id);
         }
 
-        // Check for direct circular dependencies (A↔B)
+        // Detect direct circular dependencies (A↔B) for observability.
+        // NOTE: This block is purely informational — it does NOT cause blocking.
+        // Both issues are already blocked naturally by the logic above: when A is
+        // processed it sees B as a non-terminal blocker, and vice versa. The warning
+        // simply makes circular relationships visible in logs for operators.
         if !blocking_identifiers.is_empty() {
             for blocker in &issue.blocked_by {
                 if let Some(blocker_issue_id) = &blocker.id {
                     if candidate_ids.contains(blocker_issue_id) {
-                        // Check if the blocker also has this issue as a blocker
                         if let Some(blocker_issue) =
                             all_issues.iter().find(|i| i.id == *blocker_issue_id)
                         {
@@ -2633,7 +2655,8 @@ impl Orchestrator {
                                     event = "circular_dependency_detected",
                                     issue_a = %issue.identifier,
                                     issue_b = %blocker_issue.identifier,
-                                    "circular dependency detected; both issues will be blocked"
+                                    "circular dependency detected between issues (both are \
+                                     already blocked individually by the non-terminal blocker check above)"
                                 );
                             }
                         }

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -435,11 +435,18 @@ fn draw_dashboard(
 
     let summary_lines_data = build_summary_lines(snapshot, throughput_line);
     let summary_height = summary_lines_data.len() as u16;
+    let has_blocked = !snapshot.blocked.is_empty();
+    let blocked_height = if has_blocked {
+        (snapshot.blocked.len() as u16 + 2).min(7)
+    } else {
+        0
+    };
     let sections = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(summary_height),
             Constraint::Min(8),
+            Constraint::Length(blocked_height),
             Constraint::Length(7),
             Constraint::Length(7),
             Constraint::Length(2),
@@ -489,6 +496,47 @@ fn draw_dashboard(
     );
     frame.render_widget(running_table, sections[1]);
 
+    // Blocked section (between Running and Retry)
+    if has_blocked {
+        let blocked_header = Row::new(vec![
+            Cell::from("ID"),
+            Cell::from("State"),
+            Cell::from("Blocked By"),
+        ])
+        .style(
+            Style::default()
+                .add_modifier(Modifier::BOLD)
+                .fg(Color::Yellow),
+        );
+        let blocked_rows: Vec<Row<'static>> = snapshot
+            .blocked
+            .iter()
+            .map(|entry| {
+                Row::new(vec![
+                    Cell::from(entry.identifier.clone()),
+                    Cell::from(entry.state.clone()),
+                    Cell::from(entry.blocker_identifiers.join(", ")),
+                ])
+            })
+            .collect();
+        let blocked_table = Table::new(
+            blocked_rows,
+            [
+                Constraint::Length(12),
+                Constraint::Length(14),
+                Constraint::Min(20),
+            ],
+        )
+        .header(blocked_header)
+        .block(
+            Block::default()
+                .title("Blocked")
+                .title_style(Style::default().fg(Color::Yellow))
+                .borders(Borders::ALL),
+        );
+        frame.render_widget(blocked_table, sections[2]);
+    }
+
     let retry_header = Row::new(vec![
         Cell::from("ID"),
         Cell::from("Attempt"),
@@ -510,12 +558,12 @@ fn draw_dashboard(
     )
     .header(retry_header)
     .block(Block::default().title("Retry Queue").borders(Borders::ALL));
-    frame.render_widget(retry_table, sections[2]);
+    frame.render_widget(retry_table, sections[3]);
 
     let completed_items = completed_items(snapshot);
     let completed_list =
         List::new(completed_items).block(Block::default().title("Completed").borders(Borders::ALL));
-    frame.render_widget(completed_list, sections[3]);
+    frame.render_widget(completed_list, sections[4]);
 
     let polling_last = snapshot
         .polling
@@ -533,7 +581,7 @@ fn draw_dashboard(
     let rate_summary = rate_summary(snapshot, now);
     let footer = Paragraph::new(vec![Line::from(polling_line), Line::from(rate_summary)])
         .wrap(Wrap { trim: true });
-    frame.render_widget(footer, sections[4]);
+    frame.render_widget(footer, sections[5]);
 }
 
 fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<'static>> {
@@ -941,6 +989,7 @@ mod tests {
                 event_count: 0,
                 seconds_running: 0.0,
             },
+            blocked: Vec::new(),
             codex_rate_limits: None,
             polling: crate::domain::PollingSnapshot {
                 checking: false,

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -343,6 +343,7 @@ fn test_orchestrator_snapshot_serializes() {
                 completed_at: Some(Utc::now()),
             },
         ],
+        blocked: vec![],
         codex_totals: CodexTotals::default(),
         codex_rate_limits: None,
         polling: PollingSnapshot {

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -7,8 +7,8 @@ use axum::http::{Method, Request, StatusCode};
 use chrono::{TimeZone, Utc};
 use serde_json::{json, Value};
 use symphony::domain::{
-    CodexTotals, CompletedEntry, OrchestratorSnapshot, PollingSnapshot, RateLimitInfo,
-    RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot,
+    BlockedIssueEntry, CodexTotals, CompletedEntry, OrchestratorSnapshot, PollingSnapshot,
+    RateLimitInfo, RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot,
     SessionTokenUsage, WorkerSessionInfo,
 };
 use symphony::http_server::{build_router, HttpServerState, RefreshControl, SnapshotSource};
@@ -135,6 +135,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
             event_count: 55,
             seconds_running: 42.5,
         },
+        blocked: vec![],
         codex_rate_limits: Some(RateLimitInfo {
             data: json!({
                 "remaining": 88,
@@ -480,5 +481,66 @@ async fn test_wrong_method_on_known_api_route_returns_json_405_error_envelope() 
             .unwrap_or_default()
             .contains("GET"),
         "405 envelope should include rejected method"
+    );
+}
+
+#[tokio::test]
+async fn test_dashboard_html_includes_blocked_section() {
+    let mut snapshot = fixture_snapshot();
+    snapshot.blocked = vec![BlockedIssueEntry {
+        issue_id: "issue-blocked-1".to_string(),
+        identifier: "SIM-100".to_string(),
+        title: "Blocked task".to_string(),
+        state: "Todo".to_string(),
+        blocker_identifiers: vec!["SIM-99".to_string()],
+    }];
+
+    let source = StaticSnapshotSource { snapshot };
+    let state = HttpServerState::new(Arc::new(source), Arc::new(FakeRefreshControl::default()));
+    let app = build_router(state);
+
+    let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let html = String::from_utf8_lossy(&body);
+    assert!(
+        html.contains("Blocked issues"),
+        "dashboard HTML should contain blocked issues section"
+    );
+}
+
+#[tokio::test]
+async fn test_state_json_includes_blocked_array() {
+    let mut snapshot = fixture_snapshot();
+    snapshot.blocked = vec![BlockedIssueEntry {
+        issue_id: "issue-blocked-2".to_string(),
+        identifier: "SIM-200".to_string(),
+        title: "Another blocked".to_string(),
+        state: "In Progress".to_string(),
+        blocker_identifiers: vec!["SIM-198".to_string(), "SIM-199".to_string()],
+    }];
+
+    let source = StaticSnapshotSource { snapshot };
+    let state = HttpServerState::new(Arc::new(source), Arc::new(FakeRefreshControl::default()));
+    let app = build_router(state);
+
+    let req = Request::builder()
+        .uri("/api/v1/state")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+
+    let blocked = payload["blocked"]
+        .as_array()
+        .expect("blocked should be an array");
+    assert_eq!(blocked.len(), 1);
+    assert_eq!(blocked[0]["identifier"], "SIM-200");
+    assert_eq!(
+        blocked[0]["blocker_identifiers"].as_array().unwrap().len(),
+        2
     );
 }

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -3114,3 +3114,183 @@ async fn test_execute_worker_attempt_stops_when_issue_unassigned_between_turns()
         "unassigned stop should not enqueue continuation retry"
     );
 }
+
+// ── T01: Generalized blocker + circular dependency tests ──────────────
+
+#[test]
+fn test_blocked_issue_in_progress_not_dispatched() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+
+    let mut blocked = issue("issue-blocked", "SIM-50", "In Progress", Some(1), 0);
+    blocked.blocked_by.push(BlockerRef {
+        id: Some("issue-blocker".to_string()),
+        identifier: Some("SIM-49".to_string()),
+        state: Some("In Progress".to_string()),
+    });
+
+    let unblocked = issue("issue-ok", "SIM-51", "Todo", Some(2), 0);
+
+    let mut port = FakePort {
+        candidate_issues: vec![blocked.clone(), unblocked.clone()],
+        ..FakePort::default()
+    };
+
+    let tick = orchestrator.tick(&mut port).expect("tick should succeed");
+    assert_eq!(
+        tick.dispatched_issue_ids,
+        vec![unblocked.id],
+        "In Progress issue with non-terminal blocker must not dispatch"
+    );
+}
+
+#[test]
+fn test_blocked_issue_with_terminal_blocker_dispatched() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+
+    let mut candidate = issue("issue-unblocked", "SIM-52", "Todo", Some(1), 0);
+    candidate.blocked_by.push(BlockerRef {
+        id: Some("issue-done".to_string()),
+        identifier: Some("SIM-48".to_string()),
+        state: Some("Done".to_string()),
+    });
+
+    let mut port = FakePort {
+        candidate_issues: vec![candidate.clone()],
+        ..FakePort::default()
+    };
+
+    let tick = orchestrator.tick(&mut port).expect("tick should succeed");
+    assert_eq!(
+        tick.dispatched_issue_ids,
+        vec![candidate.id],
+        "issue with terminal blocker should dispatch normally"
+    );
+}
+
+#[test]
+fn test_blocked_issue_in_agent_review_not_dispatched() {
+    let mut config = test_config(2);
+    config
+        .tracker
+        .active_states
+        .push("Agent Review".to_string());
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let mut blocked = issue("issue-ar", "SIM-53", "Agent Review", Some(1), 0);
+    blocked.blocked_by.push(BlockerRef {
+        id: Some("issue-dep".to_string()),
+        identifier: Some("SIM-47".to_string()),
+        state: Some("Todo".to_string()),
+    });
+
+    let mut port = FakePort {
+        candidate_issues: vec![blocked.clone()],
+        ..FakePort::default()
+    };
+
+    let tick = orchestrator.tick(&mut port).expect("tick should succeed");
+    assert!(
+        tick.dispatched_issue_ids.is_empty(),
+        "Agent Review issue with non-terminal blocker must not dispatch"
+    );
+}
+
+#[test]
+fn test_circular_dependency_blocks_both_issues() {
+    let mut orchestrator = Orchestrator::new(test_config(5), String::new());
+
+    let mut issue_a = issue("issue-a", "SIM-60", "Todo", Some(1), 0);
+    issue_a.blocked_by.push(BlockerRef {
+        id: Some("issue-b".to_string()),
+        identifier: Some("SIM-61".to_string()),
+        state: Some("Todo".to_string()),
+    });
+
+    let mut issue_b = issue("issue-b", "SIM-61", "Todo", Some(1), 0);
+    issue_b.blocked_by.push(BlockerRef {
+        id: Some("issue-a".to_string()),
+        identifier: Some("SIM-60".to_string()),
+        state: Some("Todo".to_string()),
+    });
+
+    let mut port = FakePort {
+        candidate_issues: vec![issue_a.clone(), issue_b.clone()],
+        ..FakePort::default()
+    };
+
+    let tick = orchestrator.tick(&mut port).expect("tick should succeed");
+    assert!(
+        tick.dispatched_issue_ids.is_empty(),
+        "circular dependency: neither issue should dispatch"
+    );
+}
+
+#[test]
+fn test_cross_project_unknown_blocker_treated_as_non_blocking() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+
+    let mut candidate = issue("issue-cross", "SIM-70", "Todo", Some(1), 0);
+    candidate.blocked_by.push(BlockerRef {
+        id: Some("ext-issue".to_string()),
+        identifier: Some("EXT-99".to_string()),
+        state: None, // cross-project, unknown state
+    });
+
+    let mut port = FakePort {
+        candidate_issues: vec![candidate.clone()],
+        ..FakePort::default()
+    };
+
+    let tick = orchestrator.tick(&mut port).expect("tick should succeed");
+    assert_eq!(
+        tick.dispatched_issue_ids,
+        vec![candidate.id],
+        "cross-project blocker with unknown state should be treated as non-blocking"
+    );
+}
+
+#[test]
+fn test_unblocked_issue_dispatches_normally() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+    let candidate = issue("issue-free", "SIM-80", "Todo", Some(1), 0);
+
+    let mut port = FakePort {
+        candidate_issues: vec![candidate.clone()],
+        ..FakePort::default()
+    };
+
+    let tick = orchestrator.tick(&mut port).expect("tick should succeed");
+    assert_eq!(
+        tick.dispatched_issue_ids,
+        vec![candidate.id],
+        "issue with no blockers should dispatch normally"
+    );
+}
+
+#[test]
+fn test_snapshot_includes_blocked_issues() {
+    let mut orchestrator = Orchestrator::new(test_config(2), String::new());
+
+    let mut blocked = issue("issue-snap-blocked", "SIM-90", "Todo", Some(1), 0);
+    blocked.blocked_by.push(BlockerRef {
+        id: Some("issue-snap-blocker".to_string()),
+        identifier: Some("SIM-89".to_string()),
+        state: Some("In Progress".to_string()),
+    });
+
+    let mut port = FakePort {
+        candidate_issues: vec![blocked.clone()],
+        ..FakePort::default()
+    };
+
+    orchestrator.tick(&mut port).expect("tick should succeed");
+    let snapshot = orchestrator.snapshot(chrono::Utc::now().timestamp_millis());
+
+    assert_eq!(
+        snapshot.blocked.len(),
+        1,
+        "snapshot should have 1 blocked entry"
+    );
+    assert_eq!(snapshot.blocked[0].identifier, "SIM-90");
+    assert_eq!(snapshot.blocked[0].blocker_identifiers, vec!["SIM-89"]);
+}


### PR DESCRIPTION
## Summary

Generalize blocker check to all active states, add circular dependency detection, and surface blocked issues in TUI and HTTP dashboard.

### Changes

- **Blocker generalization**: Renamed `todo_issue_blocked_by_non_terminal()` to `is_blocked_by_dependency()`, removed the Todo-only guard so the check applies to all active issue states
- **Circular dependency detection**: Direct A↔B cycles are detected and both issues are blocked with a warning log
- **Cross-project blockers**: Blockers with unknown state (cross-project) are treated as non-blocking with a warning
- **BlockedIssueEntry**: New struct in `domain.rs` with issue_id, identifier, title, state, blocker_identifiers
- **Snapshot**: `OrchestratorSnapshot.blocked` populated during dispatch phase
- **TUI**: Blocked section rendered between Running Sessions and Retry Queue (yellow header)
- **HTTP dashboard**: Blocked issues table in HTML, JS polling renders dynamically
- **API**: `/api/v1/state` JSON includes `blocked` array

### Tests

- 7 new orchestrator tests: all-state blocking, terminal blocker passthrough, Agent Review blocking, circular deps, cross-project handling, unblocked dispatch, snapshot inclusion
- 2 new HTTP server tests: dashboard HTML contains blocked section, JSON API includes blocked array

### Validation

- `cargo test` — 393 tests pass (9 new)
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean

Closes KAT-937, KAT-938
Refs KAT-927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Blocked issues" section to the dashboard and CLI/TUI, showing issues blocked by dependencies.
  * State endpoint now includes blocked-issue data so clients can render and react to blocked entries.

* **Tests**
  * Added unit and integration tests covering blocker gating, circular dependencies, API JSON, and dashboard rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR generalizes issue dependency blocking from Todo-only to all active states, adds direct circular dependency detection (A↔B), surfaces blocked issues in the orchestrator snapshot, and renders them in both the TUI (yellow \"Blocked\" section) and HTTP dashboard (dynamically polled table). The implementation is well-structured, comprehensively tested (9 new tests, all 393 pass), and the XSS-safe JS rendering is correct.\n\n**Key changes:**\n- `is_blocked_by_dependency()` replaces `todo_issue_blocked_by_non_terminal()` — applies to all active states, handles cross-project blockers as non-blocking with a warning\n- `BlockedIssueEntry` struct and `OrchestratorSnapshot.blocked` added in `domain.rs`; `#[serde(default)]` ensures backward compatibility\n- TUI inserts a conditional `Constraint::Length(blocked_height)` section and correctly renumbers all downstream section indices\n- HTTP dashboard hides the blocked section when the list is empty; `escapeHtml()` is used consistently\n\n**Issues found:**\n- `self.blocked_issues` is **not cleared** on early-return dispatch skips (preflight/config validation failures), causing the TUI and API to show stale blocked data until the next full dispatch\n- When the dispatch loop breaks at slot exhaustion, candidates not yet examined are silently omitted from `blocked_issues`

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the stale blocked_issues on skipped dispatch; all other changes are well-tested and logically sound.

The core dependency-ordering logic is correct and thoroughly tested. The P1 stale-state issue is a real UX regression but does not affect dispatch correctness — no issues are incorrectly dispatched or dropped. The P2s are observability-only. Domain model, TUI layout, HTTP surface, serialisation, and XSS handling are all clean.

apps/symphony/src/orchestrator.rs — the two early-return paths that skip updating self.blocked_issues

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Core logic change: replaces `todo_issue_blocked_by_non_terminal` with `is_blocked_by_dependency` (all active states); adds circular dep detection (log-only), cross-project blocker handling, and `blocked_issues` snapshot population. P1: stale `blocked_issues` on skipped dispatch. P2: incomplete blocked list on slot exhaustion. |
| apps/symphony/src/domain.rs | Adds `BlockedIssueEntry` struct and `blocked` field to `OrchestratorSnapshot` with `#[serde(default)]`; clean, minimal change. |
| apps/symphony/src/http_server.rs | Adds `blocked` to `StateResponse`, injects blocked issues into the HTML dashboard (with `escapeHtml` XSS protection), and populates via JS polling; straightforward and correct. |
| apps/symphony/src/tui.rs | Inserts a new `Constraint::Length(blocked_height)` section between Running and Retry; correctly shifts all downstream section indices and guards rendering behind `has_blocked`. |
| apps/symphony/tests/orchestrator_tests.rs | 7 new tests covering all-state blocking, terminal blocker passthrough, Agent Review blocking, circular deps, cross-project non-blocking, unblocked dispatch, and snapshot inclusion. |
| apps/symphony/tests/http_server_tests.rs | 2 new integration tests verifying dashboard HTML contains the blocked section and `/api/v1/state` JSON includes the `blocked` array. |
| apps/symphony/tests/domain_tests.rs | Trivial fixture update: adds `blocked: vec![]` so the existing serialization test compiles with the new field. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[dispatch_phase called] --> B{preflight / config valid?}
    B -- No --> C[return dispatch_skipped=true\nblocked_issues UNCHANGED ⚠️]
    B -- Yes --> D[fetch_candidate_issues\nsort_issues_for_dispatch\nbuild candidate_ids set]
    D --> E{for each candidate}
    E --> F{available_slots == 0?}
    F -- Yes --> G[break loop\nremaining candidates not checked ⚠️]
    F -- No --> H{should_dispatch_issue?}
    H -- No --> E
    H -- Yes --> I{is_blocked_by_dependency?}
    I -- Yes --> J[push BlockedIssueEntry\ncontinue]
    J --> E
    I -- No --> K[refresh_issue\ndispatch]
    K --> E
    E -- done --> L[self.blocked_issues = blocked_entries]
    L --> M[OrchestratorSnapshot.blocked populated]
    M --> N[TUI: yellow Blocked section]
    M --> O[HTTP /api/v1/state blocked array]
    M --> P[Dashboard JS polls & renders table]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/src/orchestrator.rs`, line 1465-1485 ([link](https://github.com/gannonh/kata/blob/2a5c17bd76280b339312d4c66d3faf23a1e98ed6/apps/symphony/src/orchestrator.rs#L1465-L1485)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale `blocked_issues` on skipped dispatch**

   When dispatch is skipped early — due to config validation failure or preflight failure — `self.blocked_issues` is never reset. It retains whatever entries were recorded in the previous successful dispatch run. This means the TUI and HTTP dashboard will continue showing issues as blocked even after their blockers may have been resolved, until the next full dispatch cycle runs successfully.

   A simple fix is to clear `blocked_issues` at the top of the dispatch method, before the early-return checks:

   ```rust
   // Reset blocked issues at the start of each dispatch attempt
   self.blocked_issues.clear();
   ```

   This way, a skipped dispatch will produce an empty blocked list rather than stale data.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/orchestrator.rs
   Line: 1465-1485

   Comment:
   **Stale `blocked_issues` on skipped dispatch**

   When dispatch is skipped early — due to config validation failure or preflight failure — `self.blocked_issues` is never reset. It retains whatever entries were recorded in the previous successful dispatch run. This means the TUI and HTTP dashboard will continue showing issues as blocked even after their blockers may have been resolved, until the next full dispatch cycle runs successfully.

   A simple fix is to clear `blocked_issues` at the top of the dispatch method, before the early-return checks:

   ```rust
   // Reset blocked issues at the start of each dispatch attempt
   self.blocked_issues.clear();
   ```

   This way, a skipped dispatch will produce an empty blocked list rather than stale data.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 1465-1485

Comment:
**Stale `blocked_issues` on skipped dispatch**

When dispatch is skipped early — due to config validation failure or preflight failure — `self.blocked_issues` is never reset. It retains whatever entries were recorded in the previous successful dispatch run. This means the TUI and HTTP dashboard will continue showing issues as blocked even after their blockers may have been resolved, until the next full dispatch cycle runs successfully.

A simple fix is to clear `blocked_issues` at the top of the dispatch method, before the early-return checks:

```rust
// Reset blocked issues at the start of each dispatch attempt
self.blocked_issues.clear();
```

This way, a skipped dispatch will produce an empty blocked list rather than stale data.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 1498-1530

Comment:
**Incomplete blocked list when loop breaks at slot exhaustion**

When `available_slots() == 0`, the dispatch loop breaks immediately and no further candidates are examined. `blocked_entries` (and therefore `self.blocked_issues`) will only contain blocked issues from candidates processed before the break — candidates later in the sorted order are silently omitted.

This is largely a cosmetic/observability concern but could be surprising: a user sees an issue as "not blocked" in the dashboard simply because all slots were full when its turn came. At minimum, a comment acknowledging this behaviour would help future readers.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 2618-2643

Comment:
**Circular dependency detection is informational-only**

The circular A↔B detection block logs a warning but does not alter the return value or otherwise change program behaviour. Both issues are already blocked naturally: when A is processed first, it sees B as a non-terminal blocker and returns `(true, [...])`. When B is processed, it sees A the same way.

The doc-string says "both issues will be **blocked**", which could mislead readers into thinking this block is the mechanism causing blocking. Consider adding an inline comment clarifying it is purely observability.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): generalize blocker check..."](https://github.com/gannonh/kata/commit/2a5c17bd76280b339312d4c66d3faf23a1e98ed6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26390549)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->