### PR TITLE
[S07] Supervisor Agent orchestration + visibility wiring

### DIFF
--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -568,6 +568,7 @@ Core Rust modules:
 | --- | --- | --- |
 | CLI/runtime entrypoint | `src/main.rs` | CLI parsing, startup validation, tracing setup, runtime wiring |
 | Orchestrator loop | `src/orchestrator.rs` | Poll/dispatch loop, retries, worker lifecycle, state snapshots |
+| Supervisor runtime | `src/supervisor.rs` | Background supervisor lifecycle, stuck/conflict/pattern detection, steering + escalation decisions |
 | HTTP dashboard/API | `src/http_server.rs` | `/`, `/api/v1/state`, `/api/v1/events` websocket stream, `/api/v1/escalations`, `/api/v1/escalations/:request_id/respond`, `/api/v1/:issue_identifier`, refresh endpoint, dashboard Linear project link card |
 | Terminal dashboard | `src/tui.rs` | Ratatui renderer with throughput sparkline, color-coded status dots, keyboard handling, and live snapshot display |
 | Workflow/config parser | `src/workflow.rs`, `src/config.rs` | Front-matter parsing, env/tilde resolution, typed config defaults |

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -417,6 +417,7 @@ All configuration lives in the YAML front-matter of your WORKFLOW.md. See [`docs
 | `tracker`                 | Linear connection, project, assignee filter, state mappings       |
 | `polling`                 | How often to check for new/changed issues                         |
 | `shared_context`          | Ephemeral cross-worker context retention (TTL + max entries)      |
+| `supervisor`              | Autonomous supervisor loop (steering, conflict detection, escalation fallback) |
 | `workspace`               | Where and how workspaces are created, Docker config               |
 | `agent`                   | Backend selection, concurrency limits, max turns, retry backoff   |
 | `kata_agent` / `pi_agent` | Kata CLI backend config: command, model, timeouts                 |
@@ -465,6 +466,39 @@ Events emitted on `/api/v1/events`:
 - `event=shared_context_written`
 - `event=shared_context_read`
 - `event=shared_context_expired`
+
+## Supervisor Agent
+
+Symphony can run an autonomous supervisor loop that watches all worker events and intervenes when workers get stuck or diverge.
+
+Enable it in `WORKFLOW.md`:
+
+```yaml
+supervisor:
+  enabled: true
+  model: anthropic/claude-sonnet-4-6   # optional; defaults to kata_agent.model when omitted
+  steer_cooldown_ms: 120000            # minimum delay between steers to the same issue
+```
+
+When enabled, the supervisor:
+
+- Detects stuck workers (repeated tool errors, no-progress streaks, repeated test failures) and emits `supervisor_steer`
+- Detects cross-worker conflicts (shared file overlap, contradictory context decisions) and emits `supervisor_conflict_detected`
+- Detects systemic multi-worker failures and emits `supervisor_pattern_detected`
+- Escalates unresolved situations to humans via the escalation registry and emits `supervisor_escalated`
+
+Safety defaults:
+
+- Disabled by default (`supervisor.enabled: false`)
+- Cooldown enforced per worker (`steer_cooldown_ms`)
+- Coordination prefers shared context writes before steering
+- Escalates when conflict/pattern resolution is uncertain
+
+Runtime visibility:
+
+- `GET /api/v1/state` includes a `supervisor` section (status + counters + last decision)
+- Web dashboard shows a dedicated **Supervisor** section
+- TUI summary line shows supervisor status and action counters
 
 ## Lifecycle Hooks
 
@@ -541,13 +575,13 @@ Each host must have the agent backend (Kata CLI or Codex) installed and on PATH.
 
 Available at `http://localhost:<port>`. Auto-refreshes every 2 seconds.
 
-Shows: running sessions (with turn count, token usage, last activity), retry queue, shared context table (author/scope/preview/age/TTL), completed issues, polling stats, rate limits, and a link to the Linear project.
+Shows: running sessions (with turn count, token usage, last activity), retry queue, shared context table (author/scope/preview/age/TTL), supervisor status/counters, completed issues, polling stats, rate limits, and a link to the Linear project.
 
 HTTP surfaces:
 
 | Endpoint | Purpose |
 | --- | --- |
-| `GET /api/v1/state` | Full orchestrator snapshot JSON (includes `pending_escalations` and `shared_context` summary) |
+| `GET /api/v1/state` | Full orchestrator snapshot JSON (includes `pending_escalations`, `shared_context`, and `supervisor` summary) |
 | `GET /api/v1/context` | List active shared context entries (optional `scope` filter) |
 | `POST /api/v1/context` | Write a shared context entry |
 | `DELETE /api/v1/context/{id}` | Delete a specific shared context entry |

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -277,6 +277,20 @@ kata_agent:  # alias: pi_agent
   # Default parser value: 300000.
   stall_timeout_ms: 300000
 
+# ─── Supervisor (M002/S07) ────────────────────────────────────────────────────
+# Optional autonomous supervisor loop for cross-worker orchestration.
+supervisor:
+  # Enable supervisor runtime. Default parser value: false.
+  enabled: false
+
+  # Optional model identifier for future model-backed supervisor reasoning.
+  # Defaults to kata_agent.model when omitted.
+  # model: anthropic/claude-sonnet-4-6
+
+  # Minimum milliseconds between steer actions for the same worker issue.
+  # Default parser value: 120000.
+  steer_cooldown_ms: 120000
+
 # ─── Worker (SSH) ─────────────────────────────────────────────────────────────
 # Distribute agent sessions across remote SSH hosts.
 # When ssh_hosts is empty (default), all sessions run locally.

--- a/apps/symphony/prompts/supervisor.md
+++ b/apps/symphony/prompts/supervisor.md
@@ -1,0 +1,51 @@
+# Symphony Supervisor Agent
+
+You are the **Symphony Supervisor**, an orchestration safety agent that continuously monitors the full Symphony event stream.
+
+## Mission
+
+Observe all worker activity, detect coordination risks early, and intervene safely:
+
+1. **Detect stuck workers** (repeated failures, no progress, repeated test failures)
+2. **Detect cross-worker conflicts** (file overlap, contradictory shared decisions)
+3. **Detect systemic failure patterns** (same error across multiple workers)
+4. **Escalate to the operator** when confidence is low or conflict is unresolvable
+
+## Control Surfaces
+
+- Event stream: `GET /api/v1/events` (unfiltered)
+- Shared context: `GET /api/v1/context`, `POST /api/v1/context`
+- Escalations: `POST /api/v1/escalations`
+- Steering surface: `symphony_steer` / steer endpoint (when available)
+
+## Decision Framework
+
+Use this loop continuously:
+
+1. **Observe**: Ingest worker/tool/runtime events and update a per-worker model.
+2. **Classify**: Decide if the signal is stuck, conflict, systemic, or informational.
+3. **Act** (least invasive first):
+   - Prefer writing **shared context** before steering.
+   - Use **targeted steer** only when a worker is likely stuck.
+   - **Escalate** when two good options conflict or confidence is low.
+4. **Verify**: Confirm the action changed behavior; avoid repeated interventions.
+
+## Safety Constraints (Hard Rules)
+
+- Never merge pull requests.
+- Never delete files or request destructive actions.
+- Never force workers to bypass validation gates.
+- Respect per-worker steer cooldowns.
+- Prefer shared context coordination over direct steering when possible.
+- Escalate to humans when uncertain.
+
+## Output and Logging
+
+Every intervention must map to a structured event:
+
+- `supervisor_steer`
+- `supervisor_conflict_detected`
+- `supervisor_pattern_detected`
+- `supervisor_escalated`
+
+Keep reasoning summaries short and bounded; do not leak large code excerpts in events.

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -1001,7 +1001,9 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     };
 
     let supervisor = SupervisorConfig {
-        enabled: raw_supervisor.enabled.unwrap_or(defaults.supervisor.enabled),
+        enabled: raw_supervisor
+            .enabled
+            .unwrap_or(defaults.supervisor.enabled),
         model: raw_supervisor
             .model
             .map(|value| resolve_env(&value))

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -13,8 +13,8 @@ use serde_yaml::{Mapping, Value};
 use crate::domain::{
     AgentBackend, AgentConfig, ApiKey, CodexConfig, DockerCodexAuth, DockerConfig, HooksConfig,
     NotificationsConfig, PiAgentConfig, PollingConfig, PromptsConfig, ServerConfig, ServiceConfig,
-    SharedContextConfig, SlackConfig, TrackerConfig, WorkerConfig, WorkspaceConfig,
-    WorkspaceIsolation, WorkspaceRepoStrategy,
+    SharedContextConfig, SlackConfig, SupervisorConfig, TrackerConfig, WorkerConfig,
+    WorkspaceConfig, WorkspaceIsolation, WorkspaceRepoStrategy,
 };
 use crate::error::{Result, SymphonyError};
 use crate::notifications;
@@ -316,6 +316,14 @@ struct RawSharedContextConfig {
 
 #[derive(Deserialize, Default)]
 #[serde(default)]
+struct RawSupervisorConfig {
+    enabled: Option<bool>,
+    model: Option<String>,
+    steer_cooldown_ms: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
 struct RawSlackConfig {
     webhook_url: Option<String>,
     events: Option<Vec<String>>,
@@ -502,6 +510,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
     let raw_notifications: RawNotificationsConfig = extract_section(&normalized, "notifications")?;
     let raw_shared_context: RawSharedContextConfig =
         extract_section(&normalized, "shared_context")?;
+    let raw_supervisor: RawSupervisorConfig = extract_section(&normalized, "supervisor")?;
 
     let defaults = ServiceConfig::default();
     let has_kata_agent_section = normalized.get("kata_agent").is_some();
@@ -991,6 +1000,18 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
             .unwrap_or(defaults.shared_context.max_entries),
     };
 
+    let supervisor = SupervisorConfig {
+        enabled: raw_supervisor.enabled.unwrap_or(defaults.supervisor.enabled),
+        model: raw_supervisor
+            .model
+            .map(|value| resolve_env(&value))
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        steer_cooldown_ms: raw_supervisor
+            .steer_cooldown_ms
+            .unwrap_or(defaults.supervisor.steer_cooldown_ms),
+    };
+
     Ok(ServiceConfig {
         tracker,
         polling,
@@ -1005,6 +1026,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         prompts,
         notifications,
         shared_context,
+        supervisor,
     })
 }
 

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -1251,6 +1251,48 @@ mod tests {
     }
 
     #[test]
+    fn raw_supervisor_config_defaults_when_section_omitted() {
+        let yaml: Value =
+            serde_yaml::from_str("tracker: { kind: linear }").expect("yaml fixture should parse");
+        let normalized = normalize_keys(yaml);
+        let raw: RawSupervisorConfig =
+            extract_section(&normalized, "supervisor").expect("section should parse");
+
+        assert_eq!(raw.enabled, None);
+        assert_eq!(raw.model, None);
+        assert_eq!(raw.steer_cooldown_ms, None);
+    }
+
+    #[test]
+    fn raw_supervisor_config_honors_explicit_cooldown() {
+        let yaml: Value = serde_yaml::from_str(
+            "tracker: { kind: linear }\nsupervisor:\n  steer_cooldown_ms: 45000",
+        )
+        .expect("yaml fixture should parse");
+        let normalized = normalize_keys(yaml);
+        let raw: RawSupervisorConfig =
+            extract_section(&normalized, "supervisor").expect("section should parse");
+
+        assert_eq!(raw.steer_cooldown_ms, Some(45_000));
+    }
+
+    #[test]
+    fn supervisor_model_env_and_empty_values_resolve_to_none() {
+        let env_yaml: Value = serde_yaml::from_str(
+            "tracker: { kind: linear }\nsupervisor:\n  model: $SYMPHONY_TEST_UNSET_SUPERVISOR_MODEL",
+        )
+        .expect("yaml fixture should parse");
+        let env_config = from_workflow(&env_yaml).expect("workflow should parse");
+        assert_eq!(env_config.supervisor.model, None);
+
+        let empty_yaml: Value =
+            serde_yaml::from_str("tracker: { kind: linear }\nsupervisor:\n  model: \"\"")
+                .expect("yaml fixture should parse");
+        let empty_config = from_workflow(&empty_yaml).expect("workflow should parse");
+        assert_eq!(empty_config.supervisor.model, None);
+    }
+
+    #[test]
     fn api_key_debug_is_redacted() {
         let key = ApiKey::new("super-secret-key");
         assert_eq!(format!("{:?}", key), "[REDACTED]");

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -172,6 +172,10 @@ pub enum EventKind {
     EscalationCancelled,
     SharedContextWritten,
     SharedContextExpired,
+    SupervisorSteer,
+    SupervisorConflictDetected,
+    SupervisorEscalated,
+    SupervisorPatternDetected,
 }
 
 impl EventKind {
@@ -188,6 +192,10 @@ impl EventKind {
             "escalation_cancelled" => Some(Self::EscalationCancelled),
             "shared_context_written" => Some(Self::SharedContextWritten),
             "shared_context_expired" => Some(Self::SharedContextExpired),
+            "supervisor_steer" => Some(Self::SupervisorSteer),
+            "supervisor_conflict_detected" => Some(Self::SupervisorConflictDetected),
+            "supervisor_escalated" => Some(Self::SupervisorEscalated),
+            "supervisor_pattern_detected" => Some(Self::SupervisorPatternDetected),
             _ => None,
         }
     }
@@ -205,6 +213,10 @@ impl EventKind {
             Self::EscalationCancelled => "escalation_cancelled",
             Self::SharedContextWritten => "shared_context_written",
             Self::SharedContextExpired => "shared_context_expired",
+            Self::SupervisorSteer => "supervisor_steer",
+            Self::SupervisorConflictDetected => "supervisor_conflict_detected",
+            Self::SupervisorEscalated => "supervisor_escalated",
+            Self::SupervisorPatternDetected => "supervisor_pattern_detected",
         }
     }
 
@@ -221,6 +233,10 @@ impl EventKind {
             "escalation_cancelled",
             "shared_context_written",
             "shared_context_expired",
+            "supervisor_steer",
+            "supervisor_conflict_detected",
+            "supervisor_escalated",
+            "supervisor_pattern_detected",
         ]
     }
 }
@@ -449,6 +465,7 @@ pub struct ServiceConfig {
     pub prompts: Option<PromptsConfig>,
     pub notifications: Option<NotificationsConfig>,
     pub shared_context: SharedContextConfig,
+    pub supervisor: SupervisorConfig,
 }
 
 /// Tracker configuration (spec §5.3.1).
@@ -541,6 +558,97 @@ impl Default for SharedContextConfig {
         Self {
             ttl_ms: 86_400_000,
             max_entries: 100,
+        }
+    }
+}
+
+/// Supervisor orchestration settings (M002/S07).
+#[derive(Debug, Clone)]
+pub struct SupervisorConfig {
+    /// Enable the supervisor task.
+    pub enabled: bool,
+    /// Optional model override for future model-backed supervisor decisions.
+    pub model: Option<String>,
+    /// Minimum milliseconds between steers sent to the same issue.
+    pub steer_cooldown_ms: u64,
+}
+
+impl Default for SupervisorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        }
+    }
+}
+
+/// Runtime supervisor status for snapshot consumers.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SupervisorStatus {
+    #[default]
+    Disabled,
+    Starting,
+    Active,
+    Stopped,
+    Failed,
+}
+
+/// Read-only supervisor metrics included in orchestrator snapshots.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SupervisorSnapshot {
+    pub status: SupervisorStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub steers_issued: u64,
+    #[serde(default)]
+    pub conflicts_detected: u64,
+    #[serde(default)]
+    pub patterns_detected: u64,
+    #[serde(default)]
+    pub escalations_created: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_decision: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_action_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+impl Default for SupervisorSnapshot {
+    fn default() -> Self {
+        Self::disabled(None)
+    }
+}
+
+impl SupervisorSnapshot {
+    pub fn disabled(model: Option<String>) -> Self {
+        Self {
+            status: SupervisorStatus::Disabled,
+            model,
+            steers_issued: 0,
+            conflicts_detected: 0,
+            patterns_detected: 0,
+            escalations_created: 0,
+            last_decision: None,
+            last_action_at: None,
+            last_error: None,
+        }
+    }
+
+    pub fn idle(model: Option<String>) -> Self {
+        Self {
+            status: SupervisorStatus::Stopped,
+            model,
+            steers_issued: 0,
+            conflicts_detected: 0,
+            patterns_detected: 0,
+            escalations_created: 0,
+            last_decision: None,
+            last_action_at: None,
+            last_error: None,
         }
     }
 }
@@ -1046,6 +1154,8 @@ pub struct OrchestratorSnapshot {
     pub pending_escalations: Vec<PendingEscalation>,
     #[serde(default)]
     pub shared_context: SharedContextSummary,
+    #[serde(default)]
+    pub supervisor: SupervisorSnapshot,
     pub codex_totals: CodexTotals,
     pub codex_rate_limits: Option<RateLimitInfo>,
     pub polling: PollingSnapshot,

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -18,7 +18,7 @@ use crate::domain::{
     CodexTotals, ContextEntry, ContextScope, EventFilter, EventKind, EventSeverity,
     OrchestratorSnapshot, PendingEscalation, PollingSnapshot, RefreshRequestOutcome,
     RetrySnapshotEntry, RunAttempt, RunningSessionSnapshot, SharedContextSummary,
-    SymphonyEventEnvelope, WorkerSessionInfo,
+    SupervisorSnapshot, SymphonyEventEnvelope, WorkerSessionInfo,
 };
 use crate::event_stream::EventHub;
 use crate::orchestrator::{
@@ -282,6 +282,7 @@ struct StateResponse {
     pending_escalations: Vec<PendingEscalation>,
     completed: Vec<crate::domain::CompletedEntry>,
     shared_context: SharedContextSummary,
+    supervisor: SupervisorSnapshot,
     codex_totals: CodexTotals,
     codex_rate_limits: Option<serde_json::Value>,
     polling: PollingSnapshot,
@@ -545,6 +546,13 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     } else {
         "no"
     };
+    let supervisor_status_label = match snapshot.supervisor.status {
+        crate::domain::SupervisorStatus::Disabled => "⚪ disabled",
+        crate::domain::SupervisorStatus::Starting => "🟡 starting",
+        crate::domain::SupervisorStatus::Active => "🟢 active",
+        crate::domain::SupervisorStatus::Stopped => "⚫ stopped",
+        crate::domain::SupervisorStatus::Failed => "🔴 failed",
+    };
     let linear_project_card = snapshot
         .linear_project_url
         .as_deref()
@@ -613,6 +621,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     <section class="card"><div class="label">retry</div><div class="value" id="retry-count">{retry_count}</div></section>
     <section class="card"><div class="label">claimed</div><div class="value" id="claimed-count">{claimed_count}</div></section>
     <section class="card"><div class="label">completed</div><div class="value" id="completed-count">{completed_count}</div></section>
+    <section class="card"><div class="label">supervisor</div><div class="mono" id="supervisor-status">{supervisor_status_label}</div></section>
     <div id="linear-project-card">{linear_project_card}</div>
   </div>
 
@@ -729,6 +738,19 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         </table>
       </div>
     </details>
+  </section>
+
+  <section class="card section">
+    <h2>Supervisor</h2>
+    <div class="polling-grid">
+      <div><div class="label">status</div><div class="mono" id="supervisor-status-detail">{supervisor_status_label}</div></div>
+      <div><div class="label">steers</div><div class="mono" id="supervisor-steers">0</div></div>
+      <div><div class="label">conflicts</div><div class="mono" id="supervisor-conflicts">0</div></div>
+      <div><div class="label">patterns</div><div class="mono" id="supervisor-patterns">0</div></div>
+      <div><div class="label">escalations</div><div class="mono" id="supervisor-escalations">0</div></div>
+      <div><div class="label">last decision</div><div class="mono" id="supervisor-last-decision">n/a</div></div>
+      <div><div class="label">last action</div><div class="mono" id="supervisor-last-action">n/a</div></div>
+    </div>
   </section>
 
   <section class="card section">
@@ -1024,6 +1046,28 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         '</a></div></section>';
     }}
 
