### PR TITLE
feat(symphony): add tracker.exclude_labels to block kata:task dispatch

### DIFF
--- a/apps/cli/src/resources/extensions/symphony/config-model.ts
+++ b/apps/cli/src/resources/extensions/symphony/config-model.ts
@@ -228,6 +228,15 @@ export const CONFIG_FIELD_DEFINITIONS: readonly ConfigFieldDefinition[] = [
     description: "Issue states that mark a run as completed.",
   },
   {
+    section: "tracker",
+    key: "exclude_labels",
+    label: "Exclude Labels",
+    path: ["tracker", "exclude_labels"],
+    type: "string[]",
+    description:
+      "Labels that disqualify an issue from dispatch. Any issue carrying at least one of these labels is skipped (case-insensitive). Use [\"kata:task\"] to prevent sub-tasks from being dispatched as independent workers.",
+  },
+  {
     section: "workspace",
     key: "root",
     label: "Workspace Root",

--- a/apps/cli/src/resources/extensions/symphony/config-parser.ts
+++ b/apps/cli/src/resources/extensions/symphony/config-parser.ts
@@ -1,4 +1,5 @@
-import { dump, load, type YAMLException } from "js-yaml";
+import { createRequire } from "node:module";
+import { join } from "node:path";
 import {
   cloneConfig,
   CONFIG_FIELD_DEFINITIONS,
@@ -11,6 +12,19 @@ import {
   type ConfigSectionKey,
   type WorkflowFrontmatter,
 } from "./config-model.js";
+
+// js-yaml is not in pi-coding-agent's extension alias list, so it cannot be
+// resolved via a static top-level import when the extension runs from
+// ~/.kata-cli/agent/. Use createRequire pointed at PI_PACKAGE_DIR (which has
+// js-yaml in its node_modules) so it resolves correctly at runtime.
+const _require = createRequire(
+  process.env.PI_PACKAGE_DIR
+    ? join(process.env.PI_PACKAGE_DIR, "package.json")
+    : import.meta.url,
+);
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { dump, load } = _require("js-yaml") as typeof import("js-yaml");
+type YAMLException = import("js-yaml").YAMLException;
 
 const TOP_LEVEL_KEY_ORDER = [
   "tracker",

--- a/apps/cli/src/resources/extensions/symphony/config-validator.ts
+++ b/apps/cli/src/resources/extensions/symphony/config-validator.ts
@@ -155,16 +155,21 @@ function assertNotifications(
   );
 
   if (webhook) {
-    try {
-      const parsed = new URL(webhook);
-      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-        throw new Error("unsupported protocol");
+    // Skip URL validation for $VAR references — they are resolved by Symphony
+    // at startup time and are not resolvable in the config editor context.
+    const isEnvRef = /^\$[A-Z_][A-Z0-9_]*$/.test(webhook.trim());
+    if (!isEnvRef) {
+      try {
+        const parsed = new URL(webhook);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+          throw new Error("unsupported protocol");
+        }
+      } catch {
+        issues.push({
+          path: "notifications.slack.webhook_url",
+          message: "notifications.slack.webhook_url must be a valid http(s) URL",
+        });
       }
-    } catch {
-      issues.push({
-        path: "notifications.slack.webhook_url",
-        message: "notifications.slack.webhook_url must be a valid http(s) URL",
-      });
     }
   }
 

--- a/apps/cli/src/resources/extensions/symphony/config-writer.ts
+++ b/apps/cli/src/resources/extensions/symphony/config-writer.ts
@@ -1,5 +1,14 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
 import { readFileSync, writeFileSync } from "node:fs";
-import { dump } from "js-yaml";
+
+// js-yaml must be loaded dynamically via createRequire — see config-parser.ts
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { dump } = (createRequire(
+  process.env.PI_PACKAGE_DIR
+    ? join(process.env.PI_PACKAGE_DIR, "package.json")
+    : import.meta.url,
+))("js-yaml") as typeof import("js-yaml");
 import type { ConfigEditorModel } from "./config-model.js";
 import {
   applyModelToConfig,

--- a/apps/cli/src/resources/extensions/symphony/tests/symphony-config-editor.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/symphony/tests/symphony-config-editor.vitest.test.ts
@@ -449,6 +449,18 @@ describe("config-validator", () => {
     const issues = validateConfigModel(model);
     expect(issues).toEqual([]);
   });
+
+  it("accepts $VAR env reference for webhook_url without URL validation", () => {
+    const source = readFileSync(workflowReferencePath, "utf-8");
+    const model = parseWorkflowConfig(source);
+
+    setField(model, "workspace", "repo", "/tmp/local-repo");
+    setField(model, "notifications", "slack.webhook_url", "$SLACK_WEBHOOK_URL");
+    setField(model, "notifications", "slack.events", ["all"]);
+
+    const issues = validateConfigModel(model);
+    expect(issues).toEqual([]);
+  });
 });
 
 describe("config-writer", () => {

--- a/apps/symphony/AGENTS.md
+++ b/apps/symphony/AGENTS.md
@@ -92,6 +92,7 @@ is at `docs/WORKFLOW-REFERENCE.md`. Copy it to your project root as
 | `tracker.assignee`        | string   | _(none)_                                                   | Filter candidate issues to this Linear username. Supports `$VAR` indirection.                                                                    |
 | `tracker.active_states`   | string[] | `["Todo", "In Progress"]`                                  | Issue states that are eligible for dispatch.                                                                                                     |
 | `tracker.terminal_states` | string[] | `["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]` | Issue states that mark an agent run as complete.                                                                                                 |
+| `tracker.exclude_labels`  | string[] | `[]`                                                       | Labels that disqualify an issue from dispatch. Any issue carrying at least one of these labels is skipped (case-insensitive). Use `["kata:task"]` to prevent Kata sub-tasks from being dispatched as independent workers. |
 
 #### `polling` section
 

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -85,6 +85,16 @@ tracker:
     - Duplicate
     - Done
 
+  # Optional: labels that disqualify an issue from dispatch entirely.
+  # Any issue carrying at least one of these labels is silently skipped,
+  # regardless of its state. Matching is case-insensitive.
+  # Use ["kata:task"] when running Symphony against a Kata-planned project
+  # to prevent sub-tasks from being dispatched as independent workers —
+  # sub-tasks should only be executed by the parent slice worker.
+  # Default: [] (no issues excluded by label).
+  # exclude_labels:
+  #   - kata:task
+
 # ─── Polling ──────────────────────────────────────────────────────────────────
 # Controls how frequently Symphony polls the tracker for new/changed issues.
 polling:

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -193,6 +193,7 @@ struct RawTrackerConfig {
     assignee: Option<String>,
     active_states: Option<Vec<String>>,
     terminal_states: Option<Vec<String>>,
+    exclude_labels: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default)]
@@ -577,6 +578,9 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         terminal_states: raw_tracker
             .terminal_states
             .unwrap_or(defaults.tracker.terminal_states.clone()),
+        exclude_labels: raw_tracker
+            .exclude_labels
+            .unwrap_or(defaults.tracker.exclude_labels.clone()),
     };
 
     // ── PollingConfig ─────────────────────────────────────────────────────

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -488,6 +488,10 @@ pub struct TrackerConfig {
     pub assignee: Option<String>,
     pub active_states: Vec<String>,
     pub terminal_states: Vec<String>,
+    /// Labels that disqualify an issue from dispatch.  Any issue carrying at
+    /// least one of these labels (case-insensitive) is silently skipped.
+    /// Use `["kata:task"]` to prevent Symphony from dispatching Kata sub-tasks.
+    pub exclude_labels: Vec<String>,
 }
 
 const DEFAULT_LINEAR_WORKSPACE_SLUG: &str = "kata-sh";
@@ -509,6 +513,7 @@ impl Default for TrackerConfig {
                 "Duplicate".to_string(),
                 "Done".to_string(),
             ],
+            exclude_labels: vec![],
         }
     }
 }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -4092,6 +4092,9 @@ impl Orchestrator {
         if !self.active_state_set().contains(&normalized_state) {
             return false;
         }
+        if self.issue_has_excluded_label(issue) {
+            return false;
+        }
         true
     }
 
