### PR TITLE
[S03] pr-runner.ts Refactor & Orchestration Tests

### DIFF
--- a/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner-runtime.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner-runtime.ts
@@ -1,0 +1,90 @@
+/**
+ * pr-runner-runtime.ts — Injectable runtime seams for `runCreatePr()`.
+ *
+ * The `PrRunnerRuntime` interface covers all I/O boundaries used by
+ * the PR creation orchestration: command execution, temp-file lifecycle,
+ * pre-flight checks, and branch detection.
+ *
+ * `defaultRuntime` provides the production implementation backed by
+ * Node primitives. Tests inject a mock runtime to make orchestration
+ * flows deterministic and network-free.
+ */
+
+import { execSync } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import {
+  isGhInstalled,
+  isGhAuthenticated,
+  getCurrentBranch,
+  parseBranchToSlice,
+} from "./gh-utils.js";
+
+// ─── Runtime interface ────────────────────────────────────────────────────────
+
+export interface PrRunnerExecOptions {
+  cwd: string;
+  env?: Record<string, string | undefined>;
+}
+
+export interface PrRunnerRuntime {
+  /** Execute a shell command synchronously, returning stdout. Throws on non-zero exit. */
+  exec(command: string, options: PrRunnerExecOptions): string;
+
+  /** Write UTF-8 content to a file. */
+  writeFile(path: string, content: string): void;
+
+  /** Remove a file (best-effort, should not throw). */
+  removeFile(path: string): void;
+
+  /** Generate a unique temp file path with the given extension. */
+  tempFilePath(extension: string): string;
+
+  /** Returns true when `gh` CLI is installed and callable. */
+  isGhInstalled(): boolean;
+
+  /** Returns true when `gh` CLI is authenticated. */
+  isGhAuthenticated(): boolean;
+
+  /** Returns the current git branch name, or null on failure. */
+  getCurrentBranch(cwd: string): string | null;
+
+  /** Parses a Kata-convention branch into milestone/slice IDs, or null. */
+  parseBranchToSlice(branch: string): { milestoneId: string; sliceId: string } | null;
+}
+
+// ─── Default production runtime ───────────────────────────────────────────────
+
+const PIPE = { stdio: ["pipe", "pipe", "pipe"] as ["pipe", "pipe", "pipe"] };
+
+export const defaultRuntime: PrRunnerRuntime = {
+  exec(command: string, options: PrRunnerExecOptions): string {
+    return execSync(command, {
+      encoding: "utf8",
+      cwd: options.cwd,
+      env: options.env ? (options.env as NodeJS.ProcessEnv) : undefined,
+      ...PIPE,
+    });
+  },
+
+  writeFile(path: string, content: string): void {
+    writeFileSync(path, content, "utf8");
+  },
+
+  removeFile(path: string): void {
+    try {
+      unlinkSync(path);
+    } catch { /* ignore */ }
+  },
+
+  tempFilePath(extension: string): string {
+    return join(tmpdir(), randomUUID() + extension);
+  },
+
+  isGhInstalled,
+  isGhAuthenticated,
+  getCurrentBranch,
+  parseBranchToSlice,
+};

--- a/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/pr-runner.ts
@@ -6,25 +6,20 @@
  *
  * All failure paths return a structured `{ ok: false, phase, error, hint }`
  * object — the runner never throws.
+ *
+ * Orchestration side effects (command execution, temp files, pre-flight checks)
+ * are delegated to an injectable `PrRunnerRuntime`. Production callers use
+ * the default runtime automatically; tests inject a mock runtime for
+ * deterministic assertion coverage.
  */
 
-import { execSync } from "node:child_process";
-import { writeFileSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { randomUUID } from "node:crypto";
-import {
-  isGhInstalled,
-  isGhAuthenticated,
-  getCurrentBranch,
-  parseBranchToSlice,
-} from "./gh-utils.js";
 import { composePRBody } from "./pr-body-composer.js";
 import {
   shouldCrossLink,
   resolveSliceLinearIdentifier,
   postPrLinkComment,
 } from "../kata/linear-crosslink.js";
+import { defaultRuntime, type PrRunnerRuntime } from "./pr-runner-runtime.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -49,6 +44,8 @@ export interface PrCreateOptions {
   };
   /** Pre-fetched Linear document content for PR body (bypasses disk reads). */
   linearDocuments?: Record<string, string>;
+  /** Injectable runtime for testing. Uses defaultRuntime when omitted. */
+  _runtime?: PrRunnerRuntime;
 }
 
 // ─── Shell escaping ───────────────────────────────────────────────────────────
