### PR TITLE
feat(symphony): inter-worker shared context coordination (KAT-1322)

### DIFF
--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -2219,6 +2219,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -2701,6 +2702,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -57,6 +57,7 @@ regex = "1"
 dotenvy = "0.15.7"
 shell-words = "1"
 futures-util = "0.3"
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -415,6 +415,7 @@ All configuration lives in the YAML front-matter of your WORKFLOW.md. See [`docs
 | ------------------------- | ----------------------------------------------------------------- |
 | `tracker`                 | Linear connection, project, assignee filter, state mappings       |
 | `polling`                 | How often to check for new/changed issues                         |
+| `shared_context`          | Ephemeral cross-worker context retention (TTL + max entries)      |
 | `workspace`               | Where and how workspaces are created, Docker config               |
 | `agent`                   | Backend selection, concurrency limits, max turns, retry backoff   |
 | `kata_agent` / `pi_agent` | Kata CLI backend config: command, model, timeouts                 |
@@ -437,6 +438,32 @@ tracker:
 ### Dynamic reload
 
 Symphony watches WORKFLOW.md for changes and applies config updates without restart.
+
+## Inter-worker Shared Context
+
+Symphony includes an **ephemeral shared context store** for cross-worker coordination.
+Workers automatically receive the most relevant recent entries (project + matching labels)
+in their prompt preamble, so follow-up workers can reuse decisions and avoid conflicts.
+
+Properties:
+
+- In-memory only (restarts intentionally clear it)
+- Configurable TTL (`shared_context.ttl_ms`, default 24h)
+- Configurable cap (`shared_context.max_entries`, default 100)
+- Automatic expiry pruning on every poll cycle
+
+HTTP API:
+
+- `POST /api/v1/context` — write `{ author_issue, scope, content, ttl_ms? }`
+- `GET /api/v1/context` — list current entries (optional `?scope=project,label:backend`)
+- `DELETE /api/v1/context/{id}` — delete one entry
+- `DELETE /api/v1/context?scope=...` — clear by scope (or all when omitted)
+
+Events emitted on `/api/v1/events`:
+
+- `event=shared_context_written`
+- `event=shared_context_read`
+- `event=shared_context_expired`
 
 ## Lifecycle Hooks
 
@@ -513,13 +540,17 @@ Each host must have the agent backend (Kata CLI or Codex) installed and on PATH.
 
 Available at `http://localhost:<port>`. Auto-refreshes every 2 seconds.
 
-Shows: running sessions (with turn count, token usage, last activity), retry queue, completed issues, polling stats, rate limits, and a link to the Linear project.
+Shows: running sessions (with turn count, token usage, last activity), retry queue, shared context table (author/scope/preview/age/TTL), completed issues, polling stats, rate limits, and a link to the Linear project.
 
 HTTP surfaces:
 
 | Endpoint | Purpose |
 | --- | --- |
-| `GET /api/v1/state` | Full orchestrator snapshot JSON |
+| `GET /api/v1/state` | Full orchestrator snapshot JSON (includes `shared_context` summary) |
+| `GET /api/v1/context` | List active shared context entries (optional `scope` filter) |
+| `POST /api/v1/context` | Write a shared context entry |
+| `DELETE /api/v1/context/{id}` | Delete a specific shared context entry |
+| `DELETE /api/v1/context` | Clear shared context (optionally by `scope`) |
 | `GET /api/v1/{ISSUE-ID}` | Per-issue running/retry projection |
 | `POST /api/v1/refresh` | Queue an immediate poll tick |
 | `GET /api/v1/events` | Live websocket stream (`SymphonyEventEnvelope`) |

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -68,6 +68,20 @@ polling:
   # Milliseconds between poll cycles. Lower = more responsive, more API calls.
   interval_ms: 30000
 
+# ─── Shared Context (Inter-worker coordination, M002/S06) ───────────────────
+# Ephemeral in-memory context entries shared across worker sessions.
+# Restarts clear this store by design.
+shared_context:
+  # Default TTL for new context entries in milliseconds.
+  # Entries older than ttl_ms are pruned automatically each poll cycle.
+  # Default: 86400000 (24h)
+  ttl_ms: 86400000
+
+  # Maximum number of entries retained in memory.
+  # When exceeded, the oldest entries are evicted first.
+  # Default: 100
+  max_entries: 100
+
 # ─── Workspace ────────────────────────────────────────────────────────────────
 # Configures how agent workspaces are created and managed.
 # Each dispatched issue gets its own workspace directory.

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -976,8 +976,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
             .unwrap_or(defaults.shared_context.ttl_ms),
         max_entries: raw_shared_context
             .max_entries
-            .unwrap_or(defaults.shared_context.max_entries)
-            .max(1),
+            .unwrap_or(defaults.shared_context.max_entries),
     };
 
     Ok(ServiceConfig {

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -13,8 +13,8 @@ use serde_yaml::{Mapping, Value};
 use crate::domain::{
     AgentBackend, AgentConfig, ApiKey, CodexConfig, DockerCodexAuth, DockerConfig, HooksConfig,
     NotificationsConfig, PiAgentConfig, PollingConfig, PromptsConfig, ServerConfig, ServiceConfig,
-    SlackConfig, TrackerConfig, WorkerConfig, WorkspaceConfig, WorkspaceIsolation,
-    WorkspaceRepoStrategy,
+    SharedContextConfig, SlackConfig, TrackerConfig, WorkerConfig, WorkspaceConfig,
+    WorkspaceIsolation, WorkspaceRepoStrategy,
 };
 use crate::error::{Result, SymphonyError};
 use crate::notifications;
@@ -302,6 +302,13 @@ struct RawNotificationsConfig {
 
 #[derive(Deserialize, Default)]
 #[serde(default)]
+struct RawSharedContextConfig {
+    ttl_ms: Option<u64>,
+    max_entries: Option<usize>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
 struct RawSlackConfig {
     webhook_url: Option<String>,
     events: Option<Vec<String>>,
@@ -485,6 +492,8 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let raw_server: RawServerConfig = extract_section(&normalized, "server")?;
     let raw_prompts: RawPromptsConfig = extract_section(&normalized, "prompts")?;
     let raw_notifications: RawNotificationsConfig = extract_section(&normalized, "notifications")?;
+    let raw_shared_context: RawSharedContextConfig =
+        extract_section(&normalized, "shared_context")?;
 
     let defaults = ServiceConfig::default();
     let has_kata_agent_section = normalized.get("kata_agent").is_some();
@@ -961,6 +970,16 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
 
     let notifications = slack.map(|slack| NotificationsConfig { slack: Some(slack) });
 
+    let shared_context = SharedContextConfig {
+        ttl_ms: raw_shared_context
+            .ttl_ms
+            .unwrap_or(defaults.shared_context.ttl_ms),
+        max_entries: raw_shared_context
+            .max_entries
+            .unwrap_or(defaults.shared_context.max_entries)
+            .max(1),
+    };
+
     Ok(ServiceConfig {
         tracker,
         polling,
@@ -974,6 +993,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         server,
         prompts,
         notifications,
+        shared_context,
     })
 }
 
@@ -1066,6 +1086,18 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
                     .to_string(),
             ));
         }
+    }
+
+    if config.shared_context.ttl_ms == 0 {
+        return Err(SymphonyError::InvalidWorkflowConfig(
+            "shared_context.ttl_ms must be greater than 0".to_string(),
+        ));
+    }
+
+    if config.shared_context.max_entries == 0 {
+        return Err(SymphonyError::InvalidWorkflowConfig(
+            "shared_context.max_entries must be greater than 0".to_string(),
+        ));
     }
 
     Ok(ValidatedServiceConfig(config.clone()))

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -81,29 +81,18 @@ impl ContextScope {
             return Some(Self::Project);
         }
 
-        if let Some(raw) = normalized
-            .strip_prefix("milestone:")
-            .or_else(|| normalized.strip_prefix("Milestone:"))
-        {
-            let id = raw.trim();
-            if !id.is_empty() {
-                return Some(Self::Milestone(id.to_string()));
-            }
+        let (raw_kind, raw_value) = normalized.split_once(':')?;
+        let kind = raw_kind.trim().to_ascii_lowercase();
+        let raw_value = raw_value.trim();
+        if raw_value.is_empty() {
             return None;
         }
 
-        if let Some(raw) = normalized
-            .strip_prefix("label:")
-            .or_else(|| normalized.strip_prefix("Label:"))
-        {
-            let label = raw.trim();
-            if !label.is_empty() {
-                return Some(Self::Label(label.to_ascii_lowercase()));
-            }
-            return None;
+        match kind.as_str() {
+            "milestone" => Some(Self::Milestone(raw_value.to_string())),
+            "label" => Some(Self::Label(raw_value.to_ascii_lowercase())),
+            _ => None,
         }
-
-        None
     }
 
     pub fn as_scope_key(&self) -> String {
@@ -143,6 +132,8 @@ pub enum EventKind {
     Worker,
     Tool,
     Heartbeat,
+    SharedContextWritten,
+    SharedContextExpired,
 }
 
 impl EventKind {
@@ -153,6 +144,8 @@ impl EventKind {
             "worker" => Some(Self::Worker),
             "tool" => Some(Self::Tool),
             "heartbeat" => Some(Self::Heartbeat),
+            "shared_context_written" => Some(Self::SharedContextWritten),
+            "shared_context_expired" => Some(Self::SharedContextExpired),
             _ => None,
         }
     }
@@ -164,11 +157,21 @@ impl EventKind {
             Self::Worker => "worker",
             Self::Tool => "tool",
             Self::Heartbeat => "heartbeat",
+            Self::SharedContextWritten => "shared_context_written",
+            Self::SharedContextExpired => "shared_context_expired",
         }
     }
 
     pub fn variants() -> &'static [&'static str] {
-        &["snapshot", "runtime", "worker", "tool", "heartbeat"]
+        &[
+            "snapshot",
+            "runtime",
+            "worker",
+            "tool",
+            "heartbeat",
+            "shared_context_written",
+            "shared_context_expired",
+        ]
     }
 }
 
@@ -395,6 +398,7 @@ pub struct ServiceConfig {
     pub server: ServerConfig,
     pub prompts: Option<PromptsConfig>,
     pub notifications: Option<NotificationsConfig>,
+    pub shared_context: SharedContextConfig,
 }
 
 /// Tracker configuration (spec §5.3.1).
@@ -471,6 +475,22 @@ impl Default for PollingConfig {
     fn default() -> Self {
         Self {
             interval_ms: 30_000,
+        }
+    }
+}
+
+/// Shared context configuration (M002/S06).
+#[derive(Debug, Clone)]
+pub struct SharedContextConfig {
+    pub ttl_ms: u64,
+    pub max_entries: usize,
+}
+
+impl Default for SharedContextConfig {
+    fn default() -> Self {
+        Self {
+            ttl_ms: 86_400_000,
+            max_entries: 100,
         }
     }
 }
@@ -940,6 +960,18 @@ pub struct PollingSnapshot {
     pub poll_count: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SharedContextSummary {
+    #[serde(default)]
+    pub total_entries: usize,
+    #[serde(default)]
+    pub entries_by_scope: BTreeMap<String, usize>,
+    #[serde(default)]
+    pub oldest_entry_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub newest_entry_at: Option<DateTime<Utc>>,
+}
+
 /// Read-only serializable view of orchestrator state for the HTTP API.
 /// Uses `BTreeMap` for deterministic JSON key ordering.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -958,6 +990,8 @@ pub struct OrchestratorSnapshot {
     pub completed: Vec<CompletedEntry>,
     #[serde(default)]
     pub blocked: Vec<BlockedIssueEntry>,
+    #[serde(default)]
+    pub shared_context: SharedContextSummary,
     pub codex_totals: CodexTotals,
     pub codex_rate_limits: Option<RateLimitInfo>,
     pub polling: PollingSnapshot,

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -64,6 +64,73 @@ pub struct BlockedIssueEntry {
     pub blocker_identifiers: Vec<String>,
 }
 
+// ── Shared context contract (M002/S06) ──────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum ContextScope {
+    Project,
+    Milestone(String),
+    Label(String),
+}
+
+impl ContextScope {
+    pub fn parse(value: &str) -> Option<Self> {
+        let normalized = value.trim();
+        if normalized.eq_ignore_ascii_case("project") {
+            return Some(Self::Project);
+        }
+
+        if let Some(raw) = normalized
+            .strip_prefix("milestone:")
+            .or_else(|| normalized.strip_prefix("Milestone:"))
+        {
+            let id = raw.trim();
+            if !id.is_empty() {
+                return Some(Self::Milestone(id.to_string()));
+            }
+            return None;
+        }
+
+        if let Some(raw) = normalized
+            .strip_prefix("label:")
+            .or_else(|| normalized.strip_prefix("Label:"))
+        {
+            let label = raw.trim();
+            if !label.is_empty() {
+                return Some(Self::Label(label.to_ascii_lowercase()));
+            }
+            return None;
+        }
+
+        None
+    }
+
+    pub fn as_scope_key(&self) -> String {
+        match self {
+            Self::Project => "project".to_string(),
+            Self::Milestone(id) => format!("milestone:{id}"),
+            Self::Label(label) => format!("label:{label}"),
+        }
+    }
+}
+
+impl fmt::Display for ContextScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.as_scope_key())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextEntry {
+    pub id: String,
+    pub author_issue: String,
+    pub scope: ContextScope,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub ttl_ms: u64,
+}
+
 // ── Event stream contract (M002/S01) ───────────────────────────────────
 
 pub const SYMPHONY_EVENT_STREAM_VERSION: &str = "v1";

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -21,7 +21,9 @@ use crate::domain::{
 };
 use crate::event_stream::EventHub;
 use crate::orchestrator::{RefreshSender, SnapshotHandle};