@@ -4114,6 +4117,11 @@ impl Orchestrator {
             return false;
         }
 
+        // Skip issues carrying any of the configured exclude_labels.
+        if self.issue_has_excluded_label(issue) {
+            return false;
+        }
+
         // NOTE: blocker checks are done at the dispatch loop level via
         // is_blocked_by_dependency() which needs access to all candidates.
 
@@ -4126,6 +4134,25 @@ impl Orchestrator {
         }
 
         true
+    }
+
+    /// Returns `true` if the issue carries at least one label that matches an
+    /// entry in `tracker.exclude_labels` (comparison is case-insensitive).
+    fn issue_has_excluded_label(&self, issue: &Issue) -> bool {
+        let excluded: std::collections::HashSet<String> = self
+            .config
+            .tracker
+            .exclude_labels
+            .iter()
+            .map(|l| l.trim().to_ascii_lowercase())
+            .collect();
+        if excluded.is_empty() {
+            return false;
+        }
+        issue
+            .labels
+            .iter()
+            .any(|l| excluded.contains(l.trim().to_ascii_lowercase().as_str()))
     }
 
     /// Returns `true` if the issue has at least one non-terminal blocker,

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -4145,6 +4145,7 @@ impl Orchestrator {
             .exclude_labels
             .iter()
             .map(|l| l.trim().to_ascii_lowercase())
+            .filter(|l| !l.is_empty())
             .collect();
         if excluded.is_empty() {
             return false;
@@ -4152,7 +4153,9 @@ impl Orchestrator {
         issue
             .labels
             .iter()
-            .any(|l| excluded.contains(l.trim().to_ascii_lowercase().as_str()))
+            .map(|l| l.trim().to_ascii_lowercase())
+            .filter(|l| !l.is_empty())
+            .any(|l| excluded.contains(l.as_str()))
     }
 
     /// Returns `true` if the issue has at least one non-terminal blocker,

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -602,6 +602,7 @@ async fn test_check_linear_auth_failure() {
         assignee: None,
         active_states: vec!["Todo".to_string()],
         terminal_states: vec!["Done".to_string()],
+        exclude_labels: vec![],
     };
 
     let results = doctor::check_linear(&config).await;

--- a/apps/symphony/tests/linear_client_tests.rs
+++ b/apps/symphony/tests/linear_client_tests.rs
@@ -25,6 +25,7 @@ fn test_config(server: &ServerGuard, assignee: Option<&str>) -> TrackerConfig {
         assignee: assignee.map(String::from),
         active_states: vec!["Todo".to_string(), "In Progress".to_string()],
         terminal_states: vec!["Done".to_string(), "Cancelled".to_string()],
+        exclude_labels: vec![],
     }
 }
 
@@ -745,6 +746,7 @@ async fn test_error_transport_error() {
         assignee: None,
         active_states: vec!["Todo".to_string()],
         terminal_states: vec![],
+        exclude_labels: vec![],
     };
 
     let client = LinearClient::new(config);

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -4806,3 +4806,30 @@ fn test_exclude_labels_empty_skips_no_issues() {
         "with no exclude_labels, kata:task issue should dispatch normally"
     );
 }
