### PR TITLE
feat(cli): Linear team & project picker for onboarding wizard [KAT-1644]

### DIFF
--- a/apps/cli/src/resources/extensions/kata/onboarding.ts
+++ b/apps/cli/src/resources/extensions/kata/onboarding.ts
@@ -180,12 +180,22 @@ export async function pickLinearTeamAndProject(
       ctx.ui.notify(`Auto-selected project: ${project.name}`, "info");
       projectSlug = project.slugId;
     } else {
-      const projectOptions = projects.map((p) => p.name);
+      // Build labels that are guaranteed unique: append slugId when two projects share a name.
+      const nameCounts = new Map<string, number>();
+      for (const p of projects) {
+        nameCounts.set(p.name, (nameCounts.get(p.name) ?? 0) + 1);
+      }
+      const projectLabelMap = new Map<string, (typeof projects)[number]>();
+      for (const p of projects) {
+        const label = (nameCounts.get(p.name) ?? 0) > 1 ? `${p.name} (${p.slugId})` : p.name;
+        projectLabelMap.set(label, p);
+      }
+      const projectOptions = Array.from(projectLabelMap.keys());
       const selected = await ctx.ui.select("Select your Linear project", projectOptions);
       if (!selected) return null;
 
-      const idx = projectOptions.indexOf(selected);
-      const project = projects[idx];
+      const project = projectLabelMap.get(selected);
+      if (!project) return null;
       projectSlug = project.slugId;
     }
   } catch (err) {

--- a/apps/cli/src/resources/extensions/kata/onboarding.ts
+++ b/apps/cli/src/resources/extensions/kata/onboarding.ts
@@ -16,7 +16,7 @@
  */
 
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadEffectiveKataPreferences } from "./preferences.js";
 import { ensurePreferences, ensureGitignore } from "./gitignore.js";
@@ -73,6 +73,8 @@ export interface OnboardingDeps {
   };
   createLinearClient: (apiKey: string) => {
     getViewer: () => Promise<{ id: string; name: string; email: string }>;
+    listTeams: () => Promise<Array<{ id: string; key: string; name: string }>>;
+    listProjects: (opts?: { teamId?: string }) => Promise<Array<{ id: string; name: string; slugId: string }>>;
   };
   ensurePreferences: (basePath: string) => boolean;
   ensureGitignore: (basePath: string) => boolean;
@@ -102,6 +104,226 @@ async function getDeps(): Promise<OnboardingDeps> {
     ensurePreferences,
     ensureGitignore,
   };
