### PR TITLE
feat(symphony): surface persistent worker errors in TUI/dashboard/state

### DIFF
--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -979,6 +979,9 @@ pub struct WorkerSessionInfo {
     /// Short preview of the arguments for the currently executing tool.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_tool_args_preview: Option<String>,
+    /// Last worker error surfaced for operator visibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 // ── LiveSession (spec §4.1.6) ─────────────────────────────────────────
@@ -1113,6 +1116,9 @@ pub struct RunningSessionSnapshot {
     /// Short preview of the arguments for the currently executing tool.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_tool_args_preview: Option<String>,
+    /// Last worker error mirrored from `WorkerSessionInfo` for TUI rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 /// Polling state for the snapshot.

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -620,6 +620,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     td {{ color: #d7e1ee; }}
     td.mono {{ word-break: break-all; }}
     .stale-activity {{ color: #fca5a5; font-weight: 600; }}
+    .error-text {{ color: #e5484d; font-weight: 600; }}
     .list {{ margin: 0; padding-left: 20px; }}
     .muted {{ color: #94a3b8; }}
     .error {{ margin-top: 12px; color: #fca5a5; }}
@@ -660,6 +661,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
             <th>Linear State</th>
             <th>Status</th>
             <th>Activity</th>
+            <th>Error</th>
             <th>Attempt</th>
             <th>Turn</th>
             <th>Last Activity</th>
@@ -671,7 +673,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
           </tr>
         </thead>
         <tbody id="running-table-body">
-          <tr><td class="muted" colspan="12">Loading...</td></tr>
+          <tr><td class="muted" colspan="13">Loading...</td></tr>
         </tbody>
       </table>
     </div>
@@ -859,7 +861,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }});
 
       if (rows.length === 0) {{
-        return '<tr><td class="muted" colspan="12">No running sessions.</td></tr>';
+        return '<tr><td class="muted" colspan="13">No running sessions.</td></tr>';
       }}
 
       return rows.map(function(entry) {{
@@ -889,11 +891,16 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         const toolName = sessionInfo.current_tool_name || '';
         const toolArgs = sessionInfo.current_tool_args_preview || '';
         const activityLabel = toolName ? 'tool: ' + toolName + (toolArgs ? ' (' + toolArgs + ')' : '') : '-';
+        const errorValue = sessionInfo.last_error;
+        const errorCell = errorValue
+          ? '<td class="mono error-text">' + escapeHtml(errorValue) + '</td>'
+          : '<td class="muted">-</td>';
         return '<tr>' +
           '<td class="mono">' + escapeHtml(run.issue_identifier || '-') + '</td>' +
           '<td>' + escapeHtml(run.linear_state || '-') + '</td>' +
           '<td>' + escapeHtml(run.status || '-') + '</td>' +
           '<td class="mono">' + escapeHtml(activityLabel) + '</td>' +
+          errorCell +
           '<td>' + escapeHtml(attempt) + '</td>' +
           '<td class="mono">' + escapeHtml(turnLabel) + '</td>' +
           '<td class="' + escapeHtml(lastActivityClass) + '">' + escapeHtml(lastActivityLabel) + '</td>' +

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -32,6 +32,11 @@ static SHARED_CONTEXT_PLACEHOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\{\{\s*shared_context\s*\}\}")
         .expect("shared_context placeholder regex must compile")
 });
+static RATE_LIMIT_WINDOW_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(\d+)\s*(hours?|hrs?|hr|h|minutes?|mins?|min|m|seconds?|secs?|sec|s)")
+        .expect("rate-limit window regex must compile")
+});
+const WORKER_LAST_ERROR_MAX_CHARS: usize = 200;
 
 // ── Standalone Worker Task ──────────────────────────────────────────────
 
@@ -2216,6 +2221,7 @@ impl Orchestrator {
                 session_tokens: SessionTokenUsage::default(),
                 current_tool_name: None,
                 current_tool_args_preview: None,
+                last_error: None,
             });
         if info.max_turns == 0 {
             info.max_turns = max_turns;
@@ -2316,6 +2322,19 @@ impl Orchestrator {
             }
         }
 
+        let event_error = match event {
+            AgentEvent::TurnFailed { error, .. }
+            | AgentEvent::TurnEndedWithError { error, .. }
+            | AgentEvent::StartupFailed { error, .. } => Some(error.as_str()),
+            _ => None,
+        };
+
+        if let Some(error) = event_error {
+            if let Some(info) = self.worker_session_info.get_mut(issue_id) {
+                info.last_error = Some(format_rate_limit_error(error));
+            }
+        }
+
         match event {
             AgentEvent::EscalationCreated { request, .. } => {
                 tracing::info!(
@@ -2391,6 +2410,9 @@ impl Orchestrator {
                 .session_tokens
                 .total_tokens
                 .saturating_add(*total_tokens);
+            if *total_tokens > 0 {
+                session_info.last_error = None;
+            }
             self.advance_turn_counter(issue_id);
             self.apply_turn_metrics(&TurnMetrics {
                 input_tokens: *input_tokens,
@@ -3490,6 +3512,10 @@ impl Orchestrator {
                         current_tool_name: stats.and_then(|s| s.current_tool_name.clone()),
                         current_tool_args_preview: stats
                             .and_then(|s| s.current_tool_args_preview.clone()),
+                        last_error: self
+                            .worker_session_info
+                            .get(issue_id)
+                            .and_then(|info| info.last_error.clone()),
                     },
                 )
             })
@@ -4341,6 +4367,58 @@ fn event_severity_for_agent_event(event: &AgentEvent) -> EventSeverity {
         AgentEvent::OtherMessage { .. } => EventSeverity::Debug,
         _ => EventSeverity::Info,
     }
+}
+
+fn format_rate_limit_error(error: &str) -> String {
+    let truncated = truncate_for_display(error, WORKER_LAST_ERROR_MAX_CHARS);
+    let normalized = error.to_ascii_lowercase();
+    let is_rate_limit = normalized.contains("rate limit") || normalized.contains("usage limit");
+
+    if !is_rate_limit {
+        return truncated;
+    }
+
+    if let Some(minutes) = extract_retry_window_minutes(error) {
+        return format!("rate limit: retry in ~{minutes} min");
+    }
+
+    format!("rate limit: {truncated}")
+}
+
+fn extract_retry_window_minutes(message: &str) -> Option<u64> {
+    let mut total_seconds: u64 = 0;
+    let mut matched = false;
+
+    for captures in RATE_LIMIT_WINDOW_RE.captures_iter(message) {
+        let Some(amount_match) = captures.get(1) else {
+            continue;
+        };
+        let Some(unit_match) = captures.get(2) else {
+            continue;
+        };
+
+        let Ok(amount) = amount_match.as_str().parse::<u64>() else {
+            continue;
+        };
+
+        let unit = unit_match.as_str().to_ascii_lowercase();
+        let seconds = if unit.starts_with('h') {
+            amount.saturating_mul(3_600)
+        } else if unit.starts_with('m') {
+            amount.saturating_mul(60)
+        } else {
+            amount
+        };
+
+        total_seconds = total_seconds.saturating_add(seconds);
+        matched = true;
+    }
+
+    if !matched {
+        return None;
+    }
+
+    Some(((total_seconds.saturating_add(59)) / 60).max(1))
 }
 
 fn event_summary(event: &AgentEvent) -> (String, Option<String>) {

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -2410,9 +2410,7 @@ impl Orchestrator {
                 .session_tokens
                 .total_tokens
                 .saturating_add(*total_tokens);
-            if *total_tokens > 0 {
-                session_info.last_error = None;
-            }
+            session_info.last_error = None;
             self.advance_turn_counter(issue_id);
             self.apply_turn_metrics(&TurnMetrics {
                 input_tokens: *input_tokens,
@@ -4370,19 +4368,19 @@ fn event_severity_for_agent_event(event: &AgentEvent) -> EventSeverity {
 }
 
 fn format_rate_limit_error(error: &str) -> String {
-    let truncated = truncate_for_display(error, WORKER_LAST_ERROR_MAX_CHARS);
     let normalized = error.to_ascii_lowercase();
     let is_rate_limit = normalized.contains("rate limit") || normalized.contains("usage limit");
 
     if !is_rate_limit {
-        return truncated;
+        return truncate_for_display(error, WORKER_LAST_ERROR_MAX_CHARS);
     }
 
     if let Some(minutes) = extract_retry_window_minutes(error) {
         return format!("rate limit: retry in ~{minutes} min");
     }
 
-    format!("rate limit: {truncated}")
+    let formatted = format!("rate limit: {error}");
+    truncate_for_display(&formatted, WORKER_LAST_ERROR_MAX_CHARS)
 }
 
 fn extract_retry_window_minutes(message: &str) -> Option<u64> {

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -4399,6 +4399,11 @@ fn extract_retry_window_minutes(message: &str) -> Option<u64> {
             continue;
         };
 
+        let next_char = message[unit_match.end()..].chars().next();
+        if next_char.is_some_and(|ch| ch.is_ascii_alphabetic()) {
+            continue;
+        }
+
         let unit = unit_match.as_str().to_ascii_lowercase();
         let seconds = if unit.starts_with('h') {
             amount.saturating_mul(3_600)

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -642,6 +642,7 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
         let current_tool_name = metrics.and_then(|m| m.current_tool_name.as_deref());
         let current_tool_args = metrics.and_then(|m| m.current_tool_args_preview.as_deref());
         let escalation = pending_by_issue.get(issue_id.as_str()).copied();
+        let last_error = metrics.and_then(|m| m.last_error.as_deref());
         let stale = escalation.is_none() && is_stale_session(last_activity, now);
         let state = if escalation.is_some() {
             format!(
@@ -664,11 +665,20 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
             Cell::from(last_activity_text)
         };
 
-        let activity_message = if let Some(pending) = escalation {
+        let activity_message = if let Some(error) = last_error {
+            format!("🚨 {error}")
+        } else if let Some(pending) = escalation {
             let waiting = format_age(Some(pending.created_at), now);
             format!("⚠ escalation: \"{}\" ({waiting})", pending.preview)
         } else {
             format_activity_message(current_tool_name, current_tool_args, last_event_message)
+        };
+
+        let activity_text = truncate_for_display(&activity_message, MESSAGE_COLUMN_TRUNCATE_WIDTH);
+        let activity_cell = if last_error.is_some() {
+            Cell::from(Span::styled(activity_text, Style::default().fg(Color::Red)))
+        } else {
+            Cell::from(activity_text)
         };
 
         let status_last_activity = if escalation.is_some() {
@@ -678,7 +688,12 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
         };
 
         let mut row = Row::new(vec![
-            Cell::from(status_dot(last_event, status_last_activity, now)),
+            Cell::from(status_dot(
+                last_event,
+                status_last_activity,
+                now,
+                last_error.is_some(),
+            )),
             Cell::from(run.issue_identifier.clone()),
             Cell::from(compact_session_id(session_id)),
             Cell::from(state),
@@ -687,10 +702,7 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
                 last_event.unwrap_or("-"),
                 LAST_EVENT_COLUMN_WIDTH as usize,
             )),
-            Cell::from(truncate_for_display(
-                &activity_message,
-                MESSAGE_COLUMN_TRUNCATE_WIDTH,
-            )),
+            activity_cell,
             last_activity_cell,
             Cell::from(format_tokens(total_tokens)),
             Cell::from(run.model.clone().unwrap_or_else(|| "-".to_string())),
@@ -702,7 +714,7 @@ fn running_rows(snapshot: &OrchestratorSnapshot, now: DateTime<Utc>) -> Vec<Row<
             ),
         ]);
 
-        if escalation.is_some() {
+        if escalation.is_some() && last_error.is_none() {
             row = row.style(Style::default().fg(Color::Yellow));
         }
 
@@ -755,10 +767,11 @@ fn status_dot(
     last_event: Option<&str>,
     last_activity: Option<DateTime<Utc>>,
     now: DateTime<Utc>,
+    has_error: bool,
 ) -> Span<'static> {
     Span::styled(
         "●",
-        Style::default().fg(status_color(last_event, last_activity, now)),
+        Style::default().fg(status_color(last_event, last_activity, now, has_error)),
     )
 }
 
@@ -766,7 +779,12 @@ fn status_color(
     last_event: Option<&str>,
     last_activity: Option<DateTime<Utc>>,
     now: DateTime<Utc>,
+    has_error: bool,
 ) -> Color {
+    if has_error {
+        return Color::Red;
+    }
+
     if is_stale_session(last_activity, now) {
         return Color::Red;
     }
@@ -1196,6 +1214,7 @@ mod tests {
                 session_id: Some("1234567890abcdef".to_string()),
                 current_tool_name: None,
                 current_tool_args_preview: None,
+                last_error: None,
             },
         );
 
@@ -1210,6 +1229,60 @@ mod tests {
         assert!(
             rendered.contains(&expected),
             "expected dashboard output to include truncated last event {expected:?}, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn draw_dashboard_shows_running_error_indicator() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 22, 16, 0, 0)
+            .single()
+            .expect("valid fixture timestamp");
+        let mut snapshot = snapshot_fixture(0, None);
+        let issue_id = "issue-error".to_string();
+
+        snapshot.running.insert(
+            issue_id.clone(),
+            crate::domain::RunAttempt {
+                issue_id: issue_id.clone(),
+                issue_identifier: "KAT-1660".to_string(),
+                issue_title: Some("Worker error visibility".to_string()),
+                attempt: Some(1),
+                workspace_path: "/tmp/workspace".to_string(),
+                started_at: now,
+                status: "running".to_string(),
+                error: None,
+                worker_host: None,
+                model: Some("anthropic/claude-sonnet-4-6".to_string()),
+                linear_state: Some("In Progress".to_string()),
+                issue_url: None,
+            },
+        );
+        snapshot.running_sessions.insert(
+            issue_id,
+            crate::domain::RunningSessionSnapshot {
+                turn_count: 2,
+                last_activity_at: Some(now),
+                total_tokens: 1024,
+                last_event: Some("codex/event/task_started".to_string()),
+                last_event_message: Some("working".to_string()),
+                session_id: Some("session-error".to_string()),
+                current_tool_name: None,
+                current_tool_args_preview: None,
+                last_error: Some("rate limit: retry in ~80 min".to_string()),
+            },
+        );
+
+        let backend = TestBackend::new(200, 30);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| draw_dashboard(frame, &snapshot, now, "Throughput: 0.0 tps ▁▁▁▁▁▁▁▁"))
+            .expect("dashboard draw should succeed");
+
+        let rendered = render_text(terminal.backend());
+        assert!(
+            rendered.contains("🚨") && rendered.contains("rate limit: retry in ~80 min"),
+            "expected running table to show red error indicator text, got:\n{rendered}"
         );
     }
 
@@ -1229,36 +1302,45 @@ mod tests {
             .expect("valid fixture timestamp");
 
         assert_eq!(
-            status_color(Some("codex/event/task_started"), Some(fresh), now),
+            status_color(Some("codex/event/task_started"), Some(fresh), now, false),
             Color::Green
         );
         assert_eq!(
-            status_color(Some("codex/event/token_count"), Some(fresh), now),
+            status_color(Some("codex/event/token_count"), Some(fresh), now, false),
             Color::Yellow
         );
         assert_eq!(
-            status_color(Some("turn_completed"), Some(fresh), now),
+            status_color(Some("turn_completed"), Some(fresh), now, false),
             Color::Magenta
         );
         assert_eq!(
-            status_color(Some("codex/event/turn/completed"), Some(fresh), now),
+            status_color(Some("codex/event/turn/completed"), Some(fresh), now, false),
             Color::Magenta
         );
         assert_eq!(
-            status_color(Some("codex/event/tool_call_failed"), Some(fresh), now),
+            status_color(
+                Some("codex/event/tool_call_failed"),
+                Some(fresh),
+                now,
+                false
+            ),
             Color::Red
         );
         assert_eq!(
-            status_color(Some("startup_failed"), Some(fresh), now),
+            status_color(Some("startup_failed"), Some(fresh), now, false),
             Color::Red
         );
         assert_eq!(
-            status_color(Some("notification"), Some(fresh), now),
+            status_color(Some("notification"), Some(fresh), now, false),
             Color::Blue
         );
-        assert_eq!(status_color(None, Some(fresh), now), Color::Red);
+        assert_eq!(status_color(None, Some(fresh), now, false), Color::Red);
         assert_eq!(
-            status_color(Some("turn_completed"), Some(stale), now),
+            status_color(Some("turn_completed"), Some(stale), now, false),
+            Color::Red
+        );
+        assert_eq!(
+            status_color(Some("codex/event/task_started"), Some(fresh), now, true),
             Color::Red
         );
     }

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -337,6 +337,7 @@ fn test_orchestrator_snapshot_serializes() {
                     session_id: None,
                     current_tool_name: None,
                     current_tool_args_preview: None,
+                    last_error: None,
                 },
             );
             m.insert(
@@ -350,6 +351,7 @@ fn test_orchestrator_snapshot_serializes() {
                     session_id: None,
                     current_tool_name: None,
                     current_tool_args_preview: None,
+                    last_error: None,
                 },
             );
             m

--- a/apps/symphony/tests/event_stream_tests.rs
+++ b/apps/symphony/tests/event_stream_tests.rs
@@ -77,6 +77,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                 session_id: Some("session-920".to_string()),
                 current_tool_name: None,
                 current_tool_args_preview: None,
+                last_error: None,
             },
         )]),
         running_session_info: BTreeMap::from([(
@@ -89,6 +90,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                 session_tokens: Default::default(),
                 current_tool_name: None,
                 current_tool_args_preview: None,
+                last_error: None,
             },
         )]),
         claimed: BTreeSet::from(["issue-920".to_string()]),

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -96,6 +96,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                     session_id: Some("session-12345678".to_string()),
                     current_tool_name: None,
                     current_tool_args_preview: None,
+                    last_error: None,
                 },
             );
             sessions
@@ -114,6 +115,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
                 },
                 current_tool_name: None,
                 current_tool_args_preview: None,
+                last_error: None,
             },
         )]),
         claimed: BTreeSet::from(["issue-123".to_string()]),
@@ -241,8 +243,20 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "running table should include the per-session token column header"
     );
     assert!(
+        body.contains("<th>Error</th>"),
+        "running table should include the error column header"
+    );
+    assert!(
         body.contains("stale-activity"),
         "dashboard script should include stale activity highlighting styles/logic"
+    );
+    assert!(
+        body.contains("error-text"),
+        "dashboard script should include error styling styles/logic"
+    );
+    assert!(
+        body.contains("sessionInfo.last_error"),
+        "dashboard script should consume running-session last_error values"
     );
     assert!(
         body.contains("lastActivityValue != null ? Number(lastActivityValue) : NaN"),
@@ -364,6 +378,88 @@ async fn test_dashboard_initial_supervisor_metrics_use_snapshot_values() {
     assert!(
         body.contains(r#"id="supervisor-last-action">2026-03-22T09:15:00+00:00"#),
         "dashboard should server-render supervisor last action timestamp"
+    );
+}
+
+#[tokio::test]
+async fn test_dashboard_html_includes_error_column_rendering_logic() {
+    let mut snapshot = fixture_snapshot();
+    let issue_id = "issue-123".to_string();
+    let session_info = snapshot
+        .running_session_info
+        .get_mut(&issue_id)
+        .expect("fixture running session info should include issue-123");
+    session_info.last_error = Some("You have hit your ChatGPT usage limit".to_string());
+
+    let app = build_router(HttpServerState::new(
+        Arc::new(StaticSnapshotSource { snapshot }),
+        Arc::new(FakeRefreshControl::default()),
+        symphony::orchestrator::EscalationRegistry::default(),
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+
+    let body = body_text(response).await;
+
+    assert!(
+        body.contains("<th>Error</th>"),
+        "dashboard should expose the error column header"
+    );
+    assert!(
+        body.contains("<td class=\"mono error-text\">"),
+        "dashboard script should render an error-text table cell when last_error is present"
+    );
+    assert!(
+        body.contains("<td class=\"muted\">-</td>"),
+        "dashboard script should render muted fallback when last_error is absent"
+    );
+    assert!(
+        body.contains("colspan=\"13\""),
+        "running empty state should reserve the extra error column"
+    );
+}
+
+#[tokio::test]
+async fn test_get_api_state_includes_worker_last_error_when_present() {
+    let mut snapshot = fixture_snapshot();
+    let issue_id = "issue-123".to_string();
+    let session_info = snapshot
+        .running_session_info
+        .get_mut(&issue_id)
+        .expect("fixture running session info should include issue-123");
+    session_info.last_error = Some("You have hit your ChatGPT usage limit".to_string());
+
+    let app = build_router(HttpServerState::new(
+        Arc::new(StaticSnapshotSource { snapshot }),
+        Arc::new(FakeRefreshControl::default()),
+        symphony::orchestrator::EscalationRegistry::default(),
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v1/state")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+
+    let payload = body_json(response).await;
+
+    assert_eq!(
+        payload["running_session_info"]["issue-123"]["last_error"],
+        "You have hit your ChatGPT usage limit"
     );
 }
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1699,7 +1699,7 @@ fn test_worker_session_info_last_error_set_on_failed_turn_and_exposed_in_snapsho
 }
 
 #[test]
-fn test_worker_session_info_last_error_clears_after_successful_turn_completed() {
+fn test_worker_session_info_last_error_clears_after_zero_token_turn_completed() {
     let mut orchestrator = Orchestrator::new(test_config(1), String::new());
     let now_ms = 4_800_000;
     let issue_id = "issue-last-error-clear";
@@ -1739,9 +1739,9 @@ fn test_worker_session_info_last_error_clears_after_successful_turn_completed() 
             codex_app_server_pid: Some("9999".to_string()),
             turn_id: "turn-2".to_string(),
             message: Some("completed".to_string()),
-            input_tokens: 21,
-            output_tokens: 9,
-            total_tokens: 30,
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
             rate_limits: None,
         },
     );
@@ -1804,6 +1804,62 @@ fn test_worker_session_info_last_error_formats_rate_limit_retry_window() {
     assert_eq!(
         session_info.last_error.as_deref(),
         Some("rate limit: retry in ~80 min")
+    );
+}
+
+#[test]
+fn test_worker_session_info_last_error_rate_limit_fallback_is_truncated_to_display_cap() {
+    let mut orchestrator = Orchestrator::new(test_config(1), String::new());
+    let now_ms = 5_400_000;
+    let issue_id = "issue-last-error-rate-limit-fallback";
+
+    orchestrator.state_mut().running.insert(
+        issue_id.to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: issue_id.to_string(),
+            issue_identifier: "SIM-LAST-ERROR-RATE-FALLBACK".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-last-error-rate-fallback".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            model: None,
+            linear_state: None,
+            issue_url: None,
+        },
+    );
+
+    let long_tail = "x".repeat(260);
+    orchestrator.ingest_agent_event(
+        issue_id,
+        &AgentEvent::TurnFailed {
+            timestamp: utc_ms(now_ms - 1_000),
+            codex_app_server_pid: Some("9999".to_string()),
+            turn_id: "turn-1".to_string(),
+            error: format!("usage limit reached for account. details: {long_tail}"),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session_info = snapshot
+        .running_session_info
+        .get(issue_id)
+        .expect("running session info should exist");
+
+    let last_error = session_info
+        .last_error
+        .as_deref()
+        .expect("last_error should be populated for failed turns");
+
+    assert!(
+        last_error.starts_with("rate limit:"),
+        "rate limit fallback should preserve the rate-limit prefix"
+    );
+    assert!(
+        last_error.chars().count() <= 200,
+        "formatted fallback should obey the 200-char display cap"
     );
 }
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1645,6 +1645,169 @@ fn test_event_count_increments_on_ingest() {
 }
 
 #[test]
+fn test_worker_session_info_last_error_set_on_failed_turn_and_exposed_in_snapshot() {
+    let mut orchestrator = Orchestrator::new(test_config(1), String::new());
+    let now_ms = 4_500_000;
+    let issue_id = "issue-last-error";
+
+    orchestrator.state_mut().running.insert(
+        issue_id.to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: issue_id.to_string(),
+            issue_identifier: "SIM-LAST-ERROR".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-last-error".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            model: None,
+            linear_state: None,
+            issue_url: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        issue_id,
+        &AgentEvent::TurnFailed {
+            timestamp: utc_ms(now_ms - 1_000),
+            codex_app_server_pid: Some("9999".to_string()),
+            turn_id: "turn-1".to_string(),
+            error: "authentication failed: token expired".to_string(),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session_info = snapshot
+        .running_session_info
+        .get(issue_id)
+        .expect("running session info should exist");
+    assert_eq!(
+        session_info.last_error.as_deref(),
+        Some("authentication failed: token expired")
+    );
+
+    let running_session = snapshot
+        .running_sessions
+        .get(issue_id)
+        .expect("running session snapshot should exist");
+    assert_eq!(
+        running_session.last_error.as_deref(),
+        Some("authentication failed: token expired")
+    );
+}
+
+#[test]
+fn test_worker_session_info_last_error_clears_after_successful_turn_completed() {
+    let mut orchestrator = Orchestrator::new(test_config(1), String::new());
+    let now_ms = 4_800_000;
+    let issue_id = "issue-last-error-clear";
+
+    orchestrator.state_mut().running.insert(
+        issue_id.to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: issue_id.to_string(),
+            issue_identifier: "SIM-LAST-ERROR-CLEAR".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-last-error-clear".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            model: None,
+            linear_state: None,
+            issue_url: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        issue_id,
+        &AgentEvent::TurnFailed {
+            timestamp: utc_ms(now_ms - 3_000),
+            codex_app_server_pid: Some("9999".to_string()),
+            turn_id: "turn-1".to_string(),
+            error: "usage limit reached".to_string(),
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        issue_id,
+        &AgentEvent::TurnCompleted {
+            timestamp: utc_ms(now_ms - 1_000),
+            codex_app_server_pid: Some("9999".to_string()),
+            turn_id: "turn-2".to_string(),
+            message: Some("completed".to_string()),
+            input_tokens: 21,
+            output_tokens: 9,
+            total_tokens: 30,
+            rate_limits: None,
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session_info = snapshot
+        .running_session_info
+        .get(issue_id)
+        .expect("running session info should exist");
+    assert_eq!(session_info.last_error, None);
+
+    let running_session = snapshot
+        .running_sessions
+        .get(issue_id)
+        .expect("running session snapshot should exist");
+    assert_eq!(running_session.last_error, None);
+}
+
+#[test]
+fn test_worker_session_info_last_error_formats_rate_limit_retry_window() {
+    let mut orchestrator = Orchestrator::new(test_config(1), String::new());
+    let now_ms = 5_100_000;
+    let issue_id = "issue-last-error-rate-limit";
+
+    orchestrator.state_mut().running.insert(
+        issue_id.to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: issue_id.to_string(),
+            issue_identifier: "SIM-LAST-ERROR-RATE".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-last-error-rate".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            model: None,
+            linear_state: None,
+            issue_url: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        issue_id,
+        &AgentEvent::TurnFailed {
+            timestamp: utc_ms(now_ms - 1_000),
+            codex_app_server_pid: Some("9999".to_string()),
+            turn_id: "turn-1".to_string(),
+            error: "You have hit your ChatGPT usage limit. Please retry in 1 hour 20 minutes."
+                .to_string(),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session_info = snapshot
+        .running_session_info
+        .get(issue_id)
+        .expect("running session info should exist");
+
+    assert_eq!(
+        session_info.last_error.as_deref(),
+        Some("rate limit: retry in ~80 min")
+    );
+}
+
+#[test]
 fn test_late_streamed_event_after_completion_is_ignored() {
     let mut orchestrator = Orchestrator::new(test_config(2), String::new());
     let now_ms = 4_000_000;

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -1808,6 +1808,61 @@ fn test_worker_session_info_last_error_formats_rate_limit_retry_window() {
 }
 
 #[test]
+fn test_worker_session_info_last_error_does_not_treat_milliseconds_as_minutes() {
+    let mut orchestrator = Orchestrator::new(test_config(1), String::new());
+    let now_ms = 5_250_000;
+    let issue_id = "issue-last-error-rate-limit-ms";
+
+    orchestrator.state_mut().running.insert(
+        issue_id.to_string(),
+        symphony::domain::RunAttempt {
+            issue_id: issue_id.to_string(),
+            issue_identifier: "SIM-LAST-ERROR-RATE-MS".to_string(),
+            issue_title: None,
+            attempt: Some(1),
+            workspace_path: "/tmp/workspace-last-error-rate-ms".to_string(),
+            started_at: utc_ms(now_ms - 300_000),
+            status: "running".to_string(),
+            error: None,
+            worker_host: None,
+            model: None,
+            linear_state: None,
+            issue_url: None,
+        },
+    );
+
+    orchestrator.ingest_agent_event(
+        issue_id,
+        &AgentEvent::TurnFailed {
+            timestamp: utc_ms(now_ms - 1_000),
+            codex_app_server_pid: Some("9999".to_string()),
+            turn_id: "turn-1".to_string(),
+            error: "Rate limit exceeded. Retry in 500ms.".to_string(),
+        },
+    );
+
+    let snapshot = orchestrator.snapshot(now_ms);
+    let session_info = snapshot
+        .running_session_info
+        .get(issue_id)
+        .expect("running session info should exist");
+
+    let last_error = session_info
+        .last_error
+        .as_deref()
+        .expect("last_error should be populated for failed turns");
+
+    assert!(
+        !last_error.contains("~500 min"),
+        "millisecond values should not be interpreted as minutes"
+    );
+    assert_eq!(
+        last_error,
+        "rate limit: Rate limit exceeded. Retry in 500ms."
+    );
+}
+
+#[test]
 fn test_worker_session_info_last_error_rate_limit_fallback_is_truncated_to_display_cap() {
     let mut orchestrator = Orchestrator::new(test_config(1), String::new());
     let now_ms = 5_400_000;


### PR DESCRIPTION
## Summary
- add \ to \ and \
- propagate worker failures into \ during \ and clear on successful \ (\)
- format rate-limit/usage-limit errors with retry-window hints when parseable (e.g. \), with 200-char truncation for redaction safety
- render running-session errors in the TUI message column with 🚨 + red styling and red status dot override
- add an Error column + \ styling to the HTTP dashboard running sessions table and keep empty-state colspan in sync
- add orchestrator/http tests covering set/clear/format behavior and API/dashboard rendering hooks

## Validation
- \
running 82 tests
test test_dispatch_predispatch_refresh_rejects_stale_state ... ok
test test_blocked_issues_cleared_on_tick_start ... ok
test test_circular_dependency_blocks_both_issues ... ok
test test_blocked_issue_in_agent_review_not_dispatched ... ok
test test_escalation_registry_resolve_not_found_when_receiver_dropped ... ok
test test_escalation_registry_cancel_for_issue_cleans_up ... ok
test test_escalation_registry_resolve_round_trip ... ok
test test_event_count_increments_on_ingest ... ok
test test_blocked_issue_with_terminal_blocker_dispatched ... ok
test test_dispatch_candidate_sorting_and_gating_rules ... ok
test test_cross_project_unknown_blocker_treated_as_non_blocking ... ok
test test_dispatch_docker_isolation_never_assigns_ssh_worker_host ... ok
test test_completed_is_bookkeeping_and_does_not_block_dispatch ... ok
test test_blocked_issue_in_progress_not_dispatched ... ok
test test_escalation_registry_resolved_cache_is_bounded ... ok
test test_handle_worker_completion_cleans_pending_escalations_for_released_issue ... ok
test test_ingest_agent_event_cleans_pending_escalation_for_non_running_issue ... ok
test test_late_streamed_event_after_completion_is_ignored ... ok
test test_notification_does_not_fire_without_prior_state_snapshot ... ok
test test_notification_failure_does_not_block_orchestrator ... ok
test test_notification_fires_on_human_review_transition ... ok
test test_notification_fires_on_rework_transition ... ok
test test_notification_fires_on_terminal_failure ... ok
test test_notification_fires_on_worker_stall ... ok
test test_notification_skips_unconfigured_events ... ok
test test_orchestrator_create_refresh_channel_returns_functional_sender ... ok
test test_orchestrator_create_snapshot_handle_and_refresh_channel_independently ... ok
test test_preflight_validation_failure_skips_dispatch_but_reconcile_continues ... ok
test test_reconcile_non_active_state_stops_run_without_cleanup ... ok
test test_reconcile_refresh_failure_is_non_fatal_and_dispatch_continues ... ok
test test_reconcile_startup_terminal_cleanup_excludes_terminal_issues_from_completed ... ok
test test_reconcile_terminal_state_cleans_pending_escalations ... ok
test test_reconcile_tick_reconcile_before_validate_before_dispatch ... ok
test test_refresh_channel_duplicate_requests_coalesce ... ok
test test_refresh_channel_first_request_is_queued ... ok
test test_refresh_channel_notified_wakes_on_request ... ok
test test_refresh_channel_resets_after_take_allows_new_queued_request ... ok
test test_refresh_channel_take_pending_clears_flag ... ok
test test_refresh_sender_is_clone_cheap ... ok
test test_retry_scheduling_continuation_and_failure_backoff_rules ... ok
test test_snapshot_exposes_running_and_retry_diagnostics ... ok
test test_snapshot_handle_is_clone_cheap_and_shares_state ... ok
test test_snapshot_handle_preserves_codex_totals_and_rate_limits ... ok
test test_snapshot_handle_read_returns_published_state ... ok
test test_snapshot_handle_reflects_retry_queue_for_api_use ... ok
test test_snapshot_handle_updates_after_publish ... ok
test test_snapshot_includes_blocked_issues ... ok
test test_stale_retry_timer_is_ignored ... ok
test test_stall_detection_schedules_forced_retry ... ok
test test_startup_terminal_cleanup_clears_runtime_bookkeeping_without_completed_insert ... ok
test test_startup_terminal_cleanup_removes_orphan_workspace_from_scan ... ok
test test_streamed_event_updates_activity_before_worker_completion ... ok
test test_streamed_events_keep_refreshing_stall_detection_window ... ok
test test_streamed_notification_records_event_method_and_message ... ok
test test_streamed_tool_call_completed_uses_completed_summary ... ok
test test_streamed_turn_completed_events_update_token_totals_in_real_time ... ok
test test_terminal_state_cleanup_defers_until_worker_completion ... ok
test test_terminal_state_cleanup_failure_is_non_fatal ... ok
test test_terminal_state_cleanup_preserves_workspace_when_disabled ... ok
test test_due_continuation_retry_marks_terminal_issue_completed_when_not_visible_in_candidates ... ok
test test_terminal_state_cleanup_removes_workspace_when_enabled ... ok
test test_terminal_state_cleanup_removes_retry_workspace_when_enabled ... ok
test test_terminal_state_cleanup_removes_worktree_checkout_when_enabled ... ok
test test_tick_applies_server_port_override_over_workflow_store_config ... ok
test test_terminal_state_cleanup_runs_before_remove_hook ... ok
test test_token_totals_and_rate_limits_accumulate_into_snapshot ... ok
test test_unblocked_issue_dispatches_normally ... ok
test test_worker_completion_schedules_continuation_retry_with_session_context ... ok
test test_worker_completion_without_continuation_does_not_queue_retry ... ok
test test_worker_failure_preserves_attempt_and_backoff_cap ... ok
test test_worker_session_info_last_error_clears_after_successful_turn_completed ... ok
test test_worker_session_info_last_error_formats_rate_limit_retry_window ... ok
test test_worker_session_info_last_error_set_on_failed_turn_and_exposed_in_snapshot ... ok
test test_tick_refreshes_runtime_state_from_workflow_store_reload ... ok
test test_execute_worker_attempt_shared_context_is_injected_into_prompt ... ok
test test_execute_worker_attempt_stops_when_issue_changes_to_different_active_state ... ok
test test_execute_worker_attempt_stops_when_issue_leaves_active_state_after_first_turn ... ok
test test_execute_worker_attempt_preserves_last_non_null_rate_limits ... ok
test test_execute_worker_attempt_failure_on_turn_two_keeps_turn_one_metrics ... ok
test test_execute_worker_attempt_stops_when_issue_unassigned_between_turns ... ok
test test_execute_worker_attempt_runs_multiple_turns_in_one_session_and_uses_continuation_prompt ... ok
test test_execute_worker_attempt_stops_when_issue_turns_terminal_after_first_turn ... ok

test result: ok. 82 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.39s
- \
running 20 tests
test test_event_filter_issue_normalizes_valid_identifier ... ok
test test_event_filter_invalid_type_returns_machine_readable_error ... ok
test test_event_filter_issue_requires_team_number_shape ... ok
test test_escalation_endpoints_return_empty_or_not_found_when_unknown ... ok
test test_dashboard_html_includes_blocked_section ... ok
test test_context_post_publishes_shared_context_written_event ... ok
test test_dashboard_html_includes_error_column_rendering_logic ... ok
test test_get_api_state_returns_snapshot_projection ... ok
test test_context_post_get_and_delete_round_trip ... ok
test test_context_scope_filter_and_clear_endpoint ... ok
test test_escalation_dashboard_section_renders ... ok
test test_dashboard_initial_supervisor_metrics_use_snapshot_values ... ok
test test_get_issue_returns_not_found_envelope_for_unknown_identifier ... ok
test test_get_api_state_includes_worker_last_error_when_present ... ok
test test_post_refresh_reports_queued_then_coalesced_state ... ok
test test_unknown_api_path_returns_json_404_error_envelope ... ok
test test_state_json_includes_blocked_array ... ok
test test_get_issue_returns_projection_for_known_issue_identifier ... ok
test test_wrong_method_on_known_api_route_returns_json_405_error_envelope ... ok
test test_get_root_returns_html_dashboard_shell_with_structured_sections ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
- \
running 108 tests
test codex::token_accounting::tests::empty_payload_returns_zero_delta ... ok
test codex::token_accounting::tests::no_rate_limit_in_empty_payload ... ok
test config::tests::api_key_deref_gives_str ... ok
test codex::token_accounting::tests::absolute_path_extraction ... ok
test codex::token_accounting::tests::delta_is_zero_on_decrease ... ok
test codex::token_accounting::tests::rate_limit_extraction_with_limit_name ... ok
test codex::token_accounting::tests::rate_limit_extraction_with_limit_id_and_buckets ... ok
test config::tests::api_key_debug_is_redacted ... ok
test codex::token_accounting::tests::incremental_delta_computation ... ok
test config::tests::expand_tilde_home_unset_keeps_input ... ok
test config::tests::expand_tilde_no_op ... ok
test config::tests::parse_codex_command_empty_string ... ok
test config::tests::expand_tilde_home ... ok
test config::tests::resolve_env_returns_empty_for_unset_var ... ok
test config::tests::parse_pi_agent_command_string_shell_words ... ok
test config::tests::parse_codex_command_string ... ok
test config::tests::resolve_env_returns_raw_for_non_dollar ... ok
test config::tests::parse_codex_command_list ... ok
test config::tests::parse_pi_agent_command_list ... ok
test config::tests::normalize_coerces_keys ... ok
test config::tests::normalize_drops_nulls ... ok
test config::tests::raw_supervisor_config_honors_explicit_cooldown ... ok
test docker::tests::test_codex_auth_install_script_uses_dynamic_home_path ... ok
test docker::tests::test_derived_image_dockerfile_runs_setup_as_root_then_restores_user ... ok
test config::tests::raw_supervisor_config_defaults_when_section_omitted ... ok
test event_stream::tests::next_sequence_is_shared_across_clones ... ok
test http_server::tests::event_filter_parsing_rejects_unknown_type_with_deterministic_error ... ok
test notifications::tests::test_is_supported_slack_event ... ok
test http_server::tests::event_filter_parsing_accepts_or_within_fields_and_and_across_fields ... ok
test event_stream::tests::zero_capacity_hub_is_clamped_and_operational ... ok
test event_stream::tests::publish_subscribe_round_trip ... ok
test config::tests::supervisor_model_env_and_empty_values_resolve_to_none ... ok
test logging::tests::writes_logs_to_log_subdirectory_under_logs_root ... ok
test http_server::tests::bind_http_listener_with_fallback_increments_when_configured_port_is_in_use ... ok
test http_server::tests::bind_http_listener_with_fallback_errors_after_retry_cap_is_exhausted ... ok
test notifications::tests::test_should_notify_canceled_alias ... ok
test notifications::tests::test_should_notify_filters_by_event_list ... ok
test notifications::tests::test_should_notify_wildcard_all ... ok
test orchestrator::tests::build_tool_args_preview_fallback_to_keys ... ok
test orchestrator::tests::build_tool_args_preview_extracts_command ... ok
test orchestrator::tests::build_tool_args_preview_extracts_path ... ok
test orchestrator::tests::build_tool_args_preview_invalid_json ... ok
test orchestrator::tests::build_tool_args_preview_strips_control_chars_on_invalid_json ... ok
test orchestrator::tests::extract_tool_activity_clears_on_turn_completed ... ok
test orchestrator::tests::extract_tool_activity_clears_on_turn_failed ... ok
test orchestrator::tests::find_preferred_text_stops_searching_past_depth_limit ... ok
test orchestrator::tests::create_event_hub_is_idempotent ... ok
test notifications::tests::test_notification_dispatch_filters_events ... ok
test orchestrator::tests::parse_tool_notification_error ... ok
test orchestrator::tests::parse_tool_notification_end ... ok
test orchestrator::tests::parse_tool_notification_start_no_args ... ok
test orchestrator::tests::parse_tool_notification_start_with_args ... ok
test orchestrator::tests::parse_tool_notification_unrelated ... ok
test path_safety::tests::test_sanitize_empty ... ok
test pi_agent::rpc_bridge::tests::build_command_parts_uses_state_selected_model ... ok
test pi_agent::rpc_bridge::tests::pi_agent_config_model_for_state_prefers_state_override_then_default ... ok
test repo_url::tests::test_repo_is_remote ... ok
test session_summary::tests::compact_session_id_limits_to_first_eight_chars ... ok
test session_summary::tests::normalize_whitespace_collapses_runs_and_trims ... ok
test session_summary::tests::truncate_for_display_applies_whitespace_normalization_before_length_check ... ok
test session_summary::tests::truncate_for_display_returns_empty_for_zero_width ... ok
test shared_context::tests::clear_filters_by_scope ... ok
test shared_context::tests::max_entries_eviction_keeps_most_recent_entries ... ok
test shared_context::tests::write_truncates_content_and_read_returns_newest_first ... ok
test shared_context::tests::prune_expired_entries_removes_stale_entries ... ok
test docker::tests::test_command_output_summary_redacts_credentials ... ok
test supervisor::tests::conflict_key_is_order_independent ... ok
test supervisor::tests::decision_token_extracts_expected_markers ... ok
test supervisor::tests::decision_token_returns_none_without_extractable_token ... ok
test logging::tests::rotates_at_size_and_keeps_five_total_files ... ok
test repo_url::tests::test_redact_url_credentials ... ok
test supervisor::tests::detect_context_conflict_skips_non_decision_entries ... ok
test supervisor::tests::repeated_test_failure_signature_detects_expected_patterns ... ok
test supervisor::tests::file_edit_path_skips_read_only_or_non_tool_start_events ... ok
test supervisor::tests::start_restarts_when_previous_handle_is_finished ... ok
test supervisor::tests::systemic_error_signature_requires_error_event_and_substantive_summary ... ok
test tui::tests::build_summary_lines_adds_context_count_when_present ... ok
test tui::tests::build_summary_lines_includes_active_supervisor_counters ... ok
test path_safety::tests::test_sanitize_replaces_unsafe ... ok
test path_safety::tests::test_sanitize_preserves_safe_chars ... ok
test tui::tests::build_summary_lines_includes_disabled_supervisor_status ... ok
test tui::tests::build_summary_lines_includes_linear_project_url_when_available ... ok
test tui::tests::compact_session_id_truncates_to_first_eight_chars ... ok
test tui::tests::format_age_returns_seconds_ago ... ok
test tui::tests::format_retry_delay_handles_ready_and_future ... ok
test supervisor::tests::file_edit_path_extracts_mutating_tool_paths ... ok
test tui::tests::status_color_respects_event_mapping_and_staleness ... ok
test tui::tests::summarize_rate_limits_extracts_usage ... ok
test tui::tests::throughput_tracker_event_based_activity_with_zero_tokens ... ok
test tui::tests::throughput_tracker_prefers_token_tps_when_available ... ok
test tui::tests::throughput_tracker_renders_flat_sparkline_for_zero_throughput ... ok
test tui::tests::throughput_tracker_reports_current_tps_from_last_five_seconds ... ok
test tui::tests::throughput_tracker_trims_samples_to_window_with_one_preceding_point ... ok
test tui::tests::throughput_tracker_renders_recent_spike_in_last_bucket ... ok
test tui::tests::validate_terminal_requires_tty_stdout ... ok
test workflow_store::tests::event_ignores_unrelated_paths ... ok
test workflow_store::tests::event_matches_exact_workflow_path ... ok
test workflow_store::tests::event_matches_when_workflow_path_is_relative ... ok
test workspace::tests::scan_workspace_root_falls_back_to_root_when_prefix_missing ... ok
test workspace::tests::scan_workspace_root_maps_matching_directories ... ok
test workspace::tests::scan_workspace_root_supports_nested_branch_prefix ... ok
test notifications::tests::test_notification_request_error_message_does_not_include_webhook_url ... ok
test notifications::tests::test_notification_failure_is_non_fatal ... ok
test notifications::tests::test_notification_dispatch_formats_slack_message ... ok
test tui::tests::draw_dashboard_truncates_last_event_at_column_width ... ok
test tui::tests::draw_dashboard_shows_running_error_indicator ... ok
test tui::tests::draw_dashboard_renders_throughput_row ... ok
test supervisor::tests::stop_timeout_aborts_background_task ... ok

test result: ok. 108 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.02s

running 6 tests
test tests::startup_banner_binding_keeps_ephemeral_marker_for_zero_port ... ok
test tests::startup_banner_binding_uses_bound_port_when_configured_port_changes ... ok
test tests::parse_cli_defaults_tui_to_true ... ok
test tests::parse_cli_no_tui_wins_when_both_flags_are_present ... ok
test tests::parse_cli_accepts_tui_flag ... ok
test tests::parse_cli_accepts_no_tui_flag ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 21 tests
test main_bin::tests::startup_banner_binding_uses_bound_port_when_configured_port_changes ... ok
test main_bin::tests::startup_banner_binding_keeps_ephemeral_marker_for_zero_port ... ok
test test_default_workflow_path_is_workflow_md ... ok
test main_bin::tests::parse_cli_accepts_tui_flag ... ok
test test_effective_http_binding_uses_workflow_server_port_when_cli_port_missing ... ok
test main_bin::tests::parse_cli_defaults_tui_to_true ... ok
test main_bin::tests::parse_cli_accepts_no_tui_flag ... ok
test test_missing_workflow_path_returns_startup_failure ... ok
test test_effective_http_binding_prefers_cli_port_override ... ok
test main_bin::tests::parse_cli_no_tui_wins_when_both_flags_are_present ... ok
test test_effective_http_binding_defaults_to_8080 ... ok
test test_orchestrator_start_failure_surfaces_error ... ok
test test_startup_banner_marks_ephemeral_dashboard_port ... ok
test test_successful_bootstrap_invokes_orchestrator_start ... ok
test test_startup_banner_includes_expected_runtime_summary_fields ... ok
test test_positional_workflow_override_is_respected ... ok
test test_startup_banner_brackets_ipv6_dashboard_host ... ok
test test_startup_validation_failure_surfaces_error_and_stops_bootstrap ... ok
test test_without_logs_root_suppresses_stdout_logs_when_tui_defaults_on ... ok
test test_without_logs_root_no_tui_streams_stdout_logs ... ok
test test_logs_root_writes_startup_logs_to_file_and_suppresses_stdout_logs ... ok

test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.30s

running 34 tests
test linear_graphql_rejects_blank_raw_query_string ... ok
test linear_graphql_rejects_missing_and_blank_query_in_object ... ok
test linear_graphql_formats_unexpected_executor_failures ... ok
test linear_graphql_success_returns_tool_text ... ok
test linear_graphql_marks_graphql_errors_as_failure_preserving_body ... ok
test linear_graphql_rejects_non_object_variables ... ok
test linear_graphql_rejects_invalid_argument_types ... ok
test linear_graphql_accepts_raw_query_string ... ok
test linear_graphql_ignores_operation_name_field ... ok
test linear_graphql_treats_empty_errors_array_as_success ... ok
test linear_graphql_formats_transport_and_auth_failures ... ok
test test_app_server_cwd_rejects_workspace_root ... ok
test test_app_server_cwd_rejects_outside_root ... ok
test test_app_server_cwd_rejects_symlink_escape ... ok
test test_app_server_non_interactive_freeform_input ... ok
test test_app_server_auto_approves_command_execution ... ok
test test_app_server_input_required_hard_failure ... ok
test test_app_server_emits_tool_call_failed_event ... ok
test test_app_server_auto_approves_mcp_tool_prompts ... ok
test test_app_server_basic_handshake_and_completion ... ok
test test_app_server_rejects_unsupported_tool_calls ... ok
test test_app_server_dispatches_supported_tool_calls ... ok
test tool_result_always_has_content_items_matching_output ... ok
test tool_specs_contract ... ok
test unsupported_tool_returns_failure_with_supported_list ... ok
test test_app_server_partial_line_buffering ... ok
test test_app_server_rejects_approval_when_not_auto ... ok
test test_app_server_subprocess_exit ... ok
test test_app_server_turn_cancellation ... ok
test test_app_server_turn_failure ... ok
test test_token_delta_extraction_absolute_totals ... ok
test test_token_delta_zero_on_decrease ... ok
test test_turn_completed_with_failed_status_treated_as_failure ... ok
test test_turn_completed_with_usage_limit_exceeded_surfaces_error_message ... ok

test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.72s

running 6 tests
test store_enforces_500_char_content_limit ... ok
test store_write_and_read_with_scope_filtering ... ok
test store_clear_scope_and_clear_all ... ok
test store_prune_expired_removes_stale_entries ... ok
test store_summary_reports_scope_distribution ... ok
test shared_context_expired_event_emitted_when_orchestrator_prunes ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

running 7 tests
test test_docker_available ... ok
test test_setup_script_runs_as_root_and_restores_non_root_default_user ... ok
test test_env_auth_mode_works_in_non_root_container ... ok
test test_exec_in_container ... ok
test test_auth_resolution_auto ... ok
test test_mount_auth_installs_in_non_root_home ... ok
test test_start_and_stop_container ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 11 tests
test test_exec_command_builds_correct_args ... ok
test test_container_name_from_issue ... ok
test test_derived_image_tag_matches_stable_known_value ... ok
test test_derived_image_tag_is_deterministic ... ok
test test_derived_image_tag_changes_with_content ... ok
test test_resolve_codex_auth_auto_neither_errors ... ok
test test_resolve_codex_auth_env_missing_errors ... ok
test test_resolve_codex_auth_auto_with_auth_json ... ok
test test_resolve_codex_auth_mount_missing_errors ... ok
test test_resolve_codex_auth_mount_with_auth_json ... ok
test test_resolve_codex_auth_auto_with_api_key ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 16 tests
test test_codex_totals_default_is_zero ... ok
test test_issue_missing_optionals_defaults ... ok
test test_retry_entry_construction ... ok
test test_issue_assigned_to_worker_defaults_true ... ok
test test_run_attempt_deserializes_when_issue_url_missing ... ok
test test_agent_event_variants ... ok
test test_run_attempt_construction_and_serialization ... ok
test test_live_session_token_defaults ... ok
test test_escalation_request_response_round_trip ... ok
test test_issue_json_round_trip ... ok
test test_server_config_default_host ... ok
test test_service_config_defaults_match_spec ... ok
test test_symphony_error_display ... ok
test test_tracker_linear_project_url_uses_project_and_workspace_slug ... ok
test test_workspace_construction ... ok
test test_orchestrator_snapshot_serializes ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 6 tests
test test_escalation_timeout_cancels_cleanly ... ok
test test_escalation_cancel_for_issue_cleans_up ... ok
test test_escalation_full_round_trip ... ok
test test_escalation_http_list_pending ... ok
test test_escalation_http_respond_unknown_id ... ok
test test_escalation_http_respond_endpoint ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

running 8 tests
test orchestrator_session_started_event_includes_session_id ... ok
test tool_error_notification_maps_to_tool_error_envelope ... ok
test orchestrator_event_stream_emits_runtime_and_tool_events ... ok
test filtered_runtime_event_delivery ... ok
test websocket_upgrade_and_heartbeat ... ok
test websocket_ping_receives_protocol_pong ... ok
test slow_consumer_backpressure ... ok
test queue_full_honors_backpressure_drop_threshold ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.77s

running 20 tests
test test_event_filter_invalid_type_returns_machine_readable_error ... ok
test test_event_filter_issue_normalizes_valid_identifier ... ok
test test_event_filter_issue_requires_team_number_shape ... ok
test test_dashboard_initial_supervisor_metrics_use_snapshot_values ... ok
test test_escalation_dashboard_section_renders ... ok
test test_escalation_endpoints_return_empty_or_not_found_when_unknown ... ok
test test_dashboard_html_includes_blocked_section ... ok
test test_context_post_publishes_shared_context_written_event ... ok
test test_context_post_get_and_delete_round_trip ... ok
test test_dashboard_html_includes_error_column_rendering_logic ... ok
test test_context_scope_filter_and_clear_endpoint ... ok
test test_get_api_state_includes_worker_last_error_when_present ... ok
test test_get_issue_returns_not_found_envelope_for_unknown_identifier ... ok
test test_get_issue_returns_projection_for_known_issue_identifier ... ok
test test_get_api_state_returns_snapshot_projection ... ok
test test_post_refresh_reports_queued_then_coalesced_state ... ok
test test_get_root_returns_html_dashboard_shell_with_structured_sections ... ok
test test_wrong_method_on_known_api_route_returns_json_405_error_envelope ... ok
test test_unknown_api_path_returns_json_404_error_envelope ... ok
test test_state_json_includes_blocked_array ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 47 tests
test test_assignee_filter_no_assignee_on_issue ... ok
test test_assignee_filter_mismatch ... ok
test test_assignee_no_filter_all_true ... ok
test test_assignee_filter_match ... ok
test test_create_comment_success ... ok
test test_adapter_fetch_by_ids ... ok
test test_create_comment_non_retryable_failure_does_not_retry ... ok
test test_error_graphql_errors ... ok
test test_adapter_fetch_by_states ... ok
test test_error_missing_end_cursor ... ok
test test_adapter_fetch_candidates ... ok
test test_error_non_200_status ... ok
test test_fetch_by_ids_preserves_order ... ok
test test_error_unknown_payload ... ok
test test_fetch_candidates_single_page ... ok
test test_fetch_candidates_multi_page_preserves_order ... ok
test test_fetch_candidates_with_ambiguous_assignee_errors ... ok
test test_fetch_candidates_named_assignee_uses_session_cache ... ok
test test_fetch_candidates_with_email_assignee ... ok
test test_fetch_candidates_with_unresolvable_assignee_errors_with_identifiers ... ok
test test_fetch_candidates_with_me_assignee ... ok
test test_fetch_by_ids_batched_beyond_50 ... ok
test test_fetch_candidates_with_me_filters_out_unassigned ... ok
test test_fetch_candidates_with_uuid_assignee_skips_users_query ... ok
test test_fetch_issue_states_by_ids_empty_input ... ok
test test_fetch_candidates_with_uppercase_uuid_assignee_normalizes_to_lowercase ... ok
test test_fetch_issues_by_states_empty_input ... ok
test test_normalization_blocker_type_case_insensitive ... ok
test test_fetch_candidates_named_assignee_concurrent_requests_share_users_fetch ... ok
test test_normalization_blockers_filtered_by_type ... ok
test test_normalization_branch_name_mapping ... ok
test test_normalization_datetime_parsing ... ok
test test_fetch_issue_states_by_ids_deduplicates ... ok
test test_fetch_candidates_with_username_assignee ... ok
test test_normalization_non_object_returns_none ... ok
test test_normalization_labels_lowercase ... ok
test test_normalization_full_field_extraction ... ok
test test_normalization_priority_coercion ... ok
test test_fetch_issues_by_states_deduplicates ... ok
test test_fetch_candidates_with_username_assignee_paginates_users_query ... ok
test test_fetch_issues_by_states_no_assignee_filter ... ok
test test_resolve_state_id_returns_error_when_not_found ... ok
test test_resolve_state_id_returns_matching_state ... ok
test test_update_issue_state_resolves_and_updates ... ok
test test_create_comment_failure_includes_retry_diagnostics ... ok
test test_create_comment_retries_after_first_failure_then_succeeds ... ok
test test_error_transport_error ... ok

test result: ok. 47 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 30.03s

running 82 tests
test test_blocked_issue_in_agent_review_not_dispatched ... ok
test test_circular_dependency_blocks_both_issues ... ok
test test_blocked_issues_cleared_on_tick_start ... ok
test test_dispatch_predispatch_refresh_rejects_stale_state ... ok
test test_escalation_registry_resolve_not_found_when_receiver_dropped ... ok
test test_escalation_registry_cancel_for_issue_cleans_up ... ok
test test_escalation_registry_resolve_round_trip ... ok
test test_event_count_increments_on_ingest ... ok
test test_cross_project_unknown_blocker_treated_as_non_blocking ... ok
test test_dispatch_docker_isolation_never_assigns_ssh_worker_host ... ok
test test_blocked_issue_in_progress_not_dispatched ... ok
test test_blocked_issue_with_terminal_blocker_dispatched ... ok
test test_dispatch_candidate_sorting_and_gating_rules ... ok
test test_completed_is_bookkeeping_and_does_not_block_dispatch ... ok
test test_escalation_registry_resolved_cache_is_bounded ... ok
test test_handle_worker_completion_cleans_pending_escalations_for_released_issue ... ok
test test_ingest_agent_event_cleans_pending_escalation_for_non_running_issue ... ok
test test_late_streamed_event_after_completion_is_ignored ... ok
test test_notification_does_not_fire_without_prior_state_snapshot ... ok
test test_notification_failure_does_not_block_orchestrator ... ok
test test_notification_fires_on_human_review_transition ... ok
test test_notification_fires_on_rework_transition ... ok
test test_notification_fires_on_terminal_failure ... ok
test test_notification_fires_on_worker_stall ... ok
test test_notification_skips_unconfigured_events ... ok
test test_orchestrator_create_refresh_channel_returns_functional_sender ... ok
test test_orchestrator_create_snapshot_handle_and_refresh_channel_independently ... ok
test test_preflight_validation_failure_skips_dispatch_but_reconcile_continues ... ok
test test_reconcile_non_active_state_stops_run_without_cleanup ... ok
test test_reconcile_refresh_failure_is_non_fatal_and_dispatch_continues ... ok
test test_reconcile_startup_terminal_cleanup_excludes_terminal_issues_from_completed ... ok
test test_reconcile_terminal_state_cleans_pending_escalations ... ok
test test_reconcile_tick_reconcile_before_validate_before_dispatch ... ok
test test_refresh_channel_duplicate_requests_coalesce ... ok
test test_refresh_channel_first_request_is_queued ... ok
test test_refresh_channel_notified_wakes_on_request ... ok
test test_refresh_channel_resets_after_take_allows_new_queued_request ... ok
test test_refresh_channel_take_pending_clears_flag ... ok
test test_refresh_sender_is_clone_cheap ... ok
test test_retry_scheduling_continuation_and_failure_backoff_rules ... ok
test test_snapshot_exposes_running_and_retry_diagnostics ... ok
test test_snapshot_handle_is_clone_cheap_and_shares_state ... ok
test test_snapshot_handle_preserves_codex_totals_and_rate_limits ... ok
test test_snapshot_handle_read_returns_published_state ... ok
test test_snapshot_handle_reflects_retry_queue_for_api_use ... ok
test test_snapshot_handle_updates_after_publish ... ok
test test_snapshot_includes_blocked_issues ... ok
test test_stale_retry_timer_is_ignored ... ok
test test_stall_detection_schedules_forced_retry ... ok
test test_startup_terminal_cleanup_clears_runtime_bookkeeping_without_completed_insert ... ok
test test_startup_terminal_cleanup_removes_orphan_workspace_from_scan ... ok
test test_streamed_event_updates_activity_before_worker_completion ... ok
test test_streamed_events_keep_refreshing_stall_detection_window ... ok
test test_streamed_notification_records_event_method_and_message ... ok
test test_streamed_tool_call_completed_uses_completed_summary ... ok
test test_streamed_turn_completed_events_update_token_totals_in_real_time ... ok
test test_terminal_state_cleanup_defers_until_worker_completion ... ok
test test_terminal_state_cleanup_failure_is_non_fatal ... ok
test test_terminal_state_cleanup_preserves_workspace_when_disabled ... ok
test test_due_continuation_retry_marks_terminal_issue_completed_when_not_visible_in_candidates ... ok
test test_terminal_state_cleanup_removes_workspace_when_enabled ... ok
test test_terminal_state_cleanup_removes_retry_workspace_when_enabled ... ok
test test_terminal_state_cleanup_removes_worktree_checkout_when_enabled ... ok
test test_tick_applies_server_port_override_over_workflow_store_config ... ok
test test_terminal_state_cleanup_runs_before_remove_hook ... ok
test test_token_totals_and_rate_limits_accumulate_into_snapshot ... ok
test test_unblocked_issue_dispatches_normally ... ok
test test_worker_completion_schedules_continuation_retry_with_session_context ... ok
test test_worker_completion_without_continuation_does_not_queue_retry ... ok
test test_worker_failure_preserves_attempt_and_backoff_cap ... ok
test test_worker_session_info_last_error_clears_after_successful_turn_completed ... ok
test test_worker_session_info_last_error_formats_rate_limit_retry_window ... ok
test test_worker_session_info_last_error_set_on_failed_turn_and_exposed_in_snapshot ... ok
test test_execute_worker_attempt_stops_when_issue_changes_to_different_active_state ... ok
test test_tick_refreshes_runtime_state_from_workflow_store_reload ... ok
test test_execute_worker_attempt_stops_when_issue_leaves_active_state_after_first_turn ... ok
test test_execute_worker_attempt_failure_on_turn_two_keeps_turn_one_metrics ... ok
test test_execute_worker_attempt_runs_multiple_turns_in_one_session_and_uses_continuation_prompt ... ok
test test_execute_worker_attempt_shared_context_is_injected_into_prompt ... ok
test test_execute_worker_attempt_stops_when_issue_turns_terminal_after_first_turn ... ok
test test_execute_worker_attempt_preserves_last_non_null_rate_limits ... ok
test test_execute_worker_attempt_stops_when_issue_unassigned_between_turns ... ok

test result: ok. 82 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.00s

running 16 tests
test has_rate_limit_hint_detects_expected_keywords ... ok
test extension_ui_response_helpers ... ok
test extract_stop_reason_returns_error_reason_and_message ... ok
test extract_stop_reason_ignores_end_turn_and_missing_stop_reason ... ok
test parse_session_stats_payload ... ok
test serialize_get_state_command ... ok
test serialize_prompt_command ... ok
test parse_tool_execution_start_event ... ok
test token_tracker_clamps_negative_deltas_to_zero ... ok
test token_tracker_computes_deltas ... ok
test parse_prompt_response_line ... ok
test rpc_bridge_escalation_times_out_and_falls_back ... ok
test rpc_bridge_escalation_holds_and_resumes_with_response ... ok
test rpc_bridge_start_turn_stop_smoke ... ok
test rpc_bridge_turn_fails_on_message_end_error_stop_reason ... ok
test rpc_bridge_escalation_channel_close_emits_cancelled ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.61s

running 15 tests
test test_select_worker_host_local_mode ... ok
test test_remote_workspace_validation ... ok
test test_parse_target_host_port ... ok
test test_parse_target_user_at_host_port ... ok
test test_parse_target_ipv6_unbracketed ... ok
test test_parse_target_plain_host ... ok
test test_parse_target_ipv6_bracketed ... ok
test test_shell_escape_plain ... ok
test test_shell_escape_with_single_quote ... ok
test test_select_worker_host_blocks_when_all_full ... ok
test test_select_worker_host_prefers_prior_host ... ok
test test_select_worker_host_skips_full_host ... ok
test test_ssh_args_no_config ... ok
test test_fake_ssh_launch ... FAILED
test test_ssh_args_with_config ... ok

failures:

---- test_fake_ssh_launch stdout ----

thread 'test_fake_ssh_launch' (5940121) panicked at tests/ssh_tests.rs:177:49:
read trace: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    test_fake_ssh_launch

test result: FAILED. 14 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s
- \

Closes KAT-1660

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces persistent worker errors (rate-limit, usage-limit, auth failures, etc.) into the TUI, HTTP dashboard, and orchestrator snapshot so operators can see session-level failure state in real time without digging through logs.

**Key changes:**
- Adds `last_error: Option<String>` to `WorkerSessionInfo` and `RunningSessionSnapshot`; set on `TurnFailed`/`TurnEndedWithError`/`StartupFailed`, cleared on `TurnCompleted` (when `total_tokens > 0`)
- `format_rate_limit_error` detects rate/usage-limit keywords and formats with a human-readable retry-window hint extracted via a `LazyLock` regex, with a 200-char truncation for redaction safety
- TUI renders errors as `🚨 <message>` in red with a red status-dot override; escalation yellow styling is gated to error-free sessions
- Dashboard gains an Error column (colspan bumped to 13) with `escapeHtml`-safe inline rendering of `last_error`
- New tests: 3 orchestrator tests (set/clear/rate-limit formatting), 2 HTTP tests (column presence, API projection), 1 TUI draw test

<h3>Confidence Score: 5/5</h3>

Safe to merge; both remaining findings are minor P2 style/edge-case concerns that do not affect the primary operator-visibility use case.

All test suites pass (280+ tests). The two findings are: (1) a `total_tokens > 0` guard that could theoretically keep a stale error banner after a zero-token TurnCompleted — unusual in practice; (2) the rate-limit prefix adds ~12 chars beyond the stated 200-char truncation goal. Neither causes incorrect data, data loss, or a broken user path.

apps/symphony/src/orchestrator.rs — the `last_error` clear condition and `format_rate_limit_error` output length

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Adds `last_error` tracking: set on TurnFailed/TurnEndedWithError/StartupFailed, cleared on TurnCompleted with total_tokens > 0, and formatted with retry-window hints for rate/usage-limit errors via regex. Two minor issues: the `total_tokens > 0` guard can prevent clearing stale errors after valid zero-token completions, and the rate-limit formatting prefix slightly exceeds the 200-char truncation target. |
| apps/symphony/src/tui.rs | Adds `last_error`-aware rendering: 🚨 red activity cell, red status dot override, and escalation yellow row style gated to error-free sessions. Clean implementation that correctly prioritises error state over escalation and staleness. |
| apps/symphony/src/http_server.rs | Adds an Error column to the running-sessions table, correct colspan bump to 13 in both static loading and empty-state rows, and `escapeHtml`-safe rendering of `sessionInfo.last_error` in the JS template. No issues found. |
| apps/symphony/src/domain.rs | Adds `last_error: Option<String>` to both `WorkerSessionInfo` and `RunningSessionSnapshot` with correct serde defaults and skip-if-none annotations. |
| apps/symphony/tests/orchestrator_tests.rs | Three new tests covering set-on-failure, clear-on-success, and rate-limit formatting with compound time expressions. Good coverage of the happy and reset paths. |
| apps/symphony/tests/http_server_tests.rs | Two new integration tests: one verifying the HTML template includes error-column markup and colspan=13, another verifying the API state JSON includes `last_error` when set. Fixtures updated with the new field. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AgentEvent received] --> B{Event type?}
    B -- TurnFailed or StartupFailed --> C[format_rate_limit_error]
    C --> D{Rate or usage limit keyword?}
    D -- Yes and window parseable --> E["rate limit: retry in ~N min"]
    D -- Yes no window --> F["rate limit: truncate error 200 chars"]
    D -- No --> G["truncate error 200 chars"]
    E --> H[worker_session_info.last_error = formatted]
    F --> H
    G --> H
    H --> I[Propagated to RunningSessionSnapshot on snapshot]
    B -- TurnCompleted with total_tokens greater than 0 --> J[worker_session_info.last_error = None]
    J --> I
    I --> K[TUI: red cell and red status dot]
    I --> L[Dashboard: Error column via sessionInfo.last_error]
    I --> M[API state JSON: running_session_info.last_error]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 2413-2415

Comment:
**`last_error` persists after a zero-token `TurnCompleted`**

The guard `if *total_tokens > 0` means a `TurnCompleted` event with `total_tokens = 0` will **not** clear `last_error`, leaving a stale error banner visible to operators even though the worker reported a successful turn. A `TurnCompleted` already signals a meaningful turn boundary, so the additional token guard creates a subtle state inconsistency. If the intent is specifically to skip no-op or accounting-only completions, that should be documented; otherwise, the unconditional clear is safer:

```suggestion
            session_info.last_error = None;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 4372-4386

Comment:
**Formatted output can slightly exceed 200-char truncation target**

When the error is detected as a rate-limit but no retry window can be extracted, the function returns `format!("rate limit: {truncated}")`, where `truncated` is already up to 200 chars. The `"rate limit: "` prefix (12 chars) pushes the final string to up to ~212 chars, slightly overshooting the "200-char truncation for redaction safety" stated in the PR description.

If strict character-level redaction is required, apply `truncate_for_display` to the final formatted string instead:

```rust
fn format_rate_limit_error(error: &str) -> String {
    let normalized = error.to_ascii_lowercase();
    let is_rate_limit = normalized.contains("rate limit") || normalized.contains("usage limit");

    if !is_rate_limit {
        return truncate_for_display(error, WORKER_LAST_ERROR_MAX_CHARS);
    }

    if let Some(minutes) = extract_retry_window_minutes(error) {
        return format!("rate limit: retry in ~{minutes} min");
    }

    let formatted = format!("rate limit: {error}");
    truncate_for_display(&formatted, WORKER_LAST_ERROR_MAX_CHARS)
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/gannonh/kata/commit/fd1f78932c3a1f1a3d027ddee0eb919c9fbac510) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26677000)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->