### PR TITLE
feat(cli): M009 end-to-end acceptance tests and 0.13.0 release [KAT-1656]

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.13.0
+
+### Features
+
+- **M009: OOBE & Onboarding** — New interactive onboarding wizard for first-time project setup.
+  - **Onboarding wizard core** — `/kata` detects unconfigured projects and offers a guided setup flow. Collects `LINEAR_API_KEY` with masked input, validates via `getViewer()`, stores in `auth.json`, creates `.kata/preferences.md` with `.gitignore` entry. Non-TTY environments gracefully degrade with a warning. Session-scoped skip flag prevents re-prompting within the same session.
+  - **Linear team & project picker** — After API key validation, fetches teams and projects from Linear API. Single-team/project accounts auto-select without prompting. Multi-item lists present interactive pickers. Duplicate project names are disambiguated with slug IDs. API failures fall back to manual text entry.
+  - **Symphony silence** — Fresh installations without Symphony configuration no longer emit escalation listener warnings. The `isSymphonyConfigured()` guard prevents the listener from starting when no Symphony URL is set.
+  - **Comprehensive test coverage** — 47 Vitest tests covering the full onboarding flow: end-to-end wizard path, skip-and-retrigger lifecycle, non-TTY degradation, picker edge cases, fallback paths, and preferences file manipulation.
+
 ## 0.12.1
 
 ### Bug Fixes

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, writeFileSync, readFileSync, rmSync, realpathSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, rmSync, realpathSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -842,6 +842,311 @@ pr:
       } finally {
         delete process.env.LINEAR_API_KEY;
       }