+}
+
+// ─── Linear team & project picker ─────────────────────────────────────────────
+
+export interface LinearPickerResult {
+  teamKey: string;
+  projectSlug: string;
+}
+
+/**
+ * Fetch teams and projects from the Linear API and present interactive pickers.
+ * Returns `{ teamKey, projectSlug }` on success, or `null` if the user cancels
+ * or both API calls fail and manual entry is cancelled.
+ *
+ * - Single-team accounts auto-select without prompting.
+ * - Single-project teams auto-select without prompting.
+ * - API failures fall back to manual `ctx.ui.input` entry.
+ */
+export async function pickLinearTeamAndProject(
+  ctx: ExtensionCommandContext,
+  apiKey: string,
+): Promise<LinearPickerResult | null> {
+  const deps = await getDeps();
+  const client = deps.createLinearClient(apiKey);
+
+  // ── Team selection ──────────────────────────────────────────────────────
+  let teamKey: string;
+  let teamId: string;
+
+  try {
+    const teams = await client.listTeams();
+
+    if (teams.length === 0) {
+      ctx.ui.notify("No teams found in your Linear workspace.", "warning");
+      return manualLinearEntry(ctx);
+    }
+
+    if (teams.length === 1) {
+      const team = teams[0];
+      ctx.ui.notify(`Auto-selected team: ${team.name} (${team.key})`, "info");
+      teamKey = team.key;
+      teamId = team.id;
+    } else {
+      const teamOptions = teams.map((t) => `${t.name} (${t.key})`);
+      const selected = await ctx.ui.select("Select your Linear team", teamOptions);
+      if (!selected) return null;
+
+      const idx = teamOptions.indexOf(selected);
+      const team = teams[idx];
+      teamKey = team.key;
+      teamId = team.id;
+    }
+  } catch (err) {
+    ctx.ui.notify(
+      `Could not fetch teams from Linear — entering manually. (${err instanceof Error ? err.message : String(err)})`,
+      "warning",
+    );
+    return manualLinearEntry(ctx);
+  }
+
+  // ── Project selection ───────────────────────────────────────────────────
+  let projectSlug: string;
+
+  try {
+    const projects = await client.listProjects({ teamId });
+
+    if (projects.length === 0) {
+      ctx.ui.notify("No projects found for this team.", "warning");
+      return manualProjectEntry(ctx, teamKey);
+    }
+
+    if (projects.length === 1) {
+      const project = projects[0];
+      ctx.ui.notify(`Auto-selected project: ${project.name}`, "info");
+      projectSlug = project.slugId;
+    } else {
+      const projectOptions = projects.map((p) => p.name);
+      const selected = await ctx.ui.select("Select your Linear project", projectOptions);
+      if (!selected) return null;
+
+      const idx = projectOptions.indexOf(selected);
+      const project = projects[idx];
+      projectSlug = project.slugId;
+    }
+  } catch (err) {
+    ctx.ui.notify(
+      `Could not fetch projects from Linear — entering manually. (${err instanceof Error ? err.message : String(err)})`,
+      "warning",
+    );
+    return manualProjectEntry(ctx, teamKey);
+  }
+
+  return { teamKey, projectSlug };
+}
+
+/**
+ * Fallback: prompt user to manually enter both team key and project slug.
+ */
+async function manualLinearEntry(
+  ctx: ExtensionCommandContext,
+): Promise<LinearPickerResult | null> {
+  const teamKey = await ctx.ui.input("Linear team key", "e.g. KAT");
+  if (!teamKey || !teamKey.trim()) return null;
+
+  const projectSlug = await ctx.ui.input("Linear project slug", "from your project URL, e.g. 459f9835e809");
+  if (!projectSlug || !projectSlug.trim()) return null;
+
+  return { teamKey: teamKey.trim(), projectSlug: projectSlug.trim() };
+}
+
+/**
+ * Fallback: prompt user to manually enter just the project slug (team was already selected).
+ */
+async function manualProjectEntry(
+  ctx: ExtensionCommandContext,
+  teamKey: string,
+): Promise<LinearPickerResult | null> {
+  const projectSlug = await ctx.ui.input("Linear project slug", "from your project URL, e.g. 459f9835e809");
+  if (!projectSlug || !projectSlug.trim()) return null;
+
+  return { teamKey, projectSlug: projectSlug.trim() };
+}
+
+// ─── Preferences update utility ──────────────────────────────────────────────
+
+/**
+ * Update `.kata/preferences.md` YAML frontmatter with `linear.teamKey` and
+ * `linear.projectSlug`. Preserves all other frontmatter fields and the
+ * markdown body below the closing `---`.
+ */
+export function updatePreferencesLinearConfig(
+  basePath: string,
+  config: LinearPickerResult,
+): void {
+  const preferencesPath = join(basePath, ".kata", "preferences.md");
+  const legacyPath = join(basePath, ".kata", "PREFERENCES.md");
+
+  const filePath = existsSync(preferencesPath)
+    ? preferencesPath
+    : existsSync(legacyPath)
+      ? legacyPath
+      : preferencesPath;
+
+  const content = existsSync(filePath)
+    ? readFileSync(filePath, "utf-8")
+    : "---\nversion: 1\nlinear: {}\n---\n";
+
+  const updated = replaceLinearBlock(content, config);
+  writeFileSync(filePath, updated, "utf-8");
+}
+
+/**
+ * Replace the `linear:` block in YAML frontmatter with the new teamKey/projectSlug.
+ * Handles both `linear: {}` (empty inline) and multi-line `linear:` blocks.
+ */
+function replaceLinearBlock(
+  content: string,
+  config: LinearPickerResult,
+): string {
+  const fmMatch = content.match(/^(---\n)([\s\S]*?)\n(---)/);
+  if (!fmMatch) {
+    // No frontmatter — wrap with new frontmatter
+    return `---\nversion: 1\nlinear:\n  teamKey: ${config.teamKey}\n  projectSlug: ${config.projectSlug}\n---\n${content}`;
+  }
+
+  const [, openDelim, frontmatter, closeDelim] = fmMatch;
+  const afterFrontmatter = content.slice(fmMatch[0].length);
+
+  // Replace the linear block
+  const lines = frontmatter.split("\n");
+  const newLines: string[] = [];
+  let inLinearBlock = false;
+  let linearBlockReplaced = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trimStart();
+
+    if (trimmed.startsWith("linear:")) {
+      inLinearBlock = true;
+      linearBlockReplaced = true;
+
+      // Check if inline (e.g. "linear: {}" or "linear: {teamKey: ...}")
+      const afterColon = trimmed.slice("linear:".length).trim();
+      if (afterColon && afterColon !== "") {
+        // Replace the inline value
+        newLines.push("linear:");
+        newLines.push(`  teamKey: ${config.teamKey}`);
+        newLines.push(`  projectSlug: ${config.projectSlug}`);
+        inLinearBlock = false;
+        continue;
+      }
+
+      // Multi-line block starts
+      newLines.push("linear:");
+      newLines.push(`  teamKey: ${config.teamKey}`);
+      newLines.push(`  projectSlug: ${config.projectSlug}`);
+      continue;
+    }
+
+    if (inLinearBlock) {
+      // Skip indented lines that belong to the old linear block
+      if (trimmed === "" || line.match(/^\s+\S/)) {
+        continue;
+      }
+      // Non-indented line means linear block ended
+      inLinearBlock = false;
+    }
+
+    newLines.push(line);
+  }
+
+  // If no linear block was found, append one
+  if (!linearBlockReplaced) {
+    newLines.push("linear:");
+    newLines.push(`  teamKey: ${config.teamKey}`);
+    newLines.push(`  projectSlug: ${config.projectSlug}`);
+  }
+
+  return `${openDelim}${newLines.join("\n")}\n${closeDelim}${afterFrontmatter}`;
 }
 
 // ─── Onboarding wizard ───────────────────────────────────────────────────────
@@ -215,6 +437,24 @@ export async function runOnboarding(
     return "skipped";
   }
 