-use crate::shared_context::{ContextEntryDraft, SharedContextStore};
+use crate::shared_context::{
+    ContextEntryDraft, SharedContextStore, MAX_SHARED_CONTEXT_CONTENT_CHARS,
+};
 
 pub const HTTP_PORT_RETRY_LIMIT: u16 = 10;
 
@@ -1115,16 +1117,19 @@ async fn post_context(
             .into_response();
     }
 
-    if content_len > 500 {
+    if content_len > MAX_SHARED_CONTEXT_CONTENT_CHARS {
         return (
             StatusCode::BAD_REQUEST,
             Json(ApiErrorEnvelope {
                 error: ApiError {
                     code: "invalid_content",
-                    message: "shared context content must be 500 characters or fewer".to_string(),
+                    message: format!(
+                        "shared context content must be {} characters or fewer",
+                        MAX_SHARED_CONTEXT_CONTENT_CHARS
+                    ),
                     status: StatusCode::BAD_REQUEST.as_u16(),
                     details: Some(serde_json::json!({
-                        "max_chars": 500,
+                        "max_chars": MAX_SHARED_CONTEXT_CONTENT_CHARS,
                         "actual_chars": content_len,
                     })),
                 },

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -7,7 +7,7 @@ use axum::extract::ws::{close_code, CloseFrame, Message, WebSocket, WebSocketUpg
 use axum::extract::{Path, Query, State};
 use axum::http::{Method, StatusCode, Uri};
 use axum::response::{Html, IntoResponse};
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use chrono::Utc;
 use futures_util::{SinkExt, StreamExt};
@@ -15,12 +15,13 @@ use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
 use crate::domain::{
-    CodexTotals, EventFilter, EventKind, EventSeverity, OrchestratorSnapshot, PollingSnapshot,
-    RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot,
-    SymphonyEventEnvelope, WorkerSessionInfo,
+    CodexTotals, ContextEntry, ContextScope, EventFilter, EventKind, EventSeverity,
+    OrchestratorSnapshot, PollingSnapshot, RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt,
+    RunningSessionSnapshot, SharedContextSummary, SymphonyEventEnvelope, WorkerSessionInfo,
 };
 use crate::event_stream::EventHub;
 use crate::orchestrator::{RefreshSender, SnapshotHandle};
+use crate::shared_context::{ContextEntryDraft, SharedContextStore};
 
 pub const HTTP_PORT_RETRY_LIMIT: u16 = 10;
 
@@ -114,6 +115,7 @@ pub struct HttpServerState {
     snapshot_source: Arc<dyn SnapshotSource>,
     refresh_control: Arc<dyn RefreshControl>,
     event_hub: EventHub,
+    shared_context_store: SharedContextStore,
     event_stream_config: EventStreamConfig,
     event_stream_counters: Arc<EventStreamCounters>,
     next_client_id: Arc<AtomicU64>,
@@ -142,10 +144,16 @@ impl HttpServerState {
             snapshot_source,
             refresh_control,
             event_hub,
+            shared_context_store: SharedContextStore::default(),
             event_stream_config,
             event_stream_counters: Arc::new(EventStreamCounters::default()),
             next_client_id: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    pub fn with_shared_context_store(mut self, shared_context_store: SharedContextStore) -> Self {
+        self.shared_context_store = shared_context_store;
+        self
     }
 
     pub fn snapshot(&self) -> OrchestratorSnapshot {
@@ -158,6 +166,10 @@ impl HttpServerState {
 
     pub fn event_hub(&self) -> EventHub {
         self.event_hub.clone()
+    }
+
+    pub fn shared_context_store(&self) -> SharedContextStore {
+        self.shared_context_store.clone()
     }
 
     pub fn event_stream_config(&self) -> EventStreamConfig {
@@ -237,6 +249,7 @@ struct StateResponse {
     retry_queue: Vec<RetrySnapshotEntry>,
     blocked: Vec<crate::domain::BlockedIssueEntry>,
     completed: Vec<crate::domain::CompletedEntry>,
+    shared_context: SharedContextSummary,
     codex_totals: CodexTotals,
     codex_rate_limits: Option<serde_json::Value>,
     polling: PollingSnapshot,
@@ -263,6 +276,36 @@ struct RefreshResponse {
     queued: bool,
     coalesced: bool,
     pending_requests: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SharedContextWriteRequest {
+    author_issue: String,
+    scope: String,
+    content: String,
+    ttl_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SharedContextQuery {
+    scope: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SharedContextListResponse {
+    entries: Vec<ContextEntry>,
+    summary: SharedContextSummary,
+}
+
+#[derive(Debug, Serialize)]
+struct SharedContextWriteResponse {
+    id: String,
+    created_at: chrono::DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+struct SharedContextDeleteResponse {
+    deleted: usize,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -348,6 +391,11 @@ pub fn build_router(state: HttpServerState) -> Router {
     Router::new()
         .route("/", get(get_dashboard))
         .route("/api/v1/state", get(get_state))
+        .route(
+            "/api/v1/context",
+            get(get_context).post(post_context).delete(delete_context),
+        )
+        .route("/api/v1/context/{entry_id}", delete(delete_context_entry))
         .route("/api/v1/events", get(get_events))
         .route("/api/v1/{issue_identifier}", get(get_issue))
         .route("/api/v1/refresh", post(post_refresh))
@@ -591,6 +639,28 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
   </section>
 
   <section class="card section">
+    <details id="shared-context-details" open>
+      <summary>Shared Context (<span id="context-count">0</span>)</summary>
+      <div class="table-wrap" style="margin-top: 10px;">
+        <table>
+          <thead>
+            <tr>
+              <th>Author</th>
+              <th>Scope</th>
+              <th>Content Preview</th>
+              <th>Age</th>
+              <th>TTL Remaining</th>
+            </tr>
+          </thead>
+          <tbody id="context-table-body">
+            <tr><td class="muted" colspan="5">Loading...</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </details>
+  </section>
+
+  <section class="card section">
     <h2>Completed issues</h2>
     <ul id="completed-list" class="list">
       <li class="muted">Loading...</li>
@@ -770,6 +840,67 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }}).join('');
     }}
 
+    function formatContextScope(scope) {{
+      if (!scope || typeof scope !== 'object') return '-';
+      const type = scope.type || '';
+      if (type === 'project') return 'project';
+      if (type === 'milestone') return 'milestone:' + (scope.value || '-');
+      if (type === 'label') return 'label:' + (scope.value || '-');
+      return '-';
+    }}
+
+    function contextAgeAndTtl(entry, nowMs) {{
+      const createdAtMs = Date.parse(entry.created_at || '');
+      if (!Number.isFinite(createdAtMs)) {{
+        return {{ age: 'n/a', ttlRemaining: 'n/a' }};
+      }}
+
+      const ageMs = Math.max(0, nowMs - createdAtMs);
+      const ttlMs = Number(entry.ttl_ms || 0);
+      const ttlRemainingMs = Number.isFinite(ttlMs) && ttlMs > 0
+        ? Math.max(0, ttlMs - ageMs)
+        : NaN;
+
+      return {{
+        age: formatTimeAgo(ageMs),
+        ttlRemaining: Number.isFinite(ttlRemainingMs) ? formatDuration(ttlRemainingMs) : 'n/a',
+      }};
+    }}
+
+    function renderSharedContext(entries) {{
+      const list = Array.isArray(entries) ? entries.slice() : [];
+      list.sort(function(a, b) {{
+        return Date.parse(b.created_at || '') - Date.parse(a.created_at || '');
+      }});
+
+      if (list.length === 0) {{
+        return '<tr><td class="muted" colspan="5">No active shared context entries.</td></tr>';
+      }}
+
+      const nowMs = Date.now();
+      return list.map(function(entry) {{
+        const timing = contextAgeAndTtl(entry, nowMs);
+        return '<tr>' +
+          '<td class="mono">' + escapeHtml(entry.author_issue || '-') + '</td>' +
+          '<td class="mono">' + escapeHtml(formatContextScope(entry.scope)) + '</td>' +
+          '<td>' + escapeHtml(entry.content || '-') + '</td>' +
+          '<td class="mono">' + escapeHtml(timing.age) + '</td>' +
+          '<td class="mono">' + escapeHtml(timing.ttlRemaining) + '</td>' +
+          '</tr>';
+      }}).join('');
+    }}
+
+    function updateSharedContextSection(entries) {{
+      const list = Array.isArray(entries) ? entries : [];
+      document.getElementById('context-count').textContent = String(list.length);
+      document.getElementById('context-table-body').innerHTML = renderSharedContext(list);
+
+      const details = document.getElementById('shared-context-details');
+      if (details) {{
+        details.open = list.length <= 5;
+      }}
+    }}
+
     function renderLinearProjectCard(url) {{
       if (!url) {{
         return '<section class="card"><div class="label">linear project</div><div class="mono muted">n/a</div></section>';
@@ -806,12 +937,19 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
 
     async function refreshState() {{
       try {{
-        const response = await fetch('/api/v1/state');
-        if (!response.ok) throw new Error('state fetch failed: ' + response.status);
-        const state = await response.json();
+        const [stateResponse, contextResponse] = await Promise.all([
+          fetch('/api/v1/state'),
+          fetch('/api/v1/context'),
+        ]);
+        if (!stateResponse.ok) throw new Error('state fetch failed: ' + stateResponse.status);
+        if (!contextResponse.ok) throw new Error('context fetch failed: ' + contextResponse.status);
+
+        const state = await stateResponse.json();
+        const contextPayload = await contextResponse.json();
         const running = state.running || {{}};
         const retryQueue = state.retry_queue || [];
         const completed = state.completed || [];
+        const sharedContextEntries = contextPayload.entries || [];
 
         document.getElementById('running-count').textContent = Object.keys(running).length;
         document.getElementById('retry-count').textContent = retryQueue.length;
@@ -840,6 +978,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         }}
 
         document.getElementById('completed-list').innerHTML = renderCompleted(completed);
+        updateSharedContextSection(sharedContextEntries);
         document.getElementById('token-input').textContent = state.codex_totals?.input_tokens ?? 0;
         document.getElementById('token-output').textContent = state.codex_totals?.output_tokens ?? 0;
         document.getElementById('token-total').textContent = state.codex_totals?.total_tokens ?? 0;
@@ -874,10 +1013,238 @@ async fn get_state(State(state): State<HttpServerState>) -> impl IntoResponse {
         retry_queue: snapshot.retry_queue,
         blocked: snapshot.blocked,
         completed: snapshot.completed,
+        shared_context: snapshot.shared_context,
         codex_totals: snapshot.codex_totals,
         codex_rate_limits: snapshot.codex_rate_limits.map(|r| r.data),
         polling: snapshot.polling,
     })
+}
+
+fn parse_shared_context_scopes(
+    raw: Option<&str>,
+) -> std::result::Result<Vec<ContextScope>, ApiErrorEnvelope> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+
+    let mut scopes = Vec::new();
+    for token in raw.split(',') {
+        let trimmed = token.trim();
+        if trimmed.is_empty() {
+            return Err(ApiErrorEnvelope {
+                error: ApiError {
+                    code: "invalid_scope",
+                    message: "shared context scope filter cannot contain empty values".to_string(),
+                    status: StatusCode::BAD_REQUEST.as_u16(),
+                    details: Some(serde_json::json!({
+                        "allowed": ["project", "milestone:<id>", "label:<name>"],
+                    })),
+                },
+            });
+        }
+
+        let Some(scope) = ContextScope::parse(trimmed) else {
+            return Err(ApiErrorEnvelope {
+                error: ApiError {
+                    code: "invalid_scope",
+                    message: format!(
+                        "invalid shared context scope '{trimmed}'. Use project, milestone:<id>, or label:<name>"
+                    ),
+                    status: StatusCode::BAD_REQUEST.as_u16(),
+                    details: Some(serde_json::json!({
+                        "scope": trimmed,
+                        "allowed": ["project", "milestone:<id>", "label:<name>"],
+                    })),
+                },
+            });
+        };
+
+        scopes.push(scope);
+    }
+
+    scopes.sort();
+    scopes.dedup();
+    Ok(scopes)
+}
+
+fn shared_context_preview(value: &str) -> String {
+    const MAX_PREVIEW_CHARS: usize = 120;
+    value.chars().take(MAX_PREVIEW_CHARS).collect()
+}
+
+async fn get_context(
+    Query(query): Query<SharedContextQuery>,
+    State(state): State<HttpServerState>,
+) -> impl IntoResponse {
+    let scopes = match parse_shared_context_scopes(query.scope.as_deref()) {
+        Ok(scopes) => scopes,
+        Err(err) => return (StatusCode::BAD_REQUEST, Json(err)).into_response(),
+    };
+
+    let store = state.shared_context_store();
+    let entries = if scopes.is_empty() {
+        store.list()
+    } else {
+        store.read(&scopes)
+    };
+
+    Json(SharedContextListResponse {
+        entries,
+        summary: store.summary(),
+    })
+    .into_response()
+}
+
+async fn post_context(
+    State(state): State<HttpServerState>,
+    Json(payload): Json<SharedContextWriteRequest>,
+) -> impl IntoResponse {
+    let content_len = payload.content.chars().count();
+    if content_len == 0 || payload.content.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiErrorEnvelope {
+                error: ApiError {
+                    code: "invalid_content",
+                    message: "shared context content must be non-empty".to_string(),
+                    status: StatusCode::BAD_REQUEST.as_u16(),
+                    details: None,
+                },
+            }),
+        )
+            .into_response();
+    }
+
+    if content_len > 500 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiErrorEnvelope {
+                error: ApiError {
+                    code: "invalid_content",
+                    message: "shared context content must be 500 characters or fewer".to_string(),
+                    status: StatusCode::BAD_REQUEST.as_u16(),
+                    details: Some(serde_json::json!({
+                        "max_chars": 500,
+                        "actual_chars": content_len,
+                    })),
+                },
+            }),
+        )
+            .into_response();
+    }
+
+    let scope = match ContextScope::parse(&payload.scope) {
+        Some(scope) => scope,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiErrorEnvelope {
+                    error: ApiError {
+                        code: "invalid_scope",
+                        message: format!(
+                            "invalid shared context scope '{}'. Use project, milestone:<id>, or label:<name>",
+                            payload.scope
+                        ),
+                        status: StatusCode::BAD_REQUEST.as_u16(),
+                        details: Some(serde_json::json!({
+                            "scope": payload.scope,
+                            "allowed": ["project", "milestone:<id>", "label:<name>"],
+                        })),
+                    },
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    if payload.ttl_ms == Some(0) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiErrorEnvelope {
+                error: ApiError {
+                    code: "invalid_ttl",
+                    message: "ttl_ms must be greater than 0 when provided".to_string(),
+                    status: StatusCode::BAD_REQUEST.as_u16(),
+                    details: Some(serde_json::json!({
+                        "ttl_ms": 0,
+                    })),
+                },
+            }),
+        )
+            .into_response();
+    }
+
+    let store = state.shared_context_store();
+    let entry = store.write_entry(ContextEntryDraft {
+        author_issue: payload.author_issue,
+        scope,
+        content: payload.content,
+        ttl_ms: payload.ttl_ms,
+    });
+
+    state.event_hub().publish_with_timestamp(
+        EventKind::SharedContextWritten,
+        EventSeverity::Info,
+        Some(entry.author_issue.clone()),
+        "shared_context_written",
+        serde_json::json!({
+            "entry_id": entry.id,
+            "author_issue": entry.author_issue,
+            "scope": entry.scope.as_scope_key(),
+            "preview": shared_context_preview(&entry.content),
+        }),
+        entry.created_at,
+    );
+
+    (
+        StatusCode::CREATED,
+        Json(SharedContextWriteResponse {
+            id: entry.id,
+            created_at: entry.created_at,
+        }),
+    )
+        .into_response()
+}
+
+async fn delete_context(
+    Query(query): Query<SharedContextQuery>,
+    State(state): State<HttpServerState>,
+) -> impl IntoResponse {
+    let scopes = match parse_shared_context_scopes(query.scope.as_deref()) {
+        Ok(scopes) => scopes,
+        Err(err) => return (StatusCode::BAD_REQUEST, Json(err)).into_response(),
+    };
+
+    let deleted = if scopes.is_empty() {
+        state.shared_context_store().clear(None)
+    } else {
+        state.shared_context_store().clear(Some(&scopes))
+    };
+
+    Json(SharedContextDeleteResponse { deleted }).into_response()
+}
+
+async fn delete_context_entry(
+    Path(entry_id): Path<String>,
+    State(state): State<HttpServerState>,
+) -> impl IntoResponse {
+    let store = state.shared_context_store();
+    if store.remove_entry(&entry_id).is_none() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ApiErrorEnvelope {
+                error: ApiError {
+                    code: "context_not_found",
+                    message: format!("shared context entry '{}' was not found", entry_id),
+                    status: StatusCode::NOT_FOUND.as_u16(),
+                    details: None,
+                },
+            }),
+        )
+            .into_response();
+    }
+
+    Json(SharedContextDeleteResponse { deleted: 1 }).into_response()
 }
 
 async fn get_events(
@@ -1651,7 +2018,9 @@ mod tests {
         assert_eq!(err.value, "wat");
         assert!(
             err.message
-                .contains("Allowed values: snapshot,runtime,worker,tool,heartbeat"),
+                .contains(
+                    "Allowed values: snapshot,runtime,worker,tool,heartbeat,shared_context_written,shared_context_expired",
+                ),
             "error should list deterministic allowed values"
         );
     }

--- a/apps/symphony/src/lib.rs
+++ b/apps/symphony/src/lib.rs
@@ -13,6 +13,8 @@ pub mod repo_url;
 pub mod ssh;
 pub mod workspace;
 
+pub mod shared_context;
+
 pub mod codex;
 pub mod event_stream;
 pub mod http_server;

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -265,7 +265,8 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             Arc::new(refresh_sender),
             event_hub,
             symphony::http_server::EventStreamConfig::default(),
-        );
+        )
+        .with_shared_context_store(orchestrator.shared_context_store());
 
         let mut tui_shutdown = None;
         let mut tui_exit = None;

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -9,17 +9,18 @@ use std::time::Duration;
 use crate::codex::app_server;
 use crate::config;
 use crate::domain::{
-    AgentBackend, AgentEvent, CodexConfig, CodexTotals, CompletedEntry, EventKind, EventSeverity,
-    HooksConfig, Issue, OrchestratorSnapshot, OrchestratorState, PiAgentConfig, PollingSnapshot,
-    RateLimitInfo, RefreshRequestOutcome, RetryEntry, RetrySnapshotEntry, RunAttempt,
-    RunningSessionSnapshot, ServiceConfig, SessionTokenUsage, TrackerConfig, WorkerSessionInfo,
-    WorkspaceConfig, WorkspaceIsolation,
+    AgentBackend, AgentEvent, CodexConfig, CodexTotals, CompletedEntry, ContextScope, EventKind,
+    EventSeverity, HooksConfig, Issue, OrchestratorSnapshot, OrchestratorState, PiAgentConfig,
+    PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetryEntry, RetrySnapshotEntry,
+    RunAttempt, RunningSessionSnapshot, ServiceConfig, SessionTokenUsage, TrackerConfig,
+    WorkerSessionInfo, WorkspaceConfig, WorkspaceIsolation,
 };
 use crate::error::{Result, SymphonyError};
 use crate::event_stream::EventHub;
 use crate::notifications;
 use crate::pi_agent::rpc_bridge;
 use crate::session_summary::{compact_session_id, normalize_whitespace, truncate_for_display};
+use crate::shared_context::SharedContextStore;
 use crate::ssh::{self, WorkerHostSelection};
 use crate::workflow_store::WorkflowStore;
 use crate::{docker, path_safety, prompt_builder, workspace};
@@ -37,6 +38,7 @@ struct WorkerTaskConfig {
     max_turns: u32,
     tracker: TrackerConfig,
     prompt_template: String,
+    shared_context: String,
     event_tx: tokio::sync::mpsc::UnboundedSender<(String, AgentEvent)>,
 }
 
@@ -484,11 +486,12 @@ async fn run_worker_task(
                     .map_err(|err| format!("before_run hook failed: {err}"))?;
                 }
 
-                let prompt = prompt_builder::render_prompt(
+                let prompt = prompt_builder::render_prompt_with_shared_context(
                     &config.prompt_template,
                     issue,
                     attempt,
                     config.workspace.base_branch.as_deref(),
+                    &config.shared_context,
                 )
                 .map_err(|err| format!("prompt rendering failed: {err}"))?;
 
@@ -712,11 +715,12 @@ async fn run_worker_task(
     }
 
     // 3. Render prompt
-    let prompt = match prompt_builder::render_prompt(
+    let prompt = match prompt_builder::render_prompt_with_shared_context(
         &config.prompt_template,
         issue,
         attempt,
         config.workspace.base_branch.as_deref(),
+        &config.shared_context,
     ) {
         Ok(prompt) => prompt,
         Err(err) => {
@@ -1190,6 +1194,8 @@ pub struct Orchestrator {
     worker_event_rx: tokio::sync::mpsc::UnboundedReceiver<(String, AgentEvent)>,
     /// Sender half cloned into each spawned worker task for event streaming.
     worker_event_tx: tokio::sync::mpsc::UnboundedSender<(String, AgentEvent)>,
+    /// Shared ephemeral cross-worker context store.
+    shared_context_store: SharedContextStore,
     /// The prompt template from the WORKFLOW.md body, used to render per-issue prompts.
     prompt_template: String,
 }
@@ -1260,6 +1266,7 @@ impl Orchestrator {
             worker_result_tx,
             worker_event_rx,
             worker_event_tx,
+            shared_context_store: SharedContextStore::default(),
             prompt_template,
         }
     }
@@ -1474,7 +1481,10 @@ impl Orchestrator {
                 .cloned()
                 .unwrap_or_else(|| issue.state.clone());
             issue.state = effective_state.clone();
-            let prompt_template = self.resolve_prompt_for_state(&effective_state);
+            let prompt_template = Self::ensure_shared_context_placeholder(
+                self.resolve_prompt_for_state(&effective_state),
+            );
+            let shared_context = self.build_shared_context_block_for_issue(&issue);
 
             let task_config = WorkerTaskConfig {
                 workspace: self.config.workspace.clone(),
@@ -1485,6 +1495,7 @@ impl Orchestrator {
                 max_turns: self.config.agent.max_turns,
                 tracker: self.config.tracker.clone(),
                 prompt_template,
+                shared_context,
                 event_tx: self.worker_event_tx.clone(),
             };
 
@@ -2206,11 +2217,15 @@ impl Orchestrator {
             return Err(err);
         }
 
-        let prompt = match prompt_builder::render_prompt(
-            prompt_template,
+        let prompt_template = Self::ensure_shared_context_placeholder(prompt_template.to_string());
+        let shared_context = self.build_shared_context_block_for_issue(issue);
+
+        let prompt = match prompt_builder::render_prompt_with_shared_context(
+            &prompt_template,
             issue,
             attempt,
             self.config.workspace.base_branch.as_deref(),
+            &shared_context,
         ) {
             Ok(prompt) => prompt,
             Err(err) => {
@@ -2672,6 +2687,78 @@ impl Orchestrator {
 
     pub fn state_mut(&mut self) -> &mut OrchestratorState {
         &mut self.state
+    }
+
+    pub fn shared_context_store(&self) -> SharedContextStore {
+        self.shared_context_store.clone()
+    }
+
+    fn shared_context_scopes_for_issue(issue: &Issue) -> Vec<ContextScope> {
+        let mut scopes = vec![ContextScope::Project];
+
+        for label in &issue.labels {
+            let normalized = label.trim().to_ascii_lowercase();
+            if !normalized.is_empty() {
+                scopes.push(ContextScope::Label(normalized));
+            }
+        }
+
+        scopes.sort();
+        scopes.dedup();
+        scopes
+    }
+
+    fn ensure_shared_context_placeholder(prompt_template: String) -> String {
+        if prompt_template.contains("shared_context") {
+            return prompt_template;
+        }
+
+        format!("{{{{ shared_context }}}}\n\n{prompt_template}")
+    }
+
+    fn format_shared_context_age(now: DateTime<Utc>, created_at: DateTime<Utc>) -> String {
+        let age_seconds = now.signed_duration_since(created_at).num_seconds().max(0) as u64;
+
+        if age_seconds < 60 {
+            return format!("{age_seconds}s ago");
+        }
+
+        let age_minutes = age_seconds / 60;
+        if age_minutes < 60 {
+            return format!("{age_minutes}m ago");
+        }
+
+        let age_hours = age_minutes / 60;
+        if age_hours < 24 {
+            return format!("{age_hours}h ago");
+        }
+
+        let age_days = age_hours / 24;
+        format!("{age_days}d ago")
+    }
+
+    fn build_shared_context_block_for_issue(&self, issue: &Issue) -> String {
+        let scopes = Self::shared_context_scopes_for_issue(issue);
+        let entries = self.shared_context_store.read(&scopes);
+        if entries.is_empty() {
+            return String::new();
+        }
+
+        let now = Utc::now();
+        let mut lines = vec![
+            "## Shared Context from Other Workers".to_string(),
+            String::new(),
+        ];
+
+        for entry in entries.into_iter().take(10) {
+            let age = Self::format_shared_context_age(now, entry.created_at);
+            lines.push(format!(
+                "- [{}] ({age}, {}): {}",
+                entry.author_issue, entry.scope, entry.content
+            ));
+        }
+
+        lines.join("\n")
     }
 
     /// Create a shared snapshot handle for concurrent HTTP reads.

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
+use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, LazyLock, RwLock};
 use std::time::Duration;
 
 use crate::codex::app_server;
@@ -24,6 +25,11 @@ use crate::shared_context::SharedContextStore;
 use crate::ssh::{self, WorkerHostSelection};
 use crate::workflow_store::WorkflowStore;
 use crate::{docker, path_safety, prompt_builder, workspace};
+
+static SHARED_CONTEXT_PLACEHOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\{\{\s*shared_context\s*\}\}")
+        .expect("shared_context placeholder regex must compile")
+});
 
 // ── Standalone Worker Task ──────────────────────────────────────────────
 
@@ -1287,10 +1293,19 @@ impl Orchestrator {
             self.config.server.port = Some(port);
         }
 
-        self.shared_context_store.update_settings(
-            self.config.shared_context.ttl_ms,
-            self.config.shared_context.max_entries,
-        );
+        if self.config.shared_context.ttl_ms > 0 && self.config.shared_context.max_entries > 0 {
+            self.shared_context_store.update_settings(
+                self.config.shared_context.ttl_ms,
+                self.config.shared_context.max_entries,
+            );
+        } else {
+            tracing::warn!(
+                event = "shared_context_config_invalid",
+                ttl_ms = self.config.shared_context.ttl_ms,
+                max_entries = self.config.shared_context.max_entries,
+                "skipping shared context store settings update because workflow config is invalid"
+            );
+        }
 
         self.state.max_concurrent_agents = self.config.agent.max_concurrent_agents;
         self.state.poll_interval_ms = self.config.polling.interval_ms;
@@ -2728,7 +2743,7 @@ impl Orchestrator {
     }
 
     fn ensure_shared_context_placeholder(prompt_template: String) -> String {
-        if prompt_template.contains("shared_context") {
+        if SHARED_CONTEXT_PLACEHOLDER_RE.is_match(&prompt_template) {
             return prompt_template;
         }
 
@@ -2758,7 +2773,13 @@ impl Orchestrator {
 
     fn build_shared_context_block_for_issue(&self, issue: &Issue) -> String {
         let scopes = Self::shared_context_scopes_for_issue(issue);
-        let entries = self.shared_context_store.read(&scopes);
+        let entries: Vec<_> = self
+            .shared_context_store
+            .read(&scopes)
+            .into_iter()
+            .filter(|entry| entry.author_issue != issue.identifier)
+            .take(10)
+            .collect();
 
         if let Some(hub) = &self.event_hub {
             hub.publish(
@@ -2784,7 +2805,7 @@ impl Orchestrator {
             String::new(),
         ];
 
-        for entry in entries.into_iter().take(10) {
+        for entry in entries {
             let age = Self::format_shared_context_age(now, entry.created_at);
             lines.push(format!(
                 "- [{}] ({age}, {}): {}",

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -9,11 +9,11 @@ use std::time::Duration;
 use crate::codex::app_server;
 use crate::config;
 use crate::domain::{
-    AgentBackend, AgentEvent, CodexConfig, CodexTotals, CompletedEntry, ContextScope, EventKind,
-    EventSeverity, HooksConfig, Issue, OrchestratorSnapshot, OrchestratorState, PiAgentConfig,
-    PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetryEntry, RetrySnapshotEntry,
-    RunAttempt, RunningSessionSnapshot, ServiceConfig, SessionTokenUsage, TrackerConfig,
-    WorkerSessionInfo, WorkspaceConfig, WorkspaceIsolation,
+    AgentBackend, AgentEvent, CodexConfig, CodexTotals, CompletedEntry, ContextEntry, ContextScope,
+    EventKind, EventSeverity, HooksConfig, Issue, OrchestratorSnapshot, OrchestratorState,
+    PiAgentConfig, PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetryEntry,
+    RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot, ServiceConfig, SessionTokenUsage,
+    TrackerConfig, WorkerSessionInfo, WorkspaceConfig, WorkspaceIsolation,
 };
 use crate::error::{Result, SymphonyError};
 use crate::event_stream::EventHub;
@@ -1230,6 +1230,8 @@ impl Orchestrator {
     ) -> Self {
         let poll_interval_ms = config.polling.interval_ms;
         let max_concurrent_agents = config.agent.max_concurrent_agents;
+        let shared_context_ttl_ms = config.shared_context.ttl_ms;
+        let shared_context_max_entries = config.shared_context.max_entries;
         let (worker_result_tx, worker_result_rx) = tokio::sync::mpsc::unbounded_channel();
         let (worker_event_tx, worker_event_rx) = tokio::sync::mpsc::unbounded_channel();
 
@@ -1266,7 +1268,10 @@ impl Orchestrator {
             worker_result_tx,
             worker_event_rx,
             worker_event_tx,
-            shared_context_store: SharedContextStore::default(),
+            shared_context_store: SharedContextStore::new(
+                shared_context_ttl_ms,
+                shared_context_max_entries,
+            ),
             prompt_template,
         }
     }
@@ -1281,6 +1286,11 @@ impl Orchestrator {
         if let Some(port) = self.server_port_override {
             self.config.server.port = Some(port);
         }
+
+        self.shared_context_store.update_settings(
+            self.config.shared_context.ttl_ms,
+            self.config.shared_context.max_entries,
+        );
 
         self.state.max_concurrent_agents = self.config.agent.max_concurrent_agents;
         self.state.poll_interval_ms = self.config.polling.interval_ms;
@@ -1584,6 +1594,15 @@ impl Orchestrator {
 
         if refresh_runtime_config {
             self.refresh_runtime_config();
+        }
+
+        let pruned_entries = self.prune_expired_shared_context(Utc::now());
+        if pruned_entries > 0 {
+            tracing::info!(
+                event = "shared_context_pruned",
+                pruned_entries,
+                "pruned expired shared context entries"
+            );
         }
 
         self.emit_runtime_event(RuntimeEvent::Reconcile);
@@ -2740,6 +2759,21 @@ impl Orchestrator {
     fn build_shared_context_block_for_issue(&self, issue: &Issue) -> String {
         let scopes = Self::shared_context_scopes_for_issue(issue);
         let entries = self.shared_context_store.read(&scopes);
+
+        if let Some(hub) = &self.event_hub {
+            hub.publish(
+                EventKind::Runtime,
+                EventSeverity::Debug,
+                Some(issue.identifier.clone()),
+                "shared_context_read",
+                serde_json::json!({
+                    "reader_issue": issue.identifier,
+                    "entries_count": entries.len(),
+                    "scopes": scopes.iter().map(ContextScope::as_scope_key).collect::<Vec<_>>(),
+                }),
+            );
+        }
+
         if entries.is_empty() {
             return String::new();
         }
@@ -2759,6 +2793,44 @@ impl Orchestrator {
         }
 
         lines.join("\n")
+    }
+
+    fn shared_context_preview(content: &str) -> String {
+        truncate_for_display(content, 120)
+    }
+
+    fn publish_shared_context_expired_event(&self, entry: &ContextEntry, now: DateTime<Utc>) {
+        let Some(hub) = &self.event_hub else {
+            return;
+        };
+
+        let age_ms = now
+            .signed_duration_since(entry.created_at)
+            .num_milliseconds()
+            .max(0);
+
+        hub.publish_with_timestamp(
+            EventKind::SharedContextExpired,
+            EventSeverity::Info,
+            Some(entry.author_issue.clone()),
+            "shared_context_expired",
+            serde_json::json!({
+                "entry_id": entry.id,
+                "author_issue": entry.author_issue,
+                "scope": entry.scope.as_scope_key(),
+                "age_ms": age_ms,
+                "preview": Self::shared_context_preview(&entry.content),
+            }),
+            now,
+        );
+    }
+
+    fn prune_expired_shared_context(&mut self, now: DateTime<Utc>) -> usize {
+        let expired_entries = self.shared_context_store.prune_expired_entries_at(now);
+        for entry in &expired_entries {
+            self.publish_shared_context_expired_event(entry, now);
+        }
+        expired_entries.len()
     }
 
     /// Create a shared snapshot handle for concurrent HTTP reads.
@@ -2920,6 +2992,7 @@ impl Orchestrator {
             running,
             running_sessions,
             blocked: self.blocked_issues.clone(),
+            shared_context: self.shared_context_store.summary(),
             running_session_info,
             claimed,
             retry_queue,

--- a/apps/symphony/src/prompt_builder.rs
+++ b/apps/symphony/src/prompt_builder.rs
@@ -24,6 +24,17 @@ pub fn render_prompt(
     attempt: Option<u32>,
     workspace_base_branch: Option<&str>,
 ) -> Result<String> {
+    render_prompt_with_shared_context(template, issue, attempt, workspace_base_branch, "")
+}
+
+/// Render a Liquid template with optional shared context preamble content.
+pub fn render_prompt_with_shared_context(
+    template: &str,
+    issue: &Issue,
+    attempt: Option<u32>,
+    workspace_base_branch: Option<&str>,
+    shared_context: &str,
+) -> Result<String> {
     // 1. Parse the template
     let parser = liquid::ParserBuilder::with_stdlib()
         .build()
@@ -59,6 +70,10 @@ pub fn render_prompt(
     globals.insert(
         "workspace".into(),
         liquid_core::model::Value::Object(workspace_obj),
+    );
+    globals.insert(
+        "shared_context".into(),
+        liquid_core::model::Value::scalar(shared_context.to_string()),
     );
 
     // 4. Render (liquid-rs is strict by default — unknown variables error)

--- a/apps/symphony/src/shared_context.rs
+++ b/apps/symphony/src/shared_context.rs
@@ -51,16 +51,17 @@ impl SharedContextStore {
     }
 
     pub fn update_settings(&self, default_ttl_ms: u64, max_entries: usize) {
+        let max_entries = max_entries.max(1);
         {
             let mut settings = self
                 .settings
                 .write()
                 .expect("shared context settings lock poisoned");
             settings.default_ttl_ms = default_ttl_ms;
-            settings.max_entries = max_entries.max(1);
+            settings.max_entries = max_entries;
         }
         let mut entries = self.entries.write().expect("shared context lock poisoned");
-        self.enforce_max_entries(&mut entries);
+        Self::enforce_max_entries(&mut entries, max_entries);
     }
 
     pub fn write(&self, draft: ContextEntryDraft) -> String {
@@ -73,6 +74,7 @@ impl SharedContextStore {
             .read()
             .expect("shared context settings lock poisoned");
         let ttl_ms = draft.ttl_ms.unwrap_or(settings.default_ttl_ms).max(1);
+        let max_entries = settings.max_entries;
         let content = truncate_chars(&draft.content, MAX_SHARED_CONTEXT_CONTENT_CHARS);
         let author_issue = draft.author_issue.trim();
 
@@ -91,7 +93,7 @@ impl SharedContextStore {
 
         let mut entries = self.entries.write().expect("shared context lock poisoned");
         entries.push(entry.clone());
-        self.enforce_max_entries(&mut entries);
+        Self::enforce_max_entries(&mut entries, max_entries);
 
         entry
     }
@@ -209,12 +211,8 @@ impl SharedContextStore {
         }
     }
 
-    fn enforce_max_entries(&self, entries: &mut Vec<ContextEntry>) {
-        let max_entries = self
-            .settings
-            .read()
-            .expect("shared context settings lock poisoned")
-            .max_entries;
+    fn enforce_max_entries(entries: &mut Vec<ContextEntry>, max_entries: usize) {
+        let max_entries = max_entries.max(1);
         if entries.len() <= max_entries {
             return;
         }

--- a/apps/symphony/src/shared_context.rs
+++ b/apps/symphony/src/shared_context.rs
@@ -1,0 +1,332 @@
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::domain::{ContextEntry, ContextScope};
+
+pub const DEFAULT_SHARED_CONTEXT_TTL_MS: u64 = 86_400_000;
+pub const DEFAULT_SHARED_CONTEXT_MAX_ENTRIES: usize = 100;
+pub const MAX_SHARED_CONTEXT_CONTENT_CHARS: usize = 500;
+
+#[derive(Debug, Clone, Copy)]
+struct SharedContextSettings {
+    default_ttl_ms: u64,
+    max_entries: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct SharedContextStore {
+    entries: Arc<RwLock<Vec<ContextEntry>>>,
+    settings: Arc<RwLock<SharedContextSettings>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ContextEntryDraft {
+    pub author_issue: String,
+    pub scope: ContextScope,
+    pub content: String,
+    pub ttl_ms: Option<u64>,
+}
+
+impl Default for SharedContextStore {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_SHARED_CONTEXT_TTL_MS,
+            DEFAULT_SHARED_CONTEXT_MAX_ENTRIES,
+        )
+    }
+}
+
+impl SharedContextStore {
+    pub fn new(default_ttl_ms: u64, max_entries: usize) -> Self {
+        Self {
+            entries: Arc::new(RwLock::new(Vec::new())),
+            settings: Arc::new(RwLock::new(SharedContextSettings {
+                default_ttl_ms,
+                max_entries: max_entries.max(1),
+            })),
+        }
+    }
+
+    pub fn update_settings(&self, default_ttl_ms: u64, max_entries: usize) {
+        {
+            let mut settings = self
+                .settings
+                .write()
+                .expect("shared context settings lock poisoned");
+            settings.default_ttl_ms = default_ttl_ms;
+            settings.max_entries = max_entries.max(1);
+        }
+        let mut entries = self.entries.write().expect("shared context lock poisoned");
+        self.enforce_max_entries(&mut entries);
+    }
+
+    pub fn write(&self, draft: ContextEntryDraft) -> String {
+        self.write_entry(draft).id
+    }
+
+    pub fn write_entry(&self, draft: ContextEntryDraft) -> ContextEntry {
+        let settings = *self
+            .settings
+            .read()
+            .expect("shared context settings lock poisoned");
+        let ttl_ms = draft.ttl_ms.unwrap_or(settings.default_ttl_ms).max(1);
+        let content = truncate_chars(&draft.content, MAX_SHARED_CONTEXT_CONTENT_CHARS);
+        let author_issue = draft.author_issue.trim();
+
+        let entry = ContextEntry {
+            id: Uuid::new_v4().to_string(),
+            author_issue: if author_issue.is_empty() {
+                "unknown".to_string()
+            } else {
+                author_issue.to_string()
+            },
+            scope: normalize_scope(draft.scope),
+            content,
+            created_at: Utc::now(),
+            ttl_ms,
+        };
+
+        let mut entries = self.entries.write().expect("shared context lock poisoned");
+        entries.push(entry.clone());
+        self.enforce_max_entries(&mut entries);
+
+        entry
+    }
+
+    pub fn read(&self, scope_filter: &[ContextScope]) -> Vec<ContextEntry> {
+        self.prune_expired();
+
+        let filters: HashSet<ContextScope> =
+            scope_filter.iter().cloned().map(normalize_scope).collect();
+        let mut entries = self
+            .entries
+            .read()
+            .expect("shared context lock poisoned")
+            .clone();
+        entries.retain(|entry| {
+            filters.is_empty() || filters.contains(&normalize_scope(entry.scope.clone()))
+        });
+        entries.sort_by(|a, b| {
+            b.created_at
+                .cmp(&a.created_at)
+                .then_with(|| b.id.cmp(&a.id))
+        });
+        entries
+    }
+
+    pub fn list(&self) -> Vec<ContextEntry> {
+        self.read(&[])
+    }
+
+    pub fn clear(&self, scope_filter: Option<&[ContextScope]>) -> usize {
+        let mut entries = self.entries.write().expect("shared context lock poisoned");
+        let before = entries.len();
+
+        if let Some(filters) = scope_filter {
+            if !filters.is_empty() {
+                let filters: HashSet<ContextScope> =
+                    filters.iter().cloned().map(normalize_scope).collect();
+                entries.retain(|entry| !filters.contains(&normalize_scope(entry.scope.clone())));
+            } else {
+                entries.clear();
+            }
+        } else {
+            entries.clear();
+        }
+
+        before.saturating_sub(entries.len())
+    }
+
+    pub fn remove_entry(&self, entry_id: &str) -> Option<ContextEntry> {
+        let mut entries = self.entries.write().expect("shared context lock poisoned");
+        let index = entries.iter().position(|entry| entry.id == entry_id)?;
+        Some(entries.remove(index))
+    }
+
+    pub fn prune_expired(&self) -> usize {
+        self.prune_expired_entries().len()
+    }
+
+    pub fn prune_expired_entries(&self) -> Vec<ContextEntry> {
+        self.prune_expired_entries_at(Utc::now())
+    }
+
+    pub fn prune_expired_entries_at(&self, now: DateTime<Utc>) -> Vec<ContextEntry> {
+        let mut entries = self.entries.write().expect("shared context lock poisoned");
+        let mut expired = Vec::new();
+
+        entries.retain(|entry| {
+            if is_expired(entry, now) {
+                expired.push(entry.clone());
+                false
+            } else {
+                true
+            }
+        });
+
+        expired
+    }
+
+    pub fn total_entries(&self) -> usize {
+        self.entries
+            .read()
+            .expect("shared context lock poisoned")
+            .len()
+    }
+
+    fn enforce_max_entries(&self, entries: &mut Vec<ContextEntry>) {
+        let max_entries = self
+            .settings
+            .read()
+            .expect("shared context settings lock poisoned")
+            .max_entries;
+        if entries.len() <= max_entries {
+            return;
+        }
+
+        entries.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        let overflow = entries.len().saturating_sub(max_entries);
+        entries.drain(0..overflow);
+    }
+}
+
+fn normalize_scope(scope: ContextScope) -> ContextScope {
+    match scope {
+        ContextScope::Project => ContextScope::Project,
+        ContextScope::Milestone(id) => ContextScope::Milestone(id.trim().to_string()),
+        ContextScope::Label(label) => ContextScope::Label(label.trim().to_ascii_lowercase()),
+    }
+}
+
+pub fn truncate_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+pub fn is_expired(entry: &ContextEntry, now: DateTime<Utc>) -> bool {
+    let age_ms = now
+        .signed_duration_since(entry.created_at)
+        .num_milliseconds()
+        .max(0) as u64;
+    age_ms > entry.ttl_ms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[test]
+    fn write_truncates_content_and_read_returns_newest_first() {
+        let store = SharedContextStore::new(DEFAULT_SHARED_CONTEXT_TTL_MS, 100);
+        let first = store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-100".to_string(),
+            scope: ContextScope::Project,
+            content: "first".to_string(),
+            ttl_ms: None,
+        });
+        let long_content = "x".repeat(MAX_SHARED_CONTEXT_CONTENT_CHARS + 25);
+        let second = store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-101".to_string(),
+            scope: ContextScope::Project,
+            content: long_content,
+            ttl_ms: None,
+        });
+
+        let entries = store.read(&[ContextScope::Project]);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].id, second.id);
+        assert_eq!(entries[1].id, first.id);
+        assert_eq!(
+            entries[0].content.chars().count(),
+            MAX_SHARED_CONTEXT_CONTENT_CHARS
+        );
+    }
+
+    #[test]
+    fn clear_filters_by_scope() {
+        let store = SharedContextStore::default();
+        store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-100".to_string(),
+            scope: ContextScope::Project,
+            content: "project".to_string(),
+            ttl_ms: None,
+        });
+        store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-101".to_string(),
+            scope: ContextScope::Label("api".to_string()),
+            content: "label".to_string(),
+            ttl_ms: None,
+        });
+
+        let removed = store.clear(Some(&[ContextScope::Label("api".to_string())]));
+        assert_eq!(removed, 1);
+        assert_eq!(store.total_entries(), 1);
+
+        let removed_all = store.clear(None);
+        assert_eq!(removed_all, 1);
+        assert_eq!(store.total_entries(), 0);
+    }
+
+    #[test]
+    fn prune_expired_entries_removes_stale_entries() {
+        let store = SharedContextStore::default();
+        let stale = store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-200".to_string(),
+            scope: ContextScope::Project,
+            content: "stale".to_string(),
+            ttl_ms: Some(10),
+        });
+        let fresh = store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-201".to_string(),
+            scope: ContextScope::Project,
+            content: "fresh".to_string(),
+            ttl_ms: Some(10_000),
+        });
+
+        let now = stale.created_at + Duration::milliseconds(20);
+        let expired = store.prune_expired_entries_at(now);
+
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].id, stale.id);
+
+        let remaining = store.list();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, fresh.id);
+    }
+
+    #[test]
+    fn max_entries_eviction_keeps_most_recent_entries() {
+        let store = SharedContextStore::new(DEFAULT_SHARED_CONTEXT_TTL_MS, 2);
+
+        let first = store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-1".to_string(),
+            scope: ContextScope::Project,
+            content: "1".to_string(),
+            ttl_ms: None,
+        });
+        let second = store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-2".to_string(),
+            scope: ContextScope::Project,
+            content: "2".to_string(),
+            ttl_ms: None,
+        });
+        let third = store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-3".to_string(),
+            scope: ContextScope::Project,
+            content: "3".to_string(),
+            ttl_ms: None,
+        });
+
+        let ids: Vec<String> = store.list().into_iter().map(|entry| entry.id).collect();
+        assert!(ids.contains(&second.id));
+        assert!(ids.contains(&third.id));
+        assert!(!ids.contains(&first.id));
+    }
+}

--- a/apps/symphony/src/shared_context.rs
+++ b/apps/symphony/src/shared_context.rs
@@ -1,10 +1,10 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
-use crate::domain::{ContextEntry, ContextScope};
+use crate::domain::{ContextEntry, ContextScope, SharedContextSummary};
 
 pub const DEFAULT_SHARED_CONTEXT_TTL_MS: u64 = 86_400_000;
 pub const DEFAULT_SHARED_CONTEXT_MAX_ENTRIES: usize = 100;
@@ -175,6 +175,38 @@ impl SharedContextStore {
             .read()
             .expect("shared context lock poisoned")
             .len()
+    }
+
+    pub fn summary(&self) -> SharedContextSummary {
+        self.prune_expired();
+        let entries = self.entries.read().expect("shared context lock poisoned");
+
+        let mut entries_by_scope: BTreeMap<String, usize> = BTreeMap::new();
+        let mut oldest_entry_at: Option<DateTime<Utc>> = None;
+        let mut newest_entry_at: Option<DateTime<Utc>> = None;
+
+        for entry in entries.iter() {
+            *entries_by_scope
+                .entry(entry.scope.as_scope_key())
+                .or_insert(0usize) += 1;
+
+            oldest_entry_at = match oldest_entry_at {
+                Some(current) if current <= entry.created_at => Some(current),
+                _ => Some(entry.created_at),
+            };
+
+            newest_entry_at = match newest_entry_at {
+                Some(current) if current >= entry.created_at => Some(current),
+                _ => Some(entry.created_at),
+            };
+        }
+
+        SharedContextSummary {
+            total_entries: entries.len(),
+            entries_by_scope,
+            oldest_entry_at,
+            newest_entry_at,
+        }
     }
 
     fn enforce_max_entries(&self, entries: &mut Vec<ContextEntry>) {

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -403,16 +403,22 @@ fn cleanup_partial_terminal_state() {
 }
 
 fn build_summary_lines(snapshot: &OrchestratorSnapshot, throughput_line: &str) -> Vec<String> {
-    let mut lines = vec![
-        format!(
-            "Running: {}  Retry: {}  Completed: {}  Tokens: {}",
-            snapshot.running.len(),
-            snapshot.retry_queue.len(),
-            snapshot.completed.len(),
-            format_tokens(snapshot.codex_totals.total_tokens)
-        ),
-        throughput_line.to_string(),
-    ];
+    let mut primary_summary = format!(
+        "Running: {}  Retry: {}  Completed: {}  Tokens: {}",
+        snapshot.running.len(),
+        snapshot.retry_queue.len(),
+        snapshot.completed.len(),
+        format_tokens(snapshot.codex_totals.total_tokens)
+    );
+
+    if snapshot.shared_context.total_entries > 0 {
+        primary_summary.push_str(&format!(
+            "  Context: {} entries",
+            snapshot.shared_context.total_entries
+        ));
+    }
+
+    let mut lines = vec![primary_summary, throughput_line.to_string()];
 
     if let Some(project_url) = snapshot.linear_project_url.as_deref() {
         lines.push(format!("Linear Project: {project_url}"));
@@ -991,6 +997,7 @@ mod tests {
                 seconds_running: 0.0,
             },
             blocked: Vec::new(),
+            shared_context: crate::domain::SharedContextSummary::default(),
             codex_rate_limits: None,
             polling: crate::domain::PollingSnapshot {
                 checking: false,
@@ -1207,6 +1214,21 @@ mod tests {
                 .iter()
                 .any(|line| line == "Linear Project: https://linear.app/kata-sh/project/symphony"),
             "summary lines should include the linear project URL when configured"
+        );
+    }
+
+    #[test]
+    fn build_summary_lines_adds_context_count_when_present() {
+        let mut snapshot = snapshot_fixture(42, None);
+        snapshot.shared_context.total_entries = 5;
+
+        let lines = build_summary_lines(&snapshot, "Throughput: 0.0 tps ▁▁▁▁▁▁▁▁");
+        assert!(
+            lines
+                .first()
+                .map(|line| line.contains("Context: 5 entries"))
+                .unwrap_or(false),
+            "summary line should include shared context count when entries exist"
         );
     }
 

--- a/apps/symphony/tests/context_sharing_tests.rs
+++ b/apps/symphony/tests/context_sharing_tests.rs
@@ -1,0 +1,105 @@
+use chrono::Duration;
+use symphony::domain::ContextScope;
+use symphony::shared_context::{
+    ContextEntryDraft, SharedContextStore, DEFAULT_SHARED_CONTEXT_TTL_MS,
+    MAX_SHARED_CONTEXT_CONTENT_CHARS,
+};
+
+#[test]
+fn store_write_and_read_with_scope_filtering() {
+    let store = SharedContextStore::new(DEFAULT_SHARED_CONTEXT_TTL_MS, 50);
+
+    let project_entry = store.write_entry(ContextEntryDraft {
+        author_issue: "KAT-1323".to_string(),
+        scope: ContextScope::Project,
+        content: "Decision: use shared store".to_string(),
+        ttl_ms: None,
+    });
+
+    let label_entry = store.write_entry(ContextEntryDraft {
+        author_issue: "KAT-1324".to_string(),
+        scope: ContextScope::Label("backend".to_string()),
+        content: "Pattern: keep scope labels lowercase".to_string(),
+        ttl_ms: None,
+    });
+
+    let project_entries = store.read(&[ContextScope::Project]);
+    assert_eq!(project_entries.len(), 1);
+    assert_eq!(project_entries[0].id, project_entry.id);
+
+    let label_entries = store.read(&[ContextScope::Label("BACKEND".to_string())]);
+    assert_eq!(label_entries.len(), 1);
+    assert_eq!(label_entries[0].id, label_entry.id);
+}
+
+#[test]
+fn store_enforces_500_char_content_limit() {
+    let store = SharedContextStore::default();
+    let oversized = "a".repeat(MAX_SHARED_CONTEXT_CONTENT_CHARS + 100);
+
+    let entry = store.write_entry(ContextEntryDraft {
+        author_issue: "KAT-1323".to_string(),
+        scope: ContextScope::Project,
+        content: oversized,
+        ttl_ms: None,
+    });
+
+    assert_eq!(
+        entry.content.chars().count(),
+        MAX_SHARED_CONTEXT_CONTENT_CHARS
+    );
+}
+
+#[test]
+fn store_clear_scope_and_clear_all() {
+    let store = SharedContextStore::default();
+
+    store.write_entry(ContextEntryDraft {
+        author_issue: "KAT-1323".to_string(),
+        scope: ContextScope::Project,
+        content: "project decision".to_string(),
+        ttl_ms: None,
+    });
+    store.write_entry(ContextEntryDraft {
+        author_issue: "KAT-1324".to_string(),
+        scope: ContextScope::Label("ui".to_string()),
+        content: "ui decision".to_string(),
+        ttl_ms: None,
+    });
+
+    let removed = store.clear(Some(&[ContextScope::Label("ui".to_string())]));
+    assert_eq!(removed, 1);
+    assert_eq!(store.total_entries(), 1);
+
+    let removed_all = store.clear(None);
+    assert_eq!(removed_all, 1);
+    assert_eq!(store.total_entries(), 0);
+}
+
+#[test]
+fn store_prune_expired_removes_stale_entries() {
+    let store = SharedContextStore::default();
+
+    let stale = store.write_entry(ContextEntryDraft {
+        author_issue: "KAT-1323".to_string(),
+        scope: ContextScope::Project,
+        content: "stale".to_string(),
+        ttl_ms: Some(5),
+    });
+
+    let fresh = store.write_entry(ContextEntryDraft {
+        author_issue: "KAT-1324".to_string(),
+        scope: ContextScope::Project,
+        content: "fresh".to_string(),
+        ttl_ms: Some(60_000),
+    });
+
+    let expired = store.prune_expired_entries_at(stale.created_at + Duration::milliseconds(10));
+
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].id, stale.id);
+
+    let remaining = store.read(&[ContextScope::Project]);
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].id, fresh.id);
+}

--- a/apps/symphony/tests/context_sharing_tests.rs
+++ b/apps/symphony/tests/context_sharing_tests.rs
@@ -1,9 +1,60 @@
 use chrono::Duration;
-use symphony::domain::ContextScope;
+use std::time::Duration as StdDuration;
+
+use symphony::domain::{AgentConfig, ContextScope, EventKind, Issue, ServiceConfig, TrackerConfig};
+use symphony::error::Result;
+use symphony::orchestrator::{Orchestrator, OrchestratorPort};
 use symphony::shared_context::{
     ContextEntryDraft, SharedContextStore, DEFAULT_SHARED_CONTEXT_TTL_MS,
     MAX_SHARED_CONTEXT_CONTENT_CHARS,
 };
+
+#[derive(Default)]
+struct NoopPort;
+
+impl OrchestratorPort for NoopPort {
+    fn startup_terminal_issues(&mut self, _terminal_states: &[String]) -> Result<Vec<Issue>> {
+        Ok(Vec::new())
+    }
+
+    fn reconcile_running_issues(&mut self, _running_issue_ids: &[String]) -> Result<Vec<Issue>> {
+        Ok(Vec::new())
+    }
+
+    fn validate_dispatch_preflight(&mut self, _config: &ServiceConfig) -> Result<()> {
+        Ok(())
+    }
+
+    fn fetch_candidate_issues(&mut self) -> Result<Vec<Issue>> {
+        Ok(Vec::new())
+    }
+
+    fn refresh_issue(&mut self, _issue_id: &str) -> Result<Option<Issue>> {
+        Ok(None)
+    }
+
+    fn update_issue_state(&mut self, _issue_id: &str, _state_name: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn orchestrator_config() -> ServiceConfig {
+    let mut config = ServiceConfig::default();
+    config.tracker = TrackerConfig {
+        kind: Some("linear".to_string()),
+        api_key: Some("test-key".into()),
+        project_slug: Some("project".to_string()),
+        active_states: vec!["Todo".to_string(), "In Progress".to_string()],
+        terminal_states: vec!["Done".to_string()],
+        ..TrackerConfig::default()
+    };
+    config.agent = AgentConfig {
+        max_concurrent_agents: 1,
+        max_turns: 1,
+        max_retry_backoff_ms: 60_000,
+    };
+    config
+}
 
 #[test]
 fn store_write_and_read_with_scope_filtering() {
@@ -102,4 +153,67 @@ fn store_prune_expired_removes_stale_entries() {
     let remaining = store.read(&[ContextScope::Project]);
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].id, fresh.id);
+}
+
+#[test]
+fn store_summary_reports_scope_distribution() {
+    let store = SharedContextStore::default();
+
+    store.write_entry(ContextEntryDraft {
+        author_issue: "KAT-1323".to_string(),
+        scope: ContextScope::Project,
+        content: "project decision".to_string(),
+        ttl_ms: None,
+    });
+    store.write_entry(ContextEntryDraft {
+        author_issue: "KAT-1324".to_string(),
+        scope: ContextScope::Label("backend".to_string()),
+        content: "backend pattern".to_string(),
+        ttl_ms: None,
+    });
+
+    let summary = store.summary();
+    assert_eq!(summary.total_entries, 2);
+    assert_eq!(summary.entries_by_scope.get("project"), Some(&1));
+    assert_eq!(summary.entries_by_scope.get("label:backend"), Some(&1));
+    assert!(summary.oldest_entry_at.is_some());
+    assert!(summary.newest_entry_at.is_some());
+}
+
+#[tokio::test]
+async fn shared_context_expired_event_emitted_when_orchestrator_prunes() {
+    let mut orchestrator = Orchestrator::new(orchestrator_config(), "Prompt".to_string());
+    let hub = orchestrator.create_event_hub();
+    let mut events = hub.subscribe();
+
+    orchestrator
+        .shared_context_store()
+        .write_entry(ContextEntryDraft {
+            author_issue: "KAT-1323".to_string(),
+            scope: ContextScope::Project,
+            content: "temporary context".to_string(),
+            ttl_ms: Some(1),
+        });
+
+    tokio::time::sleep(StdDuration::from_millis(10)).await;
+
+    let mut port = NoopPort;
+    orchestrator.tick(&mut port).expect("tick should succeed");
+
+    let expired_event = tokio::time::timeout(StdDuration::from_secs(1), async {
+        loop {
+            let envelope = events.recv().await.expect("event should decode");
+            if envelope.event == "shared_context_expired" {
+                break envelope;
+            }
+        }
+    })
+    .await
+    .expect("shared_context_expired event should be emitted");
+
+    assert_eq!(expired_event.kind, EventKind::SharedContextExpired);
+    assert_eq!(expired_event.payload["author_issue"], "KAT-1323");
+
+    let snapshot = orchestrator.snapshot(chrono::Utc::now().timestamp_millis());
+    assert_eq!(snapshot.shared_context.total_entries, 0);
 }

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -118,6 +118,7 @@ fn test_service_config_defaults_match_spec() {
         server: ServerConfig::default(),
         prompts: None,
         notifications: None,
+        shared_context: SharedContextConfig::default(),
     };
 
     // Polling §5.3.2
@@ -373,6 +374,7 @@ fn test_orchestrator_snapshot_serializes() {
             },
         ],
         blocked: vec![],
+        shared_context: symphony::domain::SharedContextSummary::default(),
         codex_totals: CodexTotals::default(),
         codex_rate_limits: None,
         polling: PollingSnapshot {

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -146,6 +146,10 @@ fn test_service_config_defaults_match_spec() {
 
     // Tracker §5.3.1
     assert_eq!(cfg.tracker.endpoint, "https://api.linear.app/graphql");
+
+    // Shared context defaults
+    assert_eq!(cfg.shared_context.ttl_ms, 86_400_000);
+    assert_eq!(cfg.shared_context.max_entries, 100);
 }
 
 #[test]
@@ -400,6 +404,7 @@ fn test_orchestrator_snapshot_serializes() {
     assert!(val.get("running_session_info").is_some());
     assert!(val.get("retry_queue").is_some());
     assert!(val.get("completed").is_some());
+    assert!(val.get("shared_context").is_some());
     assert!(val.get("codex_totals").is_some());
     assert!(val.get("polling").is_some());
     // Retry queue has our entry

--- a/apps/symphony/tests/event_stream_tests.rs
+++ b/apps/symphony/tests/event_stream_tests.rs
@@ -108,6 +108,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
             completed_at: Some(Utc::now()),
         }],
         blocked: vec![],
+        shared_context: symphony::domain::SharedContextSummary::default(),
         codex_totals: CodexTotals::default(),
         codex_rate_limits: None,
         polling: PollingSnapshot {

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -584,6 +584,7 @@ async fn test_context_scope_filter_and_clear_endpoint() {
     assert_eq!(filtered_payload["entries"][0]["scope"]["value"], "backend");
 
     let cleared = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method(Method::DELETE)
@@ -596,6 +597,27 @@ async fn test_context_scope_filter_and_clear_endpoint() {
     assert_eq!(cleared.status(), StatusCode::OK);
     let cleared_payload = body_json(cleared).await;
     assert_eq!(cleared_payload["deleted"], 1);
+
+    let remaining = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v1/context?scope=label:backend")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+    assert_eq!(remaining.status(), StatusCode::OK);
+    let remaining_payload = body_json(remaining).await;
+    assert_eq!(
+        remaining_payload["entries"]
+            .as_array()
+            .expect("entries should be an array")
+            .len(),
+        1,
+        "scoped clear should preserve non-matching entries"
+    );
 }
 
 #[tokio::test]

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -7,9 +7,9 @@ use axum::http::{Method, Request, StatusCode};
 use chrono::{TimeZone, Utc};
 use serde_json::{json, Value};
 use symphony::domain::{
-    BlockedIssueEntry, CodexTotals, CompletedEntry, OrchestratorSnapshot, PollingSnapshot,
-    RateLimitInfo, RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot,
-    SessionTokenUsage, WorkerSessionInfo,
+    BlockedIssueEntry, CodexTotals, CompletedEntry, EventKind, OrchestratorSnapshot,
+    PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt,
+    RunningSessionSnapshot, SessionTokenUsage, SharedContextSummary, WorkerSessionInfo,
 };
 use symphony::http_server::{
     build_router, parse_event_filter_contract, HttpServerState, RefreshControl, SnapshotSource,
@@ -131,6 +131,12 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
             title: "Completed issue".to_string(),
             completed_at: Some(chrono::Utc::now()),
         }],
+        shared_context: SharedContextSummary {
+            total_entries: 1,
+            entries_by_scope: BTreeMap::from([("project".to_string(), 1)]),
+            oldest_entry_at: Some(started_at),
+            newest_entry_at: Some(started_at),
+        },
         codex_totals: CodexTotals {
             input_tokens: 120,
             output_tokens: 80,
@@ -243,6 +249,10 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "dashboard shell should include retry queue table section"
     );
     assert!(
+        body.contains("Shared Context"),
+        "dashboard shell should include shared context section"
+    );
+    assert!(
         body.contains("Completed issues"),
         "dashboard shell should include completed issue list section"
     );
@@ -324,6 +334,7 @@ async fn test_get_api_state_returns_snapshot_projection() {
         "session-12345678"
     );
     assert_eq!(payload["retry_queue"][0]["identifier"], "SIM-777");
+    assert_eq!(payload["shared_context"]["total_entries"], 1);
     assert_eq!(payload["codex_totals"]["total_tokens"], 200);
     assert_eq!(payload["codex_rate_limits"]["remaining"], 88);
     assert_eq!(
@@ -427,6 +438,209 @@ async fn test_post_refresh_reports_queued_then_coalesced_state() {
     assert_eq!(second_payload["pending_requests"], 1);
 }
 
+#[tokio::test]
+async fn test_context_post_get_and_delete_round_trip() {
+    let app = test_router();
+
+    let post_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/context")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "author_issue": "KAT-920",
+                        "scope": "project",
+                        "content": "Decision: use zod schemas",
+                    }))
+                    .expect("request body should serialize"),
+                ))
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond to context post");
+
+    assert_eq!(post_response.status(), StatusCode::CREATED);
+    let post_payload = body_json(post_response).await;
+    let entry_id = post_payload["id"]
+        .as_str()
+        .expect("response should include entry id")
+        .to_string();
+
+    let get_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v1/context")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond to context get");
+
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let get_payload = body_json(get_response).await;
+    let entries = get_payload["entries"]
+        .as_array()
+        .expect("entries should be an array");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["id"], entry_id);
+    assert_eq!(entries[0]["author_issue"], "KAT-920");
+    assert_eq!(entries[0]["scope"]["type"], "project");
+
+    let delete_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri(&format!("/api/v1/context/{entry_id}"))
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond to context delete");
+
+    assert_eq!(delete_response.status(), StatusCode::OK);
+    let delete_payload = body_json(delete_response).await;
+    assert_eq!(delete_payload["deleted"], 1);
+
+    let get_after_delete = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v1/context")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond to context get");
+
+    let payload_after_delete = body_json(get_after_delete).await;
+    assert_eq!(
+        payload_after_delete["entries"]
+            .as_array()
+            .expect("entries should remain an array")
+            .len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn test_context_scope_filter_and_clear_endpoint() {
+    let app = test_router();
+
+    for payload in [
+        json!({
+            "author_issue": "KAT-920",
+            "scope": "project",
+            "content": "Global decision",
+        }),
+        json!({
+            "author_issue": "KAT-921",
+            "scope": "label:backend",
+            "content": "Backend-specific decision",
+        }),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/context")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&payload).expect("request body should serialize"),
+                    ))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("router should respond");
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
+    let filtered = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v1/context?scope=label:backend")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+    assert_eq!(filtered.status(), StatusCode::OK);
+    let filtered_payload = body_json(filtered).await;
+    assert_eq!(
+        filtered_payload["entries"]
+            .as_array()
+            .expect("entries should be an array")
+            .len(),
+        1
+    );
+    assert_eq!(filtered_payload["entries"][0]["scope"]["value"], "backend");
+
+    let cleared = app
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/v1/context?scope=project")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+    assert_eq!(cleared.status(), StatusCode::OK);
+    let cleared_payload = body_json(cleared).await;
+    assert_eq!(cleared_payload["deleted"], 1);
+}
+
+#[tokio::test]
+async fn test_context_post_publishes_shared_context_written_event() {
+    let state = HttpServerState::new(
+        Arc::new(StaticSnapshotSource {
+            snapshot: fixture_snapshot(),
+        }),
+        Arc::new(FakeRefreshControl::default()),
+    );
+    let mut events = state.event_hub().subscribe();
+    let app = build_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/context")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "author_issue": "KAT-921",
+                        "scope": "label:backend",
+                        "content": "Pattern: keep schema in one module",
+                    }))
+                    .expect("request body should serialize"),
+                ))
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let envelope = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+        .await
+        .expect("event should arrive before timeout")
+        .expect("event should decode");
+
+    assert_eq!(envelope.kind, EventKind::SharedContextWritten);
+    assert_eq!(envelope.event, "shared_context_written");
+    assert_eq!(envelope.payload["author_issue"], "KAT-921");
+    assert_eq!(envelope.payload["scope"], "label:backend");
+}
+
 #[test]
 fn test_event_filter_invalid_type_returns_machine_readable_error() {
     let err = parse_event_filter_contract(None, Some("worker,wat"), None)
@@ -436,7 +650,9 @@ fn test_event_filter_invalid_type_returns_machine_readable_error() {
     assert_eq!(err.value, "wat");
     assert!(
         err.message
-            .contains("Allowed values: snapshot,runtime,worker,tool,heartbeat"),
+            .contains(
+                "Allowed values: snapshot,runtime,worker,tool,heartbeat,shared_context_written,shared_context_expired",
+            ),
         "error should list deterministic allowed values"
     );
 }

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -12,14 +12,15 @@ use serde_json::json;
 use tempfile::{tempdir, NamedTempFile};
 
 use symphony::domain::{
-    AgentConfig, AgentEvent, ApiKey, BlockerRef, Issue, NotificationsConfig, ServiceConfig,
-    SlackConfig, TrackerConfig, WorkspaceIsolation,
+    AgentConfig, AgentEvent, ApiKey, BlockerRef, ContextScope, Issue, NotificationsConfig,
+    ServiceConfig, SlackConfig, TrackerConfig, WorkspaceIsolation,
 };
 use symphony::error::{Result, SymphonyError};
 use symphony::orchestrator::{
     refresh_channel, Orchestrator, OrchestratorPort, RetryContext, RetryKind, RuntimeEvent,
     TurnMetrics, WorkerCompletion, CONTINUATION_RETRY_DELAY_MS,
 };
+use symphony::shared_context::ContextEntryDraft;
 use symphony::workflow_store::WorkflowStore;
 
 #[derive(Default)]
@@ -3789,6 +3790,86 @@ async fn test_execute_worker_attempt_stops_when_issue_changes_to_different_activ
         1,
         "state change from In Progress to Agent Review should stop after turn 1 — \
          the orchestrator needs to re-dispatch with the agent-review prompt"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_worker_attempt_shared_context_is_injected_into_prompt() {
+    let mut server = Server::new_async().await;
+    let issue = issue(
+        "issue-shared-context",
+        "SIM-SHARED",
+        "In Progress",
+        Some(1),
+        0,
+    );
+
+    let _state_lookup = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&state_lookup_response(
+                &issue.id,
+                &issue.identifier,
+                "In Progress",
+                None,
+            ))
+            .expect("state response should serialize"),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let scripts_dir = tempdir().expect("scripts dir should be created");
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let prompt_log = scripts_dir.path().join("prompts.log");
+    let script = write_script(
+        scripts_dir.path(),
+        "codex.sh",
+        &script_two_successful_turns(&prompt_log),
+    );
+
+    let mut orchestrator = Orchestrator::new(
+        make_worker_config(&server, &script, workspace_root.path(), 2),
+        String::new(),
+    );
+
+    orchestrator
+        .shared_context_store()
+        .write_entry(ContextEntryDraft {
+            author_issue: "KAT-920".to_string(),
+            scope: ContextScope::Project,
+            content: "Decision: using Zod for validation".to_string(),
+            ttl_ms: None,
+        });
+
+    let result = orchestrator
+        .execute_worker_attempt(
+            &issue,
+            "Worker prompt for {{ issue.identifier }}",
+            Some(1),
+            |_query, _vars| async { Ok(serde_json::json!({ "data": {} })) },
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "worker attempt with shared context should succeed: {result:?}"
+    );
+
+    let prompt_lines: Vec<String> = std::fs::read_to_string(&prompt_log)
+        .expect("prompt log should exist")
+        .lines()
+        .map(|line| line.to_string())
+        .collect();
+
+    assert!(
+        prompt_lines
+            .first()
+            .map(|line| line.contains("Decision: using Zod for validation"))
+            .unwrap_or(false),
+        "first worker prompt should include the shared context decision"
     );
 }
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -3864,11 +3864,17 @@ async fn test_execute_worker_attempt_shared_context_is_injected_into_prompt() {
         .map(|line| line.to_string())
         .collect();
 
+    let first_prompt = prompt_lines.first().cloned().unwrap_or_default();
     assert!(
-        prompt_lines
-            .first()
-            .map(|line| line.contains("Decision: using Zod for validation"))
-            .unwrap_or(false),
+        first_prompt.contains("## Shared Context from Other Workers"),
+        "first worker prompt should include the shared-context header"
+    );
+    assert!(
+        first_prompt.contains("[KAT-920]"),
+        "first worker prompt should preserve shared-context author attribution"
+    );
+    assert!(
+        first_prompt.contains("Decision: using Zod for validation"),
         "first worker prompt should include the shared context decision"
     );
 }

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -207,6 +207,32 @@ fn test_config_defaults() {
 }
 
 #[test]
