### PR TITLE
feat(symphony): add symphony doctor preflight diagnostics

### DIFF
--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -230,7 +230,7 @@ Exit codes:
 - `0` when no `🚨` errors are found
 - `1` when any `🚨` error is found
 
-`doctor` is diagnostic only — it does not auto-fix configuration or environment problems.
+`doctor` is diagnostic only — it does not auto-fix configuration or environment problems. The one intentional local side effect is creating `workspace.root` when it does not exist so writability can be verified.
 
 ### 4. Create issues in Linear
 

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -191,6 +191,47 @@ Optional flags:
 
 Symphony starts polling Linear. Open `http://localhost:8080` for the web dashboard, or watch the built-in terminal dashboard (enabled by default).
 
+### Doctor preflight checks
+
+Before launching the orchestrator, you can validate your setup with:
+
+```bash
+symphony doctor [WORKFLOW.md]
+```
+
+Doctor prints deterministic traffic-light output:
+
+- `✅` pass
+- `⚠️` warning (non-fatal)
+- `🚨` error (fatal)
+- `⏭️` skipped
+
+Example:
+
+```text
+Symphony Doctor
+✅ Config Parse: Parsed WORKFLOW.md
+✅ Config Validate: Required workflow settings are present
+✅ Linear Project: Resolved project "sym" (sym)
+🚨 Backend: 'kata' not found on PATH
+⚠️ Orphans: Workspace /tmp/symphony-workspaces/KAT-999 has no matching active issue (KAT-999)
+```
+
+Checks currently cover:
+
+- Workflow parse/validation, `$ENV_VAR` resolution, prompt path existence, notification event names
+- Linear auth/project/workflow-state/assignee checks
+- Agent backend command handshake (`--version`)
+- Workspace root/repo/git strategy/docker daemon checks
+- Orphan workspace detection under `workspace.root`
+
+Exit codes:
+
+- `0` when no `🚨` errors are found
+- `1` when any `🚨` error is found
+
+`doctor` is diagnostic only — it does not auto-fix configuration or environment problems.
+
 ### 4. Create issues in Linear
 
 Create issues in your Linear project. Set them to `Todo`. Symphony picks them up on the next poll cycle (default: every 30 seconds).

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -36,7 +36,8 @@
 # Notes:
 #   - Exit code is 0 when no 🚨 errors are found, otherwise 1.
 #   - SSH host reachability checks are currently reported as ⏭️ skipped (future work).
-#   - Doctor is report-only (no auto-fix).
+#   - Doctor is report-only (no auto-fix), except it may create `workspace.root`
+#     when missing so writability can be validated.
 
 # ─── Tracker ──────────────────────────────────────────────────────────────────
 # Configures which issue tracker to poll and how to filter issues.

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -16,6 +16,28 @@
 # Unset variables resolve to empty string with a warning.
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# ─── Doctor CLI reference ─────────────────────────────────────────────────────
+# Run: symphony doctor [WORKFLOW.md]
+#
+# Doctor validates this workflow before runtime and prints traffic-light lines:
+#   ✅ pass      — healthy
+#   ⚠️ warning   — non-fatal issue to review
+#   🚨 error     — fatal issue (doctor exits 1)
+#   ⏭️ skipped   — check intentionally not run
+#
+# Current check groups:
+#   - Config: parse + validate + env-var resolution + prompt file paths + Slack event names
+#   - Linear: auth (viewer), project slug resolution, workflow state alignment, assignee lookup
+#   - Backend: configured backend command present on PATH and responds to `--version`
+#   - Workspace: root path writable/creatable, repo reference sanity, git strategy compatibility,
+#                Docker daemon availability when isolation=docker
+#   - Orphans: on-disk workspace directories that do not map to active tracker issues
+#
+# Notes:
+#   - Exit code is 0 when no 🚨 errors are found, otherwise 1.
+#   - SSH host reachability checks are currently reported as ⏭️ skipped (future work).
+#   - Doctor is report-only (no auto-fix).
+
 # ─── Tracker ──────────────────────────────────────────────────────────────────
 # Configures which issue tracker to poll and how to filter issues.
 tracker:

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -1104,8 +1104,18 @@ fn assert_directory_writable(path: &Path) -> std::io::Result<()> {
         chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
     ));
 
+    struct ProbeCleanup(PathBuf);
+
+    impl Drop for ProbeCleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+
+    let cleanup = ProbeCleanup(probe_path.clone());
     fs::write(&probe_path, b"doctor")?;