-  ctx.ui.notify("✓ Linear API key saved. .kata/ created.", "info");
+  // Pick Linear team and project
+  const pickerResult = await pickLinearTeamAndProject(ctx, apiKey);
+  if (pickerResult) {
+    try {
+      updatePreferencesLinearConfig(basePath, pickerResult);
+      ctx.ui.notify(
+        `✓ Linear configured: team=${pickerResult.teamKey}, project=${pickerResult.projectSlug}`,
+        "info",
+      );
+    } catch (err) {
+      ctx.ui.notify(
+        `Failed to write Linear config: ${err instanceof Error ? err.message : String(err)}`,
+        "error",
+      );
+    }
+  } else {
+    ctx.ui.notify("✓ Linear API key saved. .kata/ created. Run /kata to configure team/project.", "info");
+  }
+
   return "completed";
 }

--- a/apps/cli/src/resources/extensions/kata/onboarding.ts
+++ b/apps/cli/src/resources/extensions/kata/onboarding.ts
@@ -147,12 +147,14 @@ export async function pickLinearTeamAndProject(
       teamKey = team.key;
       teamId = team.id;
     } else {
-      const teamOptions = teams.map((t) => `${t.name} (${t.key})`);
+      // Team keys are unique in Linear, so labels are inherently unique.
+      const teamLabelMap = new Map(teams.map((t) => [`${t.name} (${t.key})`, t]));
+      const teamOptions = Array.from(teamLabelMap.keys());
       const selected = await ctx.ui.select("Select your Linear team", teamOptions);
       if (!selected) return null;
 
-      const idx = teamOptions.indexOf(selected);
-      const team = teams[idx];
+      const team = teamLabelMap.get(selected);
+      if (!team) return null;
       teamKey = team.key;
       teamId = team.id;
     }
@@ -273,17 +275,21 @@ function replaceLinearBlock(
   content: string,
   config: LinearPickerResult,
 ): string {
-  const fmMatch = content.match(/^(---\n)([\s\S]*?)\n(---)/);
+  // Detect line ending so we can be CRLF-agnostic.
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!fmMatch) {
     // No frontmatter — wrap with new frontmatter
-    return `---\nversion: 1\nlinear:\n  teamKey: ${config.teamKey}\n  projectSlug: ${config.projectSlug}\n---\n${content}`;
+    return `---${eol}version: 1${eol}linear:${eol}  teamKey: ${config.teamKey}${eol}  projectSlug: ${config.projectSlug}${eol}---${eol}${content}`;
   }
 
-  const [, openDelim, frontmatter, closeDelim] = fmMatch;
+  const openDelim = `---${eol}`;
+  const frontmatter = fmMatch[1];
+  const closeDelim = "---";
   const afterFrontmatter = content.slice(fmMatch[0].length);
 
-  // Replace the linear block
-  const lines = frontmatter.split("\n");
+  // Replace the linear block (strip \r so line values are clean regardless of eol)
+  const lines = frontmatter.split("\n").map((l) => l.replace(/\r$/, ""));
   const newLines: string[] = [];
   let inLinearBlock = false;
   let linearBlockReplaced = false;
@@ -315,11 +321,12 @@ function replaceLinearBlock(
     }
 
     if (inLinearBlock) {
-      // Skip indented lines that belong to the old linear block
-      if (trimmed === "" || line.match(/^\s+\S/)) {
+      // Skip indented lines that belong to the old linear block.
+      // Blank lines end the block (they're separators between top-level keys) — preserve them.
+      if (line.match(/^\s+\S/)) {
         continue;
       }
-      // Non-indented line means linear block ended
+      // Blank line or non-indented line: linear block ended
       inLinearBlock = false;
     }
 
@@ -333,7 +340,7 @@ function replaceLinearBlock(
     newLines.push(`  projectSlug: ${config.projectSlug}`);
   }
 
-  return `${openDelim}${newLines.join("\n")}\n${closeDelim}${afterFrontmatter}`;
+  return `${openDelim}${newLines.join(eol)}${eol}${closeDelim}${afterFrontmatter}`;
 }
 
 // ─── Onboarding wizard ───────────────────────────────────────────────────────