@@ -142,6 +139,7 @@ async function loadLinearPrDocuments(
 export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateResult> {
   const { title, baseBranch = "main" } = options;
   const cwd = options.cwd ?? process.cwd();
+  const rt = options._runtime ?? defaultRuntime;
 
   if (typeof title !== "string" || title.trim().length === 0) {
     return {
@@ -154,7 +152,7 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
 
   // ── Pre-flight checks ────────────────────────────────────────────────────────
 
-  if (!isGhInstalled()) {
+  if (!rt.isGhInstalled()) {
     return {
       ok: false,
       phase: "gh-missing",
@@ -163,7 +161,7 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
     };
   }
 
-  if (!isGhAuthenticated()) {
+  if (!rt.isGhAuthenticated()) {
     return {
       ok: false,
       phase: "gh-unauth",
@@ -178,7 +176,7 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
   let sliceId = options.sliceId;
 
   if (!milestoneId || !sliceId) {
-    const branch = getCurrentBranch(cwd);
+    const branch = rt.getCurrentBranch(cwd);
     if (!branch) {
       return {
         ok: false,
@@ -187,7 +185,7 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
         hint: "Run from a git repository, or pass milestoneId and sliceId explicitly.",
       };
     }
-    const parsed = parseBranchToSlice(branch);
+    const parsed = rt.parseBranchToSlice(branch);
     if (!parsed) {
       return {
         ok: false,
@@ -275,31 +273,30 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
 
   // ── Create PR via gh CLI with body-file ──────────────────────────────────────
 
-  const tmpPath = join(tmpdir(), randomUUID() + ".md");
+  const tmpPath = rt.tempFilePath(".md");
   let prUrl: string;
 
   try {
-    writeFileSync(tmpPath, body, "utf8");
+    rt.writeFile(tmpPath, body);
 
-    const PIPE = { stdio: ["pipe", "pipe", "pipe"] as ["pipe", "pipe", "pipe"] };
     const ghEnv = { ...process.env, GH_PAGER: "" };
 
     // Resolve branch and ensure it's pushed to the remote
-    const head = getCurrentBranch(cwd) ?? "";
+    const head = rt.getCurrentBranch(cwd) ?? "";
 
     if (head) {
       // Check if branch exists on remote; push if not
       try {
-        const remoteRef = execSync(
+        const remoteRef = rt.exec(
           `git ls-remote --heads origin ${head}`,
-          { encoding: "utf8", cwd, ...PIPE },
+          { cwd },
         ).trim();
         if (!remoteRef) {
           // Branch not on remote — push with upstream tracking
           try {
-            execSync(
+            rt.exec(
               `git push -u origin ${head}`,
-              { encoding: "utf8", cwd, ...PIPE },
+              { cwd },
             );
           } catch (pushErr) {
             const pe = pushErr as { stderr?: string; message?: string };
@@ -324,7 +321,7 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
       : title;
 
     try {
-      execSync(
+      rt.exec(
         [
           "gh", "pr", "create",
           "--title", shellEscape(normalizedTitle),
@@ -332,7 +329,7 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
           "--head", shellEscape(head),
           "--body-file", shellEscape(tmpPath),
         ].join(" "),
-        { encoding: "utf8", cwd, env: ghEnv, ...PIPE },
+        { cwd, env: ghEnv },
       );
     } catch (err) {
       const e = err as { stderr?: string; message?: string };
@@ -349,20 +346,20 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
     const expected = normalize(body);
 
     try {
-      const actualBody = execSync(
+      const actualBody = rt.exec(
         "gh pr view --json body --jq .body",
-        { encoding: "utf8", cwd, env: ghEnv, ...PIPE },
+        { cwd, env: ghEnv },
       );
 
       if (normalize(actualBody) !== expected) {
         // Auto-repair via gh pr edit
-        const prNumber = execSync(
+        const prNumber = rt.exec(
           "gh pr view --json number --jq .number",
-          { encoding: "utf8", cwd, env: ghEnv, ...PIPE },
+          { cwd, env: ghEnv },
         ).trim();
-        execSync(
+        rt.exec(
           ["gh", "pr", "edit", prNumber, "--body-file", shellEscape(tmpPath)].join(" "),
-          { encoding: "utf8", cwd, env: ghEnv, ...PIPE },
+          { cwd, env: ghEnv },
         );
       }
     } catch {
@@ -371,15 +368,15 @@ export async function runCreatePr(options: PrCreateOptions): Promise<PrCreateRes
 
     // Get the PR URL
     try {
-      prUrl = execSync(
+      prUrl = rt.exec(
         "gh pr view --json url --jq .url",
-        { encoding: "utf8", cwd, env: ghEnv, ...PIPE },
+        { cwd, env: ghEnv },
       ).trim();
     } catch {
       prUrl = "(PR created but could not retrieve URL)";
     }
   } finally {
-    try { unlinkSync(tmpPath); } catch { /* ignore */ }
+    rt.removeFile(tmpPath);
   }
 
   // ── Post Linear comment (best-effort) ────────────────────────────────────────

--- a/apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner-fixtures.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner-fixtures.ts
@@ -1,0 +1,166 @@
+/**
+ * pr-runner-fixtures.ts — Deterministic test helpers for `runCreatePr()`.
+ *
+ * Provides:
+ * - `createMockRuntime()` — builds a mock PrRunnerRuntime that records
+ *   commands and returns scripted responses.
+ * - `PLAN_CONTENT` / `SUMMARY_CONTENT` — minimal valid artifact content
+ *   that passes `parsePlan()` / `parseSummary()`.
+ */
+
+import type { PrRunnerRuntime, PrRunnerExecOptions } from "../pr-runner-runtime.js";
+
+// ─── Minimal valid artifact content ───────────────────────────────────────────
+
+/** Minimal PLAN content that satisfies `parsePlan()` expectations. */
+export const PLAN_CONTENT = `# S01: Test Slice
+
+**Goal:** Deterministic orchestration testing.
+
+## Must-Haves
+
+- Orchestration paths covered
+
+## Tasks
+
+- [ ] **T01: Fixture task** \`est:10m\`
+`;
+
+/** Minimal SUMMARY content that satisfies `parseSummary()` expectations. */
+export const SUMMARY_CONTENT = `---
+one_liner: Test summary
+---
+
+# S01 Summary
+
+Test summary content.
+`;
+
+// ─── Command transcript types ─────────────────────────────────────────────────
+
+export interface MockCommandEntry {
+  command: string;
+  cwd: string;
+  response: string | Error;
+}
+
+export interface MockRuntimeOptions {
+  /**
+   * Branch name returned by getCurrentBranch().
+   * Set to null to simulate "not in a git repo".
+   */
+  branch?: string | null;
+
+  /**
+   * Scripted command responses. Each entry maps a command prefix to a
+   * response string (stdout) or an Error to throw.
+   *
+   * Commands are matched by `command.startsWith(entry.command)`.
+   * First match wins.
+   */
+  commands?: Array<{
+    match: string | RegExp;
+    response: string | Error;
+  }>;
+
+  /**
+   * Override parseBranchToSlice result.
+   * Default: returns { milestoneId, sliceId } parsed from the branch.
+   */
+  parsedBranch?: { milestoneId: string; sliceId: string } | null;
+}
+
+// ─── Mock runtime factory ─────────────────────────────────────────────────────
+
+export interface MockRuntime extends PrRunnerRuntime {
+  /** Recorded exec() calls in order. */
+  execLog: Array<{ command: string; cwd: string }>;
+  /** Recorded writeFile() calls in order. */
+  writeLog: Array<{ path: string; content: string }>;
+  /** Recorded removeFile() calls in order. */
+  removeLog: string[];
+}
+
+/**
+ * Creates a mock `PrRunnerRuntime` for deterministic orchestration testing.
+ *
+ * - `exec()` records the call and returns the first matching scripted response.
+ * - `writeFile()` / `removeFile()` record calls but do no I/O.
+ * - `tempFilePath()` returns a deterministic path.
+ * - Pre-flight checks return `true` by default.
+ * - `getCurrentBranch()` returns the configured branch name.
+ * - `parseBranchToSlice()` returns the configured parsed result.
+ */
+export function createMockRuntime(opts: MockRuntimeOptions = {}): MockRuntime {
+  const branch = opts.branch !== undefined ? opts.branch : "kata/apps-cli/M001/S01";
+  const commands = opts.commands ?? [];
+
+  // Default parsedBranch: parse from configured branch if it looks like kata format
+  const defaultParsed = branch && /^kata\//.test(branch)
+    ? (() => {
+        // Namespaced: kata/<scope>/<M>/<S>
+        const ns = branch.match(/^kata\/[^/]+\/(M\d+)\/(S\d+)$/);
+        if (ns) return { milestoneId: ns[1], sliceId: ns[2] };
+        // Legacy: kata/<M>/<S>
+        const leg = branch.match(/^kata\/(M\d+)\/(S\d+)$/);
+        if (leg) return { milestoneId: leg[1], sliceId: leg[2] };
+        return null;
+      })()
+    : null;
+  const parsedBranch = opts.parsedBranch !== undefined ? opts.parsedBranch : defaultParsed;
+
+  const execLog: Array<{ command: string; cwd: string }> = [];
+  const writeLog: Array<{ path: string; content: string }> = [];
+  const removeLog: string[] = [];
+
+  return {
+    execLog,
+    writeLog,
+    removeLog,
+
+    exec(command: string, options: PrRunnerExecOptions): string {
+      execLog.push({ command, cwd: options.cwd });
+
+      for (const entry of commands) {
+        const matches = typeof entry.match === "string"
+          ? command.includes(entry.match)
+          : entry.match.test(command);
+        if (matches) {
+          if (entry.response instanceof Error) throw entry.response;
+          return entry.response;
+        }
+      }
+
+      // Default: return empty string for unmatched commands
+      return "";
+    },
+
+    writeFile(path: string, content: string): void {
+      writeLog.push({ path, content });
+    },
+
+    removeFile(path: string): void {
+      removeLog.push(path);
+    },
+
+    tempFilePath(extension: string): string {
+      return `/tmp/mock-pr-body${extension}`;
+    },
+
+    isGhInstalled(): boolean {
+      return true;
+    },
+
+    isGhAuthenticated(): boolean {
+      return true;
+    },
+
+    getCurrentBranch(_cwd: string): string | null {
+      return branch;
+    },
+
+    parseBranchToSlice(_branch: string): { milestoneId: string; sliceId: string } | null {
+      return parsedBranch;
+    },
+  };
+}

--- a/apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner-fixtures.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner-fixtures.ts
@@ -28,12 +28,12 @@ export const PLAN_CONTENT = `# S01: Test Slice
 
 /** Minimal SUMMARY content that satisfies `parseSummary()` expectations. */
 export const SUMMARY_CONTENT = `---
-one_liner: Test summary
+id: S01
 ---
 
 # S01 Summary
 
-Test summary content.
+**Test summary content.**
 `;
 
 // ─── Command transcript types ─────────────────────────────────────────────────
@@ -55,7 +55,7 @@ export interface MockRuntimeOptions {
    * Scripted command responses. Each entry maps a command prefix to a
    * response string (stdout) or an Error to throw.
    *
-   * Commands are matched by `command.startsWith(entry.command)`.
+   * Commands are matched by `command.includes(entry.match)` (substring match).
    * First match wins.
    */
   commands?: Array<{

--- a/apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner.vitest.test.ts
@@ -15,7 +15,6 @@ import { runCreatePr } from "../pr-runner.js";
 import {
   createMockRuntime,
   PLAN_CONTENT,
-  SUMMARY_CONTENT,
 } from "./pr-runner-fixtures.js";
 
 // ─── Happy path ───────────────────────────────────────────────────────────────
@@ -178,6 +177,235 @@ describe("runCreatePr — push-failed", () => {
       expect(result.phase).toBe("push-failed");
       expect(result.error).toContain("push failed");
     }
+  });
+});
+
+// ─── Parse-failed ─────────────────────────────────────────────────────────────
+
+describe("runCreatePr — branch-parse-failed", () => {
+  it("returns branch-parse-failed when branch is not a kata format and IDs are omitted", async () => {
+    const rt = createMockRuntime({
+      branch: "feature/random-work",
+      parsedBranch: null,
+    });
+
+    const result = await runCreatePr({
+      title: "Non-kata branch",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.phase).toBe("branch-parse-failed");
+      expect(result.error).toContain("feature/random-work");
+      expect(result.error).toContain("does not match supported Kata slice branch formats");
+      expect(result.hint).toContain("milestoneId and sliceId explicitly");
+    }
+  });
+
+  it("returns branch-parse-failed when getCurrentBranch returns null", async () => {
+    const rt = createMockRuntime({
+      branch: null,
+    });
+
+    const result = await runCreatePr({
+      title: "No branch",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.phase).toBe("branch-parse-failed");
+      expect(result.error).toContain("Could not determine current git branch");
+    }
+  });
+});
+
+// ─── Explicit-ID bypass ───────────────────────────────────────────────────────
+
+describe("runCreatePr — explicit milestoneId + sliceId", () => {
+  it("skips branch parsing when milestoneId and sliceId are provided explicitly", async () => {
+    const rt = createMockRuntime({
+      // Non-kata branch — would fail parsing normally
+      branch: "feature/unrelated",
+      parsedBranch: null,
+      commands: [
+        { match: "git ls-remote --heads origin", response: "abc\trefs/heads/feature/unrelated\n" },
+        { match: "gh pr create", response: "" },
+        { match: "gh pr view --json body", response: "" },
+        { match: "gh pr view --json url", response: "https://github.com/test/repo/pull/99\n" },
+      ],
+    });
+
+    const result = await runCreatePr({
+      title: "Explicit ID test",
+      milestoneId: "M005",
+      sliceId: "S03",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    // Should succeed because explicit IDs bypass branch parsing
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url).toBe("https://github.com/test/repo/pull/99");
+    }
+
+    // Verify PR was actually created (not short-circuited)
+    const createCmd = rt.execLog.find((e) => e.command.includes("gh pr create"));
+    expect(createCmd).toBeDefined();
+  });
+
+  it("uses explicit IDs even when branch is a valid kata format", async () => {
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+      commands: [
+        { match: "git ls-remote --heads origin", response: "abc\trefs/heads/kata/apps-cli/M001/S01\n" },
+        { match: "gh pr create", response: "" },
+        { match: "gh pr view --json body", response: "" },
+        { match: "gh pr view --json url", response: "https://github.com/test/repo/pull/100\n" },
+      ],
+    });
+
+    const result = await runCreatePr({
+      title: "Override IDs test",
+      milestoneId: "M099",
+      sliceId: "S99",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    // Should succeed — explicit IDs take priority
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ─── Body-integrity ───────────────────────────────────────────────────────────
+
+describe("runCreatePr — body-integrity", () => {
+  it("triggers body repair via gh pr edit when body does not match", async () => {
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+      commands: [
+        { match: "git ls-remote --heads origin", response: "abc\trefs/heads/kata/apps-cli/M001/S01\n" },
+        { match: "gh pr create", response: "" },
+        // Body view returns mangled content (different from expected)
+        { match: "gh pr view --json body", response: "Mangled body content that does not match\n" },
+        // PR number for repair
+        { match: "gh pr view --json number", response: "42\n" },
+        // Edit command succeeds
+        { match: "gh pr edit", response: "" },
+        // URL retrieval
+        { match: "gh pr view --json url", response: "https://github.com/test/repo/pull/42\n" },
+      ],
+    });
+
+    const result = await runCreatePr({
+      title: "Body repair test",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(true);
+
+    // Verify the repair sequence: view body → get number → edit
+    const editCmd = rt.execLog.find((e) => e.command.includes("gh pr edit"));
+    expect(editCmd).toBeDefined();
+    expect(editCmd!.command).toContain("42");
+    expect(editCmd!.command).toContain("--body-file");
+  });
+
+  it("does not trigger body repair when body matches expected", async () => {
+    // We need the actual body content that composePRBody generates
+    // The mock runtime captures what was written to the temp file
+    let capturedBody = "";
+
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+      commands: [
+        { match: "git ls-remote --heads origin", response: "abc\trefs/heads/kata/apps-cli/M001/S01\n" },
+        { match: "gh pr create", response: "" },
+        // Body view returns the exact content (matched dynamically below)
+        {
+          match: "gh pr view --json body",
+          // Will be set after we capture the body
+          response: "",
+        },
+        { match: "gh pr view --json url", response: "https://github.com/test/repo/pull/50\n" },
+      ],
+    });
+
+    // Override exec to capture body from writeFile and return it in view
+    const originalExec = rt.exec.bind(rt);
+    rt.exec = (command: string, options: { cwd: string; env?: Record<string, string | undefined> }) => {
+      if (command.includes("gh pr view --json body")) {
+        // Return exactly what was written to the body file
+        return capturedBody;
+      }
+      return originalExec(command, options);
+    };
+
+    // Override writeFile to capture the body
+    const originalWrite = rt.writeFile.bind(rt);
+    rt.writeFile = (path: string, content: string) => {
+      if (path.endsWith(".md")) {
+        capturedBody = content;
+      }
+      originalWrite(path, content);
+    };
+
+    const result = await runCreatePr({
+      title: "No repair needed",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(true);
+
+    // Verify NO gh pr edit was called (body matched)
+    const editCmd = rt.execLog.find((e) => e.command.includes("gh pr edit"));
+    expect(editCmd).toBeUndefined();
+  });
+});
+
+// ─── Create-failed ────────────────────────────────────────────────────────────
+
+describe("runCreatePr — create-failed", () => {
+  it("returns create-failed when gh pr create throws", async () => {
+    const ghError = new Error("gh pr create failed") as Error & { stderr: string };
+    ghError.stderr = "GraphQL: Resource not accessible by integration";
+
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+      commands: [
+        { match: "git ls-remote --heads origin", response: "abc\trefs/heads/kata/apps-cli/M001/S01\n" },
+        { match: "gh pr create", response: ghError },
+      ],
+    });
+
+    const result = await runCreatePr({
+      title: "Create failure",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.phase).toBe("create-failed");
+      expect(result.error).toContain("Resource not accessible");
+    }
+
+    // Verify temp file cleanup still happened
+    expect(rt.removeLog).toContain("/tmp/mock-pr-body.md");
   });
 });
 

--- a/apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner.vitest.test.ts
@@ -1,0 +1,254 @@
+/**
+ * pr-runner.vitest.test.ts — Orchestration tests for `runCreatePr()`.
+ *
+ * Uses injectable PrRunnerRuntime (from T01) with mock command transcripts
+ * to exercise deterministic PR creation paths:
+ * - Happy path: branch resolves, body written, PR created, URL returned
+ * - Push-failed: branch missing on remote + push failure
+ * - Parse-failed: non-kata branch with omitted IDs
+ * - Explicit-ID bypass: milestoneId + sliceId skip branch parsing
+ * - Body-integrity: repair-on-mismatch via gh pr edit
+ */
+
+import { describe, it, expect } from "vitest";
+import { runCreatePr } from "../pr-runner.js";
+import {
+  createMockRuntime,
+  PLAN_CONTENT,
+  SUMMARY_CONTENT,
+} from "./pr-runner-fixtures.js";
+
+// ─── Happy path ───────────────────────────────────────────────────────────────
+
+describe("runCreatePr — happy path", () => {
+  it("creates a PR and returns the URL when all steps succeed", async () => {
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+      commands: [
+        // ls-remote: branch exists on remote
+        { match: "git ls-remote --heads origin", response: "abc123\trefs/heads/kata/apps-cli/M001/S01\n" },
+        // gh pr create: succeeds
+        { match: "gh pr create", response: "https://github.com/test/repo/pull/42\n" },
+        // gh pr view body: matches expected (no repair needed)
+        { match: "gh pr view --json body", response: "" },
+        // gh pr view url
+        { match: "gh pr view --json url", response: "https://github.com/test/repo/pull/42\n" },
+      ],
+    });
+
+    const result = await runCreatePr({
+      title: "Test PR",
+      baseBranch: "main",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url).toBe("https://github.com/test/repo/pull/42");
+    }
+
+    // Verify body file was written and cleaned up
+    expect(rt.writeLog).toHaveLength(1);
+    expect(rt.writeLog[0].path).toBe("/tmp/mock-pr-body.md");
+    expect(rt.removeLog).toContain("/tmp/mock-pr-body.md");
+
+    // Verify gh pr create was called with correct title prefixing
+    const createCmd = rt.execLog.find((e) => e.command.includes("gh pr create"));
+    expect(createCmd).toBeDefined();
+    expect(createCmd!.command).toContain("[kata/apps-cli/M001/S01]");
+    expect(createCmd!.command).toContain("Test PR");
+  });
+
+  it("does not prefix title when branch name is already included", async () => {
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+      commands: [
+        { match: "git ls-remote --heads origin", response: "abc123\trefs/heads/kata/apps-cli/M001/S01\n" },
+        { match: "gh pr create", response: "" },
+        { match: "gh pr view --json body", response: "" },
+        { match: "gh pr view --json url", response: "https://github.com/test/repo/pull/43\n" },
+      ],
+    });
+
+    const result = await runCreatePr({
+      title: "[kata/apps-cli/M001/S01] Already prefixed",
+      baseBranch: "main",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(true);
+    // Title should NOT be double-prefixed
+    const createCmd = rt.execLog.find((e) => e.command.includes("gh pr create"));
+    expect(createCmd).toBeDefined();
+    // Should contain the title as-is, not "[kata/...] [kata/...] Already prefixed"
+    const titleMatches = createCmd!.command.match(/\[kata\/apps-cli\/M001\/S01\]/g);
+    expect(titleMatches).toHaveLength(1);
+  });
+
+  it("pushes branch when not on remote", async () => {
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+      commands: [
+        // ls-remote: branch NOT on remote (empty output)
+        { match: "git ls-remote --heads origin", response: "" },
+        // push succeeds
+        { match: "git push -u origin", response: "Branch pushed\n" },
+        // gh pr create succeeds
+        { match: "gh pr create", response: "" },
+        { match: "gh pr view --json body", response: "" },
+        { match: "gh pr view --json url", response: "https://github.com/test/repo/pull/44\n" },
+      ],
+    });
+
+    const result = await runCreatePr({
+      title: "Push test",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(true);
+
+    // Verify push was attempted
+    const pushCmd = rt.execLog.find((e) => e.command.includes("git push -u origin"));
+    expect(pushCmd).toBeDefined();
+  });
+});
+
+// ─── Push-failed ──────────────────────────────────────────────────────────────
+
+describe("runCreatePr — push-failed", () => {
+  it("returns push-failed when branch is missing on remote and push fails", async () => {
+    const pushError = new Error("fatal: remote rejected") as Error & { stderr: string };
+    pushError.stderr = "fatal: remote rejected (permission denied)";
+
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+      commands: [
+        // ls-remote: branch NOT on remote
+        { match: "git ls-remote --heads origin", response: "" },
+        // push fails
+        { match: "git push -u origin", response: pushError },
+      ],
+    });
+
+    const result = await runCreatePr({
+      title: "Push failure test",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.phase).toBe("push-failed");
+      expect(result.error).toContain("push failed");
+      expect(result.error).toContain("remote rejected");
+      expect(result.hint).toBeTruthy();
+    }
+
+    // Verify temp file cleanup still happened
+    expect(rt.removeLog).toContain("/tmp/mock-pr-body.md");
+  });
+
+  it("returns push-failed with error message when stderr is absent", async () => {
+    const pushError = new Error("git push command failed");
+
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+      commands: [
+        { match: "git ls-remote --heads origin", response: "" },
+        { match: "git push -u origin", response: pushError },
+      ],
+    });
+
+    const result = await runCreatePr({
+      title: "Push failure no stderr",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.phase).toBe("push-failed");
+      expect(result.error).toContain("push failed");
+    }
+  });
+});
+
+// ─── Pre-flight failures ──────────────────────────────────────────────────────
+
+describe("runCreatePr — pre-flight failures", () => {
+  it("returns title-missing when title is empty", async () => {
+    const rt = createMockRuntime();
+    const result = await runCreatePr({
+      title: "",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.phase).toBe("title-missing");
+    }
+  });
+
+  it("returns gh-missing when gh CLI is not installed", async () => {
+    const rt = createMockRuntime();
+    rt.isGhInstalled = () => false;
+
+    const result = await runCreatePr({
+      title: "Test",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.phase).toBe("gh-missing");
+    }
+  });
+
+  it("returns gh-unauth when gh CLI is not authenticated", async () => {
+    const rt = createMockRuntime();
+    rt.isGhAuthenticated = () => false;
+
+    const result = await runCreatePr({
+      title: "Test",
+      cwd: "/tmp/test-repo",
+      linearDocuments: { PLAN: PLAN_CONTENT },
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.phase).toBe("gh-unauth");
+    }
+  });
+
+  it("returns artifact-error when PLAN document is missing", async () => {
+    const rt = createMockRuntime({
+      branch: "kata/apps-cli/M001/S01",
+    });
+
+    const result = await runCreatePr({
+      title: "Test",
+      cwd: "/tmp/test-repo",
+      // No linearDocuments provided
+      _runtime: rt,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.phase).toBe("artifact-error");
+      expect(result.error).toContain("Missing required Linear artifact");
+    }
+  });
+});


### PR DESCRIPTION
## What Changed

Refactored `pr-runner.ts` orchestration boundaries to be deterministic and testable, then added Vitest orchestration tests exercising real runner flow against mocked runtime behavior.

## Changes

### T01: Runtime abstraction (`pr-runner-runtime.ts`)
- Introduced `PrRunnerRuntime` interface covering command execution, temp-file lifecycle, pre-flight checks, and branch detection
- Implemented `defaultRuntime` with existing Node primitives (behavior-preserving)
- Refactored `runCreatePr()` to accept optional `_runtime` parameter while preserving the stable `PrCreateOptions` caller API

### T02: Happy-path + push-failed tests
- Created `pr-runner-fixtures.ts` with `createMockRuntime()` factory and minimal PLAN/SUMMARY content
- Added happy-path orchestration test (PR URL, title prefixing, body file lifecycle)
- Added push-failed test (`phase === 'push-failed'`)
- Added pre-flight failure tests (title-missing, gh-missing, gh-unauth, artifact-error)

### T03: Parse-failed + explicit-ID + body-integrity tests
- Added parse-failed tests (non-kata branch, null branch)
- Added explicit milestoneId/sliceId bypass tests (skips branch parsing)
- Added body-integrity tests (repair-on-mismatch via `gh pr edit`, no-repair-on-match)
- Added create-failed test (`gh pr create` error handling)

## Test Coverage

- 16 Vitest orchestration tests covering all `runCreatePr()` phase paths
- All tests use injected mock runtime — zero network or GitHub dependency
- Bun legacy suite (51 tests) remains fully green

## Verification

- `npx vitest run src/resources/extensions/pr-lifecycle/tests/pr-runner.vitest.test.ts` — 16/16 pass
- `bun test --path-ignore-patterns '**/*.vitest.test.ts' src/` — 51/51 pass
- `npx tsc --noEmit` — clean
- Pre-push validation: lint + typecheck + 124 Vitest + 51 Bun — all green

## Files Changed

- `src/resources/extensions/pr-lifecycle/pr-runner-runtime.ts` (new) — Runtime abstraction + default implementation
- `src/resources/extensions/pr-lifecycle/pr-runner.ts` — Refactored to use injectable runtime
- `src/resources/extensions/pr-lifecycle/tests/pr-runner-fixtures.ts` (new) — Mock runtime factory + test artifacts
- `src/resources/extensions/pr-lifecycle/tests/pr-runner.vitest.test.ts` (new) — 16 orchestration tests

Refs: KAT-1033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code modularity by introducing an injectable runtime abstraction for PR creation orchestration, enabling better separation of concerns.

* **Tests**
  * Added comprehensive test coverage for PR creation workflows, including happy paths, error scenarios, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a clean runtime-injection pattern (`PrRunnerRuntime`) to make `runCreatePr()` fully testable without network or filesystem access, then adds 16 Vitest orchestration tests covering every phase path. The refactor is behaviour-preserving: `defaultRuntime` wraps the same Node primitives that were previously used inline, and the `_runtime` escape hatch in `PrCreateOptions` is explicitly opt-in and clearly documented.\n\nKey changes:\n- `pr-runner-runtime.ts` (new): `PrRunnerRuntime` interface + `defaultRuntime` covering `exec`, `writeFile`, `removeFile`, `tempFilePath`, pre-flight checks, and branch detection\n- `pr-runner.ts`: All direct I/O replaced with `rt.*` delegates; caller API (`PrCreateOptions`) is stable aside from the new optional `_runtime` field\n- `pr-runner-fixtures.ts` (new): `createMockRuntime()` factory with scripted command responses and full call recording; one minor doc discrepancy — the JSDoc says `startsWith` matching but the implementation uses `includes`\n- `pr-runner.vitest.test.ts` (new): 16 tests covering happy-path, push-failed, branch-parse-failed, explicit-ID bypass, body-integrity repair/no-repair, create-failed, and all pre-flight failures

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive refactor and test coverage with no behaviour change to production paths

All remaining findings are P2 (a one-line JSDoc correction). The production defaultRuntime is a direct, behaviour-preserving extraction of the previous inline Node calls. The 16 new tests exercise every documented phase path deterministically. TypeScript passes clean and the existing 51 Bun tests remain green.

No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/pr-lifecycle/pr-runner-runtime.ts | New file: defines PrRunnerRuntime interface and defaultRuntime implementation, cleanly extracting all I/O seams from pr-runner.ts into an injectable abstraction |
| apps/cli/src/resources/extensions/pr-lifecycle/pr-runner.ts | Refactored to use injectable PrRunnerRuntime via options._runtime; all direct Node I/O calls replaced with rt.* delegates; production behavior is fully preserved |
| apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner-fixtures.ts | New mock runtime factory; one documentation mismatch: JSDoc says startsWith but implementation uses includes for command matching |
| apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner.vitest.test.ts | 16 deterministic orchestration tests covering all runner phases; uses runtime injection cleanly; body-integrity no-repair test correctly intercepts exec to compare against captured body |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant runCreatePr
    participant Runtime as PrRunnerRuntime
    participant composePRBody

    Caller->>runCreatePr: runCreatePr(options)
    Note over runCreatePr: rt = options._runtime ?? defaultRuntime

    runCreatePr->>Runtime: isGhInstalled()
    runCreatePr->>Runtime: isGhAuthenticated()
    runCreatePr->>Runtime: getCurrentBranch(cwd)
    runCreatePr->>Runtime: parseBranchToSlice(branch)

    runCreatePr->>composePRBody: composePRBody(milestoneId, sliceId, cwd, ...)
    composePRBody-->>runCreatePr: body

    runCreatePr->>Runtime: tempFilePath(".md")
    runCreatePr->>Runtime: writeFile(tmpPath, body)

    runCreatePr->>Runtime: exec("git ls-remote --heads origin ...")
    alt branch not on remote
        runCreatePr->>Runtime: exec("git push -u origin HEAD")
        alt push fails
            runCreatePr-->>Caller: { ok: false, phase: "push-failed" }
        end
    end

    runCreatePr->>Runtime: exec("gh pr create --title ... --body-file ...")
    alt gh pr create fails
        runCreatePr-->>Caller: { ok: false, phase: "create-failed" }
    end

    runCreatePr->>Runtime: exec("gh pr view --json body --jq .body")
    alt body mismatch
        runCreatePr->>Runtime: exec("gh pr view --json number --jq .number")
        runCreatePr->>Runtime: exec("gh pr edit n --body-file ...")
    end

    runCreatePr->>Runtime: exec("gh pr view --json url --jq .url")
    runCreatePr->>Runtime: removeFile(tmpPath)
    runCreatePr-->>Caller: { ok: true, url }
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/pr-lifecycle/tests/pr-runner-fixtures.ts
Line: 57-59

Comment:
**JSDoc says `startsWith`, implementation uses `includes`**

The comment on line 57 documents that commands are matched with `command.startsWith(entry.match)`, but the actual implementation on line 126 uses `command.includes(entry.match)`:

```typescript
// line 126
const matches = typeof entry.match === "string"
  ? command.includes(entry.match)   // ← not startsWith
  : entry.match.test(command);
```

The two strategies behave identically for the current test suite because all match strings are specific enough, but the discrepancy could mislead future test authors into assuming anchored-prefix semantics when writing new command entries. The doc comment should be updated to reflect the actual behaviour:

```suggestion
   * Commands are matched by `command.includes(entry.match)` (substring match).
   * First match wins.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(pr-lifecycle): add parse-failed, ex..."](https://github.com/gannonh/kata/commit/98d15d3b100b68d4f676fff073448105f1780216) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26591786)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->