### PR TITLE
feat(cli): preferences validator and ConfigEditor integration (KAT-1880)

### DIFF
--- a/apps/cli/src/resources/extensions/kata/prefs-validator.ts
+++ b/apps/cli/src/resources/extensions/kata/prefs-validator.ts
@@ -8,13 +8,12 @@
  */
 
 import type { ConfigEditorModel } from "../symphony/config-model.js";
-import { PREFS_FIELD_DEFINITIONS } from "./prefs-model.js";
+import { PREFS_FIELD_DEFINITIONS, readPath } from "./prefs-model.js";
 import { applyPrefsModelToConfig } from "./prefs-writer.js";
-import { readPath } from "./prefs-model.js";
-
-// Re-export ConfigValidationIssue so consumers don't need a separate import
-export type { ConfigValidationIssue } from "../symphony/config-validator.js";
 import type { ConfigValidationIssue } from "../symphony/config-validator.js";
+
+// Re-export so consumers don't need a separate import
+export type { ConfigValidationIssue };
 
 // ---------------------------------------------------------------------------
 // Enum value set (same pattern as Symphony's ENUM_VALUE_SET)

--- a/apps/cli/src/resources/extensions/kata/prefs-validator.ts
+++ b/apps/cli/src/resources/extensions/kata/prefs-validator.ts
@@ -1,0 +1,146 @@
+/**
+ * Preferences field validator.
+ *
+ * Validates a `ConfigEditorModel` produced by the preferences parser,
+ * checking enum values, number types, and boolean types before the writer
+ * persists them. Returns `ConfigValidationIssue[]` matching Symphony's
+ * validator interface.
+ */
+
+import type { ConfigEditorModel } from "../symphony/config-model.js";
+import { PREFS_FIELD_DEFINITIONS } from "./prefs-model.js";
+import { applyPrefsModelToConfig } from "./prefs-writer.js";
+import { readPath } from "./prefs-model.js";
+
+// Re-export ConfigValidationIssue so consumers don't need a separate import
+export type { ConfigValidationIssue } from "../symphony/config-validator.js";
+import type { ConfigValidationIssue } from "../symphony/config-validator.js";
+
+// ---------------------------------------------------------------------------
+// Enum value set (same pattern as Symphony's ENUM_VALUE_SET)
+// ---------------------------------------------------------------------------
+
+const PREFS_ENUM_VALUE_SET = new Map(
+  PREFS_FIELD_DEFINITIONS.filter((field) => field.type === "enum").map((field) => [
+    field.path.join("."),
+    new Set(field.enumValues ?? []),
+  ]),
+);
+
+// ---------------------------------------------------------------------------
+// Number field paths
+// ---------------------------------------------------------------------------
+
+const NUMBER_FIELD_PATHS = PREFS_FIELD_DEFINITIONS.filter(
+  (field) => field.type === "number",
+).map((field) => ({
+  path: field.path,
+  dotPath: field.path.join("."),
+  label: field.label,
+}));
+
+// ---------------------------------------------------------------------------
+// Boolean field paths
+// ---------------------------------------------------------------------------
+
+const BOOLEAN_FIELD_PATHS = PREFS_FIELD_DEFINITIONS.filter(
+  (field) => field.type === "boolean",
+).map((field) => ({
+  path: field.path,
+  dotPath: field.path.join("."),
+  label: field.label,
+}));
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a preferences `ConfigEditorModel` and return issues found.
+ *
+ * Checks:
+ * 1. Enum fields have valid values (or are empty/unset).
+ * 2. Number fields are finite numbers and non-negative where applicable.
+ * 3. Boolean fields are actual booleans (not strings).
+ *
+ * Empty/unset optional fields are accepted gracefully.
+ * Returns an empty array when the model is fully valid.
+ */
+export function validatePreferencesModel(
+  model: ConfigEditorModel,
+): ConfigValidationIssue[] {
+  const issues: ConfigValidationIssue[] = [];
+  const config = applyPrefsModelToConfig(model);
+
+  assertEnumValues(config, issues);
+  assertNumberFields(config, issues);
+  assertBooleanFields(config, issues);
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// Assertion helpers
+// ---------------------------------------------------------------------------
+
+function assertEnumValues(
+  config: Record<string, unknown>,
+  issues: ConfigValidationIssue[],
+): void {
+  for (const [path, allowedValues] of PREFS_ENUM_VALUE_SET) {
+    const value = readPath(config, path.split("."));
+    // Accept empty/unset optional fields
+    if (value === undefined || value === null || value === "") continue;
+
+    if (typeof value !== "string" || !allowedValues.has(value)) {
+      issues.push({
+        path,
+        message: `${path} must be one of: ${Array.from(allowedValues).join(", ")}`,
+      });
+    }
+  }
+}
+
+function assertNumberFields(
+  config: Record<string, unknown>,
+  issues: ConfigValidationIssue[],
+): void {
+  for (const { path, dotPath } of NUMBER_FIELD_PATHS) {
+    const value = readPath(config, path);
+    // Accept empty/unset optional fields
+    if (value === undefined || value === null) continue;
+
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      issues.push({
+        path: dotPath,
+        message: `${dotPath} must be a valid number`,
+      });
+      continue;
+    }
+
+    if (value < 0) {
+      issues.push({
+        path: dotPath,
+        message: `${dotPath} must be non-negative`,
+      });
+    }
+  }
+}
+
+function assertBooleanFields(
+  config: Record<string, unknown>,
+  issues: ConfigValidationIssue[],
+): void {
+  for (const { path, dotPath } of BOOLEAN_FIELD_PATHS) {
+    const value = readPath(config, path);
+    // Accept empty/unset optional fields
+    if (value === undefined || value === null) continue;
+
+    if (typeof value !== "boolean") {
+      issues.push({
+        path: dotPath,
+        message: `${dotPath} must be a boolean (true or false)`,
+      });
+    }
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-integration.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-integration.vitest.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+import { parsePreferencesFile } from "../prefs-parser.js";
+import { writePreferencesFile } from "../prefs-writer.js";
+import { validatePreferencesModel } from "../prefs-validator.js";
+import {
+  ConfigEditor,
+  type ConfigEditorUI,
+  type ConfigEditorResult,
+} from "../../symphony/config-editor.js";
+import type { ConfigEditorModel } from "../../symphony/config-model.js";
+
+// ---------------------------------------------------------------------------
+// Realistic preferences.md fixture
+// ---------------------------------------------------------------------------
+
+const FIXTURE_BODY = `
+## Notes
+
+These are project-specific notes that must survive round-tripping.
+
+- Keep this content intact.
+- Body preservation is critical.
+`;
+
+const FIXTURE_CONTENT = `---
+version: 1
+uat_dispatch: true
+budget_ceiling: 100
+workflow:
+  mode: linear
+linear:
+  teamKey: KAT
+  projectSlug: kata-cli
+pr:
+  enabled: true
+  auto_create: false
+  base_branch: main
+  review_on_create: true
+  linear_link: false
+models:
+  research: claude-sonnet-4-5
+  review: claude-sonnet-4-6
+symphony:
+  url: http://localhost:8080
+  console_position: below-output
+skill_discovery: auto
+auto_supervisor:
+  model: claude-sonnet-4-6
+  soft_timeout_minutes: 20
+  idle_timeout_minutes: 10
+  hard_timeout_minutes: 30
+---
+${FIXTURE_BODY}`;
+
+// ---------------------------------------------------------------------------
+// Mock UI
+// ---------------------------------------------------------------------------
+
+type MockAction =
+  | { type: "selectContaining"; text: string }
+  | { type: "selectExact"; text: string }
+  | { type: "input"; value: string }
+  | { type: "confirm"; value: boolean };
+
+/**
+ * Mock `ConfigEditorUI` that replays a scripted sequence of actions.
+ * Each `select()`, `input()`, or `confirm()` call pops the next action.
+ */
+class MockConfigEditorUI implements ConfigEditorUI {
+  private readonly actions: MockAction[];
+  private cursor = 0;
+  readonly notifications: Array<{ message: string; type?: string }> = [];
+
+  constructor(actions: MockAction[]) {
+    this.actions = actions;
+  }
+
+  async select(
+    _title: string,
+    options: string[],
+  ): Promise<string | undefined> {
+    const action = this.next();
+    if (action.type === "selectContaining") {
+      const match = options.find((opt) => opt.includes(action.text));
+      if (!match) {
+        throw new Error(
+          `MockUI: no option containing "${action.text}" in [${options.join(", ")}]`,
+        );
+      }
+      return match;
+    }
+    if (action.type === "selectExact") {
+      if (!options.includes(action.text)) {
+        throw new Error(
+          `MockUI: exact option "${action.text}" not in [${options.join(", ")}]`,
+        );
+      }
+      return action.text;
+    }
+    throw new Error(`MockUI: expected select action, got ${action.type}`);
+  }
+
+  async input(_title: string, _placeholder?: string): Promise<string | undefined> {
+    const action = this.next();
+    if (action.type !== "input") {
+      throw new Error(`MockUI: expected input action, got ${action.type}`);
+    }
+    return action.value;
+  }
+
+  async confirm(_title: string, _message: string): Promise<boolean> {
+    const action = this.next();
+    if (action.type !== "confirm") {
+      throw new Error(`MockUI: expected confirm action, got ${action.type}`);
+    }
+    return action.value;
+  }
+
+  notify(message: string, type?: "info" | "warning" | "error"): void {
+    this.notifications.push({ message, type });
+  }
+
+  private next(): MockAction {
+    if (this.cursor >= this.actions.length) {
+      throw new Error(
+        `MockUI: ran out of scripted actions at step ${this.cursor}`,
+      );
+    }
+    return this.actions[this.cursor++];
+  }
+
+  get consumed(): number {
+    return this.cursor;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test scenarios
+// ---------------------------------------------------------------------------
+
+describe("ConfigEditor integration with preferences model", () => {
+  it("scenario 1: edit a string field (linear.teamKey) → save → validate → write", async () => {
+    // Parse fixture
+    const { model, body } = parsePreferencesFile(FIXTURE_CONTENT);
+
+    // Script: select Linear section → select Team Key field → input new value → back → save → confirm
+    const mockUI = new MockConfigEditorUI([
+      { type: "selectContaining", text: "Linear" },          // select Linear section
+      { type: "selectContaining", text: "Team Key" },         // select teamKey field
+      { type: "input", value: "NEW" },                        // input new value
+      { type: "selectContaining", text: "← Back" },           // back to section list
+      { type: "selectContaining", text: "Save changes" },     // save
+      { type: "confirm", value: true },                        // confirm save
+    ]);
+
+    // Run ConfigEditor
+    const editor = new ConfigEditor(model, mockUI);
+    const result: ConfigEditorResult = await editor.run();
+
+    // Assert saved
+    expect(result.type).toBe("saved");
+    if (result.type !== "saved") throw new Error("unreachable");
+
+    // Assert changes include the teamKey edit
+    expect(result.changes.length).toBeGreaterThanOrEqual(1);
+    const teamKeyChange = result.changes.find((c) => c.includes("teamKey"));
+    expect(teamKeyChange).toBeDefined();
+    expect(teamKeyChange).toContain("KAT");
+    expect(teamKeyChange).toContain("NEW");
+
+    // Validate the saved model — no issues
+    const issues = validatePreferencesModel(result.model);
+    expect(issues).toEqual([]);
+
+    // Write and check output
+    const output = writePreferencesFile(result.model, body);
+    expect(output).toContain("teamKey: NEW");
+    // Old value should not appear
+    expect(output).not.toMatch(/teamKey: KAT\b/);
+
+    // Body preservation: markdown body is identical
+    expect(output).toContain(FIXTURE_BODY);
+  });
+
+  it("scenario 2: edit an enum field (skill_discovery) → save → validate → write", async () => {
+    // Parse fixture
+    const { model, body } = parsePreferencesFile(FIXTURE_CONTENT);
+
+    // Script: select Skills section → select Skill Discovery field → select "suggest" → back → save → confirm
+    const mockUI = new MockConfigEditorUI([
+      { type: "selectContaining", text: "Skills" },           // select Skills section
+      { type: "selectContaining", text: "Skill Discovery" },  // select skill_discovery field
+      { type: "selectExact", text: "suggest" },                // select enum value "suggest"
+      { type: "selectContaining", text: "← Back" },           // back to section list
+      { type: "selectContaining", text: "Save changes" },     // save
+      { type: "confirm", value: true },                        // confirm save
+    ]);
+
+    // Run ConfigEditor
+    const editor = new ConfigEditor(model, mockUI);
+    const result: ConfigEditorResult = await editor.run();
+
+    // Assert saved
+    expect(result.type).toBe("saved");
+    if (result.type !== "saved") throw new Error("unreachable");
+
+    // Assert changes include the skill_discovery edit
+    expect(result.changes.length).toBeGreaterThanOrEqual(1);
+    const sdChange = result.changes.find((c) => c.includes("skill_discovery"));
+    expect(sdChange).toBeDefined();
+    expect(sdChange).toContain("suggest");
+
+    // Validate the saved model — no issues
+    const issues = validatePreferencesModel(result.model);
+    expect(issues).toEqual([]);
+
+    // Write and check output
+    const output = writePreferencesFile(result.model, body);
+    expect(output).toContain("skill_discovery: suggest");
+    expect(output).not.toMatch(/skill_discovery: auto\b/);
+
+    // Body preservation
+    expect(output).toContain(FIXTURE_BODY);
+  });
+
+  it("scenario 3: cancel → no side effects", async () => {
+    // Parse fixture
+    const { model, body } = parsePreferencesFile(FIXTURE_CONTENT);
+
+    // Snapshot original output for comparison
+    const originalOutput = writePreferencesFile(model, body);
+
+    // Script: cancel immediately
+    const mockUI = new MockConfigEditorUI([
+      { type: "selectContaining", text: "Cancel" },  // select cancel
+    ]);
+
+    // Run ConfigEditor
+    const editor = new ConfigEditor(model, mockUI);
+    const result: ConfigEditorResult = await editor.run();
+
+    // Assert cancelled
+    expect(result.type).toBe("cancelled");
+
+    // Verify model is unchanged — write produces the same output
+    const afterOutput = writePreferencesFile(result.model, body);
+    expect(afterOutput).toBe(originalOutput);
+  });
+
+  it("body is byte-identical after full save pipeline", async () => {
+    // Parse fixture
+    const { model, body } = parsePreferencesFile(FIXTURE_CONTENT);
+
+    // Edit something trivial, then save
+    const mockUI = new MockConfigEditorUI([
+      { type: "selectContaining", text: "Linear" },
+      { type: "selectContaining", text: "Team Key" },
+      { type: "input", value: "CHANGED" },
+      { type: "selectContaining", text: "← Back" },
+      { type: "selectContaining", text: "Save changes" },
+      { type: "confirm", value: true },
+    ]);
+
+    const editor = new ConfigEditor(model, mockUI);
+    const result = await editor.run();
+    expect(result.type).toBe("saved");
+
+    // Write the output
+    if (result.type !== "saved") throw new Error("unreachable");
+    const output = writePreferencesFile(result.model, body);
+
+    // Extract the body portion after the closing ---
+    const closingIndex = output.indexOf("---\n", 4); // skip the opening ---
+    const outputBody = output.slice(closingIndex + 4);
+
+    // Body must be byte-identical to the original fixture body
+    expect(outputBody).toBe(FIXTURE_BODY);
+  });
+});

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-integration.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-integration.vitest.test.ts
@@ -7,7 +7,7 @@ import {
   type ConfigEditorUI,
   type ConfigEditorResult,
 } from "../../symphony/config-editor.js";
-import type { ConfigEditorModel } from "../../symphony/config-model.js";
+
 
 // ---------------------------------------------------------------------------
 // Realistic preferences.md fixture

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts
@@ -168,14 +168,25 @@ describe("validatePreferencesModel — rejects invalid numbers", () => {
   });
 
   it("rejects NaN and Infinity in number fields", () => {
-    const model = buildModelFromConfig({
+    // NaN
+    const nanModel = buildModelFromConfig({
       auto_supervisor: { hard_timeout_minutes: NaN },
     });
-    const issues = validatePreferencesModel(model);
-    const issue = issues.find(
+    const nanIssues = validatePreferencesModel(nanModel);
+    const nanIssue = nanIssues.find(
       (i) => i.path === "auto_supervisor.hard_timeout_minutes",
     );
-    expect(issue).toBeDefined();
+    expect(nanIssue).toBeDefined();
+
+    // Infinity
+    const infModel = buildModelFromConfig({
+      auto_supervisor: { hard_timeout_minutes: Infinity },
+    });
+    const infIssues = validatePreferencesModel(infModel);
+    const infIssue = infIssues.find(
+      (i) => i.path === "auto_supervisor.hard_timeout_minutes",
+    );
+    expect(infIssue).toBeDefined();
   });
 });
 

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import { validatePreferencesModel } from "../prefs-validator.js";
+import { buildPreferencesModel } from "../prefs-model.js";
+import type { ConfigEditorModel } from "../../symphony/config-model.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildModelFromConfig(
+  config: Record<string, unknown>,
+): ConfigEditorModel {
+  return buildPreferencesModel(config);
+}
+
+// ---------------------------------------------------------------------------
+// Valid config fixture
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG: Record<string, unknown> = {
+  version: 1,
+  uat_dispatch: true,
+  budget_ceiling: 100,
+  workflow: { mode: "linear" },
+  linear: { teamKey: "KAT", projectSlug: "kata-cli" },
+  pr: {
+    enabled: true,
+    auto_create: false,
+    base_branch: "main",
+    review_on_create: true,
+    linear_link: false,
+  },
+  models: { research: "claude-sonnet-4-5", review: "claude-sonnet-4-6" },
+  symphony: { url: "http://localhost:8080", console_position: "below-output" },
+  skill_discovery: "auto",
+  auto_supervisor: {
+    model: "claude-sonnet-4-6",
+    soft_timeout_minutes: 20,
+    idle_timeout_minutes: 10,
+    hard_timeout_minutes: 30,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Acceptance tests — valid configs
+// ---------------------------------------------------------------------------
+
+describe("validatePreferencesModel — accepts valid configs", () => {
+  it("returns empty array for a fully valid config", () => {
+    const model = buildModelFromConfig(VALID_CONFIG);
+    const issues = validatePreferencesModel(model);
+    expect(issues).toEqual([]);
+  });
+
+  it("returns empty array for an empty config (all fields unset)", () => {
+    const model = buildModelFromConfig({});
+    const issues = validatePreferencesModel(model);
+    expect(issues).toEqual([]);
+  });
+
+  it("accepts valid enum values individually", () => {
+    // workflow.mode = "linear"
+    const m1 = buildModelFromConfig({ workflow: { mode: "linear" } });
+    expect(validatePreferencesModel(m1)).toEqual([]);
+
+    // skill_discovery = "suggest"
+    const m2 = buildModelFromConfig({ skill_discovery: "suggest" });
+    expect(validatePreferencesModel(m2)).toEqual([]);
+
+    // skill_discovery = "off"
+    const m3 = buildModelFromConfig({ skill_discovery: "off" });
+    expect(validatePreferencesModel(m3)).toEqual([]);
+
+    // symphony.console_position = "above-status"
+    const m4 = buildModelFromConfig({
+      symphony: { console_position: "above-status" },
+    });
+    expect(validatePreferencesModel(m4)).toEqual([]);
+  });
+
+  it("accepts valid number fields", () => {
+    const model = buildModelFromConfig({
+      version: 2,
+      budget_ceiling: 0,
+      auto_supervisor: {
+        soft_timeout_minutes: 0,
+        idle_timeout_minutes: 5,
+        hard_timeout_minutes: 60,
+      },
+    });
+    expect(validatePreferencesModel(model)).toEqual([]);
+  });
+
+  it("accepts valid boolean fields", () => {
+    const model = buildModelFromConfig({
+      uat_dispatch: false,
+      pr: {
+        enabled: false,
+        auto_create: true,
+        review_on_create: false,
+        linear_link: true,
+      },
+    });
+    expect(validatePreferencesModel(model)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection tests — invalid enum values
+// ---------------------------------------------------------------------------
+
+describe("validatePreferencesModel — rejects invalid enums", () => {
+  it('rejects workflow.mode = "file" (only "linear" is valid)', () => {
+    const model = buildModelFromConfig({ workflow: { mode: "file" } });
+    const issues = validatePreferencesModel(model);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe("workflow.mode");
+    expect(issues[0].message).toContain("linear");
+  });
+
+  it('rejects skill_discovery = "never"', () => {
+    const model = buildModelFromConfig({ skill_discovery: "never" });
+    const issues = validatePreferencesModel(model);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe("skill_discovery");
+    expect(issues[0].message).toContain("auto");
+    expect(issues[0].message).toContain("suggest");
+    expect(issues[0].message).toContain("off");
+  });
+
+  it('rejects symphony.console_position = "left"', () => {
+    const model = buildModelFromConfig({
+      symphony: { console_position: "left" },
+    });
+    const issues = validatePreferencesModel(model);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe("symphony.console_position");
+    expect(issues[0].message).toContain("below-output");
+    expect(issues[0].message).toContain("above-status");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection tests — invalid number fields
+// ---------------------------------------------------------------------------
+
+describe("validatePreferencesModel — rejects invalid numbers", () => {
+  it('rejects non-numeric string in number field (auto_supervisor.soft_timeout_minutes = "abc")', () => {
+    const model = buildModelFromConfig({
+      auto_supervisor: { soft_timeout_minutes: "abc" },
+    });
+    const issues = validatePreferencesModel(model);
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const issue = issues.find(
+      (i) => i.path === "auto_supervisor.soft_timeout_minutes",
+    );
+    expect(issue).toBeDefined();
+    expect(issue!.message).toContain("valid number");
+  });
+
+  it("rejects negative budget_ceiling", () => {
+    const model = buildModelFromConfig({ budget_ceiling: -5 });
+    const issues = validatePreferencesModel(model);
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const issue = issues.find((i) => i.path === "budget_ceiling");
+    expect(issue).toBeDefined();
+    expect(issue!.message).toContain("non-negative");
+  });
+
+  it("rejects NaN and Infinity in number fields", () => {
+    const model = buildModelFromConfig({
+      auto_supervisor: { hard_timeout_minutes: NaN },
+    });
+    const issues = validatePreferencesModel(model);
+    const issue = issues.find(
+      (i) => i.path === "auto_supervisor.hard_timeout_minutes",
+    );
+    expect(issue).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection tests — invalid boolean fields
+// ---------------------------------------------------------------------------
+
+describe("validatePreferencesModel — rejects invalid booleans", () => {
+  it('rejects string "yes" in boolean field', () => {
+    const model = buildModelFromConfig({ uat_dispatch: "yes" });
+    const issues = validatePreferencesModel(model);
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const issue = issues.find((i) => i.path === "uat_dispatch");
+    expect(issue).toBeDefined();
+    expect(issue!.message).toContain("boolean");
+  });
+
+  it('rejects string "true" in boolean field (should be actual boolean)', () => {
+    // Note: the model builder coerces string "true" to boolean true,
+    // so the validator should accept the coerced value.
+    // This test validates that the coercion works correctly through the pipeline.
+    const model = buildModelFromConfig({ pr: { enabled: "true" } });
+    const issues = validatePreferencesModel(model);
+    // After coercion, "true" string becomes boolean true → no issue
+    const issue = issues.find((i) => i.path === "pr.enabled");
+    expect(issue).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed valid/invalid
+// ---------------------------------------------------------------------------
+
+describe("validatePreferencesModel — mixed valid/invalid", () => {
+  it("returns only issues for invalid fields in a mixed config", () => {
+    const model = buildModelFromConfig({
+      version: 1,
+      workflow: { mode: "file" }, // invalid
+      linear: { teamKey: "KAT" }, // valid
+      budget_ceiling: -10, // invalid
+      skill_discovery: "auto", // valid
+      symphony: { console_position: "below-output" }, // valid
+      uat_dispatch: true, // valid
+    });
+    const issues = validatePreferencesModel(model);
+    expect(issues).toHaveLength(2);
+
+    const paths = issues.map((i) => i.path);
+    expect(paths).toContain("workflow.mode");
+    expect(paths).toContain("budget_ceiling");
+  });
+});

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         'src/resources/extensions/kata/gitignore.ts',
         'src/resources/extensions/kata/prefs-model.ts',
         'src/resources/extensions/kata/prefs-parser.ts',
+        'src/resources/extensions/kata/prefs-validator.ts',
         'src/resources/extensions/kata/prefs-writer.ts',
         'src/resources/extensions/kata/prompt-loader.ts',
         'src/resources/extensions/pr-lifecycle/pr-runner.ts',


### PR DESCRIPTION
## Summary

Implements S02 of milestone M010 (Preferences Config Editor): field validation for the preferences model and integration proof with Symphony's `ConfigEditor`.

### Changes

**T01: Preferences validator** (`prefs-validator.ts`)
- `validatePreferencesModel(model)` returns `ConfigValidationIssue[]`
- Validates enum fields (workflow.mode, skill_discovery, symphony.console_position)
- Validates number fields are finite and non-negative
- Validates boolean fields are actual booleans (not strings)
- Accepts empty/unset optional fields gracefully
- Added to vitest.config.ts coverage include

**T02: ConfigEditor integration tests** (`prefs-integration.vitest.test.ts`)
- MockConfigEditorUI implements `ConfigEditorUI` with scripted responses
- Scenario 1: Edit string field (linear.teamKey) → save → validate → write
- Scenario 2: Edit enum field (skill_discovery) → save → validate → write
- Scenario 3: Cancel → no side effects
- Scenario 4: Body preservation through full save pipeline

### Validation

- `npx vitest run` — all 395 tests pass (14 validator + 4 integration + existing)
- `npx tsc --noEmit` — clean compilation
- `npx vitest run --coverage` — 94.32% stmts, 87.47% branches, 97.05% functions
- prefs-validator.ts: 100% statement coverage

### Files Changed

- `apps/cli/src/resources/extensions/kata/prefs-validator.ts` (new)
- `apps/cli/src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts` (new)
- `apps/cli/src/resources/extensions/kata/tests/prefs-integration.vitest.test.ts` (new)
- `apps/cli/vitest.config.ts` (updated coverage include)

Refs: KAT-1880, KAT-1881, KAT-1882

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements S02 of milestone M010, delivering a standalone preferences validator (`prefs-validator.ts`) and a full integration test suite confirming that `ConfigEditor` (from Symphony) can edit, validate, and write `preferences.md` end-to-end.

Key observations:
- The validator intentionally validates the **write-normalized** config (via `applyPrefsModelToConfig`) rather than raw model field values, so what the validator accepts is exactly what the writer will persist — consistent with the existing Symphony `config-validator.ts` pattern.
- Module-level `PREFS_ENUM_VALUE_SET`, `NUMBER_FIELD_PATHS`, and `BOOLEAN_FIELD_PATHS` are built once from `PREFS_FIELD_DEFINITIONS`, avoiding repeated filtering on each validation call.
- All previously raised review concerns (duplicate imports, re-export pattern, missing `Infinity` coverage) are addressed in the head commit.
- 14 unit tests + 4 integration scenarios all pass; `prefs-validator.ts` carries 100% statement coverage.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no correctness, security, or data-integrity issues found.

All four files are new additions (no regressions possible in existing code), the implementation mirrors established Symphony patterns, 100% statement coverage is reported on the new validator, all prior review concerns are addressed, and the integration tests confirm the full parse → edit → validate → write pipeline behaves correctly.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/prefs-validator.ts | New preferences validator that mirrors Symphony's config-validator.ts pattern — builds enum/number/boolean field sets at module init, then validates a write-normalized config via applyPrefsModelToConfig; no correctness issues found. |
| apps/cli/src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts | Comprehensive unit tests covering acceptance (valid full config, empty config, each enum/number/boolean type), rejection (bad enum, NaN, Infinity, negative, non-boolean), and mixed scenarios; 100% statement coverage. |
| apps/cli/src/resources/extensions/kata/tests/prefs-integration.vitest.test.ts | Four ConfigEditor integration scenarios (string edit, enum edit, cancel, body preservation) using a scripted MockConfigEditorUI; validates the full parse → edit → validate → write pipeline end-to-end. |
| apps/cli/vitest.config.ts | One-line addition of prefs-validator.ts to the coverage include list; no other changes. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Parser as prefs-parser
    participant Editor as ConfigEditor
    participant MockUI as ConfigEditorUI
    participant Validator as prefs-validator
    participant Writer as prefs-writer

    Caller->>Parser: parsePreferencesFile(content)
    Parser-->>Caller: { model, body }

    Caller->>Editor: new ConfigEditor(model, ui)
    loop Edit session
        Editor->>MockUI: select(sections)
        MockUI-->>Editor: section choice
        Editor->>MockUI: select(fields)
        MockUI-->>Editor: field choice
        Editor->>MockUI: input/select(value)
        MockUI-->>Editor: new value
    end
    Editor->>MockUI: confirm(save?)
    MockUI-->>Editor: true
    Editor-->>Caller: ConfigEditorResult { type: "saved", model, changes }

    Caller->>Validator: validatePreferencesModel(result.model)
    Validator->>Writer: applyPrefsModelToConfig(model)
    Writer-->>Validator: normalizedConfig
    Validator->>Validator: assertEnumValues(config)
    Validator->>Validator: assertNumberFields(config)
    Validator->>Validator: assertBooleanFields(config)
    Validator-->>Caller: issues[]

    alt issues.length === 0
        Caller->>Writer: writePreferencesFile(result.model, body)
        Writer->>Writer: applyPrefsModelToConfig(model)
        Writer-->>Caller: "---\nyaml---\nbody"
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(cli): address Greptile review commen..."](https://github.com/gannonh/kata/commit/f5bef575b2678383eefd50f11a5eec5193a8ed4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26704098)</sub>

<!-- /greptile_comment -->