### PR TITLE
[S02] auto.ts Decision Logic Extraction & Tests

### DIFF
--- a/apps/cli/src/resources/extensions/kata/auto-dispatch.ts
+++ b/apps/cli/src/resources/extensions/kata/auto-dispatch.ts
@@ -1,0 +1,86 @@
+/**
+ * Auto-dispatch decision logic — pure functions for determining what unit
+ * to dispatch next in auto-mode.
+ *
+ * Extracted from auto.ts to enable isolated testing. No pi SDK imports.
+ */
+
+import type { KataState } from "./types.js";
+import type { PromptOptions } from "./backend.js";
+
+// Re-export PromptOptions for convenience
+export type { PromptOptions };
+
+/**
+ * Determine the unit type to dispatch based on current state and options.
+ * Returns a string like "plan-milestone", "execute-task", etc.
+ */
+export function deriveUnitType(state: KataState, options: PromptOptions): string {
+  if (options.uatSliceId) return "run-uat";
+  if (options.reassessSliceId) return "reassess-roadmap";
+  if (options.dispatchResearch === "milestone") return "research-milestone";
+  if (options.dispatchResearch === "slice") return "research-slice";
+  switch (state.phase) {
+    case "pre-planning":
+      return "plan-milestone";
+    case "planning":
+      return "plan-slice";
+    case "executing":
+    case "verifying":
+      return "execute-task";
+    case "summarizing":
+      return "complete-slice";
+    case "completing-milestone":
+      return "complete-milestone";
+    case "replanning-slice":
+      return "replan-slice";
+    default:
+      return `unknown-${state.phase}`;
+  }
+}
+
+/**
+ * Derive the unit ID from the current state and options.
+ * Format: "mid", "mid/sid", or "mid/sid/tid" depending on depth.
+ */
+export function deriveUnitId(state: KataState, options?: PromptOptions): string {
+  const mid = state.activeMilestone?.id ?? "unknown";
+  // UAT and reassessment target the *previous* (completed) slice, not the
+  // now-active one. Use the dispatch option IDs when available so the unit
+  // key correctly identifies the work being done.
+  const sid = options?.uatSliceId ?? options?.reassessSliceId ?? state.activeSlice?.id;
+  const tid = state.activeTask?.id;
+  if (tid && sid && !options?.uatSliceId && !options?.reassessSliceId) return `${mid}/${sid}/${tid}`;
+  if (sid) return `${mid}/${sid}`;
+  return mid;
+}
+
+/**
+ * Peek at what the next unit will be after the current one completes.
+ * Used for the progress widget display.
+ */
+export function peekNext(unitType: string, state: KataState): string {
+  const sid = state.activeSlice?.id ?? "";
+  switch (unitType) {
+    case "research-milestone":
+      return "plan milestone roadmap";
+    case "plan-milestone":
+      return "research first slice";
+    case "research-slice":
+      return `plan ${sid}`;
+    case "plan-slice":
+      return "execute first task";
+    case "execute-task":
+      return `continue ${sid}`;
+    case "complete-slice":
+      return "reassess roadmap";
+    case "replan-slice":
+      return `re-execute ${sid}`;
+    case "reassess-roadmap":
+      return "advance to next slice";
+    case "run-uat":
+      return "reassess roadmap";
+    default:
+      return "";
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/auto-recovery.ts
+++ b/apps/cli/src/resources/extensions/kata/auto-recovery.ts
@@ -5,7 +5,7 @@
  * Extracted from auto.ts to enable isolated testing. No pi SDK imports.
  */
 
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
   existsSync,
   mkdirSync,
@@ -137,12 +137,12 @@ export function writeBlockerPlaceholder(
 ): string | null {
   const absPath = resolveExpectedArtifactPath(unitType, unitId, base);
   if (!absPath) return null;
-  const dir = absPath.substring(0, absPath.lastIndexOf("/"));
+  const dir = dirname(absPath);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   const content = [
     `# BLOCKER — auto-mode recovery failed`,
     ``,
-    `Unit \`${unitType}\` for \`${unitId}\` failed to produce this artifact after idle recovery exhausted all retries.`,
+    `Unit \`${unitType}\` for \`${unitId}\` failed to produce this artifact during auto-mode recovery.`,
     ``,
     `**Reason**: ${reason}`,
     ``,

--- a/apps/cli/src/resources/extensions/kata/auto-recovery.ts
+++ b/apps/cli/src/resources/extensions/kata/auto-recovery.ts
@@ -1,0 +1,194 @@
+/**
+ * Auto-recovery decision logic — pure/filesystem-only functions for crash
+ * recovery, provider backoff, skip artifacts, and expected artifact resolution.
+ *
+ * Extracted from auto.ts to enable isolated testing. No pi SDK imports.
+ */
+
+import { join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import {
+  resolveTasksDir,
+  resolveSlicePath,
+  resolveSliceFile,
+  resolveMilestonePath,
+  buildTaskFileName,
+  buildMilestoneFileName,
+  buildSliceFileName,
+  relMilestoneFile,
+  relSliceFile,
+} from "./paths.js";
+
+/** Backoff delay in ms: 5s, 10s, 20s, 40s, 60s, 60s, ... */
+export function providerBackoffMs(attempt: number): number {
+  return Math.min(5000 * Math.pow(2, attempt), 60_000);
+}
+
+/**
+ * Write skip artifacts for a stuck execute-task: a blocker task summary and
+ * the [x] checkbox in the slice plan. Returns true if artifacts were written.
+ */
+export function skipExecuteTask(
+  base: string,
+  mid: string,
+  sid: string,
+  tid: string,
+  status: { summaryExists: boolean; taskChecked: boolean },
+  reason: string,
+  maxAttempts: number,
+): boolean {
+  // Write a blocker task summary if missing.
+  if (!status.summaryExists) {
+    const tasksDir = resolveTasksDir(base, mid, sid);
+    const sDir = resolveSlicePath(base, mid, sid);
+    const targetDir = tasksDir ?? (sDir ? join(sDir, "tasks") : null);
+    if (!targetDir) return false;
+    if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
+    const summaryPath = join(targetDir, buildTaskFileName(tid, "SUMMARY"));
+    const content = [
+      `# BLOCKER — task skipped by auto-mode recovery`,
+      ``,
+      `Task \`${tid}\` in slice \`${sid}\` (milestone \`${mid}\`) failed to complete after ${reason} recovery exhausted ${maxAttempts} attempts.`,
+      ``,
+      `This placeholder was written by auto-mode so the pipeline can advance.`,
+      `Review this task manually and replace this file with a real summary.`,
+    ].join("\n");
+    writeFileSync(summaryPath, content, "utf-8");
+  }
+
+  // Mark [x] in the slice plan if not already checked.
+  if (!status.taskChecked) {
+    const planAbs = resolveSliceFile(base, mid, sid, "PLAN");
+    if (planAbs && existsSync(planAbs)) {
+      const planContent = readFileSync(planAbs, "utf-8");
+      const escapedTid = tid.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const re = new RegExp(`^(- \\[) \\] (\\*\\*${escapedTid}:)`, "m");
+      if (re.test(planContent)) {
+        writeFileSync(planAbs, planContent.replace(re, "$1x] $2"), "utf-8");
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Resolve the expected artifact for a non-execute-task unit to an absolute path.
+ * Returns null for unit types that don't produce a single file (execute-task,
+ * complete-slice, replan-slice).
+ */
+export function resolveExpectedArtifactPath(
+  unitType: string,
+  unitId: string,
+  base: string,
+): string | null {
+  const parts = unitId.split("/");
+  const mid = parts[0]!;
+  const sid = parts[1];
+  switch (unitType) {
+    case "research-milestone": {
+      const dir = resolveMilestonePath(base, mid);
+      return dir ? join(dir, buildMilestoneFileName(mid, "RESEARCH")) : null;
+    }
+    case "plan-milestone": {
+      const dir = resolveMilestonePath(base, mid);
+      return dir ? join(dir, buildMilestoneFileName(mid, "ROADMAP")) : null;
+    }
+    case "research-slice": {
+      const dir = resolveSlicePath(base, mid, sid!);
+      return dir ? join(dir, buildSliceFileName(sid!, "RESEARCH")) : null;
+    }
+    case "plan-slice": {
+      const dir = resolveSlicePath(base, mid, sid!);
+      return dir ? join(dir, buildSliceFileName(sid!, "PLAN")) : null;
+    }
+    case "reassess-roadmap": {
+      const dir = resolveSlicePath(base, mid, sid!);
+      return dir ? join(dir, buildSliceFileName(sid!, "ASSESSMENT")) : null;
+    }
+    case "run-uat": {
+      const dir = resolveSlicePath(base, mid, sid!);
+      return dir ? join(dir, buildSliceFileName(sid!, "UAT-RESULT")) : null;
+    }
+    case "complete-milestone": {
+      const dir = resolveMilestonePath(base, mid);
+      return dir ? join(dir, buildMilestoneFileName(mid, "SUMMARY")) : null;
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Write a placeholder artifact so the pipeline can advance past a stuck unit.
+ * Returns the diagnostic description of what was written, or null if the path
+ * couldn't be resolved.
+ */
+export function writeBlockerPlaceholder(
+  unitType: string,
+  unitId: string,
+  base: string,
+  reason: string,
+): string | null {
+  const absPath = resolveExpectedArtifactPath(unitType, unitId, base);
+  if (!absPath) return null;
+  const dir = absPath.substring(0, absPath.lastIndexOf("/"));
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const content = [
+    `# BLOCKER — auto-mode recovery failed`,
+    ``,
+    `Unit \`${unitType}\` for \`${unitId}\` failed to produce this artifact after idle recovery exhausted all retries.`,
+    ``,
+    `**Reason**: ${reason}`,
+    ``,
+    `This placeholder was written by auto-mode so the pipeline can advance.`,
+    `Review and replace this file before relying on downstream artifacts.`,
+  ].join("\n");
+  writeFileSync(absPath, content, "utf-8");
+  return diagnoseExpectedArtifact(unitType, unitId, base);
+}
+
+/**
+ * Return a human-readable diagnostic description of the expected artifact
+ * for a given unit type/id, or null for unknown types.
+ */
+export function diagnoseExpectedArtifact(
+  unitType: string,
+  unitId: string,
+  base: string,
+): string | null {
+  const parts = unitId.split("/");
+  const mid = parts[0];
+  const sid = parts[1];
+  switch (unitType) {
+    case "research-milestone":
+      return `${relMilestoneFile(base, mid!, "RESEARCH")} (milestone research)`;
+    case "plan-milestone":
+      return `${relMilestoneFile(base, mid!, "ROADMAP")} (milestone roadmap)`;
+    case "research-slice":
+      return `${relSliceFile(base, mid!, sid!, "RESEARCH")} (slice research)`;
+    case "plan-slice":
+      return `${relSliceFile(base, mid!, sid!, "PLAN")} (slice plan)`;
+    case "execute-task": {
+      const tid = parts[2];
+      return `Task ${tid} marked [x] in ${relSliceFile(base, mid!, sid!, "PLAN")} + summary written`;
+    }
+    case "complete-slice":
+      return `Slice ${sid} marked [x] in ${relMilestoneFile(base, mid!, "ROADMAP")} + summary written`;
+    case "replan-slice":
+      return `${relSliceFile(base, mid!, sid!, "REPLAN")} + updated ${relSliceFile(base, mid!, sid!, "PLAN")}`;
+    case "reassess-roadmap":
+      return `${relSliceFile(base, mid!, sid!, "ASSESSMENT")} (roadmap reassessment)`;
+    case "run-uat":
+      return `${relSliceFile(base, mid!, sid!, "UAT-RESULT")} (UAT result)`;
+    case "complete-milestone":
+      return `${relMilestoneFile(base, mid!, "SUMMARY")} (milestone summary)`;
+    default:
+      return null;
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/auto-transitions.ts
+++ b/apps/cli/src/resources/extensions/kata/auto-transitions.ts
@@ -1,0 +1,77 @@
+/**
+ * Auto-transitions — file-mode precondition logic for ensuring directories
+ * and branches exist before dispatching a unit.
+ *
+ * Extracted from auto.ts to enable isolated testing. No pi SDK imports.
+ */
+
+import { join } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import {
+  resolveMilestonePath,
+  resolveDir,
+  milestonesDir,
+} from "./paths.js";
+import { ensureSliceBranch } from "./worktree.ts";
+import type { KataState } from "./types.js";
+
+/** Unit types that require a slice-level branch checkout. */
+const SLICE_BRANCH_UNITS = [
+  "research-slice",
+  "plan-slice",
+  "execute-task",
+  "complete-slice",
+  "replan-slice",
+] as const;
+
+/**
+ * Ensure directories, branches, and other prerequisites exist before
+ * dispatching a unit. The LLM should never need to mkdir or git checkout.
+ */
+export function ensurePreconditions(
+  unitType: string,
+  unitId: string,
+  base: string,
+  _state: KataState,
+): void {
+  const parts = unitId.split("/");
+  const mid = parts[0]!;
+
+  // Always ensure milestone dir exists
+  const mDir = resolveMilestonePath(base, mid);
+  if (!mDir) {
+    const newDir = join(milestonesDir(base), mid);
+    mkdirSync(join(newDir, "slices"), { recursive: true });
+  }
+
+  // For slice-level units, ensure slice dir exists
+  if (parts.length >= 2) {
+    const sid = parts[1]!;
+
+    // Re-resolve milestone path after potential creation
+    const mDirResolved = resolveMilestonePath(base, mid);
+    if (mDirResolved) {
+      const slicesDir = join(mDirResolved, "slices");
+      const sDir = resolveDir(slicesDir, sid);
+      if (!sDir) {
+        // Create slice dir with bare ID
+        const newSliceDir = join(slicesDir, sid);
+        mkdirSync(join(newSliceDir, "tasks"), { recursive: true });
+      } else {
+        // Ensure tasks/ subdir exists
+        const tasksDir = join(slicesDir, sDir, "tasks");
+        if (!existsSync(tasksDir)) {
+          mkdirSync(tasksDir, { recursive: true });
+        }
+      }
+    }
+  }
+
+  if (
+    (SLICE_BRANCH_UNITS as readonly string[]).includes(unitType) &&
+    parts.length >= 2
+  ) {
+    const sid = parts[1]!;
+    ensureSliceBranch(base, mid, sid);
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/auto-transitions.ts
+++ b/apps/cli/src/resources/extensions/kata/auto-transitions.ts
@@ -12,7 +12,7 @@ import {
   resolveDir,
   milestonesDir,
 } from "./paths.js";
-import { ensureSliceBranch } from "./worktree.ts";
+import { ensureSliceBranch as defaultEnsureSliceBranch } from "./worktree.ts";
 import type { KataState } from "./types.js";
 
 /** Unit types that require a slice-level branch checkout. */
@@ -24,6 +24,12 @@ const SLICE_BRANCH_UNITS = [
   "replan-slice",
 ] as const;
 
+/** Options for overriding dependencies in tests. */
+export interface EnsurePreconditionsOptions {
+  /** Override ensureSliceBranch for testing (default: real implementation). */
+  ensureSliceBranch?: (base: string, mid: string, sid: string) => void;
+}
+
 /**
  * Ensure directories, branches, and other prerequisites exist before
  * dispatching a unit. The LLM should never need to mkdir or git checkout.
@@ -33,7 +39,9 @@ export function ensurePreconditions(
   unitId: string,
   base: string,
   _state: KataState,
+  options?: EnsurePreconditionsOptions,
 ): void {
+  const ensureSliceBranch = options?.ensureSliceBranch ?? defaultEnsureSliceBranch;
   const parts = unitId.split("/");
   const mid = parts[0]!;
 

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -71,25 +71,14 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
-  writeFileSync,
 } from "node:fs";
 import {
   kataRoot,
   resolveMilestoneFile,
   resolveSliceFile,
-  resolveSlicePath,
   resolveMilestonePath,
   resolveDir,
-  resolveTasksDir,
-  resolveTaskFiles,
-  relMilestoneFile,
-  relSliceFile,
-  relSlicePath,
-  relMilestonePath,
   milestonesDir,
-  buildMilestoneFileName,
-  buildSliceFileName,
-  buildTaskFileName,
 } from "./paths.js";
 import {
   loadFile,
@@ -112,6 +101,8 @@ export { resolveModelSwitch, computeSupervisorTimeouts } from "./auto-helpers.js
 export type { ModelSwitchResult } from "./auto-helpers.js";
 import { deriveUnitType, deriveUnitId, peekNext } from "./auto-dispatch.js";
 export { deriveUnitType, deriveUnitId, peekNext } from "./auto-dispatch.js";
+import { providerBackoffMs, skipExecuteTask, resolveExpectedArtifactPath, writeBlockerPlaceholder, diagnoseExpectedArtifact } from "./auto-recovery.js";
+export { skipExecuteTask, resolveExpectedArtifactPath, writeBlockerPlaceholder } from "./auto-recovery.js";
 
 // ─── State ────────────────────────────────────────────────────────────────────
 
@@ -469,11 +460,6 @@ export async function startAuto(
 }
 
 // ─── Agent End Handler ────────────────────────────────────────────────────────
-
-/** Backoff delay in ms: 5s, 10s, 20s, 40s, 60s, 60s, ... */
-function providerBackoffMs(attempt: number): number {
-  return Math.min(5000 * Math.pow(2, attempt), 60_000);
-}
 
 /**
  * Handle a provider/network error during auto-mode.
@@ -1849,161 +1835,4 @@ async function recoverTimedOutUnit(
   return "paused";
 }
 
-/**
- * Write skip artifacts for a stuck execute-task: a blocker task summary and
- * the [x] checkbox in the slice plan. Returns true if artifacts were written.
- */
-export function skipExecuteTask(
-  base: string,
-  mid: string,
-  sid: string,
-  tid: string,
-  status: { summaryExists: boolean; taskChecked: boolean },
-  reason: string,
-  maxAttempts: number,
-): boolean {
-  // Write a blocker task summary if missing.
-  if (!status.summaryExists) {
-    const tasksDir = resolveTasksDir(base, mid, sid);
-    const sDir = resolveSlicePath(base, mid, sid);
-    const targetDir = tasksDir ?? (sDir ? join(sDir, "tasks") : null);
-    if (!targetDir) return false;
-    if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
-    const summaryPath = join(targetDir, buildTaskFileName(tid, "SUMMARY"));
-    const content = [
-      `# BLOCKER — task skipped by auto-mode recovery`,
-      ``,
-      `Task \`${tid}\` in slice \`${sid}\` (milestone \`${mid}\`) failed to complete after ${reason} recovery exhausted ${maxAttempts} attempts.`,
-      ``,
-      `This placeholder was written by auto-mode so the pipeline can advance.`,
-      `Review this task manually and replace this file with a real summary.`,
-    ].join("\n");
-    writeFileSync(summaryPath, content, "utf-8");
-  }
 
-  // Mark [x] in the slice plan if not already checked.
-  if (!status.taskChecked) {
-    const planAbs = resolveSliceFile(base, mid, sid, "PLAN");
-    if (planAbs && existsSync(planAbs)) {
-      const planContent = readFileSync(planAbs, "utf-8");
-      const escapedTid = tid.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const re = new RegExp(`^(- \\[) \\] (\\*\\*${escapedTid}:)`, "m");
-      if (re.test(planContent)) {
-        writeFileSync(planAbs, planContent.replace(re, "$1x] $2"), "utf-8");
-      }
-    }
-  }
-
-  return true;
-}
-
-/**
- * Resolve the expected artifact for a non-execute-task unit to an absolute path.
- * Returns null for unit types that don't produce a single file (execute-task,
- * complete-slice, replan-slice).
- */
-export function resolveExpectedArtifactPath(
-  unitType: string,
-  unitId: string,
-  base: string,
-): string | null {
-  const parts = unitId.split("/");
-  const mid = parts[0]!;
-  const sid = parts[1];
-  switch (unitType) {
-    case "research-milestone": {
-      const dir = resolveMilestonePath(base, mid);
-      return dir ? join(dir, buildMilestoneFileName(mid, "RESEARCH")) : null;
-    }
-    case "plan-milestone": {
-      const dir = resolveMilestonePath(base, mid);
-      return dir ? join(dir, buildMilestoneFileName(mid, "ROADMAP")) : null;
-    }
-    case "research-slice": {
-      const dir = resolveSlicePath(base, mid, sid!);
-      return dir ? join(dir, buildSliceFileName(sid!, "RESEARCH")) : null;
-    }
-    case "plan-slice": {
-      const dir = resolveSlicePath(base, mid, sid!);
-      return dir ? join(dir, buildSliceFileName(sid!, "PLAN")) : null;
-    }
-    case "reassess-roadmap": {
-      const dir = resolveSlicePath(base, mid, sid!);
-      return dir ? join(dir, buildSliceFileName(sid!, "ASSESSMENT")) : null;
-    }
-    case "run-uat": {
-      const dir = resolveSlicePath(base, mid, sid!);
-      return dir ? join(dir, buildSliceFileName(sid!, "UAT-RESULT")) : null;
-    }
-    case "complete-milestone": {
-      const dir = resolveMilestonePath(base, mid);
-      return dir ? join(dir, buildMilestoneFileName(mid, "SUMMARY")) : null;
-    }
-    default:
-      return null;
-  }
-}
-
-/**
- * Write a placeholder artifact so the pipeline can advance past a stuck unit.
- * Returns the relative path written, or null if the path couldn't be resolved.
- */
-export function writeBlockerPlaceholder(
-  unitType: string,
-  unitId: string,
-  base: string,
-  reason: string,
-): string | null {
-  const absPath = resolveExpectedArtifactPath(unitType, unitId, base);
-  if (!absPath) return null;
-  const dir = absPath.substring(0, absPath.lastIndexOf("/"));
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  const content = [
-    `# BLOCKER — auto-mode recovery failed`,
-    ``,
-    `Unit \`${unitType}\` for \`${unitId}\` failed to produce this artifact after idle recovery exhausted all retries.`,
-    ``,
-    `**Reason**: ${reason}`,
-    ``,
-    `This placeholder was written by auto-mode so the pipeline can advance.`,
-    `Review and replace this file before relying on downstream artifacts.`,
-  ].join("\n");
-  writeFileSync(absPath, content, "utf-8");
-  return diagnoseExpectedArtifact(unitType, unitId, base);
-}
-
-function diagnoseExpectedArtifact(
-  unitType: string,
-  unitId: string,
-  base: string,
-): string | null {
-  const parts = unitId.split("/");
-  const mid = parts[0];
-  const sid = parts[1];
-  switch (unitType) {
-    case "research-milestone":
-      return `${relMilestoneFile(base, mid!, "RESEARCH")} (milestone research)`;
-    case "plan-milestone":
-      return `${relMilestoneFile(base, mid!, "ROADMAP")} (milestone roadmap)`;
-    case "research-slice":
-      return `${relSliceFile(base, mid!, sid!, "RESEARCH")} (slice research)`;
-    case "plan-slice":
-      return `${relSliceFile(base, mid!, sid!, "PLAN")} (slice plan)`;
-    case "execute-task": {
-      const tid = parts[2];
-      return `Task ${tid} marked [x] in ${relSliceFile(base, mid!, sid!, "PLAN")} + summary written`;
-    }
-    case "complete-slice":
-      return `Slice ${sid} marked [x] in ${relMilestoneFile(base, mid!, "ROADMAP")} + summary written`;
-    case "replan-slice":
-      return `${relSliceFile(base, mid!, sid!, "REPLAN")} + updated ${relSliceFile(base, mid!, sid!, "PLAN")}`;
-    case "reassess-roadmap":
-      return `${relSliceFile(base, mid!, sid!, "ASSESSMENT")} (roadmap reassessment)`;
-    case "run-uat":
-      return `${relSliceFile(base, mid!, sid!, "UAT-RESULT")} (UAT result)`;
-    case "complete-milestone":
-      return `${relMilestoneFile(base, mid!, "SUMMARY")} (milestone summary)`;
-    default:
-      return null;
-  }
-}

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -69,16 +69,12 @@ import {
 import { join } from "node:path";
 import {
   existsSync,
-  mkdirSync,
   readFileSync,
 } from "node:fs";
 import {
   kataRoot,
   resolveMilestoneFile,
   resolveSliceFile,
-  resolveMilestonePath,
-  resolveDir,
-  milestonesDir,
 } from "./paths.js";
 import {
   loadFile,
@@ -89,7 +85,6 @@ import { unitVerb, unitPhaseLabel } from "./unit-display.js";
 import { formatDuration } from "./markdown-utils.js";
 import {
   autoCommitCurrentBranch,
-  ensureSliceBranch,
   switchToMain,
   mergeSliceToMain,
 } from "./worktree.ts";
@@ -103,6 +98,8 @@ import { deriveUnitType, deriveUnitId, peekNext } from "./auto-dispatch.js";
 export { deriveUnitType, deriveUnitId, peekNext } from "./auto-dispatch.js";
 import { providerBackoffMs, skipExecuteTask, resolveExpectedArtifactPath, writeBlockerPlaceholder, diagnoseExpectedArtifact } from "./auto-recovery.js";
 export { skipExecuteTask, resolveExpectedArtifactPath, writeBlockerPlaceholder } from "./auto-recovery.js";
+import { ensurePreconditions } from "./auto-transitions.js";
+export { ensurePreconditions } from "./auto-transitions.js";
 
 // ─── State ────────────────────────────────────────────────────────────────────
 
@@ -1492,66 +1489,6 @@ async function dispatchNextUnit(
         await pauseAuto(ctx, pi);
       }
     }
-  }
-}
-
-// ─── Preconditions ────────────────────────────────────────────────────────────
-
-/**
- * Ensure directories, branches, and other prerequisites exist before
- * dispatching a unit. The LLM should never need to mkdir or git checkout.
- */
-function ensurePreconditions(
-  unitType: string,
-  unitId: string,
-  base: string,
-  _state: KataState,
-): void {
-  const parts = unitId.split("/");
-  const mid = parts[0]!;
-
-  // Always ensure milestone dir exists
-  const mDir = resolveMilestonePath(base, mid);
-  if (!mDir) {
-    const newDir = join(milestonesDir(base), mid);
-    mkdirSync(join(newDir, "slices"), { recursive: true });
-  }
-
-  // For slice-level units, ensure slice dir exists
-  if (parts.length >= 2) {
-    const sid = parts[1]!;
-
-    // Re-resolve milestone path after potential creation
-    const mDirResolved = resolveMilestonePath(base, mid);
-    if (mDirResolved) {
-      const slicesDir = join(mDirResolved, "slices");
-      const sDir = resolveDir(slicesDir, sid);
-      if (!sDir) {
-        // Create slice dir with bare ID
-        const newSliceDir = join(slicesDir, sid);
-        mkdirSync(join(newSliceDir, "tasks"), { recursive: true });
-      } else {
-        // Ensure tasks/ subdir exists
-        const tasksDir = join(slicesDir, sDir, "tasks");
-        if (!existsSync(tasksDir)) {
-          mkdirSync(tasksDir, { recursive: true });
-        }
-      }
-    }
-  }
-
-  if (
-    [
-      "research-slice",
-      "plan-slice",
-      "execute-task",
-      "complete-slice",
-      "replan-slice",
-    ].includes(unitType) &&
-    parts.length >= 2
-  ) {
-    const sid = parts[1]!;
-    ensureSliceBranch(base, mid, sid);
   }
 }
 

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -77,7 +77,6 @@ import {
   resolveSliceFile,
 } from "./paths.js";
 import {
-  loadFile,
   parseRoadmap,
   parsePlan,
 } from "./files.js";

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -110,6 +110,8 @@ import { makeUI, GLYPH, INDENT } from "../shared/ui.js";
 import { resolveModelSwitch, computeSupervisorTimeouts } from "./auto-helpers.js";
 export { resolveModelSwitch, computeSupervisorTimeouts } from "./auto-helpers.js";
 export type { ModelSwitchResult } from "./auto-helpers.js";
+import { deriveUnitType, deriveUnitId, peekNext } from "./auto-dispatch.js";
+export { deriveUnitType, deriveUnitId, peekNext } from "./auto-dispatch.js";
 
 // ─── State ────────────────────────────────────────────────────────────────────
 
@@ -579,33 +581,6 @@ export async function handleAgentEnd(
 
 // ─── Progress Widget ──────────────────────────────────────────────────────
 
-
-function peekNext(unitType: string, state: KataState): string {
-  const sid = state.activeSlice?.id ?? "";
-  switch (unitType) {
-    case "research-milestone":
-      return "plan milestone roadmap";
-    case "plan-milestone":
-      return "research first slice";
-    case "research-slice":
-      return `plan ${sid}`;
-    case "plan-slice":
-      return "execute first task";
-    case "execute-task":
-      return `continue ${sid}`;
-    case "complete-slice":
-      return "reassess roadmap";
-    case "replan-slice":
-      return `re-execute ${sid}`;
-    case "reassess-roadmap":
-      return "advance to next slice";
-    case "run-uat":
-      return "reassess roadmap";
-    default:
-      return "";
-  }
-}
-
 /** Right-align helper: build a line with left content and right content. */
 function rightAlign(left: string, right: string, width: number): string {
   const leftVis = visibleWidth(left);
@@ -880,42 +855,6 @@ async function resolveDispatchOptions(
   }
 
   return options;
-}
-
-function deriveUnitType(state: KataState, options: PromptOptions): string {
-  if (options.uatSliceId) return "run-uat";
-  if (options.reassessSliceId) return "reassess-roadmap";
-  if (options.dispatchResearch === "milestone") return "research-milestone";
-  if (options.dispatchResearch === "slice") return "research-slice";
-  switch (state.phase) {
-    case "pre-planning":
-      return "plan-milestone";
-    case "planning":
-      return "plan-slice";
-    case "executing":
-    case "verifying":
-      return "execute-task";
-    case "summarizing":
-      return "complete-slice";
-    case "completing-milestone":
-      return "complete-milestone";
-    case "replanning-slice":
-      return "replan-slice";
-    default:
-      return `unknown-${state.phase}`;
-  }
-}
-
-function deriveUnitId(state: KataState, options?: PromptOptions): string {
-  const mid = state.activeMilestone?.id ?? "unknown";
-  // UAT and reassessment target the *previous* (completed) slice, not the
-  // now-active one. Use the dispatch option IDs when available so the unit
-  // key correctly identifies the work being done.
-  const sid = options?.uatSliceId ?? options?.reassessSliceId ?? state.activeSlice?.id;
-  const tid = state.activeTask?.id;
-  if (tid && sid && !options?.uatSliceId && !options?.reassessSliceId) return `${mid}/${sid}/${tid}`;
-  if (sid) return `${mid}/${sid}`;
-  return mid;
 }
 
 // ─── PR Gate Helper ───────────────────────────────────────────────────────────

--- a/apps/cli/src/resources/extensions/kata/tests/auto-dispatch.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/auto-dispatch.vitest.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from "vitest";
+import { deriveUnitType, deriveUnitId, peekNext } from "../auto-dispatch.js";
+import type { KataState } from "../types.js";
+import type { PromptOptions } from "../backend.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeState(overrides: Partial<KataState> = {}): KataState {
+  return {
+    activeMilestone: { id: "M001", title: "Milestone 1" },
+    activeSlice: { id: "S01", title: "Slice 1" },
+    activeTask: null,
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+    ...overrides,
+  };
+}
+
+function opts(overrides: Partial<PromptOptions> = {}): PromptOptions {
+  return { ...overrides };
+}
+
+// ─── deriveUnitType ───────────────────────────────────────────────────────────
+
+describe("deriveUnitType", () => {
+  it("returns 'run-uat' when uatSliceId is set", () => {
+    const state = makeState({ phase: "executing" });
+    expect(deriveUnitType(state, opts({ uatSliceId: "S01" }))).toBe("run-uat");
+  });
+
+  it("returns 'reassess-roadmap' when reassessSliceId is set", () => {
+    const state = makeState({ phase: "executing" });
+    expect(deriveUnitType(state, opts({ reassessSliceId: "S01" }))).toBe("reassess-roadmap");
+  });
+
+  it("returns 'research-milestone' when dispatchResearch is 'milestone'", () => {
+    const state = makeState({ phase: "pre-planning" });
+    expect(deriveUnitType(state, opts({ dispatchResearch: "milestone" }))).toBe("research-milestone");
+  });
+
+  it("returns 'research-slice' when dispatchResearch is 'slice'", () => {
+    const state = makeState({ phase: "planning" });
+    expect(deriveUnitType(state, opts({ dispatchResearch: "slice" }))).toBe("research-slice");
+  });
+
+  it("returns 'plan-milestone' for pre-planning phase", () => {
+    expect(deriveUnitType(makeState({ phase: "pre-planning" }), opts())).toBe("plan-milestone");
+  });
+
+  it("returns 'plan-slice' for planning phase", () => {
+    expect(deriveUnitType(makeState({ phase: "planning" }), opts())).toBe("plan-slice");
+  });
+
+  it("returns 'execute-task' for executing phase", () => {
+    expect(deriveUnitType(makeState({ phase: "executing" }), opts())).toBe("execute-task");
+  });
+
+  it("returns 'execute-task' for verifying phase", () => {
+    expect(deriveUnitType(makeState({ phase: "verifying" }), opts())).toBe("execute-task");
+  });
+
+  it("returns 'complete-slice' for summarizing phase", () => {
+    expect(deriveUnitType(makeState({ phase: "summarizing" }), opts())).toBe("complete-slice");
+  });
+
+  it("returns 'complete-milestone' for completing-milestone phase", () => {
+    expect(deriveUnitType(makeState({ phase: "completing-milestone" }), opts())).toBe("complete-milestone");
+  });
+
+  it("returns 'replan-slice' for replanning-slice phase", () => {
+    expect(deriveUnitType(makeState({ phase: "replanning-slice" }), opts())).toBe("replan-slice");
+  });
+
+  it("returns 'unknown-<phase>' for unrecognized phase", () => {
+    expect(deriveUnitType(makeState({ phase: "blocked" as any }), opts())).toBe("unknown-blocked");
+  });
+
+  it("UAT override takes priority over phase", () => {
+    const state = makeState({ phase: "pre-planning" });
+    expect(deriveUnitType(state, opts({ uatSliceId: "S02" }))).toBe("run-uat");
+  });
+
+  it("reassess override takes priority over phase but not UAT", () => {
+    const state = makeState({ phase: "planning" });
+    // reassess alone → reassess-roadmap
+    expect(deriveUnitType(state, opts({ reassessSliceId: "S01" }))).toBe("reassess-roadmap");
+    // UAT + reassess → UAT wins (checked first)
+    expect(deriveUnitType(state, opts({ uatSliceId: "S02", reassessSliceId: "S01" }))).toBe("run-uat");
+  });
+
+  it("research override takes priority over phase switch", () => {
+    const state = makeState({ phase: "executing" });
+    expect(deriveUnitType(state, opts({ dispatchResearch: "milestone" }))).toBe("research-milestone");
+    expect(deriveUnitType(state, opts({ dispatchResearch: "slice" }))).toBe("research-slice");
+  });
+
+  it("returns unknown for 'complete' phase", () => {
+    expect(deriveUnitType(makeState({ phase: "complete" as any }), opts())).toBe("unknown-complete");
+  });
+
+  it("returns unknown for 'paused' phase", () => {
+    expect(deriveUnitType(makeState({ phase: "paused" as any }), opts())).toBe("unknown-paused");
+  });
+});
+
+// ─── deriveUnitId ─────────────────────────────────────────────────────────────
+
+describe("deriveUnitId", () => {
+  it("returns mid/sid/tid when task is active", () => {
+    const state = makeState({
+      activeTask: { id: "T01", title: "Task 1" },
+    });
+    expect(deriveUnitId(state)).toBe("M001/S01/T01");
+  });
+
+  it("returns mid/sid when no task is active", () => {
+    const state = makeState();
+    expect(deriveUnitId(state)).toBe("M001/S01");
+  });
+
+  it("returns mid only when no slice or task", () => {
+    const state = makeState({ activeSlice: null, activeTask: null });
+    expect(deriveUnitId(state)).toBe("M001");
+  });
+
+  it("returns 'unknown' when no milestone", () => {
+    const state = makeState({ activeMilestone: null, activeSlice: null });
+    expect(deriveUnitId(state)).toBe("unknown");
+  });
+
+  it("uses uatSliceId instead of state slice for UAT", () => {
+    const state = makeState({
+      activeSlice: { id: "S02", title: "Slice 2" },
+      activeTask: { id: "T01", title: "Task 1" },
+    });
+    const result = deriveUnitId(state, opts({ uatSliceId: "S01" }));
+    // UAT targets previous slice; should NOT include tid
+    expect(result).toBe("M001/S01");
+  });
+
+  it("uses reassessSliceId instead of state slice for reassessment", () => {
+    const state = makeState({
+      activeSlice: { id: "S03", title: "Slice 3" },
+      activeTask: { id: "T02", title: "Task 2" },
+    });
+    const result = deriveUnitId(state, opts({ reassessSliceId: "S02" }));
+    expect(result).toBe("M001/S02");
+  });
+
+  it("includes tid when no override options", () => {
+    const state = makeState({
+      activeTask: { id: "T03", title: "Task 3" },
+    });
+    expect(deriveUnitId(state, opts())).toBe("M001/S01/T03");
+  });
+
+  it("tid excluded when uatSliceId is set even if task active", () => {
+    const state = makeState({
+      activeTask: { id: "T01", title: "Task 1" },
+    });
+    expect(deriveUnitId(state, opts({ uatSliceId: "S01" }))).toBe("M001/S01");
+  });
+
+  it("tid excluded when reassessSliceId is set even if task active", () => {
+    const state = makeState({
+      activeTask: { id: "T01", title: "Task 1" },
+    });
+    expect(deriveUnitId(state, opts({ reassessSliceId: "S01" }))).toBe("M001/S01");
+  });
+
+  it("falls back to state slice when options have no override", () => {
+    const state = makeState({ activeSlice: { id: "S05", title: "Slice 5" } });
+    expect(deriveUnitId(state, opts({ dispatchResearch: "slice" }))).toBe("M001/S05");
+  });
+
+  it("returns mid when state has milestone but no slice and no override", () => {
+    const state = makeState({ activeSlice: null });
+    expect(deriveUnitId(state, opts())).toBe("M001");
+  });
+});
+
+// ─── peekNext ─────────────────────────────────────────────────────────────────
+
+describe("peekNext", () => {
+  const state = makeState();
+
+  it("returns 'plan milestone roadmap' for research-milestone", () => {
+    expect(peekNext("research-milestone", state)).toBe("plan milestone roadmap");
+  });
+
+  it("returns 'research first slice' for plan-milestone", () => {
+    expect(peekNext("plan-milestone", state)).toBe("research first slice");
+  });
+
+  it("returns 'plan <sid>' for research-slice", () => {
+    expect(peekNext("research-slice", state)).toBe("plan S01");
+  });
+
+  it("returns 'execute first task' for plan-slice", () => {
+    expect(peekNext("plan-slice", state)).toBe("execute first task");
+  });
+
+  it("returns 'continue <sid>' for execute-task", () => {
+    expect(peekNext("execute-task", state)).toBe("continue S01");
+  });
+
+  it("returns 'reassess roadmap' for complete-slice", () => {
+    expect(peekNext("complete-slice", state)).toBe("reassess roadmap");
+  });
+
+  it("returns 're-execute <sid>' for replan-slice", () => {
+    expect(peekNext("replan-slice", state)).toBe("re-execute S01");
+  });
+
+  it("returns 'advance to next slice' for reassess-roadmap", () => {
+    expect(peekNext("reassess-roadmap", state)).toBe("advance to next slice");
+  });
+
+  it("returns 'reassess roadmap' for run-uat", () => {
+    expect(peekNext("run-uat", state)).toBe("reassess roadmap");
+  });
+
+  it("returns empty string for unknown unit type", () => {
+    expect(peekNext("unknown-xyz", state)).toBe("");
+  });
+
+  it("uses empty sid when no active slice", () => {
+    const noSlice = makeState({ activeSlice: null });
+    expect(peekNext("research-slice", noSlice)).toBe("plan ");
+    expect(peekNext("execute-task", noSlice)).toBe("continue ");
+    expect(peekNext("replan-slice", noSlice)).toBe("re-execute ");
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/auto-recovery.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/auto-recovery.vitest.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {

--- a/apps/cli/src/resources/extensions/kata/tests/auto-recovery.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/auto-recovery.vitest.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import {
+  providerBackoffMs,
+  skipExecuteTask,
+  resolveExpectedArtifactPath,
+  writeBlockerPlaceholder,
+  diagnoseExpectedArtifact,
+} from "../auto-recovery.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let tmpBase: string;
+
+function setupKataDir(): string {
+  tmpBase = mkdtempSync(join(tmpdir(), "auto-recovery-test-"));
+  return tmpBase;
+}
+
+/**
+ * Create a minimal .kata directory structure with milestone and slice.
+ * Returns the base path.
+ */
+function setupKataStructure(
+  mid = "M001",
+  sid = "S01",
+  opts?: { withPlan?: string; withTasks?: boolean },
+): string {
+  const base = setupKataDir();
+  const sliceDir = join(base, ".kata", "milestones", mid, "slices", sid);
+  const tasksDir = join(sliceDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  if (opts?.withPlan) {
+    writeFileSync(join(sliceDir, `${sid}-PLAN.md`), opts.withPlan, "utf-8");
+  }
+  return base;
+}
+
+// ─── providerBackoffMs ───────────────────────────────────────────────────────
+
+describe("providerBackoffMs", () => {
+  it("returns 5000 for attempt 0", () => {
+    expect(providerBackoffMs(0)).toBe(5000);
+  });
+
+  it("returns 10000 for attempt 1", () => {
+    expect(providerBackoffMs(1)).toBe(10_000);
+  });
+
+  it("returns 20000 for attempt 2", () => {
+    expect(providerBackoffMs(2)).toBe(20_000);
+  });
+
+  it("returns 40000 for attempt 3", () => {
+    expect(providerBackoffMs(3)).toBe(40_000);
+  });
+
+  it("caps at 60000 for attempt 4", () => {
+    expect(providerBackoffMs(4)).toBe(60_000);
+  });
+
+  it("caps at 60000 for attempt 5", () => {
+    expect(providerBackoffMs(5)).toBe(60_000);
+  });
+
+  it("caps at 60000 for attempt 6", () => {
+    expect(providerBackoffMs(6)).toBe(60_000);
+  });
+
+  it("grows exponentially: 5s, 10s, 20s, 40s, 60s", () => {
+    const values = [0, 1, 2, 3, 4, 5].map(providerBackoffMs);
+    expect(values).toEqual([5000, 10_000, 20_000, 40_000, 60_000, 60_000]);
+  });
+});
+
+// ─── skipExecuteTask ─────────────────────────────────────────────────────────
+
+describe("skipExecuteTask", () => {
+  afterEach(() => {
+    if (tmpBase) {
+      rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it("writes blocker summary when summaryExists is false", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = skipExecuteTask(
+      base, "M001", "S01", "T01",
+      { summaryExists: false, taskChecked: true },
+      "idle", 3,
+    );
+    expect(result).toBe(true);
+
+    const summaryPath = join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md");
+    expect(existsSync(summaryPath)).toBe(true);
+    const content = readFileSync(summaryPath, "utf-8");
+    expect(content).toContain("BLOCKER");
+    expect(content).toContain("T01");
+    expect(content).toContain("idle");
+    expect(content).toContain("3 attempts");
+  });
+
+  it("marks [x] in plan when taskChecked is false", () => {
+    const planContent = `# Plan\n\n- [ ] **T01: First task**\n- [ ] **T02: Second task**\n`;
+    const base = setupKataStructure("M001", "S01", { withPlan: planContent });
+    const result = skipExecuteTask(
+      base, "M001", "S01", "T01",
+      { summaryExists: true, taskChecked: false },
+      "crash", 5,
+    );
+    expect(result).toBe(true);
+
+    const planPath = join(base, ".kata", "milestones", "M001", "slices", "S01", "S01-PLAN.md");
+    const updated = readFileSync(planPath, "utf-8");
+    expect(updated).toContain("- [x] **T01:");
+    expect(updated).toContain("- [ ] **T02:");
+  });
+
+  it("writes both summary and plan checkbox when both missing", () => {
+    const planContent = `# Plan\n\n- [ ] **T01: First task**\n`;
+    const base = setupKataStructure("M001", "S01", { withPlan: planContent });
+    const result = skipExecuteTask(
+      base, "M001", "S01", "T01",
+      { summaryExists: false, taskChecked: false },
+      "timeout", 2,
+    );
+    expect(result).toBe(true);
+
+    const summaryPath = join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md");
+    expect(existsSync(summaryPath)).toBe(true);
+
+    const planPath = join(base, ".kata", "milestones", "M001", "slices", "S01", "S01-PLAN.md");
+    const updated = readFileSync(planPath, "utf-8");
+    expect(updated).toContain("- [x] **T01:");
+  });
+
+  it("does nothing when both summaryExists and taskChecked are true", () => {
+    const planContent = `# Plan\n\n- [x] **T01: First task**\n`;
+    const base = setupKataStructure("M001", "S01", { withPlan: planContent });
+    const result = skipExecuteTask(
+      base, "M001", "S01", "T01",
+      { summaryExists: true, taskChecked: true },
+      "idle", 3,
+    );
+    expect(result).toBe(true);
+    // No summary file should be written
+    const summaryPath = join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md");
+    expect(existsSync(summaryPath)).toBe(false);
+  });
+
+  it("returns false when target dir cannot be resolved", () => {
+    // base with no .kata structure at all
+    const base = mkdtempSync(join(tmpdir(), "auto-recovery-empty-"));
+    tmpBase = base;
+    const result = skipExecuteTask(
+      base, "M099", "S99", "T01",
+      { summaryExists: false, taskChecked: true },
+      "idle", 3,
+    );
+    expect(result).toBe(false);
+  });
+
+  it("skips plan checkbox when plan file does not exist", () => {
+    const base = setupKataStructure("M001", "S01");
+    // No plan file created
+    const result = skipExecuteTask(
+      base, "M001", "S01", "T01",
+      { summaryExists: true, taskChecked: false },
+      "idle", 3,
+    );
+    // Should still return true — plan update is best-effort
+    expect(result).toBe(true);
+  });
+
+  it("skips plan checkbox when regex doesn't match", () => {
+    const planContent = `# Plan\n\n- [ ] **T02: Only T02 here**\n`;
+    const base = setupKataStructure("M001", "S01", { withPlan: planContent });
+    const result = skipExecuteTask(
+      base, "M001", "S01", "T01",
+      { summaryExists: true, taskChecked: false },
+      "idle", 3,
+    );
+    expect(result).toBe(true);
+    // Plan should not be modified since T01 doesn't match
+    const planPath = join(base, ".kata", "milestones", "M001", "slices", "S01", "S01-PLAN.md");
+    const content = readFileSync(planPath, "utf-8");
+    expect(content).toBe(planContent);
+  });
+
+  it("creates tasks dir if it doesn't exist", () => {
+    const base = setupKataDir();
+    // Create slice dir but NOT tasks subdir
+    const sliceDir = join(base, ".kata", "milestones", "M001", "slices", "S01");
+    mkdirSync(sliceDir, { recursive: true });
+
+    const result = skipExecuteTask(
+      base, "M001", "S01", "T01",
+      { summaryExists: false, taskChecked: true },
+      "idle", 3,
+    );
+    expect(result).toBe(true);
+
+    const summaryPath = join(sliceDir, "tasks", "T01-SUMMARY.md");
+    expect(existsSync(summaryPath)).toBe(true);
+  });
+});
+
+// ─── resolveExpectedArtifactPath ─────────────────────────────────────────────
+
+describe("resolveExpectedArtifactPath", () => {
+  afterEach(() => {
+    if (tmpBase) {
+      rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it("returns RESEARCH path for research-milestone", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("research-milestone", "M001", base);
+    expect(result).not.toBeNull();
+    expect(result!).toContain("M001-RESEARCH.md");
+  });
+
+  it("returns ROADMAP path for plan-milestone", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("plan-milestone", "M001", base);
+    expect(result).not.toBeNull();
+    expect(result!).toContain("M001-ROADMAP.md");
+  });
+
+  it("returns RESEARCH path for research-slice", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("research-slice", "M001/S01", base);
+    expect(result).not.toBeNull();
+    expect(result!).toContain("S01-RESEARCH.md");
+  });
+
+  it("returns PLAN path for plan-slice", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("plan-slice", "M001/S01", base);
+    expect(result).not.toBeNull();
+    expect(result!).toContain("S01-PLAN.md");
+  });
+
+  it("returns ASSESSMENT path for reassess-roadmap", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("reassess-roadmap", "M001/S01", base);
+    expect(result).not.toBeNull();
+    expect(result!).toContain("S01-ASSESSMENT.md");
+  });
+
+  it("returns UAT-RESULT path for run-uat", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("run-uat", "M001/S01", base);
+    expect(result).not.toBeNull();
+    expect(result!).toContain("S01-UAT-RESULT.md");
+  });
+
+  it("returns SUMMARY path for complete-milestone", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("complete-milestone", "M001", base);
+    expect(result).not.toBeNull();
+    expect(result!).toContain("M001-SUMMARY.md");
+  });
+
+  it("returns null for execute-task", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("execute-task", "M001/S01/T01", base);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for complete-slice", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("complete-slice", "M001/S01", base);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for replan-slice", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("replan-slice", "M001/S01", base);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for unknown unit type", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("unknown-type", "M001/S01", base);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when milestone dir does not exist", () => {
+    const base = mkdtempSync(join(tmpdir(), "auto-recovery-nodir-"));
+    tmpBase = base;
+    const result = resolveExpectedArtifactPath("research-milestone", "M099", base);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when slice dir does not exist for slice-level type", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = resolveExpectedArtifactPath("research-slice", "M001/S99", base);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── writeBlockerPlaceholder ─────────────────────────────────────────────────
+
+describe("writeBlockerPlaceholder", () => {
+  afterEach(() => {
+    if (tmpBase) {
+      rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a placeholder file and returns diagnostic string", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = writeBlockerPlaceholder(
+      "research-milestone", "M001", base, "idle timeout",
+    );
+    expect(result).not.toBeNull();
+    expect(result).toContain("M001-RESEARCH.md");
+
+    const filePath = join(base, ".kata", "milestones", "M001", "M001-RESEARCH.md");
+    expect(existsSync(filePath)).toBe(true);
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("BLOCKER");
+    expect(content).toContain("idle timeout");
+    expect(content).toContain("research-milestone");
+  });
+
+  it("returns null for unit types that don't produce artifacts", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = writeBlockerPlaceholder(
+      "execute-task", "M001/S01/T01", base, "crash",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("writes placeholder for slice-level types", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = writeBlockerPlaceholder(
+      "plan-slice", "M001/S01", base, "network error",
+    );
+    expect(result).not.toBeNull();
+    const filePath = join(base, ".kata", "milestones", "M001", "slices", "S01", "S01-PLAN.md");
+    expect(existsSync(filePath)).toBe(true);
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("BLOCKER");
+    expect(content).toContain("network error");
+  });
+
+  it("returns null when path cannot be resolved", () => {
+    const base = mkdtempSync(join(tmpdir(), "auto-recovery-nodir2-"));
+    tmpBase = base;
+    const result = writeBlockerPlaceholder(
+      "research-milestone", "M099", base, "unknown",
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ─── diagnoseExpectedArtifact ────────────────────────────────────────────────
+
+describe("diagnoseExpectedArtifact", () => {
+  afterEach(() => {
+    if (tmpBase) {
+      rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it("returns description for research-milestone", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("research-milestone", "M001", base);
+    expect(result).toContain("milestone research");
+  });
+
+  it("returns description for plan-milestone", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("plan-milestone", "M001", base);
+    expect(result).toContain("milestone roadmap");
+  });
+
+  it("returns description for research-slice", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("research-slice", "M001/S01", base);
+    expect(result).toContain("slice research");
+  });
+
+  it("returns description for plan-slice", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("plan-slice", "M001/S01", base);
+    expect(result).toContain("slice plan");
+  });
+
+  it("returns description for execute-task", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("execute-task", "M001/S01/T01", base);
+    expect(result).toContain("T01");
+    expect(result).toContain("summary written");
+  });
+
+  it("returns description for complete-slice", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("complete-slice", "M001/S01", base);
+    expect(result).toContain("S01");
+    expect(result).toContain("summary written");
+  });
+
+  it("returns description for replan-slice", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("replan-slice", "M001/S01", base);
+    expect(result).toContain("REPLAN");
+  });
+
+  it("returns description for reassess-roadmap", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("reassess-roadmap", "M001/S01", base);
+    expect(result).toContain("roadmap reassessment");
+  });
+
+  it("returns description for run-uat", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("run-uat", "M001/S01", base);
+    expect(result).toContain("UAT result");
+  });
+
+  it("returns description for complete-milestone", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("complete-milestone", "M001", base);
+    expect(result).toContain("milestone summary");
+  });
+
+  it("returns null for unknown unit type", () => {
+    const base = setupKataStructure("M001", "S01");
+    const result = diagnoseExpectedArtifact("unknown-xyz", "M001/S01", base);
+    expect(result).toBeNull();
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/auto-transitions.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/auto-transitions.vitest.test.ts
@@ -8,20 +8,12 @@ import {
   rmSync,
 } from "node:fs";
 import type { KataState } from "../types.js";
-
-// Mock ensureSliceBranch before importing the module under test
-vi.mock("../worktree.ts", () => ({
-  ensureSliceBranch: vi.fn(),
-}));
-
 import { ensurePreconditions } from "../auto-transitions.js";
-import { ensureSliceBranch } from "../worktree.ts";
-
-const mockedEnsureSliceBranch = vi.mocked(ensureSliceBranch);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 let tmpBase: string;
+let mockEnsureSliceBranch: ReturnType<typeof vi.fn>;
 
 function makeState(): KataState {
   return {
@@ -41,11 +33,18 @@ function setupKataDir(): string {
   return tmpBase;
 }
 
+/** Call ensurePreconditions with the mock injected. */
+function callEnsure(unitType: string, unitId: string, base: string, state: KataState) {
+  return ensurePreconditions(unitType, unitId, base, state, {
+    ensureSliceBranch: mockEnsureSliceBranch,
+  });
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("ensurePreconditions", () => {
   beforeEach(() => {
-    mockedEnsureSliceBranch.mockReset();
+    mockEnsureSliceBranch = vi.fn();
   });
 
   afterEach(() => {
@@ -59,7 +58,7 @@ describe("ensurePreconditions", () => {
     // Ensure .kata/milestones exists but M001 doesn't
     mkdirSync(join(base, ".kata", "milestones"), { recursive: true });
 
-    ensurePreconditions("plan-milestone", "M001", base, makeState());
+    callEnsure("plan-milestone", "M001", base, makeState());
 
     expect(existsSync(join(base, ".kata", "milestones", "M001", "slices"))).toBe(true);
   });
@@ -69,7 +68,7 @@ describe("ensurePreconditions", () => {
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
 
     expect(() => {
-      ensurePreconditions("plan-milestone", "M001", base, makeState());
+      callEnsure("plan-milestone", "M001", base, makeState());
     }).not.toThrow();
   });
 
@@ -77,7 +76,7 @@ describe("ensurePreconditions", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
 
-    ensurePreconditions("plan-slice", "M001/S01", base, makeState());
+    callEnsure("plan-slice", "M001/S01", base, makeState());
 
     expect(existsSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"))).toBe(true);
   });
@@ -87,7 +86,7 @@ describe("ensurePreconditions", () => {
     // Create slice dir without tasks/
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01"), { recursive: true });
 
-    ensurePreconditions("execute-task", "M001/S01/T01", base, makeState());
+    callEnsure("execute-task", "M001/S01/T01", base, makeState());
 
     expect(existsSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"))).toBe(true);
   });
@@ -98,7 +97,7 @@ describe("ensurePreconditions", () => {
     mkdirSync(tasksDir, { recursive: true });
 
     expect(() => {
-      ensurePreconditions("execute-task", "M001/S01/T01", base, makeState());
+      callEnsure("execute-task", "M001/S01/T01", base, makeState());
     }).not.toThrow();
 
     expect(existsSync(tasksDir)).toBe(true);
@@ -108,72 +107,72 @@ describe("ensurePreconditions", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
 
-    ensurePreconditions("research-slice", "M001/S01", base, makeState());
+    callEnsure("research-slice", "M001/S01", base, makeState());
 
-    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+    expect(mockEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
   });
 
   it("calls ensureSliceBranch for plan-slice", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
 
-    ensurePreconditions("plan-slice", "M001/S01", base, makeState());
+    callEnsure("plan-slice", "M001/S01", base, makeState());
 
-    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+    expect(mockEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
   });
 
   it("calls ensureSliceBranch for execute-task", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
 
-    ensurePreconditions("execute-task", "M001/S01/T01", base, makeState());
+    callEnsure("execute-task", "M001/S01/T01", base, makeState());
 
-    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+    expect(mockEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
   });
 
   it("calls ensureSliceBranch for complete-slice", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
 
-    ensurePreconditions("complete-slice", "M001/S01", base, makeState());
+    callEnsure("complete-slice", "M001/S01", base, makeState());
 
-    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+    expect(mockEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
   });
 
   it("calls ensureSliceBranch for replan-slice", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
 
-    ensurePreconditions("replan-slice", "M001/S01", base, makeState());
+    callEnsure("replan-slice", "M001/S01", base, makeState());
 
-    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+    expect(mockEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
   });
 
   it("does NOT call ensureSliceBranch for plan-milestone", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
 
-    ensurePreconditions("plan-milestone", "M001", base, makeState());
+    callEnsure("plan-milestone", "M001", base, makeState());
 
-    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+    expect(mockEnsureSliceBranch).not.toHaveBeenCalled();
   });
 
   it("does NOT call ensureSliceBranch for research-milestone", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
 
-    ensurePreconditions("research-milestone", "M001", base, makeState());
+    callEnsure("research-milestone", "M001", base, makeState());
 
-    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+    expect(mockEnsureSliceBranch).not.toHaveBeenCalled();
   });
 
   it("does NOT call ensureSliceBranch for complete-milestone", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
 
-    ensurePreconditions("complete-milestone", "M001", base, makeState());
+    callEnsure("complete-milestone", "M001", base, makeState());
 
-    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+    expect(mockEnsureSliceBranch).not.toHaveBeenCalled();
   });
 
   it("does NOT call ensureSliceBranch for reassess-roadmap with milestone-only ID", () => {
@@ -181,28 +180,28 @@ describe("ensurePreconditions", () => {
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
 
     // reassess-roadmap is NOT in the slice branch units list
-    ensurePreconditions("reassess-roadmap", "M001", base, makeState());
+    callEnsure("reassess-roadmap", "M001", base, makeState());
 
-    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+    expect(mockEnsureSliceBranch).not.toHaveBeenCalled();
   });
 
   it("creates deeply nested structure for task-level unitId", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones"), { recursive: true });
 
-    ensurePreconditions("execute-task", "M001/S02/T03", base, makeState());
+    callEnsure("execute-task", "M001/S02/T03", base, makeState());
 
     expect(existsSync(join(base, ".kata", "milestones", "M001", "slices", "S02", "tasks"))).toBe(true);
-    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S02");
+    expect(mockEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S02");
   });
 
   it("handles run-uat with slice-level unitId (not in SLICE_BRANCH_UNITS)", () => {
     const base = setupKataDir();
     mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
 
-    ensurePreconditions("run-uat", "M001/S01", base, makeState());
+    callEnsure("run-uat", "M001/S01", base, makeState());
 
     // run-uat is NOT in SLICE_BRANCH_UNITS, so no branch checkout
-    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+    expect(mockEnsureSliceBranch).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/resources/extensions/kata/tests/auto-transitions.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/auto-transitions.vitest.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  mkdtempSync,
+  mkdirSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import type { KataState } from "../types.js";
+
+// Mock ensureSliceBranch before importing the module under test
+vi.mock("../worktree.ts", () => ({
+  ensureSliceBranch: vi.fn(),
+}));
+
+import { ensurePreconditions } from "../auto-transitions.js";
+import { ensureSliceBranch } from "../worktree.ts";
+
+const mockedEnsureSliceBranch = vi.mocked(ensureSliceBranch);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let tmpBase: string;
+
+function makeState(): KataState {
+  return {
+    activeMilestone: { id: "M001", title: "Milestone 1" },
+    activeSlice: { id: "S01", title: "Slice 1" },
+    activeTask: null,
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+  };
+}
+
+function setupKataDir(): string {
+  tmpBase = mkdtempSync(join(tmpdir(), "auto-transitions-test-"));
+  return tmpBase;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ensurePreconditions", () => {
+  beforeEach(() => {
+    mockedEnsureSliceBranch.mockReset();
+  });
+
+  afterEach(() => {
+    if (tmpBase) {
+      rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it("creates milestone dir with slices/ when it doesn't exist", () => {
+    const base = setupKataDir();
+    // Ensure .kata/milestones exists but M001 doesn't
+    mkdirSync(join(base, ".kata", "milestones"), { recursive: true });
+
+    ensurePreconditions("plan-milestone", "M001", base, makeState());
+
+    expect(existsSync(join(base, ".kata", "milestones", "M001", "slices"))).toBe(true);
+  });
+
+  it("does not error when milestone dir already exists", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
+
+    expect(() => {
+      ensurePreconditions("plan-milestone", "M001", base, makeState());
+    }).not.toThrow();
+  });
+
+  it("creates slice dir with tasks/ when it doesn't exist", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
+
+    ensurePreconditions("plan-slice", "M001/S01", base, makeState());
+
+    expect(existsSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"))).toBe(true);
+  });
+
+  it("ensures tasks/ subdir when slice dir exists but tasks/ doesn't", () => {
+    const base = setupKataDir();
+    // Create slice dir without tasks/
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+    ensurePreconditions("execute-task", "M001/S01/T01", base, makeState());
+
+    expect(existsSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"))).toBe(true);
+  });
+
+  it("no-op when slice dir and tasks/ already exist", () => {
+    const base = setupKataDir();
+    const tasksDir = join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+
+    expect(() => {
+      ensurePreconditions("execute-task", "M001/S01/T01", base, makeState());
+    }).not.toThrow();
+
+    expect(existsSync(tasksDir)).toBe(true);
+  });
+
+  it("calls ensureSliceBranch for research-slice", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+    ensurePreconditions("research-slice", "M001/S01", base, makeState());
+
+    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+  });
+
+  it("calls ensureSliceBranch for plan-slice", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+    ensurePreconditions("plan-slice", "M001/S01", base, makeState());
+
+    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+  });
+
+  it("calls ensureSliceBranch for execute-task", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+    ensurePreconditions("execute-task", "M001/S01/T01", base, makeState());
+
+    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+  });
+
+  it("calls ensureSliceBranch for complete-slice", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+    ensurePreconditions("complete-slice", "M001/S01", base, makeState());
+
+    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+  });
+
+  it("calls ensureSliceBranch for replan-slice", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+    ensurePreconditions("replan-slice", "M001/S01", base, makeState());
+
+    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S01");
+  });
+
+  it("does NOT call ensureSliceBranch for plan-milestone", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
+
+    ensurePreconditions("plan-milestone", "M001", base, makeState());
+
+    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call ensureSliceBranch for research-milestone", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
+
+    ensurePreconditions("research-milestone", "M001", base, makeState());
+
+    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call ensureSliceBranch for complete-milestone", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
+
+    ensurePreconditions("complete-milestone", "M001", base, makeState());
+
+    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call ensureSliceBranch for reassess-roadmap with milestone-only ID", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices"), { recursive: true });
+
+    // reassess-roadmap is NOT in the slice branch units list
+    ensurePreconditions("reassess-roadmap", "M001", base, makeState());
+
+    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+  });
+
+  it("creates deeply nested structure for task-level unitId", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones"), { recursive: true });
+
+    ensurePreconditions("execute-task", "M001/S02/T03", base, makeState());
+
+    expect(existsSync(join(base, ".kata", "milestones", "M001", "slices", "S02", "tasks"))).toBe(true);
+    expect(mockedEnsureSliceBranch).toHaveBeenCalledWith(base, "M001", "S02");
+  });
+
+  it("handles run-uat with slice-level unitId (not in SLICE_BRANCH_UNITS)", () => {
+    const base = setupKataDir();
+    mkdirSync(join(base, ".kata", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+    ensurePreconditions("run-uat", "M001/S01", base, makeState());
+
+    // run-uat is NOT in SLICE_BRANCH_UNITS, so no branch checkout
+    expect(mockedEnsureSliceBranch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Extract pure decision functions from `auto.ts` (2070 lines) into 3 testable modules with no pi SDK imports, write Vitest tests achieving >80% branch coverage on extracted modules, and rewire `auto.ts` to import from them.

Closes KAT-1032

## Changes

### New Modules
- **`auto-dispatch.ts`** — `deriveUnitType()`, `deriveUnitId()`, `peekNext()` pure functions for dispatch routing
- **`auto-recovery.ts`** — `providerBackoffMs()`, `skipExecuteTask()`, `resolveExpectedArtifactPath()`, `writeBlockerPlaceholder()`, `diagnoseExpectedArtifact()` for crash recovery and artifact resolution
- **`auto-transitions.ts`** — `ensurePreconditions()` for file-mode directory creation and branch setup

### New Tests
- `auto-dispatch.vitest.test.ts` — 39 tests covering all dispatch branches
- `auto-recovery.vitest.test.ts` — 44 tests covering backoff, skip artifacts, artifact paths, and blocker placeholders
- `auto-transitions.vitest.test.ts` — 16 tests with mocked git operations covering precondition creation

### auto.ts Changes
- Imports from 3 extracted modules instead of defining functions inline
- Re-exports maintained for backward compatibility (`skipExecuteTask`, `resolveExpectedArtifactPath`, `writeBlockerPlaceholder`)
- Unused imports cleaned up (net line reduction)

## Verification

| Gate | Result |
|------|--------|
| `npx vitest run` | ✅ 147 tests pass (7 test files) |
| `npx vitest --coverage` — auto-dispatch.ts | 100% branches |
| `npx vitest --coverage` — auto-recovery.ts | 89% branches |
| `npx vitest --coverage` — auto-transitions.ts | 93% branches |
| `bun test src/` | ✅ All existing tests pass |
| `npx tsc --noEmit` | ✅ No type errors |
| No pi SDK imports in extracted modules | ✅ Verified |

## Tasks
- [x] KAT-1035: Extract auto-dispatch module and write tests
- [x] KAT-1036: Extract auto-recovery module and write tests
- [x] KAT-1037: Extract auto-transitions module, write tests, and verify full extraction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Split and reorganized auto-dispatch, recovery, and transition logic into focused modules for clearer behavior and maintainability.

* **New Features**
  * Improved automatic dispatch decisions and human-readable “what’s next” descriptions.
  * Safer recovery: capped provider backoff and automated blocker-placeholder creation when tasks appear stuck.
  * Pre-dispatch setup now ensures required milestone/slice directories and optionally prepares slice branches.

* **Tests**
  * Added comprehensive tests validating dispatch, recovery, and transition behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts ~160 lines of pure decision logic from the large `auto.ts` (2070 lines) into three focused, SDK-free modules (`auto-dispatch.ts`, `auto-recovery.ts`, `auto-transitions.ts`) and ships Vitest tests that achieve ≥89% branch coverage on each. The wiring back to `auto.ts` is done cleanly via re-exports that maintain full backward compatibility for all previously-public symbols.\n\nKey changes:\n- **`auto-dispatch.ts`**: `deriveUnitType`, `deriveUnitId`, `peekNext` — 100% branch coverage, pure logic with no side effects\n- **`auto-recovery.ts`**: `providerBackoffMs`, `skipExecuteTask`, `resolveExpectedArtifactPath`, `writeBlockerPlaceholder`, `diagnoseExpectedArtifact` — 89% branch coverage; one portability nit (`lastIndexOf(\"/\")` → `path.dirname`) in `writeBlockerPlaceholder`\n- **`auto-transitions.ts`**: `ensurePreconditions` — 93% branch coverage, git operations correctly mocked in tests\n- **`auto.ts`**: Slim removal of inline definitions; re-exports preserve the public API surface for `skipExecuteTask`, `resolveExpectedArtifactPath`, `writeBlockerPlaceholder`, and newly promotes `deriveUnitType`, `deriveUnitId`, `peekNext`, `ensurePreconditions` to the public API (intentional)\n- Note: `diagnoseExpectedArtifact` is newly public in `auto-recovery.ts` but **not** re-exported from `auto.ts`, consistent with its former private status

<h3>Confidence Score: 5/5</h3>

Safe to merge — clean extraction with full backward compatibility and strong test coverage; single P2 nit does not affect correctness on the target platform.

All 147 tests pass, TypeScript compiles cleanly, no SDK imports bleed into extracted modules, and the backward-compatible re-exports ensure no caller breakage. The only finding is a POSIX-only path separator in writeBlockerPlaceholder that has zero impact on the CLI's current target platforms (macOS/Linux).

No files require special attention. The portability nit in auto-recovery.ts is advisory only.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/auto-dispatch.ts | New module extracting three pure dispatch functions (deriveUnitType, deriveUnitId, peekNext) from auto.ts; no SDK imports, clean and faithful extraction. |
| apps/cli/src/resources/extensions/kata/auto-recovery.ts | New module extracting five recovery functions; minor portability issue in writeBlockerPlaceholder where absPath.lastIndexOf("/") should be path.dirname() for Windows correctness. |
| apps/cli/src/resources/extensions/kata/auto-transitions.ts | New module extracting ensurePreconditions; correctly mocks ensureSliceBranch, uses .ts extension consistent with existing codebase convention. |
| apps/cli/src/resources/extensions/kata/auto.ts | Imports and re-exports functions from the three new modules; backward-compatible for previously-exported symbols; removes ~160 lines of inline definitions cleanly. |
| apps/cli/src/resources/extensions/kata/tests/auto-dispatch.vitest.test.ts | 39 tests covering all branches of deriveUnitType, deriveUnitId, and peekNext; achieves 100% branch coverage as claimed. |
| apps/cli/src/resources/extensions/kata/tests/auto-recovery.vitest.test.ts | 44 tests with real tmpdir filesystem fixtures; covers backoff, skip artifacts, artifact paths, blocker placeholders, and diagnosis; proper afterEach cleanup. |
| apps/cli/src/resources/extensions/kata/tests/auto-transitions.vitest.test.ts | 16 tests with vi.mock for ensureSliceBranch; covers directory creation paths and all SLICE_BRANCH_UNITS variants; mock reset in beforeEach is correct. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[auto.ts] -->|re-exports + uses| B[auto-dispatch.ts]
    A -->|re-exports + uses| C[auto-recovery.ts]
    A -->|re-exports + uses| D[auto-transitions.ts]

    B --> B1["deriveUnitType()"]
    B --> B2["deriveUnitId()"]
    B --> B3["peekNext()"]

    C --> C1["providerBackoffMs()"]
    C --> C2["skipExecuteTask()"]
    C --> C3["resolveExpectedArtifactPath()"]
    C --> C4["writeBlockerPlaceholder()"]
    C --> C5["diagnoseExpectedArtifact()"]

    D --> D1["ensurePreconditions()"]
    D1 -->|calls| E["worktree.ts: ensureSliceBranch()"]

    T1[auto-dispatch.vitest.test.ts] -.->|tests| B
    T2[auto-recovery.vitest.test.ts] -.->|tests| C
    T3[auto-transitions.vitest.test.ts] -.->|tests, mocks ensureSliceBranch| D
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/cli/src/resources/extensions/kata/auto-recovery.ts`, line 238-239 ([link](https://github.com/gannonh/kata/blob/76c29bda009c95e05c0a0dfa51fe574201e8beca/apps/cli/src/resources/extensions/kata/auto-recovery.ts#L238-L239)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Use `path.dirname` instead of `lastIndexOf("/")`**

   `absPath.lastIndexOf("/")` is POSIX-only. On Windows, `node:path`'s `join` produces backslash-separated paths, so `lastIndexOf("/")` returns `-1` and `substring(0, -1)` yields the full path minus the last character — silently corrupting `dir`. Since `join` is already imported from `node:path`, `dirname` is one import away.

   Replace with:

   ```typescript
   import { join, dirname } from "node:path";
   // …
     const dir = dirname(absPath);
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/extensions/kata/auto-recovery.ts
   Line: 238-239

   Comment:
   **Use `path.dirname` instead of `lastIndexOf("/")`**

   `absPath.lastIndexOf("/")` is POSIX-only. On Windows, `node:path`'s `join` produces backslash-separated paths, so `lastIndexOf("/")` returns `-1` and `substring(0, -1)` yields the full path minus the last character — silently corrupting `dir`. Since `join` is already imported from `node:path`, `dirname` is one import away.

   Replace with:

   ```typescript
   import { join, dirname } from "node:path";
   // …
     const dir = dirname(absPath);
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/auto-recovery.ts
Line: 238-239

Comment:
**Use `path.dirname` instead of `lastIndexOf("/")`**

`absPath.lastIndexOf("/")` is POSIX-only. On Windows, `node:path`'s `join` produces backslash-separated paths, so `lastIndexOf("/")` returns `-1` and `substring(0, -1)` yields the full path minus the last character — silently corrupting `dir`. Since `join` is already imported from `node:path`, `dirname` is one import away.

Replace with:

```typescript
import { join, dirname } from "node:path";
// …
  const dir = dirname(absPath);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(cli): clean up unused imports from..."](https://github.com/gannonh/kata/commit/76c29bda009c95e05c0a0dfa51fe574201e8beca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26493234)</sub>

<!-- /greptile_comment -->