### PR TITLE
Release: CLI v0.14.0 + Symphony v2.1.0

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.14.0
+
+### Features
+
+- **`symphony_steer` tool + `/symphony steer` command** — Live operator steering for Symphony workers. `POST /api/v1/steer` delivers guidance to active Kata RPC sessions via `follow_up`. The `symphony_steer` tool and `/symphony steer <issue> <instruction>` command are wired to the live endpoint with actionable error mapping.
+- **`model_by_label` config** — Label-first model resolution in Symphony orchestrator. Parsed from WORKFLOW.md alongside `model_by_state`, normalized to lowercase, takes priority over state-based and default model selection.
+- **Console width option** — `console-render` now accepts a width option and truncates lines accordingly, improving layout in narrow terminals.
+
+### Bug Fixes
+
+- **Onboarding broken app-paths import** — Fixed broken import in onboarding module, ensured `.kata/` directory is created before writing preferences, and added support for reusing an existing stored Linear API key instead of always prompting.
+- **Onboarding banner polish** — Shows "Run `/kata` to get started" on the post-setup banner; removed the confusing "Skip for now" option.
+- **Symphony config editor path guards** — `setPath`/`deletePath` now guard against empty paths with a `console.warn` fallback instead of crashing.
+
 ## 0.13.0
 
 ### Features

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -51,6 +51,7 @@ import {
   shouldSkipOnboarding,
   setSkipOnboarding,
 } from "./onboarding.js";
+import { clearHeaderHint } from "./header.js";
 
 // ─── Onboarding gate ──────────────────────────────────────────────────────────
 
@@ -83,11 +84,6 @@ async function ensureOnboarding(
         description: "Configure Linear integration and create .kata/ directory.",
         recommended: true,
       },
-      {
-        id: "skip",
-        label: "Skip for now",
-        description: "Skip setup for this session. Run /kata later to configure.",
-      },
     ],
     notYetMessage: "Run /kata to set up when ready.",
   });
@@ -100,15 +96,13 @@ async function ensureOnboarding(
       // flag so the wizard doesn't re-trigger on every subsequent /kata call
       // within this session.
       setSkipOnboarding(true);
+      clearHeaderHint();
       return true;
     }
     return false;
   }
 
-  // Only persist skip for the explicit "skip" action; "not_yet" just returns false
-  if (choice === "skip") {
-    setSkipOnboarding(true);
-  }
+  // "not_yet" (or Escape) — don't persist skip, just return false
   return false;
 }
 

--- a/apps/cli/src/resources/extensions/kata/header.ts
+++ b/apps/cli/src/resources/extensions/kata/header.ts
@@ -1,0 +1,58 @@
+/**
+ * Kata header rendering — shared between index.ts (session_start) and
+ * commands.ts (post-onboarding clear).
+ *
+ * Separated to avoid a circular dependency between index.ts and commands.ts.
+ */
+
+import { Text } from "@mariozechner/pi-tui";
+
+// ── ASCII logo ────────────────────────────────────────────────────────────
+const KATA_LOGO_LINES = [
+  "  ██╗  ██╗ █████╗ ████████╗ █████╗ ",
+  "  ██║ ██╔╝██╔══██╗╚══██╔══╝██╔══██╗",
+  "  █████╔╝ ███████║   ██║   ███████║",
+  "  ██╔═██╗ ██╔══██║   ██║   ██╔══██║",
+  "  ██║  ██╗██║  ██║   ██║   ██║  ██║",
+  "  ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝",
+];
+
+interface HeaderCtx {
+  ui: {
+    theme: any;
+    setHeader: (factory: (ui: any, theme: any) => any) => void;
+  };
+}
+
+let _headerCtx: HeaderCtx | null = null;
+
+/** Store the context for future header re-renders. Called once from session_start. */
+export function setHeaderCtx(ctx: HeaderCtx): void {
+  _headerCtx = ctx;
+}
+
+/** Render (or re-render) the Kata header. Pass `showHint: true` to include the getting-started line. */
+export function renderHeader(showHint: boolean): void {
+  if (!_headerCtx) return;
+  const theme = _headerCtx.ui.theme;
+  const version = process.env.KATA_VERSION || "0.0.0";
+
+  const logoText = KATA_LOGO_LINES.map((line: string) =>
+    theme.fg("accent", line),
+  ).join("\n");
+  const titleLine = `  ${theme.bold("Kata CLI")} ${theme.fg("dim", `v${version}`)}`;
+  const hintLine = showHint
+    ? `\n\n  ${theme.fg("dim", "Run")} ${theme.fg("accent", "/kata")} ${theme.fg("dim", "to get started.")}`
+    : "";
+
+  const headerContent = `${logoText}\n${titleLine}${hintLine}`;
+  _headerCtx.ui.setHeader((_ui: any, _theme: any) => new Text(headerContent, 1, 0));
+}
+
+/**
+ * Re-render the header without the getting-started hint.
+ * Call after onboarding completes to remove the stale message.
+ */
+export function clearHeaderHint(): void {
+  renderHeader(false);
+}