+
+#[test]
+fn test_exclude_labels_blank_entries_are_ignored() {
+    let mut config = test_config(1);
+    // Blank/whitespace-only entries in exclude_labels must not match anything
+    config.tracker.exclude_labels = vec!["".to_string(), "   ".to_string()];
+
+    let mut issue_with_empty_label = issue("issue-blank-label", "KAT-1885", "Todo", None, 0);
+    // Issue carries a blank label — should not be blocked by a blank exclude entry
+    issue_with_empty_label.labels = vec!["".to_string(), "  ".to_string()];
+
+    let mut port = FakePort {
+        candidate_issues: vec![issue_with_empty_label.clone()],
+        ..FakePort::default()
+    };
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let tick = orchestrator
+        .tick(&mut port)
+        .expect("tick should succeed when all exclude_labels are blank");
+
+    assert_eq!(
+        tick.dispatched_issue_ids,
+        vec![issue_with_empty_label.id.clone()],
+        "blank exclude_labels entries must not block dispatch"
+    );
+}

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -4705,3 +4705,104 @@ fn test_model_by_label_falls_back_to_default() {
         Some("anthropic/claude-haiku-3-5")
     );
 }
+
+// ── exclude_labels ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_exclude_labels_blocks_dispatch() {
+    let mut config = test_config(1);
+    config.tracker.exclude_labels = vec!["kata:task".to_string()];
+
+    let mut task_issue = issue("issue-task", "KAT-1882", "Todo", None, 0);
+    task_issue.labels = vec!["kata:task".to_string()];
+
+    let mut port = FakePort {
+        candidate_issues: vec![task_issue.clone()],
+        ..FakePort::default()
+    };
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let tick = orchestrator
+        .tick(&mut port)
+        .expect("tick should not error on excluded-label issue");
+
+    assert!(
+        tick.dispatched_issue_ids.is_empty(),
+        "kata:task issue should not be dispatched"
+    );
+}
+
+#[test]
+fn test_exclude_labels_case_insensitive() {
+    let mut config = test_config(1);
+    config.tracker.exclude_labels = vec!["kata:task".to_string()];
+
+    let mut task_issue = issue("issue-task-ci", "KAT-1883", "Todo", None, 0);
+    task_issue.labels = vec!["Kata:Task".to_string()]; // mixed case on the issue
+
+    let mut port = FakePort {
+        candidate_issues: vec![task_issue.clone()],
+        ..FakePort::default()
+    };
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let tick = orchestrator
+        .tick(&mut port)
+        .expect("tick should not error on case-variant excluded label");
+
+    assert!(
+        tick.dispatched_issue_ids.is_empty(),
+        "kata:task issue (mixed case) should not be dispatched"
+    );
+}
+
+#[test]
+fn test_exclude_labels_does_not_affect_slice() {
+    let mut config = test_config(1);
+    config.tracker.exclude_labels = vec!["kata:task".to_string()];
+
+    let mut slice_issue = issue("issue-slice", "KAT-1880", "Todo", None, 0);
+    slice_issue.labels = vec!["kata:slice".to_string()];
+
+    let mut port = FakePort {
+        candidate_issues: vec![slice_issue.clone()],
+        ..FakePort::default()
+    };
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let tick = orchestrator
+        .tick(&mut port)
+        .expect("tick should succeed for slice issue");
+
+    assert_eq!(
+        tick.dispatched_issue_ids,
+        vec![slice_issue.id.clone()],
+        "kata:slice issue should still be dispatched when only kata:task is excluded"
+    );
+}
+
+#[test]
+fn test_exclude_labels_empty_skips_no_issues() {
+    let mut config = test_config(1);
+    // No exclude_labels configured (default empty vec)
+    assert!(config.tracker.exclude_labels.is_empty());
+
+    let mut task_issue = issue("issue-task-no-excl", "KAT-1884", "Todo", None, 0);
+    task_issue.labels = vec!["kata:task".to_string()];
+
+    let mut port = FakePort {
+        candidate_issues: vec![task_issue.clone()],
+        ..FakePort::default()
+    };
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let tick = orchestrator
+        .tick(&mut port)
+        .expect("tick should succeed with no exclude_labels configured");
+
+    assert_eq!(
+        tick.dispatched_issue_ids,
+        vec![task_issue.id.clone()],
+        "with no exclude_labels, kata:task issue should dispatch normally"
+    );
+}

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -1693,3 +1693,36 @@ prompts:
     let config = parse_yaml_config(yaml);
     assert!(config.prompts.is_none(), "all-empty prompts should be None");
 }