-    fs::remove_file(probe_path)?;
+    fs::remove_file(&probe_path)?;
+    std::mem::forget(cleanup);
     Ok(())
 }
 

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -1,0 +1,1220 @@
+use std::collections::{BTreeSet, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
+
+use crate::config;
+use crate::domain::{
+    AgentBackend, ServiceConfig, TrackerConfig, WorkspaceConfig, WorkspaceIsolation,
+    WorkspaceRepoStrategy,
+};
+use crate::error::SymphonyError;
+use crate::linear::adapter::TrackerAdapter;
+use crate::linear::client::LinearClient;
+use crate::notifications;
+use crate::repo_url::repo_is_remote;
+use crate::workflow;
+use crate::workspace;
+
+const VIEWER_QUERY: &str = r#"
+query SymphonyDoctorViewer {
+  viewer {
+    id
+  }
+}
+"#;
+
+const PROJECT_QUERY: &str = r#"
+query SymphonyDoctorProject($slug: String!) {
+  projects(filter: {slugId: {eq: $slug}}, first: 1) {
+    nodes {
+      id
+      name
+      teams {
+        nodes {
+          id
+          name
+          states {
+            nodes {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+const USERS_QUERY: &str = r#"
+query SymphonyDoctorUsers($first: Int!, $after: String) {
+  users(first: $first, after: $after) {
+    nodes {
+      id
+      displayName
+      name
+      email
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckStatus {
+    Pass,
+    Warning,
+    Error,
+    Skipped,
+}
+
+impl CheckStatus {
+    fn icon(self) -> &'static str {
+        match self {
+            Self::Pass => "✅",
+            Self::Warning => "⚠️",
+            Self::Error => "🚨",
+            Self::Skipped => "⏭️",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DoctorCheckResult {
+    pub name: String,
+    pub status: CheckStatus,
+    pub message: String,
+    pub details: Option<String>,
+}
+
+impl DoctorCheckResult {
+    fn pass(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Pass,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    fn warning(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Warning,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    fn error(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Error,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    fn skipped(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Skipped,
+            message: message.into(),
+            details: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EnvReferenceIssue {
+    path: String,
+    var_name: String,
+}
+
+pub fn check_config(workflow_path: &Path) -> Vec<DoctorCheckResult> {
+    let mut results = Vec::new();
+
+    let workflow_definition = match workflow::parse_workflow(workflow_path) {
+        Ok(definition) => {
+            results.push(DoctorCheckResult::pass(
+                "Config Parse",
+                format!("Parsed {}", workflow_path.display()),
+            ));
+            definition
+        }
+        Err(err) => {
+            results.push(DoctorCheckResult::error("Config Parse", err.to_string()));
+            return results;
+        }
+    };
+
+    let unresolved_env_refs = collect_unresolved_env_refs(&workflow_definition.config);
+    if unresolved_env_refs.is_empty() {
+        results.push(DoctorCheckResult::pass(
+            "Config Env",
+            "All $ENV_VAR references resolved",
+        ));
+    } else {
+        for issue in unresolved_env_refs {
+            results.push(DoctorCheckResult::error(
+                "Config Env",
+                format!(
+                    "{} references ${} but the environment variable is unset or empty",
+                    issue.path, issue.var_name
+                ),
+            ));
+        }
+    }
+
+    let invalid_events = collect_invalid_slack_events(&workflow_definition.config);
+    if invalid_events.is_empty() {
+        results.push(DoctorCheckResult::pass(
+            "Config Notifications",
+            "Slack notification events are valid",
+        ));
+    } else {
+        for event in invalid_events {
+            results.push(DoctorCheckResult::warning(
+                "Config Notifications",
+                format!(
+                    "Unsupported notifications.slack.events value '{event}' (supported: {})",
+                    notifications::SUPPORTED_SLACK_EVENTS.join(", ")
+                ),
+            ));
+        }
+    }
+
+    let sanitized_config = sanitize_invalid_slack_events(&workflow_definition.config);
+
+    let service_config = match config::from_workflow(&sanitized_config) {
+        Ok(config) => config,
+        Err(err) => {
+            results.push(DoctorCheckResult::error("Config Parse", err.to_string()));
+            return results;
+        }
+    };
+
+    match config::validate(&service_config) {
+        Ok(_) => results.push(DoctorCheckResult::pass(
+            "Config Validate",
+            "Required workflow settings are present",
+        )),
+        Err(err) => {
+            results.push(DoctorCheckResult::error("Config Validate", err.to_string()));
+        }
+    }
+
+    let workflow_dir = workflow_path.parent().unwrap_or(Path::new("."));
+    let prompt_paths = collect_prompt_paths(&service_config);
+    if prompt_paths.is_empty() {
+        results.push(DoctorCheckResult::skipped(
+            "Config Prompts",
+            "No prompt files configured",
+        ));
+    } else {
+        let mut missing_prompt_count = 0;
+        for (prompt_slot, relative_path) in prompt_paths {
+            let candidate_path = resolve_prompt_path(workflow_dir, &relative_path);
+            if !candidate_path.exists() {
+                missing_prompt_count += 1;
+                results.push(DoctorCheckResult::warning(
+                    "Config Prompts",
+                    format!(
+                        "{prompt_slot} points to missing file {}",
+                        candidate_path.display()
+                    ),
+                ));
+            }
+        }
+
+        if missing_prompt_count == 0 {
+            results.push(DoctorCheckResult::pass(
+                "Config Prompts",
+                "All configured prompt files exist",
+            ));
+        }
+    }
+
+    results
+}
+
+pub async fn check_linear(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
+    let mut results = Vec::new();
+    let client = LinearClient::new(config.clone());
+
+    let viewer_body = match client
+        .graphql_raw(VIEWER_QUERY, serde_json::json!({}))
+        .await
+    {
+        Ok(body) => body,
+        Err(err) => {
+            results.push(DoctorCheckResult::error(
+                "Linear Auth",
+                format_linear_error("Failed to authenticate with Linear", &err),
+            ));
+            return results;
+        }
+    };
+
+    if let Some(message) = graphql_error_message(&viewer_body) {
+        results.push(DoctorCheckResult::error(
+            "Linear Auth",
+            format!("Failed to authenticate with Linear: {message}"),
+        ));
+        return results;
+    }
+
+    let viewer_id = viewer_body
+        .get("data")
+        .and_then(|data| data.get("viewer"))
+        .and_then(|viewer| viewer.get("id"))
+        .and_then(|id| id.as_str())
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string);
+
+    let viewer_id = match viewer_id {
+        Some(id) => {
+            results.push(DoctorCheckResult::pass(
+                "Linear Auth",
+                format!("Authenticated as viewer {id}"),
+            ));
+            id
+        }
+        None => {
+            results.push(DoctorCheckResult::error(
+                "Linear Auth",
+                "Linear viewer query returned no id",
+            ));
+            return results;
+        }
+    };
+
+    let Some(project_slug) = config
+        .project_slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    else {
+        results.push(DoctorCheckResult::error(
+            "Linear Project",
+            "tracker.project_slug is missing",
+        ));
+        return results;
+    };
+
+    let project_body = match client
+        .graphql_raw(PROJECT_QUERY, serde_json::json!({ "slug": project_slug }))
+        .await
+    {
+        Ok(body) => body,
+        Err(err) => {
+            results.push(DoctorCheckResult::error(
+                "Linear Project",
+                format_linear_error("Failed to fetch project by slug", &err),
+            ));
+            return results;
+        }
+    };
+
+    if let Some(message) = graphql_error_message(&project_body) {
+        results.push(DoctorCheckResult::error(
+            "Linear Project",
+            format!("Failed to fetch project by slug: {message}"),
+        ));
+        return results;
+    }
+
+    let project_node = project_body
+        .get("data")
+        .and_then(|data| data.get("projects"))
+        .and_then(|projects| projects.get("nodes"))
+        .and_then(|nodes| nodes.as_array())
+        .and_then(|nodes| nodes.first());
+
+    let Some(project_node) = project_node else {
+        results.push(DoctorCheckResult::error(
+            "Linear Project",
+            format!("No Linear project found for slug '{project_slug}'"),
+        ));
+        return results;
+    };
+
+    let project_name = project_node
+        .get("name")
+        .and_then(|name| name.as_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .unwrap_or(project_slug);
+
+    results.push(DoctorCheckResult::pass(
+        "Linear Project",
+        format!("Resolved project '{project_name}' ({project_slug})"),
+    ));
+
+    let mut team_states = HashSet::new();
+    if let Some(teams) = project_node
+        .get("teams")
+        .and_then(|teams| teams.get("nodes"))
+        .and_then(|nodes| nodes.as_array())
+    {
+        for team in teams {
+            let Some(states) = team
+                .get("states")
+                .and_then(|states| states.get("nodes"))
+                .and_then(|nodes| nodes.as_array())
+            else {
+                continue;
+            };
+
+            for state in states {
+                if let Some(name) = state.get("name").and_then(|name| name.as_str()) {
+                    let normalized = name.trim().to_ascii_lowercase();
+                    if !normalized.is_empty() {
+                        team_states.insert(normalized);
+                    }
+                }
+            }
+        }
+    }
+
+    if team_states.is_empty() {
+        results.push(DoctorCheckResult::warning(
+            "Linear States",
+            "Could not resolve team workflow states from project",
+        ));
+    } else {
+        let configured_states: BTreeSet<String> = config
+            .active_states
+            .iter()
+            .chain(config.terminal_states.iter())
+            .map(|state| state.trim())
+            .filter(|state| !state.is_empty())
+            .map(|state| state.to_string())
+            .collect();
+
+        let mut missing = Vec::new();
+        for configured_state in configured_states {
+            if !team_states.contains(&configured_state.to_ascii_lowercase()) {
+                missing.push(configured_state);
+            }
+        }
+
+        if missing.is_empty() {
+            results.push(DoctorCheckResult::pass(
+                "Linear States",
+                "Configured active/terminal states match team workflow",
+            ));
+        } else {
+            for missing_state in missing {
+                results.push(DoctorCheckResult::warning(
+                    "Linear States",
+                    format!("Configured state '{missing_state}' not found in team workflow"),
+                ));
+            }
+        }
+    }
+
+    let assignee = config
+        .assignee
+        .as_deref()
+        .map(str::trim)
+        .filter(|assignee| !assignee.is_empty());
+
+    let Some(assignee) = assignee else {
+        results.push(DoctorCheckResult::skipped(
+            "Linear Assignee",
+            "tracker.assignee is not configured",
+        ));
+        return results;
+    };
+
+    if assignee.eq_ignore_ascii_case("me") {
+        results.push(DoctorCheckResult::pass(
+            "Linear Assignee",
+            format!("tracker.assignee=me resolved to viewer {viewer_id}"),
+        ));
+        return results;
+    }
+
+    match resolve_assignee(client, assignee).await {
+        Ok(Some(user_id)) => results.push(DoctorCheckResult::pass(
+            "Linear Assignee",
+            format!("Resolved assignee '{assignee}' to user {user_id}"),
+        )),
+        Ok(None) => results.push(DoctorCheckResult::warning(
+            "Linear Assignee",
+            format!("Could not resolve assignee '{assignee}' to a Linear user"),
+        )),
+        Err(err) => results.push(DoctorCheckResult::warning(
+            "Linear Assignee",
+            format_linear_error("Assignee lookup failed", &err),
+        )),
+    }
+
+    results
+}
+
+pub fn check_backend(config: &ServiceConfig) -> Vec<DoctorCheckResult> {
+    let mut results = Vec::new();
+
+    let command = match config.agent_backend {
+        AgentBackend::KataCli => &config.pi_agent.command,
+        AgentBackend::Codex => &config.codex.command,
+    };
+
+    if command.is_empty() {
+        results.push(DoctorCheckResult::error(
+            "Backend",
+            "Configured backend command is empty",
+        ));
+        return results;
+    }
+
+    let executable = &command[0];
+    match Command::new(executable).arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let version_line = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .find(|line| !line.trim().is_empty())
+                .map(str::trim)
+                .map(str::to_string)
+                .or_else(|| {
+                    String::from_utf8_lossy(&output.stderr)
+                        .lines()
+                        .find(|line| !line.trim().is_empty())
+                        .map(str::trim)
+                        .map(str::to_string)
+                })
+                .unwrap_or_else(|| "backend responded to --version".to_string());
+
+            results.push(DoctorCheckResult::pass(
+                "Backend",
+                format!("{executable} is available ({version_line})"),
+            ));
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr)
+                .lines()
+                .find(|line| !line.trim().is_empty())
+                .map(str::trim)
+                .map(str::to_string)
+                .unwrap_or_else(|| "no stderr output".to_string());
+            results.push(DoctorCheckResult::error(
+                "Backend",
+                format!(
+                    "{executable} --version exited with status {} ({stderr})",
+                    output
+                        .status
+                        .code()
+                        .map_or_else(|| "signal".to_string(), |code| code.to_string())
+                ),
+            ));
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            results.push(DoctorCheckResult::error(
+                "Backend",
+                format!("'{executable}' not found on PATH"),
+            ));
+        }
+        Err(err) => {
+            results.push(DoctorCheckResult::error(
+                "Backend",
+                format!("Failed to execute '{executable} --version': {err}"),
+            ));
+        }
+    }
+
+    results
+}
+
+pub fn check_workspace(config: &WorkspaceConfig) -> Vec<DoctorCheckResult> {
+    let mut results = Vec::new();
+    let workspace_root = PathBuf::from(&config.root);
+
+    if workspace_root.exists() {
+        if !workspace_root.is_dir() {
+            results.push(DoctorCheckResult::error(
+                "Workspace Root",
+                format!(
+                    "workspace.root exists but is not a directory: {}",
+                    workspace_root.display()
+                ),
+            ));
+        } else if let Err(err) = assert_directory_writable(&workspace_root) {
+            results.push(DoctorCheckResult::error(
+                "Workspace Root",
+                format!(
+                    "workspace.root is not writable ({}): {err}",
+                    workspace_root.display()
+                ),
+            ));
+        } else {
+            results.push(DoctorCheckResult::pass(
+                "Workspace Root",
+                format!("workspace.root is writable: {}", workspace_root.display()),
+            ));
+        }
+    } else {
+        match fs::create_dir_all(&workspace_root) {
+            Ok(()) => {
+                if let Err(err) = assert_directory_writable(&workspace_root) {
+                    results.push(DoctorCheckResult::error(
+                        "Workspace Root",
+                        format!(
+                            "workspace.root was created but is not writable ({}): {err}",
+                            workspace_root.display()
+                        ),
+                    ));
+                } else {
+                    results.push(DoctorCheckResult::pass(
+                        "Workspace Root",
+                        format!("Created workspace.root: {}", workspace_root.display()),
+                    ));
+                }
+            }
+            Err(err) => {
+                results.push(DoctorCheckResult::error(
+                    "Workspace Root",
+                    format!(
+                        "Could not create workspace.root {}: {err}",
+                        workspace_root.display()
+                    ),
+                ));
+            }
+        }
+    }
+
+    match config
+        .repo
+        .as_deref()
+        .map(str::trim)
+        .filter(|repo| !repo.is_empty())
+    {
+        None => results.push(DoctorCheckResult::skipped(
+            "Workspace Repo",
+            "workspace.repo is not configured",
+        )),
+        Some(repo) if repo_is_remote(repo) => {
+            if remote_repo_format_is_valid(repo) {
+                results.push(DoctorCheckResult::pass(
+                    "Workspace Repo",
+                    format!("Remote repo reference format looks valid: {repo}"),
+                ));
+            } else {
+                results.push(DoctorCheckResult::warning(
+                    "Workspace Repo",
+                    format!("Remote repo reference looks invalid: {repo}"),
+                ));
+            }
+        }
+        Some(repo) => {
+            let repo_path = Path::new(repo);
+            if repo_path.exists() {
+                results.push(DoctorCheckResult::pass(
+                    "Workspace Repo",
+                    format!("Local repo path exists: {}", repo_path.display()),
+                ));
+            } else {
+                results.push(DoctorCheckResult::warning(
+                    "Workspace Repo",
+                    format!("Local repo path does not exist: {}", repo_path.display()),
+                ));
+            }
+        }
+    }
+
+    let repo_is_remote = config.repo.as_deref().map(repo_is_remote);
+    match config.strategy {
+        WorkspaceRepoStrategy::Worktree | WorkspaceRepoStrategy::CloneLocal
+            if repo_is_remote == Some(true) =>
+        {
+            results.push(DoctorCheckResult::error(
+                "Workspace Strategy",
+                format!(
+                    "workspace.git_strategy '{:?}' requires a local workspace.repo path",
+                    config.strategy
+                ),
+            ));
+        }
+        WorkspaceRepoStrategy::CloneRemote if repo_is_remote == Some(false) => {
+            results.push(DoctorCheckResult::error(
+                "Workspace Strategy",
+                "workspace.git_strategy 'clone-remote' requires a remote workspace.repo URL",
+            ));
+        }
+        _ => results.push(DoctorCheckResult::pass(
+            "Workspace Strategy",
+            "workspace.git_strategy is compatible with workspace.repo",
+        )),
+    }
+
+    if config.isolation == WorkspaceIsolation::Docker {
+        match Command::new("docker")
+            .args(["info", "--format", "{{.ServerVersion}}"])
+            .output()
+        {
+            Ok(output) if output.status.success() => {
+                let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                let version = if version.is_empty() {
+                    "daemon reachable".to_string()
+                } else {
+                    format!("daemon reachable (version {version})")
+                };
+                results.push(DoctorCheckResult::pass("Workspace Docker", version));
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                let status_code = output
+                    .status
+                    .code()
+                    .map_or_else(|| "signal".to_string(), |code| code.to_string());
+                results.push(DoctorCheckResult::error(
+                    "Workspace Docker",
+                    format!("docker info failed (status {status_code}): {stderr}"),
+                ));
+            }
+            Err(err) => {
+                results.push(DoctorCheckResult::error(
+                    "Workspace Docker",
+                    format!("Failed to execute 'docker info': {err}"),
+                ));
+            }
+        }
+    } else {
+        results.push(DoctorCheckResult::skipped(
+            "Workspace Docker",
+            "workspace.isolation is not docker",
+        ));
+    }
+
+    results
+}
+
+pub async fn check_orphans(
+    config: &ServiceConfig,
+    adapter: &dyn TrackerAdapter,
+) -> Vec<DoctorCheckResult> {
+    let mut results = Vec::new();
+
+    let workspace_root = PathBuf::from(&config.workspace.root);
+    if !workspace_root.exists() {
+        results.push(DoctorCheckResult::warning(
+            "Orphans",
+            format!(
+                "workspace.root does not exist ({}); orphan scan skipped",
+                workspace_root.display()
+            ),
+        ));
+
+        if !config.worker.ssh_hosts.is_empty() {
+            results.push(DoctorCheckResult::skipped(
+                "SSH Hosts",
+                "worker.ssh_hosts configured; SSH reachability checks are not yet implemented",
+            ));
+        }
+
+        return results;
+    }
+
+    let discovered =
+        workspace::scan_workspace_root(&workspace_root, &config.workspace.branch_prefix);
+    if discovered.is_empty() {
+        results.push(DoctorCheckResult::pass(
+            "Orphans",
+            format!("No workspaces found under {}", workspace_root.display()),
+        ));
+    } else {
+        let active_issues = match adapter
+            .fetch_issues_by_states(&config.tracker.active_states)
+            .await
+        {
+            Ok(issues) => issues,
+            Err(err) => {
+                results.push(DoctorCheckResult::error(
+                    "Orphans",
+                    format!("Failed to fetch active issues from tracker: {err}"),
+                ));
+
+                if !config.worker.ssh_hosts.is_empty() {
+                    results.push(DoctorCheckResult::skipped(
+                        "SSH Hosts",
+                        "worker.ssh_hosts configured; SSH reachability checks are not yet implemented",
+                    ));
+                }
+
+                return results;
+            }
+        };
+
+        let active_identifiers: HashSet<String> = active_issues
+            .iter()
+            .map(|issue| issue.identifier.to_ascii_uppercase())
+            .collect();
+
+        let mut orphan_count = 0usize;
+        let mut discovered_entries = discovered.into_iter().collect::<Vec<_>>();
+        discovered_entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        for (identifier, path) in discovered_entries {
+            if !active_identifiers.contains(&identifier.to_ascii_uppercase()) {
+                orphan_count += 1;
+                results.push(DoctorCheckResult::warning(
+                    "Orphans",
+                    format!(
+                        "Workspace {} has no matching active issue ({identifier})",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+
+        if orphan_count == 0 {
+            results.push(DoctorCheckResult::pass(
+                "Orphans",
+                "All on-disk workspaces map to active issues",
+            ));
+        }
+    }
+
+    if !config.worker.ssh_hosts.is_empty() {
+        results.push(DoctorCheckResult::skipped(
+            "SSH Hosts",
+            "worker.ssh_hosts configured; SSH reachability checks are not yet implemented",
+        ));
+    }
+
+    results
+}
+
+pub fn format_results(results: &[DoctorCheckResult]) -> String {
+    let mut lines = vec!["Symphony Doctor".to_string()];
+
+    for result in results {
+        let mut line = format!(
+            "{} {}: {}",
+            result.status.icon(),
+            result.name,
+            result.message
+        );
+        if let Some(details) = result
+            .details
+            .as_deref()
+            .filter(|details| !details.is_empty())
+        {
+            line.push_str(&format!(" ({details})"));
+        }
+        lines.push(line);
+    }
+
+    lines.join("\n")
+}
+
+pub fn has_errors(results: &[DoctorCheckResult]) -> bool {
+    results
+        .iter()
+        .any(|result| matches!(result.status, CheckStatus::Error))
+}
+
+pub fn load_service_config(workflow_path: &Path) -> Result<ServiceConfig, String> {
+    let workflow_definition =
+        workflow::parse_workflow(workflow_path).map_err(|err| format!("{err}"))?;
+    let sanitized = sanitize_invalid_slack_events(&workflow_definition.config);
+    config::from_workflow(&sanitized).map_err(|err| format!("{err}"))
+}
+
+fn format_linear_error(prefix: &str, err: &SymphonyError) -> String {
+    match err {
+        SymphonyError::LinearApiStatus(status) => format!("{prefix}: HTTP {status}"),
+        other => format!("{prefix}: {other}"),
+    }
+}
+
+fn graphql_error_message(body: &JsonValue) -> Option<String> {
+    let errors = body.get("errors")?.as_array()?;
+    if errors.is_empty() {
+        return None;
+    }
+
+    let messages = errors
+        .iter()
+        .filter_map(|error| {
+            error
+                .get("message")
+                .and_then(|message| message.as_str())
+                .map(str::trim)
+                .filter(|message| !message.is_empty())
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+
+    if messages.is_empty() {
+        Some("GraphQL error response".to_string())
+    } else {
+        Some(messages.join("; "))
+    }
+}
+
+async fn resolve_assignee(
+    client: LinearClient,
+    assignee: &str,
+) -> crate::error::Result<Option<String>> {
+    let lookup = assignee.trim().to_ascii_lowercase();
+    if lookup.is_empty() {
+        return Ok(None);
+    }
+
+    let mut after: Option<String> = None;
+
+    loop {
+        let mut variables = serde_json::json!({
+            "first": 100,
+        });
+        if let Some(cursor) = after.as_ref() {
+            variables["after"] = JsonValue::String(cursor.clone());
+        }
+
+        let body = client.graphql_raw(USERS_QUERY, variables).await?;
+        if graphql_error_message(&body).is_some() {
+            return Ok(None);
+        }
+
+        let nodes = body
+            .get("data")
+            .and_then(|data| data.get("users"))
+            .and_then(|users| users.get("nodes"))
+            .and_then(|nodes| nodes.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        for node in nodes {
+            let user_id = node
+                .get("id")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+
+            let Some(user_id) = user_id else {
+                continue;
+            };
+
+            let mut candidates = vec![user_id.to_ascii_lowercase()];
+            if let Some(display_name) = node
+                .get("displayName")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                candidates.push(display_name.to_ascii_lowercase());
+            }
+            if let Some(name) = node
+                .get("name")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                candidates.push(name.to_ascii_lowercase());
+            }
+            if let Some(email) = node
+                .get("email")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                candidates.push(email.to_ascii_lowercase());
+            }
+
+            if candidates.iter().any(|candidate| candidate == &lookup) {
+                return Ok(Some(user_id));
+            }
+        }
+
+        let page_info = body
+            .get("data")
+            .and_then(|data| data.get("users"))
+            .and_then(|users| users.get("pageInfo"));
+        let has_next_page = page_info
+            .and_then(|page_info| page_info.get("hasNextPage"))
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+
+        if has_next_page {
+            after = page_info
+                .and_then(|page_info| page_info.get("endCursor"))
+                .and_then(|value| value.as_str())
+                .map(str::to_string);
+
+            if after.is_none() {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    Ok(None)
+}
+
+fn collect_unresolved_env_refs(value: &YamlValue) -> Vec<EnvReferenceIssue> {
+    let mut issues = Vec::new();
+    collect_unresolved_env_refs_inner(value, "config", &mut issues);
+    issues
+}
+
+fn collect_unresolved_env_refs_inner(
+    value: &YamlValue,
+    path: &str,
+    issues: &mut Vec<EnvReferenceIssue>,
+) {
+    match value {
+        YamlValue::Mapping(mapping) => {
+            for (key, nested_value) in mapping {
+                let key = yaml_key_to_string(key);
+                let nested_path = format!("{path}.{key}");
+                collect_unresolved_env_refs_inner(nested_value, &nested_path, issues);
+            }
+        }
+        YamlValue::Sequence(items) => {
+            for (idx, item) in items.iter().enumerate() {
+                let nested_path = format!("{path}[{idx}]");
+                collect_unresolved_env_refs_inner(item, &nested_path, issues);
+            }
+        }
+        YamlValue::String(value) => {
+            if let Some(var_name) = env_reference_name(value) {
+                let resolved = std::env::var(var_name).unwrap_or_default();
+                if resolved.trim().is_empty() {
+                    issues.push(EnvReferenceIssue {
+                        path: path.to_string(),
+                        var_name: var_name.to_string(),
+                    });
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_invalid_slack_events(value: &YamlValue) -> Vec<String> {
+    let mut invalid = Vec::new();
+
+    let notifications = yaml_mapping_get(value, "notifications");
+    let slack = notifications.and_then(|value| yaml_mapping_get(value, "slack"));
+    let events = slack.and_then(|value| yaml_mapping_get(value, "events"));
+
+    let Some(YamlValue::Sequence(events)) = events else {
+        return invalid;
+    };
+
+    for event in events {
+        if let Some(event_name) = event.as_str() {
+            let normalized = event_name.trim().to_ascii_lowercase();
+            if !normalized.is_empty() && !notifications::is_supported_slack_event(&normalized) {
+                invalid.push(normalized);
+            }
+        }
+    }
+
+    invalid
+}
+
+fn sanitize_invalid_slack_events(config: &YamlValue) -> YamlValue {
+    let mut sanitized = config.clone();
+
+    let Some(root) = sanitized.as_mapping_mut() else {
+        return sanitized;
+    };
+
+    let notifications_key = YamlValue::String("notifications".to_string());
+    let slack_key = YamlValue::String("slack".to_string());
+    let events_key = YamlValue::String("events".to_string());
+
+    let Some(notifications_value) = root.get_mut(&notifications_key) else {
+        return sanitized;
+    };
+    let Some(notifications_map) = notifications_value.as_mapping_mut() else {
+        return sanitized;
+    };
+
+    let Some(slack_value) = notifications_map.get_mut(&slack_key) else {
+        return sanitized;
+    };
+    let Some(slack_map) = slack_value.as_mapping_mut() else {
+        return sanitized;
+    };
+
+    let Some(events_value) = slack_map.get_mut(&events_key) else {
+        return sanitized;
+    };
+    let Some(events) = events_value.as_sequence_mut() else {
+        return sanitized;
+    };
+
+    events.retain(|event| {
+        event
+            .as_str()
+            .map(str::trim)
+            .filter(|event| !event.is_empty())
+            .map(|event| notifications::is_supported_slack_event(event))
+            .unwrap_or(false)
+    });
+
+    sanitized
+}
+
+fn yaml_mapping_get<'a>(value: &'a YamlValue, key: &str) -> Option<&'a YamlValue> {
+    let map = value.as_mapping()?;
+    map.get(YamlValue::String(key.to_string()))
+}
+
+fn yaml_key_to_string(value: &YamlValue) -> String {
+    match value {
+        YamlValue::String(value) => value.clone(),
+        YamlValue::Bool(value) => value.to_string(),
+        YamlValue::Number(value) => value.to_string(),
+        YamlValue::Null => "null".to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+fn env_reference_name(value: &str) -> Option<&str> {
+    let variable = value.strip_prefix('$')?;
+    let is_bare_identifier = !variable.is_empty()
+        && !variable.contains('/')
+        && !variable.contains(' ')
+        && !variable.contains(':');
+
+    if is_bare_identifier {
+        Some(variable)
+    } else {
+        None
+    }
+}
+
+fn collect_prompt_paths(config: &ServiceConfig) -> Vec<(String, String)> {
+    let mut paths = Vec::new();
+    let Some(prompts) = config.prompts.as_ref() else {
+        return paths;
+    };
+
+    if let Some(path) = prompts.system.as_ref() {
+        paths.push(("prompts.system".to_string(), path.clone()));
+    }
+    if let Some(path) = prompts.repo.as_ref() {
+        paths.push(("prompts.repo".to_string(), path.clone()));
+    }
+    if let Some(path) = prompts.shared.as_ref() {
+        paths.push(("prompts.shared".to_string(), path.clone()));
+    }
+    if let Some(path) = prompts.default.as_ref() {
+        paths.push(("prompts.default".to_string(), path.clone()));
+    }
+
+    let mut by_state_entries = prompts.by_state.iter().collect::<Vec<_>>();
+    by_state_entries.sort_by(|a, b| a.0.cmp(b.0));
+    for (state, path) in by_state_entries {
+        paths.push((format!("prompts.by_state.{state}"), path.clone()));
+    }
+
+    paths
+}
+
+fn resolve_prompt_path(workflow_dir: &Path, prompt_path: &str) -> PathBuf {
+    let path = Path::new(prompt_path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        workflow_dir.join(path)
+    }
+}
+
+fn assert_directory_writable(path: &Path) -> std::io::Result<()> {
+    let probe_path = path.join(format!(
+        ".symphony-doctor-write-probe-{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+
+    fs::write(&probe_path, b"doctor")?;
+    fs::remove_file(probe_path)?;
+    Ok(())
+}
+
+fn remote_repo_format_is_valid(repo: &str) -> bool {
+    if repo.contains("://") {
+        return reqwest::Url::parse(repo).is_ok();
+    }
+
+    if let Some((host, path)) = repo.split_once(':') {
+        return !host.trim().is_empty() && !path.trim().is_empty();
+    }
+
+    repo.contains('@')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_results_renders_traffic_lights() {
+        let results = vec![
+            DoctorCheckResult::pass("Config", "ok"),
+            DoctorCheckResult::warning("Prompts", "missing file"),
+            DoctorCheckResult::error("Linear", "auth failed"),
+            DoctorCheckResult::skipped("SSH", "not implemented"),
+        ];
+
+        let rendered = format_results(&results);
+        assert!(rendered.contains("✅ Config: ok"));
+        assert!(rendered.contains("⚠️ Prompts: missing file"));
+        assert!(rendered.contains("🚨 Linear: auth failed"));
+        assert!(rendered.contains("⏭️ SSH: not implemented"));
+    }
+
+    #[test]
+    fn test_has_errors_true_when_error_present() {
+        let results = vec![
+            DoctorCheckResult::pass("Config", "ok"),
+            DoctorCheckResult::error("Linear", "failed"),
+        ];
+
+        assert!(has_errors(&results));
+    }
+
+    #[test]
+    fn test_has_errors_false_when_only_warnings() {
+        let results = vec![
+            DoctorCheckResult::pass("Config", "ok"),
+            DoctorCheckResult::warning("Prompts", "missing"),
+        ];
+
+        assert!(!has_errors(&results));
+    }
+
+    #[test]
+    fn test_check_config_catches_invalid_yaml() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let workflow_path = temp_dir.path().join("WORKFLOW.md");
+        fs::write(
+            &workflow_path,
+            "---\ntracker:\n  kind: linear\n  api_key: [broken\n---\nbody",
+        )
+        .expect("write invalid workflow");
+
+        let results = check_config(&workflow_path);
+        assert!(has_errors(&results));
+        assert!(results.iter().any(|result| {
+            result.status == CheckStatus::Error
+                && result.name == "Config Parse"
+                && result.message.contains("YAML parse error")
+        }));
+    }
+}

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -1062,7 +1062,7 @@ fn sanitize_invalid_slack_events(config: &YamlValue) -> YamlValue {
             .as_str()
             .map(str::trim)
             .filter(|event| !event.is_empty())
-            .map(|event| notifications::is_supported_slack_event(event))
+            .map(notifications::is_supported_slack_event)
             .unwrap_or(false)
     });
 

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -162,13 +162,15 @@ pub fn check_config(workflow_path: &Path) -> Vec<DoctorCheckResult> {
         ));
     } else {
         for issue in unresolved_env_refs {
-            results.push(DoctorCheckResult::error(
-                "Config Env",
-                format!(
-                    "{} references ${} but the environment variable is unset or empty",
-                    issue.path, issue.var_name
-                ),
-            ));
+            let message = format!(
+                "{} references ${} but the environment variable is unset or empty",
+                issue.path, issue.var_name
+            );
+            if is_required_env_reference_path(&issue.path) {
+                results.push(DoctorCheckResult::error("Config Env", message));
+            } else {
+                results.push(DoctorCheckResult::warning("Config Env", message));
+            }
         }
     }
 
@@ -190,9 +192,7 @@ pub fn check_config(workflow_path: &Path) -> Vec<DoctorCheckResult> {
         }
     }
 
-    let sanitized_config = sanitize_invalid_slack_events(&workflow_definition.config);
-
-    let service_config = match config::from_workflow(&sanitized_config) {
+    let service_config = match config::from_workflow(&workflow_definition.config) {
         Ok(config) => config,
         Err(err) => {
             results.push(DoctorCheckResult::error("Config Parse", err.to_string()));
@@ -825,8 +825,7 @@ pub fn has_errors(results: &[DoctorCheckResult]) -> bool {
 pub fn load_service_config(workflow_path: &Path) -> Result<ServiceConfig, String> {
     let workflow_definition =
         workflow::parse_workflow(workflow_path).map_err(|err| format!("{err}"))?;
-    let sanitized = sanitize_invalid_slack_events(&workflow_definition.config);
-    config::from_workflow(&sanitized).map_err(|err| format!("{err}"))
+    config::from_workflow(&workflow_definition.config).map_err(|err| format!("{err}"))
 }
 
 fn format_linear_error(prefix: &str, err: &SymphonyError) -> String {
@@ -1025,48 +1024,11 @@ fn collect_invalid_slack_events(value: &YamlValue) -> Vec<String> {
     invalid
 }
 
-fn sanitize_invalid_slack_events(config: &YamlValue) -> YamlValue {
-    let mut sanitized = config.clone();
-
-    let Some(root) = sanitized.as_mapping_mut() else {
-        return sanitized;
-    };
-
-    let notifications_key = YamlValue::String("notifications".to_string());
-    let slack_key = YamlValue::String("slack".to_string());
-    let events_key = YamlValue::String("events".to_string());
-
-    let Some(notifications_value) = root.get_mut(&notifications_key) else {
-        return sanitized;
-    };
-    let Some(notifications_map) = notifications_value.as_mapping_mut() else {
-        return sanitized;
-    };
-
-    let Some(slack_value) = notifications_map.get_mut(&slack_key) else {
-        return sanitized;
-    };
-    let Some(slack_map) = slack_value.as_mapping_mut() else {
-        return sanitized;
-    };
-
-    let Some(events_value) = slack_map.get_mut(&events_key) else {
-        return sanitized;
-    };
-    let Some(events) = events_value.as_sequence_mut() else {
-        return sanitized;
-    };
-
-    events.retain(|event| {
-        event
-            .as_str()
-            .map(str::trim)
-            .filter(|event| !event.is_empty())
-            .map(notifications::is_supported_slack_event)
-            .unwrap_or(false)
-    });
-
-    sanitized
+fn is_required_env_reference_path(path: &str) -> bool {
+    matches!(
+        path,
+        "config.tracker.api_key" | "config.tracker.project_slug"
+    )
 }
 
 fn yaml_mapping_get<'a>(value: &'a YamlValue, key: &str) -> Option<&'a YamlValue> {
@@ -1215,6 +1177,51 @@ mod tests {
             result.status == CheckStatus::Error
                 && result.name == "Config Parse"
                 && result.message.contains("YAML parse error")
+        }));
+    }
+
+    #[test]
+    fn test_check_config_optional_env_reference_is_warning() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let workflow_path = temp_dir.path().join("WORKFLOW.md");
+        fs::write(
+            &workflow_path,
+            "---\ntracker:\n  kind: linear\n  api_key: test-token\n  project_slug: test-project\n  assignee: $SYMPHONY_DOCTOR_OPTIONAL_ENV_UNSET_123\n---\nbody",
+        )
+        .expect("write workflow");
+
+        let results = check_config(&workflow_path);
+        assert!(!has_errors(&results));
+        assert!(results.iter().any(|result| {
+            result.status == CheckStatus::Warning
+                && result.name == "Config Env"
+                && result.message.contains("config.tracker.assignee")
+        }));
+    }
+
+    #[test]
+    fn test_check_config_invalid_slack_event_is_fatal() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let workflow_path = temp_dir.path().join("WORKFLOW.md");
+        fs::write(
+            &workflow_path,
+            "---\ntracker:\n  kind: linear\n  api_key: test-token\n  project_slug: test-project\nnotifications:\n  slack:\n    webhook_url: https://hooks.slack.com/services/test\n    events:\n      - staleled\n---\nbody",
+        )
+        .expect("write workflow");
+
+        let results = check_config(&workflow_path);
+        assert!(has_errors(&results));
+        assert!(results.iter().any(|result| {
+            result.status == CheckStatus::Warning
+                && result.name == "Config Notifications"
+                && result.message.contains("staleled")
+        }));
+        assert!(results.iter().any(|result| {
+            result.status == CheckStatus::Error
+                && result.name == "Config Parse"
+                && result
+                    .message
+                    .contains("notifications.slack.events contains unsupported value")
         }));
     }
 }

--- a/apps/symphony/src/lib.rs
+++ b/apps/symphony/src/lib.rs
@@ -17,6 +17,7 @@ pub mod shared_context;
 pub mod supervisor;
 
 pub mod codex;
+pub mod doctor;
 pub mod event_stream;
 pub mod http_server;
 pub mod logging;

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -1,9 +1,11 @@
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use symphony::domain::ServiceConfig;
 
+#[cfg(not(test))]
+use symphony::doctor;
 #[cfg(not(test))]
 use symphony::orchestrator::OrchestratorPort;
 #[cfg(not(test))]
@@ -42,12 +44,25 @@ use tracing_appender::non_blocking::WorkerGuard;
 #[cfg(not(test))]
 use tracing_subscriber::EnvFilter;
 
+#[derive(Debug, Clone, Subcommand, PartialEq, Eq)]
+pub enum CliCommand {
+    /// Run preflight diagnostics without starting the orchestrator
+    Doctor {
+        /// Path to WORKFLOW.md
+        #[arg(default_value = "WORKFLOW.md")]
+        workflow_path: String,
+    },
+}
+
 #[derive(Parser, Debug, Clone)]
 #[command(
     name = "symphony",
     about = "Symphony orchestrator — polls Linear, dispatches Codex agent sessions"
 )]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<CliCommand>,
+
     /// Path to WORKFLOW.md
     #[arg(default_value = "WORKFLOW.md")]
     pub workflow_path: String,
@@ -359,7 +374,10 @@ where
 }
 
 pub fn resolve_workflow_path(cli: &Cli) -> PathBuf {
-    PathBuf::from(&cli.workflow_path)
+    match &cli.command {
+        Some(CliCommand::Doctor { workflow_path }) => PathBuf::from(workflow_path),
+        None => PathBuf::from(&cli.workflow_path),
+    }
 }
 
 #[cfg_attr(test, allow(dead_code))]
@@ -521,6 +539,55 @@ pub fn execute_cli(cli: &Cli, deps: &mut dyn BootstrapDeps) -> Result<(), String
             workflow_path.display()
         )
     })
+}
+
+#[cfg(not(test))]
+fn run_doctor(workflow_path: &Path) -> Result<i32, String> {
+    let mut results = doctor::check_config(workflow_path);
+
+    if !doctor::has_errors(&results) {
+        match doctor::load_service_config(workflow_path) {
+            Ok(service_config) => {
+                let runtime = tokio::runtime::Handle::try_current()
+                    .map_err(|err| format!("missing tokio runtime for doctor checks: {err}"))?;
+
+                let linear_results = tokio::task::block_in_place(|| {
+                    runtime.block_on(doctor::check_linear(&service_config.tracker))
+                });
+                results.extend(linear_results);
+
+                results.extend(doctor::check_backend(&service_config));
+                results.extend(doctor::check_workspace(&service_config.workspace));
+
+                let adapter = LinearAdapter::new(LinearClient::new(service_config.tracker.clone()));
+                let orphan_results = tokio::task::block_in_place(|| {
+                    runtime.block_on(doctor::check_orphans(&service_config, &adapter))
+                });
+                results.extend(orphan_results);
+            }
+            Err(err) => results.push(doctor::DoctorCheckResult {
+                name: "Config Parse".to_string(),
+                status: doctor::CheckStatus::Error,
+                message: format!("Failed to load workflow for runtime checks: {err}"),
+                details: None,
+            }),
+        }
+    } else {
+        results.push(doctor::DoctorCheckResult {
+            name: "Runtime Checks".to_string(),
+            status: doctor::CheckStatus::Skipped,
+            message: "Skipped Linear/backend/workspace/orphan checks because config check reported errors".to_string(),
+            details: None,
+        });
+    }
+
+    println!("{}", doctor::format_results(&results));
+
+    if doctor::has_errors(&results) {
+        Ok(1)
+    } else {
+        Ok(0)
+    }
 }
 
 #[cfg(not(test))]
@@ -741,6 +808,16 @@ fn run_entrypoint(args: impl IntoIterator<Item = OsString>) -> i32 {
     };
 
     init_tracing(cli.logs_root.as_deref().map(Path::new), cli.tui);
+
+    if let Some(CliCommand::Doctor { workflow_path }) = &cli.command {
+        match run_doctor(Path::new(workflow_path)) {
+            Ok(code) => return code,
+            Err(err) => {
+                eprintln!("{err}");
+                return 1;
+            }
+        }
+    }
 
     let mut deps = RuntimeBootstrapDeps::default();
 

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -563,7 +563,9 @@ fn test_check_workspace_strategy_reports_remote_worktree_mismatch() {
     assert!(results.iter().any(|result| {
         result.status == CheckStatus::Error
             && result.name == "Workspace Strategy"
-            && result.message.contains("requires a local workspace.repo path")
+            && result
+                .message
+                .contains("requires a local workspace.repo path")
     }));
 }
 

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -549,6 +549,25 @@ fn test_check_workspace_root_nonexistent_and_creatable() {
 }
 
 #[test]
+fn test_check_workspace_strategy_reports_remote_worktree_mismatch() {
+    let mut workspace = WorkspaceConfig::default();
+    workspace.root = tempfile::tempdir()
+        .expect("temp dir should be created")
+        .path()
+        .display()
+        .to_string();
+    workspace.repo = Some("https://github.com/kata-sh/kata.git".to_string());
+    workspace.strategy = WorkspaceRepoStrategy::Worktree;
+
+    let results = doctor::check_workspace(&workspace);
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Error
+            && result.name == "Workspace Strategy"
+            && result.message.contains("requires a local workspace.repo path")
+    }));
+}
+
+#[test]
 fn test_check_workspace_root_nonexistent_and_not_creatable() {
     let mut workspace = WorkspaceConfig::default();
     workspace.root = "/dev/null/symphony-root".to_string();

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -5,8 +5,15 @@ use std::path::Path;
 use std::process::Command;
 use std::{fs, io};
 
-use main_bin::{BootstrapDeps, Cli};
-use symphony::domain::ServiceConfig;
+use main_bin::{BootstrapDeps, Cli, CliCommand};
+use mockito::{Matcher, Server};
+use symphony::doctor::{self, CheckStatus};
+use symphony::domain::{
+    AgentBackend, ApiKey, ServiceConfig, TrackerConfig, WorkspaceConfig, WorkspaceIsolation,
+    WorkspaceRepoStrategy,
+};
+use symphony::linear::adapter::LinearAdapter;
+use symphony::linear::client::LinearClient;
 
 struct FakeDeps {
     calls: Vec<String>,
@@ -82,6 +89,31 @@ fn test_positional_workflow_override_is_respected() {
         workflow_path, "tmp/custom/WORKFLOW.md",
         "explicit positional workflow path should override default"
     );
+}
+
+#[test]
+fn test_doctor_subcommand_parses() {
+    let parsed = main_bin::parse_cli_from(["symphony", "doctor", "WORKFLOW.md"])
+        .expect("CLI parse should succeed");
+
+    assert_eq!(
+        parsed.command,
+        Some(CliCommand::Doctor {
+            workflow_path: "WORKFLOW.md".to_string()
+        })
+    );
+}
+
+#[test]
+fn test_run_subcommand_backward_compat() {
+    let parsed =
+        main_bin::parse_cli_from(["symphony", "WORKFLOW.md"]).expect("CLI parse should succeed");
+
+    assert!(
+        parsed.command.is_none(),
+        "default invocation should not select a subcommand"
+    );
+    assert_eq!(parsed.workflow_path, "WORKFLOW.md");
 }
 
 #[test]
@@ -459,6 +491,190 @@ fn test_without_logs_root_no_tui_streams_stdout_logs() {
         "no log file should be created when --logs-root is omitted, found {}",
         log_file_path.display()
     );
+}
+
+#[test]
+fn test_doctor_config_check_catches_missing_api_key() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let workflow_path = temp_dir.path().join("WORKFLOW.md");
+
+    fs::write(
+        &workflow_path,
+        "---\ntracker:\n  kind: linear\n  project_slug: my-project\n---\nPrompt",
+    )
+    .expect("workflow fixture should be written");
+
+    let results = doctor::check_config(&workflow_path);
+    assert!(doctor::has_errors(&results));
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Error
+            && result.name == "Config Validate"
+            && result.message.contains("missing Linear API token")
+    }));
+}
+
+#[test]
+fn test_check_backend_with_nonexistent_command() {
+    let mut config = ServiceConfig::default();
+    config.agent_backend = AgentBackend::Codex;
+    config.codex.command = vec!["definitely-not-a-real-command-symphony".to_string()];
+
+    let results = doctor::check_backend(&config);
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Error
+            && result.name == "Backend"
+            && result.message.contains("not found on PATH")
+    }));
+}
+
+#[test]
+fn test_check_workspace_root_nonexistent_and_creatable() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let workspace_root = temp_dir.path().join("new-workspaces");
+
+    let mut workspace = WorkspaceConfig::default();
+    workspace.root = workspace_root.display().to_string();
+    workspace.repo = Some(temp_dir.path().display().to_string());
+    workspace.strategy = WorkspaceRepoStrategy::Auto;
+    workspace.isolation = WorkspaceIsolation::Local;
+
+    let results = doctor::check_workspace(&workspace);
+    assert!(results
+        .iter()
+        .any(|result| { result.status == CheckStatus::Pass && result.name == "Workspace Root" }));
+    assert!(
+        workspace_root.exists(),
+        "doctor should create workspace root"
+    );
+}
+
+#[test]
+fn test_check_workspace_root_nonexistent_and_not_creatable() {
+    let mut workspace = WorkspaceConfig::default();
+    workspace.root = "/dev/null/symphony-root".to_string();
+    workspace.strategy = WorkspaceRepoStrategy::Auto;
+    workspace.isolation = WorkspaceIsolation::Local;
+
+    let results = doctor::check_workspace(&workspace);
+    assert!(results
+        .iter()
+        .any(|result| { result.status == CheckStatus::Error && result.name == "Workspace Root" }));
+}
+
+#[tokio::test]
+async fn test_check_linear_auth_failure() {
+    let mut server = Server::new_async().await;
+    let _auth_mock = server
+        .mock("POST", "/graphql")
+        .with_status(401)
+        .with_header("content-type", "application/json")
+        .with_body("{\"error\":\"Unauthorized\"}")
+        .create_async()
+        .await;
+
+    let config = TrackerConfig {
+        kind: Some("linear".to_string()),
+        endpoint: format!("{}/graphql", server.url()),
+        api_key: Some(ApiKey::new("bad-key")),
+        project_slug: Some("proj".to_string()),
+        workspace_slug: None,
+        assignee: None,
+        active_states: vec!["Todo".to_string()],
+        terminal_states: vec!["Done".to_string()],
+    };
+
+    let results = doctor::check_linear(&config).await;
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Error
+            && result.name == "Linear Auth"
+            && result.message.contains("HTTP 401")
+    }));
+}
+
+#[tokio::test]
+async fn test_doctor_full_run_with_valid_config() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let local_repo = temp_dir.path().join("repo");
+    fs::create_dir_all(&local_repo).expect("local repo fixture should be created");
+
+    let mut server = Server::new_async().await;
+
+    let _viewer_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("SymphonyDoctorViewer".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("{\"data\":{\"viewer\":{\"id\":\"viewer-1\"}}}")
+        .create_async()
+        .await;
+
+    let _project_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("SymphonyDoctorProject".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            "{\"data\":{\"projects\":{\"nodes\":[{\"id\":\"proj-1\",\"name\":\"Project\",\"teams\":{\"nodes\":[{\"id\":\"team-1\",\"name\":\"Team\",\"states\":{\"nodes\":[{\"name\":\"Todo\"},{\"name\":\"In Progress\"},{\"name\":\"Done\"}]}}]}}]}}}",
+        )
+        .create_async()
+        .await;
+
+    let _issues_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("SymphonyLinearPoll".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            "{\"data\":{\"issues\":{\"nodes\":[],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}",
+        )
+        .create_async()
+        .await;
+
+    let workflow_path = temp_dir.path().join("WORKFLOW.md");
+    fs::write(
+        &workflow_path,
+        format!(
+            "---\ntracker:\n  kind: linear\n  api_key: test-token\n  endpoint: {endpoint}\n  project_slug: project\n  active_states:\n    - Todo\n    - In Progress\n  terminal_states:\n    - Done\nworkspace:\n  root: {workspace_root}\n  repo: {repo}\n  git_strategy: auto\n  isolation: local\nagent:\n  backend: codex\ncodex:\n  command:\n    - git\n---\nPrompt\n",
+            endpoint = format!("{}/graphql", server.url()),
+            workspace_root = workspace_root.display(),
+            repo = local_repo.display(),
+        ),
+    )
+    .expect("workflow fixture should be written");
+
+    let mut results = doctor::check_config(&workflow_path);
+    assert!(
+        !doctor::has_errors(&results),
+        "config checks should pass: {results:?}"
+    );
+
+    let service_config = doctor::load_service_config(&workflow_path)
+        .expect("doctor should load config for runtime checks");
+
+    results.extend(doctor::check_linear(&service_config.tracker).await);
+    results.extend(doctor::check_backend(&service_config));
+    results.extend(doctor::check_workspace(&service_config.workspace));
+
+    let adapter = LinearAdapter::new(LinearClient::new(service_config.tracker.clone()));
+    results.extend(doctor::check_orphans(&service_config, &adapter).await);
+
+    assert!(
+        !doctor::has_errors(&results),
+        "full doctor checks should pass: {results:?}"
+    );
+    assert!(results
+        .iter()
+        .any(|result| { result.status == CheckStatus::Pass && result.name == "Linear Auth" }));
+    assert!(results
+        .iter()
+        .any(|result| { result.status == CheckStatus::Pass && result.name == "Backend" }));
+    assert!(results
+        .iter()
+        .any(|result| { result.status == CheckStatus::Pass && result.name == "Workspace Root" }));
+    assert!(results
+        .iter()
+        .any(|result| { result.status == CheckStatus::Pass && result.name == "Orphans" }));
 }
 
 fn read_to_string_or_panic(path: &Path) -> String {


### PR DESCRIPTION
## Summary
- add a new `symphony doctor [WORKFLOW.md]` subcommand with deterministic traffic-light output and 0/1 exit behavior
- implement doctor checks for config parsing/validation, env var references, prompt file paths, Linear connectivity, backend command handshake, workspace health, and orphan workspace detection
- add doctor-focused test coverage (unit + CLI integration), including mock-backed full-run coverage and auth-failure cases
- document doctor usage/check categories/exit codes in `apps/symphony/README.md` and `apps/symphony/docs/WORKFLOW-REFERENCE.md`

## Validation
- `cd apps/symphony && cargo test --test cli_tests doctor`
- `cd apps/symphony && cargo test doctor`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- Manual: `cargo run --quiet -- doctor <temp WORKFLOW.md with invalid api_key>` (verified `🚨 Linear Auth ... HTTP 401`, exit code 1)

Closes KAT-1675

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `symphony doctor [WORKFLOW.md]` preflight diagnostics subcommand that runs six groups of checks (config parse/validate, env-var resolution, Linear auth/project/states/assignee, backend handshake, workspace health, orphan detection) and exits 0/1 based on whether any 🚨 errors are found. The implementation is well-structured with clean separation between the pure check functions in `doctor.rs` and the async-dispatch glue in `run_doctor` in `main.rs`. Test coverage is solid, including a mock-backed full happy-path run and auth-failure cases.

Key findings:

- **`run_doctor` implicit tokio runtime dependency** (`main.rs` lines 551-555): `Handle::try_current()` + `block_in_place` silently fails if no active runtime is present or **panics** if the active runtime is `current_thread` flavored. Creating a dedicated runtime inside `run_doctor` would make it self-contained.
- **Probe-file leak in `assert_directory_writable`** (`doctor.rs` lines 1145-1146): If `fs::write` succeeds but `fs::remove_file` fails, a `.symphony-doctor-write-probe-*` file is left in `workspace.root`.
- **`${VAR}` env-var syntax not detected** (`doctor.rs` lines 1087-1099): `env_reference_name` only matches the `$VAR` bare-dollar form; users who write `${LINEAR_API_KEY}` will not receive an unresolved-variable warning.
- **Documentation inconsistency** (`doctor.rs` line 565, `WORKFLOW-REFERENCE.md`): `check_workspace` creates the workspace root directory as a side effect, but `WORKFLOW-REFERENCE.md` states \"Doctor is report-only (no auto-fix).\"
- **Workflow file parsed twice** (`main.rs` lines 546-550): `check_config` and `load_service_config` each independently parse the workflow file.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/improvement suggestions that do not block functionality.

All five findings are P2 level — none represent a present runtime breakage or data-loss risk. The block_in_place concern is real but the manual test validated it works in the actual runtime topology. The probe-file leak and ${VAR} gap are edge cases. The double-parse is a minor efficiency concern. The doc inconsistency is cosmetic. The new feature is well-tested with mocks and integrates cleanly with the existing CLI structure.

apps/symphony/src/doctor.rs (assert_directory_writable probe leak, env_reference_name ${VAR} gap), apps/symphony/src/main.rs (run_doctor runtime dependency), apps/symphony/docs/WORKFLOW-REFERENCE.md (no-auto-fix claim)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/doctor.rs | New 1220-line module implementing all doctor check functions (config, linear, backend, workspace, orphans); probe-file leak in assert_directory_writable and ${VAR} env-ref gap are the main issues. |
| apps/symphony/src/main.rs | Adds CliCommand::Doctor subcommand, run_doctor orchestrator, and run_entrypoint dispatch; run_doctor has an implicit tokio runtime dependency (block_in_place) and double-parses the workflow file. |
| apps/symphony/tests/cli_tests.rs | Adds comprehensive doctor test coverage: CLI parse, missing API key, non-existent backend, workspace strategy mismatch, auth failure via mockito, and a full mock-backed happy-path run. |
| apps/symphony/src/lib.rs | Single-line addition exposing the new doctor module publicly; no issues. |
| apps/symphony/README.md | Documents doctor subcommand usage, traffic-light symbols, example output, check categories, and exit codes; clear and accurate. |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Adds doctor CLI reference comment block to the WORKFLOW.md template; "report-only (no auto-fix)" claim is contradicted by check_workspace's directory-creation side effect. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([symphony doctor WORKFLOW.md]) --> B[check_config]
    B --> B1{Parse YAML}
    B1 -- Error --> BAIL1[🚨 Config Parse\nreturn early]
    B1 -- OK --> B2[collect_unresolved_env_refs]
    B2 --> B3[collect_invalid_slack_events\nsanitize_invalid_slack_events]
    B3 --> B4[config::from_workflow\nconfig::validate]
    B4 --> B5[collect_prompt_paths\ncheck file existence]
    B5 --> HAS_ERR{has_errors?}
    HAS_ERR -- Yes --> SKIP[⏭️ Runtime Checks Skipped]
    HAS_ERR -- No --> LC[load_service_config]
    LC --> CL[check_linear async]
    CL --> CL1[VIEWER_QUERY Linear Auth]
    CL1 --> CL2[PROJECT_QUERY Linear Project + States]
    CL2 --> CL3[resolve_assignee paginated]
    LC --> CB[check_backend sync]
    CB --> CB1[executable --version]
    LC --> CW[check_workspace sync]
    CW --> CW1[fs::create_dir_all if missing]
    CW1 --> CW2[repo_is_remote + git_strategy compat]
    CW2 --> CW3[docker info if isolation=docker]
    LC --> CO[check_orphans async]
    CO --> CO1[scan_workspace_root]
    CO1 --> CO2[fetch_issues_by_states]
    CO2 --> CO3[diff on-disk vs active]
    CL --> FR
    CB --> FR
    CW --> FR
    CO --> FR
    SKIP --> FR
    FR[format_results print to stdout]
    FR --> EXIT{has_errors?}
    EXIT -- Yes --> E1([exit 1])
    EXIT -- No --> E0([exit 0])
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/doctor.rs
Line: 1145-1147

Comment:
**Probe file left on disk if removal fails**

`fs::write` creates the probe file, but if `fs::remove_file` then fails (e.g., due to a concurrent directory rename, a file-system error, or a signal), the function propagates the error while leaving the `.symphony-doctor-write-probe-*` file behind in `workspace.root`. The caller treats the I/O error as "not writable" and reports an error, but the probe file persists until manually cleaned up.

A safer pattern is to use a guard / `defer` equivalent, or at minimum attempt the removal even on error paths:

```suggestion
    fs::write(&probe_path, b"doctor")?;
    let remove_result = fs::remove_file(&probe_path);
    remove_result?;
    Ok(())
```

Alternatively, clean up proactively even when removal fails:
```rust
fs::write(&probe_path, b"doctor")?;
fs::remove_file(&probe_path).ok(); // best-effort removal; not a write-ability signal
Ok(())
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/doctor.rs
Line: 1087-1099

Comment:
**`${VAR}` env-var syntax silently skipped**

`env_reference_name` only recognises the `$VAR` bare-dollar form. The very common shell expansion `${LINEAR_API_KEY}` (curly-brace delimited) starts with `$` but the remainder contains `{` so `is_bare_identifier` would include it (since `{` is not filtered), yet the resolved value would be the literal string `{LINEAR_API_KEY}` rather than the env var content — meaning a genuinely unset `${VAR}` will _not_ be flagged.

Consider expanding the check to strip `{` and `}` delimiters:

```rust
fn env_reference_name(value: &str) -> Option<&str> {
    let variable = value.strip_prefix('$')?;
    let variable = variable
        .strip_prefix('{')
        .and_then(|v| v.strip_suffix('}'))
        .unwrap_or(variable);
    let is_bare_identifier = !variable.is_empty()
        && !variable.contains('/')
        && !variable.contains(' ')
        && !variable.contains(':');
    if is_bare_identifier { Some(variable) } else { None }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/doctor.rs
Line: 565-579

Comment:
**Directory creation contradicts "no auto-fix" documentation**

`check_workspace` calls `fs::create_dir_all` when `workspace.root` does not exist and reports a ✅ pass with "Created workspace.root: ...". The `README.md` example output implies this is intentional, but `WORKFLOW-REFERENCE.md` states:

> `Doctor is report-only (no auto-fix).`

Silently creating a directory is a side-effectful mutation that could be surprising to users running `doctor` in CI expecting a pure no-op validation.

Consider either:
1. Changing the behaviour to report ⚠️ warning "workspace.root does not exist; it will be created on first run" and skip the write-probe in that path, OR
2. Updating `WORKFLOW-REFERENCE.md` to clarify that `doctor` may create `workspace.root` as part of its validation.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/main.rs
Line: 551-555

Comment:
**`block_in_place` panics on `current_thread` runtime flavor**

`run_doctor` depends on two implicit assumptions:

1. A tokio runtime is already active when it is called (`Handle::try_current()`). If the runtime is created _inside_ `execute_cli` (after the doctor dispatch), `try_current()` fails and doctor exits with "missing tokio runtime for doctor checks" instead of running any async checks.
2. The active runtime is multi-threaded. `tokio::task::block_in_place` **panics** at runtime if called from a `current_thread` runtime (e.g. `#[tokio::main(flavor = "current_thread")]`).

A self-contained approach avoids both hazards:

```rust
let rt = tokio::runtime::Builder::new_multi_thread()
    .enable_all()
    .build()
    .map_err(|err| format!("failed to build tokio runtime: {err}"))?;

let linear_results = rt.block_on(doctor::check_linear(&service_config.tracker));
let orphan_results = rt.block_on(doctor::check_orphans(&service_config, &adapter));
```

This keeps `run_doctor` independent of the surrounding runtime topology.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/main.rs
Line: 546-550

Comment:
**Workflow file parsed twice per `doctor` invocation**

`run_doctor` first calls `doctor::check_config(workflow_path)` (which internally calls `workflow::parse_workflow` and `config::from_workflow`), and then — if no errors — calls `doctor::load_service_config(workflow_path)` which repeats the same parse-and-sanitize sequence to produce the `ServiceConfig` needed for runtime checks.

A cleaner design would be to have `check_config` return the parsed `ServiceConfig` alongside its results (e.g., `(Vec<DoctorCheckResult>, Option<ServiceConfig>)`), so `run_doctor` can reuse it directly. This avoids redundant I/O and parsing in the hot path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/gannonh/kata/commit/ca30fb51e51972de551d9ac554235b659443f5e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26677053)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->