--- a/apps/cli/src/resources/extensions/kata/header.ts
+++ b/apps/cli/src/resources/extensions/kata/header.ts
@@ -31,6 +31,11 @@ export function setHeaderCtx(ctx: HeaderCtx): void {
   _headerCtx = ctx;
 }
 
+/** Clear the stored context. Useful for testing or session teardown to prevent stale references. */
+export function resetHeaderCtx(): void {
+  _headerCtx = null;
+}
+
 /** Render (or re-render) the Kata header. Pass `showHint: true` to include the getting-started line. */
 export function renderHeader(showHint: boolean): void {
   if (!_headerCtx) return;

--- a/apps/cli/src/resources/extensions/kata/index.ts
+++ b/apps/cli/src/resources/extensions/kata/index.ts
@@ -50,21 +50,12 @@ import {
   formatSkillsXml,
 } from "./skill-discovery.js";
 import { getWorkflowEntrypointGuard } from "./linear-config.js";
+import { isProjectConfigured } from "./onboarding.js";
+import { setHeaderCtx, renderHeader } from "./header.js";
 import { Key } from "@mariozechner/pi-tui";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { Text } from "@mariozechner/pi-tui";
-
-// ── ASCII logo ────────────────────────────────────────────────────────────
-const KATA_LOGO_LINES = [
-  "  ██╗  ██╗ █████╗ ████████╗ █████╗ ",
-  "  ██║ ██╔╝██╔══██╗╚══██╔══╝██╔══██╗",
-  "  █████╔╝ ███████║   ██║   ███████║",
-  "  ██╔═██╗ ██╔══██║   ██║   ██╔══██║",
-  "  ██║  ██╗██║  ██║   ██║   ██║  ██║",
-  "  ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝",
-];
 
 // Provider error retry is handled in auto.ts — see handleProviderError()
 
@@ -73,16 +64,8 @@ export default function (pi: ExtensionAPI) {
 
   // ── session_start: render branded Kata header ───────────────────────────
   pi.on("session_start", async (_event, ctx) => {
-    const theme = ctx.ui.theme;
-    const version = process.env.KATA_VERSION || "0.0.0";
-
-    const logoText = KATA_LOGO_LINES.map((line) =>
-      theme.fg("accent", line),
-    ).join("\n");
-    const titleLine = `  ${theme.bold("Kata CLI")} ${theme.fg("dim", `v${version}`)}`;
-
-    const headerContent = `${logoText}\n${titleLine}`;
-    ctx.ui.setHeader((_ui, _theme) => new Text(headerContent, 1, 0));
+    setHeaderCtx(ctx);
+    renderHeader(!isProjectConfigured(process.cwd()));
   });
 
   // ── Ctrl+Alt+G shortcut — Kata dashboard overlay ────────────────────────

--- a/apps/cli/src/resources/extensions/kata/index.ts
+++ b/apps/cli/src/resources/extensions/kata/index.ts
@@ -65,7 +65,17 @@ export default function (pi: ExtensionAPI) {
   // ── session_start: render branded Kata header ───────────────────────────
   pi.on("session_start", async (_event, ctx) => {
     setHeaderCtx(ctx);
-    renderHeader(!isProjectConfigured(process.cwd()));
+    // isProjectConfigured reads prefs from disk — guard against unreadable/corrupt files
+    // so a recoverable config issue doesn't prevent the extension from initializing.
+    // Note: this is evaluated once at session start. If the user completes onboarding,
+    // clearHeaderHint() removes the hint. Mid-session cwd changes won't re-evaluate.
+    let configured = false;
+    try {
+      configured = isProjectConfigured(process.cwd());
+    } catch {
+      // Prefs file unreadable or corrupt — treat as unconfigured, show hint
+    }
+    renderHeader(!configured);
   });
 
   // ── Ctrl+Alt+G shortcut — Kata dashboard overlay ────────────────────────

--- a/apps/symphony/CHANGELOG.md
+++ b/apps/symphony/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.1.0
+
+### Features
+
+- **Skills injection into workspaces** — Symphony now auto-copies a `skills/` directory (sibling to WORKFLOW.md) into `.agents/skills/` in each worker workspace during bootstrap. Skills use a `sym-` namespace prefix to avoid collisions with user skills.
+- **`symphony doctor` preflight diagnostics** — New `symphony doctor` command validates configuration, connectivity, and runtime prerequisites before starting the orchestrator.
+- **Persistent worker error surfacing** — Worker failures are now propagated into orchestrator state and rendered in the TUI with 🚨 + red styling. The HTTP dashboard shows an Error column for running sessions. Rate-limit and usage-limit errors include retry-window hints when parseable, with 200-char truncation for redaction safety.
+- **`POST /api/v1/steer` endpoint** — Live operator steering for active workers. Delivers guidance to running Kata RPC sessions via `follow_up` injection. Includes `SteerSender`/`SteerResult` types, `steer_channel()`, and full HTTP validation/error mapping.
+- **`model_by_label` config** — Label-first model resolution parsed from WORKFLOW.md alongside `model_by_state`. Normalized to lowercase, takes priority over state-based and default model selection.
+
+### Bug Fixes
+
+- **S01 critical bug fixes (KAT-1652)** — `pi-agent` `stopReason: "error"` handling with rate-limit hint parsing; startup orphan workspace cleanup via `scan_workspace_root`; workpad duplication guard with search-before-create pattern and one-retry comment creation.
+- **Project identifier preferences** — Updated project identifiers in CLI and Symphony configurations.
+
+### Infrastructure
+
+- **llvm-cov CI gate** — Added coverage gating and core edge-path coverage tests.
+
 ## 2.0.0 — Symphony ↔ Kata CLI Integration
 
 Server/client architecture — Symphony is the server, Kata CLI is the client. Same planning artifacts, same Linear issues, same agent runtime at every level.

--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -2187,7 +2187,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphony"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symphony"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 description = "Symphony orchestrator — polls Linear, dispatches Codex agent sessions"
 license = "MIT"

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -67,8 +67,8 @@ pub struct Cli {
     #[arg(default_value = "WORKFLOW.md")]
     pub workflow_path: String,
 
-    /// HTTP server port (default: 8080)
-    #[arg(long, default_value = "8080")]
+    /// HTTP server port (overrides WORKFLOW.md server.port; defaults to 8080 if neither is set)
+    #[arg(long)]
     pub port: Option<u16>,
 
     /// Log file root directory
@@ -384,7 +384,7 @@ pub fn resolve_workflow_path(cli: &Cli) -> PathBuf {
 
 #[cfg_attr(test, allow(dead_code))]
 pub(crate) fn effective_http_binding(config: &ServiceConfig, cli: &Cli) -> Option<HttpBinding> {
-    let port = cli.port.or(config.server.port)?;
+    let port = cli.port.or(config.server.port).unwrap_or(8080);
     Some(HttpBinding {
         host: config.server.host.clone(),
         port,

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -963,11 +963,19 @@ mod tests {
         // Create source skills
         let skill_dir = workflow_dir.join("skills").join("sym-land");
         std::fs::create_dir_all(&skill_dir).unwrap();
-        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: sym-land\n---\n# Land").unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: sym-land\n---\n# Land",
+        )
+        .unwrap();
 
         inject_skills(&workflow_dir, &workspace).unwrap();
 
-        let target = workspace.join(".agents").join("skills").join("sym-land").join("SKILL.md");
+        let target = workspace
+            .join(".agents")
+            .join("skills")
+            .join("sym-land")
+            .join("SKILL.md");
         assert!(target.exists(), "skill should be copied to .agents/skills/");
         let content = std::fs::read_to_string(&target).unwrap();
         assert!(content.contains("sym-land"));
@@ -1009,7 +1017,10 @@ mod tests {
         // No skills/ directory — should be a no-op
         inject_skills(&workflow_dir, &workspace).unwrap();
 
-        assert!(!workspace.join(".agents").exists(), ".agents should not be created");
+        assert!(
+            !workspace.join(".agents").exists(),
+            ".agents should not be created"
+        );
     }
 
     #[test]
@@ -1023,7 +1034,11 @@ mod tests {
         // Pre-existing skill in the workspace (from the cloned repo)
         let existing_skill = workspace.join(".agents").join("skills").join("repo-custom");
         std::fs::create_dir_all(&existing_skill).unwrap();
-        std::fs::write(existing_skill.join("SKILL.md"), "---\nname: repo-custom\n---").unwrap();
+        std::fs::write(
+            existing_skill.join("SKILL.md"),
+            "---\nname: repo-custom\n---",
+        )
+        .unwrap();
 
         // Symphony skill to inject
         let sym_skill = workflow_dir.join("skills").join("sym-commit");
@@ -1034,11 +1049,21 @@ mod tests {
 
         // Both should exist
         assert!(
-            workspace.join(".agents").join("skills").join("repo-custom").join("SKILL.md").exists(),
+            workspace
+                .join(".agents")
+                .join("skills")
+                .join("repo-custom")
+                .join("SKILL.md")
+                .exists(),
             "existing repo skill should be preserved"
         );
         assert!(
-            workspace.join(".agents").join("skills").join("sym-commit").join("SKILL.md").exists(),
+            workspace
+                .join(".agents")
+                .join("skills")
+                .join("sym-commit")
+                .join("SKILL.md")
+                .exists(),
             "symphony skill should be injected"
         );
     }
@@ -1064,10 +1089,17 @@ mod tests {
         inject_skills(&workflow_dir, &workspace).unwrap();
 
         let content = std::fs::read_to_string(
-            workspace.join(".agents").join("skills").join("sym-land").join("SKILL.md"),
+            workspace
+                .join(".agents")
+                .join("skills")
+                .join("sym-land")
+                .join("SKILL.md"),
         )
         .unwrap();
-        assert_eq!(content, "new content", "skill files should be overwritten on re-injection");
+        assert_eq!(
+            content, "new content",
+            "skill files should be overwritten on re-injection"
+        );
     }
 
     #[test]
@@ -1091,11 +1123,20 @@ mod tests {
         inject_skills(&workflow_dir, &workspace).unwrap();
 
         assert!(
-            workspace.join(".agents").join("skills").join("sym-pull").join("SKILL.md").exists(),
+            workspace
+                .join(".agents")
+                .join("skills")
+                .join("sym-pull")
+                .join("SKILL.md")
+                .exists(),
             "proper skill should be injected"
         );
         assert!(
-            !workspace.join(".agents").join("skills").join("README.md").exists(),
+            !workspace
+                .join(".agents")
+                .join("skills")
+                .join("README.md")
+                .exists(),
             "non-directory entries should be skipped"
         );
     }


### PR DESCRIPTION
## CLI v0.14.0

### Features
- **`symphony_steer` tool + `/symphony steer` command** — Live operator steering for Symphony workers
- **`model_by_label` config** — Label-first model resolution in Symphony orchestrator
- **Console width option** — Console render accepts width option and truncates lines accordingly

### Bug Fixes
- Onboarding broken app-paths import, missing .kata/ dir, reuse existing Linear key
- Onboarding banner polish ("Run `/kata` to get started", removed "Skip for now")
- Symphony config editor empty-path guards

---

## Symphony v2.1.0

### Features
- **Skills injection into workspaces** — Auto-copies `skills/` directory into worker workspaces with `sym-` namespace prefix
- **`symphony doctor` preflight diagnostics** — Validates configuration, connectivity, and runtime prerequisites
- **Persistent worker error surfacing** — Worker failures rendered in TUI/dashboard with retry-window hints
- **`POST /api/v1/steer` endpoint** — Live operator steering for active workers
- **`model_by_label` config** — Label-first model resolution

### Bug Fixes
- S01 critical bug fixes: pi-agent stopReason error handling, startup orphan cleanup, workpad duplication guard
- Project identifier preferences update

### Infrastructure
- llvm-cov CI gate and core edge-path coverage tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated CLI header with ASCII logo, version display, and contextual "Run /kata to get started" hint
  * Streamlined onboarding prompts: skip option removed; hint cleared after setup

* **Chores**
  * Package version bumps: CLI to 0.14.0, Symphony to 2.1.0
  * Tests and formatting improvements for maintainability

* **Behavior**
  * Server CLI: --port is now optional; default port is 8080 when unset
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR bumps CLI to v0.14.0 and Symphony to v2.1.0. The code-level changes included in the diff are focused on CLI onboarding UX polish and a clean header-rendering refactor; the Symphony-side features (skills injection, `symphony doctor`, steer endpoint, `model_by_label`, S01 bug fixes) appear in the changelogs and version bumps, with `workspace.rs` carrying only test formatting changes for the skills-injection feature.

**Key changes:**
- **`header.ts` (new)** — Extracts the ASCII logo + title rendering from `index.ts` into a dedicated module to avoid a circular dependency between `index.ts` and `commands.ts`. Introduces a module-level `_headerCtx` singleton so the header can be re-rendered (hint on/off) after the initial `session_start`.
- **`index.ts`** — `session_start` now delegates to `setHeaderCtx` + `renderHeader`, conditionally showing the \"Run `/kata` to get started\" hint based on `isProjectConfigured(process.cwd())` evaluated at startup.
- **`commands.ts`** — Removes the \"Skip for now\" action from the onboarding prompt; calls `clearHeaderHint()` after a successful onboarding run; simplifies the skip-flag logic so only a completed onboarding suppresses re-triggering for the session.
- **`workspace.rs`** — Pure `rustfmt`-style reformatting of long path chains in the `inject_skills` test suite; no logic changes.
- Version bumps in `package.json`, `Cargo.toml`, and `Cargo.lock` are consistent across all files.

All findings are P2 (style/hardening suggestions). The code is safe to merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues found; all findings are minor style and hardening suggestions.

Changes are well-scoped: a clean module extraction (header.ts), an intentional UX simplification (removing 'Skip for now'), pure test formatting in Rust, and version bumps. No logic bugs, data-integrity issues, or security concerns were found. All three inline comments are P2 observations about edge-case behaviour and missing resets that don't affect the primary flows.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/header.ts | New module extracts header rendering logic from index.ts to break the circular dependency between index.ts and commands.ts; stores UI context in a module-level singleton for re-render support. |
| apps/cli/src/resources/extensions/kata/index.ts | session_start handler refactored to delegate to header.ts; now passes project configuration state to determine whether to show the getting-started hint at startup. |
| apps/cli/src/resources/extensions/kata/commands.ts | Removes 'Skip for now' onboarding action; calls clearHeaderHint() after successful onboarding completion; simplifies skip-flag logic so only a completed onboarding suppresses the prompt for the session. |
| apps/symphony/src/workspace.rs | Pure formatting change — rustfmt-style line-wrapping of long path chains and assert! macros in inject_skills test suite; no logic changes. |
| apps/cli/package.json | Version bump from 0.13.0 to 0.14.0, consistent with Cargo.toml and CHANGELOG entries. |
| apps/symphony/Cargo.toml | Version bump from 2.0.0 to 2.1.0, consistent with Cargo.lock and CHANGELOG entry. |
| apps/symphony/Cargo.lock | Lock file updated to reflect symphony version bump from 2.0.0 to 2.1.0. |
| apps/cli/CHANGELOG.md | Adds 0.14.0 changelog entry documenting symphony_steer, model_by_label, console width, and the onboarding/config editor bug fixes. |
| apps/symphony/CHANGELOG.md | Adds 2.1.0 changelog entry covering skills injection, symphony doctor, persistent error surfacing, steer endpoint, model_by_label, S01 critical bug fixes, and CI coverage gate. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant index.ts as index.ts (session_start)
    participant header.ts
    participant onboarding.ts
    participant commands.ts

    index.ts->>header.ts: setHeaderCtx(ctx)
    index.ts->>onboarding.ts: isProjectConfigured(cwd)
    onboarding.ts-->>index.ts: true / false
    index.ts->>header.ts: renderHeader(showHint)
    header.ts-->>User: Header rendered (with or without hint)

    Note over User,commands.ts: User runs /kata auto, /kata step, etc.
    commands.ts->>onboarding.ts: isProjectConfigured(basePath)
    alt not configured & not skipped
        commands.ts->>User: showNextAction (Set up Kata)
        alt User selects Set up Kata
            commands.ts->>onboarding.ts: runOnboarding(ctx, basePath)
            onboarding.ts-->>commands.ts: completed
            commands.ts->>onboarding.ts: setSkipOnboarding(true)
            commands.ts->>header.ts: clearHeaderHint()
            header.ts->>header.ts: renderHeader(false)
            header.ts-->>User: Header re-rendered without hint
        else User presses Escape / not_yet
            commands.ts-->>User: returns false (prompt will re-appear next command)
        end
    else configured or skip flag set
        commands.ts-->>commands.ts: proceed with command
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/cli/src/resources/extensions/kata/commands.ts`, line 91-106 ([link](https://github.com/gannonh/kata/blob/b4d59c4f9e78a88389abb761a5854e20604c8c16/apps/cli/src/resources/extensions/kata/commands.ts#L91-L106)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Onboarding prompt re-fires on every gated command after dismissal**

   With "Skip for now" removed and `setSkipOnboarding(true)` now only called on a `"completed"` result, dismissing the prompt (Escape / `"not_yet"`) no longer suppresses it for the session. Every subsequent gated subcommand (`/kata auto`, `/kata step`, `/kata queue`, `/kata discuss`, `/kata plan`) will re-trigger the prompt until the user either completes onboarding or ends the session.

   This is intentional per the changelog, but the comment on line 105 (`// "not_yet" (or Escape) — don't persist skip, just return false`) no longer distinguishes from a *mid-wizard cancel* (`runOnboarding` returns something other than `"completed"`, line 102). Consider adding a brief inline note clarifying that repeated prompts are deliberate, so future maintainers don't accidentally reintroduce a session-skip path for the dismiss case.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/extensions/kata/commands.ts
   Line: 91-106

   Comment:
   **Onboarding prompt re-fires on every gated command after dismissal**

   With "Skip for now" removed and `setSkipOnboarding(true)` now only called on a `"completed"` result, dismissing the prompt (Escape / `"not_yet"`) no longer suppresses it for the session. Every subsequent gated subcommand (`/kata auto`, `/kata step`, `/kata queue`, `/kata discuss`, `/kata plan`) will re-trigger the prompt until the user either completes onboarding or ends the session.

   This is intentional per the changelog, but the comment on line 105 (`// "not_yet" (or Escape) — don't persist skip, just return false`) no longer distinguishes from a *mid-wizard cancel* (`runOnboarding` returns something other than `"completed"`, line 102). Consider adding a brief inline note clarifying that repeated prompts are deliberate, so future maintainers don't accidentally reintroduce a session-skip path for the dismiss case.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/commands.ts
Line: 91-106

Comment:
**Onboarding prompt re-fires on every gated command after dismissal**

With "Skip for now" removed and `setSkipOnboarding(true)` now only called on a `"completed"` result, dismissing the prompt (Escape / `"not_yet"`) no longer suppresses it for the session. Every subsequent gated subcommand (`/kata auto`, `/kata step`, `/kata queue`, `/kata discuss`, `/kata plan`) will re-trigger the prompt until the user either completes onboarding or ends the session.

This is intentional per the changelog, but the comment on line 105 (`// "not_yet" (or Escape) — don't persist skip, just return false`) no longer distinguishes from a *mid-wizard cancel* (`runOnboarding` returns something other than `"completed"`, line 102). Consider adding a brief inline note clarifying that repeated prompts are deliberate, so future maintainers don't accidentally reintroduce a session-skip path for the dismiss case.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/header.ts
Line: 27-32

Comment:
**Module singleton holds live UI context reference indefinitely**

`_headerCtx` retains a reference to the session `ctx` object for the entire module lifetime. In the current single-session CLI lifecycle this is fine, but `setHeaderCtx` has no matching `clearHeaderCtx` / reset path for when a session ends. If the runtime ever supports session teardown and re-init (or tests re-use the module), the stale `ctx` could be called after the session is gone.

A lightweight guard — e.g. a `resetHeaderCtx()` exported for testing — would make the intent explicit and prevent accidental re-renders against a dead session object.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/index.ts
Line: 66-69

Comment:
**`isProjectConfigured` evaluated once at session start**

`renderHeader(!isProjectConfigured(process.cwd()))` snapshots the project state at `session_start`. If the user runs `/kata` (completing onboarding) the header hint is correctly cleared via `clearHeaderHint()`. However if the user changes the working directory during the session and the new `cwd` *is* configured, the hint would remain visible until the session restarts.

This is a minor edge case (changing `cwd` mid-session is uncommon) and the existing `clearHeaderHint()` call after onboarding covers the primary flow, but it's worth a comment near the call-site so the trade-off is documented.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump cli to 0.14.0 and s..."](https://github.com/gannonh/kata/commit/b4d59c4f9e78a88389abb761a5854e20604c8c16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26700133)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->