+
+#[test]
+fn test_exclude_labels_parses_from_yaml() {
+    let yaml = r#"
+tracker:
+  kind: linear
+  api_key: test-key
+  project_slug: test-slug
+  exclude_labels:
+    - kata:task
+    - wontfix
+"#;
+    let config = parse_yaml_config(yaml);
+    assert_eq!(
+        config.tracker.exclude_labels,
+        vec!["kata:task".to_string(), "wontfix".to_string()]
+    );
+}
+
+#[test]
+fn test_exclude_labels_defaults_to_empty() {
+    let yaml = r#"
+tracker:
+  kind: linear
+  api_key: test-key
+  project_slug: test-slug
+"#;
+    let config = parse_yaml_config(yaml);
+    assert!(
+        config.tracker.exclude_labels.is_empty(),
+        "exclude_labels should default to empty vec"
+    );
+}


### PR DESCRIPTION
## Problem

Symphony was dispatching `kata:task` sub-issues as independent workers when their state got flipped to Todo/In Progress (e.g. by an agent incorrectly transitioning state). Sub-tasks should only be executed by the parent slice worker, never as top-level dispatch targets.

## Solution

Add `tracker.exclude_labels` to the WORKFLOW.md config — a label filter that silently skips any issue carrying a matching label at dispatch time.

