### PR TITLE
CLI v0.8.0

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.1
+
+### Fixes
+
+- **Linear error retry classification crash** — Fixed a runtime error in Linear HTTP retry handling where `isRetryable()` called a non-existent classifier (`classifyError`), which could surface as `classifyError is not defined` on auth/error paths.
+- **Doctor provider HOME-path test isolation** — Stabilized the provider diagnostics test by explicitly clearing and restoring `KATA_CODING_AGENT_DIR` in the HOME-resolution test to avoid environment leakage between test contexts.
+
 ## 0.7.0
 
 ### Features

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.7.1
+## 0.8.0
+
+### Features
+
+- **Issue relation support in built-in Linear tools (KAT-952)** — Added `linear_create_relation` and `linear_list_relations` for `blocks`, `blocked_by`, `relates_to`, and `duplicate` relationships. `linear_get_issue` responses now include normalized `relations` and a derived `blockedBy` array for dependency-aware consumers.
 
 ### Fixes
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
@@ -5,6 +5,14 @@ import { describe, it } from "node:test";
 
 import { formatProviderReport, runProviderChecks } from "../doctor-providers.ts";
 
+function restoreEnvVar(key: string, original: string | undefined): void {
+  if (original === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = original;
+}
+
 describe("runProviderChecks", () => {
   it("reports configured provider models as pass", async () => {
     const result = await runProviderChecks({
@@ -167,8 +175,8 @@ describe("runProviderChecks", () => {
       assert.ok(provider);
       assert.equal(provider.hasStoredCredential, true);
     } finally {
-      process.env.HOME = originalHome;
-      process.env.KATA_CODING_AGENT_DIR = originalAgentDir;
+      restoreEnvVar("HOME", originalHome);
+      restoreEnvVar("KATA_CODING_AGENT_DIR", originalAgentDir);
       rmSync(tempHome, { recursive: true, force: true });
     }
   });
@@ -206,8 +214,32 @@ describe("runProviderChecks", () => {
       assert.ok(provider);
       assert.equal(provider.hasStoredCredential, true);
     } finally {
-      process.env.KATA_CODING_AGENT_DIR = originalAgentDir;
+      restoreEnvVar("KATA_CODING_AGENT_DIR", originalAgentDir);
       rmSync(tempRoot, { recursive: true, force: true });
     }
+  });
+});
+
+describe("restoreEnvVar", () => {
+  it("deletes env var when original value is undefined", () => {
+    const key = "KATA_TEST_RESTORE_ENV_VAR";
+    const saved = process.env[key];
+
+    process.env[key] = "temp";
+    restoreEnvVar(key, undefined);
+
+    assert.equal(process.env[key], undefined);
+    restoreEnvVar(key, saved);
+  });
+
+  it("restores env var when original value exists", () => {
+    const key = "KATA_TEST_RESTORE_ENV_VAR";
+    const saved = process.env[key];
+
+    process.env[key] = "temp";
+    restoreEnvVar(key, "original");
+
+    assert.equal(process.env[key], "original");
+    restoreEnvVar(key, saved);
   });
 });

--- a/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
@@ -135,6 +135,7 @@ describe("runProviderChecks", () => {
 
   it("resolves default auth path from current HOME at check time", async () => {
     const originalHome = process.env.HOME;
+    const originalAgentDir = process.env.KATA_CODING_AGENT_DIR;
     const targetProvider = "anthropic";
 
     const tempHome = mkdtempSync(join(process.cwd(), ".tmp-doctor-provider-home-"));
@@ -152,6 +153,7 @@ describe("runProviderChecks", () => {
 
     try {
       process.env.HOME = tempHome;
+      delete process.env.KATA_CODING_AGENT_DIR;
       const result = await runProviderChecks({
         env: {},
         overrides: {
@@ -166,6 +168,7 @@ describe("runProviderChecks", () => {
       assert.equal(provider.hasStoredCredential, true);
     } finally {
       process.env.HOME = originalHome;
+      process.env.KATA_CODING_AGENT_DIR = originalAgentDir;
       rmSync(tempHome, { recursive: true, force: true });
     }
   });

--- a/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
@@ -225,21 +225,27 @@ describe("restoreEnvVar", () => {
     const key = "KATA_TEST_RESTORE_ENV_VAR";
     const saved = process.env[key];
 
-    process.env[key] = "temp";
-    restoreEnvVar(key, undefined);
+    try {
+      process.env[key] = "temp";
+      restoreEnvVar(key, undefined);
 
-    assert.equal(process.env[key], undefined);
-    restoreEnvVar(key, saved);
+      assert.equal(process.env[key], undefined);
+    } finally {
+      restoreEnvVar(key, saved);
+    }
   });
 
   it("restores env var when original value exists", () => {
     const key = "KATA_TEST_RESTORE_ENV_VAR";
     const saved = process.env[key];
 
-    process.env[key] = "temp";
-    restoreEnvVar(key, "original");
+    try {
+      process.env[key] = "temp";
+      restoreEnvVar(key, "original");
 
-    assert.equal(process.env[key], "original");
-    restoreEnvVar(key, saved);
+      assert.equal(process.env[key], "original");
+    } finally {
+      restoreEnvVar(key, saved);
+    }
   });
 });

--- a/apps/cli/src/resources/extensions/linear/http.ts
+++ b/apps/cli/src/resources/extensions/linear/http.ts
@@ -199,8 +199,8 @@ function isRetryable(error: unknown): boolean {
   }
   if (error instanceof LinearGraphQLError) {
     // GraphQL-level rate-limit or server errors should be retried.
-    // classifyError() identifies these via extensions.code / message patterns.
-    const classified = classifyError(error);
+    // classifyLinearError() identifies these via extensions.code / message patterns.
+    const classified = classifyLinearError(error);
     return classified.kind === "rate_limited" || classified.kind === "server_error";
   }
   if (error instanceof TypeError) return (error as TypeError).message.includes("fetch");

--- a/apps/cli/src/resources/extensions/linear/http.ts
+++ b/apps/cli/src/resources/extensions/linear/http.ts
@@ -31,14 +31,17 @@ export class LinearHttpError extends Error {
 /** Structured error for GraphQL-level failures (HTTP 200 but errors in body). */
 export class LinearGraphQLError extends Error {
   readonly errors: Array<{ message: string; extensions?: Record<string, unknown> }>;
+  readonly statusCode?: number;
 
   constructor(
     message: string,
     errors: Array<{ message: string; extensions?: Record<string, unknown> }>,
+    statusCode?: number,
   ) {
     super(message);
     this.name = "LinearGraphQLError";
     this.errors = errors;
+    this.statusCode = statusCode;
     Object.setPrototypeOf(this, LinearGraphQLError.prototype);
   }
 }
@@ -108,14 +111,20 @@ export function classifyLinearError(err: unknown): ClassifiedError {
 
     const extCode = String(extensions.code ?? "").toUpperCase();
     const extType = String(extensions.type ?? "").toLowerCase();
-    const extStatus = Number(extensions.statusCode ?? NaN);
+    const extensionStatus = Number(
+      extensions.statusCode
+      ?? extensions.httpStatus
+      ?? extensions.status
+      ?? NaN,
+    );
+    const statusCode = Number.isFinite(extensionStatus) ? extensionStatus : err.statusCode;
     const lowerMsg = firstMsg.toLowerCase();
 
     if (
-      extCode === "RATELIMITED" ||
-      extType === "ratelimited" ||
-      extStatus === 429 ||
-      lowerMsg.includes("rate limit")
+      extCode === "RATELIMITED"
+      || extType === "ratelimited"
+      || statusCode === 429
+      || lowerMsg.includes("rate limit")
     ) {
       // Linear's documented rate-limit info is in HTTP headers (X-RateLimit-Requests-Reset),
       // not in a GraphQL extensions.meta.rateLimitResult field. Try the undocumented path
@@ -131,6 +140,19 @@ export function classifyLinearError(err: unknown): ClassifiedError {
         message: `Rate limited: ${firstMsg}`,
         retryAfterMs,
       };
+    }
+
+    if (statusCode === 401 || statusCode === 403) {
+      return {
+        kind: "auth_error",
+        message: `Authentication error: ${firstMsg}. Use secure_env_collect to set LINEAR_API_KEY.`,
+      };
+    }
+    if (statusCode === 404) {
+      return { kind: "not_found", message: firstMsg };
+    }
+    if (typeof statusCode === "number" && statusCode >= 500) {
+      return { kind: "server_error", message: `Server error (HTTP ${statusCode}): ${firstMsg}` };
     }
 
     // Check for common GraphQL error patterns
@@ -259,7 +281,7 @@ export async function fetchWithRetry(
             : [];
 
         if (errors.length > 0) {
-          throw new LinearGraphQLError(errors[0].message, errors);
+          throw new LinearGraphQLError(errors[0].message, errors, response.status);
         }
 
         throw new LinearHttpError(

--- a/apps/cli/src/resources/extensions/linear/linear-client.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-client.ts
@@ -735,28 +735,26 @@ export class LinearClient {
   }
 
   async listRelations(issueId: string): Promise<LinearIssueRelation[]> {
-    try {
-      const data = await this.graphql<{
-        issue:
-          | {
-              relations?: { nodes?: unknown[] } | unknown[];
-              inverseRelations?: { nodes?: unknown[] } | unknown[];
-            }
-          | null;
-      }>(`
-        query ListIssueRelations($id: String!) {
-          issue(id: $id) {
-            ${LinearClient.ISSUE_RELATION_FIELDS}
+    const data = await this.graphql<{
+      issue:
+        | {
+            relations?: { nodes?: unknown[] } | unknown[];
+            inverseRelations?: { nodes?: unknown[] } | unknown[];
           }
+        | null;
+    }>(`
+      query ListIssueRelations($id: String!) {
+        issue(id: $id) {
+          ${LinearClient.ISSUE_RELATION_FIELDS}
         }
-      `, { id: issueId });
+      }
+    `, { id: issueId });
 
-      if (!data.issue) return [];
-      return this.normalizeRelations(data.issue as LinearIssue);
-    } catch (err) {
-      if (this.isNotFound(err)) return [];
-      throw err;
+    if (!data.issue) {
+      throw new LinearGraphQLError(`Issue not found: ${issueId}`, []);
     }
+
+    return this.normalizeRelations(data.issue as LinearIssue);
   }
 
   private normalizeRelationType(type: string): "blocks" | "relates_to" | "duplicate" {

--- a/apps/cli/src/resources/extensions/linear/linear-client.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-client.ts
@@ -452,63 +452,7 @@ export class LinearClient {
   // Issues (including sub-issues via parentId)
   // ===========================================================================
 
-  private static readonly ISSUE_FIELDS = `
-    id
-    identifier
-    title
-    description
-    priority
-    estimate
-    url
-    createdAt
-    updatedAt
-    state {
-      id
-      name
-      type
-      color
-      position
-    }
-    assignee {
-      id
-      name
-      email
-      displayName
-    }
-    labels {
-      nodes {
-        id
-        name
-        color
-      }
-    }
-    parent {
-      id
-      identifier
-      title
-    }
-    children {
-      nodes {
-        id
-        identifier
-        title
-        state {
-          id
-          name
-          type
-          color
-          position
-        }
-      }
-    }
-    project {
-      id
-      name
-    }
-    projectMilestone {
-      id
-      name
-    }
+  private static readonly ISSUE_RELATION_FIELDS = `
     relations {
       nodes {
         id
@@ -569,6 +513,66 @@ export class LinearClient {
         }
       }
     }
+  `;
+
+  private static readonly ISSUE_FIELDS = `
+    id
+    identifier
+    title
+    description
+    priority
+    estimate
+    url
+    createdAt
+    updatedAt
+    state {
+      id
+      name
+      type
+      color
+      position
+    }
+    assignee {
+      id
+      name
+      email
+      displayName
+    }
+    labels {
+      nodes {
+        id
+        name
+        color
+      }
+    }
+    parent {
+      id
+      identifier
+      title
+    }
+    children {
+      nodes {
+        id
+        identifier
+        title
+        state {
+          id
+          name
+          type
+          color
+          position
+        }
+      }
+    }
+    project {
+      id
+      name
+    }
+    projectMilestone {
+      id
+      name
+    }
+    ${LinearClient.ISSUE_RELATION_FIELDS}
   `;
 
   async createIssue(input: IssueCreateInput): Promise<LinearIssue> {
@@ -731,17 +735,44 @@ export class LinearClient {
   }
 
   async listRelations(issueId: string): Promise<LinearIssueRelation[]> {
-    const issue = await this.getIssue(issueId);
-    return issue?.relations ?? [];
+    try {
+      const data = await this.graphql<{
+        issue:
+          | {
+              relations?: { nodes?: unknown[] } | unknown[];
+              inverseRelations?: { nodes?: unknown[] } | unknown[];
+            }
+          | null;
+      }>(`
+        query ListIssueRelations($id: String!) {
+          issue(id: $id) {
+            ${LinearClient.ISSUE_RELATION_FIELDS}
+          }
+        }
+      `, { id: issueId });
+
+      if (!data.issue) return [];
+      return this.normalizeRelations(data.issue as LinearIssue);
+    } catch (err) {
+      if (this.isNotFound(err)) return [];
+      throw err;
+    }
   }
 
   private normalizeRelationType(type: string): "blocks" | "relates_to" | "duplicate" {
-    const normalized = (type ?? "").toLowerCase();
+    const normalized = (type ?? "").toLowerCase().trim();
+    if (normalized === "blocks") return "blocks";
     if (normalized === "duplicate") return "duplicate";
-    if (normalized === "related" || normalized === "relatedto" || normalized === "relates_to") {
+    if (
+      normalized === "related"
+      || normalized === "relatedto"
+      || normalized === "relates_to"
+      || normalized === "relatesto"
+      || normalized === "relates-to"
+    ) {
       return "relates_to";
     }
-    return "blocks";
+    return "relates_to";
   }
 
   private relationIssueRef(input: unknown): LinearIssueRelationIssueRef {

--- a/apps/cli/src/resources/extensions/linear/linear-client.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-client.ts
@@ -32,6 +32,9 @@ import type {
   IssueCreateInput,
   IssueUpdateInput,
   IssueFilter,
+  IssueRelationCreateInput,
+  LinearIssueRelation,
+  LinearIssueRelationIssueRef,
   LabelCreateInput,
   DocumentCreateInput,
   DocumentUpdateInput,
@@ -506,6 +509,66 @@ export class LinearClient {
       id
       name
     }
+    relations {
+      nodes {
+        id
+        type
+        issue {
+          id
+          identifier
+          title
+          state {
+            id
+            name
+            type
+            color
+            position
+          }
+        }
+        relatedIssue {
+          id
+          identifier
+          title
+          state {
+            id
+            name
+            type
+            color
+            position
+          }
+        }
+      }
+    }
+    inverseRelations {
+      nodes {
+        id
+        type
+        issue {
+          id
+          identifier
+          title
+          state {
+            id
+            name
+            type
+            color
+            position
+          }
+        }
+        relatedIssue {
+          id
+          identifier
+          title
+          state {
+            id
+            name
+            type
+            color
+            position
+          }
+        }
+      }
+    }
   `;
 
   async createIssue(input: IssueCreateInput): Promise<LinearIssue> {
@@ -605,11 +668,135 @@ export class LinearClient {
     return this.normalizeIssue(data.issueUpdate.issue);
   }
 
-  /** Normalize issue labels from connection format to flat array. */
+  private relationTypeToLinear(type: IssueRelationCreateInput["type"]): "blocks" | "related" | "duplicate" {
+    if (type === "duplicate") return "duplicate";
+    if (type === "relates_to") return "related";
+    return "blocks";
+  }
+
+  async createRelation(input: IssueRelationCreateInput): Promise<LinearIssueRelation> {
+    const isBlockedBy = input.type === "blocked_by";
+    const linearType = this.relationTypeToLinear(input.type);
+    const issueId = isBlockedBy ? input.relatedIssueId : input.issueId;
+    const relatedIssueId = isBlockedBy ? input.issueId : input.relatedIssueId;
+
+    const data = await this.graphql<{
+      issueRelationCreate: {
+        success: boolean;
+        issueRelation: {
+          id: string;
+          type: string;
+          issue: LinearIssueRelationIssueRef;
+          relatedIssue: LinearIssueRelationIssueRef;
+        };
+      };
+    }>(`
+      mutation CreateIssueRelation($input: IssueRelationCreateInput!) {
+        issueRelationCreate(input: $input) {
+          success
+          issueRelation {
+            id
+            type
+            issue { id identifier title }
+            relatedIssue { id identifier title }
+          }
+        }
+      }
+    `, {
+      input: {
+        issueId,
+        relatedIssueId,
+        type: linearType,
+      },
+    });
+
+    this.assertSuccess("issueRelationCreate", data.issueRelationCreate.success);
+
+    const raw = data.issueRelationCreate.issueRelation;
+    const normalizedType = this.normalizeRelationType(raw.type);
+    const direction: "outbound" | "inbound" = input.type === "blocked_by" ? "inbound" : "outbound";
+    const relationType = direction === "inbound" && normalizedType === "blocks" ? "blocked_by" : normalizedType;
+
+    const issueRef = this.relationIssueRef(raw.issue);
+    const relatedRef = this.relationIssueRef(raw.relatedIssue);
+
+    return {
+      id: raw.id,
+      type: relationType,
+      direction,
+      issue: issueRef,
+      relatedIssue: relatedRef,
+      otherIssue: direction === "outbound" ? relatedRef : issueRef,
+    };
+  }
+
+  async listRelations(issueId: string): Promise<LinearIssueRelation[]> {
+    const issue = await this.getIssue(issueId);
+    return issue?.relations ?? [];
+  }
+
+  private normalizeRelationType(type: string): "blocks" | "relates_to" | "duplicate" {
+    const normalized = (type ?? "").toLowerCase();
+    if (normalized === "duplicate") return "duplicate";
+    if (normalized === "related" || normalized === "relatedto" || normalized === "relates_to") {
+      return "relates_to";
+    }
+    return "blocks";
+  }
+
+  private relationIssueRef(input: unknown): LinearIssueRelationIssueRef {
+    const value = (input ?? {}) as Partial<LinearIssueRelationIssueRef>;
+    return {
+      id: value.id ?? "",
+      identifier: value.identifier ?? "",
+      title: value.title ?? "",
+      state: value.state ?? null,
+    };
+  }
+
+  private normalizeRelations(issue: LinearIssue): LinearIssueRelation[] {
+    const outboundRaw = (issue as unknown as { relations?: { nodes?: unknown[] } | unknown[] }).relations;
+    const inboundRaw = (issue as unknown as { inverseRelations?: { nodes?: unknown[] } | unknown[] }).inverseRelations;
+    const outbound = Array.isArray(outboundRaw) ? outboundRaw : (outboundRaw?.nodes ?? []);
+    const inbound = Array.isArray(inboundRaw) ? inboundRaw : (inboundRaw?.nodes ?? []);
+
+    const mapRelation = (raw: unknown, direction: "outbound" | "inbound"): LinearIssueRelation => {
+      const item = raw as {
+        id?: string;
+        type?: string;
+        issue?: unknown;
+        relatedIssue?: unknown;
+      };
+      const issueRef = this.relationIssueRef(item.issue);
+      const relatedRef = this.relationIssueRef(item.relatedIssue);
+      const otherIssue = direction === "outbound" ? relatedRef : issueRef;
+      const baseType = this.normalizeRelationType(item.type ?? "");
+      const type = direction === "inbound" && baseType === "blocks" ? "blocked_by" : baseType;
+      return {
+        id: item.id ?? "",
+        type,
+        direction,
+        issue: issueRef,
+        relatedIssue: relatedRef,
+        otherIssue,
+      };
+    };
+
+    return [
+      ...outbound.map((item) => mapRelation(item, "outbound")),
+      ...inbound.map((item) => mapRelation(item, "inbound")),
+    ];
+  }
+
+  /** Normalize issue labels from connection format to flat array and include relation helpers. */
   private normalizeIssue(issue: LinearIssue): LinearIssue {
     const raw = issue.labels as unknown as { nodes?: LinearLabel[] } | LinearLabel[];
     const labels = Array.isArray(raw) ? raw : (raw?.nodes ?? []);
-    return { ...issue, labels };
+    const relations = this.normalizeRelations(issue);
+    const blockedBy = relations
+      .filter((relation) => relation.type === "blocked_by")
+      .map((relation) => relation.otherIssue);
+    return { ...issue, labels, relations, blockedBy };
   }
 
   // ===========================================================================

--- a/apps/cli/src/resources/extensions/linear/linear-tools.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-tools.ts
@@ -306,6 +306,42 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
   });
 
   pi.registerTool({
+    name: "linear_create_relation",
+    label: "Linear: Create Relation",
+    description: "Create an issue relation (blocks, blocked_by, relates_to, duplicate).",
+    promptSnippet: "Create an issue relation between two issues.",
+    parameters: Type.Object({
+      issueId: Type.String({ description: "UUID of the source issue" }),
+      relatedIssueId: Type.String({ description: "UUID of the related issue" }),
+      type: Type.Union(
+        [
+          Type.Literal("blocks"),
+          Type.Literal("blocked_by"),
+          Type.Literal("relates_to"),
+          Type.Literal("duplicate"),
+        ],
+        { description: "Relation type" }
+      ),
+    }),
+    async execute(_id, params) {
+      return run(() => client.createRelation(params));
+    },
+  });
+
+  pi.registerTool({
+    name: "linear_list_relations",
+    label: "Linear: List Relations",
+    description: "List all relations for an issue (outbound and inbound) with normalized direction.",
+    promptSnippet: "List all relations for an issue.",
+    parameters: Type.Object({
+      issueId: Type.String({ description: "Issue UUID" }),
+    }),
+    async execute(_id, params) {
+      return run(() => client.listRelations(params.issueId));
+    },
+  });
+
+  pi.registerTool({
     name: "linear_update_issue",
     label: "Linear: Update Issue",
     description: "Update an issue's title, description, state, labels, priority, assignee, parent, project, or milestone.",

--- a/apps/cli/src/resources/extensions/linear/linear-types.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-types.ts
@@ -20,6 +20,7 @@ export interface LinearPageInfo {
 
 export type ProjectState = "planned" | "started" | "paused" | "completed" | "canceled" | "backlog";
 export type LinearPriority = 0 | 1 | 2 | 3 | 4;
+export type LinearIssueRelationKind = "blocks" | "blocked_by" | "relates_to" | "duplicate";
 
 // =============================================================================
 // Entities
@@ -82,6 +83,22 @@ export interface LinearLabel {
   parentId?: string;
 }
 
+export interface LinearIssueRelationIssueRef {
+  id: string;
+  identifier: string;
+  title: string;
+  state?: LinearWorkflowState | null;
+}
+
+export interface LinearIssueRelation {
+  id: string;
+  type: LinearIssueRelationKind;
+  direction: "outbound" | "inbound";
+  issue: LinearIssueRelationIssueRef;
+  relatedIssue: LinearIssueRelationIssueRef;
+  otherIssue: LinearIssueRelationIssueRef;
+}
+
 export interface LinearIssue {
   id: string;
   identifier: string;
@@ -97,6 +114,8 @@ export interface LinearIssue {
   children: { nodes: Array<{ id: string; identifier: string; title: string; state: LinearWorkflowState }> };
   project?: { id: string; name: string } | null;
   projectMilestone?: { id: string; name: string } | null;
+  relations?: LinearIssueRelation[];
+  blockedBy?: LinearIssueRelationIssueRef[];
   createdAt: string;
   updatedAt: string;
 }
@@ -238,6 +257,12 @@ export interface IssueFilter {
   labelIds?: string[];
   assigneeId?: string;
   first?: number;
+}
+
+export interface IssueRelationCreateInput {
+  issueId: string;
+  relatedIssueId: string;
+  type: LinearIssueRelationKind;
 }
 
 export interface LabelCreateInput {

--- a/apps/cli/src/resources/extensions/linear/tests/http-retry.test.ts
+++ b/apps/cli/src/resources/extensions/linear/tests/http-retry.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { fetchWithRetry } from "../http.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("fetchWithRetry", () => {
+  it("retries GraphQL-wrapped 5xx responses and succeeds on a subsequent attempt", async () => {
+    let attempts = 0;
+
+    globalThis.fetch = (async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response(
+          JSON.stringify({
+            errors: [{ message: "Transient upstream failure" }],
+          }),
+          {
+            status: 503,
+            statusText: "Service Unavailable",
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const response = await fetchWithRetry("https://example.invalid/graphql", { method: "POST" }, 1);
+
+    assert.equal(response.status, 200);
+    assert.equal(attempts, 2);
+  });
+});

--- a/apps/cli/src/resources/extensions/linear/tests/linear-client-relations.test.ts
+++ b/apps/cli/src/resources/extensions/linear/tests/linear-client-relations.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { LinearClient } from "../linear-client.ts";
+
+describe("LinearClient relation helpers", () => {
+  it("listRelations queries relations directly instead of delegating to getIssue", async () => {
+    const client = new LinearClient("test-key", "https://example.invalid/graphql");
+
+    (client as unknown as { getIssue: (id: string) => Promise<unknown> }).getIssue = async () => {
+      throw new Error("listRelations should not call getIssue");
+    };
+
+    (client as unknown as { graphql: (query: string, vars?: Record<string, unknown>) => Promise<unknown> }).graphql =
+      async (_query: string, vars?: Record<string, unknown>) => {
+        assert.deepEqual(vars, { id: "issue-1" });
+        return {
+          issue: {
+            relations: { nodes: [] },
+            inverseRelations: { nodes: [] },
+          },
+        };
+      };
+
+    const relations = await client.listRelations("issue-1");
+    assert.deepEqual(relations, []);
+  });
+
+  it("normalizes unknown relation types to relates_to instead of blocks", () => {
+    const client = new LinearClient("test-key", "https://example.invalid/graphql");
+    const normalize = (client as unknown as { normalizeRelationType: (type: string) => string }).normalizeRelationType;
+
+    assert.equal(normalize("mystery_relation"), "relates_to");
+    assert.equal(normalize(""), "relates_to");
+    assert.equal(normalize("blocks"), "blocks");
+  });
+});

--- a/apps/cli/src/resources/extensions/linear/tests/linear-client-relations.test.ts
+++ b/apps/cli/src/resources/extensions/linear/tests/linear-client-relations.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { LinearClient } from "../linear-client.ts";
+import { LinearGraphQLError } from "../http.ts";
 
 describe("LinearClient relation helpers", () => {
   it("listRelations queries relations directly instead of delegating to getIssue", async () => {
@@ -33,5 +34,17 @@ describe("LinearClient relation helpers", () => {
     assert.equal(normalize("mystery_relation"), "relates_to");
     assert.equal(normalize(""), "relates_to");
     assert.equal(normalize("blocks"), "blocks");
+  });
+
+  it("throws for missing issues instead of returning an empty relation list", async () => {
+    const client = new LinearClient("test-key", "https://example.invalid/graphql");
+
+    (client as unknown as { graphql: (query: string, vars?: Record<string, unknown>) => Promise<unknown> }).graphql =
+      async (_query: string, vars?: Record<string, unknown>) => {
+        assert.deepEqual(vars, { id: "missing-issue" });
+        throw new LinearGraphQLError("Issue not found", []);
+      };
+
+    await assert.rejects(() => client.listRelations("missing-issue"));
   });
 });


### PR DESCRIPTION
CLI release v0.8.0

## Highlights
- Add built-in Linear issue relation support (KAT-952):
  - `linear_create_relation`
  - `linear_list_relations`
  - `linear_get_issue` now includes normalized `relations` and derived `blockedBy`
- Fix Linear retry classifier runtime crash in `linear/http.ts`
- Stabilize provider diagnostics HOME-path test isolation

## Verification
- `npx tsc`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linear: create and list issue relationships (blocks, blocked_by, relates_to, duplicate). Issues now include relation and blocked-by info.

* **Bug Fixes**
  * Improved Linear GraphQL error classification and retry behavior to better detect auth, not-found, rate-limit, and server errors.

* **Tests**
  * Added tests for relation handling and fetch retry behavior; safer env-var restore helper in tests.

* **Chores**
  * CLI package version bumped to 0.8.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR releases CLI v0.8.0 with three distinct changes: built-in Linear issue relation support (`linear_create_relation` and `linear_list_relations`), a runtime crash fix in the Linear HTTP retry classifier, and improved test isolation for the doctor-providers HOME-path test.

**Key changes:**
- **Linear relation tools**: `createRelation` handles `blocks`, `blocked_by`, `relates_to`, and `duplicate` by swapping arguments for `blocked_by` before sending the canonical `blocks` mutation to Linear's API, then re-normalizing the response direction. `normalizeIssue` now also hydrates `relations` and a derived `blockedBy` array on every `getIssue`/`updateIssue` response by combining outbound `relations` and inbound `inverseRelations` from GraphQL.
- **Crash fix in `http.ts`**: `isRetryable` was calling the non-existent `classifyError`; now correctly calls `classifyLinearError`, fixing a runtime `ReferenceError` on any GraphQL-level rate-limit or error path.
- **Test stabilization**: The HOME-path isolation test now saves and restores `KATA_CODING_AGENT_DIR` in addition to `HOME`, preventing env-variable leakage across test contexts — though the restore has a subtle Node.js coercion issue (see inline comment).

<h3>Confidence Score: 4/5</h3>

Safe to merge with one targeted fix — the P1 test isolation bug has no production impact.

Crash fix and new relation tools are correct. The single P1 is in a test file only: a one-liner fix needed in the finally block.

apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts — env-var restore in finally block needs a conditional delete

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts | Adds KATA_CODING_AGENT_DIR save/restore, but the finally block coerces undefined to the string "undefined" instead of deleting the key. |
| apps/cli/src/resources/extensions/linear/linear-client.ts | Adds createRelation, listRelations, and normalization helpers; blocked_by direction-swap logic is correct. |
| apps/cli/src/resources/extensions/linear/http.ts | Fixes isRetryable crash by using the correct classifyLinearError function name. |
| apps/cli/src/resources/extensions/linear/linear-tools.ts | Registers two new relation tools with correct TypeBox schemas. |
| apps/cli/src/resources/extensions/linear/linear-types.ts | Adds relation interfaces and extends LinearIssue — clean, well-typed. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/tests/doctor-providers.test.ts
Line: 171

Comment:
**Restoring `undefined` env var writes the string `"undefined"` instead of deleting the key**

In Node.js, assigning `undefined` to a `process.env` property coerces it to the string `"undefined"`. When `KATA_CODING_AGENT_DIR` was not set before the test, the `finally` block sets it to `"undefined"` rather than leaving it unset. Use a conditional restore mirroring the `delete` pattern in the `try` block.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/linear/linear-client.ts
Line: 733-736

Comment:
**`listRelations` fetches the full issue — a dedicated query would be cheaper**

`listRelations` delegates to `getIssue`, which fetches all issue fields just to read the `relations` array. A dedicated query would be more efficient.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/linear/linear-client.ts
Line: 738-745

Comment:
**`normalizeRelationType` silently maps unknown/empty types to `"blocks"`**

Any unrecognized type string falls through to `"blocks"`. If Linear adds new relation types, they'd be silently misclassified.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(linear): add issue relation support..."](https://github.com/gannonh/kata/commit/83f8296d98ea2ed03b51bbc03f81d2786c54761b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26450112)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->