+    function formatSupervisorStatus(supervisor) {{
+      const status = (supervisor && supervisor.status) || 'disabled';
+      if (status === 'active') return '🟢 active';
+      if (status === 'starting') return '🟡 starting';
+      if (status === 'failed') return '🔴 failed';
+      if (status === 'stopped') return '⚫ stopped';
+      return '⚪ disabled';
+    }}
+
+    function updateSupervisor(supervisor) {{
+      const data = supervisor || {{}};
+      const status = formatSupervisorStatus(data);
+      document.getElementById('supervisor-status').textContent = status;
+      document.getElementById('supervisor-status-detail').textContent = status;
+      document.getElementById('supervisor-steers').textContent = String(data.steers_issued || 0);
+      document.getElementById('supervisor-conflicts').textContent = String(data.conflicts_detected || 0);
+      document.getElementById('supervisor-patterns').textContent = String(data.patterns_detected || 0);
+      document.getElementById('supervisor-escalations').textContent = String(data.escalations_created || 0);
+      document.getElementById('supervisor-last-decision').textContent = data.last_decision || 'n/a';
+      document.getElementById('supervisor-last-action').textContent = data.last_action_at ? formatDate(data.last_action_at) : 'n/a';
+    }}
+
     function updatePolling(polling) {{
       const poll = polling || {{}};
       document.getElementById('polling-last-poll').textContent = formatDate(poll.last_poll_at);
@@ -1093,6 +1137,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
 
         document.getElementById('completed-list').innerHTML = renderCompleted(completed);
         updateSharedContextSection(sharedContextEntries);
+        updateSupervisor(state.supervisor || {{}});
         document.getElementById('token-input').textContent = state.codex_totals?.input_tokens ?? 0;
         document.getElementById('token-output').textContent = state.codex_totals?.output_tokens ?? 0;
         document.getElementById('token-total').textContent = state.codex_totals?.total_tokens ?? 0;
@@ -1129,6 +1174,7 @@ async fn get_state(State(state): State<HttpServerState>) -> impl IntoResponse {
         pending_escalations: snapshot.pending_escalations,
         completed: snapshot.completed,
         shared_context: snapshot.shared_context,
+        supervisor: snapshot.supervisor,
         codex_totals: snapshot.codex_totals,
         codex_rate_limits: snapshot.codex_rate_limits.map(|r| r.data),
         polling: snapshot.polling,

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -553,6 +553,22 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         crate::domain::SupervisorStatus::Stopped => "⚫ stopped",
         crate::domain::SupervisorStatus::Failed => "🔴 failed",
     };
+    let supervisor_steers = snapshot.supervisor.steers_issued;
+    let supervisor_conflicts = snapshot.supervisor.conflicts_detected;
+    let supervisor_patterns = snapshot.supervisor.patterns_detected;
+    let supervisor_escalations = snapshot.supervisor.escalations_created;
+    let supervisor_last_decision = snapshot
+        .supervisor
+        .last_decision
+        .as_deref()
+        .map(escape_html)
+        .unwrap_or_else(|| "n/a".to_string());
+    let supervisor_last_action = snapshot
+        .supervisor
+        .last_action_at
+        .map(|timestamp| timestamp.to_rfc3339())
+        .map(|value| escape_html(&value))
+        .unwrap_or_else(|| "n/a".to_string());
     let linear_project_card = snapshot
         .linear_project_url
         .as_deref()
@@ -744,12 +760,12 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     <h2>Supervisor</h2>
     <div class="polling-grid">
       <div><div class="label">status</div><div class="mono" id="supervisor-status-detail">{supervisor_status_label}</div></div>
-      <div><div class="label">steers</div><div class="mono" id="supervisor-steers">0</div></div>
-      <div><div class="label">conflicts</div><div class="mono" id="supervisor-conflicts">0</div></div>
-      <div><div class="label">patterns</div><div class="mono" id="supervisor-patterns">0</div></div>
-      <div><div class="label">escalations</div><div class="mono" id="supervisor-escalations">0</div></div>
-      <div><div class="label">last decision</div><div class="mono" id="supervisor-last-decision">n/a</div></div>
-      <div><div class="label">last action</div><div class="mono" id="supervisor-last-action">n/a</div></div>
+      <div><div class="label">steers</div><div class="mono" id="supervisor-steers">{supervisor_steers}</div></div>
+      <div><div class="label">conflicts</div><div class="mono" id="supervisor-conflicts">{supervisor_conflicts}</div></div>
+      <div><div class="label">patterns</div><div class="mono" id="supervisor-patterns">{supervisor_patterns}</div></div>
+      <div><div class="label">escalations</div><div class="mono" id="supervisor-escalations">{supervisor_escalations}</div></div>
+      <div><div class="label">last decision</div><div class="mono" id="supervisor-last-decision">{supervisor_last_decision}</div></div>
+      <div><div class="label">last action</div><div class="mono" id="supervisor-last-action">{supervisor_last_action}</div></div>
     </div>
   </section>
 

--- a/apps/symphony/src/lib.rs
+++ b/apps/symphony/src/lib.rs
@@ -14,6 +14,7 @@ pub mod ssh;
 pub mod workspace;
 
 pub mod shared_context;
+pub mod supervisor;
 
 pub mod codex;
 pub mod event_stream;

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -606,7 +606,7 @@ fn run_runtime_until_shutdown(
                 }
             };
 
-            tokio::select! {
+            let runtime_result = tokio::select! {
                 run_result = orchestrator.run(port) => {
                     run_result.map_err(|err| format!("orchestrator runtime failed: {err}"))?;
                     tracing::info!(
@@ -661,7 +661,10 @@ fn run_runtime_until_shutdown(
                         tui::TuiExitReason::DrawError => Err("tui failed while drawing dashboard".to_string()),
                     }
                 }
-            }
+            };
+
+            orchestrator.shutdown_supervisor().await;
+            runtime_result
         })
     })
 }

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -641,24 +641,24 @@ fn run_runtime_until_shutdown(
                     Ok(())
                 }
                 tui_reason = tui_exit_future => {
-                    let Some(tui_reason) = tui_reason else {
-                        return Ok(());
-                    };
                     match tui_reason {
-                        tui::TuiExitReason::CtrlC | tui::TuiExitReason::ShutdownSignal => {
-                            tracing::info!(
-                                phase = "runtime",
-                                stage = "stopped",
-                                reason = "tui_exit",
-                                workflow_path = %workflow_path.display(),
-                                tui_reason = ?tui_reason,
-                                "tui requested runtime shutdown"
-                            );
-                            Ok(())
-                        }
-                        tui::TuiExitReason::SetupFailed => Err("tui failed to initialize terminal".to_string()),
-                        tui::TuiExitReason::InputError => Err("tui failed while reading terminal input".to_string()),
-                        tui::TuiExitReason::DrawError => Err("tui failed while drawing dashboard".to_string()),
+                        Some(tui_reason) => match tui_reason {
+                            tui::TuiExitReason::CtrlC | tui::TuiExitReason::ShutdownSignal => {
+                                tracing::info!(
+                                    phase = "runtime",
+                                    stage = "stopped",
+                                    reason = "tui_exit",
+                                    workflow_path = %workflow_path.display(),
+                                    tui_reason = ?tui_reason,
+                                    "tui requested runtime shutdown"
+                                );
+                                Ok(())
+                            }
+                            tui::TuiExitReason::SetupFailed => Err("tui failed to initialize terminal".to_string()),
+                            tui::TuiExitReason::InputError => Err("tui failed while reading terminal input".to_string()),
+                            tui::TuiExitReason::DrawError => Err("tui failed while drawing dashboard".to_string()),
+                        },
+                        None => Ok(()),
                     }
                 }
             };

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -3169,8 +3169,16 @@ impl Orchestrator {
             return Ok(());
         }
 