## Changes

**Symphony (Rust)**
- `TrackerConfig` gains `exclude_labels: Vec<String>` (default `[]`)
- `should_dispatch_issue` and `is_candidate_for_blocked_check` both call a new `issue_has_excluded_label()` helper (case-insensitive match)
- `config.rs` wires `exclude_labels` from WORKFLOW.md front-matter

**Config / Docs**
- `WORKFLOW-REFERENCE.md` — documents the new field with usage guidance
- `AGENTS.md` — adds row to the tracker config field reference table
- `config-model.ts` — adds field to `/symphony config` TUI editor

**Tests**
- 4 orchestrator tests: blocks dispatch, case-insensitive, doesn't affect slices, empty list passes all
- 2 config parse tests: parses from YAML, defaults to empty

## Usage

```yaml
tracker:
  exclude_labels:
    - kata:task
```

Any issue with the `kata:task` label is skipped regardless of state. `kata:slice` and unlabelled issues are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `exclude_labels` tracker setting to silently skip issues that carry any listed label (matching is trimmed and case-insensitive). Excluded issues are neither dispatched nor included in blocked-candidate sets. Defaults to empty.

* **Tests**
  * Added unit and integration tests covering parsing, defaulting behavior, case-insensitive matching, and dispatch gating for label exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `tracker.exclude_labels` config option to Symphony that silently skips any issue carrying a matching label at dispatch time, preventing `kata:task` sub-issues from being picked up as independent top-level workers.

**Key changes:**
- `TrackerConfig` gains `exclude_labels: Vec<String>` (defaults to `[]`) in `domain.rs`, wired from YAML front-matter in `config.rs`
- New `issue_has_excluded_label()` helper in `orchestrator.rs` performs case-insensitive set-intersection; called from both `should_dispatch_issue` and `is_candidate_for_blocked_check`
- Config TUI (`config-model.ts`), reference docs (`WORKFLOW-REFERENCE.md`), and agent docs (`AGENTS.md`) all updated consistently
- 6 new tests cover the expected behaviour thoroughly (dispatch blocked, case-insensitive, slice unaffected, empty list passes all, YAML parse, default)

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic is correct, tests are comprehensive, and the single remaining finding is a minor allocation style issue with no correctness impact

All findings are P2. The only notable observation is that `issue_has_excluded_label` rebuilds the excluded-label `HashSet` on every per-issue call rather than once per tick, but this has no bearing on correctness. The feature is additive and backward-compatible (default empty list), the check placement in both dispatch functions is correct, and the test coverage addresses the important edge cases.

