### PR TITLE
[S01] Preferences model, parser, and writer

### DIFF
--- a/apps/cli/src/resources/extensions/kata/prefs-model.ts
+++ b/apps/cli/src/resources/extensions/kata/prefs-model.ts
@@ -1,0 +1,510 @@
+/**
+ * Preferences field model for the Kata config editor.
+ *
+ * Defines section definitions, field definitions, and `buildPreferencesModel()`
+ * which takes a parsed YAML config and returns a `ConfigEditorModel` compatible
+ * with Symphony's `ConfigEditor`.
+ */
+
+import type {
+  ConfigEditorModel,
+  ConfigField,
+  ConfigFieldType,
+  ConfigSection,
+  ConfigSectionKey,
+  WorkflowFrontmatter,
+} from "../symphony/config-model.js";
+
+// ---------------------------------------------------------------------------
+// Section keys
+// ---------------------------------------------------------------------------
+
+export type PrefsSectionKey =
+  | "general"
+  | "workflow"
+  | "linear"
+  | "pr"
+  | "models"
+  | "symphony"
+  | "skills"
+  | "auto_supervisor";
+
+// ---------------------------------------------------------------------------
+// Section definitions
+// ---------------------------------------------------------------------------
+
+export interface PrefsSectionDefinition {
+  key: PrefsSectionKey;
+  label: string;
+  description: string;
+}
+
+export const PREFS_SECTION_DEFINITIONS: readonly PrefsSectionDefinition[] = [
+  {
+    key: "general",
+    label: "General",
+    description: "Schema version, UAT dispatch, and budget settings.",
+  },
+  {
+    key: "workflow",
+    label: "Workflow",
+    description: "Workflow-mode configuration.",
+  },
+  {
+    key: "linear",
+    label: "Linear",
+    description: "Linear binding configuration for Linear-backed workflow.",
+  },
+  {
+    key: "pr",
+    label: "PR",
+    description: "Pull request lifecycle configuration.",
+  },
+  {
+    key: "models",
+    label: "Models",
+    description: "Per-stage model selection for auto-mode, step mode, and PR review.",
+  },
+  {
+    key: "symphony",
+    label: "Symphony",
+    description: "Symphony orchestration server configuration.",
+  },
+  {
+    key: "skills",
+    label: "Skills",
+    description: "Skill routing, discovery, and custom instructions.",
+  },
+  {
+    key: "auto_supervisor",
+    label: "Auto Supervisor",
+    description: "Auto-mode supervisor timeouts and model configuration.",
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Field definitions
+// ---------------------------------------------------------------------------
+
+export interface PrefsFieldDefinition {
+  section: PrefsSectionKey;
+  key: string;
+  label: string;
+  path: string[];
+  type: ConfigFieldType;
+  required?: boolean;
+  description: string;
+  enumValues?: string[];
+}
+
+export const PREFS_FIELD_DEFINITIONS: readonly PrefsFieldDefinition[] = [
+  // ── General ───────────────────────────────────────────────────────────────
+  {
+    section: "general",
+    key: "version",
+    label: "Version",
+    path: ["version"],
+    type: "number",
+    description: "Schema version. Start at 1.",
+  },
+  {
+    section: "general",
+    key: "uat_dispatch",
+    label: "UAT Dispatch",
+    path: ["uat_dispatch"],
+    type: "boolean",
+    description: "Enable UAT dispatch for acceptance testing.",
+  },
+  {
+    section: "general",
+    key: "budget_ceiling",
+    label: "Budget Ceiling",
+    path: ["budget_ceiling"],
+    type: "number",
+    description: "Maximum budget ceiling for auto-mode operations.",
+  },
+
+  // ── Workflow ──────────────────────────────────────────────────────────────
+  {
+    section: "workflow",
+    key: "mode",
+    label: "Mode",
+    path: ["workflow", "mode"],
+    type: "enum",
+    enumValues: ["linear"],
+    description: "Workflow mode. Currently only 'linear' is supported.",
+  },
+
+  // ── Linear ────────────────────────────────────────────────────────────────
+  {
+    section: "linear",
+    key: "teamKey",
+    label: "Team Key",
+    path: ["linear", "teamKey"],
+    type: "string",
+    description: "Linear team key such as KAT.",
+  },
+  {
+    section: "linear",
+    key: "projectSlug",
+    label: "Project Slug",
+    path: ["linear", "projectSlug"],
+    type: "string",
+    description:
+      "Linear project slug ID (from the project URL). Preferred over projectId.",
+  },
+  {
+    section: "linear",
+    key: "teamId",
+    label: "Team ID",
+    path: ["linear", "teamId"],
+    type: "string",
+    description: "Optional Linear team UUID.",
+  },
+  {
+    section: "linear",
+    key: "projectId",
+    label: "Project ID",
+    path: ["linear", "projectId"],
+    type: "string",
+    description:
+      "Optional Linear project UUID. Supported for backward compatibility; prefer projectSlug.",
+  },
+
+  // ── PR ────────────────────────────────────────────────────────────────────
+  {
+    section: "pr",
+    key: "enabled",
+    label: "Enabled",
+    path: ["pr", "enabled"],
+    type: "boolean",
+    description: "Set to true to activate the PR lifecycle.",
+  },
+  {
+    section: "pr",
+    key: "auto_create",
+    label: "Auto Create",
+    path: ["pr", "auto_create"],
+    type: "boolean",
+    description:
+      "Automatically open a PR after each slice completes in auto-mode.",
+  },
+  {
+    section: "pr",
+    key: "base_branch",
+    label: "Base Branch",
+    path: ["pr", "base_branch"],
+    type: "string",
+    description: "Target branch for PRs (default: main).",
+  },
+  {
+    section: "pr",
+    key: "review_on_create",
+    label: "Review on Create",
+    path: ["pr", "review_on_create"],
+    type: "boolean",
+    description:
+      "Automatically run parallel reviewer subagents after PR creation.",
+  },
+  {
+    section: "pr",
+    key: "linear_link",
+    label: "Linear Link",
+    path: ["pr", "linear_link"],
+    type: "boolean",
+    description:
+      "Include Linear issue references in PR bodies and update Linear issues on merge.",
+  },
+
+  // ── Models ────────────────────────────────────────────────────────────────
+  {
+    section: "models",
+    key: "research",
+    label: "Research",
+    path: ["models", "research"],
+    type: "string",
+    description: "Model ID for research stages.",
+  },
+  {
+    section: "models",
+    key: "planning",
+    label: "Planning",
+    path: ["models", "planning"],
+    type: "string",
+    description: "Model ID for planning stages.",
+  },
+  {
+    section: "models",
+    key: "execution",
+    label: "Execution",
+    path: ["models", "execution"],
+    type: "string",
+    description: "Model ID for execution stages.",
+  },
+  {
+    section: "models",
+    key: "completion",
+    label: "Completion",
+    path: ["models", "completion"],
+    type: "string",
+    description: "Model ID for completion stages.",
+  },
+  {
+    section: "models",
+    key: "review",
+    label: "Review",
+    path: ["models", "review"],
+    type: "string",
+    description: "Model ID for PR reviewer subagents.",
+  },
+
+  // ── Symphony ──────────────────────────────────────────────────────────────
+  {
+    section: "symphony",
+    key: "url",
+    label: "URL",
+    path: ["symphony", "url"],
+    type: "string",
+    description: "Base URL for the Symphony server.",
+  },
+  {
+    section: "symphony",
+    key: "workflow_path",
+    label: "Workflow Path",
+    path: ["symphony", "workflow_path"],
+    type: "string",
+    description: "Absolute path to the Symphony WORKFLOW.md file.",
+  },
+  {
+    section: "symphony",
+    key: "console_position",
+    label: "Console Position",
+    path: ["symphony", "console_position"],
+    type: "enum",
+    enumValues: ["below-output", "above-status"],
+    description: "Placement of the /symphony console panel in the TUI.",
+  },
+
+  // ── Skills ────────────────────────────────────────────────────────────────
+  {
+    section: "skills",
+    key: "always_use_skills",
+    label: "Always Use Skills",
+    path: ["always_use_skills"],
+    type: "string[]",
+    description: "Skills Kata should use whenever they are relevant.",
+  },
+  {
+    section: "skills",
+    key: "prefer_skills",
+    label: "Prefer Skills",
+    path: ["prefer_skills"],
+    type: "string[]",
+    description: "Soft defaults Kata should prefer when relevant.",
+  },
+  {
+    section: "skills",
+    key: "avoid_skills",
+    label: "Avoid Skills",
+    path: ["avoid_skills"],
+    type: "string[]",
+    description: "Skills Kata should avoid unless clearly needed.",
+  },
+  {
+    section: "skills",
+    key: "skill_rules",
+    label: "Skill Rules",
+    path: ["skill_rules"],
+    type: "string[]",
+    description:
+      "Situational rules with a when trigger and use/prefer/avoid actions. Edit as YAML text.",
+  },
+  {
+    section: "skills",
+    key: "custom_instructions",
+    label: "Custom Instructions",
+    path: ["custom_instructions"],
+    type: "string[]",
+    description: "Extra durable instructions related to skill use.",
+  },
+  {
+    section: "skills",
+    key: "skill_discovery",
+    label: "Skill Discovery",
+    path: ["skill_discovery"],
+    type: "enum",
+    enumValues: ["auto", "suggest", "off"],
+    description:
+      "Controls how Kata discovers and applies skills during auto-mode.",
+  },
+
+  // ── Auto Supervisor ───────────────────────────────────────────────────────
+  {
+    section: "auto_supervisor",
+    key: "model",
+    label: "Model",
+    path: ["auto_supervisor", "model"],
+    type: "string",
+    description: "Model ID for the supervisor process.",
+  },
+  {
+    section: "auto_supervisor",
+    key: "soft_timeout_minutes",
+    label: "Soft Timeout (min)",
+    path: ["auto_supervisor", "soft_timeout_minutes"],
+    type: "number",
+    description: "Minutes before the supervisor issues a soft warning (default: 20).",
+  },
+  {
+    section: "auto_supervisor",
+    key: "idle_timeout_minutes",
+    label: "Idle Timeout (min)",
+    path: ["auto_supervisor", "idle_timeout_minutes"],
+    type: "number",
+    description:
+      "Minutes of inactivity before the supervisor intervenes (default: 10).",
+  },
+  {
+    section: "auto_supervisor",
+    key: "hard_timeout_minutes",
+    label: "Hard Timeout (min)",
+    path: ["auto_supervisor", "hard_timeout_minutes"],
+    type: "number",
+    description:
+      "Minutes before the supervisor forces termination (default: 30).",
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function getPrefsFieldDefinitionsForSection(
+  sectionKey: PrefsSectionKey,
+): PrefsFieldDefinition[] {
+  return PREFS_FIELD_DEFINITIONS.filter((f) => f.section === sectionKey);
+}
+
+/**
+ * Read a nested value from an object by path segments.
+ * Returns `undefined` when any intermediate segment is missing.
+ */
+export function readPath(root: Record<string, unknown>, path: string[]): unknown {
+  let current: unknown = root;
+  for (const segment of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+// ---------------------------------------------------------------------------
+// Value coercion
+// ---------------------------------------------------------------------------
+
+function coerceFieldValue(
+  value: unknown,
+  definition: PrefsFieldDefinition,
+): unknown {
+  if (definition.type === "string") {
+    if (value === undefined || value === null) return "";
+    if (Array.isArray(value)) return value.map(String).join(" ");
+    return String(value);
+  }
+
+  if (definition.type === "number") {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) return null;
+      const parsed = Number(trimmed);
+      return Number.isFinite(parsed) ? parsed : value;
+    }
+    if (value === undefined || value === null) return null;
+    return value;
+  }
+
+  if (definition.type === "boolean") {
+    if (value === undefined || value === null) {
+      return definition.required ? false : null;
+    }
+    if (typeof value === "boolean") return value;
+    if (typeof value === "string") {
+      const lowered = value.trim().toLowerCase();
+      if (lowered === "true") return true;
+      if (lowered === "false") return false;
+      return value;
+    }
+    return value;
+  }
+
+  if (definition.type === "enum") {
+    if (value === undefined || value === null) return "";
+    return String(value);
+  }
+
+  if (definition.type === "string[]") {
+    if (Array.isArray(value)) return value.map((entry) => String(entry));
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed ? [trimmed] : [];
+    }
+    return [];
+  }
+
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Build model
+// ---------------------------------------------------------------------------
+
+function buildPrefsSection(
+  sectionDef: PrefsSectionDefinition,
+  config: Record<string, unknown>,
+): ConfigSection {
+  const fields: ConfigField[] = getPrefsFieldDefinitionsForSection(
+    sectionDef.key,
+  ).map((fieldDef) => ({
+    key: fieldDef.key,
+    label: fieldDef.label,
+    path: fieldDef.path,
+    type: fieldDef.type,
+    value: coerceFieldValue(readPath(config, fieldDef.path), fieldDef),
+    required: !!fieldDef.required,
+    description: fieldDef.description,
+    ...(fieldDef.enumValues ? { enumValues: [...fieldDef.enumValues] } : {}),
+  }));
+
+  return {
+    key: sectionDef.key as ConfigSectionKey,
+    label: sectionDef.label,
+    description: sectionDef.description,
+    fields,
+  };
+}
+
+/**
+ * Build a `ConfigEditorModel` from a parsed YAML config object.
+ *
+ * The returned model has 8 sections covering all `KataPreferences` fields.
+ * The `workflow` field is populated with the config object; `raw` and `body`
+ * are set to empty strings and should be populated by the parser (T03).
+ */
+export function buildPreferencesModel(
+  config: Record<string, unknown>,
+): ConfigEditorModel {
+  const sections: ConfigSection[] = PREFS_SECTION_DEFINITIONS.map(
+    (sectionDef) => buildPrefsSection(sectionDef, config),
+  );
+
+  const workflow: WorkflowFrontmatter = {
+    config,
+    raw: "",
+    body: "",
+  };
+
+  return { sections, workflow };
+}

--- a/apps/cli/src/resources/extensions/kata/prefs-parser.ts
+++ b/apps/cli/src/resources/extensions/kata/prefs-parser.ts
@@ -1,0 +1,114 @@
+/**
+ * Preferences file parser.
+ *
+ * Extracts YAML frontmatter from `.kata/preferences.md`, parses it with
+ * js-yaml, and builds a `ConfigEditorModel` via `buildPreferencesModel`.
+ */
+
+import { load, type YAMLException } from "js-yaml";
+import type { ConfigEditorModel, WorkflowFrontmatter } from "../symphony/config-model.js";
+import { buildPreferencesModel } from "./prefs-model.js";
+
+// ---------------------------------------------------------------------------
+// Error class
+// ---------------------------------------------------------------------------
+
+export class PreferencesParseError extends Error {
+  readonly line?: number;
+
+  constructor(message: string, line?: number) {
+    super(message);
+    this.name = "PreferencesParseError";
+    this.line = line;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+export interface ParsedPreferencesFile {
+  model: ConfigEditorModel;
+  body: string;
+}
+
+/**
+ * Parse a `preferences.md` file content into a `ConfigEditorModel` and body.
+ *
+ * Extracts `---` delimited YAML frontmatter, parses it, builds the field
+ * model, and returns both the model and the markdown body below the
+ * closing `---`.
+ *
+ * Edge cases handled:
+ * - BOM prefix (stripped)
+ * - CRLF line endings (preserved in body, normalized for YAML parsing)
+ * - Empty frontmatter (`---\n---`) → empty config
+ * - Missing frontmatter → error
+ */
+export function parsePreferencesFile(content: string): ParsedPreferencesFile {
+  // Strip BOM
+  const stripped = content.startsWith("\uFEFF") ? content.slice(1) : content;
+
+  // Match frontmatter: must start with --- on the first line
+  const match = stripped.match(
+    /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/,
+  );
+
+  if (!match) {
+    throw new PreferencesParseError(
+      "preferences.md must begin with YAML frontmatter delimited by ---",
+    );
+  }
+
+  const rawFrontmatter = match[1];
+  const body = stripped.slice(match[0].length);
+
+  const config = parseYamlConfig(rawFrontmatter);
+
+  const model = buildPreferencesModel(config);
+
+  // Populate the workflow field with raw frontmatter and body
+  const workflow: WorkflowFrontmatter = {
+    config,
+    raw: rawFrontmatter,
+    body,
+  };
+  model.workflow = workflow;
+
+  return { model, body };
+}
+
+function parseYamlConfig(frontmatter: string): Record<string, unknown> {
+  // Empty frontmatter
+  const trimmed = frontmatter.trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  try {
+    const parsed = load(frontmatter) ?? {};
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    throw new PreferencesParseError(
+      "YAML frontmatter must parse to an object at the top level",
+    );
+  } catch (error) {
+    if (error instanceof PreferencesParseError) {
+      throw error;
+    }
+
+    const yamlError = error as YAMLException & {
+      mark?: { line?: number };
+      message?: string;
+    };
+
+    const line =
+      typeof yamlError.mark?.line === "number"
+        ? yamlError.mark.line + 1
+        : undefined;
+    const message = yamlError.message ?? "Failed to parse YAML frontmatter";
+
+    throw new PreferencesParseError(message, line);
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/prefs-parser.ts
+++ b/apps/cli/src/resources/extensions/kata/prefs-parser.ts
@@ -42,7 +42,7 @@ export interface ParsedPreferencesFile {
  * Edge cases handled:
  * - BOM prefix (stripped)
  * - CRLF line endings (preserved in body, normalized for YAML parsing)
- * - Empty frontmatter (`---\n---`) → empty config
+ * - Empty frontmatter (`---\n\n---`, blank line between delimiters) → empty config
  * - Missing frontmatter → error
  */
 export function parsePreferencesFile(content: string): ParsedPreferencesFile {

--- a/apps/cli/src/resources/extensions/kata/prefs-writer.ts
+++ b/apps/cli/src/resources/extensions/kata/prefs-writer.ts
@@ -1,0 +1,202 @@
+/**
+ * Preferences file writer.
+ *
+ * Serializes a `ConfigEditorModel` back to YAML frontmatter + markdown body.
+ * Pairs with `prefs-parser.ts` for round-trip preservation.
+ */
+
+import { dump } from "js-yaml";
+import { cloneConfig, type ConfigEditorModel, type ConfigField } from "../symphony/config-model.js";
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+function setPath(
+  root: Record<string, unknown>,
+  path: string[],
+  value: unknown,
+): void {
+  if (path.length === 0) return;
+
+  let current: Record<string, unknown> = root;
+  for (let i = 0; i < path.length - 1; i++) {
+    const segment = path[i];
+    const next = current[segment];
+    if (!next || typeof next !== "object" || Array.isArray(next)) {
+      current[segment] = {};
+    }
+    current = current[segment] as Record<string, unknown>;
+  }
+  current[path[path.length - 1]] = value;
+}
+
+function deletePath(root: Record<string, unknown>, path: string[]): void {
+  if (path.length === 0) return;
+
+  const trail: Array<{ node: Record<string, unknown>; key: string }> = [];
+  let current: Record<string, unknown> = root;
+
+  for (let i = 0; i < path.length - 1; i++) {
+    const segment = path[i];
+    const next = current[segment];
+    if (!next || typeof next !== "object" || Array.isArray(next)) return;
+    trail.push({ node: current, key: segment });
+    current = next as Record<string, unknown>;
+  }
+
+  delete current[path[path.length - 1]];
+
+  // Clean up empty parent objects
+  for (let i = trail.length - 1; i >= 0; i--) {
+    const { node, key } = trail[i];
+    const candidate = node[key];
+    if (
+      candidate &&
+      typeof candidate === "object" &&
+      !Array.isArray(candidate) &&
+      Object.keys(candidate as Record<string, unknown>).length === 0
+    ) {
+      delete node[key];
+      continue;
+    }
+    break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Value normalization
+// ---------------------------------------------------------------------------
+
+function normalizeFieldValueForWrite(field: ConfigField): unknown {
+  if (field.type === "string" || field.type === "enum") {
+    const text = typeof field.value === "string" ? field.value.trim() : "";
+    if (!text && !field.required) return undefined;
+    return text;
+  }
+
+  if (field.type === "number") {
+    if (field.value === null || field.value === undefined || field.value === "") {
+      return undefined;
+    }
+    if (typeof field.value === "number" && Number.isFinite(field.value)) {
+      return field.value;
+    }
+    if (typeof field.value === "string") {
+      const trimmed = field.value.trim();
+      if (trimmed.length === 0) return undefined;
+      const parsed = Number(trimmed);
+      return Number.isFinite(parsed) ? parsed : field.value;
+    }
+    return field.value;
+  }
+
+  if (field.type === "boolean") {
+    if (field.value === null || field.value === undefined || field.value === "") {
+      return field.required ? false : undefined;
+    }
+    if (typeof field.value === "boolean") return field.value;
+    if (typeof field.value === "string") {
+      const lowered = field.value.trim().toLowerCase();
+      if (lowered === "true") return true;
+      if (lowered === "false") return false;
+      return field.value;
+    }
+    return field.value;
+  }
+
+  if (field.type === "string[]") {
+    const values = Array.isArray(field.value)
+      ? field.value
+      : typeof field.value === "string"
+        ? field.value
+            .split(/\r?\n/)
+            .map((entry: string) => entry.trim())
+            .filter(Boolean)
+        : [];
+
+    const normalized = values
+      .map((entry: unknown) => String(entry).trim())
+      .filter(Boolean);
+
+    if (normalized.length === 0 && !field.required) return undefined;
+    return normalized;
+  }
+
+  return field.value;
+}
+
+// ---------------------------------------------------------------------------
+// Apply model to config
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply model field values back to a config object.
+ * Returns a new config object with all field values written to their paths.
+ */
+export function applyPrefsModelToConfig(
+  model: ConfigEditorModel,
+  baseConfig?: Record<string, unknown>,
+): Record<string, unknown> {
+  const nextConfig = baseConfig
+    ? cloneConfig(baseConfig)
+    : cloneConfig(model.workflow.config);
+
+  for (const section of model.sections) {
+    for (const field of section.fields) {
+      const value = normalizeFieldValueForWrite(field);
+      if (value === undefined) {
+        deletePath(nextConfig, field.path);
+      } else {
+        setPath(nextConfig, field.path, value);
+      }
+    }
+  }
+
+  return nextConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a config object to YAML frontmatter string (without `---` delimiters).
+ * Produces trailing newline.
+ */
+function serializePrefsYaml(config: Record<string, unknown>): string {
+  // For empty config, return empty string (no YAML to write)
+  if (Object.keys(config).length === 0) return "";
+
+  const serialized = dump(config, {
+    noRefs: true,
+    lineWidth: -1,
+    quotingType: "'",
+    forceQuotes: false,
+  });
+
+  return serialized.endsWith("\n") ? serialized : `${serialized}\n`;
+}
+
+/**
+ * Serialize a `ConfigEditorModel` back to a complete `preferences.md` file.
+ *
+ * @param model - The model with current field values.
+ * @param body - The markdown body to append after the frontmatter.
+ * @returns The full file content: `---\n{yaml}\n---\n{body}`.
+ */
+export function writePreferencesFile(
+  model: ConfigEditorModel,
+  body: string,
+): string {
+  const config = applyPrefsModelToConfig(model);
+  const yaml = serializePrefsYaml(config);
+
+  // Reassemble: ---\n{yaml}---\n{body}
+  // When yaml is empty (all fields unset), produce ---\n\n---
+  if (!yaml) {
+    return `---\n\n---\n${body}`;
+  }
+
+  return `---\n${yaml}---\n${body}`;
+}

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-model.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-model.vitest.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPreferencesModel,
+  PREFS_FIELD_DEFINITIONS,
+  PREFS_SECTION_DEFINITIONS,
+  getPrefsFieldDefinitionsForSection,
+} from "../prefs-model.js";
+
+// ---------------------------------------------------------------------------
+// All flat and nested keys from KataPreferences that should be represented
+// ---------------------------------------------------------------------------
+
+const EXPECTED_PREFS_KEYS = [
+  // General
+  "version",
+  "uat_dispatch",
+  "budget_ceiling",
+  // Workflow
+  "workflow.mode",
+  // Linear
+  "linear.teamKey",
+  "linear.projectSlug",
+  "linear.teamId",
+  "linear.projectId",
+  // PR
+  "pr.enabled",
+  "pr.auto_create",
+  "pr.base_branch",
+  "pr.review_on_create",
+  "pr.linear_link",
+  // Models
+  "models.research",
+  "models.planning",
+  "models.execution",
+  "models.completion",
+  "models.review",
+  // Symphony
+  "symphony.url",
+  "symphony.workflow_path",
+  "symphony.console_position",
+  // Skills
+  "always_use_skills",
+  "prefer_skills",
+  "avoid_skills",
+  "skill_rules",
+  "custom_instructions",
+  "skill_discovery",
+  // Auto Supervisor
+  "auto_supervisor.model",
+  "auto_supervisor.soft_timeout_minutes",
+  "auto_supervisor.idle_timeout_minutes",
+  "auto_supervisor.hard_timeout_minutes",
+];
+
+describe("PREFS_SECTION_DEFINITIONS", () => {
+  it("contains exactly 8 sections", () => {
+    expect(PREFS_SECTION_DEFINITIONS).toHaveLength(8);
+  });
+
+  it("has all expected section keys", () => {
+    const keys = PREFS_SECTION_DEFINITIONS.map((s) => s.key);
+    expect(keys).toEqual([
+      "general",
+      "workflow",
+      "linear",
+      "pr",
+      "models",
+      "symphony",
+      "skills",
+      "auto_supervisor",
+    ]);
+  });
+
+  it("every section has a label and description", () => {
+    for (const section of PREFS_SECTION_DEFINITIONS) {
+      expect(section.label).toBeTruthy();
+      expect(section.description).toBeTruthy();
+    }
+  });
+});
+
+describe("PREFS_FIELD_DEFINITIONS", () => {
+  it("covers every KataPreferences key", () => {
+    const fieldPaths = PREFS_FIELD_DEFINITIONS.map((f) => f.path.join("."));
+    for (const expectedKey of EXPECTED_PREFS_KEYS) {
+      expect(fieldPaths).toContain(expectedKey);
+    }
+  });
+
+  it("every field belongs to a valid section", () => {
+    const validSections = new Set(
+      PREFS_SECTION_DEFINITIONS.map((s) => s.key),
+    );
+    for (const field of PREFS_FIELD_DEFINITIONS) {
+      expect(validSections.has(field.section)).toBe(true);
+    }
+  });
+
+  it("getPrefsFieldDefinitionsForSection returns the right fields", () => {
+    const prFields = getPrefsFieldDefinitionsForSection("pr");
+    expect(prFields.map((f) => f.key)).toEqual([
+      "enabled",
+      "auto_create",
+      "base_branch",
+      "review_on_create",
+      "linear_link",
+    ]);
+  });
+});
+
+describe("field types", () => {
+  function findField(pathStr: string) {
+    return PREFS_FIELD_DEFINITIONS.find((f) => f.path.join(".") === pathStr);
+  }
+
+  it("pr.enabled is boolean", () => {
+    expect(findField("pr.enabled")?.type).toBe("boolean");
+  });
+
+  it("models.research is string", () => {
+    expect(findField("models.research")?.type).toBe("string");
+  });
+
+  it("workflow.mode is enum with 'linear'", () => {
+    const f = findField("workflow.mode");
+    expect(f?.type).toBe("enum");
+    expect(f?.enumValues).toEqual(["linear"]);
+  });
+
+  it("skill_discovery is enum with auto/suggest/off", () => {
+    const f = findField("skill_discovery");
+    expect(f?.type).toBe("enum");
+    expect(f?.enumValues).toEqual(["auto", "suggest", "off"]);
+  });
+
+  it("symphony.console_position is enum", () => {
+    const f = findField("symphony.console_position");
+    expect(f?.type).toBe("enum");
+    expect(f?.enumValues).toEqual(["below-output", "above-status"]);
+  });
+
+  it("always_use_skills is string[]", () => {
+    expect(findField("always_use_skills")?.type).toBe("string[]");
+  });
+
+  it("skill_rules is string[]", () => {
+    expect(findField("skill_rules")?.type).toBe("string[]");
+  });
+
+  it("custom_instructions is string[]", () => {
+    expect(findField("custom_instructions")?.type).toBe("string[]");
+  });
+
+  it("version is number", () => {
+    expect(findField("version")?.type).toBe("number");
+  });
+
+  it("auto_supervisor.soft_timeout_minutes is number", () => {
+    expect(findField("auto_supervisor.soft_timeout_minutes")?.type).toBe(
+      "number",
+    );
+  });
+});
+
+describe("buildPreferencesModel", () => {
+  it("returns a model with 8 sections from empty config", () => {
+    const model = buildPreferencesModel({});
+    expect(model.sections).toHaveLength(8);
+    expect(model.sections.map((s) => s.key)).toEqual([
+      "general",
+      "workflow",
+      "linear",
+      "pr",
+      "models",
+      "symphony",
+      "skills",
+      "auto_supervisor",
+    ]);
+  });
+
+  it("populates values from config", () => {
+    const config = {
+      version: 1,
+      uat_dispatch: true,
+      budget_ceiling: 50,
+      workflow: { mode: "linear" },
+      linear: { teamKey: "KAT", projectSlug: "abc123" },
+      pr: { enabled: true, auto_create: false, base_branch: "main" },
+      models: { research: "claude-sonnet-4-6", planning: "claude-opus-4-6" },
+      symphony: { url: "http://localhost:8080", console_position: "below-output" },
+      always_use_skills: ["skill-a", "skill-b"],
+      prefer_skills: ["skill-c"],
+      avoid_skills: [],
+      skill_discovery: "auto",
+      custom_instructions: ["Do X"],
+      auto_supervisor: { model: "claude-sonnet-4-6", soft_timeout_minutes: 15 },
+    };
+
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+
+    // Check General section
+    const general = model.sections.find((s) => s.key === "general")!;
+    expect(general.fields.find((f) => f.key === "version")?.value).toBe(1);
+    expect(general.fields.find((f) => f.key === "uat_dispatch")?.value).toBe(true);
+    expect(general.fields.find((f) => f.key === "budget_ceiling")?.value).toBe(50);
+
+    // Check Workflow section
+    const workflow = model.sections.find((s) => s.key === "workflow")!;
+    expect(workflow.fields.find((f) => f.key === "mode")?.value).toBe("linear");
+
+    // Check Linear section
+    const linear = model.sections.find((s) => s.key === "linear")!;
+    expect(linear.fields.find((f) => f.key === "teamKey")?.value).toBe("KAT");
+    expect(linear.fields.find((f) => f.key === "projectSlug")?.value).toBe("abc123");
+
+    // Check PR section
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    expect(pr.fields.find((f) => f.key === "enabled")?.value).toBe(true);
+    expect(pr.fields.find((f) => f.key === "auto_create")?.value).toBe(false);
+    expect(pr.fields.find((f) => f.key === "base_branch")?.value).toBe("main");
+
+    // Check Models section
+    const models = model.sections.find((s) => s.key === "models")!;
+    expect(models.fields.find((f) => f.key === "research")?.value).toBe(
+      "claude-sonnet-4-6",
+    );
+    expect(models.fields.find((f) => f.key === "planning")?.value).toBe(
+      "claude-opus-4-6",
+    );
+
+    // Check Symphony section
+    const symphony = model.sections.find((s) => s.key === "symphony")!;
+    expect(symphony.fields.find((f) => f.key === "url")?.value).toBe(
+      "http://localhost:8080",
+    );
+    expect(
+      symphony.fields.find((f) => f.key === "console_position")?.value,
+    ).toBe("below-output");
+
+    // Check Skills section
+    const skills = model.sections.find((s) => s.key === "skills")!;
+    expect(
+      skills.fields.find((f) => f.key === "always_use_skills")?.value,
+    ).toEqual(["skill-a", "skill-b"]);
+    expect(skills.fields.find((f) => f.key === "prefer_skills")?.value).toEqual(
+      ["skill-c"],
+    );
+    expect(skills.fields.find((f) => f.key === "avoid_skills")?.value).toEqual(
+      [],
+    );
+    expect(
+      skills.fields.find((f) => f.key === "custom_instructions")?.value,
+    ).toEqual(["Do X"]);
+    expect(
+      skills.fields.find((f) => f.key === "skill_discovery")?.value,
+    ).toBe("auto");
+
+    // Check Auto Supervisor section
+    const autoSupervisor = model.sections.find(
+      (s) => s.key === "auto_supervisor",
+    )!;
+    expect(autoSupervisor.fields.find((f) => f.key === "model")?.value).toBe(
+      "claude-sonnet-4-6",
+    );
+    expect(
+      autoSupervisor.fields.find((f) => f.key === "soft_timeout_minutes")
+        ?.value,
+    ).toBe(15);
+  });
+
+  it("defaults to empty/null for missing config values", () => {
+    const model = buildPreferencesModel({});
+
+    const general = model.sections.find((s) => s.key === "general")!;
+    expect(general.fields.find((f) => f.key === "version")?.value).toBeNull();
+    expect(general.fields.find((f) => f.key === "uat_dispatch")?.value).toBeNull();
+
+    const linear = model.sections.find((s) => s.key === "linear")!;
+    expect(linear.fields.find((f) => f.key === "teamKey")?.value).toBe("");
+
+    const skills = model.sections.find((s) => s.key === "skills")!;
+    expect(
+      skills.fields.find((f) => f.key === "always_use_skills")?.value,
+    ).toEqual([]);
+  });
+
+  it("has a workflow field with config reference", () => {
+    const config = { version: 1 };
+    const model = buildPreferencesModel(config);
+    expect(model.workflow.config).toBe(config);
+    expect(model.workflow.raw).toBe("");
+    expect(model.workflow.body).toBe("");
+  });
+
+  it("coerces string values from arrays", () => {
+    // When a string field receives an array, it joins with space
+    const config = { symphony: { url: ["a", "b"] } };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const symphony = model.sections.find((s) => s.key === "symphony")!;
+    expect(symphony.fields.find((f) => f.key === "url")?.value).toBe("a b");
+  });
+
+  it("coerces number from string", () => {
+    const config = { version: "2" };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const general = model.sections.find((s) => s.key === "general")!;
+    expect(general.fields.find((f) => f.key === "version")?.value).toBe(2);
+  });
+
+  it("returns null for empty string number", () => {
+    const config = { version: "" };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const general = model.sections.find((s) => s.key === "general")!;
+    expect(general.fields.find((f) => f.key === "version")?.value).toBeNull();
+  });
+
+  it("returns raw value for non-numeric string in number field", () => {
+    const config = { version: "abc" };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const general = model.sections.find((s) => s.key === "general")!;
+    expect(general.fields.find((f) => f.key === "version")?.value).toBe("abc");
+  });
+
+  it("returns raw value for unexpected type in number field", () => {
+    const config = { version: [1, 2] };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const general = model.sections.find((s) => s.key === "general")!;
+    expect(general.fields.find((f) => f.key === "version")?.value).toEqual([1, 2]);
+  });
+
+  it("coerces boolean from string 'true'/'false'", () => {
+    const config = { pr: { enabled: "true", auto_create: "false" } };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    expect(pr.fields.find((f) => f.key === "enabled")?.value).toBe(true);
+    expect(pr.fields.find((f) => f.key === "auto_create")?.value).toBe(false);
+  });
+
+  it("returns raw value for non-boolean string in boolean field", () => {
+    const config = { pr: { enabled: "maybe" } };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    expect(pr.fields.find((f) => f.key === "enabled")?.value).toBe("maybe");
+  });
+
+  it("returns raw value for unexpected type in boolean field", () => {
+    const config = { pr: { enabled: 42 } };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    expect(pr.fields.find((f) => f.key === "enabled")?.value).toBe(42);
+  });
+
+  it("coerces string[] from a single string", () => {
+    const config = { always_use_skills: "single-skill" };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const skills = model.sections.find((s) => s.key === "skills")!;
+    expect(
+      skills.fields.find((f) => f.key === "always_use_skills")?.value,
+    ).toEqual(["single-skill"]);
+  });
+
+  it("coerces string[] from empty string returns empty array", () => {
+    const config = { always_use_skills: "" };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const skills = model.sections.find((s) => s.key === "skills")!;
+    expect(
+      skills.fields.find((f) => f.key === "always_use_skills")?.value,
+    ).toEqual([]);
+  });
+
+  it("readPath returns undefined for non-object intermediate", () => {
+    const config = { linear: "not-an-object" };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const linear = model.sections.find((s) => s.key === "linear")!;
+    expect(linear.fields.find((f) => f.key === "teamKey")?.value).toBe("");
+  });
+
+  it("model sections are structurally compatible with ConfigEditorModel", () => {
+    const model = buildPreferencesModel({});
+    // Verify each section has the required shape
+    for (const section of model.sections) {
+      expect(typeof section.key).toBe("string");
+      expect(typeof section.label).toBe("string");
+      expect(typeof section.description).toBe("string");
+      expect(Array.isArray(section.fields)).toBe(true);
+      for (const field of section.fields) {
+        expect(typeof field.key).toBe("string");
+        expect(typeof field.label).toBe("string");
+        expect(Array.isArray(field.path)).toBe(true);
+        expect(typeof field.type).toBe("string");
+        expect(typeof field.required).toBe("boolean");
+        expect(typeof field.description).toBe("string");
+      }
+    }
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-parser.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-parser.vitest.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import { parsePreferencesFile, PreferencesParseError } from "../prefs-parser.js";
+import { writePreferencesFile } from "../prefs-writer.js";
+
+// ---------------------------------------------------------------------------
+// Realistic fixture
+// ---------------------------------------------------------------------------
+
+const REALISTIC_FIXTURE = `---
+version: 1
+workflow:
+  mode: linear
+linear:
+  teamKey: KAT
+  projectSlug: 459f9835e809
+pr:
+  enabled: true
+  auto_create: true
+  base_branch: main
+  review_on_create: false
+  linear_link: true
+models:
+  research: claude-sonnet-4-6
+  planning: claude-opus-4-6
+  execution: claude-sonnet-4-6
+  completion: claude-sonnet-4-6
+  review: claude-sonnet-4-6
+always_use_skills:
+  - skill-a
+  - skill-b
+prefer_skills:
+  - skill-c
+skill_discovery: auto
+symphony:
+  url: http://localhost:8080
+  console_position: below-output
+auto_supervisor:
+  model: claude-sonnet-4-6
+  soft_timeout_minutes: 20
+  idle_timeout_minutes: 10
+  hard_timeout_minutes: 30
+---
+# Kata Preferences
+
+This is the markdown body that should survive the round-trip unchanged.
+
+## Quick Start
+
+Some instructions here.
+`;
+
+const REALISTIC_BODY = `# Kata Preferences
+
+This is the markdown body that should survive the round-trip unchanged.
+
+## Quick Start
+
+Some instructions here.
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("parsePreferencesFile", () => {
+  it("parses a realistic preferences.md", () => {
+    const { model, body } = parsePreferencesFile(REALISTIC_FIXTURE);
+
+    expect(model.sections).toHaveLength(8);
+    expect(body).toBe(REALISTIC_BODY);
+
+    // Check workflow populated
+    expect(model.workflow.config).toBeTruthy();
+    expect(model.workflow.body).toBe(REALISTIC_BODY);
+    expect(model.workflow.raw).toBeTruthy();
+
+    // Spot-check values
+    const linear = model.sections.find((s) => s.key === "linear")!;
+    expect(linear.fields.find((f) => f.key === "teamKey")?.value).toBe("KAT");
+
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    expect(pr.fields.find((f) => f.key === "enabled")?.value).toBe(true);
+
+    const models = model.sections.find((s) => s.key === "models")!;
+    expect(models.fields.find((f) => f.key === "research")?.value).toBe(
+      "claude-sonnet-4-6",
+    );
+
+    const skills = model.sections.find((s) => s.key === "skills")!;
+    expect(
+      skills.fields.find((f) => f.key === "always_use_skills")?.value,
+    ).toEqual(["skill-a", "skill-b"]);
+  });
+
+  it("handles empty frontmatter", () => {
+    const content = `---
+
+---
+Some body here.
+`;
+    const { model, body } = parsePreferencesFile(content);
+
+    expect(model.sections).toHaveLength(8);
+    expect(body).toBe("Some body here.\n");
+
+    // All string fields default to ""
+    const linear = model.sections.find((s) => s.key === "linear")!;
+    expect(linear.fields.find((f) => f.key === "teamKey")?.value).toBe("");
+  });
+
+  it("handles missing optional fields", () => {
+    const content = `---
+version: 1
+---
+Body text.
+`;
+    const { model, body } = parsePreferencesFile(content);
+
+    expect(body).toBe("Body text.\n");
+
+    const general = model.sections.find((s) => s.key === "general")!;
+    expect(general.fields.find((f) => f.key === "version")?.value).toBe(1);
+
+    // Missing fields default properly
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    expect(pr.fields.find((f) => f.key === "enabled")?.value).toBeNull();
+  });
+
+  it("handles CRLF line endings", () => {
+    const content = "---\r\nversion: 1\r\n---\r\nBody with CRLF.\r\n";
+    const { model, body } = parsePreferencesFile(content);
+
+    const general = model.sections.find((s) => s.key === "general")!;
+    expect(general.fields.find((f) => f.key === "version")?.value).toBe(1);
+    // Body preserves CRLF
+    expect(body).toBe("Body with CRLF.\r\n");
+  });
+
+  it("handles BOM prefix", () => {
+    const content = "\uFEFF---\nversion: 1\n---\nBody.\n";
+    const { model, body } = parsePreferencesFile(content);
+
+    const general = model.sections.find((s) => s.key === "general")!;
+    expect(general.fields.find((f) => f.key === "version")?.value).toBe(1);
+    expect(body).toBe("Body.\n");
+  });
+
+  it("throws PreferencesParseError for missing frontmatter", () => {
+    expect(() => parsePreferencesFile("No frontmatter here")).toThrow(
+      PreferencesParseError,
+    );
+  });
+
+  it("throws PreferencesParseError for non-object YAML", () => {
+    const content = `---
+just a string
+---
+Body.
+`;
+    expect(() => parsePreferencesFile(content)).toThrow(PreferencesParseError);
+  });
+
+  it("throws PreferencesParseError with line number for malformed YAML", () => {
+    const content = `---
+version: 1
+bad: [
+  unterminated
+---
+Body.
+`;
+    try {
+      parsePreferencesFile(content);
+      expect.fail("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PreferencesParseError);
+      const pe = e as PreferencesParseError;
+      expect(pe.line).toBeDefined();
+      expect(typeof pe.line).toBe("number");
+    }
+  });
+});
+
+describe("round-trip preservation", () => {
+  it("parse → write produces identical frontmatter for realistic fixture", () => {
+    const { model, body } = parsePreferencesFile(REALISTIC_FIXTURE);
+    const output = writePreferencesFile(model, body);
+
+    // Re-parse the output
+    const { model: model2, body: body2 } = parsePreferencesFile(output);
+
+    // Body is identical
+    expect(body2).toBe(REALISTIC_BODY);
+
+    // All field values match between parses
+    for (let i = 0; i < model.sections.length; i++) {
+      const section1 = model.sections[i];
+      const section2 = model2.sections[i];
+      expect(section2.key).toBe(section1.key);
+      for (let j = 0; j < section1.fields.length; j++) {
+        expect(section2.fields[j].value).toEqual(section1.fields[j].value);
+      }
+    }
+  });
+
+  it("body is byte-identical after round-trip", () => {
+    const { model, body } = parsePreferencesFile(REALISTIC_FIXTURE);
+    const output = writePreferencesFile(model, body);
+    const { body: body2 } = parsePreferencesFile(output);
+    expect(body2).toBe(body);
+  });
+
+  it("parse(write(parse(content))) equals parse(content)", () => {
+    const parsed1 = parsePreferencesFile(REALISTIC_FIXTURE);
+    const written = writePreferencesFile(parsed1.model, parsed1.body);
+    const parsed2 = parsePreferencesFile(written);
+    const written2 = writePreferencesFile(parsed2.model, parsed2.body);
+    const parsed3 = parsePreferencesFile(written2);
+
+    // Compare all field values
+    for (let i = 0; i < parsed2.sections?.length ?? 0; i++) {
+      for (let j = 0; j < parsed2.model.sections[i].fields.length; j++) {
+        expect(parsed3.model.sections[i].fields[j].value).toEqual(
+          parsed2.model.sections[i].fields[j].value,
+        );
+      }
+    }
+    expect(parsed3.body).toBe(parsed2.body);
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-parser.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-parser.vitest.test.ts
@@ -217,7 +217,7 @@ describe("round-trip preservation", () => {
     const parsed3 = parsePreferencesFile(written2);
 
     // Compare all field values
-    for (let i = 0; i < parsed2.sections?.length ?? 0; i++) {
+    for (let i = 0; i < (parsed2.model.sections?.length ?? 0); i++) {
       for (let j = 0; j < parsed2.model.sections[i].fields.length; j++) {
         expect(parsed3.model.sections[i].fields[j].value).toEqual(
           parsed2.model.sections[i].fields[j].value,

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+import { buildPreferencesModel } from "../prefs-model.js";
+import { parsePreferencesFile } from "../prefs-parser.js";
+import {
+  applyPrefsModelToConfig,
+  writePreferencesFile,
+} from "../prefs-writer.js";
+
+describe("applyPrefsModelToConfig", () => {
+  it("writes populated values back to nested config paths", () => {
+    const config = {
+      version: 1,
+      linear: { teamKey: "KAT", projectSlug: "abc" },
+      pr: { enabled: true, base_branch: "main" },
+    };
+
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const result = applyPrefsModelToConfig(model);
+
+    expect(result.version).toBe(1);
+    expect((result.linear as Record<string, unknown>).teamKey).toBe("KAT");
+    expect((result.linear as Record<string, unknown>).projectSlug).toBe("abc");
+    expect((result.pr as Record<string, unknown>).enabled).toBe(true);
+    expect((result.pr as Record<string, unknown>).base_branch).toBe("main");
+  });
+
+  it("omits unset/null fields from output", () => {
+    const model = buildPreferencesModel({});
+    const result = applyPrefsModelToConfig(model);
+
+    // Unset string fields should not appear
+    expect(result.linear).toBeUndefined();
+    expect(result.pr).toBeUndefined();
+    expect(result.models).toBeUndefined();
+    expect(result.symphony).toBeUndefined();
+    expect(result.version).toBeUndefined();
+    expect(result.always_use_skills).toBeUndefined();
+  });
+
+  it("serializes string[] fields as arrays", () => {
+    const config = {
+      always_use_skills: ["skill-a", "skill-b"],
+      custom_instructions: ["Do X", "Do Y"],
+    };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const result = applyPrefsModelToConfig(model);
+
+    expect(result.always_use_skills).toEqual(["skill-a", "skill-b"]);
+    expect(result.custom_instructions).toEqual(["Do X", "Do Y"]);
+  });
+});
+
+describe("writePreferencesFile", () => {
+  it("produces valid YAML frontmatter + body", () => {
+    const config = {
+      version: 1,
+      workflow: { mode: "linear" },
+      linear: { teamKey: "KAT" },
+    };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const body = "# My Preferences\n\nSome content.\n";
+    const output = writePreferencesFile(model, body);
+
+    expect(output.startsWith("---\n")).toBe(true);
+    expect(output).toContain("\n---\n");
+    expect(output.endsWith(body)).toBe(true);
+  });
+
+  it("nested objects are serialized correctly", () => {
+    const config = {
+      linear: { teamKey: "KAT", projectSlug: "abc123" },
+      pr: { enabled: true, auto_create: false },
+      models: { research: "claude-sonnet-4-6" },
+    };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const output = writePreferencesFile(model, "");
+
+    expect(output).toContain("linear:");
+    expect(output).toContain("teamKey: KAT");
+    expect(output).toContain("projectSlug: abc123");
+    expect(output).toContain("pr:");
+    expect(output).toContain("enabled: true");
+    expect(output).toContain("auto_create: false");
+    expect(output).toContain("models:");
+    expect(output).toContain("research: claude-sonnet-4-6");
+  });
+
+  it("string[] fields are formatted as YAML arrays", () => {
+    const config = {
+      always_use_skills: ["skill-a", "skill-b"],
+      prefer_skills: ["skill-c"],
+    };
+    const model = buildPreferencesModel(config as Record<string, unknown>);
+    const output = writePreferencesFile(model, "");
+
+    expect(output).toContain("always_use_skills:");
+    expect(output).toContain("- skill-a");
+    expect(output).toContain("- skill-b");
+    expect(output).toContain("prefer_skills:");
+    expect(output).toContain("- skill-c");
+  });
+
+  it("empty config produces minimal frontmatter", () => {
+    const model = buildPreferencesModel({});
+    const output = writePreferencesFile(model, "Body.\n");
+
+    // Should start with --- and have closing ---
+    expect(output).toMatch(/^---\n/);
+    expect(output).toContain("---\nBody.\n");
+  });
+
+  it("edit-then-write: changed value appears, others preserved", () => {
+    const fixture = `---
+version: 1
+workflow:
+  mode: linear
+linear:
+  teamKey: KAT
+  projectSlug: abc123
+pr:
+  enabled: true
+  base_branch: main
+models:
+  research: claude-sonnet-4-6
+---
+# Body content
+`;
+
+    const { model, body } = parsePreferencesFile(fixture);
+
+    // Change a value
+    const prSection = model.sections.find((s) => s.key === "pr")!;
+    const baseBranchField = prSection.fields.find(
+      (f) => f.key === "base_branch",
+    )!;
+    baseBranchField.value = "develop";
+
+    const output = writePreferencesFile(model, body);
+
+    // The changed value appears
+    expect(output).toContain("base_branch: develop");
+
+    // Other values preserved
+    expect(output).toContain("version: 1");
+    expect(output).toContain("teamKey: KAT");
+    expect(output).toContain("projectSlug: abc123");
+    expect(output).toContain("enabled: true");
+    expect(output).toContain("research: claude-sonnet-4-6");
+    expect(output).toContain("mode: linear");
+
+    // Body preserved
+    expect(output.endsWith("# Body content\n")).toBe(true);
+  });
+
+  it("edit-then-write: setting a new value adds it", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+
+    // Add a new value
+    const linear = model.sections.find((s) => s.key === "linear")!;
+    const teamKeyField = linear.fields.find((f) => f.key === "teamKey")!;
+    teamKeyField.value = "MYTEAM";
+
+    const output = writePreferencesFile(model, body);
+    expect(output).toContain("teamKey: MYTEAM");
+    expect(output).toContain("version: 1");
+  });
+
+  it("handles boolean fields with string values", () => {
+    const fixture = `---
+pr:
+  enabled: true
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    pr.fields.find((f) => f.key === "enabled")!.value = "true";
+    pr.fields.find((f) => f.key === "auto_create")!.value = "false";
+    const output = writePreferencesFile(model, body);
+    expect(output).toContain("enabled: true");
+    expect(output).toContain("auto_create: false");
+  });
+
+  it("handles number fields with string values", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const general = model.sections.find((s) => s.key === "general")!;
+    general.fields.find((f) => f.key === "version")!.value = "2";
+    const output = writePreferencesFile(model, body);
+    expect(output).toContain("version: 2");
+  });
+
+  it("handles empty number string by omitting the field", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const general = model.sections.find((s) => s.key === "general")!;
+    general.fields.find((f) => f.key === "version")!.value = "";
+    const output = writePreferencesFile(model, body);
+    expect(output).not.toContain("version");
+  });
+
+  it("handles null boolean by omitting", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    pr.fields.find((f) => f.key === "enabled")!.value = null;
+    const output = writePreferencesFile(model, body);
+    expect(output).not.toContain("enabled");
+  });
+
+  it("handles empty string boolean by omitting", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    pr.fields.find((f) => f.key === "enabled")!.value = "";
+    const output = writePreferencesFile(model, body);
+    expect(output).not.toContain("enabled");
+  });
+
+  it("handles string[] from newline-delimited string", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const skills = model.sections.find((s) => s.key === "skills")!;
+    skills.fields.find((f) => f.key === "always_use_skills")!.value =
+      "skill-a\nskill-b\n";
+    const output = writePreferencesFile(model, body);
+    expect(output).toContain("- skill-a");
+    expect(output).toContain("- skill-b");
+  });
+
+  it("handles non-array, non-string string[] value", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const skills = model.sections.find((s) => s.key === "skills")!;
+    skills.fields.find((f) => f.key === "always_use_skills")!.value = 42;
+    const output = writePreferencesFile(model, body);
+    // 42 is not a string or array, so no skills written
+    expect(output).not.toContain("always_use_skills");
+  });
+
+  it("handles non-boolean, non-string boolean value passthrough", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    pr.fields.find((f) => f.key === "enabled")!.value = 42;
+    const output = writePreferencesFile(model, body);
+    // 42 is not a valid boolean, but it should be written as-is
+    expect(output).toContain("enabled: 42");
+  });
+
+  it("handles non-string boolean that isn't parseable", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const pr = model.sections.find((s) => s.key === "pr")!;
+    pr.fields.find((f) => f.key === "enabled")!.value = "maybe";
+    const output = writePreferencesFile(model, body);
+    // "maybe" is not true/false, so it gets written as the raw string
+    expect(output).toContain("enabled: maybe");
+  });
+
+  it("handles non-finite number string value", () => {
+    const fixture = `---
+version: 1
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+    const general = model.sections.find((s) => s.key === "general")!;
+    general.fields.find((f) => f.key === "version")!.value = "abc";
+    const output = writePreferencesFile(model, body);
+    expect(output).toContain("version: abc");
+  });
+
+  it("edit-then-write: clearing a value removes it", () => {
+    const fixture = `---
+version: 1
+linear:
+  teamKey: KAT
+---
+Body.
+`;
+    const { model, body } = parsePreferencesFile(fixture);
+
+    // Clear the value
+    const linear = model.sections.find((s) => s.key === "linear")!;
+    const teamKeyField = linear.fields.find((f) => f.key === "teamKey")!;
+    teamKeyField.value = "";
+
+    const output = writePreferencesFile(model, body);
+    // teamKey should be removed since it's optional and empty
+    expect(output).not.toContain("teamKey");
+    // linear section should be removed since it's empty
+    expect(output).not.toContain("linear:");
+  });
+});

--- a/apps/cli/src/resources/extensions/symphony/config-model.ts
+++ b/apps/cli/src/resources/extensions/symphony/config-model.ts
@@ -1,6 +1,6 @@
 export type ConfigFieldType = "string" | "number" | "boolean" | "enum" | "string[]";
 
-export type ConfigSectionKey =
+export type SymphonySectionKey =
   | "tracker"
   | "workspace"
   | "agent"
@@ -10,6 +10,8 @@ export type ConfigSectionKey =
   | "server"
   | "hooks"
   | "worker";
+
+export type ConfigSectionKey = SymphonySectionKey | (string & {});
 
 export interface ConfigField<T = unknown> {
   key: string;
@@ -72,18 +74,20 @@ export interface WorkflowFrontmatter {
   body: string;
 }
 
+export type SymphonySections = [
+  TrackerSection,
+  WorkspaceSection,
+  AgentSection,
+  KataAgentSection,
+  NotificationsSection,
+  PromptsSection,
+  ServerSection,
+  HooksSection,
+  WorkerSection,
+];
+
 export interface ConfigEditorModel {
-  sections: [
-    TrackerSection,
-    WorkspaceSection,
-    AgentSection,
-    KataAgentSection,
-    NotificationsSection,
-    PromptsSection,
-    ServerSection,
-    HooksSection,
-    WorkerSection,
-  ];
+  sections: ConfigSection[];
   workflow: WorkflowFrontmatter;
 }
 

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
       include: [
         'src/resources/extensions/kata/auto-dispatch.ts',
         'src/resources/extensions/kata/gitignore.ts',
+        'src/resources/extensions/kata/prefs-model.ts',
+        'src/resources/extensions/kata/prefs-parser.ts',
+        'src/resources/extensions/kata/prefs-writer.ts',
         'src/resources/extensions/kata/prompt-loader.ts',
         'src/resources/extensions/pr-lifecycle/pr-runner.ts',
         'src/resources/extensions/pr-lifecycle/pr-body-composer.ts',


### PR DESCRIPTION
## Summary

Build the data layer for the preferences config editor — field model definitions, YAML frontmatter parser, and writer — producing a `ConfigEditorModel` compatible with Symphony's `ConfigEditor`.

## Changes

### T01: Generalize ConfigEditorModel types for reuse (KAT-1870)
- Widen `ConfigSectionKey` to accept arbitrary strings via `SymphonySectionKey | (string & {})`
- Change `ConfigEditorModel.sections` from Symphony-specific 9-element tuple to `ConfigSection[]`
- All 120 existing Symphony tests pass unchanged

### T02: Build preferences field model (KAT-1871)
- New `prefs-model.ts`: 8 sections (General, Workflow, Linear, PR, Models, Symphony, Skills, Auto Supervisor) covering all `KataPreferences` fields
- `buildPreferencesModel(config)` returns `ConfigEditorModel` with populated values
- All field types covered: string, number, boolean, enum, string[]
- Complex fields (`skill_rules`, `custom_instructions`) represented as `string[]` per D021

### T03: Build preferences parser and writer (KAT-1872)
- New `prefs-parser.ts`: `parsePreferencesFile(content)` extracts YAML frontmatter, returns `{ model, body }`
  - Handles BOM, CRLF, empty frontmatter edge cases
  - `PreferencesParseError` with line numbers for structured error reporting
- New `prefs-writer.ts`: `writePreferencesFile(model, body)` serializes back to YAML + body
  - Round-trip preservation: parse → write without edits produces identical YAML
  - Markdown body survives round-trip byte-identical
- Updated `vitest.config.ts` coverage include with new source files

## Verification

- `npx tsc --noEmit` — clean
- 63 new Vitest tests (32 model + 11 parser + 20 writer) all passing
- 120 existing Symphony tests pass unchanged  
- Coverage thresholds met (lines 90%+, branches 80%+)

## Linear

Closes KAT-1870
Closes KAT-1871
Closes KAT-1872
Closes KAT-1868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preferences configuration model with predefined sections and field definitions
  * Implemented preferences file parser supporting YAML frontmatter in markdown format
  * Implemented preferences file writer for serializing configuration changes back to markdown
  * Enhanced configuration model to support extensible section structures

* **Tests**
  * Added comprehensive test coverage for preferences model, parser, and writer
  * Included round-trip tests ensuring configuration preservation across parse-write cycles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the data layer for the Kata preferences config editor: a field model (`prefs-model.ts`) covering all `KataPreferences` fields across 8 sections, a YAML frontmatter parser (`prefs-parser.ts`), and a writer (`prefs-writer.ts`) that together provide a full parse→edit→write round-trip. The Symphony `config-model.ts` is also lightly generalised to allow the new prefs layer to share its types. The implementation is well-structured and the test coverage is broad.

**Key findings:**
- **Dead assertions in round-trip test** (`prefs-parser.vitest.test.ts:220`) — The outer `for` loop in the triple round-trip test accesses `parsed2.sections` instead of `parsed2.model.sections`. Because `sections` is not a property of `ParsedPreferencesFile`, the loop condition is `i < undefined` which is immediately `false`, so all field-comparison `expect(...)` calls inside are unreachable dead code. The test passes but provides no coverage of idempotent field values across the three parse cycles.
- **Misleading doc comment** (`prefs-parser.ts:46`) — The JSDoc states `---\
---` (no blank line) produces an empty config, but the regex requires at least one `\
` between the delimiters, so that exact form would throw. The test correctly uses `---\
\
---`; only the comment needs updating.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the dead test loop — the production code is correct, but the broken assertion reduces confidence in round-trip correctness.

One P1 finding: the triple round-trip test's outer loop never executes due to `parsed2.sections` instead of `parsed2.model.sections`, leaving field-value idempotency assertions as dead code. The P2 doc-comment inaccuracy is minor. Production logic in prefs-model, prefs-parser, and prefs-writer all look correct and well-tested by the other 60+ assertions.

apps/cli/src/resources/extensions/kata/tests/prefs-parser.vitest.test.ts — the triple round-trip test needs `parsed2.model.sections` instead of `parsed2.sections`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/prefs-model.ts | New file: 8-section field model + `buildPreferencesModel()` with thorough coercion for all field types; clean and well-structured. |
| apps/cli/src/resources/extensions/kata/prefs-parser.ts | New file: YAML frontmatter parser with BOM/CRLF handling and structured error reporting; one doc-comment inaccuracy about `---\n---` edge case. |
| apps/cli/src/resources/extensions/kata/prefs-writer.ts | New file: round-trip serializer with correct path-set/delete helpers and empty-object cleanup; logic is sound. |
| apps/cli/src/resources/extensions/kata/tests/prefs-parser.vitest.test.ts | Test file: line 220 has `parsed2.sections` (undefined on `ParsedPreferencesFile`) causing the triple round-trip field-comparison loop to never execute — assertions are dead code. |
| apps/cli/src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts | Comprehensive writer tests covering all field types, edit-then-write flows, and edge cases; no issues found. |
| apps/cli/src/resources/extensions/kata/tests/prefs-model.vitest.test.ts | Model tests cover section/field completeness, coercion, defaults, and path reading; solid coverage. |
| apps/cli/src/resources/extensions/symphony/config-model.ts | Generalised `ConfigSectionKey` and widened `sections` from 9-tuple to `ConfigSection[]` — minimal, backward-compatible change. |
| apps/cli/vitest.config.ts | New source files added to coverage `include` list; no issues. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant F as preferences.md
    participant P as prefs-parser.ts
    participant M as prefs-model.ts
    participant W as prefs-writer.ts

    F->>P: parsePreferencesFile(content)
    P->>P: strip BOM / match --- regex
    P->>P: parseYamlConfig(rawFrontmatter)
    P->>M: buildPreferencesModel(config)
    M-->>P: ConfigEditorModel (sections + placeholder workflow)
    P->>P: populate model.workflow {config, raw, body}
    P-->>F: { model, body }

    Note over F,W: User edits field values in ConfigEditor

    F->>W: writePreferencesFile(model, body)
    W->>W: applyPrefsModelToConfig(model)
    W->>W: normalizeFieldValueForWrite per field
    W->>W: setPath / deletePath on cloned config
    W->>W: serializePrefsYaml(config) via js-yaml dump
    W-->>F: ---\n{yaml}---\n{body}
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/tests/prefs-parser.vitest.test.ts
Line: 220-227

Comment:
**Dead loop — `parsed2.sections` doesn't exist on `ParsedPreferencesFile`**

`parsed2` is typed as `ParsedPreferencesFile`, whose only properties are `model` and `body`. Accessing `parsed2.sections` always returns `undefined`, so `i < undefined` evaluates to `false` immediately and the outer `for` loop never executes. Every `expect(...)` inside it is unreachable dead code — the triple round-trip test only actually asserts `parsed3.body === parsed2.body`.

The property should be `parsed2.model.sections`. Additionally, the `??` lacks parentheses around the comparison: `i < x ?? 0` parses as `(i < x) ?? 0`, which never falls back to `0` because a boolean is never nullish — the intended guard needs explicit grouping.

```suggestion
  for (let i = 0; i < (parsed2.model.sections?.length ?? 0); i++) {
    for (let j = 0; j < parsed2.model.sections[i].fields.length; j++) {
      expect(parsed3.model.sections[i].fields[j].value).toEqual(
        parsed2.model.sections[i].fields[j].value,
      );
    }
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/prefs-parser.ts
Line: 44-46

Comment:
**Inaccurate doc comment about empty-frontmatter edge case**

The comment documents: `- Empty frontmatter (---\n---) → empty config`. However the regex `^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*` requires **at least one newline before the closing delimiter** — it can never match `---\n---` because after consuming the opening `---\n` there is no `\n` remaining before `---`. The actual supported form is `---\n\n---` (blank line between delimiters), which is correctly tested in the suite.

The comment should be corrected to avoid confusion:

```suggestion
 * - Empty frontmatter (`---\n\n---`, blank line between delimiters) → empty config
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add preferences model, parser..."](https://github.com/gannonh/kata/commit/7ef1e4cdb4f54af8be1f1590e6c27fbc55cf4e43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26702784)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->