### PR TITLE
fix(symphony): resolve S01 critical bug fixes for KAT-1652

### DIFF
--- a/apps/symphony/prompts/agent-review.md
+++ b/apps/symphony/prompts/agent-review.md
@@ -14,7 +14,7 @@ Read `.codex/skills/address-comments/SKILL.md` if available and follow its steps
 3. Treat every actionable reviewer comment (human or bot), including inline review comments, as blocking until one of these is true:
    - Code/test/docs updated to address it, **or**
    - Explicit, justified pushback reply posted on that thread.
-4. Update the workpad plan/checklist to include each feedback item and its resolution status.
+4. Update the workpad plan/checklist (using the Workpad search protocol from `prompts/system.md`) to include each feedback item and its resolution status.
 5. Re-run validation after feedback-driven changes and push updates.
 6. Repeat until there are no outstanding actionable comments.
 

--- a/apps/symphony/prompts/in-progress.md
+++ b/apps/symphony/prompts/in-progress.md
@@ -81,7 +81,7 @@ This issue is a **Kata task** under parent slice {{ issue.parent_identifier }}. 
 This is a standalone ticket. Read the description, plan your approach, implement, and validate.
 
 1. Analyze the issue description and any linked context.
-2. Write a plan in the workpad comment before coding.
+2. Locate/update the existing workpad using the **Workpad search protocol in `prompts/system.md`**, then write the plan before coding.
 3. Before implementing, capture a concrete reproduction signal and record it in the workpad Notes section.
 4. Implement the solution.
 5. Run appropriate validation (tests, lint, build).
@@ -91,7 +91,7 @@ This is a standalone ticket. Read the description, plan your approach, implement
 ## Implementation steps
 
 1. Run pull-sync against `origin/{{ workspace.base_branch }}` before any code edits.
-2. Implement the work, keeping the workpad current as you go.
+2. Implement the work, keeping the workpad current as you go (always reusing the same workpad located via the system workpad search protocol).
 3. Run validation/tests required for the scope.
    - Mandatory gate: execute all ticket-provided `Validation`/`Test Plan`/`Testing` requirements when present.
    - Prefer targeted proofs that directly demonstrate the behavior you changed.

--- a/apps/symphony/prompts/rework.md
+++ b/apps/symphony/prompts/rework.md
@@ -4,9 +4,9 @@ The issue is in `Rework`. The reviewer rejected the current approach. Your job i
 
 1. Re-read the full issue body and all human comments. Explicitly identify what will be done differently this attempt.
 2. Close the existing PR tied to the issue.
-3. Remove the existing `## Agent Workpad` comment from the issue.
+3. Locate the existing `## Agent Workpad` using the **Workpad search protocol in `prompts/system.md`**, then remove the currently active workpad before restarting.
 4. Create a fresh branch from `origin/{{ workspace.base_branch }}`.
-5. Create a new `## Agent Workpad` comment with a fresh plan.
+5. Create a new `## Agent Workpad` comment with a fresh plan (again following the system workpad search protocol to avoid duplicates).
 6. Implement the new approach from scratch.
 7. Follow the same validation and publish flow as a normal In Progress execution.
 8. Move issue to `Agent Review` when the new PR is ready.