apps/symphony/src/orchestrator.rs — minor allocation inefficiency in `issue_has_excluded_label`

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/orchestrator.rs | Adds `issue_has_excluded_label` helper called from `should_dispatch_issue` and `is_candidate_for_blocked_check`; the excluded label HashSet is rebuilt on every call rather than once per tick |
| apps/symphony/src/domain.rs | Adds `exclude_labels: Vec<String>` field to `TrackerConfig` with correct default empty vec |
| apps/symphony/src/config.rs | Wires `exclude_labels` from YAML front-matter into `TrackerConfig` with correct `unwrap_or(defaults)` fallback |
| apps/symphony/tests/orchestrator_tests.rs | Adds 4 well-scoped tests: blocks dispatch, case-insensitive match, slice unaffected, empty list passes all |
| apps/symphony/tests/workflow_config_tests.rs | Adds 2 config tests verifying YAML parse and empty default; both correct |
| apps/cli/src/resources/extensions/symphony/config-model.ts | Adds `exclude_labels` `string[]` field to the TUI config editor model; correct section and path |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Documents `exclude_labels` with correct example, case-insensitivity note, and commented-out default |
| apps/symphony/AGENTS.md | Adds `tracker.exclude_labels` row to the config reference table with correct type, default, and description |
| apps/symphony/tests/cli_tests.rs | Mechanical struct update — adds `exclude_labels: vec![]` to satisfy updated `TrackerConfig` |
| apps/symphony/tests/linear_client_tests.rs | Mechanical struct update — adds `exclude_labels: vec![]` to two test fixture helpers |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tick loop: candidate issues] --> B[is_candidate_for_blocked_check]
    B --> C{required fields\n& assigned_to_worker?}
    C -- No --> SKIP1[skip]
    C -- Yes --> D{active state?}
    D -- No --> SKIP1
    D -- Yes --> E{issue_has_excluded_label?}
    E -- Yes --> SKIP1
    E -- No --> F[add to blocked-check candidates]

    A --> G[should_dispatch_issue]
    G --> H{required fields\n& assigned_to_worker?}
    H -- No --> SKIP2[skip]
    H -- Yes --> I{active state?}
    I -- No --> SKIP2
    I -- Yes --> J{issue_has_excluded_label?}
    J -- Yes --> SKIP2
    J -- No --> K{already claimed\nor running?}
    K -- Yes --> SKIP2
    K -- No --> L{slots available?}
    L -- No --> SKIP2
    L -- Yes --> M[dispatch issue]

    subgraph issue_has_excluded_label
        N[build HashSet from\nexclude_labels config] --> O{any issue label\nin excluded set?\ncase-insensitive}
        O -- Yes --> P[return true]
        O -- No --> Q[return false]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/orchestrator.rs
Line: 4141-4156

Comment:
**HashSet rebuilt on every call per-issue per-tick**

`issue_has_excluded_label` allocates and populates a `HashSet<String>` on every invocation. Because this helper is called from both `is_candidate_for_blocked_check` and `should_dispatch_issue`, it can be called twice per candidate issue per tick loop. For a project with many issues and a non-trivial `exclude_labels` list, this produces redundant heap allocations every polling cycle.

Since `self.config` is immutable during a tick, the excluded-label set could be computed once — for example by pre-building it ahead of the candidate loop, or by caching it lazily on the `Orchestrator` when the config is applied:

```rust
// Compute once before the loop in the caller (or as a field on Orchestrator):
let excluded_labels: std::collections::HashSet<String> = self
    .config
    .tracker
    .exclude_labels
    .iter()
    .map(|l| l.trim().to_ascii_lowercase())
    .collect();
```

Then pass it (or a reference) into the helper. This is purely a performance/allocation concern with no correctness impact, but it scales poorly as candidate counts or label list sizes grow.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(symphony): add tracker.exclude\_labe..."](https://github.com/gannonh/kata/commit/d6430547e26058c6577b453377772a5454ba60c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26707232)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->