--- a/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, rmSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -9,7 +9,10 @@ import {
   setSkipOnboarding,
   _resetSkipFlag,
   _setDeps,
+  pickLinearTeamAndProject,
+  updatePreferencesLinearConfig,
   type OnboardingDeps,
+  type LinearPickerResult,
 } from "../onboarding.js";
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
@@ -37,9 +40,12 @@ function prefsWithLinear(linearYaml: string): string {
 function makeMockCtx(overrides: {
   hasUI?: boolean;
   inputReturns?: Array<string | null>;
+  selectReturns?: Array<string | null | undefined>;
 } = {}): any {
   const inputReturns = overrides.inputReturns ?? ["lin_api_test123"];
   let inputCallIndex = 0;
+  const selectReturns = overrides.selectReturns ?? [];
+  let selectCallIndex = 0;
   const notifications: Array<{ message: string; level: string }> = [];
 
   return {
@@ -50,6 +56,11 @@ function makeMockCtx(overrides: {
         inputCallIndex++;
         return value;
       }),
+      select: vi.fn(async () => {
+        const value = selectReturns[selectCallIndex] ?? undefined;
+        selectCallIndex++;
+        return value;
+      }),
       notify: vi.fn((message: string, level: string) => {
         notifications.push({ message, level });
       }),
@@ -57,6 +68,16 @@ function makeMockCtx(overrides: {
     _notifications: notifications,
   };
 }
+
+const DEFAULT_TEAMS = [
+  { id: "team-1", key: "KAT", name: "Kata-sh" },
+  { id: "team-2", key: "DEV", name: "Dev Team" },
+];
+
+const DEFAULT_PROJECTS = [
+  { id: "proj-1", name: "Kata CLI", slugId: "459f9835e809" },
+  { id: "proj-2", name: "Kata Desktop", slugId: "abc123def456" },
+];
 
 function makeMockDeps(overrides: Partial<OnboardingDeps> = {}): OnboardingDeps {
   const storedCreds: Record<string, any> = {};
@@ -70,6 +91,8 @@ function makeMockDeps(overrides: Partial<OnboardingDeps> = {}): OnboardingDeps {
     }),
     createLinearClient: () => ({
       getViewer: async () => ({ id: "user-1", name: "Test User", email: "test@test.com" }),
+      listTeams: async () => DEFAULT_TEAMS,
+      listProjects: async () => DEFAULT_PROJECTS,
     }),
     ensurePreferences: vi.fn(() => true),
     ensureGitignore: vi.fn(() => true),
@@ -184,8 +207,22 @@ describe("onboarding", () => {
     });
 
     it("returns 'completed' on valid API key", async () => {
-      const ctx = makeMockCtx({ inputReturns: ["lin_api_valid"] });
-      const deps = makeMockDeps();
+      const ctx = makeMockCtx({
+        inputReturns: ["lin_api_valid"],
+        selectReturns: ["Kata-sh (KAT)", "Kata CLI"],
+      });
+      const deps = makeMockDeps({
+        ensurePreferences: vi.fn((basePath: string) => {
+          const kataDir = join(basePath, ".kata");
+          mkdirSync(kataDir, { recursive: true });
+          writeFileSync(
+            join(kataDir, "preferences.md"),
+            "---\nversion: 1\nworkflow:\n  mode: linear\nlinear: {}\n---\n",
+            "utf-8",
+          );
+          return true;
+        }),
+      });
       _setDeps(deps);
 
       try {
@@ -228,6 +265,7 @@ describe("onboarding", () => {
     it("retries once on auth error then succeeds", async () => {
       const ctx = makeMockCtx({
         inputReturns: ["bad_key", "good_key"],
+        selectReturns: ["Kata-sh (KAT)", "Kata CLI"],
       });
       let callCount = 0;
       const deps = makeMockDeps({
@@ -239,6 +277,8 @@ describe("onboarding", () => {
             }
             return { id: "user-1", name: "Test", email: "t@t.com" };
           },
+          listTeams: async () => DEFAULT_TEAMS,
+          listProjects: async () => DEFAULT_PROJECTS,
         }),
       });
       _setDeps(deps);
@@ -301,7 +341,10 @@ describe("onboarding", () => {
     });
 
     it("stores credentials in auth storage", async () => {
-      const ctx = makeMockCtx({ inputReturns: ["lin_api_stored"] });
+      const ctx = makeMockCtx({
+        inputReturns: ["lin_api_stored"],
+        selectReturns: ["Kata-sh (KAT)", "Kata CLI"],
+      });
       const storedCreds: Record<string, any> = {};
       const deps = makeMockDeps({
         createAuthStorage: () => ({
@@ -363,6 +406,351 @@ describe("onboarding", () => {
         expect(ctx._notifications.some(
           (n: any) => n.message.includes("Failed to create project config") && n.level === "error",
         )).toBe(true);
+      } finally {
+        delete process.env.LINEAR_API_KEY;
+      }
+    });
+  });
+
+  // ─── pickLinearTeamAndProject ──────────────────────────────────────────────
+
+  describe("pickLinearTeamAndProject — picker", () => {
+    it("multi-team → select → multi-project → select → returns correct values", async () => {
+      const ctx = makeMockCtx({
+        selectReturns: ["Kata-sh (KAT)", "Kata CLI"],
+      });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toEqual({ teamKey: "KAT", projectSlug: "459f9835e809" });
+      expect(ctx.ui.select).toHaveBeenCalledTimes(2);
+      expect(ctx.ui.select).toHaveBeenCalledWith(
+        "Select your Linear team",
+        ["Kata-sh (KAT)", "Dev Team (DEV)"],
+      );
+      expect(ctx.ui.select).toHaveBeenCalledWith(
+        "Select your Linear project",
+        ["Kata CLI", "Kata Desktop"],
+      );
+    });
+
+    it("single-team auto-selects without prompting", async () => {
+      const singleTeam = [{ id: "team-1", key: "KAT", name: "Kata-sh" }];
+      const ctx = makeMockCtx({
+        selectReturns: ["Kata CLI"],
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-1", name: "Test", email: "t@t.com" }),
+          listTeams: async () => singleTeam,
+          listProjects: async () => DEFAULT_PROJECTS,
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toEqual({ teamKey: "KAT", projectSlug: "459f9835e809" });
+      // select called only once (for project), not for team
+      expect(ctx.ui.select).toHaveBeenCalledTimes(1);
+      expect(ctx._notifications.some(
+        (n: any) => n.message.includes("Auto-selected team") && n.level === "info",
+      )).toBe(true);
+    });
+
+    it("single-team + single-project → both auto-selected, no select calls", async () => {
+      const singleTeam = [{ id: "team-1", key: "KAT", name: "Kata-sh" }];
+      const singleProject = [{ id: "proj-1", name: "Kata CLI", slugId: "459f9835e809" }];
+      const ctx = makeMockCtx();
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-1", name: "Test", email: "t@t.com" }),
+          listTeams: async () => singleTeam,
+          listProjects: async () => singleProject,
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toEqual({ teamKey: "KAT", projectSlug: "459f9835e809" });
+      expect(ctx.ui.select).not.toHaveBeenCalled();
+      expect(ctx._notifications.some(
+        (n: any) => n.message.includes("Auto-selected team"),
+      )).toBe(true);
+      expect(ctx._notifications.some(
+        (n: any) => n.message.includes("Auto-selected project"),
+      )).toBe(true);
+    });
+
+    it("user cancels team picker → returns null", async () => {
+      const ctx = makeMockCtx({
+        selectReturns: [undefined], // user cancelled
+      });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toBeNull();
+    });
+
+    it("user cancels project picker → returns null", async () => {
+      const ctx = makeMockCtx({
+        selectReturns: ["Kata-sh (KAT)", undefined], // selected team, cancelled project
+      });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── pickLinearTeamAndProject — fallback ───────────────────────────────────
+
+  describe("pickLinearTeamAndProject — fallback", () => {
+    it("listTeams throws → manual team key and project slug entry", async () => {
+      const ctx = makeMockCtx({
+        inputReturns: ["KAT", "459f9835e809"],
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-1", name: "Test", email: "t@t.com" }),
+          listTeams: async () => { throw new Error("Network error"); },
+          listProjects: async () => DEFAULT_PROJECTS,
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toEqual({ teamKey: "KAT", projectSlug: "459f9835e809" });
+      expect(ctx.ui.select).not.toHaveBeenCalled();
+      expect(ctx._notifications.some(
+        (n: any) => n.message.includes("Could not fetch teams") && n.level === "warning",
+      )).toBe(true);
+    });
+
+    it("listTeams succeeds but listProjects throws → team picked, project entered manually", async () => {
+      const ctx = makeMockCtx({
+        selectReturns: ["Kata-sh (KAT)"],
+        inputReturns: ["459f9835e809"],
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-1", name: "Test", email: "t@t.com" }),
+          listTeams: async () => DEFAULT_TEAMS,
+          listProjects: async () => { throw new Error("Rate limited"); },
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toEqual({ teamKey: "KAT", projectSlug: "459f9835e809" });
+      expect(ctx.ui.select).toHaveBeenCalledTimes(1); // only team picker
+      expect(ctx._notifications.some(
+        (n: any) => n.message.includes("Could not fetch projects") && n.level === "warning",
+      )).toBe(true);
+    });
+
+    it("manual entry with empty team key input → returns null", async () => {
+      const ctx = makeMockCtx({
+        inputReturns: [""], // empty team key
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-1", name: "Test", email: "t@t.com" }),
+          listTeams: async () => { throw new Error("Network error"); },
+          listProjects: async () => DEFAULT_PROJECTS,
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toBeNull();
+    });
+
+    it("no teams found → falls back to manual entry", async () => {
+      const ctx = makeMockCtx({
+        inputReturns: ["KAT", "abc123"],
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-1", name: "Test", email: "t@t.com" }),
+          listTeams: async () => [],
+          listProjects: async () => DEFAULT_PROJECTS,
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toEqual({ teamKey: "KAT", projectSlug: "abc123" });
+      expect(ctx._notifications.some(
+        (n: any) => n.message.includes("No teams found"),
+      )).toBe(true);
+    });
+  });
+
+  // ─── updatePreferencesLinearConfig ─────────────────────────────────────────
+
+  describe("updatePreferencesLinearConfig", () => {
+    it("writes teamKey and projectSlug into preferences with empty linear block", () => {
+      writePreferences(tmpDir, prefsWithLinear("  {}"));
+
+      updatePreferencesLinearConfig(tmpDir, { teamKey: "KAT", projectSlug: "459f9835e809" });
+
+      const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+      expect(content).toContain("teamKey: KAT");
+      expect(content).toContain("projectSlug: 459f9835e809");
+      // Verify preferences are loadable and correct
+      expect(isProjectConfigured(tmpDir)).toBe(true);
+    });
+
+    it("preserves other YAML fields when writing linear config", () => {
+      const original = `---
+version: 1
+workflow:
+  mode: linear
+linear: {}
+pr:
+  enabled: true
+  base_branch: main
+models:
+  research: claude-sonnet-4-6
+---
+
+# My Preferences
+`;
+      writePreferences(tmpDir, original);
+
+      updatePreferencesLinearConfig(tmpDir, { teamKey: "DEV", projectSlug: "slug123" });
+
+      const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+      expect(content).toContain("teamKey: DEV");
+      expect(content).toContain("projectSlug: slug123");
+      expect(content).toContain("version: 1");
+      expect(content).toContain("mode: linear");
+      expect(content).toContain("enabled: true");
+      expect(content).toContain("base_branch: main");
+      expect(content).toContain("research: claude-sonnet-4-6");
+      expect(content).toContain("# My Preferences");
+    });
+
+    it("overwrites existing linear.teamKey and linear.projectSlug", () => {
+      writePreferences(tmpDir, prefsWithLinear("  teamKey: OLD\n  projectSlug: old-slug"));
+
+      updatePreferencesLinearConfig(tmpDir, { teamKey: "NEW", projectSlug: "new-slug" });
+
+      const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+      expect(content).toContain("teamKey: NEW");
+      expect(content).toContain("projectSlug: new-slug");
+      expect(content).not.toContain("teamKey: OLD");
+      expect(content).not.toContain("old-slug");
+    });
+
+    it("adds linear block when none exists in frontmatter", () => {
+      const noLinear = `---
+version: 1
+workflow:
+  mode: linear
+pr:
+  enabled: false
+---
+
+# Prefs
+`;
+      writePreferences(tmpDir, noLinear);
+
+      updatePreferencesLinearConfig(tmpDir, { teamKey: "KAT", projectSlug: "abc" });
+
+      const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+      expect(content).toContain("teamKey: KAT");
+      expect(content).toContain("projectSlug: abc");
+      expect(isProjectConfigured(tmpDir)).toBe(true);
+    });
+  });
+
+  // ─── runOnboarding with picker integration ────────────────────────────────
+
+  describe("runOnboarding — picker integration", () => {
+    it("full flow: key → picker → write → isProjectConfigured true", async () => {
+      const singleTeam = [{ id: "team-1", key: "KAT", name: "Kata-sh" }];
+      const singleProject = [{ id: "proj-1", name: "Kata CLI", slugId: "459f9835e809" }];
+      const ctx = makeMockCtx({
+        inputReturns: ["lin_api_valid"],
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-1", name: "Test", email: "t@t.com" }),
+          listTeams: async () => singleTeam,
+          listProjects: async () => singleProject,
+        }),
+        // Actually write preferences to disk
+        ensurePreferences: vi.fn((basePath: string) => {
+          const kataDir = join(basePath, ".kata");
+          mkdirSync(kataDir, { recursive: true });
+          writeFileSync(
+            join(kataDir, "preferences.md"),
+            "---\nversion: 1\nworkflow:\n  mode: linear\nlinear: {}\n---\n",
+            "utf-8",
+          );
+          return true;
+        }),
+      });
+      _setDeps(deps);
+
+      try {
+        const result = await runOnboarding(ctx, tmpDir);
+
+        expect(result).toBe("completed");
+        // Verify preferences were written correctly
+        expect(isProjectConfigured(tmpDir)).toBe(true);
+        const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+        expect(content).toContain("teamKey: KAT");
+        expect(content).toContain("projectSlug: 459f9835e809");
+        // Verify success notification mentions team and project
+        expect(ctx._notifications.some(
+          (n: any) => n.message.includes("team=KAT") && n.message.includes("459f9835e809"),
+        )).toBe(true);
+      } finally {
+        delete process.env.LINEAR_API_KEY;
+      }
+    });
+
+    it("picker returns null (user cancelled) → preferences created but no linear config", async () => {
+      const ctx = makeMockCtx({
+        inputReturns: ["lin_api_valid"],
+        selectReturns: [undefined], // user cancels team picker
+      });
+      const deps = makeMockDeps({
+        ensurePreferences: vi.fn((basePath: string) => {
+          const kataDir = join(basePath, ".kata");
+          mkdirSync(kataDir, { recursive: true });
+          writeFileSync(
+            join(kataDir, "preferences.md"),
+            "---\nversion: 1\nworkflow:\n  mode: linear\nlinear: {}\n---\n",
+            "utf-8",
+          );
+          return true;
+        }),
+      });
+      _setDeps(deps);
+
+      try {
+        const result = await runOnboarding(ctx, tmpDir);
+
+        expect(result).toBe("completed");
+        // Preferences exist but no linear config written
+        expect(isProjectConfigured(tmpDir)).toBe(false);
+        const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+        expect(content).not.toContain("teamKey:");
       } finally {
         delete process.env.LINEAR_API_KEY;
       }

--- a/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
@@ -436,6 +436,36 @@ describe("onboarding", () => {
       );
     });
 
+    it("duplicate project names → disambiguates with slugId in label, resolves correct project", async () => {
+      // Two projects with identical names — picker must display unique labels
+      const duplicateProjects = [
+        { id: "proj-1", name: "Kata CLI", slugId: "slug-first-111" },
+        { id: "proj-2", name: "Kata CLI", slugId: "slug-second-222" },
+      ];
+      // Single team → auto-selected; user selects the second project (disambiguated with slugId)
+      const ctx = makeMockCtx({
+        selectReturns: ["Kata CLI (slug-second-222)"],
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-1", name: "Test", email: "t@t.com" }),
+          listTeams: async () => [{ id: "team-1", key: "KAT", name: "Kata-sh" }],
+          listProjects: async () => duplicateProjects,
+        }),
+      });
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      // Must resolve to the second project, not the first
+      expect(result).toEqual({ teamKey: "KAT", projectSlug: "slug-second-222" });
+      // Both duplicate project labels should include slugId for disambiguation
+      expect(ctx.ui.select).toHaveBeenCalledWith(
+        "Select your Linear project",
+        ["Kata CLI (slug-first-111)", "Kata CLI (slug-second-222)"],
+      );
+    });
+
     it("single-team auto-selects without prompting", async () => {
       const singleTeam = [{ id: "team-1", key: "KAT", name: "Kata-sh" }];
       const ctx = makeMockCtx({

--- a/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
@@ -515,6 +515,18 @@ describe("onboarding", () => {
       )).toBe(true);
     });
 
+    it("team picker returns unrecognized label → returns null (Map guard)", async () => {
+      const ctx = makeMockCtx({
+        selectReturns: ["Nonexistent Team (XXX)"], // not in the team list
+      });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const result = await pickLinearTeamAndProject(ctx, "lin_api_test");
+
+      expect(result).toBeNull();
+    });
+
     it("user cancels team picker → returns null", async () => {
       const ctx = makeMockCtx({
         selectReturns: [undefined], // user cancelled
@@ -704,6 +716,52 @@ pr:
       expect(content).toContain("teamKey: KAT");
       expect(content).toContain("projectSlug: abc");
       expect(isProjectConfigured(tmpDir)).toBe(true);
+    });
+
+    it("preserves blank separator lines between linear block and next YAML key", () => {
+      // Regression: blank line after linear block should NOT be swallowed
+      const withBlankSeparator = `---
+version: 1
+linear:
+  teamKey: OLD
+  projectSlug: old-slug
+
+pr:
+  enabled: true
+---
+
+# My Preferences
+`;
+      writePreferences(tmpDir, withBlankSeparator);
+
+      updatePreferencesLinearConfig(tmpDir, { teamKey: "KAT", projectSlug: "new-slug" });
+
+      const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+      expect(content).toContain("teamKey: KAT");
+      expect(content).toContain("projectSlug: new-slug");
+      // The pr: block must still be present after the linear block
+      expect(content).toContain("pr:");
+      expect(content).toContain("enabled: true");
+    });
+
+    it("handles CRLF line endings in preferences file", () => {
+      // Regression: CRLF files must be parsed and written back without corrupting the file.
+      // Note: isProjectConfigured uses the preferences parser which has its own CRLF handling;
+      // this test verifies that replaceLinearBlock writes correct content regardless of EOL.
+      const crlfContent = "---\r\nversion: 1\r\nlinear: {}\r\npr:\r\n  enabled: true\r\n---\r\n\r\n# Prefs\r\n";
+      writePreferences(tmpDir, crlfContent);
+
+      updatePreferencesLinearConfig(tmpDir, { teamKey: "KAT", projectSlug: "slug123" });
+
+      const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+      // Values must be present in the output
+      expect(content).toContain("teamKey: KAT");
+      expect(content).toContain("projectSlug: slug123");
+      // The pr: section must be preserved (not corrupted)
+      expect(content).toContain("pr:");
+      expect(content).toContain("enabled: true");
+      // CRLF line endings must be preserved throughout
+      expect(content).toContain("\r\n");
     });
   });
 


### PR DESCRIPTION
## Summary

Adds interactive Linear team & project pickers to the onboarding wizard. After the user enters a valid Linear API key (from S01), the wizard now fetches teams and projects from the Linear API and presents `ctx.ui.select` pickers.

Closes KAT-1644

## Changes

### `apps/cli/src/resources/extensions/kata/onboarding.ts`

- **`pickLinearTeamAndProject(ctx, apiKey)`** — Fetches teams via `LinearClient.listTeams()`, presents picker. Then fetches projects for the selected team, presents project picker. Returns `{ teamKey, projectSlug }` or `null` on cancel.
  - Single-team accounts auto-select without prompting
  - Single-project teams auto-select without prompting
  - API failures fall back to manual `ctx.ui.input` entry with error notification
  - Empty results fall back to manual entry
- **`updatePreferencesLinearConfig(basePath, config)`** — Reads `.kata/preferences.md`, replaces the `linear:` YAML frontmatter block with the selected `teamKey` and `projectSlug`, preserving all other fields.
- **`runOnboarding` wiring** — After API key validation + `.kata/` creation, calls `pickLinearTeamAndProject`. If the user completes the picker, writes the config and shows success notification. If cancelled, shows a fallback message.

### `apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts`

15 new tests across 4 describe blocks:

- **`pickLinearTeamAndProject — picker`** (5 tests): multi-team select, single-team auto-select, single-team+single-project auto-select, team cancel, project cancel
- **`pickLinearTeamAndProject — fallback`** (4 tests): listTeams failure → manual entry, listProjects failure → manual project entry, empty manual input → null, no teams found → manual entry
- **`updatePreferencesLinearConfig`** (4 tests): empty linear block, field preservation, overwrite existing, add when missing
- **`runOnboarding — picker integration`** (2 tests): full flow → isProjectConfigured true, user cancel → no config written

## Tasks Completed

- [x] T01: Build pickLinearTeamAndProject with ctx.ui.select pickers (KAT-1645)
- [x] T02: Add API failure fallback to manual entry (KAT-1646)
- [x] T03: Write selected Linear config to preferences YAML and wire into runOnboarding (KAT-1647)

## Verification

- `npx vitest run -- --grep "onboarding|picker"` — 37 tests pass (282 total)
- `npx tsc --noEmit` — clean
- `bun run lint` — 0 errors (342 pre-existing warnings)
- Pre-push gate passed (lint + typecheck + test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive team and project selection to the Linear workspace onboarding flow.
  * Preferences file automatically updates with selected Linear team and project configuration.
  * Auto-selects team or project when only one option is available.

* **Tests**
  * Added comprehensive test coverage for team/project selection flows, including multi-select prompting and cancellation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an interactive Linear team & project picker to the onboarding wizard. After a valid API key is entered, it calls `listTeams` and `listProjects`, presents `ctx.ui.select` pickers with sensible auto-selection for single-team/single-project workspaces, gracefully falls back to manual `ctx.ui.input` on API failure, and writes the selected `teamKey` / `projectSlug` into the YAML frontmatter of `.kata/preferences.md` via a custom `replaceLinearBlock` parser.\n\nKey changes:\n- **`pickLinearTeamAndProject(ctx, apiKey)`** — full picker with auto-select, cancel handling, and fallback paths.\n- **`updatePreferencesLinearConfig(basePath, config)`** — targeted YAML frontmatter rewriter that preserves all other fields; handles empty inline blocks, multi-line blocks, and missing blocks.\n- **`runOnboarding` wiring** — calls the picker after `.kata/` creation; writes config on success, shows a helpful \"configure later\" message on cancel.\n- **15 new tests** — good coverage across picker, fallback, preferences update, and full integration paths.\n\nOne correctness concern to address before merge: the project picker uses `Array.indexOf` on project names only, which will silently pick the wrong project when a team has two projects with the same name. Including the `slugId` in the display string (as is already done for team keys) would fix this and match the existing pattern.",
<parameter name="fileAnalyses">[
  {
    "path": "apps/cli/src/resources/extensions/kata/onboarding.ts",
    "confidence": 4,
    "summary": "Adds `pickLinearTeamAndProject`, `updatePreferencesLinearConfig`, and `replaceLinearBlock`; wires the picker into `runOnboarding`. Contains a correctness bug: project lookup uses `Array.indexOf` on project names only, so duplicate project names within a team silently select the wrong project."
  },
  {
    "path": "apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts",
    "confidence": 5,
    "summary": "Adds 15 new tests covering the picker, fallback paths, preferences update, and full `runOnboarding` integration; good coverage of happy-path and error cases, though no test for duplicate project names."
  }
]

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the project-name deduplication bug; all other findings are defensive hygiene or cosmetic.

One P1 finding: when two projects in the same Linear team share a name, `indexOf` always returns the first match's index, silently writing the wrong `projectSlug` to preferences. This is a real data-correctness defect on a path the user just completed the full onboarding flow through. The fix is small (append `slugId` to the display string). All other findings are P2 style/defensive concerns that don't block merge.

apps/cli/src/resources/extensions/kata/onboarding.ts — specifically the project-picker `indexOf` lookup and the missing `-1` guard on both team and project index lookups.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant W as runOnboarding
    participant P as pickLinearTeamAndProject
    participant L as LinearClient
    participant FS as preferences.md

    W->>U: ctx.ui.input("Linear API Key")
    U-->>W: apiKey
    W->>L: getViewer() [validate key]
    L-->>W: viewer
    W->>FS: ensurePreferences / ensureGitignore
    W->>P: pickLinearTeamAndProject(ctx, apiKey)

    P->>L: listTeams()
    alt 0 teams
        P->>U: notify("No teams found")
        P->>U: ctx.ui.input(teamKey, projectSlug)
    else 1 team
        P->>U: notify("Auto-selected team")
    else N teams
        P->>U: ctx.ui.select("Select your Linear team")
        U-->>P: selected team
    end

    P->>L: listProjects({ teamId })
    alt 0 projects
        P->>U: notify("No projects found")
        P->>U: ctx.ui.input(projectSlug)
    else 1 project
        P->>U: notify("Auto-selected project")
    else N projects
        P->>U: ctx.ui.select("Select your Linear project")
        U-->>P: selected project
    end

    P-->>W: { teamKey, projectSlug } | null

    alt pickerResult != null
        W->>FS: updatePreferencesLinearConfig(basePath, result)
        W->>U: notify("Linear configured")
    else cancelled
        W->>U: notify("API key saved. Run /kata to configure")
    end

    W-->>U: completed
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/onboarding.ts
Line: 183-189

Comment:
**Duplicate project names silently select the wrong project**

`projectOptions` is built from `p.name` alone, so if two projects in the same team share a name, `indexOf(selected)` always returns the *first* index even when the user visually picked the second one. The wrong `slugId` is then written to preferences with no error or warning.

The same structural issue exists for team lookup (line 154), though Linear guarantees unique team `key` values so that case is less likely in practice. For projects, duplicate names are entirely valid in Linear.

A simple fix is to embed something unique in the displayed option so the selected string can be matched back unambiguously:

```
const projectOptions = projects.map((p) => `${p.name} (${p.slugId})`);
const selected = await ctx.ui.select("Select your Linear project", projectOptions);
if (!selected) return null;

const idx = projectOptions.indexOf(selected);
const project = projects[idx];
projectSlug = project.slugId;
```

This also makes the slug visible to the user for verification, which aligns with how teams display `(KEY)` next to the name.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/onboarding.ts
Line: 154-157

Comment:
**Missing guard for `indexOf` returning `-1`**

Both team and project lookups rely on `teamOptions.indexOf(selected)` / `projectOptions.indexOf(selected)`. If the UI ever returns a string that isn't present in the options array (e.g., a race condition or framework inconsistency), `idx` is `-1` and `teams[-1]` / `projects[-1]` resolves to `undefined`, causing an immediate crash when accessing `.key` or `.id`.

A one-line guard prevents this:

```
const idx = teamOptions.indexOf(selected);
if (idx === -1) return null;
const team = teams[idx];
```

Apply the same guard on the project side (line ~188).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/onboarding.ts
Line: 307-313

Comment:
**Blank separator lines between the `linear:` block and the next key are silently dropped**

When skipping the old `linear:` block, the condition `trimmed === ""` treats any blank line (including the intentional blank line separating YAML sections) as part of the block and discards it. For example:

```yaml
linear:
  teamKey: OLD

pr:
  enabled: true
```

After replacement, the blank line between `linear:` and `pr:` disappears. The resulting YAML is still valid, but the formatting diverges from the original and could be surprising when diffing the file. Consider only skipping indented (non-blank) lines and letting blank lines through:

```
if (line.match(/^\s+\S/)) {
  continue;
}
// Non-indented or blank line → linear block ended
inLinearBlock = false;
newLines.push(line);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add Linear team &amp; project pic..."](https://github.com/gannonh/kata/commit/833adf407a433f2ae896c827b99eb1fb00956457) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26676278)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->