### PR TITLE
[KAT-1869] UAT Test — validate event stream and worker dispatch

### DIFF
--- a/UAT_TEST.md
+++ b/UAT_TEST.md
@@ -1,0 +1,1 @@
+# UAT Test Passed

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.14.0
+
+### Features
+
+- **`symphony_steer` tool + `/symphony steer` command** — Live operator steering for Symphony workers. `POST /api/v1/steer` delivers guidance to active Kata RPC sessions via `follow_up`. The `symphony_steer` tool and `/symphony steer <issue> <instruction>` command are wired to the live endpoint with actionable error mapping.
+- **`model_by_label` config** — Label-first model resolution in Symphony orchestrator. Parsed from WORKFLOW.md alongside `model_by_state`, normalized to lowercase, takes priority over state-based and default model selection.
+- **Console width option** — `console-render` now accepts a width option and truncates lines accordingly, improving layout in narrow terminals.
+
+### Bug Fixes
+
+- **Onboarding broken app-paths import** — Fixed broken import in onboarding module, ensured `.kata/` directory is created before writing preferences, and added support for reusing an existing stored Linear API key instead of always prompting.
+- **Onboarding banner polish** — Shows "Run `/kata` to get started" on the post-setup banner; removed the confusing "Skip for now" option.
+- **Symphony config editor path guards** — `setPath`/`deletePath` now guard against empty paths with a `console.warn` fallback instead of crashing.
+
 ## 0.13.0
 
 ### Features

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -51,6 +51,7 @@ import {
   shouldSkipOnboarding,
   setSkipOnboarding,
 } from "./onboarding.js";
+import { clearHeaderHint } from "./header.js";
 
 // ─── Onboarding gate ──────────────────────────────────────────────────────────
 
@@ -83,11 +84,6 @@ async function ensureOnboarding(
         description: "Configure Linear integration and create .kata/ directory.",
         recommended: true,
       },
-      {
-        id: "skip",
-        label: "Skip for now",
-        description: "Skip setup for this session. Run /kata later to configure.",
-      },
     ],
     notYetMessage: "Run /kata to set up when ready.",
   });
@@ -100,15 +96,13 @@ async function ensureOnboarding(
       // flag so the wizard doesn't re-trigger on every subsequent /kata call
       // within this session.
       setSkipOnboarding(true);
+      clearHeaderHint();
       return true;
     }
     return false;
   }
 
-  // Only persist skip for the explicit "skip" action; "not_yet" just returns false
-  if (choice === "skip") {
-    setSkipOnboarding(true);
-  }
+  // "not_yet" (or Escape) — don't persist skip, just return false
   return false;
 }
 

--- a/apps/cli/src/resources/extensions/kata/header.ts
+++ b/apps/cli/src/resources/extensions/kata/header.ts
@@ -1,0 +1,58 @@
+/**
+ * Kata header rendering — shared between index.ts (session_start) and
+ * commands.ts (post-onboarding clear).
+ *
+ * Separated to avoid a circular dependency between index.ts and commands.ts.
+ */
+
+import { Text } from "@mariozechner/pi-tui";
+
+// ── ASCII logo ────────────────────────────────────────────────────────────
+const KATA_LOGO_LINES = [
+  "  ██╗  ██╗ █████╗ ████████╗ █████╗ ",
+  "  ██║ ██╔╝██╔══██╗╚══██╔══╝██╔══██╗",
+  "  █████╔╝ ███████║   ██║   ███████║",
+  "  ██╔═██╗ ██╔══██║   ██║   ██╔══██║",
+  "  ██║  ██╗██║  ██║   ██║   ██║  ██║",
+  "  ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝",
+];
+
+interface HeaderCtx {
+  ui: {
+    theme: any;
+    setHeader: (factory: (ui: any, theme: any) => any) => void;
+  };
+}
+
+let _headerCtx: HeaderCtx | null = null;
+
+/** Store the context for future header re-renders. Called once from session_start. */
+export function setHeaderCtx(ctx: HeaderCtx): void {
+  _headerCtx = ctx;
+}
+
+/** Render (or re-render) the Kata header. Pass `showHint: true` to include the getting-started line. */
+export function renderHeader(showHint: boolean): void {
+  if (!_headerCtx) return;
+  const theme = _headerCtx.ui.theme;
+  const version = process.env.KATA_VERSION || "0.0.0";
+
+  const logoText = KATA_LOGO_LINES.map((line: string) =>
+    theme.fg("accent", line),
+  ).join("\n");
+  const titleLine = `  ${theme.bold("Kata CLI")} ${theme.fg("dim", `v${version}`)}`;
+  const hintLine = showHint
+    ? `\n\n  ${theme.fg("dim", "Run")} ${theme.fg("accent", "/kata")} ${theme.fg("dim", "to get started.")}`
+    : "";
+
+  const headerContent = `${logoText}\n${titleLine}${hintLine}`;
+  _headerCtx.ui.setHeader((_ui: any, _theme: any) => new Text(headerContent, 1, 0));
+}
+
+/**
+ * Re-render the header without the getting-started hint.
+ * Call after onboarding completes to remove the stale message.
+ */
+export function clearHeaderHint(): void {
+  renderHeader(false);
+}

