### PR TITLE
fix(symphony): end multi-turn session when issue state changes

### DIFF
--- a/apps/symphony/CHANGELOG.md
+++ b/apps/symphony/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.1 — Fix multi-turn session continuing after state change
+
+### Critical Fix
+
+- **Multi-turn session now ends when issue state changes** — when an agent moves an issue from one active state to another (e.g. `In Progress` → `Agent Review`), the session now ends so the orchestrator can re-dispatch with the correct per-state prompt. Previously the multi-turn loop continued with the stale prompt because both states were "active," which could lead to the agent taking unauthorized actions (like merging a PR) after running out of meaningful work.
+
 ## 1.2.0 — Per-state prompts, dependency ordering, live tool activity
 
 ### Per-State Prompt Injection

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symphony"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Symphony orchestrator — polls Linear, dispatches Codex agent sessions"
 license = "MIT"

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1388,19 +1388,20 @@ impl Orchestrator {
             if let Some(attempt) = self.state.running.get_mut(&d.issue.id) {
                 attempt.status = "running".to_string();
             }
-            let issue = d.issue.clone();
+            let mut issue = d.issue.clone();
             let attempt = d.attempt;
             let worker_host = d.worker_host.clone();
             let tx = self.worker_result_tx.clone();
 
-            // Resolve per-state prompt using the post-dispatch state from
-            // running_issue_states (set during dispatch_issue), falling back to
-            // issue.state if not yet tracked.
+            // Use the post-dispatch state (after Todo→In Progress transition) so
+            // the multi-turn loop's between-turn check compares against the actual
+            // dispatched state, not the stale pre-transition state.
             let effective_state = self
                 .running_issue_states
                 .get(&issue.id)
                 .cloned()
                 .unwrap_or_else(|| issue.state.clone());
+            issue.state = effective_state.clone();
             let prompt_template = self.resolve_prompt_for_state(&effective_state);
 
             let task_config = WorkerTaskConfig {

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -111,16 +111,33 @@ fn effective_pi_model_for_issue(config: &ServiceConfig, issue: &Issue) -> Option
     config.pi_agent.model_for_state(&issue.state)
 }
 
-fn should_continue_issue_in_session(issue: &Issue, tracker_config: &TrackerConfig) -> bool {
+/// Determine whether a multi-turn session should continue after a turn completes.
+///
+/// Returns `true` only if:
+/// - The issue is still assigned to this worker
+/// - The issue is in an active (non-terminal) state
+/// - The issue state has NOT changed from the state it was dispatched with
+///
+/// A state change (e.g. In Progress → Agent Review) means the orchestrator
+/// should end this session and dispatch a new one with the appropriate per-state
+/// prompt. Without this check, the multi-turn loop continues with a stale prompt
+/// and the agent never receives the instructions for the new state.
+fn should_continue_issue_in_session(
+    issue: &Issue,
+    tracker_config: &TrackerConfig,
+    dispatched_state: &str,
+) -> bool {
     issue.assigned_to_worker
         && is_active_state(&issue.state, tracker_config)
         && !is_terminal_state(&issue.state, tracker_config)
+        && normalize_issue_state(&issue.state) == normalize_issue_state(dispatched_state)
 }
 
 async fn check_issue_still_active(
     issue: &Issue,
     client: &crate::linear::client::LinearClient,
     tracker_config: &TrackerConfig,
+    dispatched_state: &str,
 ) -> IssueCheck {
     match client
         .fetch_issue_states_by_ids(std::slice::from_ref(&issue.id))
@@ -128,9 +145,21 @@ async fn check_issue_still_active(
     {
         Ok(issues) => match issues.first() {
             Some(refreshed) => {
-                if should_continue_issue_in_session(refreshed, tracker_config) {
+                if should_continue_issue_in_session(refreshed, tracker_config, dispatched_state) {
                     IssueCheck::Continue(refreshed.clone())
                 } else {
+                    if is_active_state(&refreshed.state, tracker_config)
+                        && normalize_issue_state(&refreshed.state)
+                            != normalize_issue_state(dispatched_state)
+                    {
+                        tracing::info!(
+                            issue_id = %refreshed.id,
+                            issue_identifier = %refreshed.identifier,
+                            dispatched_state = %dispatched_state,
+                            current_state = %refreshed.state,
+                            "issue state changed during session; ending session for re-dispatch with new prompt"
+                        );
+                    }
                     IssueCheck::Done(refreshed.clone())
                 }
             }
@@ -200,7 +229,14 @@ where
             break;
         }
 
-        match check_issue_still_active(&current_issue, &issue_state_client, tracker_config).await {
+        match check_issue_still_active(
+            &current_issue,
+            &issue_state_client,
+            tracker_config,
+            &issue.state,
+        )
+        .await
+        {
             IssueCheck::Continue(refreshed) => {
                 current_issue = refreshed;
                 turn_number = turn_number.saturating_add(1);
@@ -294,7 +330,14 @@ where
             break;
         }
 
-        match check_issue_still_active(&current_issue, &issue_state_client, tracker_config).await {
+        match check_issue_still_active(
+            &current_issue,
+            &issue_state_client,
+            tracker_config,
+            &issue.state,
+        )
+        .await
+        {
             IssueCheck::Continue(refreshed) => {
                 current_issue = refreshed;
                 turn_number = turn_number.saturating_add(1);

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -3334,3 +3334,77 @@ fn test_blocked_issues_cleared_on_tick_start() {
         "blocked should be cleared at tick start, not carry over from previous tick"
     );
 }
+
+#[tokio::test]
+async fn test_execute_worker_attempt_stops_when_issue_changes_to_different_active_state() {
+    let mut server = Server::new_async().await;
+    let issue = issue(
+        "issue-state-change",
+        "SIM-STATECHANGE",
+        "In Progress",
+        Some(1),
+        0,
+    );
+
+    // After turn 1, the issue moved to "Agent Review" — still active, but different state
+    let _state_lookup = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&state_lookup_response(
+                &issue.id,
+                &issue.identifier,
+                "Agent Review",
+                None,
+            ))
+            .expect("state response should serialize"),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let scripts_dir = tempdir().expect("scripts dir should be created");
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let prompt_log = scripts_dir.path().join("prompts.log");
+    let script = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        &script_two_successful_turns(&prompt_log),
+    );
+
+    let mut config = make_worker_config(&server, &script, workspace_root.path(), 5);
+    // Add "Agent Review" to active states so it's recognized as active
+    config
+        .tracker
+        .active_states
+        .push("Agent Review".to_string());
+
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let result = orchestrator
+        .execute_worker_attempt(
+            &issue,
+            "First prompt {{ issue.identifier }}",
+            Some(1),
+            |_query, _vars| async { Ok(serde_json::json!({ "data": {} })) },
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "worker should stop cleanly when issue changes to a different active state"
+    );
+
+    let prompt_lines: Vec<String> = std::fs::read_to_string(&prompt_log)
+        .expect("prompt log should exist")
+        .lines()
+        .map(|line| line.to_string())
+        .collect();
+    assert_eq!(
+        prompt_lines.len(),
+        1,
+        "state change from In Progress to Agent Review should stop after turn 1 — \
+         the orchestrator needs to re-dispatch with the agent-review prompt"
+    );
+}

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -3408,3 +3408,9 @@ async fn test_execute_worker_attempt_stops_when_issue_changes_to_different_activ
          the orchestrator needs to re-dispatch with the agent-review prompt"
     );
 }
+
+// Covered by test_execute_worker_attempt_runs_multiple_turns_in_one_session:
+// same-state (In Progress → In Progress) continues normally for 2+ turns.
+// The Todo→In Progress auto-transition sets issue.state = effective_state in
+// spawn_workers_for_dispatched before the worker sees it, so the dispatched
+// state is always the post-transition state.


### PR DESCRIPTION
## Problem

When an agent moves an issue from `In Progress` to `Agent Review` mid-session, the multi-turn loop continues because both states are active. The agent never receives the agent-review prompt. After enough idle continuation turns, the agent took initiative and merged a PR without human approval (KAT-999).

## Root cause

`should_continue_issue_in_session()` only checked if the issue was still in an active, non-terminal state. It didn't check if the state **changed** from the dispatched state.

## Fix

Added a `dispatched_state` parameter to `should_continue_issue_in_session()` and `check_issue_still_active()`. The between-turn check now compares the current state against the dispatched state. A state change — even to another active state — ends the session so the orchestrator can re-dispatch with the correct per-state prompt.

When a state change is detected, an info log is emitted:
```
issue state changed during session; ending session for re-dispatch with new prompt
```

## Test

`test_execute_worker_attempt_stops_when_issue_changes_to_different_active_state` — dispatches an issue as `In Progress`, mocks Linear to return `Agent Review` after the first turn, verifies the session stops after 1 turn instead of continuing.

## Impact

This is a critical fix for per-state prompts. Without it, the multi-turn loop can run indefinitely with a stale prompt when the agent advances the issue state.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical multi-turn session bug where an issue advancing from `In Progress` to `Agent Review` (both active states) caused the orchestrator to keep looping with the stale per-state prompt, eventually allowing unsupervised actions like merging a PR without approval (KAT-999).

The fix threads a `dispatched_state` value through `should_continue_issue_in_session` and `check_issue_still_active`. A simple normalized-string comparison (`normalize_issue_state(&current) != normalize_issue_state(&dispatched)`) now terminates the session when any state change is detected, even a change between two active states. The session ends with `schedule_continuation = false`, and the issue is naturally re-picked on the next orchestrator tick with the correct per-state prompt.

**Key changes:**
- `should_continue_issue_in_session` gains a `dispatched_state: &str` parameter and adds the state-equality guard
- `check_issue_still_active` gains the same parameter; an `info`-level structured log is emitted when the specific "active state changed" case triggers the session stop
- Both `run_codex_turns_in_session` and `run_pi_turns_in_session` pass `&issue.state` (the original dispatch-time state, not the mutable `current_issue.state`) ensuring the guard is evaluated against the correct baseline
- New integration test verifies the session stops after 1 turn when the mock returns a different active state after turn 1

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted, well-tested fix for a confirmed production incident with no regressions introduced.

The change is minimal and surgical: a single guard added to one function, threaded through two call sites, with a dedicated integration test that would have caught the original bug. The dispatched_state baseline is correctly captured from the immutable issue parameter rather than the mutable current_issue, so it cannot drift during a session. normalize_issue_state (trim + lowercase) is already used by the surrounding is_active_state/is_terminal_state helpers, so the comparison is consistent. The schedule_continuation = false path already existed for other session-termination reasons; the re-dispatch on the next tick is handled by the standard orchestrator loop, which does not exclude issues from completed when calling should_dispatch_issue. No public API surface changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Adds dispatched_state parameter to should_continue_issue_in_session and check_issue_still_active; a normalized state comparison now correctly terminates the multi-turn loop when the issue state changes between turns, with an info-level log for the state-change case. |
| apps/symphony/tests/orchestrator_tests.rs | Adds test_execute_worker_attempt_stops_when_issue_changes_to_different_active_state which dispatches an In Progress issue, mocks Linear to return Agent Review after turn 1, and asserts the session stops after exactly 1 turn instead of running 2. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant L as Linear
    participant A as Agent

    Note over O: Tick - issue dispatched as In Progress
    O->>A: "run_turn(turn 1, in-progress prompt)"
    A-->>O: turn completed
    O->>L: "fetch_issue_states_by_ids(issue_id)"
    L-->>O: "state = Agent Review (active)"
    Note over O: dispatched_state=In Progress, current=Agent Review - state changed
    O->>O: "log info: issue state changed, ending session"
    O->>O: "schedule_continuation = false, break"
    Note over O: Next Tick - issue re-fetched from Linear
    O->>A: "run_turn(turn 1, agent-review prompt)"
```

<sub>Reviews (1): Last reviewed commit: ["fix(symphony): end multi-turn session wh..."](https://github.com/gannonh/kata/commit/32f7505d1dc155dc9bfeaeb1223f1f931f049823) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26483301)</sub>

<!-- /greptile_comment -->