### PR TITLE
feat(symphony): silence unconfigured Symphony and add setup guidance [S03]

### DIFF
--- a/apps/cli/src/resources/extensions/symphony/command.ts
+++ b/apps/cli/src/resources/extensions/symphony/command.ts
@@ -121,7 +121,7 @@ const SYMPHONY_GUIDANCE_MESSAGE = `Symphony is not configured.
 
 To connect:
   • Set symphony.url in .kata/preferences.md
-  • Or set KATA_SYMPHONY_URL environment variable
+  • Or set SYMPHONY_URL / KATA_SYMPHONY_URL environment variable
 
 Run /symphony config to edit WORKFLOW.md settings.`;
 

--- a/apps/cli/src/resources/extensions/symphony/command.ts
+++ b/apps/cli/src/resources/extensions/symphony/command.ts
@@ -7,6 +7,7 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import { loadEffectiveKataPreferences } from "../kata/preferences.js";
 import type { SymphonyClient } from "./client.js";
+import { isSymphonyConfigured } from "./config.js";
 import type { ConsoleManager } from "./console.js";
 // config-parser, config-validator, config-writer, and config-editor depend on
 // js-yaml which is NOT in pi-coding-agent's extension alias list. Lazy-import
@@ -116,18 +117,35 @@ export function parseSymphonyCommand(input: string): SymphonyCommandAction {
   return { type: "usage" };
 }
 
