### PR TITLE
feat(kata): onboarding wizard for project setup [KAT-1640]

### DIFF
--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -45,6 +45,62 @@ import {
 import { getCurrentBranch } from "../pr-lifecycle/gh-utils.js";
 import { getPRNumber } from "../pr-lifecycle/pr-merge-utils.js";
 import { loadPrompt } from "./prompt-loader.js";
+import {
+  isProjectConfigured,
+  runOnboarding,
+  shouldSkipOnboarding,
+  setSkipOnboarding,
+} from "./onboarding.js";
+
+// ─── Onboarding gate ──────────────────────────────────────────────────────────
+
+/**
+ * Ensure the project is configured (has .kata/ with linear config).
+ * If not configured and not skipped, shows a setup-or-skip prompt.
+ *
+ * Returns true if the project is configured (or was just configured).
+ * Returns false if the user skipped or onboarding was already skipped this session.
+ */
+async function ensureOnboarding(
+  ctx: ExtensionCommandContext,
+  basePath: string,
+): Promise<boolean> {
+  if (isProjectConfigured(basePath)) return true;
+  if (shouldSkipOnboarding()) return false;
+
+  const { showNextAction } = await import("../shared/next-action-ui.js");
+
+  const choice = await showNextAction(ctx as any, {
+    title: "Kata Setup",
+    summary: [
+      "This project hasn't been set up with Kata yet.",
+      "You'll need a Linear API key to get started.",
+    ],
+    actions: [
+      {
+        id: "setup",
+        label: "Set up Kata (Recommended)",
+        description: "Configure Linear integration and create .kata/ directory.",
+        recommended: true,
+      },
+      {
+        id: "skip",
+        label: "Skip for now",
+        description: "Skip setup for this session. Run /kata later to configure.",
+      },
+    ],
+    notYetMessage: "Run /kata to set up when ready.",
+  });
+
+  if (choice === "setup") {
+    const result = await runOnboarding(ctx);
+    return result === "completed";
+  }
+
+  // User chose skip or not_yet
+  setSkipOnboarding(true);
+  return false;
+}
 
 export interface PrefsStatusReport {
   level: "info" | "warning";
@@ -228,8 +284,10 @@ export function registerKataCommand(pi: ExtensionAPI): void {
       }
 
       if (trimmed === "auto" || trimmed.startsWith("auto ")) {
+        const cwd = process.cwd();
+        if (!await ensureOnboarding(ctx, cwd)) return;
         const verboseMode = trimmed.includes("--verbose");
-        await startAuto(ctx, pi, process.cwd(), verboseMode);
+        await startAuto(ctx, pi, cwd, verboseMode);
         return;
       }
 
@@ -243,17 +301,23 @@ export function registerKataCommand(pi: ExtensionAPI): void {
       }
 
       if (trimmed === "queue") {
-        await showQueue(ctx, pi, process.cwd());
+        const cwd = process.cwd();
+        if (!await ensureOnboarding(ctx, cwd)) return;
+        await showQueue(ctx, pi, cwd);
         return;
       }
 
       if (trimmed === "discuss") {
-        await showDiscuss(ctx, pi, process.cwd());
+        const cwd = process.cwd();
+        if (!await ensureOnboarding(ctx, cwd)) return;
+        await showDiscuss(ctx, pi, cwd);
         return;
       }
 
       if (trimmed === "plan") {
-        await showPlan(ctx, pi, process.cwd());
+        const cwd = process.cwd();
+        if (!await ensureOnboarding(ctx, cwd)) return;
+        await showPlan(ctx, pi, cwd);
         return;
       }
 
@@ -263,9 +327,12 @@ export function registerKataCommand(pi: ExtensionAPI): void {
       }
 
       if (trimmed === "" || trimmed === "step") {
+        const cwd = process.cwd();
+        if (!await ensureOnboarding(ctx, cwd)) return;
+
         let stepBackend: KataBackend;
         try {
-          stepBackend = await createBackend(process.cwd());
+          stepBackend = await createBackend(cwd);
         } catch (err) {
           ctx.ui.notify(`Kata backend init failed: ${err instanceof Error ? err.message : String(err)}`, "error");
           return;
@@ -286,7 +353,7 @@ export function registerKataCommand(pi: ExtensionAPI): void {
           return;
         }
         if (state.phase === "complete" || !state.activeMilestone) {
-          await showSmartEntry(ctx, pi, process.cwd());
+          await showSmartEntry(ctx, pi, cwd);
           return;
         }
 
@@ -299,7 +366,7 @@ export function registerKataCommand(pi: ExtensionAPI): void {
         ) {
           try {
             const { ensureSliceBranch } = await import("./worktree.js");
-            ensureSliceBranch(process.cwd(), state.activeMilestone.id, state.activeSlice.id);
+            ensureSliceBranch(cwd, state.activeMilestone.id, state.activeSlice.id);
           } catch (err) {
             ctx.ui.notify(
               `Branch setup failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -94,11 +94,21 @@ async function ensureOnboarding(
 
   if (choice === "setup") {
     const result = await runOnboarding(ctx, basePath);
-    return result === "completed";
+    if (result === "completed") {
+      // API key saved and .kata/ created; isProjectConfigured() still returns
+      // false until S02 adds team/project identifiers. Set the session skip
+      // flag so the wizard doesn't re-trigger on every subsequent /kata call
+      // within this session.
+      setSkipOnboarding(true);
+      return true;
+    }
+    return false;
   }
 
-  // User chose skip or not_yet
-  setSkipOnboarding(true);
+  // Only persist skip for the explicit "skip" action; "not_yet" just returns false
+  if (choice === "skip") {
+    setSkipOnboarding(true);
+  }
   return false;
 }
 

--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -93,7 +93,7 @@ async function ensureOnboarding(
   });
 
   if (choice === "setup") {
-    const result = await runOnboarding(ctx);
+    const result = await runOnboarding(ctx, basePath);
     return result === "completed";
   }
 

--- a/apps/cli/src/resources/extensions/kata/guided-flow.ts
+++ b/apps/cli/src/resources/extensions/kata/guided-flow.ts
@@ -32,7 +32,6 @@ import type {
 } from "./types.js";
 import {
   isProjectConfigured,
-  shouldSkipOnboarding,
 } from "./onboarding.js";
 
 // ─── PR onboarding helpers ─────────────────────────────────────────────────
@@ -869,14 +868,9 @@ export async function showSmartEntry(
   pi: ExtensionAPI,
   basePath: string,
 ): Promise<void> {
-  // Onboarding guard: if unconfigured and skipped, show a brief message
+  // Onboarding guard: if unconfigured, show a brief message and return.
+  // commands.ts is the authoritative entry point for triggering the wizard.
   if (!isProjectConfigured(basePath)) {
-    if (shouldSkipOnboarding()) {
-      ctx.ui.notify("Run /kata to set up Linear integration.", "info");
-      return;
-    }
-    // If not skipped, the caller (commands.ts) should have already handled the prompt.
-    // This is a safety net — show the notification and return.
     ctx.ui.notify("Run /kata to set up Linear integration.", "info");
     return;
   }

--- a/apps/cli/src/resources/extensions/kata/guided-flow.ts
+++ b/apps/cli/src/resources/extensions/kata/guided-flow.ts
@@ -30,6 +30,10 @@ import type {
   KataState,
   RoadmapSliceEntry,
 } from "./types.js";
+import {
+  isProjectConfigured,
+  shouldSkipOnboarding,
+} from "./onboarding.js";
 
 // ─── PR onboarding helpers ─────────────────────────────────────────────────
 
@@ -865,6 +869,18 @@ export async function showSmartEntry(
   pi: ExtensionAPI,
   basePath: string,
 ): Promise<void> {
+  // Onboarding guard: if unconfigured and skipped, show a brief message
+  if (!isProjectConfigured(basePath)) {
+    if (shouldSkipOnboarding()) {
+      ctx.ui.notify("Run /kata to set up Linear integration.", "info");
+      return;
+    }
+    // If not skipped, the caller (commands.ts) should have already handled the prompt.
+    // This is a safety net — show the notification and return.
+    ctx.ui.notify("Run /kata to set up Linear integration.", "info");
+    return;
+  }
+
   const modeGate = getWorkflowEntrypointGuard("smart-entry");
   if (!modeGate.allow) {
     ctx.ui.notify(

--- a/apps/cli/src/resources/extensions/kata/onboarding.ts
+++ b/apps/cli/src/resources/extensions/kata/onboarding.ts
@@ -61,7 +61,7 @@ export function isProjectConfigured(basePath: string): boolean {
   const linear = loaded.preferences.linear;
   if (!linear) return false;
 
-  return !!(linear.teamKey || linear.projectSlug);
+  return !!(linear.teamKey || linear.projectSlug || linear.teamId || linear.projectId);
 }
 
 // ─── Dependencies (injectable for testing) ────────────────────────────────────
@@ -116,6 +116,7 @@ export type OnboardingResult = "completed" | "skipped";
  */
 export async function runOnboarding(
   ctx: ExtensionCommandContext,
+  basePath: string = process.cwd(),
 ): Promise<OnboardingResult> {
   // Non-TTY guard
   if (!ctx.hasUI) {
@@ -127,7 +128,6 @@ export async function runOnboarding(
   }
 
   const deps = await getDeps();
-  const basePath = process.cwd();
 
   // Prompt for API key (with one retry on failure)
   let apiKey: string | null = null;
@@ -212,7 +212,7 @@ export async function runOnboarding(
       `Failed to create project config: ${err instanceof Error ? err.message : String(err)}`,
       "error",
     );
-    // Key is stored even if preferences fail — not a full failure
+    return "skipped";
   }
 
   ctx.ui.notify("✓ Linear API key saved. .kata/ created.", "info");

--- a/apps/cli/src/resources/extensions/kata/onboarding.ts
+++ b/apps/cli/src/resources/extensions/kata/onboarding.ts
@@ -1,0 +1,220 @@
+/**
+ * Kata Onboarding — Project Setup Wizard
+ *
+ * Provides:
+ * - `isProjectConfigured(basePath)` — check if .kata/preferences.md exists with linear config
+ * - `runOnboarding(ctx)` — interactive wizard to collect LINEAR_API_KEY and create .kata/
+ * - `shouldSkipOnboarding()` / `setSkipOnboarding()` — session-scoped skip flag
+ *
+ * The wizard:
+ * 1. Guards non-TTY environments (returns "skipped" with warning)
+ * 2. Prompts for LINEAR_API_KEY via ctx.ui.input (masked)
+ * 3. Validates via LinearClient.getViewer() (one retry on failure)
+ * 4. Stores key in auth.json via AuthStorage
+ * 5. Creates .kata/preferences.md from template + ensures .gitignore
+ * 6. Hydrates process.env.LINEAR_API_KEY for same-session use
+ */
+
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { loadEffectiveKataPreferences } from "./preferences.js";
+import { ensurePreferences, ensureGitignore } from "./gitignore.js";
+
+// ─── Session-scoped skip flag ─────────────────────────────────────────────────
+
+let onboardingSkipped = false;
+
+export function shouldSkipOnboarding(): boolean {
+  return onboardingSkipped;
+}
+
+export function setSkipOnboarding(skip: boolean = true): void {
+  onboardingSkipped = skip;
+}
+
+/**
+ * Reset the skip flag. Exposed for testing only.
+ * @internal
+ */
+export function _resetSkipFlag(): void {
+  onboardingSkipped = false;
+}
+
+// ─── Project configuration check ─────────────────────────────────────────────
+
+/**
+ * Returns true if the project at `basePath` has a `.kata/preferences.md`
+ * file AND has either `linear.teamKey` or `linear.projectSlug` set.
+ */
+export function isProjectConfigured(basePath: string): boolean {
+  const preferencesPath = join(basePath, ".kata", "preferences.md");
+  const legacyPath = join(basePath, ".kata", "PREFERENCES.md");
+
+  if (!existsSync(preferencesPath) && !existsSync(legacyPath)) {
+    return false;
+  }
+
+  const loaded = loadEffectiveKataPreferences(basePath);
+  if (!loaded) return false;
+
+  const linear = loaded.preferences.linear;
+  if (!linear) return false;
+
+  return !!(linear.teamKey || linear.projectSlug);
+}
+
+// ─── Dependencies (injectable for testing) ────────────────────────────────────
+
+export interface OnboardingDeps {
+  getAuthFilePath: () => string;
+  createAuthStorage: (path: string) => {
+    set: (provider: string, cred: { type: string; key: string }) => void;
+  };
+  createLinearClient: (apiKey: string) => {
+    getViewer: () => Promise<{ id: string; name: string; email: string }>;
+  };
+  ensurePreferences: (basePath: string) => boolean;
+  ensureGitignore: (basePath: string) => boolean;
+}
+
+let _deps: OnboardingDeps | null = null;
+
+/**
+ * Override dependencies for testing. Pass null to reset to defaults.
+ * @internal
+ */
+export function _setDeps(deps: OnboardingDeps | null): void {
+  _deps = deps;
+}
+
+async function getDeps(): Promise<OnboardingDeps> {
+  if (_deps) return _deps;
+
+  const { authFilePath } = await import("../../../app-paths.js");
+  const { AuthStorage } = await import("@mariozechner/pi-coding-agent");
+  const { LinearClient } = await import("../linear/linear-client.js");
+
+  return {
+    getAuthFilePath: () => authFilePath,
+    createAuthStorage: (path: string) => AuthStorage.create(path),
+    createLinearClient: (apiKey: string) => new LinearClient(apiKey),
+    ensurePreferences,
+    ensureGitignore,
+  };
+}
+
+// ─── Onboarding wizard ───────────────────────────────────────────────────────
+
+export type OnboardingResult = "completed" | "skipped";
+
+/**
+ * Run the onboarding wizard.
+ *
+ * Prompts for LINEAR_API_KEY, validates it, stores it, and creates .kata/.
+ * Returns "completed" on success, "skipped" if user skips or non-TTY.
+ */
+export async function runOnboarding(
+  ctx: ExtensionCommandContext,
+): Promise<OnboardingResult> {
+  // Non-TTY guard
+  if (!ctx.hasUI) {
+    ctx.ui.notify(
+      "Kata setup requires an interactive terminal. Run /kata in a TTY to configure.",
+      "warning",
+    );
+    return "skipped";
+  }
+
+  const deps = await getDeps();
+  const basePath = process.cwd();
+
+  // Prompt for API key (with one retry on failure)
+  let apiKey: string | null = null;
+  let validated = false;
+  const maxAttempts = 2;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const input = await ctx.ui.input(
+      "Linear API Key",
+      "lin_api_...",
+    );
+
+    // Empty input → user wants to skip
+    if (!input || !input.trim()) {
+      return "skipped";
+    }
+
+    apiKey = input.trim();
+
+    // Validate the key
+    try {
+      const client = deps.createLinearClient(apiKey);
+      await client.getViewer();
+      validated = true;
+      break;
+    } catch (err) {
+      const isAuthError =
+        err instanceof Error &&
+        (err.message.includes("401") ||
+          err.message.includes("403") ||
+          err.message.includes("Authentication") ||
+          err.message.includes("Unauthorized"));
+
+      if (isAuthError) {
+        ctx.ui.notify(
+          "Invalid API key — please check and try again.",
+          "error",
+        );
+      } else {
+        ctx.ui.notify(
+          "Could not reach Linear API — check your connection.",
+          "error",
+        );
+      }
+
+      if (attempt === maxAttempts - 1) {
+        ctx.ui.notify(
+          "Setup cancelled after failed validation. Run /kata to try again.",
+          "warning",
+        );
+        return "skipped";
+      }
+    }
+  }
+
+  if (!validated || !apiKey) {
+    return "skipped";
+  }
+
+  // Store the key in auth.json
+  try {
+    const authPath = deps.getAuthFilePath();
+    const authStorage = deps.createAuthStorage(authPath);
+    authStorage.set("linear", { type: "api_key", key: apiKey });
+  } catch (err) {
+    ctx.ui.notify(
+      `Failed to store API key: ${err instanceof Error ? err.message : String(err)}`,
+      "error",
+    );
+    return "skipped";
+  }
+
+  // Hydrate process.env immediately for same-session use
+  process.env.LINEAR_API_KEY = apiKey;
+
+  // Create .kata/preferences.md + ensure .gitignore
+  try {
+    deps.ensurePreferences(basePath);
+    deps.ensureGitignore(basePath);
+  } catch (err) {
+    ctx.ui.notify(
+      `Failed to create project config: ${err instanceof Error ? err.message : String(err)}`,
+      "error",
+    );
+    // Key is stored even if preferences fail — not a full failure
+  }
+
+  ctx.ui.notify("✓ Linear API key saved. .kata/ created.", "info");
+  return "completed";
+}

--- a/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, realpathSync } from "node:fs";
+import { mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -109,9 +109,19 @@ describe("onboarding", () => {
       expect(isProjectConfigured(tmpDir)).toBe(false);
     });
 
-    it("returns false when preferences exist but linear has no teamKey or projectSlug", () => {
-      writePreferences(tmpDir, prefsWithLinear("  projectId: some-uuid"));
+    it("returns false when preferences exist but linear block has no known identifier", () => {
+      writePreferences(tmpDir, prefsWithLinear("  foo: bar"));
       expect(isProjectConfigured(tmpDir)).toBe(false);
+    });
+
+    it("returns true when preferences have linear.teamId", () => {
+      writePreferences(tmpDir, prefsWithLinear("  teamId: some-uuid"));
+      expect(isProjectConfigured(tmpDir)).toBe(true);
+    });
+
+    it("returns true when preferences have linear.projectId", () => {
+      writePreferences(tmpDir, prefsWithLinear("  projectId: some-uuid"));
+      expect(isProjectConfigured(tmpDir)).toBe(true);
     });
 
     it("returns true when preferences have linear.teamKey", () => {
@@ -178,10 +188,8 @@ describe("onboarding", () => {
       const deps = makeMockDeps();
       _setDeps(deps);
 
-      const savedCwd = process.cwd();
-      process.chdir(tmpDir);
       try {
-        const result = await runOnboarding(ctx);
+        const result = await runOnboarding(ctx, tmpDir);
 
         expect(result).toBe("completed");
         expect(ctx.ui.input).toHaveBeenCalledOnce();
@@ -192,7 +200,6 @@ describe("onboarding", () => {
           (n: any) => n.message.includes("✓") && n.level === "info",
         )).toBe(true);
       } finally {
-        process.chdir(savedCwd);
         delete process.env.LINEAR_API_KEY;
       }
     });
@@ -236,10 +243,8 @@ describe("onboarding", () => {
       });
       _setDeps(deps);
 
-      const savedCwd = process.cwd();
-      process.chdir(tmpDir);
       try {
-        const result = await runOnboarding(ctx);
+        const result = await runOnboarding(ctx, tmpDir);
 
         expect(result).toBe("completed");
         expect(ctx.ui.input).toHaveBeenCalledTimes(2);
@@ -248,7 +253,6 @@ describe("onboarding", () => {
         )).toBe(true);
         expect(process.env.LINEAR_API_KEY).toBe("good_key");
       } finally {
-        process.chdir(savedCwd);
         delete process.env.LINEAR_API_KEY;
       }
     });
@@ -308,17 +312,14 @@ describe("onboarding", () => {
       });
       _setDeps(deps);
 
-      const savedCwd = process.cwd();
-      process.chdir(tmpDir);
       try {
-        await runOnboarding(ctx);
+        await runOnboarding(ctx, tmpDir);
 
         expect(storedCreds.linear).toEqual({
           type: "api_key",
           key: "lin_api_stored",
         });
       } finally {
-        process.chdir(savedCwd);
         delete process.env.LINEAR_API_KEY;
       }
     });
@@ -344,6 +345,27 @@ describe("onboarding", () => {
       const result = await runOnboarding(ctx);
 
       expect(result).toBe("skipped");
+    });
+
+    it("returns 'skipped' when ensurePreferences throws", async () => {
+      const ctx = makeMockCtx({ inputReturns: ["lin_api_good"] });
+      const deps = makeMockDeps({
+        ensurePreferences: vi.fn(() => {
+          throw new Error("Permission denied");
+        }),
+      });
+      _setDeps(deps);
+
+      try {
+        const result = await runOnboarding(ctx, tmpDir);
+
+        expect(result).toBe("skipped");
+        expect(ctx._notifications.some(
+          (n: any) => n.message.includes("Failed to create project config") && n.level === "error",
+        )).toBe(true);
+      } finally {
+        delete process.env.LINEAR_API_KEY;
+      }
     });
   });
 });

--- a/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  isProjectConfigured,
+  runOnboarding,
+  shouldSkipOnboarding,
+  setSkipOnboarding,
+  _resetSkipFlag,
+  _setDeps,
+  type OnboardingDeps,
+} from "../onboarding.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `kata-onboard-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  // Resolve symlinks (macOS /var -> /private/var) so path comparisons work
+  return realpathSync(dir);
+}
+
+function writePreferences(basePath: string, content: string): void {
+  const kataDir = join(basePath, ".kata");
+  mkdirSync(kataDir, { recursive: true });
+  writeFileSync(join(kataDir, "preferences.md"), content, "utf-8");
+}
+
+/**
+ * Build a preferences.md with frontmatter containing the given linear block.
+ */
+function prefsWithLinear(linearYaml: string): string {
+  return `---\nversion: 1\nworkflow:\n  mode: linear\nlinear:\n${linearYaml}\n---\n`;
+}
+
+function makeMockCtx(overrides: {
+  hasUI?: boolean;
+  inputReturns?: Array<string | null>;
+} = {}): any {
+  const inputReturns = overrides.inputReturns ?? ["lin_api_test123"];
+  let inputCallIndex = 0;
+  const notifications: Array<{ message: string; level: string }> = [];
+
+  return {
+    hasUI: overrides.hasUI ?? true,
+    ui: {
+      input: vi.fn(async () => {
+        const value = inputReturns[inputCallIndex] ?? null;
+        inputCallIndex++;
+        return value;
+      }),
+      notify: vi.fn((message: string, level: string) => {
+        notifications.push({ message, level });
+      }),
+    },
+    _notifications: notifications,
+  };
+}
+
+function makeMockDeps(overrides: Partial<OnboardingDeps> = {}): OnboardingDeps {
+  const storedCreds: Record<string, any> = {};
+
+  return {
+    getAuthFilePath: () => "/tmp/fake-auth.json",
+    createAuthStorage: () => ({
+      set: (provider: string, cred: any) => {
+        storedCreds[provider] = cred;
+      },
+    }),
+    createLinearClient: () => ({
+      getViewer: async () => ({ id: "user-1", name: "Test User", email: "test@test.com" }),
+    }),
+    ensurePreferences: vi.fn(() => true),
+    ensureGitignore: vi.fn(() => true),
+    ...overrides,
+    _storedCreds: storedCreds,
+  } as any;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("onboarding", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    _resetSkipFlag();
+  });
+
+  afterEach(() => {
+    _setDeps(null);
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  // ─── isProjectConfigured ──────────────────────────────────────────────────
+
+  describe("isProjectConfigured", () => {
+    it("returns false when .kata/ does not exist", () => {
+      expect(isProjectConfigured(tmpDir)).toBe(false);
+    });
+
+    it("returns false when preferences exist but linear block is empty", () => {
+      writePreferences(tmpDir, prefsWithLinear("  {}"));
+      expect(isProjectConfigured(tmpDir)).toBe(false);
+    });
+
+    it("returns false when preferences exist but linear has no teamKey or projectSlug", () => {
+      writePreferences(tmpDir, prefsWithLinear("  projectId: some-uuid"));
+      expect(isProjectConfigured(tmpDir)).toBe(false);
+    });
+
+    it("returns true when preferences have linear.teamKey", () => {
+      writePreferences(tmpDir, prefsWithLinear("  teamKey: KAT"));
+      expect(isProjectConfigured(tmpDir)).toBe(true);
+    });
+
+    it("returns true when preferences have linear.projectSlug", () => {
+      writePreferences(tmpDir, prefsWithLinear("  projectSlug: abc123"));
+      expect(isProjectConfigured(tmpDir)).toBe(true);
+    });
+
+    it("returns true when preferences have both teamKey and projectSlug", () => {
+      writePreferences(tmpDir, prefsWithLinear("  teamKey: KAT\n  projectSlug: abc123"));
+      expect(isProjectConfigured(tmpDir)).toBe(true);
+    });
+  });
+
+  // ─── shouldSkipOnboarding / setSkipOnboarding ─────────────────────────────
+
+  describe("skip flag", () => {
+    it("defaults to false", () => {
+      expect(shouldSkipOnboarding()).toBe(false);
+    });
+
+    it("can be set to true", () => {
+      setSkipOnboarding(true);
+      expect(shouldSkipOnboarding()).toBe(true);
+    });
+
+    it("can be reset to false", () => {
+      setSkipOnboarding(true);
+      setSkipOnboarding(false);
+      expect(shouldSkipOnboarding()).toBe(false);
+    });
+
+    it("_resetSkipFlag resets to false", () => {
+      setSkipOnboarding(true);
+      _resetSkipFlag();
+      expect(shouldSkipOnboarding()).toBe(false);
+    });
+  });
+
+  // ─── runOnboarding ────────────────────────────────────────────────────────
+
+  describe("runOnboarding", () => {
+    it("returns 'skipped' with warning when ctx.hasUI is false", async () => {
+      const ctx = makeMockCtx({ hasUI: false });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const result = await runOnboarding(ctx);
+
+      expect(result).toBe("skipped");
+      expect(ctx.ui.input).not.toHaveBeenCalled();
+      expect(ctx.ui.notify).toHaveBeenCalledWith(
+        expect.stringContaining("interactive terminal"),
+        "warning",
+      );
+    });
+
+    it("returns 'completed' on valid API key", async () => {
+      const ctx = makeMockCtx({ inputReturns: ["lin_api_valid"] });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const savedCwd = process.cwd();
+      process.chdir(tmpDir);
+      try {
+        const result = await runOnboarding(ctx);
+
+        expect(result).toBe("completed");
+        expect(ctx.ui.input).toHaveBeenCalledOnce();
+        expect(deps.ensurePreferences).toHaveBeenCalledWith(tmpDir);
+        expect(deps.ensureGitignore).toHaveBeenCalledWith(tmpDir);
+        expect(process.env.LINEAR_API_KEY).toBe("lin_api_valid");
+        expect(ctx._notifications.some(
+          (n: any) => n.message.includes("✓") && n.level === "info",
+        )).toBe(true);
+      } finally {
+        process.chdir(savedCwd);
+        delete process.env.LINEAR_API_KEY;
+      }
+    });
+
+    it("returns 'skipped' on empty input", async () => {
+      const ctx = makeMockCtx({ inputReturns: [""] });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const result = await runOnboarding(ctx);
+
+      expect(result).toBe("skipped");
+      expect(deps.ensurePreferences).not.toHaveBeenCalled();
+    });
+
+    it("returns 'skipped' on null input", async () => {
+      const ctx = makeMockCtx({ inputReturns: [null] });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const result = await runOnboarding(ctx);
+
+      expect(result).toBe("skipped");
+    });
+
+    it("retries once on auth error then succeeds", async () => {
+      const ctx = makeMockCtx({
+        inputReturns: ["bad_key", "good_key"],
+      });
+      let callCount = 0;
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => {
+            callCount++;
+            if (callCount === 1) {
+              throw new Error("401 Unauthorized");
+            }
+            return { id: "user-1", name: "Test", email: "t@t.com" };
+          },
+        }),
+      });
+      _setDeps(deps);
+
+      const savedCwd = process.cwd();
+      process.chdir(tmpDir);
+      try {
+        const result = await runOnboarding(ctx);
+
+        expect(result).toBe("completed");
+        expect(ctx.ui.input).toHaveBeenCalledTimes(2);
+        expect(ctx._notifications.some(
+          (n: any) => n.message.includes("Invalid API key") && n.level === "error",
+        )).toBe(true);
+        expect(process.env.LINEAR_API_KEY).toBe("good_key");
+      } finally {
+        process.chdir(savedCwd);
+        delete process.env.LINEAR_API_KEY;
+      }
+    });
+
+    it("returns 'skipped' after two consecutive failures", async () => {
+      const ctx = makeMockCtx({
+        inputReturns: ["bad1", "bad2"],
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => {
+            throw new Error("401 Unauthorized");
+          },
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await runOnboarding(ctx);
+
+      expect(result).toBe("skipped");
+      expect(ctx.ui.input).toHaveBeenCalledTimes(2);
+      expect(ctx._notifications.some(
+        (n: any) => n.message.includes("cancelled") && n.level === "warning",
+      )).toBe(true);
+    });
+
+    it("shows network error message for non-auth errors", async () => {
+      const ctx = makeMockCtx({
+        inputReturns: ["key1", "key2"],
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => {
+            throw new Error("fetch failed: ENOTFOUND");
+          },
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await runOnboarding(ctx);
+
+      expect(result).toBe("skipped");
+      expect(ctx._notifications.some(
+        (n: any) => n.message.includes("Could not reach Linear API") && n.level === "error",
+      )).toBe(true);
+    });
+
+    it("stores credentials in auth storage", async () => {
+      const ctx = makeMockCtx({ inputReturns: ["lin_api_stored"] });
+      const storedCreds: Record<string, any> = {};
+      const deps = makeMockDeps({
+        createAuthStorage: () => ({
+          set: (provider: string, cred: any) => {
+            storedCreds[provider] = cred;
+          },
+        }),
+      });
+      _setDeps(deps);
+
+      const savedCwd = process.cwd();
+      process.chdir(tmpDir);
+      try {
+        await runOnboarding(ctx);
+
+        expect(storedCreds.linear).toEqual({
+          type: "api_key",
+          key: "lin_api_stored",
+        });
+      } finally {
+        process.chdir(savedCwd);
+        delete process.env.LINEAR_API_KEY;
+      }
+    });
+
+    it("returns 'skipped' if empty input after a failed attempt", async () => {
+      const ctx = makeMockCtx({
+        inputReturns: ["bad_key", ""],
+      });
+      let callCount = 0;
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => {
+            callCount++;
+            if (callCount === 1) {
+              throw new Error("401 Unauthorized");
+            }
+            return { id: "user-1", name: "Test", email: "t@t.com" };
+          },
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await runOnboarding(ctx);
+
+      expect(result).toBe("skipped");
+    });
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -88,14 +88,14 @@
     },
     "apps/cli": {
       "name": "@kata-sh/cli",
-      "version": "0.9.0",
+      "version": "0.12.1",
       "bin": {
         "kata": "dist/loader.js",
         "kata-cli": "dist/loader.js",
       },
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.63.1",
-        "@mariozechner/pi-tui": "^0.62.0",
+        "@mariozechner/pi-tui": "^0.63.1",
         "@sinclair/typebox": "^0.34.48",
         "js-yaml": "^4.1.1",
         "playwright": "^1.58.2",
@@ -789,7 +789,7 @@
 
     "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.63.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.63.1", "@mariozechner/pi-ai": "^0.63.1", "@mariozechner/pi-tui": "^0.63.1", "@silvia-odwyer/photon-node": "^0.3.4", "ajv": "^8.17.1", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-XSoMyLtuMA7ePK1UBWqSJ/BBdtBdJUHY9nbtnNyG6GeW7Gbgd+iqljIuwmAUf8wlYL981UIfYM/WIPQ6t/dIxw=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.62.0", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-/At11PPe8l319MnUoK4wN5L/uVCU6bDdiIUzH8Ez0stOkjSF6isRXScZ+RMM+6iCKsD4muBTX8Cmcif+3/UWHA=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.63.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-G5p+eh1EPkFCNaaggX6vRrqttnDscK6npgmEOknoCQXZtch8XNgh9Lf3VJ0A2lZXSgR7IntG5dfXHPH/Ki64wA=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -3737,8 +3737,6 @@
 
     "@mariozechner/pi-ai/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@mariozechner/pi-coding-agent/@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.63.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-G5p+eh1EPkFCNaaggX6vRrqttnDscK6npgmEOknoCQXZtch8XNgh9Lf3VJ0A2lZXSgR7IntG5dfXHPH/Ki64wA=="],
-
     "@mariozechner/pi-coding-agent/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "@mariozechner/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -4377,8 +4375,6 @@
 
     "@mariozechner/pi-ai/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@mariozechner/pi-coding-agent/@mariozechner/pi-tui/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "@mariozechner/pi-coding-agent/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@mariozechner/pi-tui/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
@@ -4716,8 +4712,6 @@
     "@humanwhocodes/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@kata/context/vitest/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
-
-    "@mariozechner/pi-coding-agent/@mariozechner/pi-tui/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "@sentry/node/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 


### PR DESCRIPTION
## Summary

Implements S01: Onboarding Wizard Core — when a user runs any `/kata` command in a project without `.kata/`, an interactive onboarding wizard collects LINEAR_API_KEY, creates `.kata/preferences.md` with minimal Linear config, and subsequent commands work without error.

## Changes

### New files
- **`apps/cli/src/resources/extensions/kata/onboarding.ts`** — Core onboarding module with:
  - `isProjectConfigured(basePath)` — checks `.kata/preferences.md` exists AND has `linear.teamKey` or `linear.projectSlug`
  - `runOnboarding(ctx)` — wizard flow: prompt for API key → validate via LinearClient.getViewer() (one retry) → store in auth.json → create .kata/ → hydrate process.env
  - `shouldSkipOnboarding()` / `setSkipOnboarding()` — session-scoped skip flag
  - Non-TTY guard (returns "skipped" with warning)
- **`apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts`** — 19 Vitest tests covering all paths

### Modified files
- **`apps/cli/src/resources/extensions/kata/commands.ts`** — Added `ensureOnboarding()` gate before `createBackend` for: bare `/kata`, `/kata step`, `auto`, `queue`, `discuss`, `plan`. `prefs`, `pr`, `status`, `stop` bypass the gate.
- **`apps/cli/src/resources/extensions/kata/guided-flow.ts`** — Added onboarding guard at top of `showSmartEntry()`

## Testing

- `npx vitest run -- --grep "onboarding"` — 19/19 tests pass
- `npx tsc --noEmit` — clean
- `bun run lint` — 0 errors (335 pre-existing warnings)
- Full test suite — 243 vitest + 51 bun tests pass

## Linear

Closes KAT-1640
Tasks: KAT-1641, KAT-1642, KAT-1643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added guided onboarding flow for kata commands that prompts first-time users to configure their project setup.
  * Integrated Linear API authentication during onboarding with key validation and retry support.
  * Added session-level option to skip onboarding and continue without configuration.

* **Tests**
  * Added comprehensive test coverage for onboarding functionality and configuration detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the onboarding wizard (S01: Onboarding Wizard Core) for Kata's project setup flow. When a user runs any gated `/kata` command in a project without `.kata/preferences.md`, an interactive wizard collects a `LINEAR_API_KEY`, validates it against the Linear API (with one retry), stores it in `auth.json`, and creates `.kata/preferences.md` from the template. The implementation fits neatly into the existing extension architecture using dependency injection (`_setDeps`) for testability and a session-scoped module-level skip flag.

Key changes:
- **`onboarding.ts`** — New wizard module; clean DI pattern; 19 unit tests cover all paths.
- **`commands.ts`** — `ensureOnboarding()` gate added before all Linear-dependent subcommands; `prefs`, `pr`, `status`, and `stop` correctly bypass it.
- **`guided-flow.ts`** — Safety-net guard added to `showSmartEntry()`; however, both branches of the `shouldSkipOnboarding()` check are identical, making the condition dead code.
- Minor: the success notification `\"✓ Linear API key saved. .kata/ created.\"` is shown even when `ensurePreferences` throws (error path only). `runOnboarding` also captures `basePath` from `process.cwd()` internally rather than accepting it as a parameter, requiring `process.chdir()` in tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/cleanup issues with no impact on the primary onboarding flow.

All four findings are P2: duplicate branch logic (dead code), a misleading success message in an error-only path, an internal process.cwd() coupling, and unused test imports. None affect the happy path or introduce data loss/security risk. The 19-test suite covers all branches and passes cleanly.

guided-flow.ts (dead-code branch) and onboarding.ts (success message accuracy in error path).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/onboarding.ts | New onboarding wizard: prompts for LINEAR_API_KEY, validates via LinearClient.getViewer(), stores in auth.json, creates .kata/preferences.md; DI pattern enables clean unit testing; minor issues with internal basePath capture and potentially misleading success message. |
| apps/cli/src/resources/extensions/kata/commands.ts | Added ensureOnboarding() gate before createBackend for auto/queue/discuss/plan/bare-kata/step; prefs/pr/status/stop correctly bypass the gate; implementation is straightforward and consistent. |
| apps/cli/src/resources/extensions/kata/guided-flow.ts | Added onboarding guard at top of showSmartEntry(); both branches of the shouldSkipOnboarding() check execute identical code, making the condition dead code — can be simplified. |
| apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts | 19 Vitest tests covering all paths (isProjectConfigured, skip flag, wizard success/failure/retry/abort); good use of injectable deps and mock ctx; two unused imports (existsSync, readFileSync). |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant cmd as commands.ts
    participant ob as onboarding.ts
    participant Linear as Linear API
    participant Auth as auth.json
    participant FS as .kata/preferences.md

    User->>cmd: /kata [auto|queue|discuss|plan|step]
    cmd->>ob: isProjectConfigured(basePath)
    alt configured
        ob-->>cmd: true - proceed normally
    else not configured
        alt shouldSkipOnboarding true
            cmd-->>User: return no action
        else not skipped
            cmd->>User: showNextAction Setup or Skip
            alt User chooses Setup
                cmd->>ob: runOnboarding(ctx)
                ob->>User: prompt LINEAR_API_KEY up to 2 attempts
                User-->>ob: API key
                ob->>Linear: getViewer()
                alt valid key
                    Linear-->>ob: viewer info
                    ob->>Auth: set linear api_key
                    ob->>FS: ensurePreferences + ensureGitignore
                    ob-->>cmd: completed
                else invalid or unreachable
                    Linear-->>ob: error
                    ob-->>User: notify error retry if attempt lt 2
                    ob-->>cmd: skipped
                end
            else User chooses Skip
                cmd->>ob: setSkipOnboarding true
                cmd-->>User: return no action
            end
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/guided-flow.ts
Line: 873-882

Comment:
**Duplicate branch logic — both paths are identical**

Both the `shouldSkipOnboarding() === true` branch and the fallthrough branch execute the exact same `ctx.ui.notify(...)` and `return` — the `if` condition is effectively dead code. Since the comment acknowledges that "the caller should have already handled the prompt" regardless of the skip state, there is no behavioral difference between the two paths. The condition can be removed:

```suggestion
  // Onboarding guard: if unconfigured, show a brief message and return.
  // commands.ts is the authoritative entry point for triggering the wizard.
  if (!isProjectConfigured(basePath)) {
    ctx.ui.notify("Run /kata to set up Linear integration.", "info");
    return;
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/onboarding.ts
Line: 206-218

Comment:
**Success message may be misleading when `ensurePreferences` throws**

If `deps.ensurePreferences(basePath)` (or `ensureGitignore`) throws, the error is caught and a failure notification is shown, but execution continues to line 218 where `"✓ Linear API key saved. .kata/ created."` is still displayed. The `.kata/preferences.md` may not actually have been created, so the `.kata/ created` portion is inaccurate. On the next command invocation `isProjectConfigured` will return `false` (no preferences file → gate triggers again), creating a confusing loop despite the apparent success message.

Consider tracking whether `ensurePreferences` succeeded and adjusting the notification text accordingly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/onboarding.ts
Line: 117-131

Comment:
**`basePath` captured from `process.cwd()` internally rather than accepted as a parameter**

`ensureOnboarding` in `commands.ts` accepts and validates `basePath` (always `process.cwd()` in practice), then calls `runOnboarding(ctx)` without forwarding that path. Inside `runOnboarding`, `basePath` is re-captured via `process.cwd()`. While the two values are identical today, this prevents calling `runOnboarding` with a specific project path — which is why tests must `process.chdir(tmpDir)` rather than simply passing the temp directory as an argument.

Consider accepting `basePath` as an explicit parameter with a default:

```typescript
export async function runOnboarding(
  ctx: ExtensionCommandContext,
  basePath: string = process.cwd(),
): Promise<OnboardingResult> {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
Line: 1-2

Comment:
**Unused imports `existsSync` and `readFileSync`**

`existsSync` and `readFileSync` are imported but never referenced in the test file.

```suggestion
import { mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(kata): add onboarding wizard for pr..."](https://github.com/gannonh/kata/commit/bdaa0b8736a4d951af2383f99c440c794b60d116) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26675304)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->