--- a/apps/symphony/prompts/system.md
+++ b/apps/symphony/prompts/system.md
@@ -56,6 +56,36 @@ Use the built-in Linear tools (`linear_get_issue`, `linear_list_workflow_states`
 
 Maintain a single persistent `## Agent Workpad` comment on the issue as the source of truth for progress.
 
+### Workpad search (required before create/update)
+
+1. Query issue comments first (via Linear GraphQL tooling) and locate comments whose body contains `## Agent Workpad`.
+2. Use this query shape when available:
+
+```graphql
+query IssueCommentsForWorkpad($issueId: String!) {
+  issue(id: $issueId) {
+    comments(first: 50) {
+      nodes {
+        id
+        body
+        createdAt
+        resolvedAt
+      }
+    }
+  }
+}
+```
+
+3. Filter comment bodies for `## Agent Workpad` (case-sensitive exact heading).
+
+### Workpad conflict resolution
+
+- **0 matches:** create one new `## Agent Workpad` comment.
+- **1 match:** update that existing comment; do not create a second workpad.
+- **2+ matches:** select the **oldest unresolved** workpad (`resolvedAt == null`, earliest `createdAt`), update it, and ignore newer duplicates. Add a short note in the kept workpad indicating duplicate workpads were detected.
+
+### Workpad content requirements
+
 - **Load all context BEFORE creating or updating the workpad.** Read the issue description, comments, child tasks, attached plan documents, and AGENTS.md first.
 - **Write the workpad with FULL content — never placeholder content.** Include:
   - `Environment` stamp (`<host>:<abs-workdir>@<short-sha>`)

--- a/apps/symphony/src/linear/client.rs
+++ b/apps/symphony/src/linear/client.rs
@@ -23,6 +23,10 @@ const ISSUE_PAGE_SIZE: usize = 50;
 const USER_PAGE_SIZE: usize = 100;
 const REQUEST_TIMEOUT_SECS: u64 = 30;
 const MAX_ERROR_BODY_LOG_BYTES: usize = 1_000;
+#[cfg(not(test))]
+const COMMENT_CREATE_RETRY_DELAY_MS: u64 = 1_000;
+#[cfg(test)]
+const COMMENT_CREATE_RETRY_DELAY_MS: u64 = 1;
 
 // ── GraphQL Queries (match Elixir reference exactly) ───────────────────
 
@@ -391,18 +395,78 @@ impl LinearClient {
     }
 
     /// Create a comment on an issue.
+    ///
+    /// KAT-1231: Linear intermittently returns `Entity not found: Issue` for commentCreate on
+    /// issues that are otherwise mutable. Mitigation: retry once with a short delay and include
+    /// rich diagnostics (issue ID + attempt metadata + raw response) on failure.
     pub async fn create_comment(&self, issue_id: &str, body: &str) -> Result<()> {
-        let resp = self
-            .graphql(
+        match self.create_comment_attempt(issue_id, body, 1).await {
+            Ok(()) => Ok(()),
+            Err(first_err) => {
+                let first_error_text = first_err.to_string();
+                warn!(
+                    event = "comment_create_failed",
+                    issue_id = issue_id,
+                    retry_attempted = false,
+                    error = %truncate_error_body(&first_error_text),
+                    "Linear commentCreate failed on first attempt"
+                );
+                warn!(
+                    event = "comment_create_retry",
+                    issue_id = issue_id,
+                    attempt = 2,
+                    error_preview = %truncate_error_body(&first_error_text),
+                    "retrying Linear commentCreate after initial failure"
+                );
+
+                tokio::time::sleep(std::time::Duration::from_millis(COMMENT_CREATE_RETRY_DELAY_MS))
+                    .await;
+
+                match self.create_comment_attempt(issue_id, body, 2).await {
+                    Ok(()) => Ok(()),
+                    Err(retry_err) => {
+                        let retry_error_text = retry_err.to_string();
+                        warn!(
+                            event = "comment_create_failed",
+                            issue_id = issue_id,
+                            retry_attempted = true,
+                            error = %truncate_error_body(&retry_error_text),
+                            "Linear commentCreate failed after retry"
+                        );
+
+                        Err(SymphonyError::Other(format!(
+                            "commentCreate failed after retry (issue_id='{}', retry_attempted=true, first_attempt_error='{}', retry_error='{}')",
+                            issue_id,
+                            truncate_error_body(&first_error_text),
+                            truncate_error_body(&retry_error_text)
+                        )))
+                    }
+                }
+            }
+        }
+    }
+
+    async fn create_comment_attempt(&self, issue_id: &str, body: &str, attempt: u8) -> Result<()> {
+        let response = self
+            .graphql_raw(
                 MUTATION_CREATE_COMMENT,
                 serde_json::json!({
                     "issueId": issue_id,
                     "body": body,
                 }),
             )
-            .await?;
+            .await
+            .map_err(|err| {
+                SymphonyError::Other(format!(
+                    "commentCreate transport failure (issue_id='{}', attempt={}, retry_attempted={}, error='{}')",
+                    issue_id,
+                    attempt,
+                    attempt > 1,
+                    truncate_error_body(&err.to_string())
+                ))
+            })?;
 
-        let success = resp
+        let success = response
             .get("data")
             .and_then(|d| d.get("commentCreate"))
             .and_then(|c| c.get("success"))
@@ -410,13 +474,17 @@ impl LinearClient {
             .unwrap_or(false);
 
         if success {
-            Ok(())
-        } else {
-            Err(SymphonyError::Other(format!(
-                "commentCreate failed for issue '{}'",
-                issue_id
-            )))
+            return Ok(());
         }
+
+        let raw_response = truncate_error_body(&response.to_string());
+        Err(SymphonyError::Other(format!(
+            "commentCreate failed (issue_id='{}', attempt={}, retry_attempted={}, raw_response='{}')",
+            issue_id,
+            attempt,
+            attempt > 1,
+            raw_response
+        )))
     }
 
     // ── GraphQL transport ──────────────────────────────────────────────

--- a/apps/symphony/src/linear/client.rs
+++ b/apps/symphony/src/linear/client.rs
@@ -419,8 +419,10 @@ impl LinearClient {
                     "retrying Linear commentCreate after initial failure"
                 );
 
-                tokio::time::sleep(std::time::Duration::from_millis(COMMENT_CREATE_RETRY_DELAY_MS))
-                    .await;
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    COMMENT_CREATE_RETRY_DELAY_MS,
+                ))
+                .await;
 
                 match self.create_comment_attempt(issue_id, body, 2).await {
                     Ok(()) => Ok(()),

--- a/apps/symphony/src/linear/client.rs
+++ b/apps/symphony/src/linear/client.rs
@@ -397,26 +397,45 @@ impl LinearClient {
     /// Create a comment on an issue.
     ///
     /// KAT-1231: Linear intermittently returns `Entity not found: Issue` for commentCreate on
-    /// issues that are otherwise mutable. Mitigation: retry once with a short delay and include
-    /// rich diagnostics (issue ID + attempt metadata + raw response) on failure.
+    /// issues that are otherwise mutable. Mitigation: retry once with a short delay *only* for
+    /// that known transient failure mode, and include rich diagnostics on all failures.
     pub async fn create_comment(&self, issue_id: &str, body: &str) -> Result<()> {
         match self.create_comment_attempt(issue_id, body, 1).await {
             Ok(()) => Ok(()),
             Err(first_err) => {
                 let first_error_text = first_err.to_string();
+                let first_error_preview = truncate_error_body(&first_error_text);
+
                 warn!(
                     event = "comment_create_failed",
                     issue_id = issue_id,
                     retry_attempted = false,
-                    error = %truncate_error_body(&first_error_text),
+                    error = %first_error_preview,
                     "Linear commentCreate failed on first attempt"
                 );
+
+                if !is_retryable_comment_create_failure(&first_error_text) {
+                    warn!(
+                        event = "comment_create_retry_skipped",
+                        issue_id = issue_id,
+                        retry_attempted = false,
+                        reason = "non_retryable_failure",
+                        error = %first_error_preview,
+                        "skipping Linear commentCreate retry to avoid duplicate non-idempotent writes"
+                    );
+
+                    return Err(SymphonyError::Other(format!(
+                        "commentCreate failed without retry (issue_id='{}', retry_attempted=false, error='{}')",
+                        issue_id, first_error_preview
+                    )));
+                }
+
                 warn!(
                     event = "comment_create_retry",
                     issue_id = issue_id,
                     attempt = 2,
-                    error_preview = %truncate_error_body(&first_error_text),
-                    "retrying Linear commentCreate after initial failure"
+                    error_preview = %first_error_preview,
+                    "retrying Linear commentCreate after retryable first failure"
                 );
 
                 tokio::time::sleep(std::time::Duration::from_millis(
@@ -439,7 +458,7 @@ impl LinearClient {
                         Err(SymphonyError::Other(format!(
                             "commentCreate failed after retry (issue_id='{}', retry_attempted=true, first_attempt_error='{}', retry_error='{}')",
                             issue_id,
-                            truncate_error_body(&first_error_text),
+                            first_error_preview,
                             truncate_error_body(&retry_error_text)
                         )))
                     }
@@ -1227,6 +1246,15 @@ fn format_available_assignee_identifiers(users: &[LinearUser]) -> String {
         let total = values.len();
         format!("{}, ... ({} total)", values[..MAX_VALUES].join(", "), total)
     }
+}
+
+/// Return true when a commentCreate failure is the known KAT-1231 transient issue.
+///
+/// We only retry this non-idempotent mutation for "Entity not found: Issue" responses to
+/// reduce duplicate-comment risk when the first request may have succeeded server-side.
+fn is_retryable_comment_create_failure(error_text: &str) -> bool {
+    let normalized = error_text.to_ascii_lowercase();
+    normalized.contains("entity not found") && normalized.contains("issue")
 }
 
 /// Truncate an error body to ≤1000 bytes for logging.

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1868,9 +1868,37 @@ impl Orchestrator {
         );
 
         let terminal_issues = port.startup_terminal_issues(&self.config.tracker.terminal_states)?;
+        let workspace_root = Path::new(&self.config.workspace.root);
+        let startup_workspaces = workspace::scan_workspace_root(
+            workspace_root,
+            &self.config.workspace.branch_prefix,
+        );
+
+        tracing::info!(
+            event = "startup_workspace_scan",
+            root_path = %workspace_root.display(),
+            workspace_count = startup_workspaces.len(),
+            "completed startup workspace scan"
+        );
 
         for issue in terminal_issues {
-            self.mark_issue_terminal(&issue, None, false);
+            let workspace_path_hint = startup_workspaces
+                .get(&issue.identifier)
+                .map(|path| path.to_string_lossy().to_string());
+
+            self.mark_issue_terminal(&issue, workspace_path_hint.as_deref(), false);
+
+            if let Some(workspace_path) = workspace_path_hint {
+                let workspace_path_ref = Path::new(&workspace_path);
+                if !workspace_path_ref.exists() {
+                    tracing::info!(
+                        event = "startup_orphan_workspace_removed",
+                        issue_identifier = %issue.identifier,
+                        workspace_path = %workspace_path,
+                        "removed orphan workspace during startup cleanup"
+                    );
+                }
+            }
         }
 
         Ok(())

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1893,7 +1893,7 @@ impl Orchestrator {
                         event = "startup_orphan_workspace_removed",
                         issue_identifier = %issue.identifier,
                         workspace_path = %workspace_path,
-                        "removed orphan workspace during startup cleanup"
+                        "orphan workspace no longer present after startup cleanup"
                     );
                 }
             }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1869,10 +1869,8 @@ impl Orchestrator {
 
         let terminal_issues = port.startup_terminal_issues(&self.config.tracker.terminal_states)?;
         let workspace_root = Path::new(&self.config.workspace.root);
-        let startup_workspaces = workspace::scan_workspace_root(
-            workspace_root,
-            &self.config.workspace.branch_prefix,
-        );
+        let startup_workspaces =
+            workspace::scan_workspace_root(workspace_root, &self.config.workspace.branch_prefix);
 
         tracing::info!(
             event = "startup_workspace_scan",

--- a/apps/symphony/src/pi_agent/protocol.rs
+++ b/apps/symphony/src/pi_agent/protocol.rs
@@ -193,6 +193,42 @@ pub enum RpcOutputLine {
     },
 }
 
+/// Extract a non-terminal stop reason and optional provider error message.
+///
+/// Returns `None` when `stopReason` is missing/empty or equals `end_turn`
+/// (case-insensitive), which is treated as the normal completion signal.
+pub fn extract_stop_reason(message: &Value) -> Option<(String, Option<String>)> {
+    let stop_reason = message
+        .get("stopReason")
+        .or_else(|| message.get("stop_reason"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_string();
+
+    if stop_reason.eq_ignore_ascii_case("end_turn") {
+        return None;
+    }
+
+    let error_message = message
+        .get("errorMessage")
+        .or_else(|| message.get("error_message"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+
+    Some((stop_reason, error_message))
+}
+
+/// Heuristic for provider messages that indicate rate-limit style failures.
+pub fn has_rate_limit_hint(message: &str) -> bool {
+    let normalized = message.to_ascii_lowercase();
+    normalized.contains("rate limit")
+        || normalized.contains("usage limit")
+        || normalized.contains("retry")
+}
+
 /// Response payload for extension UI requests in non-interactive mode.
 #[derive(Debug, Serialize)]
 pub struct ExtensionUIResponse {

--- a/apps/symphony/src/pi_agent/rpc_bridge.rs
+++ b/apps/symphony/src/pi_agent/rpc_bridge.rs
@@ -17,7 +17,8 @@ use crate::domain::{AgentEvent, EscalationRequest, EscalationResponse, Issue, Pi
 use crate::error::{Result, SymphonyError};
 use crate::path_safety;
 use crate::pi_agent::protocol::{
-    ExtensionUIResponse, RpcCommand, RpcOutputLine, RpcResponse, SessionStats,
+    extract_stop_reason, has_rate_limit_hint, ExtensionUIResponse, RpcCommand, RpcOutputLine,
+    RpcResponse, SessionStats,
 };
 use crate::pi_agent::token_accounting::{TokenDelta, TokenTracker};
 use crate::ssh::{self, SshRunner};
@@ -271,6 +272,51 @@ fn maybe_extract_text(message: &Value) -> Option<String> {
         }
     }
     None
+}
+
+fn truncate_for_event(message: &str) -> String {
+    const MAX_EVENT_CHARS: usize = 200;
+    if message.chars().count() <= MAX_EVENT_CHARS {
+        return message.to_string();
+    }
+
+    let truncated: String = message.chars().take(MAX_EVENT_CHARS).collect();
+    format!("{truncated}…")
+}
+
+fn parse_retry_after_ms(message: &str) -> Option<u64> {
+    let normalized = message.to_ascii_lowercase();
+    let anchor = normalized
+        .find("retry-after")
+        .or_else(|| normalized.find("retry after"))?;
+
+    let tail = &normalized[anchor..];
+    let mut digit_start = None;
+    let mut digit_end = None;
+
+    for (idx, ch) in tail.char_indices() {
+        if ch.is_ascii_digit() {
+            if digit_start.is_none() {
+                digit_start = Some(idx);
+            }
+            digit_end = Some(idx + ch.len_utf8());
+        } else if digit_start.is_some() {
+            break;
+        }
+    }
+
+    let start = digit_start?;
+    let end = digit_end?;
+    let amount: u64 = tail[start..end].parse().ok()?;
+    let unit = tail[end..].trim_start();
+
+    if unit.starts_with("ms") {
+        Some(amount)
+    } else if unit.starts_with('m') && !unit.starts_with("ms") {
+        amount.checked_mul(60_000)
+    } else {
+        amount.checked_mul(1_000)
+    }
 }
 
 async fn handle_escalation_ui_request(
@@ -775,9 +821,59 @@ pub async fn run_turn(
                 handle_escalation_ui_request(handle, &mut event_callback, id, method, extra)
                     .await?;
             }
-            RpcOutputLine::MessageUpdate { message } | RpcOutputLine::MessageEnd { message } => {
+            RpcOutputLine::MessageUpdate { message } => {
                 if let Some(text) = maybe_extract_text(&message) {
                     output_text = Some(text);
+                }
+            }
+            RpcOutputLine::MessageEnd { message } => {
+                if let Some(text) = maybe_extract_text(&message) {
+                    output_text = Some(text);
+                }
+
+                if let Some((stop_reason, error_message)) = extract_stop_reason(&message) {
+                    if stop_reason.eq_ignore_ascii_case("error") {
+                        let error_text = error_message.unwrap_or_else(|| {
+                            format!("pi-agent reported stopReason='{}'", stop_reason)
+                        });
+                        let message_preview = truncate_for_event(&error_text);
+                        let retry_after_ms = if has_rate_limit_hint(&error_text) {
+                            parse_retry_after_ms(&error_text)
+                        } else {
+                            None
+                        };
+
+                        tracing::warn!(
+                            event = "turn_error_detected",
+                            issue_id = %handle.issue_id,
+                            issue_identifier = %handle.issue_identifier,
+                            error_type = %stop_reason,
+                            message = %message_preview,
+                            retry_after_ms,
+                            "pi-agent turn ended with stopReason=error"
+                        );
+
+                        if has_rate_limit_hint(&error_text) {
+                            tracing::warn!(
+                                event = "rate_limit_detected",
+                                issue_id = %handle.issue_id,
+                                issue_identifier = %handle.issue_identifier,
+                                message = %message_preview,
+                                retry_after_ms,
+                                "pi-agent provider reported rate-limit style failure"
+                            );
+                        }
+
+                        let failed = AgentEvent::TurnFailed {
+                            timestamp: Utc::now(),
+                            codex_app_server_pid: handle.pid.clone(),
+                            turn_id: turn_id.clone(),
+                            error: error_text.clone(),
+                        };
+                        event_callback(failed.clone());
+                        events.push(failed);
+                        return Err(SymphonyError::TurnFailed(error_text));
+                    }
                 }
             }
             _ => {}

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -2,7 +2,8 @@
 //!
 //! Full implementation in S04/T03. This is the public API skeleton so tests compile.
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -155,6 +156,107 @@ pub fn validate_workspace_path(workspace: &Path, root: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Scan `<root>/<branch_prefix>/<identifier>` directories and map them by issue identifier.
+///
+/// This is used by orchestrator startup cleanup to recover orphan workspace paths for issues
+/// that reached terminal state while Symphony was not running.
+pub fn scan_workspace_root(root: &Path, branch_prefix: &str) -> HashMap<String, PathBuf> {
+    let mut discovered = HashMap::new();
+    let normalized_prefix = branch_prefix.trim_matches('/');
+    if normalized_prefix.is_empty() {
+        tracing::warn!(
+            event = "startup_workspace_scan_skipped",
+            root_path = %root.display(),
+            "workspace branch_prefix is empty; startup scan skipped"
+        );
+        return discovered;
+    }
+
+    let prefix_path = normalized_prefix
+        .split('/')
+        .fold(root.to_path_buf(), |acc, segment| acc.join(segment));
+
+    let entries = match std::fs::read_dir(&prefix_path) {
+        Ok(entries) => entries,
+        Err(err) => {
+            tracing::debug!(
+                event = "startup_workspace_scan_unavailable",
+                root_path = %root.display(),
+                branch_prefix = normalized_prefix,
+                error = %err,
+                "workspace prefix directory unavailable during startup scan"
+            );
+            return discovered;
+        }
+    };
+
+    for entry_result in entries {
+        let entry = match entry_result {
+            Ok(entry) => entry,
+            Err(err) => {
+                tracing::warn!(
+                    event = "startup_workspace_scan_entry_error",
+                    root_path = %root.display(),
+                    branch_prefix = normalized_prefix,
+                    error = %err,
+                    "failed to read workspace entry; skipping"
+                );
+                continue;
+            }
+        };
+
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) => {
+                tracing::warn!(
+                    event = "startup_workspace_scan_file_type_error",
+                    path = %entry.path().display(),
+                    error = %err,
+                    "failed to inspect workspace entry type; skipping"
+                );
+                continue;
+            }
+        };
+
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let identifier = entry
+            .file_name()
+            .to_str()
+            .map(str::trim)
+            .filter(|candidate| looks_like_issue_identifier(candidate))
+            .map(ToString::to_string);
+
+        let Some(identifier) = identifier else {
+            continue;
+        };
+
+        let path = std::fs::canonicalize(entry.path()).unwrap_or_else(|_| entry.path());
+        tracing::debug!(
+            event = "startup_workspace_scan_match",
+            issue_identifier = %identifier,
+            workspace_path = %path.display(),
+            "discovered startup workspace candidate"
+        );
+        discovered.insert(identifier, path);
+    }
+
+    discovered
+}
+
+fn looks_like_issue_identifier(value: &str) -> bool {
+    let Some((team, number)) = value.split_once('-') else {
+        return false;
+    };
+
+    !team.is_empty()
+        && !number.is_empty()
+        && team.chars().all(|ch| ch.is_ascii_alphanumeric())
+        && number.chars().all(|ch| ch.is_ascii_digit())
 }
 
 /// Run repository bootstrap (clone/worktree + branch creation) when configured.
@@ -691,5 +793,56 @@ fn truncate_output(output: &str, max_bytes: usize) -> String {
         // Find a safe UTF-8 boundary
         let truncated = &output[..output.floor_char_boundary(max_bytes)];
         format!("{}... (truncated)", truncated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scan_workspace_root;
+
+    #[test]
+    fn scan_workspace_root_maps_matching_directories() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let root = temp.path();
+
+        let matching_a = root.join("symphony").join("KAT-100");
+        let matching_b = root.join("symphony").join("KAT-200");
+        let non_matching = root.join("symphony").join("not-an-issue");
+        let wrong_prefix = root.join("other").join("KAT-300");
+
+        std::fs::create_dir_all(&matching_a).expect("matching workspace A should be created");
+        std::fs::create_dir_all(&matching_b).expect("matching workspace B should be created");
+        std::fs::create_dir_all(&non_matching).expect("non-matching directory should exist");
+        std::fs::create_dir_all(&wrong_prefix).expect("other prefix directory should exist");
+
+        let discovered = scan_workspace_root(root, "symphony");
+        let expected_a = std::fs::canonicalize(&matching_a).expect("canonical path should resolve");
+        let expected_b = std::fs::canonicalize(&matching_b).expect("canonical path should resolve");
+
+        assert_eq!(discovered.len(), 2);
+        assert_eq!(discovered.get("KAT-100"), Some(&expected_a));
+        assert_eq!(discovered.get("KAT-200"), Some(&expected_b));
+        assert!(!discovered.contains_key("KAT-300"));
+    }
+
+    #[test]
+    fn scan_workspace_root_supports_nested_branch_prefix() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let root = temp.path();
+
+        let nested_match = root.join("symphony").join("backend").join("KAT-900");
+        std::fs::create_dir_all(&nested_match)
+            .expect("nested branch prefix workspace should be created");
+
+        let discovered = scan_workspace_root(root, "symphony/backend");
+        let expected = std::fs::canonicalize(&nested_match).expect("canonical path should resolve");
+        assert_eq!(discovered.get("KAT-900"), Some(&expected));
+    }
+
+    #[test]
+    fn scan_workspace_root_returns_empty_when_prefix_missing() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let discovered = scan_workspace_root(temp.path(), "symphony");
+        assert!(discovered.is_empty());
     }
 }

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -158,19 +158,21 @@ pub fn validate_workspace_path(workspace: &Path, root: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Scan `<root>/<branch_prefix>/<identifier>` directories and map them by issue identifier.
+/// Scan workspace directories and map them by issue identifier.
+///
+/// The canonical workspace layout is `<root>/<identifier>`, but we also scan the
+/// branch-prefixed fallback `<root>/<branch_prefix>/<identifier>` to cover legacy/manual
+/// directory layouts.
 ///
 /// This is used by orchestrator startup cleanup to recover orphan workspace paths for issues
 /// that reached terminal state while Symphony was not running.
 pub fn scan_workspace_root(root: &Path, branch_prefix: &str) -> HashMap<String, PathBuf> {
     let mut discovered = HashMap::new();
+
+    scan_workspace_directory(root, &mut discovered);
+
     let normalized_prefix = branch_prefix.trim_matches('/');
     if normalized_prefix.is_empty() {
-        tracing::warn!(
-            event = "startup_workspace_scan_skipped",
-            root_path = %root.display(),
-            "workspace branch_prefix is empty; startup scan skipped"
-        );
         return discovered;
     }
 
@@ -178,17 +180,24 @@ pub fn scan_workspace_root(root: &Path, branch_prefix: &str) -> HashMap<String, 
         .split('/')
         .fold(root.to_path_buf(), |acc, segment| acc.join(segment));
 
-    let entries = match std::fs::read_dir(&prefix_path) {
+    if prefix_path != root {
+        scan_workspace_directory(&prefix_path, &mut discovered);
+    }
+
+    discovered
+}
+
+fn scan_workspace_directory(scan_root: &Path, discovered: &mut HashMap<String, PathBuf>) {
+    let entries = match std::fs::read_dir(scan_root) {
         Ok(entries) => entries,
         Err(err) => {
             tracing::debug!(
                 event = "startup_workspace_scan_unavailable",
-                root_path = %root.display(),
-                branch_prefix = normalized_prefix,
+                scan_root = %scan_root.display(),
                 error = %err,
-                "workspace prefix directory unavailable during startup scan"
+                "workspace directory unavailable during startup scan"
             );
-            return discovered;
+            return;
         }
     };
 
@@ -198,8 +207,7 @@ pub fn scan_workspace_root(root: &Path, branch_prefix: &str) -> HashMap<String, 
             Err(err) => {
                 tracing::warn!(
                     event = "startup_workspace_scan_entry_error",
-                    root_path = %root.display(),
-                    branch_prefix = normalized_prefix,
+                    scan_root = %scan_root.display(),
                     error = %err,
                     "failed to read workspace entry; skipping"
                 );
@@ -242,10 +250,9 @@ pub fn scan_workspace_root(root: &Path, branch_prefix: &str) -> HashMap<String, 
             workspace_path = %path.display(),
             "discovered startup workspace candidate"
         );
-        discovered.insert(identifier, path);
-    }
 
-    discovered
+        discovered.entry(identifier).or_insert(path);
+    }
 }
 
 fn looks_like_issue_identifier(value: &str) -> bool {
@@ -805,15 +812,13 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let root = temp.path();
 
-        let matching_a = root.join("symphony").join("KAT-100");
-        let matching_b = root.join("symphony").join("KAT-200");
-        let non_matching = root.join("symphony").join("not-an-issue");
-        let wrong_prefix = root.join("other").join("KAT-300");
+        let matching_a = root.join("KAT-100");
+        let matching_b = root.join("KAT-200");
+        let non_matching = root.join("not-an-issue");
 
         std::fs::create_dir_all(&matching_a).expect("matching workspace A should be created");
         std::fs::create_dir_all(&matching_b).expect("matching workspace B should be created");
         std::fs::create_dir_all(&non_matching).expect("non-matching directory should exist");
-        std::fs::create_dir_all(&wrong_prefix).expect("other prefix directory should exist");
 
         let discovered = scan_workspace_root(root, "symphony");
         let expected_a = std::fs::canonicalize(&matching_a).expect("canonical path should resolve");
@@ -822,7 +827,6 @@ mod tests {
         assert_eq!(discovered.len(), 2);
         assert_eq!(discovered.get("KAT-100"), Some(&expected_a));
         assert_eq!(discovered.get("KAT-200"), Some(&expected_b));
-        assert!(!discovered.contains_key("KAT-300"));
     }
 
     #[test]
@@ -840,9 +844,15 @@ mod tests {
     }
 
     #[test]
-    fn scan_workspace_root_returns_empty_when_prefix_missing() {
+    fn scan_workspace_root_falls_back_to_root_when_prefix_missing() {
         let temp = tempfile::tempdir().expect("tempdir should be created");
-        let discovered = scan_workspace_root(temp.path(), "symphony");
-        assert!(discovered.is_empty());
+        let root = temp.path();
+
+        let root_match = root.join("KAT-321");
+        std::fs::create_dir_all(&root_match).expect("root workspace should be created");
+
+        let discovered = scan_workspace_root(root, "symphony");
+        let expected = std::fs::canonicalize(&root_match).expect("canonical path should resolve");
+        assert_eq!(discovered.get("KAT-321"), Some(&expected));
     }
 }

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -982,6 +982,36 @@ async fn test_create_comment_retries_after_first_failure_then_succeeds() {
 }
 
 #[tokio::test]
+async fn test_create_comment_non_retryable_failure_does_not_retry() {
+    let mut server = Server::new_async().await;
+
+    let first_attempt = server
+        .mock("POST", "/graphql")
+        .expect(1)
+        .with_body(
+            json!({
+                "errors": [{"message": "Permission denied"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let client = test_client(&server, None);
+    let err = client
+        .create_comment("issue-42", "Hello from Symphony")
+        .await
+        .expect_err("comment creation should fail without retry on non-retryable errors");
+
+    let message = err.to_string();
+    assert!(message.contains("issue_id='issue-42'"));
+    assert!(message.contains("retry_attempted=false"));
+    assert!(message.contains("without retry"));
+
+    first_attempt.assert_async().await;
+}
+
+#[tokio::test]
 async fn test_create_comment_failure_includes_retry_diagnostics() {
     let mut server = Server::new_async().await;
 

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -939,6 +939,92 @@ async fn test_create_comment_success() {
     mock.assert_async().await;
 }
 
+#[tokio::test]
+async fn test_create_comment_retries_after_first_failure_then_succeeds() {
+    let mut server = Server::new_async().await;
+
+    let first_attempt = server
+        .mock("POST", "/graphql")
+        .expect(1)
+        .with_body(
+            json!({
+                "errors": [{"message": "Entity not found: Issue"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let retry_attempt = server
+        .mock("POST", "/graphql")
+        .expect(1)
+        .with_body(
+            json!({
+                "data": {
+                    "commentCreate": {
+                        "success": true
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let client = test_client(&server, None);
+    let result = client
+        .create_comment("issue-1", "Hello from Symphony")
+        .await;
+
+    assert!(result.is_ok(), "comment creation should succeed on retry");
+    first_attempt.assert_async().await;
+    retry_attempt.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_create_comment_failure_includes_retry_diagnostics() {
+    let mut server = Server::new_async().await;
+
+    let first_attempt = server
+        .mock("POST", "/graphql")
+        .expect(1)
+        .with_body(
+            json!({
+                "errors": [{"message": "Entity not found: Issue"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let retry_attempt = server
+        .mock("POST", "/graphql")
+        .expect(1)
+        .with_body(
+            json!({
+                "errors": [{"message": "Entity not found: Issue (retry)"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let client = test_client(&server, None);
+    let err = client
+        .create_comment("issue-99", "Hello from Symphony")
+        .await
+        .expect_err("comment creation should fail after retry exhaustion");
+
+    let message = err.to_string();
+    assert!(message.contains("issue_id='issue-99'"));
+    assert!(message.contains("retry_attempted=true"));
+    assert!(message.contains("raw_response"));
+    assert!(message.contains("Entity not found: Issue"));
+
+    first_attempt.assert_async().await;
+    retry_attempt.assert_async().await;
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // Assignee "me" resolution via viewer query
 // ═══════════════════════════════════════════════════════════════════════

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -411,8 +411,8 @@ fn test_startup_terminal_cleanup_clears_runtime_bookkeeping_without_completed_in
 #[test]
 fn test_startup_terminal_cleanup_removes_orphan_workspace_from_scan() {
     let workspace_root = tempdir().expect("workspace root should be created");
-    let orphan_workspace = workspace_root.path().join("symphony").join("SIM-10");
-    let untouched_workspace = workspace_root.path().join("symphony").join("SIM-11");
+    let orphan_workspace = workspace_root.path().join("SIM-10");
+    let untouched_workspace = workspace_root.path().join("SIM-11");
 
     fs::create_dir_all(&orphan_workspace).expect("orphan workspace should be created");
     fs::create_dir_all(&untouched_workspace).expect("untouched workspace should be created");

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -409,6 +409,41 @@ fn test_startup_terminal_cleanup_clears_runtime_bookkeeping_without_completed_in
 }
 
 #[test]
+fn test_startup_terminal_cleanup_removes_orphan_workspace_from_scan() {
+    let workspace_root = tempdir().expect("workspace root should be created");
+    let orphan_workspace = workspace_root.path().join("symphony").join("SIM-10");
+    let untouched_workspace = workspace_root.path().join("symphony").join("SIM-11");
+
+    fs::create_dir_all(&orphan_workspace).expect("orphan workspace should be created");
+    fs::create_dir_all(&untouched_workspace).expect("untouched workspace should be created");
+    fs::write(orphan_workspace.join("artifact.txt"), "orphan")
+        .expect("orphan workspace artifact should be created");
+
+    let mut config = test_config(2);
+    config.workspace.root = workspace_root.path().to_string_lossy().to_string();
+    config.workspace.cleanup_on_done = true;
+
+    let mut orchestrator = Orchestrator::new(config, String::new());
+    let mut port = FakePort {
+        terminal_issues: vec![issue("issue-terminal", "SIM-10", "Done", Some(1), 0)],
+        ..FakePort::default()
+    };
+
+    orchestrator
+        .startup_cleanup(&mut port)
+        .expect("startup cleanup should succeed");
+
+    assert!(
+        !orphan_workspace.exists(),
+        "startup cleanup should remove workspace discovered via scan"
+    );
+    assert!(
+        untouched_workspace.exists(),
+        "startup cleanup should not remove unrelated workspace"
+    );
+}
+
+#[test]
 fn test_reconcile_tick_reconcile_before_validate_before_dispatch() {
     let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let mut port = FakePort {

--- a/apps/symphony/tests/pi_agent_tests.rs
+++ b/apps/symphony/tests/pi_agent_tests.rs
@@ -3,7 +3,8 @@
 use serde_json::json;
 use std::path::Path;
 use symphony::pi_agent::protocol::{
-    ExtensionUIResponse, RpcCommand, RpcOutputLine, SessionStats, SessionTokens,
+    extract_stop_reason, has_rate_limit_hint, ExtensionUIResponse, RpcCommand, RpcOutputLine,
+    SessionStats, SessionTokens,
 };
 use symphony::pi_agent::rpc_bridge;
 use symphony::pi_agent::token_accounting::TokenTracker;
@@ -173,6 +174,45 @@ fn token_tracker_clamps_negative_deltas_to_zero() {
     assert_eq!(d.total_tokens, 0);
 }
 
+#[test]
+fn extract_stop_reason_returns_error_reason_and_message() {
+    let message = json!({
+        "stopReason": "error",
+        "errorMessage": "You have hit your ChatGPT usage limit"
+    });
+
+    let parsed = extract_stop_reason(&message);
+    assert_eq!(
+        parsed,
+        Some((
+            "error".to_string(),
+            Some("You have hit your ChatGPT usage limit".to_string())
+        ))
+    );
+}
+
+#[test]
+fn extract_stop_reason_ignores_end_turn_and_missing_stop_reason() {
+    let end_turn_message = json!({
+        "stopReason": "end_turn",
+        "errorMessage": "ignored"
+    });
+    assert_eq!(extract_stop_reason(&end_turn_message), None);
+
+    let missing_stop_reason = json!({
+        "errorMessage": "missing reason"
+    });
+    assert_eq!(extract_stop_reason(&missing_stop_reason), None);
+}
+
+#[test]
+fn has_rate_limit_hint_detects_expected_keywords() {
+    assert!(has_rate_limit_hint("Rate limit exceeded. Retry after 12s."));
+    assert!(has_rate_limit_hint("You have hit your usage limit for today."));
+    assert!(has_rate_limit_hint("Please retry this request in a moment."));
+    assert!(!has_rate_limit_hint("Model returned malformed JSON"));
+}
+
 fn write_script(dir: &Path, name: &str, content: &str) -> std::path::PathBuf {
     let path = dir.join(name);
     std::fs::write(&path, content).expect("write script");
@@ -220,6 +260,23 @@ while read -r line; do
     echo '{"type":"agent_end","messages":[]}'
   elif [[ "$line" == *'"type":"get_session_stats"'* ]]; then
     echo '{"type":"response","command":"get_session_stats","success":true,"data":{"session_id":"sess-123","tokens":{"input":10,"output":4,"total":14}}}'
+  elif [[ "$line" == *'"type":"abort"'* ]]; then
+    exit 0
+  fi
+done
+"#;
+
+const SCRIPT_ERROR_STOP_REASON_RPC: &str = r#"#!/bin/bash
+set -euo pipefail
+
+read -r line # get_state
+echo '{"type":"response","command":"get_state","success":true,"data":{"sessionId":"sess-error"}}'
+
+while read -r line; do
+  if [[ "$line" == *'"type":"prompt"'* ]]; then
+    echo '{"type":"response","command":"prompt","success":true}'
+    echo '{"type":"message_end","message":{"stopReason":"error","errorMessage":"Rate limit exceeded. Retry after 12s.","content":[]}}'
+    echo '{"type":"agent_end","messages":[]}'
   elif [[ "$line" == *'"type":"abort"'* ]]; then
     exit 0
   fi
@@ -296,6 +353,66 @@ async fn rpc_bridge_start_turn_stop_smoke() {
             .iter()
             .any(|event| matches!(event, symphony::domain::AgentEvent::TurnCompleted { .. })),
         "TurnCompleted event should be emitted"
+    );
+
+    rpc_bridge::stop_session(handle)
+        .await
+        .expect("stop_session succeeds");
+}
+
+#[tokio::test]
+async fn rpc_bridge_turn_fails_on_message_end_error_stop_reason() {
+    let scripts_dir = tempfile::tempdir().expect("scripts dir");
+    let root_dir = tempfile::tempdir().expect("root dir");
+    let workspace = root_dir.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let script_path = write_script(
+        scripts_dir.path(),
+        "fake-kata-error-stop-reason.sh",
+        SCRIPT_ERROR_STOP_REASON_RPC,
+    );
+    let config = PiAgentConfig {
+        command: vec![script_path.to_string_lossy().to_string()],
+        read_timeout_ms: 5_000,
+        stall_timeout_ms: 10_000,
+        ..PiAgentConfig::default()
+    };
+
+    let issue = make_test_issue();
+    let (escalation_tx, _escalation_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = rpc_bridge::start_session(
+        &config,
+        &issue,
+        &workspace,
+        root_dir.path(),
+        rpc_bridge::StartSessionOptions {
+            worker_host: None,
+            container_id: None,
+            escalation_tx,
+            escalation_timeout_ms: 60_000,
+        },
+    )
+    .await
+    .expect("start_session succeeds");
+
+    let mut events = Vec::new();
+    let err = rpc_bridge::run_turn(&mut handle, "hello", |event| events.push(event))
+        .await
+        .expect_err("run_turn should fail on stopReason=error");
+
+    match err {
+        symphony::error::SymphonyError::TurnFailed(message) => {
+            assert!(message.contains("Rate limit exceeded"));
+        }
+        other => panic!("expected TurnFailed error, got {other:?}"),
+    }
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, symphony::domain::AgentEvent::TurnFailed { .. })),
+        "TurnFailed event should be emitted"
     );
 
     rpc_bridge::stop_session(handle)

--- a/apps/symphony/tests/pi_agent_tests.rs
+++ b/apps/symphony/tests/pi_agent_tests.rs
@@ -208,8 +208,12 @@ fn extract_stop_reason_ignores_end_turn_and_missing_stop_reason() {
 #[test]
 fn has_rate_limit_hint_detects_expected_keywords() {
     assert!(has_rate_limit_hint("Rate limit exceeded. Retry after 12s."));
-    assert!(has_rate_limit_hint("You have hit your usage limit for today."));
-    assert!(has_rate_limit_hint("Please retry this request in a moment."));
+    assert!(has_rate_limit_hint(
+        "You have hit your usage limit for today."
+    ));
+    assert!(has_rate_limit_hint(
+        "Please retry this request in a moment."
+    ));
     assert!(!has_rate_limit_hint("Model returned malformed JSON"));
 }
 


### PR DESCRIPTION
## Summary

Implements all child tasks for KAT-1652 ([S01] Critical Bug Fixes).

### T01 / KAT-1653 — pi-agent stopReason error handling
- Added `extract_stop_reason` + rate-limit hint parsing helpers in `src/pi_agent/protocol.rs`.
- Split `MessageUpdate` vs `MessageEnd` handling in `src/pi_agent/rpc_bridge.rs`.
- `run_turn` now detects `stopReason: "error"`, emits `turn_error_detected` / `rate_limit_detected`, and returns `Err(SymphonyError::TurnFailed(...))` immediately.
- Added tests in `tests/pi_agent_tests.rs` for stop reason parsing and turn-loop failure behavior.

### T02 / KAT-1654 — startup orphan workspace cleanup
- Added `scan_workspace_root(root, branch_prefix)` in `src/workspace.rs` to map `<branch_prefix>/<identifier>` directories.
- Wired `startup_cleanup` to scan workspace root and pass resolved workspace path hints to terminal cleanup.
- Added startup diagnostics (`startup_workspace_scan`, `startup_orphan_workspace_removed`).
- Added workspace scan unit tests and startup cleanup integration test in `tests/orchestrator_tests.rs`.

### T03 / KAT-1655 — workpad duplication + comment reliability
- Strengthened workpad protocol in prompts with explicit search-before-create GraphQL query pattern and conflict resolution for 0/1/2+ matches.
- Added one-retry mitigation to `LinearClient::create_comment` with structured retry/failure diagnostics and raw response metadata (KAT-1231).
- Added regression tests in `tests/linear_client_tests.rs` for success, retry-success, and retry-exhausted paths.

## Validation

Executed in `apps/symphony`:

- `cargo test --test pi_agent_tests`
- `cargo test --test orchestrator_tests startup`
- `cargo test --test linear_client_tests`
- `cargo test`
- `cargo clippy -- -D warnings`

All passed.

Closes KAT-1652
Closes KAT-1653
Closes KAT-1654
Closes KAT-1655

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves three critical bug categories (KAT-1652 child tasks) in the `apps/symphony` codebase: it adds proper `stopReason=error` detection in the pi-agent turn loop, introduces startup orphan-workspace scanning and cleanup, and hardens Linear comment creation with a one-retry mitigation plus structured diagnostics. All three changes are well-scoped, thoroughly tested, and pass `cargo clippy -D warnings`.

**Key changes:**
- **T01 (KAT-1653):** `extract_stop_reason` / `has_rate_limit_hint` helpers in `protocol.rs`; `MessageUpdate` and `MessageEnd` are now handled separately so `stopReason=error` can abort the turn loop with a typed `TurnFailed` error and emit `turn_error_detected` / `rate_limit_detected` diagnostics.
- **T02 (KAT-1654):** `scan_workspace_root` in `workspace.rs` maps `<prefix>/<identifier>` directories at startup; `startup_cleanup` in `orchestrator.rs` passes the resolved path hint to `mark_issue_terminal` so orphaned worktrees are cleaned up even after an unclean shutdown.
- **T03 (KAT-1655):** `create_comment` in `linear/client.rs` now calls `graphql_raw` (so GraphQL-level errors don't fail immediately) and retries once with a 1 s delay; the final error message bundles both attempt errors and the raw response for KAT-1231 diagnostics. The workpad prompts are updated with an explicit search-before-create protocol and conflict resolution rules to prevent duplicate workpad comments.

**Minor findings:**
- `has_rate_limit_hint` matches the bare word `\"retry\"` which is broad enough to produce false-positive `rate_limit_detected` events for unrelated error strings.
- The `startup_orphan_workspace_removed` log fires on path absence rather than on confirmed in-session removal, so it could misattribute externally-deleted directories as having been cleaned up by this startup pass.
- `parse_retry_after_ms` produces a useful `retry_after_ms` value that is logged but never used to delay actual retry scheduling; worth a note if the hook is intended for a future orchestrator backoff layer.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three bug fixes are correct and well-tested; remaining findings are diagnostic accuracy and code clarity concerns only.

All findings are P2: the overly-broad has_rate_limit_hint "retry" keyword only affects a warning-level tracing event (no behavioral change), the orphan-workspace log is misleading but does not affect cleanup correctness, and the unused retry_after_ms is a diagnostic gap rather than a functional regression. No data-integrity or crash-path issues were found.

apps/symphony/src/pi_agent/protocol.rs (has_rate_limit_hint breadth), apps/symphony/src/orchestrator.rs (startup_orphan_workspace_removed log condition), apps/symphony/src/pi_agent/rpc_bridge.rs (retry_after_ms unused)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/pi_agent/protocol.rs | Adds extract_stop_reason and has_rate_limit_hint helpers; the "retry" keyword in has_rate_limit_hint is overly broad and could produce false-positive rate_limit_detected events. |
| apps/symphony/src/pi_agent/rpc_bridge.rs | Splits MessageUpdate/MessageEnd handling and adds stopReason=error detection with TurnFailed propagation; retry_after_ms is parsed but never acted upon for actual backoff. |
| apps/symphony/src/orchestrator.rs | Wires workspace scan into startup_cleanup for orphan removal; the startup_orphan_workspace_removed diagnostic fires on path absence rather than confirmed in-session removal, which could be misleading. |
| apps/symphony/src/linear/client.rs | Adds one-retry mitigation to create_comment using graphql_raw so GraphQL-level errors trigger a retry rather than failing immediately; implementation is correct and well-tested. |
| apps/symphony/src/workspace.rs | Adds scan_workspace_root that maps <prefix>/<identifier> directories; filtering and error handling are thorough and tests are comprehensive. |
| apps/symphony/tests/linear_client_tests.rs | Adds retry-success and retry-exhausted test cases for create_comment; covers first-attempt failure, retry success, and both-attempts-failed paths cleanly. |
| apps/symphony/tests/orchestrator_tests.rs | Adds integration test confirming orphan workspace removal via startup scan; untouched workspace guard assertion is a nice correctness check. |
| apps/symphony/tests/pi_agent_tests.rs | Adds unit tests for extract_stop_reason/has_rate_limit_hint and an integration test verifying run_turn returns TurnFailed and emits the correct event on stopReason=error. |
| apps/symphony/prompts/system.md | Adds explicit Workpad search/conflict-resolution protocol using a GraphQL query shape; the 2+ match resolution strategy (oldest unresolved) is sensible. |
| apps/symphony/prompts/in-progress.md | Minor prompt updates directing the agent to reuse the existing workpad via the system search protocol instead of creating new ones blindly. |
| apps/symphony/prompts/agent-review.md | Single-line update to reference the workpad search protocol when updating the workpad checklist during review cycles. |
| apps/symphony/prompts/rework.md | Updates rework steps to use the workpad search protocol before removing/replacing the workpad, preventing duplicate creation during rework cycles. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant W as workspace::scan_workspace_root
    participant MI as mark_issue_terminal
    participant RB as rpc_bridge::run_turn
    participant PA as pi-agent process
    participant LC as LinearClient::create_comment

    Note over O: startup_cleanup()
    O->>W: scan_workspace_root(root, branch_prefix)
    W-->>O: HashMap<identifier, PathBuf>
    loop each terminal issue
        O->>MI: mark_issue_terminal(issue, workspace_path_hint)
        MI-->>O: cleanup complete
        O->>O: log startup_orphan_workspace_removed if !path.exists()
    end

    Note over RB,PA: run_turn() — T01 error path
    RB->>PA: send prompt RPC
    PA-->>RB: message_end {stopReason:"error", errorMessage:"..."}
    RB->>RB: extract_stop_reason → ("error", Some(msg))
    RB->>RB: has_rate_limit_hint? → warn rate_limit_detected
    RB->>RB: emit TurnFailed event
    RB-->>O: Err(SymphonyError::TurnFailed)

    Note over LC: create_comment() — T03 retry path
    LC->>LC: create_comment_attempt(id, body, attempt=1)
    LC-->>LC: Err (GraphQL error / success=false)
    LC->>LC: warn comment_create_failed + comment_create_retry
    LC->>LC: sleep COMMENT_CREATE_RETRY_DELAY_MS
    LC->>LC: create_comment_attempt(id, body, attempt=2)
    alt retry succeeds
        LC-->>O: Ok(())
    else retry fails
        LC-->>O: Err(SymphonyError::Other with full diagnostics)
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/symphony/src/pi_agent/protocol.rs`, line 296-300 ([link](https://github.com/gannonh/kata/blob/2dc3927a7f6a0934921360200f0dd7192debd508/apps/symphony/src/pi_agent/protocol.rs#L296-L300)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`"retry"` keyword over-broad for rate-limit detection**

   `has_rate_limit_hint` matches any message that contains the bare word `"retry"`, which will fire for unrelated error messages such as `"failed to retry connection"`, `"retry_attempted=false"`, or even the structured diagnostics already embedded in `SymphonyError::Other` strings (which themselves include `retry_attempted=...`). This makes the `rate_limit_detected` tracing event unreliable as a signal.

   Consider tightening the match to the more-specific phrases that are already covered by the other two arms, or add a word-boundary guard:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/pi_agent/protocol.rs
   Line: 296-300

   Comment:
   **`"retry"` keyword over-broad for rate-limit detection**

   `has_rate_limit_hint` matches any message that contains the bare word `"retry"`, which will fire for unrelated error messages such as `"failed to retry connection"`, `"retry_attempted=false"`, or even the structured diagnostics already embedded in `SymphonyError::Other` strings (which themselves include `retry_attempted=...`). This makes the `rate_limit_detected` tracing event unreliable as a signal.

   Consider tightening the match to the more-specific phrases that are already covered by the other two arms, or add a word-boundary guard:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/symphony/src/pi_agent/rpc_bridge.rs`, line 392-396 ([link](https://github.com/gannonh/kata/blob/2dc3927a7f6a0934921360200f0dd7192debd508/apps/symphony/src/pi_agent/rpc_bridge.rs#L392-L396)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`retry_after_ms` is parsed but never used for actual backoff**

   `parse_retry_after_ms` is called and the result stored in `retry_after_ms`, but this value is only forwarded to the `tracing::warn!` fields — it is never passed to a sleep, queued for the orchestrator's retry scheduler, or propagated in the returned `SymphonyError::TurnFailed`. As a result, a provider hint like `"Retry after 60s"` has no effect on actual retry timing.

   If acting on the hint is deferred to the orchestrator layer (e.g. via a future `RetryAfterMs` variant on the error type), it would be worth adding a comment here so the gap is clearly intentional and not overlooked.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/pi_agent/rpc_bridge.rs
   Line: 392-396

   Comment:
   **`retry_after_ms` is parsed but never used for actual backoff**

   `parse_retry_after_ms` is called and the result stored in `retry_after_ms`, but this value is only forwarded to the `tracing::warn!` fields — it is never passed to a sleep, queued for the orchestrator's retry scheduler, or propagated in the returned `SymphonyError::TurnFailed`. As a result, a provider hint like `"Retry after 60s"` has no effect on actual retry timing.

   If acting on the hint is deferred to the orchestrator layer (e.g. via a future `RetryAfterMs` variant on the error type), it would be worth adding a comment here so the gap is clearly intentional and not overlooked.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/pi_agent/protocol.rs
Line: 296-300

Comment:
**`"retry"` keyword over-broad for rate-limit detection**

`has_rate_limit_hint` matches any message that contains the bare word `"retry"`, which will fire for unrelated error messages such as `"failed to retry connection"`, `"retry_attempted=false"`, or even the structured diagnostics already embedded in `SymphonyError::Other` strings (which themselves include `retry_attempted=...`). This makes the `rate_limit_detected` tracing event unreliable as a signal.

Consider tightening the match to the more-specific phrases that are already covered by the other two arms, or add a word-boundary guard:

```suggestion
pub fn has_rate_limit_hint(message: &str) -> bool {
    let normalized = message.to_ascii_lowercase();
    normalized.contains("rate limit")
        || normalized.contains("usage limit")
        || normalized.contains("retry-after")
        || normalized.contains("retry after")
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 1889-1898

Comment:
**`startup_orphan_workspace_removed` fires on externally-absent paths**

The log event is emitted when `!workspace_path_ref.exists()` after `mark_issue_terminal` returns. The intent is to confirm that cleanup succeeded, but the condition is only that the path is now gone — it does not verify that this orchestrator session removed it. If the directory was deleted externally between the `scan_workspace_root` call and this check (race condition), the event fires with the message `"removed orphan workspace during startup cleanup"` even though no removal occurred here.

A more accurate signal would be to observe the `mark_issue_terminal` return value, or to explicitly remove the workspace and log based on that result. At minimum, consider rewording the message to `"orphan workspace no longer present after startup cleanup"` to avoid implying the orchestrator itself performed the deletion.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/pi_agent/rpc_bridge.rs
Line: 392-396

Comment:
**`retry_after_ms` is parsed but never used for actual backoff**

`parse_retry_after_ms` is called and the result stored in `retry_after_ms`, but this value is only forwarded to the `tracing::warn!` fields — it is never passed to a sleep, queued for the orchestrator's retry scheduler, or propagated in the returned `SymphonyError::TurnFailed`. As a result, a provider hint like `"Retry after 60s"` has no effect on actual retry timing.

If acting on the hint is deferred to the orchestrator layer (e.g. via a future `RetryAfterMs` variant on the error type), it would be worth adding a comment here so the gap is clearly intentional and not overlooked.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(symphony): apply rustfmt after lin..."](https://github.com/gannonh/kata/commit/2dc3927a7f6a0934921360200f0dd7192debd508) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26675648)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->