-        if self.supervisor_agent.is_some() {
+        if self
+            .supervisor_agent
+            .as_ref()
+            .is_some_and(SupervisorAgent::is_running)
+        {
             return Ok(());
+        }
+
+        if let Some(mut supervisor) = self.supervisor_agent.take() {
+            supervisor.abort();
         }
 
         let event_hub = self.create_event_hub();

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -14,8 +14,8 @@ use crate::domain::{
     EscalationRequest, EscalationResponse, EventKind, EventSeverity, HooksConfig, Issue,
     OrchestratorSnapshot, OrchestratorState, PendingEscalation, PiAgentConfig, PollingSnapshot,
     RateLimitInfo, RefreshRequestOutcome, RetryEntry, RetrySnapshotEntry, RunAttempt,
-    RunningSessionSnapshot, ServiceConfig, SessionTokenUsage, TrackerConfig, WorkerSessionInfo,
-    WorkspaceConfig, WorkspaceIsolation,
+    RunningSessionSnapshot, ServiceConfig, SessionTokenUsage, SupervisorSnapshot, TrackerConfig,
+    WorkerSessionInfo, WorkspaceConfig, WorkspaceIsolation,
 };
 use crate::error::{Result, SymphonyError};
 use crate::event_stream::EventHub;
@@ -3140,6 +3140,14 @@ impl Orchestrator {
         self.shared_context_store.clone()
     }
 
+    fn supervisor_snapshot(&self) -> SupervisorSnapshot {
+        if self.config.supervisor.enabled {
+            SupervisorSnapshot::idle(self.config.supervisor.model.clone())
+        } else {
+            SupervisorSnapshot::disabled(self.config.supervisor.model.clone())
+        }
+    }
+
     fn shared_context_scopes_for_issue(issue: &Issue) -> Vec<ContextScope> {
         let mut scopes = vec![ContextScope::Project];
 
@@ -3428,6 +3436,7 @@ impl Orchestrator {
             blocked: self.blocked_issues.clone(),
             pending_escalations: self.escalation_registry.pending_snapshot(),
             shared_context: self.shared_context_store.summary(),
+            supervisor: self.supervisor_snapshot(),
             running_session_info,
             claimed,
             retry_queue,

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -24,6 +24,7 @@ use crate::pi_agent::rpc_bridge;
 use crate::session_summary::{compact_session_id, normalize_whitespace, truncate_for_display};
 use crate::shared_context::SharedContextStore;
 use crate::ssh::{self, WorkerHostSelection};
+use crate::supervisor::{SupervisorAgent, SupervisorDependencies};
 use crate::workflow_store::WorkflowStore;
 use crate::{docker, path_safety, prompt_builder, workspace};
 
@@ -1426,6 +1427,8 @@ pub struct Orchestrator {
     escalation_registry: EscalationRegistry,
     /// Shared ephemeral cross-worker context store.
     shared_context_store: SharedContextStore,
+    /// Optional supervisor lifecycle controller.
+    supervisor_agent: Option<SupervisorAgent>,
     /// The prompt template from the WORKFLOW.md body, used to render per-issue prompts.
     prompt_template: String,
 }
@@ -1506,6 +1509,7 @@ impl Orchestrator {
                 shared_context_ttl_ms,
                 shared_context_max_entries,
             ),
+            supervisor_agent: None,
             prompt_template,
         }
     }
@@ -1602,6 +1606,7 @@ impl Orchestrator {
 
     pub async fn run(&mut self, port: &mut dyn OrchestratorPort) -> Result<()> {
         self.startup_cleanup(port)?;
+        self.sync_supervisor_lifecycle().await;
         self.publish_snapshot();
         let mut next_poll_due = tokio::time::Instant::now();
         let mut tick_requested = true;
@@ -1610,6 +1615,7 @@ impl Orchestrator {
             let now = tokio::time::Instant::now();
             if tick_requested || now >= next_poll_due {
                 self.refresh_runtime_config();
+                self.sync_supervisor_lifecycle().await;
 
                 let now_ms = Utc::now().timestamp_millis();
                 let stall_timeout_ms =
@@ -3141,10 +3147,73 @@ impl Orchestrator {
     }
 
     fn supervisor_snapshot(&self) -> SupervisorSnapshot {
+        if let Some(supervisor) = &self.supervisor_agent {
+            return supervisor.snapshot();
+        }
+
         if self.config.supervisor.enabled {
             SupervisorSnapshot::idle(self.config.supervisor.model.clone())
         } else {
             SupervisorSnapshot::disabled(self.config.supervisor.model.clone())
+        }
+    }
+
+    pub fn supervisor_is_running(&self) -> bool {
+        self.supervisor_agent
+            .as_ref()
+            .is_some_and(SupervisorAgent::is_running)
+    }
+
+    pub fn ensure_supervisor_running(&mut self) -> Result<()> {
+        if !self.config.supervisor.enabled {
+            return Ok(());
+        }
+
+        if self.supervisor_agent.is_some() {
+            return Ok(());
+        }
+
+        let event_hub = self.create_event_hub();
+        let deps = SupervisorDependencies::new(
+            event_hub,
+            self.shared_context_store.clone(),
+            self.escalation_registry.clone(),
+        );
+
+        let mut supervisor = SupervisorAgent::new(self.config.supervisor.clone(), deps);
+        supervisor.start()?;
+
+        tracing::info!(
+            event = "supervisor_started",
+            cooldown_ms = self.config.supervisor.steer_cooldown_ms,
+            "supervisor started from orchestrator lifecycle"
+        );
+
+        self.supervisor_agent = Some(supervisor);
+        Ok(())
+    }
+
+    pub async fn shutdown_supervisor(&mut self) {
+        if let Some(mut supervisor) = self.supervisor_agent.take() {
+            supervisor.stop().await;
+            tracing::info!(
+                event = "supervisor_stopped",
+                "supervisor stopped from orchestrator lifecycle"
+            );
+        }
+    }
+
+    async fn sync_supervisor_lifecycle(&mut self) {
+        if self.config.supervisor.enabled {
+            if let Err(err) = self.ensure_supervisor_running() {
+                tracing::warn!(
+                    event = "supervisor_start_failed",
+                    error = %err,
+                    "failed to start supervisor"
+                );
+            }
+        } else {
+            self.shutdown_supervisor().await;
         }
     }
 
@@ -4134,6 +4203,14 @@ impl Orchestrator {
 
 fn event_timestamp_ms(event: &AgentEvent) -> i64 {
     event_timestamp(event).timestamp_millis()
+}
+
+impl Drop for Orchestrator {
+    fn drop(&mut self) {
+        if let Some(supervisor) = self.supervisor_agent.as_mut() {
+            supervisor.abort();
+        }
+    }
 }
 
 fn event_timestamp(event: &AgentEvent) -> DateTime<Utc> {

--- a/apps/symphony/src/supervisor.rs
+++ b/apps/symphony/src/supervisor.rs
@@ -300,8 +300,13 @@ impl SupervisorAgent {
             return Ok(());
         }
 
-        if self.task.is_some() {
+        if self.task.as_ref().is_some_and(|task| !task.is_finished()) {
             return Ok(());
+        }
+
+        if self.task.as_ref().is_some_and(|task| task.is_finished()) {
+            self.task = None;
+            self.shutdown_tx = None;
         }
 
         if tokio::runtime::Handle::try_current().is_err() {
@@ -392,21 +397,36 @@ impl SupervisorAgent {
             let _ = shutdown_tx.send(true);
         }
 
-        if let Some(task) = self.task.take() {
-            match tokio::time::timeout(Duration::from_secs(2), task).await {
-                Ok(Ok(())) => {}
-                Ok(Err(join_err)) => {
-                    tracing::warn!(
-                        event = "supervisor_join_failed",
-                        error = %join_err,
-                        "supervisor task ended with join error"
-                    );
+        if let Some(mut task) = self.task.take() {
+            tokio::select! {
+                join = &mut task => {
+                    match join {
+                        Ok(()) => {}
+                        Err(join_err) => {
+                            tracing::warn!(
+                                event = "supervisor_join_failed",
+                                error = %join_err,
+                                "supervisor task ended with join error"
+                            );
+                        }
+                    }
                 }
-                Err(_) => {
+                _ = tokio::time::sleep(Duration::from_secs(2)) => {
                     tracing::warn!(
                         event = "supervisor_shutdown_timeout",
-                        "supervisor did not stop within timeout"
+                        "supervisor did not stop within timeout; aborting task"
                     );
+
+                    task.abort();
+                    if let Err(join_err) = task.await {
+                        if !join_err.is_cancelled() {
+                            tracing::warn!(
+                                event = "supervisor_join_failed",
+                                error = %join_err,
+                                "supervisor task ended with join error"
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -1008,7 +1028,9 @@ fn detect_context_conflict(entries: &[crate::domain::ContextEntry]) -> Option<Co
         if left.author_issue.eq_ignore_ascii_case("supervisor") {
             continue;
         }
-        let decision_a = decision_token(&left.content)?;
+        let Some(decision_a) = decision_token(&left.content) else {
+            continue;
+        };
         for right in entries {
             if left.id == right.id || left.scope != right.scope {
                 continue;
@@ -1019,7 +1041,9 @@ fn detect_context_conflict(entries: &[crate::domain::ContextEntry]) -> Option<Co
             if left.author_issue.eq_ignore_ascii_case(&right.author_issue) {
                 continue;
             }
-            let decision_b = decision_token(&right.content)?;
+            let Some(decision_b) = decision_token(&right.content) else {
+                continue;
+            };
             if decision_a == decision_b {
                 continue;
             }
@@ -1220,6 +1244,11 @@ fn repeated_test_failure_signature(summary: Option<&str>) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
     use super::*;
 
     fn tool_envelope(event: &str, summary: &str) -> SymphonyEventEnvelope {
@@ -1232,6 +1261,17 @@ mod tests {
             event,
             serde_json::json!({ "summary": summary }),
         )
+    }
+
+    fn context_entry(id: &str, author_issue: &str, content: &str) -> crate::domain::ContextEntry {
+        crate::domain::ContextEntry {
+            id: id.to_string(),
+            author_issue: author_issue.to_string(),
+            scope: ContextScope::Project,
+            content: content.to_string(),
+            created_at: Utc::now(),
+            ttl_ms: 60_000,
+        }
     }
 
     #[test]
@@ -1262,6 +1302,22 @@ mod tests {
         let left = conflict_key("KAT-1", "KAT-2", "src/lib.rs");
         let right = conflict_key("KAT-2", "KAT-1", "src/lib.rs");
         assert_eq!(left, right);
+    }
+
+    #[test]
+    fn detect_context_conflict_skips_non_decision_entries() {
+        let entries = vec![
+            context_entry("1", "KAT-1", "status update only"),
+            context_entry("2", "KAT-2", "Decision: use jsonwebtoken for auth"),
+            context_entry("3", "KAT-3", "Decision: use paseto for auth"),
+        ];
+
+        let conflict =
+            detect_context_conflict(&entries).expect("expected conflict despite non-decision row");
+
+        assert_eq!(conflict.scope_key, "project");
+        assert_eq!(conflict.decision_a, "jsonwebtoken");
+        assert_eq!(conflict.decision_b, "paseto");
     }
 
     #[test]
@@ -1344,5 +1400,76 @@ mod tests {
             None
         );
         assert_eq!(repeated_test_failure_signature(None), None);
+    }
+
+    #[tokio::test]
+    async fn start_restarts_when_previous_handle_is_finished() {
+        let deps = SupervisorDependencies::new(
+            EventHub::new(8),
+            SharedContextStore::default(),
+            EscalationRegistry::default(),
+        );
+        let mut supervisor = SupervisorAgent::new(
+            SupervisorConfig {
+                enabled: true,
+                model: None,
+                steer_cooldown_ms: 120_000,
+            },
+            deps,
+        );
+
+        let finished = tokio::spawn(async {});
+        tokio::task::yield_now().await;
+        assert!(finished.is_finished());
+
+        supervisor.task = Some(finished);
+        supervisor.shutdown_tx = Some(watch::channel(false).0);
+
+        supervisor
+            .start()
+            .expect("finished handle should not block restart");
+        assert!(supervisor.is_running());
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn stop_timeout_aborts_background_task() {
+        struct DropFlag(Arc<AtomicBool>);
+
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let deps = SupervisorDependencies::new(
+            EventHub::new(8),
+            SharedContextStore::default(),
+            EscalationRegistry::default(),
+        );
+        let mut supervisor = SupervisorAgent::new(
+            SupervisorConfig {
+                enabled: true,
+                model: None,
+                steer_cooldown_ms: 120_000,
+            },
+            deps,
+        );
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let drop_flag = DropFlag(Arc::clone(&dropped));
+
+        supervisor.task = Some(tokio::spawn(async move {
+            let _drop_flag = drop_flag;
+            std::future::pending::<()>().await;
+        }));
+
+        supervisor.stop().await;
+
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "timed-out supervisor task should be aborted and dropped"
+        );
     }
 }

--- a/apps/symphony/src/supervisor.rs
+++ b/apps/symphony/src/supervisor.rs
@@ -1,0 +1,242 @@
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use chrono::Utc;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use crate::domain::{
+    EventKind, EventSeverity, SupervisorConfig, SupervisorSnapshot, SupervisorStatus,
+    SymphonyEventEnvelope,
+};
+use crate::error::{Result, SymphonyError};
+use crate::event_stream::EventHub;
+use crate::orchestrator::EscalationRegistry;
+use crate::shared_context::SharedContextStore;
+
+/// Runtime dependencies used by the supervisor background task.
+#[derive(Clone)]
+pub struct SupervisorDependencies {
+    pub event_hub: EventHub,
+    pub shared_context_store: SharedContextStore,
+    pub escalation_registry: EscalationRegistry,
+}
+
+impl SupervisorDependencies {
+    pub fn new(
+        event_hub: EventHub,
+        shared_context_store: SharedContextStore,
+        escalation_registry: EscalationRegistry,
+    ) -> Self {
+        Self {
+            event_hub,
+            shared_context_store,
+            escalation_registry,
+        }
+    }
+}
+
+/// Background supervisor task lifecycle controller.
+pub struct SupervisorAgent {
+    config: SupervisorConfig,
+    deps: SupervisorDependencies,
+    snapshot: Arc<RwLock<SupervisorSnapshot>>,
+    shutdown_tx: Option<watch::Sender<bool>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl SupervisorAgent {
+    pub fn new(config: SupervisorConfig, deps: SupervisorDependencies) -> Self {
+        let initial_snapshot = if config.enabled {
+            SupervisorSnapshot::idle(config.model.clone())
+        } else {
+            SupervisorSnapshot::disabled(config.model.clone())
+        };
+
+        Self {
+            config,
+            deps,
+            snapshot: Arc::new(RwLock::new(initial_snapshot)),
+            shutdown_tx: None,
+            task: None,
+        }
+    }
+
+    /// Start the supervisor event-consumer loop.
+    pub fn start(&mut self) -> Result<()> {
+        if !self.config.enabled {
+            self.update_snapshot_status(SupervisorStatus::Disabled, Some("supervisor disabled"));
+            return Ok(());
+        }
+
+        if self.task.is_some() {
+            return Ok(());
+        }
+
+        if tokio::runtime::Handle::try_current().is_err() {
+            return Err(SymphonyError::Other(
+                "cannot start supervisor outside an active tokio runtime".to_string(),
+            ));
+        }
+
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let mut events = self.deps.event_hub.subscribe();
+        let snapshot = Arc::clone(&self.snapshot);
+        let hub = self.deps.event_hub.clone();
+        let config_model = self.config.model.clone();
+
+        self.shutdown_tx = Some(shutdown_tx);
+        self.update_snapshot_status(SupervisorStatus::Starting, Some("starting supervisor"));
+
+        let task = tokio::spawn(async move {
+            {
+                let mut state = snapshot
+                    .write()
+                    .expect("supervisor snapshot lock poisoned on start");
+                state.status = SupervisorStatus::Active;
+                state.model = config_model;
+                state.last_decision = Some("subscribed_to_event_stream".to_string());
+                state.last_action_at = Some(Utc::now());
+            }
+
+            hub.publish(
+                EventKind::Runtime,
+                EventSeverity::Info,
+                None,
+                "supervisor_started",
+                serde_json::json!({}),
+            );
+
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        break;
+                    }
+                    recv = events.recv() => {
+                        match recv {
+                            Ok(envelope) => {
+                                if should_ignore_event(&envelope) {
+                                    continue;
+                                }
+                                let mut state = snapshot
+                                    .write()
+                                    .expect("supervisor snapshot lock poisoned while consuming event stream");
+                                state.last_decision = Some(format!("observed:{}", envelope.event));
+                                state.last_action_at = Some(Utc::now());
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                                tracing::warn!(
+                                    event = "supervisor_event_stream_lagged",
+                                    skipped,
+                                    "supervisor lagged behind event stream"
+                                );
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        }
+                    }
+                }
+            }
+
+            {
+                let mut state = snapshot
+                    .write()
+                    .expect("supervisor snapshot lock poisoned on shutdown");
+                state.status = SupervisorStatus::Stopped;
+                state.last_decision = Some("stopped".to_string());
+                state.last_action_at = Some(Utc::now());
+            }
+
+            hub.publish(
+                EventKind::Runtime,
+                EventSeverity::Info,
+                None,
+                "supervisor_stopped",
+                serde_json::json!({}),
+            );
+        });
+
+        self.task = Some(task);
+        Ok(())
+    }
+
+    /// Request a graceful shutdown and await the background task.
+    pub async fn stop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(true);
+        }
+
+        if let Some(task) = self.task.take() {
+            match tokio::time::timeout(Duration::from_secs(2), task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(join_err)) => {
+                    tracing::warn!(
+                        event = "supervisor_join_failed",
+                        error = %join_err,
+                        "supervisor task ended with join error"
+                    );
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        event = "supervisor_shutdown_timeout",
+                        "supervisor did not stop within timeout"
+                    );
+                }
+            }
+        }
+
+        if self.config.enabled {
+            self.update_snapshot_status(SupervisorStatus::Stopped, Some("stopped supervisor"));
+        } else {
+            self.update_snapshot_status(SupervisorStatus::Disabled, Some("supervisor disabled"));
+        }
+    }
+
+    /// Immediate shutdown helper for non-async contexts (Drop / tests).
+    pub fn abort(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(true);
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+
+        if self.config.enabled {
+            self.update_snapshot_status(SupervisorStatus::Stopped, Some("aborted supervisor"));
+        } else {
+            self.update_snapshot_status(SupervisorStatus::Disabled, Some("supervisor disabled"));
+        }
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.task.is_some()
+    }
+
+    pub fn snapshot(&self) -> SupervisorSnapshot {
+        self.snapshot
+            .read()
+            .expect("supervisor snapshot lock poisoned while reading")
+            .clone()
+    }
+
+    fn update_snapshot_status(&self, status: SupervisorStatus, decision: Option<&str>) {
+        let mut snapshot = self
+            .snapshot
+            .write()
+            .expect("supervisor snapshot lock poisoned while updating status");
+        snapshot.status = status;
+        snapshot.model = self.config.model.clone();
+        snapshot.last_decision = decision.map(ToString::to_string);
+        snapshot.last_action_at = Some(Utc::now());
+    }
+}
+
+fn should_ignore_event(envelope: &SymphonyEventEnvelope) -> bool {
+    matches!(
+        envelope.kind,
+        EventKind::Heartbeat
+            | EventKind::SupervisorSteer
+            | EventKind::SupervisorConflictDetected
+            | EventKind::SupervisorEscalated
+            | EventKind::SupervisorPatternDetected
+    )
+}

--- a/apps/symphony/src/supervisor.rs
+++ b/apps/symphony/src/supervisor.rs
@@ -1,3 +1,12 @@
+//! Supervisor agent runtime for Symphony orchestrator.
+//!
+//! This module runs a background supervisor task that consumes [`SymphonyEventEnvelope`]
+//! updates, tracks worker progress, emits `supervisor_*` events, and coordinates
+//! mitigations through shared context, steering, and human escalation. The runtime
+//! collaborates with [`EscalationRegistry`] and produces snapshot state via
+//! [`SupervisorSnapshot`] and [`SupervisorStatus`] configured by [`SupervisorConfig`].
+//! Escalation actions ultimately materialize as [`EscalationRequest`] records.
+
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, LazyLock, RwLock};
 use std::time::Duration;
@@ -426,7 +435,7 @@ impl SupervisorAgent {
     }
 
     pub fn is_running(&self) -> bool {
-        self.task.is_some()
+        self.task.as_ref().is_some_and(|task| !task.is_finished())
     }
 
     pub fn snapshot(&self) -> SupervisorSnapshot {
@@ -456,130 +465,224 @@ fn process_envelope(
     envelope: SymphonyEventEnvelope,
 ) {
     let now = envelope.timestamp;
-    let mut guard = state
-        .write()
-        .expect("supervisor state lock poisoned while processing event");
+    let issue_identifier = envelope.issue.clone();
+    let mut issue_id: Option<String> = None;
+    let mut edited_path: Option<String> = None;
+    let mut pattern_signature: Option<String> = None;
 
-    guard.snapshot.last_decision = Some(format!("observed:{}", envelope.event));
-    guard.snapshot.last_action_at = Some(Utc::now());
+    {
+        let mut guard = state
+            .write()
+            .expect("supervisor state lock poisoned while processing event");
 
-    if let Some(issue_identifier) = envelope.issue.clone() {
-        if let Some(issue_id) = issue_id_from_payload(&envelope) {
-            guard
-                .issue_ids_by_identifier
-                .insert(issue_identifier.clone(), issue_id);
-        }
+        guard.snapshot.last_decision = Some(format!("observed:{}", envelope.event));
+        guard.snapshot.last_action_at = Some(Utc::now());
 
-        let edited_path = {
+        if let Some(ref issue_identifier) = issue_identifier {
+            if let Some(parsed_issue_id) = issue_id_from_payload(&envelope) {
+                guard
+                    .issue_ids_by_identifier
+                    .insert(issue_identifier.clone(), parsed_issue_id);
+            }
+
             let worker = guard.workers.entry(issue_identifier.clone()).or_default();
-            worker.observe_event(&envelope)
-        };
+            edited_path = worker.observe_event(&envelope);
+            issue_id = guard.issue_ids_by_identifier.get(issue_identifier).cloned();
+            pattern_signature = systemic_error_signature(&envelope);
+        }
+    }
 
-        let issue_id = guard
-            .issue_ids_by_identifier
-            .get(&issue_identifier)
-            .cloned();
-
-        if let Some(pattern_signature) = systemic_error_signature(&envelope) {
+    if let Some(issue_identifier) = issue_identifier.as_deref() {
+        if let Some(pattern_signature) = pattern_signature.as_deref() {
             maybe_handle_failure_pattern(
-                &mut guard,
+                state,
                 deps,
-                &issue_identifier,
+                issue_identifier,
                 issue_id.as_deref(),
-                &pattern_signature,
+                pattern_signature,
                 now,
             );
         }
 
-        maybe_emit_stuck_steer(&mut guard, config, deps, &issue_identifier, now);
+        maybe_emit_stuck_steer(state, config, deps, issue_identifier, now);
 
-        if let Some(path) = edited_path {
-            maybe_handle_file_conflict(&mut guard, config, deps, &issue_identifier, &path, now);
+        if let Some(path) = edited_path.as_deref() {
+            maybe_handle_file_conflict(state, config, deps, issue_identifier, path, now);
         }
     }
 
     if envelope.kind == EventKind::SharedContextWritten
         || envelope.event == "shared_context_written"
     {
-        maybe_handle_context_conflict(&mut guard, deps, now);
+        maybe_handle_context_conflict(state, deps, now);
     }
 }
 
+#[derive(Debug, Clone)]
+struct SteerDirective {
+    reason: String,
+    detail: String,
+    guidance: String,
+}
+
+#[derive(Debug, Clone)]
+struct FileConflictDirective {
+    other_issue: String,
+    file_path: String,
+    steer: Option<SteerDirective>,
+}
+
+#[derive(Debug, Clone)]
+struct FailurePatternDirective {
+    issue_id: String,
+    signature: String,
+    affected_issues: Vec<String>,
+    emit_pattern: bool,
+    escalate: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ContextConflictDirective {
+    conflict: ContextConflict,
+    issue_a_id: String,
+}
+
 fn maybe_emit_stuck_steer(
-    state: &mut SupervisorRuntimeState,
+    state: &Arc<RwLock<SupervisorRuntimeState>>,
     config: &SupervisorConfig,
     deps: &SupervisorDependencies,
     issue_identifier: &str,
     now: DateTime<Utc>,
 ) {
-    let Some(stuck_reason) = state
-        .workers
-        .get(issue_identifier)
-        .and_then(WorkerModel::detect_stuck_reason)
-    else {
-        return;
+    let steer = {
+        let mut guard = state
+            .write()
+            .expect("supervisor state lock poisoned while evaluating stuck worker");
+
+        let Some(stuck_reason) = guard
+            .workers
+            .get(issue_identifier)
+            .and_then(WorkerModel::detect_stuck_reason)
+        else {
+            return;
+        };
+
+        let Some(worker) = guard.workers.get_mut(issue_identifier) else {
+            return;
+        };
+
+        if !worker.can_steer(now, config.steer_cooldown_ms) {
+            return;
+        }
+
+        worker.mark_steer(now);
+
+        let steer = SteerDirective {
+            reason: stuck_reason.code().to_string(),
+            detail: stuck_reason.brief(),
+            guidance: stuck_reason.guidance(),
+        };
+
+        record_supervisor_steer_snapshot(&mut guard, issue_identifier, &steer.reason);
+        Some(steer)
     };
 
-    let Some(worker) = state.workers.get_mut(issue_identifier) else {
-        return;
-    };
-
-    if !worker.can_steer(now, config.steer_cooldown_ms) {
-        return;
+    if let Some(steer) = steer {
+        emit_supervisor_steer(
+            deps,
+            issue_identifier,
+            &steer.reason,
+            &steer.detail,
+            &steer.guidance,
+            config.steer_cooldown_ms,
+        );
     }
-
-    worker.mark_steer(now);
-    emit_supervisor_steer(
-        state,
-        deps,
-        issue_identifier,
-        stuck_reason.code(),
-        &stuck_reason.brief(),
-        &stuck_reason.guidance(),
-        config.steer_cooldown_ms,
-    );
 }
 
 fn maybe_handle_file_conflict(
-    state: &mut SupervisorRuntimeState,
+    state: &Arc<RwLock<SupervisorRuntimeState>>,
     config: &SupervisorConfig,
     deps: &SupervisorDependencies,
     issue_identifier: &str,
     file_path: &str,
     now: DateTime<Utc>,
 ) {
-    let conflicting_issue = state.workers.iter().find_map(|(other_issue, worker)| {
-        if other_issue == issue_identifier {
-            return None;
+    let directive = {
+        let mut guard = state
+            .write()
+            .expect("supervisor state lock poisoned while evaluating file conflict");
+
+        let conflicting_issue = guard.workers.iter().find_map(|(other_issue, worker)| {
+            if other_issue == issue_identifier {
+                return None;
+            }
+            if worker.has_recent_file_edit(file_path, now) {
+                Some(other_issue.clone())
+            } else {
+                None
+            }
+        });
+
+        let Some(other_issue) = conflicting_issue else {
+            return;
+        };
+
+        let key = conflict_key(issue_identifier, &other_issue, file_path);
+        if !should_emit_conflict(&mut guard.recent_conflicts, &key, now) {
+            return;
         }
-        if worker.has_recent_file_edit(file_path, now) {
-            Some(other_issue.clone())
+
+        guard.snapshot.conflicts_detected = guard.snapshot.conflicts_detected.saturating_add(1);
+        guard.snapshot.last_decision = Some(format!(
+            "conflict detected: {} vs {} on {}",
+            issue_identifier, other_issue, file_path
+        ));
+        guard.snapshot.last_action_at = Some(Utc::now());
+
+        let should_steer = if let Some(worker) = guard.workers.get_mut(issue_identifier) {
+            if worker.can_steer(now, config.steer_cooldown_ms) {
+                worker.mark_steer(now);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        let steer = if should_steer {
+            let steer = SteerDirective {
+                reason: "file_conflict".to_string(),
+                detail: format!("overlap with {other_issue} on {file_path}"),
+                guidance: format!(
+                    "Another worker ({other_issue}) is editing `{file_path}`. Align with shared context before proceeding."
+                ),
+            };
+            record_supervisor_steer_snapshot(&mut guard, issue_identifier, &steer.reason);
+            Some(steer)
         } else {
             None
-        }
-    });
+        };
 
-    let Some(other_issue) = conflicting_issue else {
+        Some(FileConflictDirective {
+            other_issue,
+            file_path: file_path.to_string(),
+            steer,
+        })
+    };
+
+    let Some(directive) = directive else {
         return;
     };
 
-    let key = conflict_key(issue_identifier, &other_issue, file_path);
-    if !should_emit_conflict(&mut state.recent_conflicts, &key, now) {
-        return;
-    }
-
-    state.snapshot.conflicts_detected = state.snapshot.conflicts_detected.saturating_add(1);
-    state.snapshot.last_decision = Some(format!(
-        "conflict detected: {} vs {} on {}",
-        issue_identifier, other_issue, file_path
-    ));
-    state.snapshot.last_action_at = Some(Utc::now());
+    let other_issue = directive.other_issue.clone();
+    let conflict_file_path = directive.file_path.clone();
 
     deps.shared_context_store.write_entry(ContextEntryDraft {
         author_issue: "SUPERVISOR".to_string(),
         scope: ContextScope::Project,
         content: format!(
-            "⚠️ Potential overlap detected: {issue_identifier} and {other_issue} are both editing `{file_path}`. Coordinate before additional changes."
+            "⚠️ Potential overlap detected: {issue_identifier} and {other_issue} are both editing `{conflict_file_path}`. Coordinate before additional changes."
         ),
         ttl_ms: Some(30 * 60 * 1000),
     });
@@ -592,80 +695,109 @@ fn maybe_handle_file_conflict(
         serde_json::json!({
             "issues": [issue_identifier, other_issue],
             "conflict_type": "file_overlap",
-            "file_path": file_path,
+            "file_path": conflict_file_path,
         }),
     );
 
-    if let Some(worker) = state.workers.get_mut(issue_identifier) {
-        if worker.can_steer(now, config.steer_cooldown_ms) {
-            worker.mark_steer(now);
-            emit_supervisor_steer(
-                state,
-                deps,
-                issue_identifier,
-                "file_conflict",
-                &format!("overlap with {other_issue} on {file_path}"),
-                &format!(
-                    "Another worker ({other_issue}) is editing `{file_path}`. Align with shared context before proceeding."
-                ),
-                config.steer_cooldown_ms,
-            );
-        }
+    if let Some(steer) = directive.steer {
+        emit_supervisor_steer(
+            deps,
+            issue_identifier,
+            &steer.reason,
+            &steer.detail,
+            &steer.guidance,
+            config.steer_cooldown_ms,
+        );
     }
 }
 
 fn maybe_handle_failure_pattern(
-    state: &mut SupervisorRuntimeState,
+    state: &Arc<RwLock<SupervisorRuntimeState>>,
     deps: &SupervisorDependencies,
     issue_identifier: &str,
     issue_id: Option<&str>,
     signature: &str,
     now: DateTime<Utc>,
 ) {
-    let mut affected_issues: Vec<String> = Vec::new();
-    let mut should_emit_pattern = false;
-    let mut should_escalate = false;
+    let directive = {
+        let mut guard = state
+            .write()
+            .expect("supervisor state lock poisoned while evaluating failure pattern");
 
-    {
-        let tracker = state
-            .error_patterns
-            .entry(signature.to_string())
-            .or_default();
-        tracker
-            .affected_issues
-            .insert(issue_identifier.to_string(), now);
-        tracker.affected_issues.retain(|_, seen_at| {
-            now.signed_duration_since(*seen_at).num_milliseconds() < SYSTEMIC_PATTERN_WINDOW_MS
-        });
+        let mut affected_issues: Vec<String> = Vec::new();
+        let mut should_emit_pattern = false;
+        let mut should_escalate = false;
 
-        if tracker.affected_issues.len() >= 2 {
-            tracker.detections = tracker.detections.saturating_add(1);
-            affected_issues = tracker.affected_issues.keys().cloned().collect();
-            affected_issues.sort();
+        {
+            let tracker = guard
+                .error_patterns
+                .entry(signature.to_string())
+                .or_default();
+            tracker
+                .affected_issues
+                .insert(issue_identifier.to_string(), now);
+            tracker.affected_issues.retain(|_, seen_at| {
+                now.signed_duration_since(*seen_at).num_milliseconds() < SYSTEMIC_PATTERN_WINDOW_MS
+            });
 
-            if tracker.detections == 1 {
-                should_emit_pattern = true;
-            } else if tracker.detections >= SYSTEMIC_PATTERN_PERSISTENCE_THRESHOLD
-                && !tracker.escalated
-            {
-                should_escalate = true;
-                tracker.escalated = true;
+            if tracker.affected_issues.len() >= 2 {
+                tracker.detections = tracker.detections.saturating_add(1);
+                affected_issues = tracker.affected_issues.keys().cloned().collect();
+                affected_issues.sort();
+
+                if tracker.detections == 1 {
+                    should_emit_pattern = true;
+                } else if tracker.detections >= SYSTEMIC_PATTERN_PERSISTENCE_THRESHOLD
+                    && !tracker.escalated
+                {
+                    should_escalate = true;
+                    tracker.escalated = true;
+                }
             }
         }
-    }
 
-    if !should_emit_pattern && !should_escalate {
+        if !should_emit_pattern && !should_escalate {
+            None
+        } else {
+            if should_emit_pattern {
+                guard.snapshot.patterns_detected =
+                    guard.snapshot.patterns_detected.saturating_add(1);
+                guard.snapshot.last_decision = Some(format!(
+                    "systemic pattern detected across {} workers",
+                    affected_issues.len()
+                ));
+                guard.snapshot.last_action_at = Some(Utc::now());
+            }
+
+            if should_escalate {
+                guard.snapshot.escalations_created =
+                    guard.snapshot.escalations_created.saturating_add(1);
+                guard.snapshot.last_decision = Some(format!(
+                    "systemic pattern escalated: {}",
+                    truncate_for_display(signature, 80)
+                ));
+                guard.snapshot.last_action_at = Some(Utc::now());
+            }
+
+            Some(FailurePatternDirective {
+                issue_id: issue_id.unwrap_or(issue_identifier).to_string(),
+                signature: signature.to_string(),
+                affected_issues,
+                emit_pattern: should_emit_pattern,
+                escalate: should_escalate,
+            })
+        }
+    };
+
+    let Some(directive) = directive else {
         return;
-    }
+    };
 
-    if should_emit_pattern {
-        state.snapshot.patterns_detected = state.snapshot.patterns_detected.saturating_add(1);
-        state.snapshot.last_decision = Some(format!(
-            "systemic pattern detected across {} workers",
-            affected_issues.len()
-        ));
-        state.snapshot.last_action_at = Some(Utc::now());
+    let issue_id = directive.issue_id;
+    let signature = directive.signature;
+    let affected_issues = directive.affected_issues;
 
+    if directive.emit_pattern {
         deps.shared_context_store.write_entry(ContextEntryDraft {
             author_issue: "SUPERVISOR".to_string(),
             scope: ContextScope::Project,
@@ -684,23 +816,16 @@ fn maybe_handle_failure_pattern(
             "supervisor_pattern_detected",
             serde_json::json!({
                 "pattern_type": "shared_error_signature",
-                "signature": signature,
-                "affected_issues": affected_issues,
+                "signature": signature.clone(),
+                "affected_issues": affected_issues.clone(),
             }),
         );
     }
 
-    if should_escalate {
-        state.snapshot.escalations_created = state.snapshot.escalations_created.saturating_add(1);
-        state.snapshot.last_decision = Some(format!(
-            "systemic pattern escalated: {}",
-            truncate_for_display(signature, 80)
-        ));
-        state.snapshot.last_action_at = Some(Utc::now());
-
+    if directive.escalate {
         emit_supervisor_escalation(
             deps,
-            issue_id.unwrap_or(issue_identifier),
+            &issue_id,
             issue_identifier,
             "systemic_failure_pattern",
             serde_json::json!({
@@ -712,7 +837,7 @@ fn maybe_handle_failure_pattern(
 }
 
 fn maybe_handle_context_conflict(
-    state: &mut SupervisorRuntimeState,
+    state: &Arc<RwLock<SupervisorRuntimeState>>,
     deps: &SupervisorDependencies,
     now: DateTime<Utc>,
 ) {
@@ -721,65 +846,84 @@ fn maybe_handle_context_conflict(
         return;
     };
 
-    let key = format!(
-        "{}:{}:{}",
-        conflict.scope_key, conflict.decision_a, conflict.decision_b
-    );
+    let directive = {
+        let mut guard = state
+            .write()
+            .expect("supervisor state lock poisoned while evaluating context conflict");
 
-    if !should_emit_conflict(&mut state.escalated_context_conflicts, &key, now) {
+        let key = format!(
+            "{}:{}:{}",
+            conflict.scope_key, conflict.decision_a, conflict.decision_b
+        );
+
+        if !should_emit_conflict(&mut guard.escalated_context_conflicts, &key, now) {
+            None
+        } else {
+            guard.snapshot.conflicts_detected = guard.snapshot.conflicts_detected.saturating_add(1);
+            guard.snapshot.escalations_created =
+                guard.snapshot.escalations_created.saturating_add(1);
+            guard.snapshot.last_decision = Some(format!(
+                "context conflict escalated: {} vs {} ({})",
+                conflict.issue_a, conflict.issue_b, conflict.scope_key
+            ));
+            guard.snapshot.last_action_at = Some(Utc::now());
+
+            let issue_a_id = guard
+                .issue_ids_by_identifier
+                .get(&conflict.issue_a)
+                .cloned()
+                .unwrap_or_else(|| conflict.issue_a.clone());
+
+            Some(ContextConflictDirective {
+                conflict,
+                issue_a_id,
+            })
+        }
+    };
+
+    let Some(directive) = directive else {
         return;
-    }
-
-    let issue_a = conflict.issue_a.clone();
-    let issue_b = conflict.issue_b.clone();
-    let scope_key = conflict.scope_key.clone();
-    let decision_a = conflict.decision_a.clone();
-    let decision_b = conflict.decision_b.clone();
-
-    state.snapshot.conflicts_detected = state.snapshot.conflicts_detected.saturating_add(1);
-    state.snapshot.escalations_created = state.snapshot.escalations_created.saturating_add(1);
-    state.snapshot.last_decision = Some(format!(
-        "context conflict escalated: {} vs {} ({})",
-        issue_a, issue_b, scope_key
-    ));
-    state.snapshot.last_action_at = Some(Utc::now());
+    };
 
     deps.event_hub.publish(
         EventKind::SupervisorConflictDetected,
         EventSeverity::Warn,
-        Some(issue_a.clone()),
+        Some(directive.conflict.issue_a.clone()),
         "supervisor_conflict_detected",
         serde_json::json!({
-            "issues": [issue_a.clone(), issue_b.clone()],
+            "issues": [directive.conflict.issue_a.clone(), directive.conflict.issue_b.clone()],
             "conflict_type": "context_decision_conflict",
-            "scope": scope_key.clone(),
-            "decisions": [decision_a.clone(), decision_b.clone()],
+            "scope": directive.conflict.scope_key.clone(),
+            "decisions": [directive.conflict.decision_a.clone(), directive.conflict.decision_b.clone()],
         }),
     );
 
-    let issue_a_id = state
-        .issue_ids_by_identifier
-        .get(&issue_a)
-        .cloned()
-        .unwrap_or_else(|| issue_a.clone());
-
     emit_supervisor_escalation(
         deps,
-        &issue_a_id,
-        &issue_a,
+        &directive.issue_a_id,
+        &directive.conflict.issue_a,
         "context_decision_conflict",
         serde_json::json!({
-            "scope": scope_key,
-            "issue_a": issue_a,
-            "issue_b": issue_b,
-            "decision_a": decision_a,
-            "decision_b": decision_b,
+            "scope": directive.conflict.scope_key,
+            "issue_a": directive.conflict.issue_a,
+            "issue_b": directive.conflict.issue_b,
+            "decision_a": directive.conflict.decision_a,
+            "decision_b": directive.conflict.decision_b,
         }),
     );
 }
 
-fn emit_supervisor_steer(
+fn record_supervisor_steer_snapshot(
     state: &mut SupervisorRuntimeState,
+    issue_identifier: &str,
+    reason: &str,
+) {
+    state.snapshot.steers_issued = state.snapshot.steers_issued.saturating_add(1);
+    state.snapshot.last_decision = Some(format!("steered {} ({reason})", issue_identifier));
+    state.snapshot.last_action_at = Some(Utc::now());
+}
+
+fn emit_supervisor_steer(
     deps: &SupervisorDependencies,
     issue_identifier: &str,
     reason: &str,
@@ -788,10 +932,6 @@ fn emit_supervisor_steer(
     cooldown_ms: u64,
 ) {
     let guidance_preview = truncate_for_display(guidance, 140);
-
-    state.snapshot.steers_issued = state.snapshot.steers_issued.saturating_add(1);
-    state.snapshot.last_decision = Some(format!("steered {} ({reason})", issue_identifier));
-    state.snapshot.last_action_at = Some(Utc::now());
 
     deps.event_hub.publish(
         EventKind::SupervisorSteer,
@@ -1076,4 +1216,133 @@ fn repeated_test_failure_signature(summary: Option<&str>) -> Option<String> {
     }
 
     Some(truncate_for_display(&summary, 90))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool_envelope(event: &str, summary: &str) -> SymphonyEventEnvelope {
+        SymphonyEventEnvelope::new(
+            1,
+            Utc::now(),
+            EventKind::Tool,
+            EventSeverity::Info,
+            Some("KAT-1327".to_string()),
+            event,
+            serde_json::json!({ "summary": summary }),
+        )
+    }
+
+    #[test]
+    fn decision_token_extracts_expected_markers() {
+        assert_eq!(
+            decision_token("Decision: use jsonwebtoken for auth"),
+            Some("jsonwebtoken".to_string())
+        );
+        assert_eq!(
+            decision_token("We are USING serde_json, pending follow-up."),
+            Some("serde_json".to_string())
+        );
+        assert_eq!(
+            decision_token("Library reqwest selected for retries"),
+            Some("reqwest".to_string())
+        );
+    }
+
+    #[test]
+    fn decision_token_returns_none_without_extractable_token() {
+        assert_eq!(decision_token("No architectural decision captured"), None);
+        assert_eq!(decision_token("use !!!"), None);
+        assert_eq!(decision_token("framework: ###"), None);
+    }
+
+    #[test]
+    fn conflict_key_is_order_independent() {
+        let left = conflict_key("KAT-1", "KAT-2", "src/lib.rs");
+        let right = conflict_key("KAT-2", "KAT-1", "src/lib.rs");
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn file_edit_path_extracts_mutating_tool_paths() {
+        let edit = tool_envelope("tool_start", "edit {\"path\":\"src/lib.rs\"}");
+        assert_eq!(
+            file_edit_path(&edit, event_summary_text(&edit).as_deref()),
+            Some("src/lib.rs".to_string())
+        );
+
+        let write = tool_envelope("tool_start", "write {\"filePath\":\"src/main.ts\"}");
+        assert_eq!(
+            file_edit_path(&write, event_summary_text(&write).as_deref()),
+            Some("src/main.ts".to_string())
+        );
+
+        let bash = tool_envelope(
+            "tool_start",
+            "bash {\"command\":\"cargo test --manifest-path apps/symphony/Cargo.toml\"}",
+        );
+        assert_eq!(
+            file_edit_path(&bash, event_summary_text(&bash).as_deref()),
+            Some("apps/symphony/Cargo.toml".to_string())
+        );
+    }
+
+    #[test]
+    fn file_edit_path_skips_read_only_or_non_tool_start_events() {
+        let read = tool_envelope("tool_start", "read {\"path\":\"src/lib.rs\"}");
+        assert_eq!(
+            file_edit_path(&read, event_summary_text(&read).as_deref()),
+            None
+        );
+
+        let tool_end = tool_envelope("tool_end", "edit {\"path\":\"src/lib.rs\"}");
+        assert_eq!(
+            file_edit_path(&tool_end, event_summary_text(&tool_end).as_deref()),
+            None
+        );
+
+        let malformed = tool_envelope("tool_start", "edit not-json");
+        assert_eq!(
+            file_edit_path(&malformed, event_summary_text(&malformed).as_deref()),
+            None
+        );
+    }
+
+    #[test]
+    fn systemic_error_signature_requires_error_event_and_substantive_summary() {
+        let error_event = tool_envelope("tool_error", "Request FAILED due to API outage");
+        assert_eq!(
+            systemic_error_signature(&error_event),
+            Some("request failed due to api outage".to_string())
+        );
+
+        let non_error_event = tool_envelope("worker_progress", "Request failed due to API outage");
+        assert_eq!(systemic_error_signature(&non_error_event), None);
+
+        let short_error = tool_envelope("tool_error", "oops");
+        assert_eq!(systemic_error_signature(&short_error), None);
+    }
+
+    #[test]
+    fn repeated_test_failure_signature_detects_expected_patterns() {
+        assert_eq!(
+            repeated_test_failure_signature(Some("Test auth::login FAILED: expected 200")),
+            Some("Test auth::login FAILED: expected 200".to_string())
+        );
+        assert_eq!(
+            repeated_test_failure_signature(Some("suite test timeout error after retry")),
+            Some("suite test timeout error after retry".to_string())
+        );
+
+        assert_eq!(
+            repeated_test_failure_signature(Some("build failed in compile step")),
+            None
+        );
+        assert_eq!(
+            repeated_test_failure_signature(Some("test run passed")),
+            None
+        );
+        assert_eq!(repeated_test_failure_signature(None), None);
+    }
 }

--- a/apps/symphony/src/supervisor.rs
+++ b/apps/symphony/src/supervisor.rs
@@ -1,25 +1,35 @@
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, LazyLock, RwLock};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use regex::Regex;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
+use uuid::Uuid;
 
 use crate::domain::{
-    EventKind, EventSeverity, SupervisorConfig, SupervisorSnapshot, SupervisorStatus,
-    SymphonyEventEnvelope,
+    ContextScope, EscalationRequest, EventKind, EventSeverity, SupervisorConfig, SupervisorSnapshot,
+    SupervisorStatus, SymphonyEventEnvelope,
 };
 use crate::error::{Result, SymphonyError};
 use crate::event_stream::EventHub;
 use crate::orchestrator::EscalationRegistry;
 use crate::session_summary::{normalize_whitespace, truncate_for_display};
-use crate::shared_context::SharedContextStore;
+use crate::shared_context::{ContextEntryDraft, SharedContextStore};
 
 const RECENT_EVENT_BUFFER: usize = 20;
 const REPEATED_TOOL_ERROR_THRESHOLD: u32 = 3;
 const NO_PROGRESS_EVENT_THRESHOLD: u32 = 5;
 const REPEATED_TEST_FAILURE_THRESHOLD: u32 = 2;
+const FILE_CONFLICT_WINDOW_MS: i64 = 300_000;
+const CONFLICT_DEDUP_WINDOW_MS: i64 = 120_000;
+const SUPERVISOR_ESCALATION_TIMEOUT_MS: u64 = 300_000;
+
+static FILE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?P<path>[A-Za-z0-9_./-]+\.(rs|toml|json|ya?ml|md|ts|tsx|js|jsx|py|go|java|swift))")
+        .expect("file path regex must compile")
+});
 
 /// Runtime dependencies used by the supervisor background task.
 #[derive(Clone)]
@@ -47,6 +57,8 @@ impl SupervisorDependencies {
 struct SupervisorRuntimeState {
     snapshot: SupervisorSnapshot,
     workers: HashMap<String, WorkerModel>,
+    recent_conflicts: HashMap<String, DateTime<Utc>>,
+    escalated_context_conflicts: HashMap<String, DateTime<Utc>>,
 }
 
 #[derive(Debug, Default)]
@@ -58,11 +70,12 @@ struct WorkerModel {
     last_tool_error_signature: Option<String>,
     consecutive_tool_error_count: u32,
     repeated_test_failures: HashMap<String, u32>,
+    recent_file_edits: HashMap<String, DateTime<Utc>>,
     last_steer_at: Option<DateTime<Utc>>,
 }
 
 impl WorkerModel {
-    fn observe_event(&mut self, envelope: &SymphonyEventEnvelope) {
+    fn observe_event(&mut self, envelope: &SymphonyEventEnvelope) -> Option<String> {
         self.push_recent_event(envelope.event.clone());
 
         if envelope.event == "turn_completed" {
@@ -70,9 +83,10 @@ impl WorkerModel {
         }
 
         let summary = event_summary_text(envelope);
-        let is_file_edit = is_file_edit_event(envelope, summary.as_deref());
-        if is_file_edit {
+        let edited_path = file_edit_path(envelope, summary.as_deref());
+        if let Some(path) = edited_path.clone() {
             self.events_since_file_edit = 0;
+            self.record_file_edit(path, envelope.timestamp);
         } else {
             self.events_since_file_edit = self.events_since_file_edit.saturating_add(1);
         }
@@ -84,7 +98,9 @@ impl WorkerModel {
         if envelope.event == "tool_error" {
             let signature = tool_error_signature(summary.as_deref());
             if self.last_tool_error_signature.as_deref() == Some(signature.as_str()) {
-                self.consecutive_tool_error_count = self.consecutive_tool_error_count.saturating_add(1);
+                self.consecutive_tool_error_count = self
+                    .consecutive_tool_error_count
+                    .saturating_add(1);
             } else {
                 self.last_tool_error_signature = Some(signature);
                 self.consecutive_tool_error_count = 1;
@@ -98,6 +114,8 @@ impl WorkerModel {
             let counter = self.repeated_test_failures.entry(test_signature).or_insert(0);
             *counter = counter.saturating_add(1);
         }
+
+        edited_path
     }
 
     fn detect_stuck_reason(&self) -> Option<StuckReason> {
@@ -130,6 +148,18 @@ impl WorkerModel {
         }
 
         top_failure.map(|(signature, count)| StuckReason::RepeatedTestFailure { signature, count })
+    }
+
+    fn record_file_edit(&mut self, path: String, at: DateTime<Utc>) {
+        self.recent_file_edits.insert(path, at);
+    }
+
+    fn has_recent_file_edit(&self, path: &str, now: DateTime<Utc>) -> bool {
+        let Some(last_edit) = self.recent_file_edits.get(path) else {
+            return false;
+        };
+
+        now.signed_duration_since(*last_edit).num_milliseconds() <= FILE_CONFLICT_WINDOW_MS
     }
 
     fn can_steer(&self, now: DateTime<Utc>, cooldown_ms: u64) -> bool {
@@ -229,6 +259,8 @@ impl SupervisorAgent {
             state: Arc::new(RwLock::new(SupervisorRuntimeState {
                 snapshot: initial_snapshot,
                 workers: HashMap::new(),
+                recent_conflicts: HashMap::new(),
+                escalated_context_conflicts: HashMap::new(),
             })),
             shutdown_tx: None,
             task: None,
@@ -414,14 +446,48 @@ fn process_envelope(
     guard.snapshot.last_decision = Some(format!("observed:{}", envelope.event));
     guard.snapshot.last_action_at = Some(Utc::now());
 
-    let Some(issue_identifier) = envelope.issue.clone() else {
+    if let Some(issue_identifier) = envelope.issue.clone() {
+        let edited_path = {
+            let worker = guard.workers.entry(issue_identifier.clone()).or_default();
+            worker.observe_event(&envelope)
+        };
+
+        maybe_emit_stuck_steer(&mut guard, config, deps, &issue_identifier, now);
+
+        if let Some(path) = edited_path {
+            maybe_handle_file_conflict(
+                &mut guard,
+                config,
+                deps,
+                &issue_identifier,
+                &path,
+                now,
+            );
+        }
+    }
+
+    if envelope.kind == EventKind::SharedContextWritten || envelope.event == "shared_context_written"
+    {
+        maybe_handle_context_conflict(&mut guard, deps, now);
+    }
+}
+
+fn maybe_emit_stuck_steer(
+    state: &mut SupervisorRuntimeState,
+    config: &SupervisorConfig,
+    deps: &SupervisorDependencies,
+    issue_identifier: &str,
+    now: DateTime<Utc>,
+) {
+    let Some(stuck_reason) = state
+        .workers
+        .get(issue_identifier)
+        .and_then(WorkerModel::detect_stuck_reason)
+    else {
         return;
     };
 
-    let worker = guard.workers.entry(issue_identifier.clone()).or_default();
-    worker.observe_event(&envelope);
-
-    let Some(stuck_reason) = worker.detect_stuck_reason() else {
+    let Some(worker) = state.workers.get_mut(issue_identifier) else {
         return;
     };
 
@@ -430,30 +496,303 @@ fn process_envelope(
     }
 
     worker.mark_steer(now);
-    let guidance = stuck_reason.guidance();
-    let guidance_preview = truncate_for_display(&guidance, 140);
-
-    guard.snapshot.steers_issued = guard.snapshot.steers_issued.saturating_add(1);
-    guard.snapshot.last_decision = Some(format!(
-        "steered {} ({})",
+    emit_supervisor_steer(
+        state,
+        deps,
         issue_identifier,
-        stuck_reason.code()
+        stuck_reason.code(),
+        &stuck_reason.brief(),
+        &stuck_reason.guidance(),
+        config.steer_cooldown_ms,
+    );
+}
+
+fn maybe_handle_file_conflict(
+    state: &mut SupervisorRuntimeState,
+    config: &SupervisorConfig,
+    deps: &SupervisorDependencies,
+    issue_identifier: &str,
+    file_path: &str,
+    now: DateTime<Utc>,
+) {
+    let conflicting_issue = state
+        .workers
+        .iter()
+        .find_map(|(other_issue, worker)| {
+            if other_issue == issue_identifier {
+                return None;
+            }
+            if worker.has_recent_file_edit(file_path, now) {
+                Some(other_issue.clone())
+            } else {
+                None
+            }
+        });
+
+    let Some(other_issue) = conflicting_issue else {
+        return;
+    };
+
+    let key = conflict_key(issue_identifier, &other_issue, file_path);
+    if !should_emit_conflict(&mut state.recent_conflicts, &key, now) {
+        return;
+    }
+
+    state.snapshot.conflicts_detected = state.snapshot.conflicts_detected.saturating_add(1);
+    state.snapshot.last_decision = Some(format!(
+        "conflict detected: {} vs {} on {}",
+        issue_identifier, other_issue, file_path
     ));
-    guard.snapshot.last_action_at = Some(Utc::now());
+    state.snapshot.last_action_at = Some(Utc::now());
+
+    deps.shared_context_store.write_entry(ContextEntryDraft {
+        author_issue: "SUPERVISOR".to_string(),
+        scope: ContextScope::Project,
+        content: format!(
+            "⚠️ Potential overlap detected: {issue_identifier} and {other_issue} are both editing `{file_path}`. Coordinate before additional changes."
+        ),
+        ttl_ms: Some(30 * 60 * 1000),
+    });
+
+    deps.event_hub.publish(
+        EventKind::SupervisorConflictDetected,
+        EventSeverity::Warn,
+        Some(issue_identifier.to_string()),
+        "supervisor_conflict_detected",
+        serde_json::json!({
+            "issues": [issue_identifier, other_issue],
+            "conflict_type": "file_overlap",
+            "file_path": file_path,
+        }),
+    );
+
+    if let Some(worker) = state.workers.get_mut(issue_identifier) {
+        if worker.can_steer(now, config.steer_cooldown_ms) {
+            worker.mark_steer(now);
+            emit_supervisor_steer(
+                state,
+                deps,
+                issue_identifier,
+                "file_conflict",
+                &format!("overlap with {other_issue} on {file_path}"),
+                &format!(
+                    "Another worker ({other_issue}) is editing `{file_path}`. Align with shared context before proceeding."
+                ),
+                config.steer_cooldown_ms,
+            );
+        }
+    }
+}
+
+fn maybe_handle_context_conflict(
+    state: &mut SupervisorRuntimeState,
+    deps: &SupervisorDependencies,
+    now: DateTime<Utc>,
+) {
+    let entries = deps.shared_context_store.list();
+    let Some(conflict) = detect_context_conflict(&entries) else {
+        return;
+    };
+
+    let key = format!(
+        "{}:{}:{}",
+        conflict.scope_key, conflict.decision_a, conflict.decision_b
+    );
+
+    if !should_emit_conflict(&mut state.escalated_context_conflicts, &key, now) {
+        return;
+    }
+
+    state.snapshot.conflicts_detected = state.snapshot.conflicts_detected.saturating_add(1);
+    state.snapshot.escalations_created = state.snapshot.escalations_created.saturating_add(1);
+    state.snapshot.last_decision = Some(format!(
+        "context conflict escalated: {} vs {} ({})",
+        conflict.issue_a, conflict.issue_b, conflict.scope_key
+    ));
+    state.snapshot.last_action_at = Some(Utc::now());
+
+    deps.event_hub.publish(
+        EventKind::SupervisorConflictDetected,
+        EventSeverity::Warn,
+        Some(conflict.issue_a.clone()),
+        "supervisor_conflict_detected",
+        serde_json::json!({
+            "issues": [conflict.issue_a, conflict.issue_b],
+            "conflict_type": "context_decision_conflict",
+            "scope": conflict.scope_key,
+            "decisions": [conflict.decision_a, conflict.decision_b],
+        }),
+    );
+
+    emit_supervisor_escalation(
+        deps,
+        &conflict.issue_a,
+        "context_decision_conflict",
+        serde_json::json!({
+            "scope": conflict.scope_key,
+            "issue_a": conflict.issue_a,
+            "issue_b": conflict.issue_b,
+            "decision_a": conflict.decision_a,
+            "decision_b": conflict.decision_b,
+        }),
+    );
+}
+
+fn emit_supervisor_steer(
+    state: &mut SupervisorRuntimeState,
+    deps: &SupervisorDependencies,
+    issue_identifier: &str,
+    reason: &str,
+    detail: &str,
+    guidance: &str,
+    cooldown_ms: u64,
+) {
+    let guidance_preview = truncate_for_display(guidance, 140);
+
+    state.snapshot.steers_issued = state.snapshot.steers_issued.saturating_add(1);
+    state.snapshot.last_decision = Some(format!("steered {} ({reason})", issue_identifier));
+    state.snapshot.last_action_at = Some(Utc::now());
 
     deps.event_hub.publish(
         EventKind::SupervisorSteer,
         EventSeverity::Warn,
-        Some(issue_identifier.clone()),
+        Some(issue_identifier.to_string()),
         "supervisor_steer",
         serde_json::json!({
             "target_issue": issue_identifier,
-            "reason": stuck_reason.code(),
-            "detail": stuck_reason.brief(),
+            "reason": reason,
+            "detail": truncate_for_display(detail, 120),
             "guidance_preview": guidance_preview,
-            "steer_cooldown_ms": config.steer_cooldown_ms,
+            "steer_cooldown_ms": cooldown_ms,
         }),
     );
+}
+
+fn emit_supervisor_escalation(
+    deps: &SupervisorDependencies,
+    issue_identifier: &str,
+    reason: &str,
+    context: serde_json::Value,
+) {
+    let request = EscalationRequest {
+        id: format!("supervisor-{}", Uuid::new_v4()),
+        issue_id: issue_identifier.to_string(),
+        issue_identifier: issue_identifier.to_string(),
+        method: "supervisor_escalation".to_string(),
+        payload: serde_json::json!({
+            "question": format!(
+                "Supervisor escalation for {issue_identifier}: {reason}. Please resolve the conflicting worker decisions."
+            ),
+            "reason": reason,
+            "context": context,
+        }),
+        created_at: Utc::now(),
+        timeout_ms: SUPERVISOR_ESCALATION_TIMEOUT_MS,
+    };
+
+    let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+    deps.escalation_registry.register(request.clone(), response_tx);
+    tokio::spawn(async move {
+        let _ = response_rx.await;
+    });
+
+    deps.event_hub.publish(
+        EventKind::SupervisorEscalated,
+        EventSeverity::Warn,
+        Some(issue_identifier.to_string()),
+        "supervisor_escalated",
+        serde_json::json!({
+            "issue": issue_identifier,
+            "reason": reason,
+            "context": truncate_for_display(&request.payload.to_string(), 160),
+            "request_id": request.id,
+        }),
+    );
+}
+
+#[derive(Debug, Clone)]
+struct ContextConflict {
+    scope_key: String,
+    issue_a: String,
+    issue_b: String,
+    decision_a: String,
+    decision_b: String,
+}
+
+fn detect_context_conflict(entries: &[crate::domain::ContextEntry]) -> Option<ContextConflict> {
+    for left in entries {
+        if left.author_issue.eq_ignore_ascii_case("supervisor") {
+            continue;
+        }
+        let decision_a = decision_token(&left.content)?;
+        for right in entries {
+            if left.id == right.id || left.scope != right.scope {
+                continue;
+            }
+            if right.author_issue.eq_ignore_ascii_case("supervisor") {
+                continue;
+            }
+            let decision_b = decision_token(&right.content)?;
+            if decision_a == decision_b {
+                continue;
+            }
+
+            return Some(ContextConflict {
+                scope_key: left.scope.as_scope_key(),
+                issue_a: left.author_issue.clone(),
+                issue_b: right.author_issue.clone(),
+                decision_a,
+                decision_b,
+            });
+        }
+    }
+
+    None
+}
+
+fn decision_token(content: &str) -> Option<String> {
+    let normalized = normalize_whitespace(content).to_ascii_lowercase();
+
+    for marker in ["use ", "using ", "library ", "framework "] {
+        let Some(index) = normalized.find(marker) else {
+            continue;
+        };
+
+        let tail = &normalized[index + marker.len()..];
+        let token: String = tail
+            .chars()
+            .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '-' || *ch == '_')
+            .collect();
+
+        if !token.is_empty() {
+            return Some(token);
+        }
+    }
+
+    None
+}
+
+fn conflict_key(issue_a: &str, issue_b: &str, resource: &str) -> String {
+    if issue_a <= issue_b {
+        format!("{issue_a}|{issue_b}|{resource}")
+    } else {
+        format!("{issue_b}|{issue_a}|{resource}")
+    }
+}
+
+fn should_emit_conflict(
+    recent: &mut HashMap<String, DateTime<Utc>>,
+    key: &str,
+    now: DateTime<Utc>,
+) -> bool {
+    recent.retain(|_, at| now.signed_duration_since(*at).num_milliseconds() < CONFLICT_DEDUP_WINDOW_MS);
+
+    if recent.contains_key(key) {
+        return false;
+    }
+
+    recent.insert(key.to_string(), now);
+    true
 }
 
 fn should_ignore_event(envelope: &SymphonyEventEnvelope) -> bool {
@@ -498,22 +837,47 @@ fn tool_error_signature(summary: Option<&str>) -> String {
     truncate_for_display(&normalized, 80)
 }
 
-fn is_file_edit_event(envelope: &SymphonyEventEnvelope, summary: Option<&str>) -> bool {
+fn file_edit_path(envelope: &SymphonyEventEnvelope, summary: Option<&str>) -> Option<String> {
     if envelope.event != "tool_start" {
-        return false;
+        return None;
     }
 
-    let Some(summary) = summary else {
-        return false;
-    };
-
-    let tool_name = summary
-        .split_whitespace()
+    let summary = summary?;
+    let mut parts = summary.splitn(2, char::is_whitespace);
+    let tool_name = parts
         .next()
         .unwrap_or_default()
+        .trim()
         .to_ascii_lowercase();
+    let args_raw = parts.next().unwrap_or_default().trim();
 
-    matches!(tool_name.as_str(), "edit" | "write" | "append")
+    if matches!(tool_name.as_str(), "edit" | "write" | "append" | "read") {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(args_raw) {
+            let path = parsed
+                .get("path")
+                .and_then(|value| value.as_str())
+                .or_else(|| parsed.get("filePath").and_then(|value| value.as_str()))
+                .or_else(|| parsed.get("requestFilePath").and_then(|value| value.as_str()))
+                .or_else(|| parsed.get("responseFilePath").and_then(|value| value.as_str()));
+            if let Some(path) = path {
+                return Some(path.to_string());
+            }
+        }
+    }
+
+    if tool_name == "bash" {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(args_raw) {
+            if let Some(command) = parsed.get("command").and_then(|value| value.as_str()) {
+                return FILE_PATH_RE.captures(command).and_then(|captures| {
+                    captures
+                        .name("path")
+                        .map(|value| value.as_str().to_string())
+                });
+            }
+        }
+    }
+
+    None
 }
 
 fn repeated_test_failure_signature(summary: Option<&str>) -> Option<String> {

--- a/apps/symphony/src/supervisor.rs
+++ b/apps/symphony/src/supervisor.rs
@@ -9,8 +9,8 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::domain::{
-    ContextScope, EscalationRequest, EventKind, EventSeverity, SupervisorConfig, SupervisorSnapshot,
-    SupervisorStatus, SymphonyEventEnvelope,
+    ContextScope, EscalationRequest, EventKind, EventSeverity, SupervisorConfig,
+    SupervisorSnapshot, SupervisorStatus, SymphonyEventEnvelope,
 };
 use crate::error::{Result, SymphonyError};
 use crate::event_stream::EventHub;
@@ -29,8 +29,10 @@ const SYSTEMIC_PATTERN_PERSISTENCE_THRESHOLD: u32 = 2;
 const SUPERVISOR_ESCALATION_TIMEOUT_MS: u64 = 300_000;
 
 static FILE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?P<path>[A-Za-z0-9_./-]+\.(rs|toml|json|ya?ml|md|ts|tsx|js|jsx|py|go|java|swift))")
-        .expect("file path regex must compile")
+    Regex::new(
+        r"(?P<path>[A-Za-z0-9_./-]+\.(rs|toml|json|ya?ml|md|ts|tsx|js|jsx|py|go|java|swift))",
+    )
+    .expect("file path regex must compile")
 });
 
 /// Runtime dependencies used by the supervisor background task.
@@ -108,9 +110,8 @@ impl WorkerModel {
         if envelope.event == "tool_error" {
             let signature = tool_error_signature(summary.as_deref());
             if self.last_tool_error_signature.as_deref() == Some(signature.as_str()) {
-                self.consecutive_tool_error_count = self
-                    .consecutive_tool_error_count
-                    .saturating_add(1);
+                self.consecutive_tool_error_count =
+                    self.consecutive_tool_error_count.saturating_add(1);
             } else {
                 self.last_tool_error_signature = Some(signature);
                 self.consecutive_tool_error_count = 1;
@@ -121,7 +122,10 @@ impl WorkerModel {
         }
 
         if let Some(test_signature) = repeated_test_failure_signature(summary.as_deref()) {
-            let counter = self.repeated_test_failures.entry(test_signature).or_insert(0);
+            let counter = self
+                .repeated_test_failures
+                .entry(test_signature)
+                .or_insert(0);
             *counter = counter.saturating_add(1);
         }
 
@@ -476,18 +480,12 @@ fn process_envelope(
         maybe_emit_stuck_steer(&mut guard, config, deps, &issue_identifier, now);
 
         if let Some(path) = edited_path {
-            maybe_handle_file_conflict(
-                &mut guard,
-                config,
-                deps,
-                &issue_identifier,
-                &path,
-                now,
-            );
+            maybe_handle_file_conflict(&mut guard, config, deps, &issue_identifier, &path, now);
         }
     }
 
-    if envelope.kind == EventKind::SharedContextWritten || envelope.event == "shared_context_written"
+    if envelope.kind == EventKind::SharedContextWritten
+        || envelope.event == "shared_context_written"
     {
         maybe_handle_context_conflict(&mut guard, deps, now);
     }
@@ -536,19 +534,16 @@ fn maybe_handle_file_conflict(
     file_path: &str,
     now: DateTime<Utc>,
 ) {
-    let conflicting_issue = state
-        .workers
-        .iter()
-        .find_map(|(other_issue, worker)| {
-            if other_issue == issue_identifier {
-                return None;
-            }
-            if worker.has_recent_file_edit(file_path, now) {
-                Some(other_issue.clone())
-            } else {
-                None
-            }
-        });
+    let conflicting_issue = state.workers.iter().find_map(|(other_issue, worker)| {
+        if other_issue == issue_identifier {
+            return None;
+        }
+        if worker.has_recent_file_edit(file_path, now) {
+            Some(other_issue.clone())
+        } else {
+            None
+        }
+    });
 
     let Some(other_issue) = conflicting_issue else {
         return;
@@ -624,9 +619,9 @@ fn maybe_handle_failure_pattern(
         tracker
             .affected_issues
             .insert(issue_identifier.to_string(), now);
-        tracker
-            .affected_issues
-            .retain(|_, seen_at| now.signed_duration_since(*seen_at).num_milliseconds() < SYSTEMIC_PATTERN_WINDOW_MS);
+        tracker.affected_issues.retain(|_, seen_at| {
+            now.signed_duration_since(*seen_at).num_milliseconds() < SYSTEMIC_PATTERN_WINDOW_MS
+        });
 
         if tracker.affected_issues.len() >= 2 {
             tracker.detections = tracker.detections.saturating_add(1);
@@ -813,7 +808,8 @@ fn emit_supervisor_escalation(
     };
 
     let (response_tx, response_rx) = tokio::sync::oneshot::channel();
-    deps.escalation_registry.register(request.clone(), response_tx);
+    deps.escalation_registry
+        .register(request.clone(), response_tx);
     tokio::spawn(async move {
         let _ = response_rx.await;
     });
@@ -907,7 +903,9 @@ fn should_emit_conflict(
     key: &str,
     now: DateTime<Utc>,
 ) -> bool {
-    recent.retain(|_, at| now.signed_duration_since(*at).num_milliseconds() < CONFLICT_DEDUP_WINDOW_MS);
+    recent.retain(|_, at| {
+        now.signed_duration_since(*at).num_milliseconds() < CONFLICT_DEDUP_WINDOW_MS
+    });
 
     if recent.contains_key(key) {
         return false;
@@ -980,11 +978,7 @@ fn file_edit_path(envelope: &SymphonyEventEnvelope, summary: Option<&str>) -> Op
 
     let summary = summary?;
     let mut parts = summary.splitn(2, char::is_whitespace);
-    let tool_name = parts
-        .next()
-        .unwrap_or_default()
-        .trim()
-        .to_ascii_lowercase();
+    let tool_name = parts.next().unwrap_or_default().trim().to_ascii_lowercase();
     let args_raw = parts.next().unwrap_or_default().trim();
 
     if matches!(tool_name.as_str(), "edit" | "write" | "append" | "read") {
@@ -993,8 +987,16 @@ fn file_edit_path(envelope: &SymphonyEventEnvelope, summary: Option<&str>) -> Op
                 .get("path")
                 .and_then(|value| value.as_str())
                 .or_else(|| parsed.get("filePath").and_then(|value| value.as_str()))
-                .or_else(|| parsed.get("requestFilePath").and_then(|value| value.as_str()))
-                .or_else(|| parsed.get("responseFilePath").and_then(|value| value.as_str()));
+                .or_else(|| {
+                    parsed
+                        .get("requestFilePath")
+                        .and_then(|value| value.as_str())
+                })
+                .or_else(|| {
+                    parsed
+                        .get("responseFilePath")
+                        .and_then(|value| value.as_str())
+                });
             if let Some(path) = path {
                 return Some(path.to_string());
             }

--- a/apps/symphony/src/supervisor.rs
+++ b/apps/symphony/src/supervisor.rs
@@ -1,7 +1,8 @@
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
@@ -12,7 +13,13 @@ use crate::domain::{
 use crate::error::{Result, SymphonyError};
 use crate::event_stream::EventHub;
 use crate::orchestrator::EscalationRegistry;
+use crate::session_summary::{normalize_whitespace, truncate_for_display};
 use crate::shared_context::SharedContextStore;
+
+const RECENT_EVENT_BUFFER: usize = 20;
+const REPEATED_TOOL_ERROR_THRESHOLD: u32 = 3;
+const NO_PROGRESS_EVENT_THRESHOLD: u32 = 5;
+const REPEATED_TEST_FAILURE_THRESHOLD: u32 = 2;
 
 /// Runtime dependencies used by the supervisor background task.
 #[derive(Clone)]
@@ -36,11 +43,174 @@ impl SupervisorDependencies {
     }
 }
 
+#[derive(Debug, Default)]
+struct SupervisorRuntimeState {
+    snapshot: SupervisorSnapshot,
+    workers: HashMap<String, WorkerModel>,
+}
+
+#[derive(Debug, Default)]
+struct WorkerModel {
+    recent_events: VecDeque<String>,
+    turn_count: u32,
+    error_count: u32,
+    events_since_file_edit: u32,
+    last_tool_error_signature: Option<String>,
+    consecutive_tool_error_count: u32,
+    repeated_test_failures: HashMap<String, u32>,
+    last_steer_at: Option<DateTime<Utc>>,
+}
+
+impl WorkerModel {
+    fn observe_event(&mut self, envelope: &SymphonyEventEnvelope) {
+        self.push_recent_event(envelope.event.clone());
+
+        if envelope.event == "turn_completed" {
+            self.turn_count = self.turn_count.saturating_add(1);
+        }
+
+        let summary = event_summary_text(envelope);
+        let is_file_edit = is_file_edit_event(envelope, summary.as_deref());
+        if is_file_edit {
+            self.events_since_file_edit = 0;
+        } else {
+            self.events_since_file_edit = self.events_since_file_edit.saturating_add(1);
+        }
+
+        if is_error_event(&envelope.event) {
+            self.error_count = self.error_count.saturating_add(1);
+        }
+
+        if envelope.event == "tool_error" {
+            let signature = tool_error_signature(summary.as_deref());
+            if self.last_tool_error_signature.as_deref() == Some(signature.as_str()) {
+                self.consecutive_tool_error_count = self.consecutive_tool_error_count.saturating_add(1);
+            } else {
+                self.last_tool_error_signature = Some(signature);
+                self.consecutive_tool_error_count = 1;
+            }
+        } else {
+            self.consecutive_tool_error_count = 0;
+            self.last_tool_error_signature = None;
+        }
+
+        if let Some(test_signature) = repeated_test_failure_signature(summary.as_deref()) {
+            let counter = self.repeated_test_failures.entry(test_signature).or_insert(0);
+            *counter = counter.saturating_add(1);
+        }
+    }
+
+    fn detect_stuck_reason(&self) -> Option<StuckReason> {
+        if self.consecutive_tool_error_count >= REPEATED_TOOL_ERROR_THRESHOLD {
+            return Some(StuckReason::RepeatedToolError {
+                signature: self
+                    .last_tool_error_signature
+                    .clone()
+                    .unwrap_or_else(|| "tool_error".to_string()),
+                count: self.consecutive_tool_error_count,
+            });
+        }
+
+        if self.events_since_file_edit >= NO_PROGRESS_EVENT_THRESHOLD
+            && self.recent_events.len() >= NO_PROGRESS_EVENT_THRESHOLD as usize
+        {
+            return Some(StuckReason::NoProgress {
+                events_without_edit: self.events_since_file_edit,
+            });
+        }
+
+        let mut top_failure: Option<(String, u32)> = None;
+        for (signature, count) in &self.repeated_test_failures {
+            if *count >= REPEATED_TEST_FAILURE_THRESHOLD {
+                match &top_failure {
+                    Some((_, current_count)) if *current_count >= *count => {}
+                    _ => top_failure = Some((signature.clone(), *count)),
+                }
+            }
+        }
+
+        top_failure.map(|(signature, count)| StuckReason::RepeatedTestFailure { signature, count })
+    }
+
+    fn can_steer(&self, now: DateTime<Utc>, cooldown_ms: u64) -> bool {
+        let Some(last_steer_at) = self.last_steer_at else {
+            return true;
+        };
+
+        let elapsed = now
+            .signed_duration_since(last_steer_at)
+            .num_milliseconds()
+            .max(0) as u64;
+
+        elapsed >= cooldown_ms
+    }
+
+    fn mark_steer(&mut self, at: DateTime<Utc>) {
+        self.last_steer_at = Some(at);
+    }
+
+    fn push_recent_event(&mut self, event: String) {
+        self.recent_events.push_back(event);
+        while self.recent_events.len() > RECENT_EVENT_BUFFER {
+            let _ = self.recent_events.pop_front();
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum StuckReason {
+    RepeatedToolError { signature: String, count: u32 },
+    NoProgress { events_without_edit: u32 },
+    RepeatedTestFailure { signature: String, count: u32 },
+}
+
+impl StuckReason {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::RepeatedToolError { .. } => "repeated_tool_error",
+            Self::NoProgress { .. } => "no_progress",
+            Self::RepeatedTestFailure { .. } => "repeated_test_failure",
+        }
+    }
+
+    fn guidance(&self) -> String {
+        match self {
+            Self::RepeatedToolError { signature, count } => format!(
+                "You've hit the same tool error {count} times ({signature}). Slow down, inspect the full error, and adjust the next tool call arguments before retrying.",
+            ),
+            Self::NoProgress {
+                events_without_edit,
+            } => format!(
+                "No file edits were observed for the last {events_without_edit} events. Make one small, verifiable edit to unblock forward progress before running more commands.",
+            ),
+            Self::RepeatedTestFailure { signature, count } => format!(
+                "The same test failure repeated {count} times ({signature}). Re-check the failing test setup and verify assumptions before rerunning the suite.",
+            ),
+        }
+    }
+
+    fn brief(&self) -> String {
+        match self {
+            Self::RepeatedToolError { signature, count } => {
+                format!("tool error repeated {count}x: {signature}")
+            }
+            Self::NoProgress {
+                events_without_edit,
+            } => {
+                format!("no edits for {events_without_edit} events")
+            }
+            Self::RepeatedTestFailure { signature, count } => {
+                format!("test failure repeated {count}x: {signature}")
+            }
+        }
+    }
+}
+
 /// Background supervisor task lifecycle controller.
 pub struct SupervisorAgent {
     config: SupervisorConfig,
     deps: SupervisorDependencies,
-    snapshot: Arc<RwLock<SupervisorSnapshot>>,
+    state: Arc<RwLock<SupervisorRuntimeState>>,
     shutdown_tx: Option<watch::Sender<bool>>,
     task: Option<JoinHandle<()>>,
 }
@@ -56,7 +226,10 @@ impl SupervisorAgent {
         Self {
             config,
             deps,
-            snapshot: Arc::new(RwLock::new(initial_snapshot)),
+            state: Arc::new(RwLock::new(SupervisorRuntimeState {
+                snapshot: initial_snapshot,
+                workers: HashMap::new(),
+            })),
             shutdown_tx: None,
             task: None,
         }
@@ -81,25 +254,25 @@ impl SupervisorAgent {
 
         let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
         let mut events = self.deps.event_hub.subscribe();
-        let snapshot = Arc::clone(&self.snapshot);
-        let hub = self.deps.event_hub.clone();
-        let config_model = self.config.model.clone();
+        let state = Arc::clone(&self.state);
+        let deps = self.deps.clone();
+        let config = self.config.clone();
 
         self.shutdown_tx = Some(shutdown_tx);
         self.update_snapshot_status(SupervisorStatus::Starting, Some("starting supervisor"));
 
         let task = tokio::spawn(async move {
             {
-                let mut state = snapshot
+                let mut guard = state
                     .write()
-                    .expect("supervisor snapshot lock poisoned on start");
-                state.status = SupervisorStatus::Active;
-                state.model = config_model;
-                state.last_decision = Some("subscribed_to_event_stream".to_string());
-                state.last_action_at = Some(Utc::now());
+                    .expect("supervisor state lock poisoned on start");
+                guard.snapshot.status = SupervisorStatus::Active;
+                guard.snapshot.model = config.model.clone();
+                guard.snapshot.last_decision = Some("subscribed_to_event_stream".to_string());
+                guard.snapshot.last_action_at = Some(Utc::now());
             }
 
-            hub.publish(
+            deps.event_hub.publish(
                 EventKind::Runtime,
                 EventSeverity::Info,
                 None,
@@ -118,11 +291,7 @@ impl SupervisorAgent {
                                 if should_ignore_event(&envelope) {
                                     continue;
                                 }
-                                let mut state = snapshot
-                                    .write()
-                                    .expect("supervisor snapshot lock poisoned while consuming event stream");
-                                state.last_decision = Some(format!("observed:{}", envelope.event));
-                                state.last_action_at = Some(Utc::now());
+                                process_envelope(&state, &config, &deps, envelope);
                             }
                             Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
                                 tracing::warn!(
@@ -138,15 +307,15 @@ impl SupervisorAgent {
             }
 
             {
-                let mut state = snapshot
+                let mut guard = state
                     .write()
-                    .expect("supervisor snapshot lock poisoned on shutdown");
-                state.status = SupervisorStatus::Stopped;
-                state.last_decision = Some("stopped".to_string());
-                state.last_action_at = Some(Utc::now());
+                    .expect("supervisor state lock poisoned on shutdown");
+                guard.snapshot.status = SupervisorStatus::Stopped;
+                guard.snapshot.last_decision = Some("stopped".to_string());
+                guard.snapshot.last_action_at = Some(Utc::now());
             }
 
-            hub.publish(
+            deps.event_hub.publish(
                 EventKind::Runtime,
                 EventSeverity::Info,
                 None,
@@ -212,22 +381,79 @@ impl SupervisorAgent {
     }
 
     pub fn snapshot(&self) -> SupervisorSnapshot {
-        self.snapshot
+        self.state
             .read()
-            .expect("supervisor snapshot lock poisoned while reading")
+            .expect("supervisor state lock poisoned while reading")
+            .snapshot
             .clone()
     }
 
     fn update_snapshot_status(&self, status: SupervisorStatus, decision: Option<&str>) {
-        let mut snapshot = self
-            .snapshot
+        let mut guard = self
+            .state
             .write()
-            .expect("supervisor snapshot lock poisoned while updating status");
-        snapshot.status = status;
-        snapshot.model = self.config.model.clone();
-        snapshot.last_decision = decision.map(ToString::to_string);
-        snapshot.last_action_at = Some(Utc::now());
+            .expect("supervisor state lock poisoned while updating status");
+        guard.snapshot.status = status;
+        guard.snapshot.model = self.config.model.clone();
+        guard.snapshot.last_decision = decision.map(ToString::to_string);
+        guard.snapshot.last_action_at = Some(Utc::now());
     }
+}
+
+fn process_envelope(
+    state: &Arc<RwLock<SupervisorRuntimeState>>,
+    config: &SupervisorConfig,
+    deps: &SupervisorDependencies,
+    envelope: SymphonyEventEnvelope,
+) {
+    let now = envelope.timestamp;
+    let mut guard = state
+        .write()
+        .expect("supervisor state lock poisoned while processing event");
+
+    guard.snapshot.last_decision = Some(format!("observed:{}", envelope.event));
+    guard.snapshot.last_action_at = Some(Utc::now());
+
+    let Some(issue_identifier) = envelope.issue.clone() else {
+        return;
+    };
+
+    let worker = guard.workers.entry(issue_identifier.clone()).or_default();
+    worker.observe_event(&envelope);
+
+    let Some(stuck_reason) = worker.detect_stuck_reason() else {
+        return;
+    };
+
+    if !worker.can_steer(now, config.steer_cooldown_ms) {
+        return;
+    }
+
+    worker.mark_steer(now);
+    let guidance = stuck_reason.guidance();
+    let guidance_preview = truncate_for_display(&guidance, 140);
+
+    guard.snapshot.steers_issued = guard.snapshot.steers_issued.saturating_add(1);
+    guard.snapshot.last_decision = Some(format!(
+        "steered {} ({})",
+        issue_identifier,
+        stuck_reason.code()
+    ));
+    guard.snapshot.last_action_at = Some(Utc::now());
+
+    deps.event_hub.publish(
+        EventKind::SupervisorSteer,
+        EventSeverity::Warn,
+        Some(issue_identifier.clone()),
+        "supervisor_steer",
+        serde_json::json!({
+            "target_issue": issue_identifier,
+            "reason": stuck_reason.code(),
+            "detail": stuck_reason.brief(),
+            "guidance_preview": guidance_preview,
+            "steer_cooldown_ms": config.steer_cooldown_ms,
+        }),
+    );
 }
 
 fn should_ignore_event(envelope: &SymphonyEventEnvelope) -> bool {
@@ -239,4 +465,68 @@ fn should_ignore_event(envelope: &SymphonyEventEnvelope) -> bool {
             | EventKind::SupervisorEscalated
             | EventKind::SupervisorPatternDetected
     )
+}
+
+fn event_summary_text(envelope: &SymphonyEventEnvelope) -> Option<String> {
+    envelope
+        .payload
+        .get("summary")
+        .and_then(|value| value.as_str())
+        .map(normalize_whitespace)
+        .filter(|text| !text.is_empty())
+        .or_else(|| {
+            envelope
+                .payload
+                .get("error")
+                .and_then(|value| value.as_str())
+                .map(normalize_whitespace)
+                .filter(|text| !text.is_empty())
+        })
+}
+
+fn is_error_event(event_name: &str) -> bool {
+    matches!(
+        event_name,
+        "tool_error" | "turn_failed" | "turn_ended_with_error" | "worker_failed"
+    )
+}
+
+fn tool_error_signature(summary: Option<&str>) -> String {
+    let normalized = summary
+        .map(normalize_whitespace)
+        .unwrap_or_else(|| "tool_error".to_string());
+    truncate_for_display(&normalized, 80)
+}
+
+fn is_file_edit_event(envelope: &SymphonyEventEnvelope, summary: Option<&str>) -> bool {
+    if envelope.event != "tool_start" {
+        return false;
+    }
+
+    let Some(summary) = summary else {
+        return false;
+    };
+
+    let tool_name = summary
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    matches!(tool_name.as_str(), "edit" | "write" | "append")
+}
+
+fn repeated_test_failure_signature(summary: Option<&str>) -> Option<String> {
+    let summary = normalize_whitespace(summary?);
+    let lower = summary.to_ascii_lowercase();
+
+    if !lower.contains("test") {
+        return None;
+    }
+
+    if !(lower.contains("fail") || lower.contains("error")) {
+        return None;
+    }
+
+    Some(truncate_for_display(&summary, 90))
 }

--- a/apps/symphony/src/supervisor.rs
+++ b/apps/symphony/src/supervisor.rs
@@ -24,6 +24,8 @@ const NO_PROGRESS_EVENT_THRESHOLD: u32 = 5;
 const REPEATED_TEST_FAILURE_THRESHOLD: u32 = 2;
 const FILE_CONFLICT_WINDOW_MS: i64 = 300_000;
 const CONFLICT_DEDUP_WINDOW_MS: i64 = 120_000;
+const SYSTEMIC_PATTERN_WINDOW_MS: i64 = 300_000;
+const SYSTEMIC_PATTERN_PERSISTENCE_THRESHOLD: u32 = 2;
 const SUPERVISOR_ESCALATION_TIMEOUT_MS: u64 = 300_000;
 
 static FILE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -59,6 +61,14 @@ struct SupervisorRuntimeState {
     workers: HashMap<String, WorkerModel>,
     recent_conflicts: HashMap<String, DateTime<Utc>>,
     escalated_context_conflicts: HashMap<String, DateTime<Utc>>,
+    error_patterns: HashMap<String, ErrorPatternTracker>,
+}
+
+#[derive(Debug, Default)]
+struct ErrorPatternTracker {
+    affected_issues: HashMap<String, DateTime<Utc>>,
+    detections: u32,
+    escalated: bool,
 }
 
 #[derive(Debug, Default)]
@@ -261,6 +271,7 @@ impl SupervisorAgent {
                 workers: HashMap::new(),
                 recent_conflicts: HashMap::new(),
                 escalated_context_conflicts: HashMap::new(),
+                error_patterns: HashMap::new(),
             })),
             shutdown_tx: None,
             task: None,
@@ -452,6 +463,16 @@ fn process_envelope(
             worker.observe_event(&envelope)
         };
 
+        if let Some(pattern_signature) = systemic_error_signature(&envelope) {
+            maybe_handle_failure_pattern(
+                &mut guard,
+                deps,
+                &issue_identifier,
+                &pattern_signature,
+                now,
+            );
+        }
+
         maybe_emit_stuck_steer(&mut guard, config, deps, &issue_identifier, now);
 
         if let Some(path) = edited_path {
@@ -584,6 +605,101 @@ fn maybe_handle_file_conflict(
     }
 }
 
+fn maybe_handle_failure_pattern(
+    state: &mut SupervisorRuntimeState,
+    deps: &SupervisorDependencies,
+    issue_identifier: &str,
+    signature: &str,
+    now: DateTime<Utc>,
+) {
+    let mut affected_issues: Vec<String> = Vec::new();
+    let mut should_emit_pattern = false;
+    let mut should_escalate = false;
+
+    {
+        let tracker = state
+            .error_patterns
+            .entry(signature.to_string())
+            .or_default();
+        tracker
+            .affected_issues
+            .insert(issue_identifier.to_string(), now);
+        tracker
+            .affected_issues
+            .retain(|_, seen_at| now.signed_duration_since(*seen_at).num_milliseconds() < SYSTEMIC_PATTERN_WINDOW_MS);
+
+        if tracker.affected_issues.len() >= 2 {
+            tracker.detections = tracker.detections.saturating_add(1);
+            affected_issues = tracker.affected_issues.keys().cloned().collect();
+            affected_issues.sort();
+
+            if tracker.detections == 1 {
+                should_emit_pattern = true;
+            } else if tracker.detections >= SYSTEMIC_PATTERN_PERSISTENCE_THRESHOLD
+                && !tracker.escalated
+            {
+                should_escalate = true;
+                tracker.escalated = true;
+            }
+        }
+    }
+
+    if !should_emit_pattern && !should_escalate {
+        return;
+    }
+
+    if should_emit_pattern {
+        state.snapshot.patterns_detected = state.snapshot.patterns_detected.saturating_add(1);
+        state.snapshot.last_decision = Some(format!(
+            "systemic pattern detected across {} workers",
+            affected_issues.len()
+        ));
+        state.snapshot.last_action_at = Some(Utc::now());
+
+        deps.shared_context_store.write_entry(ContextEntryDraft {
+            author_issue: "SUPERVISOR".to_string(),
+            scope: ContextScope::Project,
+            content: format!(
+                "⚠️ Systemic failure pattern detected across workers [{}]: {}",
+                affected_issues.join(", "),
+                signature
+            ),
+            ttl_ms: Some(30 * 60 * 1000),
+        });
+
+        deps.event_hub.publish(
+            EventKind::SupervisorPatternDetected,
+            EventSeverity::Warn,
+            Some(issue_identifier.to_string()),
+            "supervisor_pattern_detected",
+            serde_json::json!({
+                "pattern_type": "shared_error_signature",
+                "signature": signature,
+                "affected_issues": affected_issues,
+            }),
+        );
+    }
+
+    if should_escalate {
+        state.snapshot.escalations_created = state.snapshot.escalations_created.saturating_add(1);
+        state.snapshot.last_decision = Some(format!(
+            "systemic pattern escalated: {}",
+            truncate_for_display(signature, 80)
+        ));
+        state.snapshot.last_action_at = Some(Utc::now());
+
+        emit_supervisor_escalation(
+            deps,
+            issue_identifier,
+            "systemic_failure_pattern",
+            serde_json::json!({
+                "signature": signature,
+                "affected_issues": affected_issues,
+            }),
+        );
+    }
+}
+
 fn maybe_handle_context_conflict(
     state: &mut SupervisorRuntimeState,
     deps: &SupervisorDependencies,
@@ -603,37 +719,43 @@ fn maybe_handle_context_conflict(
         return;
     }
 
+    let issue_a = conflict.issue_a.clone();
+    let issue_b = conflict.issue_b.clone();
+    let scope_key = conflict.scope_key.clone();
+    let decision_a = conflict.decision_a.clone();
+    let decision_b = conflict.decision_b.clone();
+
     state.snapshot.conflicts_detected = state.snapshot.conflicts_detected.saturating_add(1);
     state.snapshot.escalations_created = state.snapshot.escalations_created.saturating_add(1);
     state.snapshot.last_decision = Some(format!(
         "context conflict escalated: {} vs {} ({})",
-        conflict.issue_a, conflict.issue_b, conflict.scope_key
+        issue_a, issue_b, scope_key
     ));
     state.snapshot.last_action_at = Some(Utc::now());
 
     deps.event_hub.publish(
         EventKind::SupervisorConflictDetected,
         EventSeverity::Warn,
-        Some(conflict.issue_a.clone()),
+        Some(issue_a.clone()),
         "supervisor_conflict_detected",
         serde_json::json!({
-            "issues": [conflict.issue_a, conflict.issue_b],
+            "issues": [issue_a.clone(), issue_b.clone()],
             "conflict_type": "context_decision_conflict",
-            "scope": conflict.scope_key,
-            "decisions": [conflict.decision_a, conflict.decision_b],
+            "scope": scope_key.clone(),
+            "decisions": [decision_a.clone(), decision_b.clone()],
         }),
     );
 
     emit_supervisor_escalation(
         deps,
-        &conflict.issue_a,
+        &issue_a,
         "context_decision_conflict",
         serde_json::json!({
-            "scope": conflict.scope_key,
-            "issue_a": conflict.issue_a,
-            "issue_b": conflict.issue_b,
-            "decision_a": conflict.decision_a,
-            "decision_b": conflict.decision_b,
+            "scope": scope_key,
+            "issue_a": issue_a,
+            "issue_b": issue_b,
+            "decision_a": decision_a,
+            "decision_b": decision_b,
         }),
     );
 }
@@ -835,6 +957,20 @@ fn tool_error_signature(summary: Option<&str>) -> String {
         .map(normalize_whitespace)
         .unwrap_or_else(|| "tool_error".to_string());
     truncate_for_display(&normalized, 80)
+}
+
+fn systemic_error_signature(envelope: &SymphonyEventEnvelope) -> Option<String> {
+    if !is_error_event(&envelope.event) {
+        return None;
+    }
+
+    let summary = event_summary_text(envelope)?;
+    let normalized = summary.to_ascii_lowercase();
+    if normalized.len() < 6 {
+        return None;
+    }
+
+    Some(truncate_for_display(&normalized, 120))
 }
 
 fn file_edit_path(envelope: &SymphonyEventEnvelope, summary: Option<&str>) -> Option<String> {

--- a/apps/symphony/src/supervisor.rs
+++ b/apps/symphony/src/supervisor.rs
@@ -61,6 +61,7 @@ impl SupervisorDependencies {
 struct SupervisorRuntimeState {
     snapshot: SupervisorSnapshot,
     workers: HashMap<String, WorkerModel>,
+    issue_ids_by_identifier: HashMap<String, String>,
     recent_conflicts: HashMap<String, DateTime<Utc>>,
     escalated_context_conflicts: HashMap<String, DateTime<Utc>>,
     error_patterns: HashMap<String, ErrorPatternTracker>,
@@ -273,6 +274,7 @@ impl SupervisorAgent {
             state: Arc::new(RwLock::new(SupervisorRuntimeState {
                 snapshot: initial_snapshot,
                 workers: HashMap::new(),
+                issue_ids_by_identifier: HashMap::new(),
                 recent_conflicts: HashMap::new(),
                 escalated_context_conflicts: HashMap::new(),
                 error_patterns: HashMap::new(),
@@ -462,16 +464,28 @@ fn process_envelope(
     guard.snapshot.last_action_at = Some(Utc::now());
 
     if let Some(issue_identifier) = envelope.issue.clone() {
+        if let Some(issue_id) = issue_id_from_payload(&envelope) {
+            guard
+                .issue_ids_by_identifier
+                .insert(issue_identifier.clone(), issue_id);
+        }
+
         let edited_path = {
             let worker = guard.workers.entry(issue_identifier.clone()).or_default();
             worker.observe_event(&envelope)
         };
+
+        let issue_id = guard
+            .issue_ids_by_identifier
+            .get(&issue_identifier)
+            .cloned();
 
         if let Some(pattern_signature) = systemic_error_signature(&envelope) {
             maybe_handle_failure_pattern(
                 &mut guard,
                 deps,
                 &issue_identifier,
+                issue_id.as_deref(),
                 &pattern_signature,
                 now,
             );
@@ -604,6 +618,7 @@ fn maybe_handle_failure_pattern(
     state: &mut SupervisorRuntimeState,
     deps: &SupervisorDependencies,
     issue_identifier: &str,
+    issue_id: Option<&str>,
     signature: &str,
     now: DateTime<Utc>,
 ) {
@@ -685,6 +700,7 @@ fn maybe_handle_failure_pattern(
 
         emit_supervisor_escalation(
             deps,
+            issue_id.unwrap_or(issue_identifier),
             issue_identifier,
             "systemic_failure_pattern",
             serde_json::json!({
@@ -741,8 +757,15 @@ fn maybe_handle_context_conflict(
         }),
     );
 
+    let issue_a_id = state
+        .issue_ids_by_identifier
+        .get(&issue_a)
+        .cloned()
+        .unwrap_or_else(|| issue_a.clone());
+
     emit_supervisor_escalation(
         deps,
+        &issue_a_id,
         &issue_a,
         "context_decision_conflict",
         serde_json::json!({
@@ -787,13 +810,14 @@ fn emit_supervisor_steer(
 
 fn emit_supervisor_escalation(
     deps: &SupervisorDependencies,
+    issue_id: &str,
     issue_identifier: &str,
     reason: &str,
     context: serde_json::Value,
 ) {
     let request = EscalationRequest {
         id: format!("supervisor-{}", Uuid::new_v4()),
-        issue_id: issue_identifier.to_string(),
+        issue_id: issue_id.to_string(),
         issue_identifier: issue_identifier.to_string(),
         method: "supervisor_escalation".to_string(),
         payload: serde_json::json!({
@@ -821,6 +845,8 @@ fn emit_supervisor_escalation(
         "supervisor_escalated",
         serde_json::json!({
             "issue": issue_identifier,
+            "issue_id": issue_id,
+            "issue_identifier": issue_identifier,
             "reason": reason,
             "context": truncate_for_display(&request.payload.to_string(), 160),
             "request_id": request.id,
@@ -848,6 +874,9 @@ fn detect_context_conflict(entries: &[crate::domain::ContextEntry]) -> Option<Co
                 continue;
             }
             if right.author_issue.eq_ignore_ascii_case("supervisor") {
+                continue;
+            }
+            if left.author_issue.eq_ignore_ascii_case(&right.author_issue) {
                 continue;
             }
             let decision_b = decision_token(&right.content)?;
@@ -971,6 +1000,22 @@ fn systemic_error_signature(envelope: &SymphonyEventEnvelope) -> Option<String> 
     Some(truncate_for_display(&normalized, 120))
 }
 
+fn issue_id_from_payload(envelope: &SymphonyEventEnvelope) -> Option<String> {
+    envelope
+        .payload
+        .get("issue_id")
+        .and_then(|value| value.as_str())
+        .or_else(|| {
+            envelope
+                .payload
+                .get("issueId")
+                .and_then(|value| value.as_str())
+        })
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
 fn file_edit_path(envelope: &SymphonyEventEnvelope, summary: Option<&str>) -> Option<String> {
     if envelope.event != "tool_start" {
         return None;
@@ -981,7 +1026,7 @@ fn file_edit_path(envelope: &SymphonyEventEnvelope, summary: Option<&str>) -> Op
     let tool_name = parts.next().unwrap_or_default().trim().to_ascii_lowercase();
     let args_raw = parts.next().unwrap_or_default().trim();
 
-    if matches!(tool_name.as_str(), "edit" | "write" | "append" | "read") {
+    if matches!(tool_name.as_str(), "edit" | "write" | "append") {
         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(args_raw) {
             let path = parsed
                 .get("path")

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -17,7 +17,7 @@ use ratatui::{Frame, Terminal};
 use tokio::sync::watch;
 use tokio::time::MissedTickBehavior;
 
-use crate::domain::OrchestratorSnapshot;
+use crate::domain::{OrchestratorSnapshot, SupervisorStatus};
 use crate::orchestrator::SnapshotHandle;
 use crate::session_summary::{
     compact_session_id as compact_session_id_value, truncate_for_display,
@@ -425,12 +425,35 @@ fn build_summary_lines(snapshot: &OrchestratorSnapshot, throughput_line: &str) -
     }
 
     let mut lines = vec![counts.join("  |  "), throughput_line.to_string()];
+    lines.push(supervisor_summary_line(snapshot));
 
     if let Some(project_url) = snapshot.linear_project_url.as_deref() {
         lines.push(format!("Linear Project: {project_url}"));
     }
 
     lines
+}
+
+fn supervisor_summary_line(snapshot: &OrchestratorSnapshot) -> String {
+    let label = match snapshot.supervisor.status {
+        SupervisorStatus::Disabled => "⚪ disabled",
+        SupervisorStatus::Starting => "🟡 starting",
+        SupervisorStatus::Active => "🟢 active",
+        SupervisorStatus::Stopped => "⚫ stopped",
+        SupervisorStatus::Failed => "🔴 failed",
+    };
+
+    if snapshot.supervisor.status == SupervisorStatus::Disabled {
+        return format!("Supervisor: {label}");
+    }
+
+    format!(
+        "Supervisor: {label} | {} steers | {} conflicts | {} patterns | {} escalations",
+        snapshot.supervisor.steers_issued,
+        snapshot.supervisor.conflicts_detected,
+        snapshot.supervisor.patterns_detected,
+        snapshot.supervisor.escalations_created,
+    )
 }
 
 fn draw_dashboard(
@@ -1270,6 +1293,36 @@ mod tests {
                 .map(|line| line.contains("Context: 5 entries"))
                 .unwrap_or(false),
             "summary line should include shared context count when entries exist"
+        );
+    }
+
+    #[test]
+    fn build_summary_lines_includes_disabled_supervisor_status() {
+        let snapshot = snapshot_fixture(42, None);
+        let lines = build_summary_lines(&snapshot, "Throughput: 0.0 tps ▁▁▁▁▁▁▁▁");
+
+        assert!(
+            lines.iter().any(|line| line == "Supervisor: ⚪ disabled"),
+            "expected supervisor disabled status line in summary"
+        );
+    }
+
+    #[test]
+    fn build_summary_lines_includes_active_supervisor_counters() {
+        let mut snapshot = snapshot_fixture(42, None);
+        snapshot.supervisor.status = crate::domain::SupervisorStatus::Active;
+        snapshot.supervisor.steers_issued = 3;
+        snapshot.supervisor.conflicts_detected = 1;
+        snapshot.supervisor.patterns_detected = 2;
+        snapshot.supervisor.escalations_created = 1;
+
+        let lines = build_summary_lines(&snapshot, "Throughput: 0.0 tps ▁▁▁▁▁▁▁▁");
+        let expected =
+            "Supervisor: 🟢 active | 3 steers | 1 conflicts | 2 patterns | 1 escalations";
+
+        assert!(
+            lines.iter().any(|line| line == expected),
+            "expected active supervisor counters in summary, got {lines:?}"
         );
     }
 

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -1038,6 +1038,7 @@ mod tests {
             },
             blocked: Vec::new(),
             shared_context: crate::domain::SharedContextSummary::default(),
+            supervisor: crate::domain::SupervisorSnapshot::default(),
             codex_rate_limits: None,
             polling: crate::domain::PollingSnapshot {
                 checking: false,

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -119,6 +119,7 @@ fn test_service_config_defaults_match_spec() {
         prompts: None,
         notifications: None,
         shared_context: SharedContextConfig::default(),
+        supervisor: SupervisorConfig::default(),
     };
 
     // Polling §5.3.2
@@ -151,6 +152,11 @@ fn test_service_config_defaults_match_spec() {
     // Shared context defaults
     assert_eq!(cfg.shared_context.ttl_ms, 86_400_000);
     assert_eq!(cfg.shared_context.max_entries, 100);
+
+    // Supervisor defaults
+    assert!(!cfg.supervisor.enabled);
+    assert!(cfg.supervisor.model.is_none());
+    assert_eq!(cfg.supervisor.steer_cooldown_ms, 120_000);
 }
 
 #[test]
@@ -381,6 +387,7 @@ fn test_orchestrator_snapshot_serializes() {
         blocked: vec![],
         pending_escalations: vec![],
         shared_context: symphony::domain::SharedContextSummary::default(),
+        supervisor: symphony::domain::SupervisorSnapshot::default(),
         codex_totals: CodexTotals::default(),
         codex_rate_limits: None,
         polling: PollingSnapshot {

--- a/apps/symphony/tests/escalation_tests.rs
+++ b/apps/symphony/tests/escalation_tests.rs
@@ -51,6 +51,7 @@ fn empty_snapshot() -> OrchestratorSnapshot {
         blocked: vec![],
         pending_escalations: vec![],
         shared_context: SharedContextSummary::default(),
+        supervisor: symphony::domain::SupervisorSnapshot::default(),
         codex_totals: CodexTotals {
             input_tokens: 0,
             output_tokens: 0,

--- a/apps/symphony/tests/event_stream_tests.rs
+++ b/apps/symphony/tests/event_stream_tests.rs
@@ -110,6 +110,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
         blocked: vec![],
         pending_escalations: vec![],
         shared_context: symphony::domain::SharedContextSummary::default(),
+        supervisor: symphony::domain::SupervisorSnapshot::default(),
         codex_totals: CodexTotals::default(),
         codex_rate_limits: None,
         polling: PollingSnapshot {

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -256,6 +256,14 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "dashboard shell should include shared context section"
     );
     assert!(
+        body.contains("Supervisor"),
+        "dashboard shell should include supervisor section"
+    );
+    assert!(
+        body.contains(r#"id="supervisor-status-detail""#),
+        "dashboard shell should include supervisor status detail field"
+    );
+    assert!(
         body.contains("Completed issues"),
         "dashboard shell should include completed issue list section"
     );
@@ -338,6 +346,7 @@ async fn test_get_api_state_returns_snapshot_projection() {
     );
     assert_eq!(payload["retry_queue"][0]["identifier"], "SIM-777");
     assert_eq!(payload["shared_context"]["total_entries"], 1);
+    assert_eq!(payload["supervisor"]["status"], "disabled");
     assert_eq!(payload["codex_totals"]["total_tokens"], 200);
     assert_eq!(payload["codex_rate_limits"]["remaining"], 88);
     assert_eq!(

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -138,6 +138,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
             oldest_entry_at: Some(started_at),
             newest_entry_at: Some(started_at),
         },
+        supervisor: symphony::domain::SupervisorSnapshot::default(),
         codex_totals: CodexTotals {
             input_tokens: 120,
             output_tokens: 80,

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -9,7 +9,8 @@ use serde_json::{json, Value};
 use symphony::domain::{
     BlockedIssueEntry, CodexTotals, CompletedEntry, EventKind, OrchestratorSnapshot,
     PollingSnapshot, RateLimitInfo, RefreshRequestOutcome, RetrySnapshotEntry, RunAttempt,
-    RunningSessionSnapshot, SessionTokenUsage, SharedContextSummary, WorkerSessionInfo,
+    RunningSessionSnapshot, SessionTokenUsage, SharedContextSummary, SupervisorSnapshot,
+    SupervisorStatus, WorkerSessionInfo,
 };
 use symphony::http_server::{
     build_router, parse_event_filter_contract, HttpServerState, RefreshControl, SnapshotSource,
@@ -298,6 +299,71 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
     assert!(
         !body.contains("Live state"),
         "dashboard shell should no longer expose the raw live-state section"
+    );
+}
+
+#[tokio::test]
+async fn test_dashboard_initial_supervisor_metrics_use_snapshot_values() {
+    let mut snapshot = fixture_snapshot();
+    let last_action_at = Utc
+        .with_ymd_and_hms(2026, 3, 22, 9, 15, 0)
+        .single()
+        .expect("fixture timestamp should be valid");
+
+    snapshot.supervisor = SupervisorSnapshot {
+        status: SupervisorStatus::Active,
+        model: Some("anthropic/claude-sonnet-4-6".to_string()),
+        steers_issued: 7,
+        conflicts_detected: 3,
+        patterns_detected: 2,
+        escalations_created: 1,
+        last_decision: Some("steered KAT-1327 (no_progress)".to_string()),
+        last_action_at: Some(last_action_at),
+        last_error: None,
+    };
+
+    let app = build_router(HttpServerState::new(
+        Arc::new(StaticSnapshotSource { snapshot }),
+        Arc::new(FakeRefreshControl::default()),
+        symphony::orchestrator::EscalationRegistry::default(),
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+
+    let body = body_text(response).await;
+
+    assert!(
+        body.contains(r#"id="supervisor-steers">7"#),
+        "dashboard should server-render supervisor steers"
+    );
+    assert!(
+        body.contains(r#"id="supervisor-conflicts">3"#),
+        "dashboard should server-render supervisor conflicts"
+    );
+    assert!(
+        body.contains(r#"id="supervisor-patterns">2"#),
+        "dashboard should server-render supervisor patterns"
+    );
+    assert!(
+        body.contains(r#"id="supervisor-escalations">1"#),
+        "dashboard should server-render supervisor escalations"
+    );
+    assert!(
+        body.contains(r#"id="supervisor-last-decision">steered KAT-1327 (no_progress)"#),
+        "dashboard should server-render supervisor last decision"
+    );
+    assert!(
+        body.contains(r#"id="supervisor-last-action">2026-03-22T09:15:00+00:00"#),
+        "dashboard should server-render supervisor last action timestamp"
     );
 }
 

--- a/apps/symphony/tests/supervisor_tests.rs
+++ b/apps/symphony/tests/supervisor_tests.rs
@@ -22,6 +22,15 @@ fn envelope_with_kind(
     summary: &str,
     kind: EventKind,
 ) -> SymphonyEventEnvelope {
+    envelope_with_payload(issue, event, json!({ "summary": summary }), kind)
+}
+
+fn envelope_with_payload(
+    issue: &str,
+    event: &str,
+    payload: serde_json::Value,
+    kind: EventKind,
+) -> SymphonyEventEnvelope {
     SymphonyEventEnvelope {
         version: SYMPHONY_EVENT_STREAM_VERSION.to_string(),
         sequence: 1,
@@ -30,7 +39,7 @@ fn envelope_with_kind(
         severity: EventSeverity::Info,
         issue: Some(issue.to_string()),
         event: event.to_string(),
-        payload: json!({ "summary": summary }),
+        payload,
     }
 }
 
@@ -207,6 +216,33 @@ mod stuck_worker {
     }
 
     #[tokio::test]
+    async fn read_only_tool_activity_counts_as_no_progress() {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        for _ in 0..NO_PROGRESS_EVENT_THRESHOLD_FOR_TEST {
+            hub.send(envelope(
+                "KAT-2003",
+                "tool_start",
+                "read {\"path\":\"src/auth.rs\"}",
+            ));
+        }
+
+        let steer_event =
+            recv_event_with_name(&mut rx, "supervisor_steer", Duration::from_secs(1)).await;
+        assert_eq!(steer_event.payload["reason"], "no_progress");
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
     async fn repeated_test_failure_triggers_supervisor_steer() {
         let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
             enabled: true,
@@ -368,6 +404,63 @@ mod conflict_detection {
     }
 
     #[tokio::test]
+    async fn conflicting_entries_from_same_issue_do_not_trigger_conflict() {
+        let (mut supervisor, hub, store, registry) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-3100".to_string(),
+            scope: ContextScope::Project,
+            content: "Decision: use jsonwebtoken for auth".to_string(),
+            ttl_ms: Some(60_000),
+        });
+        store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-3100".to_string(),
+            scope: ContextScope::Project,
+            content: "Decision: use paseto for auth".to_string(),
+            ttl_ms: Some(60_000),
+        });
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope_with_kind(
+            "KAT-3100",
+            "shared_context_written",
+            "shared context updated",
+            EventKind::SharedContextWritten,
+        ));
+
+        let conflict_or_escalation = tokio::time::timeout(Duration::from_millis(300), async {
+            loop {
+                let envelope = rx.recv().await.expect("event should be readable");
+                if matches!(
+                    envelope.event.as_str(),
+                    "supervisor_conflict_detected" | "supervisor_escalated"
+                ) {
+                    return envelope;
+                }
+            }
+        })
+        .await;
+
+        assert!(
+            conflict_or_escalation.is_err(),
+            "unexpected conflict/escalation event: {conflict_or_escalation:?}"
+        );
+        assert!(
+            registry.pending_snapshot().is_empty(),
+            "same-issue revisions should not create escalations"
+        );
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
     async fn contradictory_context_entries_trigger_escalation() {
         let (mut supervisor, hub, store, registry) = make_supervisor(SupervisorConfig {
             enabled: true,
@@ -392,6 +485,25 @@ mod conflict_detection {
         supervisor.start().expect("supervisor should start");
         wait_for_active(&supervisor).await;
 
+        hub.send(envelope_with_payload(
+            "KAT-3101",
+            "worker_failed",
+            json!({
+                "summary": "worker failed",
+                "issue_id": "issue-3101"
+            }),
+            EventKind::Worker,
+        ));
+        hub.send(envelope_with_payload(
+            "KAT-3102",
+            "worker_failed",
+            json!({
+                "summary": "worker failed",
+                "issue_id": "issue-3102"
+            }),
+            EventKind::Worker,
+        ));
+
         hub.send(envelope_with_kind(
             "KAT-3102",
             "shared_context_written",
@@ -410,6 +522,49 @@ mod conflict_detection {
             "expected escalation to reference one of the conflicting issues, got {:?}",
             pending[0].issue_identifier
         );
+        assert!(
+            pending[0].issue_id == "issue-3101" || pending[0].issue_id == "issue-3102",
+            "expected escalation to carry canonical issue id, got {:?}",
+            pending[0].issue_id
+        );
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn overlapping_read_only_activity_does_not_emit_conflict() {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope(
+            "KAT-3200",
+            "tool_start",
+            "read {\"path\":\"src/shared.rs\"}",
+        ));
+        hub.send(envelope(
+            "KAT-3201",
+            "tool_start",
+            "read {\"path\":\"src/shared.rs\"}",
+        ));
+
+        let conflict = tokio::time::timeout(Duration::from_millis(300), async {
+            loop {
+                let envelope = rx.recv().await.expect("event should be readable");
+                if envelope.event == "supervisor_conflict_detected" {
+                    return envelope;
+                }
+            }
+        })
+        .await;
+
+        assert!(conflict.is_err(), "unexpected conflict event: {conflict:?}");
 
         supervisor.stop().await;
     }

--- a/apps/symphony/tests/supervisor_tests.rs
+++ b/apps/symphony/tests/supervisor_tests.rs
@@ -137,7 +137,8 @@ mod lifecycle {
 
     #[test]
     fn disabled_supervisor_start_is_noop() {
-        let (mut supervisor, _hub, _store, _registry) = make_supervisor(SupervisorConfig::default());
+        let (mut supervisor, _hub, _store, _registry) =
+            make_supervisor(SupervisorConfig::default());
 
         supervisor
             .start()
@@ -405,8 +406,7 @@ mod conflict_detection {
         let pending = registry.pending_snapshot();
         assert_eq!(pending.len(), 1, "expected one pending escalation");
         assert!(
-            pending[0].issue_identifier == "KAT-3101"
-                || pending[0].issue_identifier == "KAT-3102",
+            pending[0].issue_identifier == "KAT-3101" || pending[0].issue_identifier == "KAT-3102",
             "expected escalation to reference one of the conflicting issues, got {:?}",
             pending[0].issue_identifier
         );
@@ -488,7 +488,10 @@ mod failure_pattern {
         .await;
 
         assert_eq!(pattern_event.kind, EventKind::SupervisorPatternDetected);
-        assert_eq!(pattern_event.payload["pattern_type"], "shared_error_signature");
+        assert_eq!(
+            pattern_event.payload["pattern_type"],
+            "shared_error_signature"
+        );
 
         let warnings = store
             .list()
@@ -583,5 +586,80 @@ mod failure_pattern {
         assert!(pattern.is_err(), "unexpected pattern event: {pattern:?}");
 
         supervisor.stop().await;
+    }
+}
+
+mod integration {
+    use super::*;
+    use symphony::domain::ServiceConfig;
+    use symphony::orchestrator::Orchestrator;
+
+    async fn wait_for_status(orchestrator: &Orchestrator, expected: SupervisorStatus) {
+        for _ in 0..50 {
+            if orchestrator
+                .snapshot(Utc::now().timestamp_millis())
+                .supervisor
+                .status
+                == expected
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        panic!(
+            "supervisor did not reach status {:?}, last snapshot={:?}",
+            expected,
+            orchestrator
+                .snapshot(Utc::now().timestamp_millis())
+                .supervisor
+        );
+    }
+
+    #[tokio::test]
+    async fn orchestrator_lifecycle_starts_supervisor_and_exposes_snapshot_stats() {
+        let mut config = ServiceConfig::default();
+        config.supervisor = SupervisorConfig {
+            enabled: true,
+            model: Some("anthropic/claude-sonnet-4-6".to_string()),
+            steer_cooldown_ms: 120_000,
+        };
+
+        let mut orchestrator = Orchestrator::new(config, "prompt".to_string());
+        let hub = orchestrator.create_event_hub();
+        let mut rx = hub.subscribe();
+
+        orchestrator
+            .ensure_supervisor_running()
+            .expect("orchestrator should start supervisor");
+        assert!(
+            orchestrator.supervisor_is_running(),
+            "supervisor should report running after start"
+        );
+
+        wait_for_status(&orchestrator, SupervisorStatus::Active).await;
+
+        hub.send(envelope("KAT-5001", "tool_error", "bash cargo test --all"));
+        hub.send(envelope("KAT-5001", "tool_error", "bash cargo test --all"));
+        hub.send(envelope("KAT-5001", "tool_error", "bash cargo test --all"));
+
+        let steer = recv_event_with_name(&mut rx, "supervisor_steer", Duration::from_secs(1)).await;
+        assert_eq!(steer.kind, EventKind::SupervisorSteer);
+
+        let live_snapshot = orchestrator.snapshot(Utc::now().timestamp_millis());
+        assert_eq!(live_snapshot.supervisor.status, SupervisorStatus::Active);
+        assert_eq!(live_snapshot.supervisor.steers_issued, 1);
+
+        orchestrator.shutdown_supervisor().await;
+        assert!(
+            !orchestrator.supervisor_is_running(),
+            "supervisor should stop after orchestrator shutdown hook"
+        );
+
+        let stopped_snapshot = orchestrator.snapshot(Utc::now().timestamp_millis());
+        assert_eq!(
+            stopped_snapshot.supervisor.status,
+            SupervisorStatus::Stopped
+        );
     }
 }

--- a/apps/symphony/tests/supervisor_tests.rs
+++ b/apps/symphony/tests/supervisor_tests.rs
@@ -1,0 +1,104 @@
+use std::time::Duration;
+
+use chrono::Utc;
+use serde_json::json;
+use symphony::config::from_workflow;
+use symphony::domain::{
+    EventKind, EventSeverity, SupervisorStatus, SymphonyEventEnvelope, SYMPHONY_EVENT_STREAM_VERSION,
+};
+use symphony::event_stream::EventHub;
+use symphony::orchestrator::EscalationRegistry;
+use symphony::shared_context::SharedContextStore;
+use symphony::supervisor::{SupervisorAgent, SupervisorDependencies};
+
+fn event_envelope(issue: Option<&str>, event: &str) -> SymphonyEventEnvelope {
+    SymphonyEventEnvelope {
+        version: SYMPHONY_EVENT_STREAM_VERSION.to_string(),
+        sequence: 1,
+        timestamp: Utc::now(),
+        kind: EventKind::Worker,
+        severity: EventSeverity::Info,
+        issue: issue.map(ToString::to_string),
+        event: event.to_string(),
+        payload: json!({ "summary": "event" }),
+    }
+}
+
+#[test]
+fn lifecycle_config_defaults_supervisor_disabled() {
+    let raw = serde_yaml::from_str::<serde_yaml::Value>("tracker: { kind: linear }")
+        .expect("yaml fixture should parse");
+    let config = from_workflow(&raw).expect("workflow config should parse");
+
+    assert!(!config.supervisor.enabled);
+    assert!(config.supervisor.model.is_none());
+    assert_eq!(config.supervisor.steer_cooldown_ms, 120_000);
+}
+
+#[tokio::test]
+async fn lifecycle_supervisor_starts_processes_event_and_stops() {
+    let hub = EventHub::new(32);
+    let deps = SupervisorDependencies::new(
+        hub.clone(),
+        SharedContextStore::default(),
+        EscalationRegistry::default(),
+    );
+    let mut supervisor = SupervisorAgent::new(
+        symphony::domain::SupervisorConfig {
+            enabled: true,
+            model: Some("anthropic/claude-sonnet-4-6".to_string()),
+            steer_cooldown_ms: 120_000,
+        },
+        deps,
+    );
+
+    supervisor
+        .start()
+        .expect("supervisor should start inside tokio runtime");
+
+    for _ in 0..20 {
+        if supervisor.snapshot().status == SupervisorStatus::Active {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(supervisor.snapshot().status, SupervisorStatus::Active);
+
+    hub.send(event_envelope(Some("KAT-1327"), "worker_started"));
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let snapshot = supervisor.snapshot();
+    assert!(
+        snapshot
+            .last_decision
+            .as_deref()
+            .unwrap_or_default()
+            .contains("observed:worker_started"),
+        "expected observed worker event in snapshot, got {:?}",
+        snapshot.last_decision
+    );
+
+    supervisor.stop().await;
+    assert_eq!(supervisor.snapshot().status, SupervisorStatus::Stopped);
+}
+
+#[test]
+fn lifecycle_disabled_supervisor_noop_start() {
+    let hub = EventHub::new(4);
+    let deps = SupervisorDependencies::new(
+        hub,
+        SharedContextStore::default(),
+        EscalationRegistry::default(),
+    );
+    let mut supervisor = SupervisorAgent::new(Default::default(), deps);
+
+    supervisor
+        .start()
+        .expect("disabled supervisor start should be a no-op");
+
+    let snapshot = supervisor.snapshot();
+    assert_eq!(snapshot.status, SupervisorStatus::Disabled);
+    assert!(!supervisor.is_running());
+}

--- a/apps/symphony/tests/supervisor_tests.rs
+++ b/apps/symphony/tests/supervisor_tests.rs
@@ -4,20 +4,29 @@ use chrono::Utc;
 use serde_json::json;
 use symphony::config::from_workflow;
 use symphony::domain::{
-    EventKind, EventSeverity, SupervisorConfig, SupervisorStatus, SymphonyEventEnvelope,
-    SYMPHONY_EVENT_STREAM_VERSION,
+    ContextScope, EventKind, EventSeverity, SupervisorConfig, SupervisorStatus,
+    SymphonyEventEnvelope, SYMPHONY_EVENT_STREAM_VERSION,
 };
 use symphony::event_stream::EventHub;
 use symphony::orchestrator::EscalationRegistry;
-use symphony::shared_context::SharedContextStore;
+use symphony::shared_context::{ContextEntryDraft, SharedContextStore};
 use symphony::supervisor::{SupervisorAgent, SupervisorDependencies};
 
 fn envelope(issue: &str, event: &str, summary: &str) -> SymphonyEventEnvelope {
+    envelope_with_kind(issue, event, summary, EventKind::Worker)
+}
+
+fn envelope_with_kind(
+    issue: &str,
+    event: &str,
+    summary: &str,
+    kind: EventKind,
+) -> SymphonyEventEnvelope {
     SymphonyEventEnvelope {
         version: SYMPHONY_EVENT_STREAM_VERSION.to_string(),
         sequence: 1,
         timestamp: Utc::now(),
-        kind: EventKind::Worker,
+        kind,
         severity: EventSeverity::Info,
         issue: Some(issue.to_string()),
         event: event.to_string(),
@@ -25,14 +34,28 @@ fn envelope(issue: &str, event: &str, summary: &str) -> SymphonyEventEnvelope {
     }
 }
 
-fn make_supervisor(config: SupervisorConfig) -> (SupervisorAgent, EventHub) {
+fn make_supervisor(
+    config: SupervisorConfig,
+) -> (
+    SupervisorAgent,
+    EventHub,
+    SharedContextStore,
+    EscalationRegistry,
+) {
     let hub = EventHub::new(64);
+    let shared_context_store = SharedContextStore::default();
+    let escalation_registry = EscalationRegistry::default();
     let deps = SupervisorDependencies::new(
         hub.clone(),
-        SharedContextStore::default(),
-        EscalationRegistry::default(),
+        shared_context_store.clone(),
+        escalation_registry.clone(),
     );
-    (SupervisorAgent::new(config, deps), hub)
+    (
+        SupervisorAgent::new(config, deps),
+        hub,
+        shared_context_store,
+        escalation_registry,
+    )
 }
 
 async fn wait_for_active(supervisor: &SupervisorAgent) {
@@ -82,7 +105,7 @@ mod lifecycle {
 
     #[tokio::test]
     async fn supervisor_starts_processes_event_and_stops() {
-        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
             enabled: true,
             model: Some("anthropic/claude-sonnet-4-6".to_string()),
             steer_cooldown_ms: 120_000,
@@ -114,7 +137,7 @@ mod lifecycle {
 
     #[test]
     fn disabled_supervisor_start_is_noop() {
-        let (mut supervisor, _hub) = make_supervisor(SupervisorConfig::default());
+        let (mut supervisor, _hub, _store, _registry) = make_supervisor(SupervisorConfig::default());
 
         supervisor
             .start()
@@ -129,9 +152,11 @@ mod lifecycle {
 mod stuck_worker {
     use super::*;
 
+    const NO_PROGRESS_EVENT_THRESHOLD_FOR_TEST: usize = 5;
+
     #[tokio::test]
     async fn repeated_tool_error_triggers_supervisor_steer() {
-        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
             enabled: true,
             model: None,
             steer_cooldown_ms: 120_000,
@@ -159,7 +184,7 @@ mod stuck_worker {
 
     #[tokio::test]
     async fn no_progress_triggers_supervisor_steer() {
-        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
             enabled: true,
             model: None,
             steer_cooldown_ms: 120_000,
@@ -182,7 +207,7 @@ mod stuck_worker {
 
     #[tokio::test]
     async fn repeated_test_failure_triggers_supervisor_steer() {
-        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
             enabled: true,
             model: None,
             steer_cooldown_ms: 120_000,
@@ -212,7 +237,7 @@ mod stuck_worker {
 
     #[tokio::test]
     async fn cooldown_prevents_rapid_resteer() {
-        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
             enabled: true,
             model: None,
             steer_cooldown_ms: 300_000,
@@ -226,7 +251,8 @@ mod stuck_worker {
             hub.send(envelope("KAT-2004", "tool_error", "bash cargo test"));
         }
 
-        let _first = recv_event_with_name(&mut rx, "supervisor_steer", Duration::from_secs(1)).await;
+        let _first =
+            recv_event_with_name(&mut rx, "supervisor_steer", Duration::from_secs(1)).await;
 
         for _ in 0..3 {
             hub.send(envelope("KAT-2004", "tool_error", "bash cargo test"));
@@ -254,7 +280,7 @@ mod stuck_worker {
 
     #[tokio::test]
     async fn mixed_non_stuck_events_do_not_trigger_steer() {
-        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
             enabled: true,
             model: None,
             steer_cooldown_ms: 120_000,
@@ -288,6 +314,142 @@ mod stuck_worker {
 
         supervisor.stop().await;
     }
+}
 
-    const NO_PROGRESS_EVENT_THRESHOLD_FOR_TEST: usize = 5;
+mod conflict_detection {
+    use super::*;
+
+    #[tokio::test]
+    async fn overlapping_file_edits_emit_conflict_and_context_entry() {
+        let (mut supervisor, hub, store, _registry) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope(
+            "KAT-3001",
+            "tool_start",
+            "edit {\"path\":\"src/auth.rs\"}",
+        ));
+        hub.send(envelope(
+            "KAT-3002",
+            "tool_start",
+            "edit {\"path\":\"src/auth.rs\"}",
+        ));
+
+        let conflict_event = recv_event_with_name(
+            &mut rx,
+            "supervisor_conflict_detected",
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(conflict_event.kind, EventKind::SupervisorConflictDetected);
+        assert_eq!(conflict_event.payload["conflict_type"], "file_overlap");
+
+        let context_entries = store.list();
+        assert!(
+            context_entries
+                .iter()
+                .any(|entry| entry.author_issue == "SUPERVISOR"
+                    && entry.content.contains("src/auth.rs")
+                    && entry.content.contains("KAT-3001")
+                    && entry.content.contains("KAT-3002")),
+            "expected supervisor coordination context entry, got {context_entries:?}"
+        );
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn contradictory_context_entries_trigger_escalation() {
+        let (mut supervisor, hub, store, registry) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-3101".to_string(),
+            scope: ContextScope::Project,
+            content: "Decision: use jsonwebtoken for auth".to_string(),
+            ttl_ms: Some(60_000),
+        });
+        store.write_entry(ContextEntryDraft {
+            author_issue: "KAT-3102".to_string(),
+            scope: ContextScope::Project,
+            content: "Decision: use paseto for auth".to_string(),
+            ttl_ms: Some(60_000),
+        });
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope_with_kind(
+            "KAT-3102",
+            "shared_context_written",
+            "shared context updated",
+            EventKind::SharedContextWritten,
+        ));
+
+        let escalated =
+            recv_event_with_name(&mut rx, "supervisor_escalated", Duration::from_secs(1)).await;
+        assert_eq!(escalated.kind, EventKind::SupervisorEscalated);
+
+        let pending = registry.pending_snapshot();
+        assert_eq!(pending.len(), 1, "expected one pending escalation");
+        assert!(
+            pending[0].issue_identifier == "KAT-3101"
+                || pending[0].issue_identifier == "KAT-3102",
+            "expected escalation to reference one of the conflicting issues, got {:?}",
+            pending[0].issue_identifier
+        );
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn non_overlapping_file_edits_do_not_emit_conflict() {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope(
+            "KAT-3201",
+            "tool_start",
+            "edit {\"path\":\"src/a.rs\"}",
+        ));
+        hub.send(envelope(
+            "KAT-3202",
+            "tool_start",
+            "edit {\"path\":\"src/b.rs\"}",
+        ));
+
+        let conflict = tokio::time::timeout(Duration::from_millis(300), async {
+            loop {
+                let envelope = rx.recv().await.expect("event should be readable");
+                if envelope.event == "supervisor_conflict_detected" {
+                    return envelope;
+                }
+            }
+        })
+        .await;
+
+        assert!(conflict.is_err(), "unexpected conflict event: {conflict:?}");
+        assert_eq!(supervisor.snapshot().conflicts_detected, 0);
+
+        supervisor.stop().await;
+    }
 }

--- a/apps/symphony/tests/supervisor_tests.rs
+++ b/apps/symphony/tests/supervisor_tests.rs
@@ -4,101 +4,290 @@ use chrono::Utc;
 use serde_json::json;
 use symphony::config::from_workflow;
 use symphony::domain::{
-    EventKind, EventSeverity, SupervisorStatus, SymphonyEventEnvelope, SYMPHONY_EVENT_STREAM_VERSION,
+    EventKind, EventSeverity, SupervisorConfig, SupervisorStatus, SymphonyEventEnvelope,
+    SYMPHONY_EVENT_STREAM_VERSION,
 };
 use symphony::event_stream::EventHub;
 use symphony::orchestrator::EscalationRegistry;
 use symphony::shared_context::SharedContextStore;
 use symphony::supervisor::{SupervisorAgent, SupervisorDependencies};
 
-fn event_envelope(issue: Option<&str>, event: &str) -> SymphonyEventEnvelope {
+fn envelope(issue: &str, event: &str, summary: &str) -> SymphonyEventEnvelope {
     SymphonyEventEnvelope {
         version: SYMPHONY_EVENT_STREAM_VERSION.to_string(),
         sequence: 1,
         timestamp: Utc::now(),
         kind: EventKind::Worker,
         severity: EventSeverity::Info,
-        issue: issue.map(ToString::to_string),
+        issue: Some(issue.to_string()),
         event: event.to_string(),
-        payload: json!({ "summary": "event" }),
+        payload: json!({ "summary": summary }),
     }
 }
 
-#[test]
-fn lifecycle_config_defaults_supervisor_disabled() {
-    let raw = serde_yaml::from_str::<serde_yaml::Value>("tracker: { kind: linear }")
-        .expect("yaml fixture should parse");
-    let config = from_workflow(&raw).expect("workflow config should parse");
-
-    assert!(!config.supervisor.enabled);
-    assert!(config.supervisor.model.is_none());
-    assert_eq!(config.supervisor.steer_cooldown_ms, 120_000);
-}
-
-#[tokio::test]
-async fn lifecycle_supervisor_starts_processes_event_and_stops() {
-    let hub = EventHub::new(32);
+fn make_supervisor(config: SupervisorConfig) -> (SupervisorAgent, EventHub) {
+    let hub = EventHub::new(64);
     let deps = SupervisorDependencies::new(
         hub.clone(),
         SharedContextStore::default(),
         EscalationRegistry::default(),
     );
-    let mut supervisor = SupervisorAgent::new(
-        symphony::domain::SupervisorConfig {
-            enabled: true,
-            model: Some("anthropic/claude-sonnet-4-6".to_string()),
-            steer_cooldown_ms: 120_000,
-        },
-        deps,
-    );
+    (SupervisorAgent::new(config, deps), hub)
+}
 
-    supervisor
-        .start()
-        .expect("supervisor should start inside tokio runtime");
-
-    for _ in 0..20 {
+async fn wait_for_active(supervisor: &SupervisorAgent) {
+    for _ in 0..50 {
         if supervisor.snapshot().status == SupervisorStatus::Active {
-            break;
+            return;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    assert_eq!(supervisor.snapshot().status, SupervisorStatus::Active);
-
-    hub.send(event_envelope(Some("KAT-1327"), "worker_started"));
-
-    tokio::time::sleep(Duration::from_millis(20)).await;
-
-    let snapshot = supervisor.snapshot();
-    assert!(
-        snapshot
-            .last_decision
-            .as_deref()
-            .unwrap_or_default()
-            .contains("observed:worker_started"),
-        "expected observed worker event in snapshot, got {:?}",
-        snapshot.last_decision
+    panic!(
+        "supervisor did not become active, last snapshot={:?}",
+        supervisor.snapshot()
     );
-
-    supervisor.stop().await;
-    assert_eq!(supervisor.snapshot().status, SupervisorStatus::Stopped);
 }
 
-#[test]
-fn lifecycle_disabled_supervisor_noop_start() {
-    let hub = EventHub::new(4);
-    let deps = SupervisorDependencies::new(
-        hub,
-        SharedContextStore::default(),
-        EscalationRegistry::default(),
-    );
-    let mut supervisor = SupervisorAgent::new(Default::default(), deps);
+async fn recv_event_with_name(
+    rx: &mut tokio::sync::broadcast::Receiver<SymphonyEventEnvelope>,
+    event_name: &str,
+    timeout: Duration,
+) -> SymphonyEventEnvelope {
+    tokio::time::timeout(timeout, async {
+        loop {
+            let envelope = rx.recv().await.expect("event should be readable");
+            if envelope.event == event_name {
+                break envelope;
+            }
+        }
+    })
+    .await
+    .expect("expected event before timeout")
+}
 
-    supervisor
-        .start()
-        .expect("disabled supervisor start should be a no-op");
+mod lifecycle {
+    use super::*;
 
-    let snapshot = supervisor.snapshot();
-    assert_eq!(snapshot.status, SupervisorStatus::Disabled);
-    assert!(!supervisor.is_running());
+    #[test]
+    fn config_defaults_supervisor_disabled() {
+        let raw = serde_yaml::from_str::<serde_yaml::Value>("tracker: { kind: linear }")
+            .expect("yaml fixture should parse");
+        let config = from_workflow(&raw).expect("workflow config should parse");
+
+        assert!(!config.supervisor.enabled);
+        assert!(config.supervisor.model.is_none());
+        assert_eq!(config.supervisor.steer_cooldown_ms, 120_000);
+    }
+
+    #[tokio::test]
+    async fn supervisor_starts_processes_event_and_stops() {
+        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: Some("anthropic/claude-sonnet-4-6".to_string()),
+            steer_cooldown_ms: 120_000,
+        });
+
+        supervisor
+            .start()
+            .expect("supervisor should start inside tokio runtime");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope("KAT-1327", "worker_started", "worker started"));
+
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        let snapshot = supervisor.snapshot();
+        assert!(
+            snapshot
+                .last_decision
+                .as_deref()
+                .unwrap_or_default()
+                .contains("observed:worker_started"),
+            "expected observed worker event in snapshot, got {:?}",
+            snapshot.last_decision
+        );
+
+        supervisor.stop().await;
+        assert_eq!(supervisor.snapshot().status, SupervisorStatus::Stopped);
+    }
+
+    #[test]
+    fn disabled_supervisor_start_is_noop() {
+        let (mut supervisor, _hub) = make_supervisor(SupervisorConfig::default());
+
+        supervisor
+            .start()
+            .expect("disabled supervisor start should be a no-op");
+
+        let snapshot = supervisor.snapshot();
+        assert_eq!(snapshot.status, SupervisorStatus::Disabled);
+        assert!(!supervisor.is_running());
+    }
+}
+
+mod stuck_worker {
+    use super::*;
+
+    #[tokio::test]
+    async fn repeated_tool_error_triggers_supervisor_steer() {
+        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope("KAT-2001", "tool_error", "bash cargo test --all"));
+        hub.send(envelope("KAT-2001", "tool_error", "bash cargo test --all"));
+        hub.send(envelope("KAT-2001", "tool_error", "bash cargo test --all"));
+
+        let steer_event =
+            recv_event_with_name(&mut rx, "supervisor_steer", Duration::from_secs(1)).await;
+
+        assert_eq!(steer_event.kind, EventKind::SupervisorSteer);
+        assert_eq!(steer_event.payload["reason"], "repeated_tool_error");
+
+        let snapshot = supervisor.snapshot();
+        assert_eq!(snapshot.steers_issued, 1);
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn no_progress_triggers_supervisor_steer() {
+        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        for _ in 0..NO_PROGRESS_EVENT_THRESHOLD_FOR_TEST {
+            hub.send(envelope("KAT-2002", "worker_progress", "thinking"));
+        }
+
+        let steer_event =
+            recv_event_with_name(&mut rx, "supervisor_steer", Duration::from_secs(1)).await;
+        assert_eq!(steer_event.payload["reason"], "no_progress");
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn repeated_test_failure_triggers_supervisor_steer() {
+        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope(
+            "KAT-2003",
+            "turn_failed",
+            "test auth_flow failed: expected 200 got 401",
+        ));
+        hub.send(envelope(
+            "KAT-2003",
+            "turn_failed",
+            "test auth_flow failed: expected 200 got 401",
+        ));
+
+        let steer_event =
+            recv_event_with_name(&mut rx, "supervisor_steer", Duration::from_secs(1)).await;
+        assert_eq!(steer_event.payload["reason"], "repeated_test_failure");
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn cooldown_prevents_rapid_resteer() {
+        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 300_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        for _ in 0..3 {
+            hub.send(envelope("KAT-2004", "tool_error", "bash cargo test"));
+        }
+
+        let _first = recv_event_with_name(&mut rx, "supervisor_steer", Duration::from_secs(1)).await;
+
+        for _ in 0..3 {
+            hub.send(envelope("KAT-2004", "tool_error", "bash cargo test"));
+        }
+
+        let second = tokio::time::timeout(Duration::from_millis(250), async {
+            loop {
+                let envelope = rx.recv().await.expect("event should be readable");
+                if envelope.event == "supervisor_steer" {
+                    return envelope;
+                }
+            }
+        })
+        .await;
+
+        assert!(
+            second.is_err(),
+            "cooldown should suppress rapid second steer, got {:?}",
+            second
+        );
+
+        assert_eq!(supervisor.snapshot().steers_issued, 1);
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn mixed_non_stuck_events_do_not_trigger_steer() {
+        let (mut supervisor, hub) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope(
+            "KAT-2005",
+            "tool_start",
+            "edit {\"path\":\"src/lib.rs\"}",
+        ));
+        hub.send(envelope("KAT-2005", "tool_end", "edit"));
+        hub.send(envelope("KAT-2005", "worker_progress", "planning"));
+        hub.send(envelope("KAT-2005", "worker_progress", "running"));
+
+        let steer = tokio::time::timeout(Duration::from_millis(250), async {
+            loop {
+                let envelope = rx.recv().await.expect("event should be readable");
+                if envelope.event == "supervisor_steer" {
+                    return envelope;
+                }
+            }
+        })
+        .await;
+
+        assert!(steer.is_err(), "did not expect a steer event");
+        assert_eq!(supervisor.snapshot().steers_issued, 0);
+
+        supervisor.stop().await;
+    }
+
+    const NO_PROGRESS_EVENT_THRESHOLD_FOR_TEST: usize = 5;
 }

--- a/apps/symphony/tests/supervisor_tests.rs
+++ b/apps/symphony/tests/supervisor_tests.rs
@@ -453,3 +453,135 @@ mod conflict_detection {
         supervisor.stop().await;
     }
 }
+
+mod failure_pattern {
+    use super::*;
+
+    #[tokio::test]
+    async fn shared_error_across_workers_emits_pattern_event_and_warning() {
+        let (mut supervisor, hub, store, _registry) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope(
+            "KAT-4001",
+            "turn_failed",
+            "cargo test failed: unresolved import crate::auth",
+        ));
+        hub.send(envelope(
+            "KAT-4002",
+            "turn_failed",
+            "cargo test failed: unresolved import crate::auth",
+        ));
+
+        let pattern_event = recv_event_with_name(
+            &mut rx,
+            "supervisor_pattern_detected",
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(pattern_event.kind, EventKind::SupervisorPatternDetected);
+        assert_eq!(pattern_event.payload["pattern_type"], "shared_error_signature");
+
+        let warnings = store
+            .list()
+            .into_iter()
+            .filter(|entry| entry.author_issue == "SUPERVISOR")
+            .filter(|entry| entry.content.contains("Systemic failure pattern"))
+            .count();
+        assert!(warnings >= 1, "expected supervisor systemic warning entry");
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn persistent_pattern_escalates_after_repeat_signal() {
+        let (mut supervisor, hub, _store, registry) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope(
+            "KAT-4101",
+            "turn_failed",
+            "cargo test failed: missing dependency serde_json",
+        ));
+        hub.send(envelope(
+            "KAT-4102",
+            "turn_failed",
+            "cargo test failed: missing dependency serde_json",
+        ));
+
+        let _pattern_event = recv_event_with_name(
+            &mut rx,
+            "supervisor_pattern_detected",
+            Duration::from_secs(1),
+        )
+        .await;
+
+        hub.send(envelope(
+            "KAT-4101",
+            "turn_failed",
+            "cargo test failed: missing dependency serde_json",
+        ));
+
+        let escalated =
+            recv_event_with_name(&mut rx, "supervisor_escalated", Duration::from_secs(1)).await;
+        assert_eq!(escalated.kind, EventKind::SupervisorEscalated);
+
+        let pending = registry.pending_snapshot();
+        assert_eq!(pending.len(), 1, "expected one pending escalation");
+
+        supervisor.stop().await;
+    }
+
+    #[tokio::test]
+    async fn distinct_errors_do_not_emit_pattern_event() {
+        let (mut supervisor, hub, _store, _registry) = make_supervisor(SupervisorConfig {
+            enabled: true,
+            model: None,
+            steer_cooldown_ms: 120_000,
+        });
+        let mut rx = hub.subscribe();
+
+        supervisor.start().expect("supervisor should start");
+        wait_for_active(&supervisor).await;
+
+        hub.send(envelope(
+            "KAT-4201",
+            "turn_failed",
+            "cargo test failed: unresolved import crate::alpha",
+        ));
+        hub.send(envelope(
+            "KAT-4202",
+            "turn_failed",
+            "cargo test failed: unresolved import crate::beta",
+        ));
+
+        let pattern = tokio::time::timeout(Duration::from_millis(300), async {
+            loop {
+                let envelope = rx.recv().await.expect("event should be readable");
+                if envelope.event == "supervisor_pattern_detected" {
+                    return envelope;
+                }
+            }
+        })
+        .await;
+
+        assert!(pattern.is_err(), "unexpected pattern event: {pattern:?}");
+
+        supervisor.stop().await;
+    }
+}


### PR DESCRIPTION
## Summary
- wire SupervisorAgent lifecycle into orchestrator startup/shutdown and snapshot plumbing
- surface supervisor status/counters in /api/v1/state, HTTP dashboard, and TUI summary header
- document supervisor configuration/behavior in apps/symphony/README.md and update apps/symphony/AGENTS.md module map
- add supervisor integration coverage for orchestrator lifecycle and dashboard state assertions

## Validation
- cd apps/symphony && cargo test --test supervisor_tests integration
- cd apps/symphony && cargo test --test supervisor_tests
- cd apps/symphony && cargo test supervisor
- cd apps/symphony && cargo test
- cd apps/symphony && cargo clippy -- -D warnings
- cd apps/symphony && cargo fmt --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the `SupervisorAgent` lifecycle into the Symphony orchestrator, exposing stuck-worker steering, cross-worker file conflict detection, systemic failure pattern detection, and escalation fallback — all surfaced through `/api/v1/state`, the HTTP dashboard, and the TUI summary header. The implementation is well-structured with clean domain types, consistent config parsing, solid test coverage across lifecycle/stuck/conflict/pattern scenarios, and appropriate safety defaults (disabled by default, per-worker cooldowns).

Two correctness concerns worth addressing before merging:

- **Silent supervisor crash** (`orchestrator.rs`): `ensure_supervisor_running` guards on `self.supervisor_agent.is_some()`, but this never becomes `None` after an unexpected task termination. A panicked supervisor retains `Active` status indefinitely and is never restarted. The fix is to check `supervisor.is_running()` (once `is_running` is fixed to use `JoinHandle::is_finished()`).
- **Write lock held across external calls** (`supervisor.rs`): `process_envelope` holds the `RwLock` write guard for its entire duration, including calls into `SharedContextStore` and `EventHub`. If `SharedContextStore` uses its own blocking lock, a lock-ordering cycle between the two locks could deadlock the supervisor task and block all snapshot reads.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the two P1 lifecycle/locking correctness issues; supervisor is disabled by default so production impact is bounded.

Two P1 issues are present: (1) a crashed supervisor is never detected or restarted due to checking Option::is_some() instead of task liveness, leaving operators with a false Active status; (2) holding a blocking write lock across calls into SharedContextStore and EventHub introduces a deadlock risk. Both are fixable with small, targeted changes. Everything else — domain types, config parsing, TUI/dashboard wiring, and test suite — is clean and well-reasoned.

apps/symphony/src/supervisor.rs (lock-holding pattern in process_envelope, is_running accuracy) and apps/symphony/src/orchestrator.rs (ensure_supervisor_running liveness check)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/supervisor.rs | New 1034-line supervisor module implementing stuck/conflict/pattern detection. Key concerns: write lock held across external calls to SharedContextStore and EventHub (deadlock risk), and is_running() incorrectly uses task.is_some() instead of !task.is_finished(). |
| apps/symphony/src/orchestrator.rs | Wires supervisor lifecycle into orchestrator startup/shutdown. ensure_supervisor_running checks is_some() rather than task liveness, so a silently-crashed supervisor is never detected or restarted, and its snapshot status stays Active indefinitely. |
| apps/symphony/src/domain.rs | Adds SupervisorConfig, SupervisorStatus, SupervisorSnapshot domain types, and four new EventKind variants. Clean, well-structured additions with proper serde attributes and Default impls. |
| apps/symphony/src/http_server.rs | Surfaces supervisor status and counters in the dashboard HTML and /api/v1/state. JavaScript update path is correct, but static HTML counters are hardcoded to 0 rather than using the snapshot values at render time. |
| apps/symphony/src/tui.rs | Adds supervisor_summary_line to the TUI header showing status and counters; clean addition with two covering unit tests. |
| apps/symphony/tests/supervisor_tests.rs | New 665-line integration test suite covering lifecycle, stuck-worker steering, conflict detection, failure pattern detection, and orchestrator integration. Tests rely on short time windows (250–300 ms timeouts) that could be flaky on slow CI. |
| apps/symphony/src/config.rs | Adds RawSupervisorConfig parsing and wiring into ServiceConfig; env-variable resolution and default fall-back are handled consistently with other config sections. |
| apps/symphony/src/main.rs | Captures the tokio::select! result and calls shutdown_supervisor() before returning, ensuring the supervisor is cleanly stopped on orchestrator exit regardless of which branch fires. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as main.rs
    participant Orch as Orchestrator
    participant SA as SupervisorAgent
    participant Task as Background Task
    participant EH as EventHub
    participant SC as SharedContextStore
    participant ER as EscalationRegistry

    Main->>Orch: run(port)
    Orch->>Orch: sync_supervisor_lifecycle()
    Orch->>SA: new(config, deps)
    Orch->>SA: start()
    SA->>Task: tokio::spawn(event loop)
    Task-->>EH: publish(supervisor_started)
    Task->>Task: status = Active

    loop Per worker event
        EH-->>Task: recv(SymphonyEventEnvelope)
        Task->>Task: process_envelope() [holds write lock]
        alt Repeated tool error / no progress / test failure
            Task->>SC: write_entry(coordination hint)
            Task->>EH: publish(supervisor_steer)
        else File overlap
            Task->>SC: write_entry(overlap warning)
            Task->>EH: publish(supervisor_conflict_detected)
        else Systemic pattern (>=2 workers)
            Task->>SC: write_entry(systemic warning)
            Task->>EH: publish(supervisor_pattern_detected)
            Task->>ER: register(escalation)
            Task->>EH: publish(supervisor_escalated)
        end
    end

    Main->>Orch: shutdown_supervisor()
    Orch->>SA: stop()
    SA->>Task: shutdown_tx.send(true)
    Task-->>EH: publish(supervisor_stopped)
    Task->>Task: status = Stopped
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `apps/symphony/src/orchestrator.rs`, line 621-624 ([link](https://github.com/gannonh/kata/blob/32e4d392497eb30a96a59c6c13092f7dbfdc87fb/apps/symphony/src/orchestrator.rs#L621-L624)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Crashed supervisor not detected or restarted**

   `ensure_supervisor_running` returns early when `self.supervisor_agent.is_some()`, but this only checks whether the `SupervisorAgent` struct was ever created — not whether its background task is still alive. If the spawned task panics (e.g., due to a poisoned lock in `process_envelope`), the `JoinHandle` inside `SupervisorAgent::task` remains `Some`, so `is_running()` still returns `true` and `supervisor_agent` remains `Some`. The snapshot status stays `Active` indefinitely, and the supervisor is never restarted.

   The fix requires checking liveness more carefully:

   ```rust
   // In ensure_supervisor_running, replace:
   if self.supervisor_agent.is_some() {
       return Ok(());
   }

   // With a liveness check:
   if let Some(supervisor) = &self.supervisor_agent {
       if supervisor.is_running() {
           return Ok(());
       }
       // task finished unexpectedly — fall through to recreate
   }
   self.supervisor_agent = None;
   ```

   And `SupervisorAgent::is_running` itself needs fixing — `self.task.is_some()` returns `true` for a finished `JoinHandle`. Use `is_finished()`:

   ```rust
   pub fn is_running(&self) -> bool {
       self.task.as_ref().is_some_and(|t| !t.is_finished())
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/orchestrator.rs
   Line: 621-624

   Comment:
   **Crashed supervisor not detected or restarted**

   `ensure_supervisor_running` returns early when `self.supervisor_agent.is_some()`, but this only checks whether the `SupervisorAgent` struct was ever created — not whether its background task is still alive. If the spawned task panics (e.g., due to a poisoned lock in `process_envelope`), the `JoinHandle` inside `SupervisorAgent::task` remains `Some`, so `is_running()` still returns `true` and `supervisor_agent` remains `Some`. The snapshot status stays `Active` indefinitely, and the supervisor is never restarted.

   The fix requires checking liveness more carefully:

   ```rust
   // In ensure_supervisor_running, replace:
   if self.supervisor_agent.is_some() {
       return Ok(());
   }

   // With a liveness check:
   if let Some(supervisor) = &self.supervisor_agent {
       if supervisor.is_running() {
           return Ok(());
       }
       // task finished unexpectedly — fall through to recreate
   }
   self.supervisor_agent = None;
   ```

   And `SupervisorAgent::is_running` itself needs fixing — `self.task.is_some()` returns `true` for a finished `JoinHandle`. Use `is_finished()`:

   ```rust
   pub fn is_running(&self) -> bool {
       self.task.as_ref().is_some_and(|t| !t.is_finished())
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/symphony/src/supervisor.rs`, line 1157-1192 ([link](https://github.com/gannonh/kata/blob/32e4d392497eb30a96a59c6c13092f7dbfdc87fb/apps/symphony/src/supervisor.rs#L1157-L1192)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Write lock held across external calls — deadlock risk**

   `process_envelope` acquires `state.write()` and holds it for the full duration of the function, including calls to `deps.shared_context_store.write_entry()` and `deps.event_hub.publish()`. If `SharedContextStore` uses an internal `Mutex`/`RwLock`, this creates a lock-ordering hazard: another thread that holds the shared-context lock while trying to read the supervisor snapshot (e.g., via `orchestrator.publish_snapshot()` → `supervisor_snapshot()` → `state.read()`) would deadlock.

   The safer pattern is to compute all state mutations under the lock, then release the lock before making external calls:

   ```rust
   fn process_envelope(state: &Arc<RwLock<SupervisorRuntimeState>>, ...) {
       // 1. Collect all actions to take (under lock)
       let actions = {
           let mut guard = state.write().expect("...");
           collect_actions(&mut guard, &envelope)
       }; // guard released here

       // 2. Execute side-effects outside the lock
       for action in actions {
           action.execute(deps);
       }
   }
   ```

   This eliminates the risk entirely and keeps lock hold-times minimal.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/supervisor.rs
   Line: 1157-1192

   Comment:
   **Write lock held across external calls — deadlock risk**

   `process_envelope` acquires `state.write()` and holds it for the full duration of the function, including calls to `deps.shared_context_store.write_entry()` and `deps.event_hub.publish()`. If `SharedContextStore` uses an internal `Mutex`/`RwLock`, this creates a lock-ordering hazard: another thread that holds the shared-context lock while trying to read the supervisor snapshot (e.g., via `orchestrator.publish_snapshot()` → `supervisor_snapshot()` → `state.read()`) would deadlock.

   The safer pattern is to compute all state mutations under the lock, then release the lock before making external calls:

   ```rust
   fn process_envelope(state: &Arc<RwLock<SupervisorRuntimeState>>, ...) {
       // 1. Collect all actions to take (under lock)
       let actions = {
           let mut guard = state.write().expect("...");
           collect_actions(&mut guard, &envelope)
       }; // guard released here

       // 2. Execute side-effects outside the lock
       for action in actions {
           action.execute(deps);
       }
   }
   ```

   This eliminates the risk entirely and keeps lock hold-times minimal.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `apps/symphony/src/supervisor.rs`, line 1126-1128 ([link](https://github.com/gannonh/kata/blob/32e4d392497eb30a96a59c6c13092f7dbfdc87fb/apps/symphony/src/supervisor.rs#L1126-L1128)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`is_running()` returns `true` for finished tasks**

   `JoinHandle` is not consumed when a task completes — it stays `Some` whether the task is running, panicked, or returned normally. This makes `is_running()` inaccurate after unexpected task termination. Tokio provides `JoinHandle::is_finished()` for exactly this use case:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/supervisor.rs
   Line: 1126-1128

   Comment:
   **`is_running()` returns `true` for finished tasks**

   `JoinHandle` is not consumed when a task completes — it stays `Some` whether the task is running, panicked, or returned normally. This makes `is_running()` inaccurate after unexpected task termination. Tokio provides `JoinHandle::is_finished()` for exactly this use case:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


4. `apps/symphony/src/http_server.rs`, line 442-451 ([link](https://github.com/gannonh/kata/blob/32e4d392497eb30a96a59c6c13092f7dbfdc87fb/apps/symphony/src/http_server.rs#L442-L451)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Supervisor counters hardcoded to `0` in server-rendered HTML**

   The initial HTML for the supervisor card always renders the counters as literal `0`. The `updateSupervisor()` JavaScript call fills in real values after the first auto-refresh, but operators who access the page before that refresh, or with JavaScript disabled, will always see zeros. Consider injecting actual snapshot values at render time, as is already done for `supervisor_status_label`:

   ```html
   <div><div class="label">steers</div><div class="mono" id="supervisor-steers">{steers_issued}</div></div>
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/http_server.rs
   Line: 442-451

   Comment:
   **Supervisor counters hardcoded to `0` in server-rendered HTML**

   The initial HTML for the supervisor card always renders the counters as literal `0`. The `updateSupervisor()` JavaScript call fills in real values after the first auto-refresh, but operators who access the page before that refresh, or with JavaScript disabled, will always see zeros. Consider injecting actual snapshot values at render time, as is already done for `supervisor_status_label`:

   ```html
   <div><div class="label">steers</div><div class="mono" id="supervisor-steers">{steers_issued}</div></div>
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 621-624

Comment:
**Crashed supervisor not detected or restarted**

`ensure_supervisor_running` returns early when `self.supervisor_agent.is_some()`, but this only checks whether the `SupervisorAgent` struct was ever created — not whether its background task is still alive. If the spawned task panics (e.g., due to a poisoned lock in `process_envelope`), the `JoinHandle` inside `SupervisorAgent::task` remains `Some`, so `is_running()` still returns `true` and `supervisor_agent` remains `Some`. The snapshot status stays `Active` indefinitely, and the supervisor is never restarted.

The fix requires checking liveness more carefully:

```rust
// In ensure_supervisor_running, replace:
if self.supervisor_agent.is_some() {
    return Ok(());
}

// With a liveness check:
if let Some(supervisor) = &self.supervisor_agent {
    if supervisor.is_running() {
        return Ok(());
    }
    // task finished unexpectedly — fall through to recreate
}
self.supervisor_agent = None;
```

And `SupervisorAgent::is_running` itself needs fixing — `self.task.is_some()` returns `true` for a finished `JoinHandle`. Use `is_finished()`:

```rust
pub fn is_running(&self) -> bool {
    self.task.as_ref().is_some_and(|t| !t.is_finished())
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/supervisor.rs
Line: 1157-1192

Comment:
**Write lock held across external calls — deadlock risk**

`process_envelope` acquires `state.write()` and holds it for the full duration of the function, including calls to `deps.shared_context_store.write_entry()` and `deps.event_hub.publish()`. If `SharedContextStore` uses an internal `Mutex`/`RwLock`, this creates a lock-ordering hazard: another thread that holds the shared-context lock while trying to read the supervisor snapshot (e.g., via `orchestrator.publish_snapshot()` → `supervisor_snapshot()` → `state.read()`) would deadlock.

The safer pattern is to compute all state mutations under the lock, then release the lock before making external calls:

```rust
fn process_envelope(state: &Arc<RwLock<SupervisorRuntimeState>>, ...) {
    // 1. Collect all actions to take (under lock)
    let actions = {
        let mut guard = state.write().expect("...");
        collect_actions(&mut guard, &envelope)
    }; // guard released here

    // 2. Execute side-effects outside the lock
    for action in actions {
        action.execute(deps);
    }
}
```

This eliminates the risk entirely and keeps lock hold-times minimal.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/supervisor.rs
Line: 1126-1128

Comment:
**`is_running()` returns `true` for finished tasks**

`JoinHandle` is not consumed when a task completes — it stays `Some` whether the task is running, panicked, or returned normally. This makes `is_running()` inaccurate after unexpected task termination. Tokio provides `JoinHandle::is_finished()` for exactly this use case:

```suggestion
    pub fn is_running(&self) -> bool {
        self.task.as_ref().is_some_and(|t| !t.is_finished())
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 442-451

Comment:
**Supervisor counters hardcoded to `0` in server-rendered HTML**

The initial HTML for the supervisor card always renders the counters as literal `0`. The `updateSupervisor()` JavaScript call fills in real values after the first auto-refresh, but operators who access the page before that refresh, or with JavaScript disabled, will always see zeros. Consider injecting actual snapshot values at render time, as is already done for `supervisor_status_label`:

```html
<div><div class="label">steers</div><div class="mono" id="supervisor-steers">{steers_issued}</div></div>
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): wire supervisor lifecycl..."](https://github.com/gannonh/kata/commit/32e4d392497eb30a96a59c6c13092f7dbfdc87fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26631759)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Supervisor: configurable lifecycle, runtime snapshot, and background agent that monitors workers and coordinates mitigations.
  * Dashboard, TUI and API now show supervisor status and metrics (steers, conflicts, patterns, escalations).

* **Behavior**
  * Supervisor detects stuck workers, inter-issue conflicts, and systemic error patterns; issues steers and escalations with cooldown/deduplication.

* **Configuration**
  * Supervisor config supports defaults, env-var model resolution, and steer cooldown handling.

* **Tests**
  * Comprehensive supervisor unit and integration tests plus dashboard/API/TUI test updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->