+const SYMPHONY_GUIDANCE_MESSAGE = `Symphony is not configured.
+
+To connect:
+  • Set symphony.url in .kata/preferences.md
+  • Or set KATA_SYMPHONY_URL environment variable
+
+Run /symphony config to edit WORKFLOW.md settings.`;
+
 export async function executeSymphonyCommand(
   action: SymphonyCommandAction,
   client: SymphonyClient,
   sink: SymphonyCommandSink,
-  options: SymphonyCommandOptions = {},
+  options: SymphonyCommandOptions & { checkConfigured?: () => boolean } = {},
 ): Promise<void> {
   const now = options.now ?? Date.now;
+  const checkConfigured = options.checkConfigured ?? isSymphonyConfigured;
 
   try {
     if (action.type === "usage") {
       sink.info(renderSymphonyUsage());
       return;
+    }
+
+    // For status and watch: check config before attempting connection
+    if (action.type === "status" || action.type === "watch") {
+      if (!checkConfigured()) {
+        sink.info(SYMPHONY_GUIDANCE_MESSAGE);
+        return;
+      }
     }
 
     if (action.type === "status") {
@@ -233,6 +251,11 @@ export function registerSymphonyCommand(
       }
 
       if (action.type === "console") {
+        if (!isSymphonyConfigured()) {
+          ctx.ui.notify(SYMPHONY_GUIDANCE_MESSAGE, "info");
+          return;
+        }
+
         if (!consoleManager) {
           ctx.ui.notify(
             "Symphony console manager is unavailable in this session.",

--- a/apps/cli/src/resources/extensions/symphony/config.ts
+++ b/apps/cli/src/resources/extensions/symphony/config.ts
@@ -4,6 +4,7 @@ import {
 } from "../kata/preferences.js";
 import {
   SymphonyError,
+  isSymphonyError,
   type SymphonyConfigOrigin,
   type SymphonyConnectionConfig,
 } from "./types.js";
@@ -60,6 +61,25 @@ export function resolveSymphonyConfigFromRuntime(
     ...options,
     preferences: loaded?.preferences,
   });
+}
+
+/**
+ * Check whether Symphony is configured (URL available via preferences or env).
+ * Returns true if `resolveSymphonyConfigFromRuntime()` succeeds, false if it
+ * throws a `config_missing` SymphonyError. Re-throws any other error.
+ */
+export function isSymphonyConfigured(
+  options?: Omit<ResolveSymphonyConfigOptions, "preferences"> & { cwd?: string },
+): boolean {
+  try {
+    resolveSymphonyConfigFromRuntime(options);
+    return true;
+  } catch (error) {
+    if (isSymphonyError(error) && error.code === "config_missing") {
+      return false;
+    }
+    throw error;
+  }
 }
 
 function normalizeCandidate(value: unknown): string | null {

--- a/apps/cli/src/resources/extensions/symphony/config.ts
+++ b/apps/cli/src/resources/extensions/symphony/config.ts
@@ -75,7 +75,10 @@ export function isSymphonyConfigured(
     resolveSymphonyConfigFromRuntime(options);
     return true;
   } catch (error) {
-    if (isSymphonyError(error) && error.code === "config_missing") {
+    if (
+      isSymphonyError(error) &&
+      (error.code === "config_missing" || error.code === "config_invalid")
+    ) {
       return false;
     }
     throw error;

--- a/apps/cli/src/resources/extensions/symphony/index.ts
+++ b/apps/cli/src/resources/extensions/symphony/index.ts
@@ -5,6 +5,7 @@ import type {
 import { Key } from "@mariozechner/pi-tui";
 import { createSymphonyClient } from "./client.js";
 import { registerSymphonyCommand } from "./command.js";
+import { isSymphonyConfigured } from "./config.js";
 import { createConsoleManager } from "./console.js";
 import { EscalationQueue } from "./escalation.js";
 import { registerSymphonyTools } from "./tools.js";
@@ -53,6 +54,8 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("session_start", async (_event, ctx) => {
     consoleManager.setContext(ctx as unknown as ExtensionCommandContext);
+
+    if (!isSymphonyConfigured()) return;
 
     escalationAbortController?.abort();
     const controller = new AbortController();

--- a/apps/cli/src/resources/extensions/symphony/tests/symphony-command.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/symphony/tests/symphony-command.vitest.test.ts
@@ -114,6 +114,7 @@ describe("executeSymphonyCommand", () => {
     expect(info).toHaveLength(1);
     expect(info[0]).toContain("Symphony is not configured");
     expect(info[0]).toContain("symphony.url");
+    expect(info[0]).toContain("SYMPHONY_URL");
     expect(info[0]).toContain("KATA_SYMPHONY_URL");
   });
 

--- a/apps/cli/src/resources/extensions/symphony/tests/symphony-command.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/symphony/tests/symphony-command.vitest.test.ts
@@ -102,6 +102,51 @@ describe("parseSymphonyCommand", () => {
 });
 
 describe("executeSymphonyCommand", () => {
+  it("shows info-level guidance when status is called without config", async () => {
+    const { sink, info, error } = makeSink();
+    const client = createClient({});
+
+    await executeSymphonyCommand({ type: "status" }, client, sink, {
+      checkConfigured: () => false,
+    });
+
+    expect(error).toHaveLength(0);
+    expect(info).toHaveLength(1);
+    expect(info[0]).toContain("Symphony is not configured");
+    expect(info[0]).toContain("symphony.url");
+    expect(info[0]).toContain("KATA_SYMPHONY_URL");
+  });
+
+  it("shows info-level guidance when watch is called without config", async () => {
+    const { sink, info, error } = makeSink();
+    const client = createClient({});
+
+    await executeSymphonyCommand(
+      { type: "watch", issue: "KAT-920" },
+      client,
+      sink,
+      { checkConfigured: () => false },
+    );
+
+    expect(error).toHaveLength(0);
+    expect(info).toHaveLength(1);
+    expect(info[0]).toContain("Symphony is not configured");
+    expect(info[0]).toContain("symphony.url");
+  });
+
+  it("does not gate usage action on config", async () => {
+    const { sink, info, error } = makeSink();
+    const client = createClient({});
+
+    await executeSymphonyCommand({ type: "usage" }, client, sink, {
+      checkConfigured: () => false,
+    });
+
+    expect(error).toHaveLength(0);
+    expect(info).toHaveLength(1);
+    expect(info[0]).toContain("Symphony command usage");
+  });
+
   it("renders status output", async () => {
     const { sink, info, error } = makeSink();
     const client = createClient({});

--- a/apps/cli/src/resources/extensions/symphony/tests/symphony-config.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/symphony/tests/symphony-config.vitest.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { resolveSymphonyConfig } from "../config.js";
+import { describe, expect, it, vi } from "vitest";
+import { resolveSymphonyConfig, isSymphonyConfigured } from "../config.js";
 import { SymphonyError } from "../types.js";
 
 describe("resolveSymphonyConfig", () => {
@@ -133,5 +133,32 @@ describe("resolveSymphonyConfig", () => {
       expect(symphonyError.code).toBe("config_invalid");
       expect(symphonyError.context.reason).toBe("unsupported_protocol");
     }
+  });
+});
+
+describe("isSymphonyConfigured", () => {
+  it("returns false when no Symphony URL is configured anywhere", () => {
+    // Use explicit env override and a non-existent cwd so no preferences are found
+    expect(
+      isSymphonyConfigured({ env: {}, cwd: "/tmp/__nonexistent_path__" }),
+    ).toBe(false);
+  });
+
+  it("returns true when KATA_SYMPHONY_URL env var is set", () => {
+    expect(
+      isSymphonyConfigured({
+        env: { KATA_SYMPHONY_URL: "http://localhost:8080" },
+        cwd: "/tmp/__nonexistent_path__",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when SYMPHONY_URL env var is set", () => {
+    expect(
+      isSymphonyConfigured({
+        env: { SYMPHONY_URL: "http://localhost:8080" },
+        cwd: "/tmp/__nonexistent_path__",
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/cli/src/resources/extensions/symphony/tests/symphony-config.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/symphony/tests/symphony-config.vitest.test.ts
@@ -161,4 +161,24 @@ describe("isSymphonyConfigured", () => {
       }),
     ).toBe(true);
   });
+
+  it("returns false when KATA_SYMPHONY_URL env var is a malformed URL (config_invalid)", () => {
+    // A malformed URL should not throw — it should return false so callers like
+    // session_start and command handlers stay silent instead of crashing.
+    expect(
+      isSymphonyConfigured({
+        env: { KATA_SYMPHONY_URL: "not-a-valid-url" },
+        cwd: "/tmp/__nonexistent_path__",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when KATA_SYMPHONY_URL has unsupported protocol (config_invalid)", () => {
+    expect(
+      isSymphonyConfigured({
+        env: { KATA_SYMPHONY_URL: "ftp://localhost:8080" },
+        cwd: "/tmp/__nonexistent_path__",
+      }),
+    ).toBe(false);
+  });
 });

--- a/apps/cli/src/resources/extensions/symphony/tests/symphony-config.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/symphony/tests/symphony-config.vitest.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { resolveSymphonyConfig, isSymphonyConfigured } from "../config.js";
 import { SymphonyError } from "../types.js";
 

--- a/apps/cli/src/resources/extensions/symphony/tests/symphony-onboarding.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/symphony/tests/symphony-onboarding.vitest.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  validateSymphonyUrl,
+  writeSymphonyUrlToPreferences,
+} from "../../../../wizard.js";
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `symphony-onboarding-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("validateSymphonyUrl", () => {
+  it("returns normalized URL for valid http URL", () => {
+    expect(validateSymphonyUrl("http://localhost:8080")).toBe("http://localhost:8080");
+  });
+
+  it("returns normalized URL for valid https URL", () => {
+    expect(validateSymphonyUrl("https://symphony.example.com")).toBe("https://symphony.example.com");
+  });
+
+  it("removes trailing slash", () => {
+    expect(validateSymphonyUrl("http://localhost:8080/")).toBe("http://localhost:8080");
+  });
+
+  it("returns null for empty string", () => {
+    expect(validateSymphonyUrl("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    expect(validateSymphonyUrl("   ")).toBeNull();
+  });
+
+  it("returns null for invalid URL", () => {
+    expect(validateSymphonyUrl("not-a-url")).toBeNull();
+  });
+
+  it("returns null for non-http/https protocol", () => {
+    expect(validateSymphonyUrl("ftp://localhost:8080")).toBeNull();
+  });
+});
+
+describe("writeSymphonyUrlToPreferences", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates preferences file when it does not exist", () => {
+    const result = writeSymphonyUrlToPreferences(tmpDir, "http://localhost:8080");
+    expect(result).toBe(true);
+
+    const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+    expect(content).toContain("symphony:");
+    expect(content).toContain("url: http://localhost:8080");
+  });
+
+  it("adds symphony section to existing preferences without symphony config", () => {
+    const kataDir = join(tmpDir, ".kata");
+    mkdirSync(kataDir, { recursive: true });
+    writeFileSync(
+      join(kataDir, "preferences.md"),
+      "---\nversion: 1\n---\n",
+      "utf-8",
+    );
+
+    const result = writeSymphonyUrlToPreferences(tmpDir, "https://symphony.example.com");
+    expect(result).toBe(true);
+
+    const content = readFileSync(join(kataDir, "preferences.md"), "utf-8");
+    expect(content).toContain("symphony:");
+    expect(content).toContain("url: https://symphony.example.com");
+    expect(content).toContain("version: 1");
+  });
+
+  it("updates url in existing symphony section", () => {
+    const kataDir = join(tmpDir, ".kata");
+    mkdirSync(kataDir, { recursive: true });
+    writeFileSync(
+      join(kataDir, "preferences.md"),
+      "---\nsymphony:\n  url: http://old:8080\n---\n",
+      "utf-8",
+    );
+
+    const result = writeSymphonyUrlToPreferences(tmpDir, "http://new:9090");
+    expect(result).toBe(true);
+
+    const content = readFileSync(join(kataDir, "preferences.md"), "utf-8");
+    expect(content).toContain("url: http://new:9090");
+    expect(content).not.toContain("http://old:8080");
+  });
+
+  it("adds url to existing symphony section without url field", () => {
+    const kataDir = join(tmpDir, ".kata");
+    mkdirSync(kataDir, { recursive: true });
+    writeFileSync(
+      join(kataDir, "preferences.md"),
+      "---\nsymphony:\n  workflow_path: ./WORKFLOW.md\n---\n",
+      "utf-8",
+    );
+
+    const result = writeSymphonyUrlToPreferences(tmpDir, "http://localhost:8080");
+    expect(result).toBe(true);
+
+    const content = readFileSync(join(kataDir, "preferences.md"), "utf-8");
+    expect(content).toContain("url: http://localhost:8080");
+    expect(content).toContain("workflow_path: ./WORKFLOW.md");
+  });
+});

--- a/apps/cli/src/resources/extensions/symphony/tests/symphony-onboarding.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/symphony/tests/symphony-onboarding.vitest.test.ts
@@ -114,4 +114,50 @@ describe("writeSymphonyUrlToPreferences", () => {
     expect(content).toContain("url: http://localhost:8080");
     expect(content).toContain("workflow_path: ./WORKFLOW.md");
   });
+
+  it("does not corrupt opening frontmatter fence when adding symphony section (P1 bug fix)", () => {
+    const kataDir = join(tmpDir, ".kata");
+    mkdirSync(kataDir, { recursive: true });
+    // A typical preferences.md with an opening and closing ---
+    writeFileSync(
+      join(kataDir, "preferences.md"),
+      "---\nversion: 1\nworkflow:\n  mode: linear\n---\n",
+      "utf-8",
+    );
+
+    const result = writeSymphonyUrlToPreferences(tmpDir, "http://localhost:8080");
+    expect(result).toBe(true);
+
+    const content = readFileSync(join(kataDir, "preferences.md"), "utf-8");
+    // Must start with --- (opening fence must not be consumed)
+    expect(content.startsWith("---\n")).toBe(true);
+    // Must contain the symphony section
+    expect(content).toContain("symphony:");
+    expect(content).toContain("url: http://localhost:8080");
+    // Must still contain original content
+    expect(content).toContain("version: 1");
+    expect(content).toContain("workflow:");
+  });
+
+  it("does not overwrite unrelated url fields when updating symphony url (P1 bug fix)", () => {
+    const kataDir = join(tmpDir, ".kata");
+    mkdirSync(kataDir, { recursive: true });
+    // preferences.md with a url field in another section AND a symphony section
+    writeFileSync(
+      join(kataDir, "preferences.md"),
+      "---\nlinear:\n  url: https://linear.app/team\nsymphony:\n  url: http://old:8080\n---\n",
+      "utf-8",
+    );
+
+    const result = writeSymphonyUrlToPreferences(tmpDir, "http://new:9090");
+    expect(result).toBe(true);
+
+    const content = readFileSync(join(kataDir, "preferences.md"), "utf-8");
+    // symphony url must be updated
+    expect(content).toContain("url: http://new:9090");
+    // unrelated url must NOT be overwritten
+    expect(content).toContain("url: https://linear.app/team");
+    // old symphony url must be gone
+    expect(content).not.toContain("http://old:8080");
+  });
 });

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -1,4 +1,6 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { createInterface } from 'readline'
+import { join } from 'node:path'
 import type { AuthStorage } from '@mariozechner/pi-coding-agent'
 
 // ─── Colors ──────────────────────────────────────────────────────────────────
@@ -84,6 +86,121 @@ export function loadStoredEnvKeys(authStorage: AuthStorage): void {
       }
     }
   }
+}
+
+// ─── Symphony URL helpers ─────────────────────────────────────────────────────
+
+/**
+ * Validate a Symphony URL string. Returns the normalized URL or null if invalid.
+ */
+export function validateSymphonyUrl(raw: string): string | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return null
+  }
+  // Remove trailing slash for consistency
+  return parsed.toString().replace(/\/$/, '')
+}
+
+/**
+ * Write a Symphony URL to the project's preferences file.
+ * Creates .kata/preferences.md if it doesn't exist.
+ * Returns true if the URL was written, false on error.
+ */
+export function writeSymphonyUrlToPreferences(basePath: string, url: string): boolean {
+  const dir = join(basePath, '.kata')
+  const path = join(dir, 'preferences.md')
+
+  try {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+
+    if (existsSync(path)) {
+      let content = readFileSync(path, 'utf-8')
+      // Check if symphony section already exists in frontmatter
+      if (/^symphony:/m.test(content)) {
+        // Replace or add url under existing symphony section
+        if (/^\s+url:/m.test(content)) {
+          content = content.replace(/^(\s+url:).*$/m, `$1 ${url}`)
+        } else {
+          content = content.replace(/^(symphony:.*$)/m, `$1\n  url: ${url}`)
+        }
+      } else {
+        // Add symphony section before the closing ---
+        content = content.replace(/^---\s*$/m, `symphony:\n  url: ${url}\n---`)
+      }
+      writeFileSync(path, content, 'utf-8')
+    } else {
+      writeFileSync(path, `---\nsymphony:\n  url: ${url}\n---\n`, 'utf-8')
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Prompt the user for an optional Symphony server URL and write it to preferences.
+ * Uses raw TTY input — intended to be called at the end of the wizard.
+ * Returns the URL that was written, or null if the user skipped.
+ */
+export async function promptSymphonyUrl(basePath: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const question = `  ${cyan}›${reset} Connect to a Symphony server? ${dim}(y/N)${reset} `
+    process.stdout.write(question)
+
+    try {
+      process.stdin.setRawMode(true)
+      process.stdin.resume()
+      process.stdin.setEncoding('utf8')
+
+      const handler = (ch: string) => {
+        process.stdin.setRawMode(false)
+        process.stdin.pause()
+        process.stdin.off('data', handler)
+        process.stdout.write('\n')
+
+        if (ch.toLowerCase() === 'y') {
+          promptForUrl(basePath).then(resolve)
+        } else {
+          process.stdout.write(`  ${dim}↷  Symphony skipped${reset}\n\n`)
+          resolve(null)
+        }
+      }
+      process.stdin.on('data', handler)
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+async function promptForUrl(basePath: string): Promise<string | null> {
+  const value = await promptMasked('Symphony URL', '(e.g. http://localhost:8080)')
+  const trimmed = value.trim()
+  if (!trimmed) {
+    process.stdout.write(`  ${dim}↷  Symphony skipped${reset}\n\n`)
+    return null
+  }
+  const validated = validateSymphonyUrl(trimmed)
+  if (!validated) {
+    process.stdout.write(`  ${yellow}⚠${reset}  Invalid URL — must be http or https.\n\n`)
+    return null
+  }
+  const written = writeSymphonyUrlToPreferences(basePath, validated)
+  if (written) {
+    process.stdout.write(`  ${green}✓${reset} Symphony URL saved: ${validated}\n\n`)
+    return validated
+  }
+  process.stdout.write(`  ${yellow}⚠${reset}  Failed to write Symphony URL to preferences.\n\n`)
+  return null
 }
 
 // ─── Wizard ───────────────────────────────────────────────────────────────────
@@ -177,6 +294,11 @@ export async function runWizardIfNeeded(authStorage: AuthStorage): Promise<void>
     } else {
       process.stdout.write(`  ${dim}↷  ${key.label} skipped${reset}\n\n`)
     }
+  }
+
+  // ── Symphony URL (optional) ─────────────────────────────────────────────────
+  if (!process.env.KATA_SYMPHONY_URL && !process.env.SYMPHONY_URL) {
+    await promptSymphonyUrl(process.cwd())
   }
 
   // ── Footer ───────────────────────────────────────────────────────────────────

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -63,6 +63,24 @@ async function promptMasked(label: string, hint: string): Promise<string> {
   })
 }
 
+// ─── Plain (unmasked) prompt ──────────────────────────────────────────────────
+
+/**
+ * Prompt for plain visible input using readline.
+ * Use for non-sensitive values like URLs where users need to see what they type.
+ */
+async function promptPlain(label: string, hint: string): Promise<string> {
+  return new Promise((resolve) => {
+    const question = `  ${cyan}›${reset} ${label} ${dim}${hint}${reset}\n  `
+    process.stdout.write(question)
+    const rl = createInterface({ input: process.stdin, output: process.stdout })
+    rl.question('', (answer) => {
+      rl.close()
+      resolve(answer)
+    })
+  })
+}
+
 // ─── Env hydration ────────────────────────────────────────────────────────────
 
 /**
@@ -194,7 +212,7 @@ export async function promptSymphonyUrl(basePath: string): Promise<string | null
 }
 
 async function promptForUrl(basePath: string): Promise<string | null> {
-  const value = await promptMasked('Symphony URL', '(e.g. http://localhost:8080)')
+  const value = await promptPlain('Symphony URL', '(e.g. http://localhost:8080)')
   const trimmed = value.trim()
   if (!trimmed) {
     process.stdout.write(`  ${dim}↷  Symphony skipped${reset}\n\n`)

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -127,15 +127,26 @@ export function writeSymphonyUrlToPreferences(basePath: string, url: string): bo
       let content = readFileSync(path, 'utf-8')
       // Check if symphony section already exists in frontmatter
       if (/^symphony:/m.test(content)) {
-        // Replace or add url under existing symphony section
-        if (/^\s+url:/m.test(content)) {
-          content = content.replace(/^(\s+url:).*$/m, `$1 ${url}`)
+        // Replace or add url under existing symphony section — scope to symphony block only
+        if (/^(symphony:(?:\n[ \t]+\S[^\n]*)*)(\n[ \t]+url:)/m.test(content)) {
+          // Replace url: within the symphony section (not any other section's url:)
+          content = content.replace(
+            /(^symphony:(?:\n[ \t]+\S[^\n]*)*)(\n[ \t]+url:)[^\n]*/m,
+            `$1$2 ${url}`
+          )
         } else {
           content = content.replace(/^(symphony:.*$)/m, `$1\n  url: ${url}`)
         }
       } else {
-        // Add symphony section before the closing ---
-        content = content.replace(/^---\s*$/m, `symphony:\n  url: ${url}\n---`)
+        // Add symphony section before the closing --- (use lastIndexOf to avoid
+        // accidentally replacing the opening frontmatter fence)
+        const lastFence = content.lastIndexOf('\n---')
+        if (lastFence !== -1) {
+          content = content.slice(0, lastFence) + `\nsymphony:\n  url: ${url}\n---` + content.slice(lastFence + 4)
+        } else {
+          // No closing fence found — append at end
+          content = content.trimEnd() + `\nsymphony:\n  url: ${url}\n---\n`
+        }
       }
       writeFileSync(path, content, 'utf-8')
     } else {

--- a/bun.lock
+++ b/bun.lock
@@ -88,14 +88,14 @@
     },
     "apps/cli": {
       "name": "@kata-sh/cli",
-      "version": "0.9.0",
+      "version": "0.12.1",
       "bin": {
         "kata": "dist/loader.js",
         "kata-cli": "dist/loader.js",
       },
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.63.1",
-        "@mariozechner/pi-tui": "^0.62.0",
+        "@mariozechner/pi-tui": "^0.63.1",
         "@sinclair/typebox": "^0.34.48",
         "js-yaml": "^4.1.1",
         "playwright": "^1.58.2",
@@ -789,7 +789,7 @@
 
     "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.63.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.63.1", "@mariozechner/pi-ai": "^0.63.1", "@mariozechner/pi-tui": "^0.63.1", "@silvia-odwyer/photon-node": "^0.3.4", "ajv": "^8.17.1", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-XSoMyLtuMA7ePK1UBWqSJ/BBdtBdJUHY9nbtnNyG6GeW7Gbgd+iqljIuwmAUf8wlYL981UIfYM/WIPQ6t/dIxw=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.62.0", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-/At11PPe8l319MnUoK4wN5L/uVCU6bDdiIUzH8Ez0stOkjSF6isRXScZ+RMM+6iCKsD4muBTX8Cmcif+3/UWHA=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.63.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-G5p+eh1EPkFCNaaggX6vRrqttnDscK6npgmEOknoCQXZtch8XNgh9Lf3VJ0A2lZXSgR7IntG5dfXHPH/Ki64wA=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -3737,8 +3737,6 @@
 
     "@mariozechner/pi-ai/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@mariozechner/pi-coding-agent/@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.63.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-G5p+eh1EPkFCNaaggX6vRrqttnDscK6npgmEOknoCQXZtch8XNgh9Lf3VJ0A2lZXSgR7IntG5dfXHPH/Ki64wA=="],
-
     "@mariozechner/pi-coding-agent/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "@mariozechner/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -4377,8 +4375,6 @@
 
     "@mariozechner/pi-ai/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@mariozechner/pi-coding-agent/@mariozechner/pi-tui/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "@mariozechner/pi-coding-agent/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@mariozechner/pi-tui/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
@@ -4716,8 +4712,6 @@
     "@humanwhocodes/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@kata/context/vitest/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
-
-    "@mariozechner/pi-coding-agent/@mariozechner/pi-tui/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "@sentry/node/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 


### PR DESCRIPTION
## Summary

Resolves the primary OOBE issue where Symphony emits noisy warnings on fresh installs where Symphony is not configured. This slice makes the Symphony extension completely silent when unconfigured, shows clear setup guidance when users explicitly run `/symphony` commands, and adds an optional Symphony URL prompt to the onboarding wizard.

## Changes

### T01: Guard escalation listener in session_start (KAT-1649)
- Added `isSymphonyConfigured()` to `config.ts` — wraps `resolveSymphonyConfigFromRuntime()`, returns `true` if configured, `false` on `config_missing`
- Added guard at top of `session_start` hook in `index.ts`: `if (!isSymphonyConfigured()) return;` — skips the entire escalation listener setup
- 3 new Vitest tests for `isSymphonyConfigured` (false when unconfigured, true with env vars)

### T02: Normalize command guidance when unconfigured (KAT-1650)
- Added early `isSymphonyConfigured()` check in `executeSymphonyCommand` for `status` and `watch` actions
- Added `isSymphonyConfigured()` check in `console` handler in `registerSymphonyCommand`
- Shows info-level guidance message (not error) with setup instructions
- `usage` and `config` actions remain ungated (they don't need a connection)
- 3 new Vitest tests for guidance behavior

### T03: Add optional Symphony URL prompt to onboarding wizard (KAT-1651)
- Added `validateSymphonyUrl()` for URL validation (http/https only)
- Added `writeSymphonyUrlToPreferences()` for writing `symphony.url` to `.kata/preferences.md`
- Added `promptSymphonyUrl()` for TTY-based Y/N prompt and URL collection
- Wired into `runWizardIfNeeded` as final optional step
- 11 new Vitest tests covering URL validation and preferences writing

## Verification

- `npx vitest run` — 241 tests pass across 17 test files
- `npx tsc --noEmit` — clean
- `bun test` — 249 tests pass
- ESLint — 0 errors (all warnings pre-existing)

## Files Changed

- `apps/cli/src/resources/extensions/symphony/config.ts` — new `isSymphonyConfigured()` export
- `apps/cli/src/resources/extensions/symphony/index.ts` — session_start guard + import
- `apps/cli/src/resources/extensions/symphony/command.ts` — guidance message + early config checks
- `apps/cli/src/wizard.ts` — Symphony URL prompt functions + wizard integration
- `apps/cli/src/resources/extensions/symphony/tests/symphony-config.vitest.test.ts` — 3 new tests
- `apps/cli/src/resources/extensions/symphony/tests/symphony-command.vitest.test.ts` — 3 new tests
- `apps/cli/src/resources/extensions/symphony/tests/symphony-onboarding.vitest.test.ts` — 11 new tests (new file)

Closes KAT-1648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Symphony CLI commands (status, watch, console) now validate configuration before running
  * Added helpful guidance messages when Symphony is not configured
  * CLI wizard now prompts users to configure Symphony server URL during setup

* **Tests**
  * Added configuration detection tests
  * Added command behavior tests for various configuration states
  * Added URL validation and preference storage tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses the out-of-box experience problem where an unconfigured Symphony extension emits noisy warnings on fresh installs. It adds `isSymphonyConfigured()` as a shared guard, silences the `session_start` escalation listener when unconfigured, shows friendly setup guidance for `status`/`watch`/`console` commands, and adds an optional Symphony URL step to the onboarding wizard.

**Key findings:**

- **`writeSymphonyUrlToPreferences` regex targets the wrong delimiter (P1)** — The pattern `/^---\\s*$/m` replaces the *first* `---` (the opening frontmatter delimiter) rather than the closing one. Any existing preferences file gains a `symphony:` block *before* the opening `---`, producing malformed YAML that the preferences loader cannot parse. The test in `symphony-onboarding.vitest.test.ts` uses only `toContain()` assertions so this structural corruption is not caught.
- **Symphony URL prompt unreachable for returning users (P1)** — `runWizardIfNeeded` returns early at `if (missing.length === 0) return` when all optional API keys are already stored. The `promptSymphonyUrl` call at the end of the function is never reached for users who previously completed the wizard, so the new onboarding step has no effect for them.
- **URL input is masked (P2)** — `promptForUrl` passes the URL through `promptMasked()`, which renders every character as `*`. URLs are not sensitive and should be visible while typing.
- **Guidance message omits `SYMPHONY_URL` env var (P2)** — `SYMPHONY_URL` is the primary env key (`DEFAULT_URL_ENV_KEY`), but the guidance message only lists `KATA_SYMPHONY_URL`.
- The `isSymphonyConfigured()` helper in `config.ts`, the `session_start` guard in `index.ts`, and the command gating in `command.ts` are all well-implemented and correct.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the two P1 bugs in wizard.ts — the Symphony core silencing logic is solid.

Two P1 issues in wizard.ts need attention before merge: the frontmatter regex corrupts preferences files for users with existing content, and the early-return guard prevents the Symphony prompt from ever being shown to users with pre-configured API keys. The Symphony silencing logic in config.ts, index.ts, and command.ts is correct and well-tested.

apps/cli/src/wizard.ts — both P1 bugs live here; apps/cli/src/resources/extensions/symphony/tests/symphony-onboarding.vitest.test.ts — needs a structural validity assertion to catch the frontmatter corruption.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/wizard.ts | Adds Symphony URL helpers and wires promptSymphonyUrl into the wizard — contains two P1 bugs: the closing-`---` regex targets the wrong delimiter (corrupts frontmatter), and the early-return guard means the prompt is never reached for users with all API keys already configured. |
| apps/cli/src/resources/extensions/symphony/config.ts | Adds isSymphonyConfigured() — cleanly wraps resolveSymphonyConfigFromRuntime(), returns false on config_missing and re-throws everything else. Logic is correct and well-tested. |
| apps/cli/src/resources/extensions/symphony/command.ts | Guards status, watch, and console actions behind isSymphonyConfigured(); shows info-level guidance instead of errors. Guidance message omits SYMPHONY_URL env var (the primary key). Logic otherwise correct. |
| apps/cli/src/resources/extensions/symphony/index.ts | Adds isSymphonyConfigured() guard at the top of session_start to skip escalation listener setup when Symphony is unconfigured. Clean and correct. |
| apps/cli/src/resources/extensions/symphony/tests/symphony-onboarding.vitest.test.ts | New test file for validateSymphonyUrl and writeSymphonyUrlToPreferences — URL validation tests are thorough, but the "adds symphony section to existing preferences" test uses only toContain() assertions, masking the frontmatter-corruption bug in writeSymphonyUrlToPreferences. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[session_start] --> B{isSymphonyConfigured?}
    B -- No --> C[return early — no escalation listener]
    B -- Yes --> D[Start escalation AbortController & watch loop]

    E["/symphony cmd"] --> F{action.type}
    F -- usage --> G[Show usage — ungated]
    F -- config --> H[Open config editor — ungated]
    F -- status / watch --> I{isSymphonyConfigured?}
    F -- console --> J{isSymphonyConfigured?}
    I -- No --> K[sink.info: guidance message]
    I -- Yes --> L[Execute status/watch against client]
    J -- No --> M[ctx.ui.notify: guidance message]
    J -- Yes --> N[Toggle/close/refresh console panel]

    O[runWizardIfNeeded] --> P{missing API keys?}
    P -- None missing --> Q[return early - Symphony prompt never reached]
    P -- Some missing --> R{isTTY?}
    R -- No --> S[warn to stderr & return]
    R -- Yes --> T[Prompt for each missing API key]
    T --> U{KATA_SYMPHONY_URL / SYMPHONY_URL set?}
    U -- No --> V[promptSymphonyUrl]
    U -- Yes --> W[Skip Symphony prompt]
    V --> X{URL valid?}
    X -- Yes --> Y[Write to .kata/preferences.md - regex replaces wrong ---]
    X -- No --> Z[Show error, return null]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/cli/src/wizard.ts`, line 261-302 ([link](https://github.com/gannonh/kata/blob/067af5b7c4830e6a7addd8e61500d580cdfa1090/apps/cli/src/wizard.ts#L261-L302)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Symphony URL prompt unreachable when all API keys are already configured**

   `runWizardIfNeeded` returns early at line 266 (`if (missing.length === 0) return`) when all optional API keys are already present. The Symphony URL prompt at lines 299–302 is only reachable from the code path that runs the API-key loop, so users who have previously configured every optional key — a common state on a second or later machine — will **never** be shown the Symphony URL prompt during onboarding.

   The fix is to hoist the Symphony check to run before (or independently of) the early return, or restructure the guard so the Symphony prompt has its own TTY check:

   ```typescript
   export async function runWizardIfNeeded(authStorage: AuthStorage): Promise<void> {
     const missing = API_KEYS.filter(
       k => !authStorage.has(k.provider) && !process.env[k.envVar]
     )

     const needsSymphony =
       !process.env.KATA_SYMPHONY_URL && !process.env.SYMPHONY_URL

     if (missing.length === 0 && !needsSymphony) return

     if (!process.stdin.isTTY) {
       // ... existing non-TTY warning ...
       return
     }

     // ... existing API key prompts ...

     // ── Symphony URL (optional) ──────────────────────────────────────────────
     if (needsSymphony) {
       await promptSymphonyUrl(process.cwd())
     }
     // ...
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/wizard.ts
   Line: 261-302

   Comment:
   **Symphony URL prompt unreachable when all API keys are already configured**

   `runWizardIfNeeded` returns early at line 266 (`if (missing.length === 0) return`) when all optional API keys are already present. The Symphony URL prompt at lines 299–302 is only reachable from the code path that runs the API-key loop, so users who have previously configured every optional key — a common state on a second or later machine — will **never** be shown the Symphony URL prompt during onboarding.

   The fix is to hoist the Symphony check to run before (or independently of) the early return, or restructure the guard so the Symphony prompt has its own TTY check:

   ```typescript
   export async function runWizardIfNeeded(authStorage: AuthStorage): Promise<void> {
     const missing = API_KEYS.filter(
       k => !authStorage.has(k.provider) && !process.env[k.envVar]
     )

     const needsSymphony =
       !process.env.KATA_SYMPHONY_URL && !process.env.SYMPHONY_URL

     if (missing.length === 0 && !needsSymphony) return

     if (!process.stdin.isTTY) {
       // ... existing non-TTY warning ...
       return
     }

     // ... existing API key prompts ...

     // ── Symphony URL (optional) ──────────────────────────────────────────────
     if (needsSymphony) {
       await promptSymphonyUrl(process.cwd())
     }
     // ...
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/wizard.ts
Line: 136-138

Comment:
**Regex replaces opening `---`, not closing delimiter**

The pattern `/^---\s*$/m` with no `g` flag replaces only the **first** match, which is the opening `---`. For a file like `"---\nversion: 1\n---\n"`, the result is:

```
symphony:
  url: http://localhost:8080
---
version: 1
---
```

The `symphony:` key lands **outside** any frontmatter block and the `version: 1` value is now between two stray `---` lines — both of which make the preferences file unparseable as YAML frontmatter. The test at line 66–82 of `symphony-onboarding.vitest.test.ts` passes only because it uses `toContain()` checks, not a structural validity assertion.

Fix: match the closing delimiter specifically, e.g. by anchoring to the end of the string:

```suggestion
      } else {
        // Add symphony section before the closing ---
        content = content.replace(/\n---\s*\n?$/, `\nsymphony:\n  url: ${url}\n---\n`)
      }
```

The corresponding test assertion should also verify that the result is still valid frontmatter (i.e. starts with `---` and that the symphony key appears **between** the opening and closing delimiters).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/wizard.ts
Line: 261-302

Comment:
**Symphony URL prompt unreachable when all API keys are already configured**

`runWizardIfNeeded` returns early at line 266 (`if (missing.length === 0) return`) when all optional API keys are already present. The Symphony URL prompt at lines 299–302 is only reachable from the code path that runs the API-key loop, so users who have previously configured every optional key — a common state on a second or later machine — will **never** be shown the Symphony URL prompt during onboarding.

The fix is to hoist the Symphony check to run before (or independently of) the early return, or restructure the guard so the Symphony prompt has its own TTY check:

```typescript
export async function runWizardIfNeeded(authStorage: AuthStorage): Promise<void> {
  const missing = API_KEYS.filter(
    k => !authStorage.has(k.provider) && !process.env[k.envVar]
  )

  const needsSymphony =
    !process.env.KATA_SYMPHONY_URL && !process.env.SYMPHONY_URL

  if (missing.length === 0 && !needsSymphony) return

  if (!process.stdin.isTTY) {
    // ... existing non-TTY warning ...
    return
  }

  // ... existing API key prompts ...

  // ── Symphony URL (optional) ──────────────────────────────────────────────
  if (needsSymphony) {
    await promptSymphonyUrl(process.cwd())
  }
  // ...
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/wizard.ts
Line: 185-186

Comment:
**URL collected via masked input**

`promptMasked` renders each typed character as `*` — intentionally designed for sensitive secrets like API keys. A Symphony server URL is not sensitive and users need to see it while typing to catch typos. Using the masked prompt here will confuse users who can't see what they're entering.

Consider either re-using the `readline`-based fallback path directly, or extracting an unmasked prompt helper:

```suggestion
  const value = await promptPlain('Symphony URL', '(e.g. http://localhost:8080)')
```

where `promptPlain` uses a normal `readline.question` call rather than raw mode + asterisks.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/symphony/command.ts
Line: 120-126

Comment:
**Guidance message omits the `SYMPHONY_URL` default env var**

`SYMPHONY_URL` is the primary/default environment key (`DEFAULT_URL_ENV_KEY` in `config.ts`) and `KATA_SYMPHONY_URL` is the fallback. The guidance message only mentions `KATA_SYMPHONY_URL`, so users who set `SYMPHONY_URL` won't recognise their own configuration and may follow the setup steps unnecessarily.

```suggestion
const SYMPHONY_GUIDANCE_MESSAGE = `Symphony is not configured.

To connect:
  • Set symphony.url in .kata/preferences.md
  • Or set SYMPHONY_URL / KATA_SYMPHONY_URL environment variable

Run /symphony config to edit WORKFLOW.md settings.`;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): add optional Symphony UR..."](https://github.com/gannonh/kata/commit/067af5b7c4830e6a7addd8e61500d580cdfa1090) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26675392)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->