+    });
+  });
+
+  // ─── End-to-end onboarding integration tests ──────────────────────────────
+
+  describe("onboarding end-to-end", () => {
+    it("full wizard: API key → validate → multi-team picker → multi-project picker → preferences correct → isProjectConfigured true", async () => {
+      // Simulate the complete onboarding wizard flow with multiple teams and projects,
+      // exercising the full path from S01 (key collection + validation) through
+      // S02 (team/project picker + preferences write).
+      const ctx = makeMockCtx({
+        inputReturns: ["lin_api_e2e_test_key"],
+        selectReturns: ["Dev Team (DEV)", "Kata Desktop"],
+      });
+      const storedCreds: Record<string, any> = {};
+      const deps = makeMockDeps({
+        createAuthStorage: () => ({
+          set: (provider: string, cred: any) => {
+            storedCreds[provider] = cred;
+          },
+        }),
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-e2e", name: "E2E Tester", email: "e2e@test.com" }),
+          listTeams: async () => DEFAULT_TEAMS,
+          listProjects: async () => DEFAULT_PROJECTS,
+        }),
+        // Write real preferences to disk so the full pipeline is exercised
+        ensurePreferences: vi.fn((basePath: string) => {
+          const kataDir = join(basePath, ".kata");
+          mkdirSync(kataDir, { recursive: true });
+          writeFileSync(
+            join(kataDir, "preferences.md"),
+            "---\nversion: 1\nworkflow:\n  mode: linear\nlinear: {}\n---\n",
+            "utf-8",
+          );
+          return true;
+        }),
+      });
+      _setDeps(deps);
+
+      try {
+        const result = await runOnboarding(ctx, tmpDir);
+
+        // ── Wizard completed ──────────────────────────────────────────────
+        expect(result).toBe("completed");
+
+        // ── Preferences file exists with correct Linear config ────────────
+        const prefsPath = join(tmpDir, ".kata", "preferences.md");
+        expect(existsSync(prefsPath)).toBe(true);
+        const content = readFileSync(prefsPath, "utf-8");
+        expect(content).toContain("teamKey: DEV");
+        expect(content).toContain("projectSlug: abc123def456");
+
+        // ── isProjectConfigured returns true ──────────────────────────────
+        expect(isProjectConfigured(tmpDir)).toBe(true);
+
+        // ── process.env.LINEAR_API_KEY hydrated ──────────────────────────
+        expect(process.env.LINEAR_API_KEY).toBe("lin_api_e2e_test_key");
+
+        // ── Auth storage has linear provider entry ────────────────────────
+        expect(storedCreds.linear).toEqual({
+          type: "api_key",
+          key: "lin_api_e2e_test_key",
+        });
+
+        // ── ctx.ui interactions were called correctly ─────────────────────
+        expect(ctx.ui.input).toHaveBeenCalledOnce(); // API key prompt
+        expect(ctx.ui.select).toHaveBeenCalledTimes(2); // team + project
+        expect(ctx.ui.select).toHaveBeenCalledWith(
+          "Select your Linear team",
+          ["Kata-sh (KAT)", "Dev Team (DEV)"],
+        );
+        expect(ctx.ui.select).toHaveBeenCalledWith(
+          "Select your Linear project",
+          ["Kata CLI", "Kata Desktop"],
+        );
+
+        // ── Success notification emitted ──────────────────────────────────
+        expect(ctx._notifications.some(
+          (n: any) => n.message.includes("✓") && n.message.includes("team=DEV"),
+        )).toBe(true);
+      } finally {
+        delete process.env.LINEAR_API_KEY;
+      }
+    });
+
+    it("full wizard with picker cancelled: API key validated but no team/project selected → completed but isProjectConfigured false", async () => {
+      // User enters a valid API key, validation succeeds, but cancels the
+      // team picker. The wizard should still return "completed" (API key was
+      // stored), but isProjectConfigured should be false (no team/project config).
+      const ctx = makeMockCtx({
+        inputReturns: ["lin_api_e2e_noproject"],
+        selectReturns: [undefined], // cancel team picker
+      });
+      const storedCreds: Record<string, any> = {};
+      const deps = makeMockDeps({
+        createAuthStorage: () => ({
+          set: (provider: string, cred: any) => {
+            storedCreds[provider] = cred;
+          },
+        }),
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-e2e", name: "E2E Tester", email: "e2e@test.com" }),
+          listTeams: async () => DEFAULT_TEAMS,
+          listProjects: async () => DEFAULT_PROJECTS,
+        }),
+        ensurePreferences: vi.fn((basePath: string) => {
+          const kataDir = join(basePath, ".kata");
+          mkdirSync(kataDir, { recursive: true });
+          writeFileSync(
+            join(kataDir, "preferences.md"),
+            "---\nversion: 1\nworkflow:\n  mode: linear\nlinear: {}\n---\n",
+            "utf-8",
+          );
+          return true;
+        }),
+      });
+      _setDeps(deps);
+
+      try {
+        const result = await runOnboarding(ctx, tmpDir);
+
+        // ── Wizard completed (API key was stored) ─────────────────────────
+        expect(result).toBe("completed");
+
+        // ── Preferences exist but no team/project config ──────────────────
+        const prefsPath = join(tmpDir, ".kata", "preferences.md");
+        expect(existsSync(prefsPath)).toBe(true);
+        const content = readFileSync(prefsPath, "utf-8");
+        expect(content).not.toContain("teamKey: DEV");
+        expect(content).not.toContain("teamKey: KAT");
+
+        // ── isProjectConfigured returns false (no identifiers) ────────────
+        expect(isProjectConfigured(tmpDir)).toBe(false);
+
+        // ── API key was still stored in auth + env ────────────────────────
+        expect(storedCreds.linear).toEqual({
+          type: "api_key",
+          key: "lin_api_e2e_noproject",
+        });
+        expect(process.env.LINEAR_API_KEY).toBe("lin_api_e2e_noproject");
+
+        // ── Fallback notification emitted ─────────────────────────────────
+        expect(ctx._notifications.some(
+          (n: any) => n.message.includes("Run /kata to configure team/project"),
+        )).toBe(true);
+      } finally {
+        delete process.env.LINEAR_API_KEY;
+      }
+    });
+
+    it("retry then succeed: first key invalid → retry → second key valid → full flow completes", async () => {
+      // Tests the retry path: first API key fails validation, second succeeds,
+      // then team/project picker completes successfully.
+      let viewerCallCount = 0;
+      const ctx = makeMockCtx({
+        inputReturns: ["lin_api_bad", "lin_api_good"],
+        selectReturns: ["Kata-sh (KAT)", "Kata CLI"],
+      });
+      const deps = makeMockDeps({
+        createLinearClient: () => ({
+          getViewer: async () => {
+            viewerCallCount++;
+            if (viewerCallCount === 1) {
+              throw new Error("401 Unauthorized");
+            }
+            return { id: "user-1", name: "Test", email: "t@t.com" };
+          },
+          listTeams: async () => DEFAULT_TEAMS,
+          listProjects: async () => DEFAULT_PROJECTS,
+        }),
+        ensurePreferences: vi.fn((basePath: string) => {
+          const kataDir = join(basePath, ".kata");
+          mkdirSync(kataDir, { recursive: true });
+          writeFileSync(
+            join(kataDir, "preferences.md"),
+            "---\nversion: 1\nworkflow:\n  mode: linear\nlinear: {}\n---\n",
+            "utf-8",
+          );
+          return true;
+        }),
+      });
+      _setDeps(deps);
+
+      try {
+        const result = await runOnboarding(ctx, tmpDir);
+
+        expect(result).toBe("completed");
+        expect(isProjectConfigured(tmpDir)).toBe(true);
+        const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+        expect(content).toContain("teamKey: KAT");
+        expect(content).toContain("projectSlug: 459f9835e809");
+        expect(process.env.LINEAR_API_KEY).toBe("lin_api_good");
+
+        // Error notification was shown for first attempt
+        expect(ctx._notifications.some(
+          (n: any) => n.message.includes("Invalid API key") && n.level === "error",
+        )).toBe(true);
+      } finally {
+        delete process.env.LINEAR_API_KEY;
+      }
+    });
+  });
+
+  // ─── Onboarding edge cases (skip & non-TTY integration) ──────────────────
+
+  describe("onboarding edge cases", () => {
+    it("skip → re-trigger: first call skipped → isProjectConfigured false → reset → second call completes → isProjectConfigured true", async () => {
+      // Simulates the ensureOnboarding gate logic:
+      // 1. User skips onboarding → skip flag set → isProjectConfigured false
+      // 2. New session (skip flag reset) → user completes wizard → isProjectConfigured true
+      //
+      // First call: user provides empty input (skip)
+      const ctx1 = makeMockCtx({ inputReturns: [""] });
+      const deps = makeMockDeps({
+        ensurePreferences: vi.fn((basePath: string) => {
+          const kataDir = join(basePath, ".kata");
+          mkdirSync(kataDir, { recursive: true });
+          writeFileSync(
+            join(kataDir, "preferences.md"),
+            "---\nversion: 1\nworkflow:\n  mode: linear\nlinear: {}\n---\n",
+            "utf-8",
+          );
+          return true;
+        }),
+        createLinearClient: () => ({
+          getViewer: async () => ({ id: "user-1", name: "Test", email: "t@t.com" }),
+          listTeams: async () => [{ id: "team-1", key: "KAT", name: "Kata-sh" }],
+          listProjects: async () => [{ id: "proj-1", name: "Kata CLI", slugId: "459f9835e809" }],
+        }),
+      });
+      _setDeps(deps);
+
+      // ── First call: user skips ──────────────────────────────────────────
+      const result1 = await runOnboarding(ctx1, tmpDir);
+      expect(result1).toBe("skipped");
+      expect(isProjectConfigured(tmpDir)).toBe(false);
+
+      // Simulate the gate: skip flag would be set by ensureOnboarding
+      setSkipOnboarding(true);
+      expect(shouldSkipOnboarding()).toBe(true);
+
+      // ── Simulate new session: reset skip flag ───────────────────────────
+      setSkipOnboarding(false);
+      expect(shouldSkipOnboarding()).toBe(false);
+
+      // ── Second call: user completes wizard ──────────────────────────────
+      const ctx2 = makeMockCtx({
+        inputReturns: ["lin_api_second_try"],
+      });
+
+      try {
+        const result2 = await runOnboarding(ctx2, tmpDir);
+
+        expect(result2).toBe("completed");
+        expect(isProjectConfigured(tmpDir)).toBe(true);
+        const content = readFileSync(join(tmpDir, ".kata", "preferences.md"), "utf-8");
+        expect(content).toContain("teamKey: KAT");
+        expect(content).toContain("projectSlug: 459f9835e809");
+      } finally {
+        delete process.env.LINEAR_API_KEY;
+      }
+    });
+
+    it("non-TTY: ctx.hasUI = false → returns 'skipped' with warning, no .kata/ created, no interactive calls", async () => {
+      // Proves R001: non-TTY environments gracefully degrade without crashing
+      const ctx = makeMockCtx({ hasUI: false });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const result = await runOnboarding(ctx, tmpDir);
+
+      // ── Returns "skipped" ───────────────────────────────────────────────
+      expect(result).toBe("skipped");
+
+      // ── Warning notification emitted with guidance ──────────────────────
+      expect(ctx.ui.notify).toHaveBeenCalledWith(
+        expect.stringContaining("interactive terminal"),
+        "warning",
+      );
+
+      // ── No .kata/ directory created ─────────────────────────────────────
+      expect(existsSync(join(tmpDir, ".kata"))).toBe(false);
+
+      // ── No interactive UI calls made ────────────────────────────────────
+      expect(ctx.ui.input).not.toHaveBeenCalled();
+      expect(ctx.ui.select).not.toHaveBeenCalled();
+
+      // ── ensurePreferences never called ──────────────────────────────────
+      expect(deps.ensurePreferences).not.toHaveBeenCalled();
+    });
+
+    it("non-TTY: multiple calls don't crash or change state", async () => {
+      // Proves non-TTY is idempotent and safe to call repeatedly
+      const ctx = makeMockCtx({ hasUI: false });
+      const deps = makeMockDeps();
+      _setDeps(deps);
+
+      const result1 = await runOnboarding(ctx, tmpDir);
+      const result2 = await runOnboarding(ctx, tmpDir);
+
+      expect(result1).toBe("skipped");
+      expect(result2).toBe("skipped");
+      expect(ctx.ui.notify).toHaveBeenCalledTimes(2);
+      expect(existsSync(join(tmpDir, ".kata"))).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements the final slice (S04) of the M009 OOBE & Onboarding milestone: end-to-end integration tests verifying the fully assembled onboarding wizard, plus version bump and CHANGELOG for the 0.13.0 release.

Closes KAT-1656

## Changes

### New Integration Tests (6 tests added)

**End-to-end onboarding flow** (`onboarding end-to-end` describe block):
- Full wizard: API key → validate → multi-team picker → multi-project picker → preferences file with correct `teamKey`/`projectSlug` → `isProjectConfigured` true → `process.env.LINEAR_API_KEY` hydrated → auth storage populated
- Picker cancelled variant: API key stored but no team/project selected → `completed` but `isProjectConfigured` false
- Retry path: first key invalid → error notification → retry → second key valid → full flow completes

**Edge case tests** (`onboarding edge cases` describe block):
- Skip → re-trigger: user skips → `isProjectConfigured` false → reset skip flag → second call completes → `isProjectConfigured` true (proves D017)
- Non-TTY: `ctx.hasUI = false` → returns `skipped` with warning, no `.kata/` created, no interactive UI calls
- Non-TTY idempotent: multiple non-TTY calls safe and stable

### Release Prep
- Version bump: `0.12.1` → `0.13.0`
- CHANGELOG: M009 milestone completion entry

## Verification Matrix

| Gate | Result |
|------|--------|
| `npx tsc --noEmit` | ✅ Clean |
| `npx vitest run` | ✅ 292 tests pass (18 files) |
| Coverage | ✅ lines 93.22%, branches 83.75%, functions 93.93% |
| Symphony warnings | ✅ 0 matches for 'Symphony escalation listener' |

## Tasks

- [x] T01: Write end-to-end onboarding integration test (KAT-1657)
- [x] T02: Write skip-and-retrigger and non-TTY integration tests (KAT-1658)
- [x] T03: Run full milestone verification matrix and prepare release (KAT-1659)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the M009 OOBE & Onboarding milestone (S04) by adding 6 end-to-end integration tests that exercise the fully assembled onboarding wizard, along with a version bump to `0.13.0` and a CHANGELOG entry.

**Key changes:**
- **End-to-end tests** (`onboarding end-to-end` describe block): Full wizard path (API key → validate → multi-team picker → multi-project picker → preferences written → `isProjectConfigured` true), picker-cancelled variant (key stored but no team/project → `completed` but `isProjectConfigured` false), and retry path (bad key → error notification → good key → full flow).
- **Edge case tests** (`onboarding edge cases` describe block): Skip-then-retrigger lifecycle (proves the `setSkipOnboarding` session flag mechanism and D017), non-TTY degradation (returns `skipped` with warning, no `.kata/` dir created, no interactive calls), and non-TTY idempotency (multiple calls stable).
- Tests use the existing `makeMockCtx`/`makeMockDeps`/`_setDeps` dependency-injection pattern already established in the file, with correct `beforeEach`/`afterEach` isolation and `finally { delete process.env.LINEAR_API_KEY }` cleanup.
- Version bump `0.12.1` → `0.13.0` and CHANGELOG are clean and consistent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — tests are correct, well-isolated, and no production code is changed.

All three changed files are test-only or release metadata. The 6 new tests are logically correct: mock closures (viewerCallCount, storedCreds) are properly scoped, selectCallIndex sequencing matches the picker call order in the source, auto-selection paths are exercised for single-team/project accounts, and process.env is cleaned up in finally blocks. No P0 or P1 findings were identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/tests/onboarding.vitest.test.ts | Adds 6 end-to-end and edge-case integration tests for the onboarding wizard; tests are well-isolated with proper beforeEach/afterEach guards and process.env cleanup. |
| apps/cli/package.json | Version bump from 0.12.1 to 0.13.0 for the M009 milestone release. |
| apps/cli/CHANGELOG.md | Adds 0.13.0 changelog entry documenting the M009 OOBE & Onboarding milestone features. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Test
    participant RO as runOnboarding()
    participant UI as ctx.ui
    participant DC as deps.createLinearClient()
    participant EP as deps.ensurePreferences()
    participant PT as pickLinearTeamAndProject()
    participant UP as updatePreferencesLinearConfig()

    Note over T,UP: Full wizard flow (e2e test 1)
    T->>RO: runOnboarding(ctx, tmpDir)
    RO->>UI: input("Linear API Key")
    UI-->>RO: "lin_api_e2e_test_key"
    RO->>DC: createLinearClient(apiKey).getViewer()
    DC-->>RO: { id, name, email }
    RO->>RO: store key in auth + hydrate process.env
    RO->>EP: ensurePreferences(tmpDir)
    EP-->>RO: writes .kata/preferences.md
    RO->>PT: pickLinearTeamAndProject(ctx, apiKey)
    PT->>DC: listTeams()
    DC-->>PT: [KAT, DEV]
    PT->>UI: select("Select your Linear team", [...])
    UI-->>PT: "Dev Team (DEV)"
    PT->>DC: listProjects({ teamId })
    DC-->>PT: [Kata CLI, Kata Desktop]
    PT->>UI: select("Select your Linear project", [...])
    UI-->>PT: "Kata Desktop"
    PT-->>RO: { teamKey: "DEV", projectSlug: "abc123def456" }
    RO->>UP: updatePreferencesLinearConfig(tmpDir, result)
    UP-->>RO: writes teamKey + projectSlug into frontmatter
    RO->>UI: notify("✓ Linear configured: team=DEV …", "info")
    RO-->>T: "completed"

    Note over T,UP: Retry path (e2e test 3)
    T->>RO: runOnboarding(ctx, tmpDir)
    RO->>UI: input("Linear API Key")
    UI-->>RO: "lin_api_bad"
    RO->>DC: getViewer() throws "401 Unauthorized"
    RO->>UI: notify("Invalid API key …", "error")
    RO->>UI: input("Linear API Key")
    UI-->>RO: "lin_api_good"
    RO->>DC: getViewer() success
    RO-->>T: "completed" (after full picker flow)
```

<sub>Reviews (1): Last reviewed commit: ["chore(cli): bump version to 0.13.0 and a..."](https://github.com/gannonh/kata/commit/509e701d40676bb88977c520060da15f41f7cda4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26677062)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI version bumped to 0.13.0

* **Tests**
  * Expanded onboarding integration test coverage including API key validation, team and project selection flows, preferences persistence, retry scenarios, and non-TTY environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->