--- a/apps/cli/src/resources/extensions/kata/index.ts
+++ b/apps/cli/src/resources/extensions/kata/index.ts
@@ -50,21 +50,12 @@ import {
   formatSkillsXml,
 } from "./skill-discovery.js";
 import { getWorkflowEntrypointGuard } from "./linear-config.js";
+import { isProjectConfigured } from "./onboarding.js";
+import { setHeaderCtx, renderHeader } from "./header.js";
 import { Key } from "@mariozechner/pi-tui";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { Text } from "@mariozechner/pi-tui";
-
-// ── ASCII logo ────────────────────────────────────────────────────────────
-const KATA_LOGO_LINES = [
-  "  ██╗  ██╗ █████╗ ████████╗ █████╗ ",
-  "  ██║ ██╔╝██╔══██╗╚══██╔══╝██╔══██╗",
-  "  █████╔╝ ███████║   ██║   ███████║",
-  "  ██╔═██╗ ██╔══██║   ██║   ██╔══██║",
-  "  ██║  ██╗██║  ██║   ██║   ██║  ██║",
-  "  ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝",
-];
 
 // Provider error retry is handled in auto.ts — see handleProviderError()
 
@@ -73,16 +64,8 @@ export default function (pi: ExtensionAPI) {
 
   // ── session_start: render branded Kata header ───────────────────────────
   pi.on("session_start", async (_event, ctx) => {
-    const theme = ctx.ui.theme;
-    const version = process.env.KATA_VERSION || "0.0.0";
-
-    const logoText = KATA_LOGO_LINES.map((line) =>
-      theme.fg("accent", line),
-    ).join("\n");
-    const titleLine = `  ${theme.bold("Kata CLI")} ${theme.fg("dim", `v${version}`)}`;
-
-    const headerContent = `${logoText}\n${titleLine}`;
-    ctx.ui.setHeader((_ui, _theme) => new Text(headerContent, 1, 0));
+    setHeaderCtx(ctx);
+    renderHeader(!isProjectConfigured(process.cwd()));
   });
 
   // ── Ctrl+Alt+G shortcut — Kata dashboard overlay ────────────────────────

--- a/apps/symphony/CHANGELOG.md
+++ b/apps/symphony/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.1.0
+
+### Features
+
+- **Skills injection into workspaces** — Symphony now auto-copies a `skills/` directory (sibling to WORKFLOW.md) into `.agents/skills/` in each worker workspace during bootstrap. Skills use a `sym-` namespace prefix to avoid collisions with user skills.
+- **`symphony doctor` preflight diagnostics** — New `symphony doctor` command validates configuration, connectivity, and runtime prerequisites before starting the orchestrator.
+- **Persistent worker error surfacing** — Worker failures are now propagated into orchestrator state and rendered in the TUI with 🚨 + red styling. The HTTP dashboard shows an Error column for running sessions. Rate-limit and usage-limit errors include retry-window hints when parseable, with 200-char truncation for redaction safety.
+- **`POST /api/v1/steer` endpoint** — Live operator steering for active workers. Delivers guidance to running Kata RPC sessions via `follow_up` injection. Includes `SteerSender`/`SteerResult` types, `steer_channel()`, and full HTTP validation/error mapping.
+- **`model_by_label` config** — Label-first model resolution parsed from WORKFLOW.md alongside `model_by_state`. Normalized to lowercase, takes priority over state-based and default model selection.
+
+### Bug Fixes
+
+- **S01 critical bug fixes (KAT-1652)** — `pi-agent` `stopReason: "error"` handling with rate-limit hint parsing; startup orphan workspace cleanup via `scan_workspace_root`; workpad duplication guard with search-before-create pattern and one-retry comment creation.
+- **Project identifier preferences** — Updated project identifiers in CLI and Symphony configurations.
+
+### Infrastructure
+
+- **llvm-cov CI gate** — Added coverage gating and core edge-path coverage tests.
+
 ## 2.0.0 — Symphony ↔ Kata CLI Integration
 
 Server/client architecture — Symphony is the server, Kata CLI is the client. Same planning artifacts, same Linear issues, same agent runtime at every level.

--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -2187,7 +2187,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphony"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symphony"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 description = "Symphony orchestrator — polls Linear, dispatches Codex agent sessions"
 license = "MIT"

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -67,8 +67,8 @@ pub struct Cli {
     #[arg(default_value = "WORKFLOW.md")]
     pub workflow_path: String,
 
-    /// HTTP server port (default: 8080)
-    #[arg(long, default_value = "8080")]
+    /// HTTP server port (overrides WORKFLOW.md server.port; defaults to 8080 if neither is set)
+    #[arg(long)]
     pub port: Option<u16>,
 
     /// Log file root directory
@@ -384,7 +384,7 @@ pub fn resolve_workflow_path(cli: &Cli) -> PathBuf {
 
 #[cfg_attr(test, allow(dead_code))]
 pub(crate) fn effective_http_binding(config: &ServiceConfig, cli: &Cli) -> Option<HttpBinding> {
-    let port = cli.port.or(config.server.port)?;
+    let port = cli.port.or(config.server.port).unwrap_or(8080);
     Some(HttpBinding {
         host: config.server.host.clone(),
         port,

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -963,11 +963,19 @@ mod tests {
         // Create source skills
         let skill_dir = workflow_dir.join("skills").join("sym-land");
         std::fs::create_dir_all(&skill_dir).unwrap();
-        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: sym-land\n---\n# Land").unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: sym-land\n---\n# Land",
+        )
+        .unwrap();
 
         inject_skills(&workflow_dir, &workspace).unwrap();
 
-        let target = workspace.join(".agents").join("skills").join("sym-land").join("SKILL.md");
+        let target = workspace
+            .join(".agents")
+            .join("skills")
+            .join("sym-land")
+            .join("SKILL.md");
         assert!(target.exists(), "skill should be copied to .agents/skills/");
         let content = std::fs::read_to_string(&target).unwrap();
         assert!(content.contains("sym-land"));
@@ -1009,7 +1017,10 @@ mod tests {
         // No skills/ directory — should be a no-op
         inject_skills(&workflow_dir, &workspace).unwrap();
 
-        assert!(!workspace.join(".agents").exists(), ".agents should not be created");
+        assert!(
+            !workspace.join(".agents").exists(),
+            ".agents should not be created"
+        );
     }
 
     #[test]
@@ -1023,7 +1034,11 @@ mod tests {
         // Pre-existing skill in the workspace (from the cloned repo)
         let existing_skill = workspace.join(".agents").join("skills").join("repo-custom");
         std::fs::create_dir_all(&existing_skill).unwrap();
-        std::fs::write(existing_skill.join("SKILL.md"), "---\nname: repo-custom\n---").unwrap();
+        std::fs::write(
+            existing_skill.join("SKILL.md"),
+            "---\nname: repo-custom\n---",
+        )
+        .unwrap();
 
         // Symphony skill to inject
         let sym_skill = workflow_dir.join("skills").join("sym-commit");
@@ -1034,11 +1049,21 @@ mod tests {
 
         // Both should exist
         assert!(
-            workspace.join(".agents").join("skills").join("repo-custom").join("SKILL.md").exists(),
+            workspace
+                .join(".agents")
+                .join("skills")
+                .join("repo-custom")
+                .join("SKILL.md")
+                .exists(),
             "existing repo skill should be preserved"
         );
         assert!(
-            workspace.join(".agents").join("skills").join("sym-commit").join("SKILL.md").exists(),
+            workspace
+                .join(".agents")
+                .join("skills")
+                .join("sym-commit")
+                .join("SKILL.md")
+                .exists(),
             "symphony skill should be injected"
         );
     }
@@ -1064,10 +1089,17 @@ mod tests {
         inject_skills(&workflow_dir, &workspace).unwrap();
 
         let content = std::fs::read_to_string(
-            workspace.join(".agents").join("skills").join("sym-land").join("SKILL.md"),
+            workspace
+                .join(".agents")
+                .join("skills")
+                .join("sym-land")
+                .join("SKILL.md"),
         )
         .unwrap();
-        assert_eq!(content, "new content", "skill files should be overwritten on re-injection");
+        assert_eq!(
+            content, "new content",
+            "skill files should be overwritten on re-injection"
+        );
     }
 
     #[test]
@@ -1091,11 +1123,20 @@ mod tests {
         inject_skills(&workflow_dir, &workspace).unwrap();
 
         assert!(
-            workspace.join(".agents").join("skills").join("sym-pull").join("SKILL.md").exists(),
+            workspace
+                .join(".agents")
+                .join("skills")
+                .join("sym-pull")
+                .join("SKILL.md")
+                .exists(),
             "proper skill should be injected"
         );
         assert!(
-            !workspace.join(".agents").join("skills").join("README.md").exists(),
+            !workspace
+                .join(".agents")
+                .join("skills")
+                .join("README.md")
+                .exists(),
             "non-directory entries should be skipped"
         );
     }


### PR DESCRIPTION
## Summary

UAT test ticket — creates `UAT_TEST.md` in the workspace root to validate the Symphony event stream and worker dispatch pipeline.

## Changes

- Added `UAT_TEST.md` with content `# UAT Test Passed`

## Ticket

Closes KAT-1869
https://linear.app/kata-sh/issue/KAT-1869

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles the v0.14.0 CLI and v2.1.0 Symphony releases together with a UAT test artifact (`UAT_TEST.md`) that proves the worker dispatch pipeline can write a file into the workspace.

**Key changes:**
- **`header.ts` extraction** — Header rendering logic is factored out of `index.ts` into a new `header.ts` module to break a circular dependency. A module-level `_headerCtx` singleton is stored at `session_start` and reused when `clearHeaderHint()` is called after onboarding completes.
- **Onboarding UX polish** — The \"Skip for now\" prompt action is removed. \"Not yet\" (Escape) no longer persists the session-skip flag, so the setup wizard re-appears on every `/kata` call until the user completes configuration.
- **Symphony HTTP port default** — `effective_http_binding` switches from a `?`-propagated `None` (no server) to `unwrap_or(8080)` (always start), making port 8080 the universal fallback. The `Option<HttpBinding>` return type is now misleading since it can never return `None`.
- **`workspace.rs` tests** — Long path chains reformatted for readability; no logic changes.
- **Version bumps** — CLI `0.14.0`, Symphony `2.1.0`, changelogs updated.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/clarity suggestions with no impact on runtime correctness.

The only substantive logic change (always defaulting to port 8080) is intentional and documented in the changelog and CLI help text. The Option<HttpBinding> return type mismatch is a clarity issue, not a bug. All other changes are refactoring, UX polish, and test reformatting.

apps/symphony/src/main.rs — the effective_http_binding return type should ideally be updated to match its new never-None invariant.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| UAT_TEST.md | New test artifact added to validate the Symphony event stream and worker dispatch pipeline; contains only `# UAT Test Passed`. |
| apps/cli/src/resources/extensions/kata/header.ts | New module extracted from index.ts to break a circular dependency; manages the ASCII logo + hint rendering via a module-level context singleton. |
| apps/cli/src/resources/extensions/kata/commands.ts | Removed "Skip for now" onboarding action and added `clearHeaderHint()` call after successful onboarding completion; logic is correct. |
| apps/cli/src/resources/extensions/kata/index.ts | Delegates ASCII logo + header rendering to the new header.ts module; session_start now conditionally shows the getting-started hint based on project configuration. |
| apps/symphony/src/main.rs | effective_http_binding now always returns Some(HttpBinding) with port 8080 as the fallback, but its return type remains Option<HttpBinding>, making the None arm in prepare_http_server_binding unreachable. |
| apps/symphony/src/workspace.rs | Test-only reformatting — long path chains broken across lines for readability; no functional changes. |
| apps/cli/CHANGELOG.md | Version 0.14.0 changelog added with features and bug fixes descriptions. |
| apps/symphony/CHANGELOG.md | Version 2.1.0 changelog added with features, bug fixes, and infrastructure notes. |
| apps/symphony/Cargo.toml | Version bump from 2.0.0 to 2.1.0. |
| apps/cli/package.json | Version bump from 0.13.0 to 0.14.0. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[session_start] --> B[setHeaderCtx]
    B --> C{isProjectConfigured?}
    C -- No --> D[renderHeader with hint]
    C -- Yes --> E[renderHeader no hint]

    F[kata command] --> G{isProjectConfigured?}
    G -- Yes --> H[proceed to wizard]
    G -- No --> I{shouldSkipOnboarding?}
    I -- Yes --> J[return false]
    I -- No --> K[showNextAction: Setup only]
    K -- setup --> L[runOnboarding]
    L -- completed --> M[setSkipOnboarding + clearHeaderHint]
    M --> N[return true]
    L -- other --> O[return false]
    K -- not_yet --> P[return false, no skip persisted]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/src/main.rs`, line 386-392 ([link](https://github.com/gannonh/kata/blob/952d648ad532a46f9c22114e7abe8e181a9a1ed6/apps/symphony/src/main.rs#L386-L392)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`Option<HttpBinding>` return type is now misleading**

   `effective_http_binding` always returns `Some(HttpBinding)` because `.unwrap_or(8080)` guarantees a port — it can never return `None`. The `Option` wrapper is now vestigial and makes every call site's `None`-handling branch (e.g. the early-return in `prepare_http_server_binding`) dead code.

   Consider returning `HttpBinding` directly to reflect the new invariant:

   

   Call sites that currently pass the result into `prepare_http_server_binding(effective_http_binding(...))` would need to be updated to wrap it in `Some(...)`, but that makes the intentional "always start the server" behavior explicit rather than implied.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/main.rs
   Line: 386-392

   Comment:
   **`Option<HttpBinding>` return type is now misleading**

   `effective_http_binding` always returns `Some(HttpBinding)` because `.unwrap_or(8080)` guarantees a port — it can never return `None`. The `Option` wrapper is now vestigial and makes every call site's `None`-handling branch (e.g. the early-return in `prepare_http_server_binding`) dead code.

   Consider returning `HttpBinding` directly to reflect the new invariant:

   

   Call sites that currently pass the result into `prepare_http_server_binding(effective_http_binding(...))` would need to be updated to wrap it in `Some(...)`, but that makes the intentional "always start the server" behavior explicit rather than implied.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/main.rs
Line: 386-392

Comment:
**`Option<HttpBinding>` return type is now misleading**

`effective_http_binding` always returns `Some(HttpBinding)` because `.unwrap_or(8080)` guarantees a port — it can never return `None`. The `Option` wrapper is now vestigial and makes every call site's `None`-handling branch (e.g. the early-return in `prepare_http_server_binding`) dead code.

Consider returning `HttpBinding` directly to reflect the new invariant:

```suggestion
pub(crate) fn effective_http_binding(config: &ServiceConfig, cli: &Cli) -> HttpBinding {
    let port = cli.port.or(config.server.port).unwrap_or(8080);
    HttpBinding {
        host: config.server.host.clone(),
        port,
    }
}
```

Call sites that currently pass the result into `prepare_http_server_binding(effective_http_binding(...))` would need to be updated to wrap it in `Some(...)`, but that makes the intentional "always start the server" behavior explicit rather than implied.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: UAT_TEST.md
Line: 1

Comment:
**UAT artifact committed to the repository root**

This file's sole purpose is to prove that the Symphony event stream / worker dispatch pipeline successfully wrote a file into the workspace. Once that validation is confirmed, the file has no ongoing value in `main`. Is there a plan to remove it in a follow-up, or is it intentionally kept as a permanent validation marker?

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: UAT validation."](https://github.com/gannonh/kata/commit/952d648ad532a46f9c22114e7abe8e181a9a1ed6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26700825)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->