+fn test_shared_context_max_entries_zero_is_not_normalized() {
+    let yaml_str = r#"
+tracker:
+  kind: linear
+  api_key: test-key
+  project_slug: test-project
+shared_context:
+  max_entries: 0
+"#;
+
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("workflow config should parse");
+
+    assert_eq!(
+        config.shared_context.max_entries, 0,
+        "from_workflow should preserve explicit zero values for validation"
+    );
+
+    let err = validate(&config).expect_err("shared_context.max_entries=0 must fail validation");
+    assert!(
+        matches!(err, SymphonyError::InvalidWorkflowConfig(ref msg) if msg.contains("shared_context.max_entries must be greater than 0")),
+        "expected shared_context.max_entries validation failure, got: {err}"
+    );
+}
+
+#[test]
 fn test_server_public_url_parses_and_trims_trailing_slash() {
     let yaml_str = r#"
 server:


### PR DESCRIPTION
## Summary
- add an in-memory SharedContextStore with scoped entries, TTL pruning, max-entry enforcement, and summary reporting
- inject shared context into worker prompt preambles via {{ shared_context }} and auto-prepend behavior
- add shared-context HTTP APIs (GET/POST/DELETE /api/v1/context) and emit event-stream envelopes for writes/reads/expiry
- surface shared-context summary in orchestrator snapshots, TUI summary line, and dashboard context table
- document shared_context.ttl_ms and shared_context.max_entries in WORKFLOW reference and README

## Validation
- cd apps/symphony && cargo test --test context_sharing_tests store
- cd apps/symphony && cargo test --test orchestrator_tests shared_context
- cd apps/symphony && cargo test --test http_server_tests context
- cd apps/symphony && cargo test shared_context
- cd apps/symphony && cargo test --test context_sharing_tests
- cd apps/symphony && cargo test
- cd apps/symphony && cargo clippy -- -D warnings

Closes KAT-1322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared context management system with HTTP API endpoints to create, retrieve, and delete context entries filtered by scope.
  * Dashboard now displays a "Shared Context" section with entry metadata.
  * Workers can now access shared context from other workers via prompt injection.

* **Chores**
  * Added `uuid` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an ephemeral in-memory `SharedContextStore` to Symphony, enabling workers to share short-lived coordination signals with one another across issues. The implementation includes TTL-based pruning, max-entry eviction, scope filtering (`project` / `milestone:<id>` / `label:<name>`), HTTP CRUD endpoints, SSE event emission, TUI/dashboard surfaces, and a comprehensive test suite — a well-scoped feature addition.\n\nTwo P1 correctness issues were found:\n\n- **Silent context-injection bypass** (`orchestrator.rs`): `ensure_shared_context_placeholder` guards with `prompt_template.contains(\"shared_context\")` rather than the exact Liquid tag `contains(\"{{ shared_context }}\")`. Any template that mentions the word \"shared_context\" in a comment or prose (without the Liquid placeholder) will be considered already handled and no context block will be prepended — workers silently miss all peer context.\n\n- **Undiscoverable `shared_context_read` event** (`domain.rs`): The README documents `event=shared_context_read` as a filterable event type on `/api/v1/events`, but `SharedContextRead` was not added to `EventKind`. The event is published as `EventKind::Runtime`, so `?type=shared_context_read` returns a validation error. Either add the variant or remove it from the docs.\n\nAdditional P2 items:\n- `clear(Some(&[]))` clears all entries (same as `None`) — non-obvious contract.\n- 120-char preview truncation is duplicated between `http_server.rs` and `orchestrator.rs`.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the ensure_shared_context_placeholder substring check and the shared_context_read EventKind gap.

Two P1 defects exist: the overly broad contains("shared_context") guard that silently skips context injection for certain prompt templates, and the missing SharedContextRead EventKind that makes the documented filter contract unworkable. Both require small, targeted fixes before shipping. The rest of the feature — store correctness, HTTP layer, TUI, tests — is well-implemented.

apps/symphony/src/orchestrator.rs (placeholder check) and apps/symphony/src/domain.rs (missing EventKind variant)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Integrates SharedContextStore; builds context blocks per-issue and prunes expired entries each tick. ensure_shared_context_placeholder uses an overly broad substring check that silently skips injection when the word appears in comments/prose without the Liquid tag. |
| apps/symphony/src/domain.rs | Adds ContextScope, ContextEntry, SharedContextSummary, and two new EventKind variants. SharedContextRead is NOT added as a variant despite being documented as a filterable event type — emitted as EventKind::Runtime instead, breaking the documented API contract. |
| apps/symphony/src/shared_context.rs | New SharedContextStore with Arc/RwLock thread safety, TTL pruning, max-entry eviction, scope filtering, and unit tests. The clear(Some(&[])) API contract is ambiguous. |
| apps/symphony/src/http_server.rs | Adds GET/POST/DELETE /api/v1/context endpoints with scope filtering, thorough input validation, and event publishing. Duplicates the 120-char preview truncation helper. |
| apps/symphony/src/config.rs | Adds RawSharedContextConfig deserialization and wires SharedContextConfig into ServiceConfig with defaults and validation. |
| apps/symphony/src/prompt_builder.rs | Adds render_prompt_with_shared_context; original render_prompt delegates to it with an empty string. The shared_context Liquid variable is always injected into render globals. |
| apps/symphony/src/tui.rs | Surfaces shared context entry count in the TUI summary line when non-zero. Minimal, well-tested change. |
| apps/symphony/tests/context_sharing_tests.rs | New integration tests covering store CRUD, scope filtering, TTL pruning, max-entry eviction, summary reporting, and orchestrator expired-event emission. |
| apps/symphony/tests/http_server_tests.rs | Tests for context POST/GET/DELETE round-trip, scope filtering, bulk clear, and write event publication. |
| apps/symphony/tests/orchestrator_tests.rs | Adds a test verifying shared context is injected into the rendered worker prompt. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W1 as Worker A (KAT-920)
    participant HTTP as HTTP /api/v1/context
    participant Store as SharedContextStore
    participant Orch as Orchestrator
    participant W2 as Worker B (KAT-921)
    participant SSE as Event Stream

    W1->>HTTP: POST /api/v1/context
    HTTP->>Store: write_entry(draft)
    Store-->>HTTP: ContextEntry {id, created_at}
    HTTP->>SSE: publish SharedContextWritten
    HTTP-->>W1: 201 {id, created_at}

    Note over Orch: On each poll tick
    Orch->>Store: prune_expired_entries_at(now)
    Store-->>Orch: Vec expired entries
    Orch->>SSE: publish SharedContextExpired

    Note over Orch: Dispatching Worker B
    Orch->>Orch: ensure_shared_context_placeholder(template)
    Orch->>Store: read([Project, Label])
    Store-->>Orch: Vec entries newest first
    Orch->>SSE: publish Runtime/shared_context_read
    Orch->>W2: render_prompt_with_shared_context
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `apps/symphony/src/orchestrator.rs`, line 1097-1103 ([link](https://github.com/gannonh/kata/blob/22ecaccb5259e2188909ee734a6345fb49a6b4fa/apps/symphony/src/orchestrator.rs#L1097-L1103)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`ensure_shared_context_placeholder` substring check is too broad**

   The guard `prompt_template.contains("shared_context")` matches any occurrence of the word "shared_context" — including comments, variable names, or prose — not just the Liquid tag `{{ shared_context }}`. A template like:

   ```markdown
   <!-- This prompt does not inject shared_context entries -->
   ## Task for {{ issue.identifier }}
   ```

   …will cause `ensure_shared_context_placeholder` to return the template unchanged because the substring matches, but there is no `{{ shared_context }}` Liquid tag present. Workers silently receive no peer context.

   The check should match the exact Liquid placeholder:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/orchestrator.rs
   Line: 1097-1103

   Comment:
   **`ensure_shared_context_placeholder` substring check is too broad**

   The guard `prompt_template.contains("shared_context")` matches any occurrence of the word "shared_context" — including comments, variable names, or prose — not just the Liquid tag `{{ shared_context }}`. A template like:

   ```markdown
   <!-- This prompt does not inject shared_context entries -->
   ## Task for {{ issue.identifier }}
   ```

   …will cause `ensure_shared_context_placeholder` to return the template unchanged because the substring matches, but there is no `{{ shared_context }}` Liquid tag present. Workers silently receive no peer context.

   The check should match the exact Liquid placeholder:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/symphony/src/domain.rs`, line 283-310 ([link](https://github.com/gannonh/kata/blob/22ecaccb5259e2188909ee734a6345fb49a6b4fa/apps/symphony/src/domain.rs#L283-L310)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`shared_context_read` is not a filterable `EventKind` but is documented as one**

   The README lists `event=shared_context_read` as an event emitted on `/api/v1/events` alongside `shared_context_written` and `shared_context_expired`. The latter two are properly added as `EventKind` variants and appear in the allowed type filter list. However, `SharedContextRead` is **not** added — the read event is published as `EventKind::Runtime` with event name `"shared_context_read"`.

   A subscriber who tries `?type=shared_context_read` will receive a validation error listing the allowed values, which does not include `shared_context_read`. This is a broken API contract.

   Either add `SharedContextRead` to `EventKind` (alongside `SharedContextWritten`/`SharedContextExpired`), or remove it from the public documentation and keep it as a debug-only `runtime` sub-event.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/domain.rs
   Line: 283-310

   Comment:
   **`shared_context_read` is not a filterable `EventKind` but is documented as one**

   The README lists `event=shared_context_read` as an event emitted on `/api/v1/events` alongside `shared_context_written` and `shared_context_expired`. The latter two are properly added as `EventKind` variants and appear in the allowed type filter list. However, `SharedContextRead` is **not** added — the read event is published as `EventKind::Runtime` with event name `"shared_context_read"`.

   A subscriber who tries `?type=shared_context_read` will receive a validation error listing the allowed values, which does not include `shared_context_read`. This is a broken API contract.

   Either add `SharedContextRead` to `EventKind` (alongside `SharedContextWritten`/`SharedContextExpired`), or remove it from the public documentation and keep it as a debug-only `runtime` sub-event.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `apps/symphony/src/shared_context.rs`, line 1376-1393 ([link](https://github.com/gannonh/kata/blob/22ecaccb5259e2188909ee734a6345fb49a6b4fa/apps/symphony/src/shared_context.rs#L1376-L1393)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`clear(Some(&[]))` clears all entries — same as `clear(None)`**

   When `scope_filter` is `Some` but the slice is empty, the code falls through to `entries.clear()`, identical to the `None` branch. Callers might reasonably expect "no scope matches, so nothing is removed". The HTTP handler avoids this today by calling `clear(None)` when scopes is empty, so the production path is safe — but the API is a footgun for future callers. Consider treating `Some(&[])` as a no-op or documenting the contract explicitly.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/shared_context.rs
   Line: 1376-1393

   Comment:
   **`clear(Some(&[]))` clears all entries — same as `clear(None)`**

   When `scope_filter` is `Some` but the slice is empty, the code falls through to `entries.clear()`, identical to the `None` branch. Callers might reasonably expect "no scope matches, so nothing is removed". The HTTP handler avoids this today by calling `clear(None)` when scopes is empty, so the production path is safe — but the API is a footgun for future callers. Consider treating `Some(&[])` as a no-op or documenting the contract explicitly.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


4. `apps/symphony/src/orchestrator.rs`, line 1165-1167 ([link](https://github.com/gannonh/kata/blob/22ecaccb5259e2188909ee734a6345fb49a6b4fa/apps/symphony/src/orchestrator.rs#L1165-L1167)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`shared_context_preview` is duplicated**

   An identical 120-char preview truncation helper exists in both `orchestrator.rs` and `http_server.rs`. Both should delegate to the already-public `shared_context::truncate_chars` so the limit stays in sync in one place.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/orchestrator.rs
   Line: 1165-1167

   Comment:
   **`shared_context_preview` is duplicated**

   An identical 120-char preview truncation helper exists in both `orchestrator.rs` and `http_server.rs`. Both should delegate to the already-public `shared_context::truncate_chars` so the limit stays in sync in one place.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 1097-1103

Comment:
**`ensure_shared_context_placeholder` substring check is too broad**

The guard `prompt_template.contains("shared_context")` matches any occurrence of the word "shared_context" — including comments, variable names, or prose — not just the Liquid tag `{{ shared_context }}`. A template like:

```markdown
<!-- This prompt does not inject shared_context entries -->
## Task for {{ issue.identifier }}
```

…will cause `ensure_shared_context_placeholder` to return the template unchanged because the substring matches, but there is no `{{ shared_context }}` Liquid tag present. Workers silently receive no peer context.

The check should match the exact Liquid placeholder:

```suggestion
    fn ensure_shared_context_placeholder(prompt_template: String) -> String {
        if prompt_template.contains("{{ shared_context }}") {
            return prompt_template;
        }

        format!("{{{{ shared_context }}}}\n\n{prompt_template}")
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/domain.rs
Line: 283-310

Comment:
**`shared_context_read` is not a filterable `EventKind` but is documented as one**

The README lists `event=shared_context_read` as an event emitted on `/api/v1/events` alongside `shared_context_written` and `shared_context_expired`. The latter two are properly added as `EventKind` variants and appear in the allowed type filter list. However, `SharedContextRead` is **not** added — the read event is published as `EventKind::Runtime` with event name `"shared_context_read"`.

A subscriber who tries `?type=shared_context_read` will receive a validation error listing the allowed values, which does not include `shared_context_read`. This is a broken API contract.

Either add `SharedContextRead` to `EventKind` (alongside `SharedContextWritten`/`SharedContextExpired`), or remove it from the public documentation and keep it as a debug-only `runtime` sub-event.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/shared_context.rs
Line: 1376-1393

Comment:
**`clear(Some(&[]))` clears all entries — same as `clear(None)`**

When `scope_filter` is `Some` but the slice is empty, the code falls through to `entries.clear()`, identical to the `None` branch. Callers might reasonably expect "no scope matches, so nothing is removed". The HTTP handler avoids this today by calling `clear(None)` when scopes is empty, so the production path is safe — but the API is a footgun for future callers. Consider treating `Some(&[])` as a no-op or documenting the contract explicitly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 1165-1167

Comment:
**`shared_context_preview` is duplicated**

An identical 120-char preview truncation helper exists in both `orchestrator.rs` and `http_server.rs`. Both should delegate to the already-public `shared_context::truncate_chars` so the limit stays in sync in one place.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(tui): surface shared context visibi..."](https://github.com/gannonh/kata/commit/22ecaccb5259e2188909ee734a6345fb49a6b4fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26594729)</sub>

<!-- /greptile_comment -->