### PR TITLE
KAT-1889: dual GitHub state management (Projects v2 + labels)

### DIFF
--- a/apps/symphony/src/error.rs
+++ b/apps/symphony/src/error.rs
@@ -59,6 +59,9 @@ pub enum SymphonyError {
     #[error("GitHub API status error: {status} ({message})")]
     GithubApiStatus { status: u16, message: String },
 
+    #[error("GitHub Projects v2 error: {0}")]
+    GithubProjectsV2Error(String),
+
     // ── Workspace ──────────────────────────────────────────────────────
     #[error("workspace path outside root: {workspace} not under {root}")]
     WorkspaceOutsideRoot { workspace: String, root: String },

--- a/apps/symphony/src/github/adapter.rs
+++ b/apps/symphony/src/github/adapter.rs
@@ -1,20 +1,63 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
+use tokio::sync::OnceCell;
 
 use crate::domain::{Issue, TrackerConfig};
 use crate::error::{Result, SymphonyError};
 use crate::github::client::{GithubClient, GithubIssue};
+use crate::github::projects_v2::{ProjectsV2Client, StatusFieldInfo, StatusOption};
 use crate::linear::adapter::TrackerAdapter;
+
+#[derive(Debug, Clone)]
+pub enum StateMode {
+    ProjectsV2 {
+        project_number: u64,
+        v2_client: ProjectsV2Client,
+    },
+    Labels,
+}
+
+impl std::fmt::Display for StateMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProjectsV2 { project_number, .. } => {
+                write!(f, "projects_v2(project_number={project_number})")
+            }
+            Self::Labels => write!(f, "labels"),
+        }
+    }
+}
 
 pub struct GithubAdapter {
     pub client: GithubClient,
     pub config: TrackerConfig,
+    pub state_mode: StateMode,
+    status_field_cache: OnceCell<StatusFieldInfo>,
 }
 
 impl GithubAdapter {
     pub fn new(client: GithubClient, config: TrackerConfig) -> Self {
-        Self { client, config }
+        let state_mode = match config.github_project_number {
+            Some(project_number) => StateMode::ProjectsV2 {
+                project_number,
+                v2_client: ProjectsV2Client::new(client.clone()),
+            },
+            None => StateMode::Labels,
+        };
+
+        tracing::info!(state_mode = %state_mode, "GithubAdapter initialized");
+
+        Self {
+            client,
+            config,
+            state_mode,
+            status_field_cache: OnceCell::new(),
+        }
+    }
+
+    pub fn state_mode(&self) -> &StateMode {
+        &self.state_mode
     }
 
     fn state_prefix(&self) -> &str {
@@ -24,10 +67,12 @@ impl GithubAdapter {
             .unwrap_or(self.client.label_prefix.as_str())
     }
 
-    fn issue_to_domain(&self, gh: &GithubIssue) -> Issue {
-        let state = extract_state_from_labels(&gh.labels, self.state_prefix())
-            .map(|(_, display)| display)
-            .unwrap_or_default();
+    fn issue_to_domain_with_state(&self, gh: &GithubIssue, state_override: Option<&str>) -> Issue {
+        let state = state_override.map(ToString::to_string).unwrap_or_else(|| {
+            extract_state_from_labels(&gh.labels, self.state_prefix())
+                .map(|(_, display)| display)
+                .unwrap_or_default()
+        });
 
         let labels = gh.labels.iter().map(|label| label.name.clone()).collect();
         let url = gh.html_url.clone().or_else(|| {
@@ -63,6 +108,10 @@ impl GithubAdapter {
         }
     }
 
+    fn issue_to_domain(&self, gh: &GithubIssue) -> Issue {
+        self.issue_to_domain_with_state(gh, None)
+    }
+
     fn candidate_state_set(&self) -> HashSet<String> {
         self.config
             .active_states
@@ -87,14 +136,92 @@ impl GithubAdapter {
 
         issue_matches_assignee(issue, &assignee)
     }
-}
 
-#[async_trait]
-impl TrackerAdapter for GithubAdapter {
-    async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>> {
+    fn projects_mode(&self) -> Option<(u64, &ProjectsV2Client)> {
+        match &self.state_mode {
+            StateMode::ProjectsV2 {
+                project_number,
+                v2_client,
+            } => Some((*project_number, v2_client)),
+            StateMode::Labels => None,
+        }
+    }
+
+    async fn ensure_status_field(&self) -> Result<&StatusFieldInfo> {
+        let (project_number, v2_client) = self.projects_mode().ok_or_else(|| {
+            SymphonyError::GithubProjectsV2Error(
+                "Projects v2 mode not enabled for this GitHub adapter".to_string(),
+            )
+        })?;
+
+        let owner = self.client.repo_owner.clone();
+        self.status_field_cache
+            .get_or_try_init(|| async {
+                v2_client.resolve_status_field(&owner, project_number).await
+            })
+            .await
+    }
+
+    fn status_option_ids_for_names(
+        &self,
+        status_field: &StatusFieldInfo,
+        state_names: &[String],
+    ) -> Result<Vec<String>> {
+        let mut option_ids = Vec::new();
+        let mut seen = HashSet::new();
+
+        for state_name in state_names {
+            let normalized = normalize_state_for_compare(state_name);
+            let option = status_field
+                .options
+                .iter()
+                .find(|option| normalize_state_for_compare(&option.name) == normalized)
+                .ok_or_else(|| {
+                    let available = status_field
+                        .options
+                        .iter()
+                        .map(|option| option.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    SymphonyError::GithubProjectsV2Error(format!(
+                        "status option '{state_name}' not found; available: [{available}]"
+                    ))
+                })?;
+
+            if seen.insert(option.id.clone()) {
+                option_ids.push(option.id.clone());
+            }
+        }
+
+        Ok(option_ids)
+    }
+
+    fn status_option_for_name<'a>(
+        &self,
+        status_field: &'a StatusFieldInfo,
+        state_name: &str,
+    ) -> Result<&'a StatusOption> {
+        let normalized = normalize_state_for_compare(state_name);
+        status_field
+            .options
+            .iter()
+            .find(|option| normalize_state_for_compare(&option.name) == normalized)
+            .ok_or_else(|| {
+                let available = status_field
+                    .options
+                    .iter()
+                    .map(|option| option.name.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                SymphonyError::GithubProjectsV2Error(format!(
+                    "status option '{state_name}' not found on project; available: [{available}]"
+                ))
+            })
+    }
+
+    async fn fetch_candidate_issues_labels(&self) -> Result<Vec<Issue>> {
         let issues = self.client.list_issues("open", &[]).await?;
         let allowed_states = self.candidate_state_set();
-
         let assignee_filter = self.assignee_filter();
 
         let filtered = issues
@@ -135,7 +262,60 @@ impl TrackerAdapter for GithubAdapter {
         Ok(filtered)
     }
 
-    async fn fetch_issues_by_states(&self, state_names: &[String]) -> Result<Vec<Issue>> {
+    async fn fetch_candidate_issues_projects(
+        &self,
+        _project_number: u64,
+        v2_client: &ProjectsV2Client,
+    ) -> Result<Vec<Issue>> {
+        let status_field = self.ensure_status_field().await?;
+        let option_ids =
+            self.status_option_ids_for_names(status_field, &self.config.active_states)?;
+        if option_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let project_items = v2_client
+            .query_items_by_status(&status_field.project_id, &option_ids)
+            .await?;
+
+        let assignee_filter = self.assignee_filter();
+        let mut issues = Vec::new();
+
+        for item in project_items {
+            let issue = match self.client.get_issue(item.issue_number).await {
+                Ok(issue) => issue,
+                Err(SymphonyError::GithubApiStatus { status: 404, .. }) => {
+                    tracing::debug!(
+                        issue_number = item.issue_number,
+                        "GitHub issue missing while reading Projects v2 candidate"
+                    );
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
+
+            if issue.pull_request.is_some() {
+                tracing::debug!(
+                    issue_number = issue.number,
+                    "Skipping GitHub pull request from Projects v2 candidate issue set"
+                );
+                continue;
+            }
+
+            if let Some(assignee) = assignee_filter.as_deref() {
+                if !issue_matches_assignee(&issue, assignee) {
+                    continue;
+                }
+            }
+
+            let issue_state = item.status.as_deref().unwrap_or_default();
+            issues.push(self.issue_to_domain_with_state(&issue, Some(issue_state)));
+        }
+
+        Ok(issues)
+    }
+
+    async fn fetch_issues_by_states_labels(&self, state_names: &[String]) -> Result<Vec<Issue>> {
         // NOTE: We intentionally query only GitHub-open issues.
         // Symphony tracker state is label-driven (`{prefix}:{state}`), and this adapter does not
         // transition GitHub's native open/closed field.
@@ -166,7 +346,53 @@ impl TrackerAdapter for GithubAdapter {
         Ok(filtered)
     }
 
-    async fn fetch_issue_states_by_ids(&self, issue_ids: &[String]) -> Result<Vec<Issue>> {
+    async fn fetch_issues_by_states_projects(
+        &self,
+        _project_number: u64,
+        v2_client: &ProjectsV2Client,
+        state_names: &[String],
+    ) -> Result<Vec<Issue>> {
+        let status_field = self.ensure_status_field().await?;
+        let option_ids = self.status_option_ids_for_names(status_field, state_names)?;
+        if option_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let project_items = v2_client
+            .query_items_by_status(&status_field.project_id, &option_ids)
+            .await?;
+
+        let mut issues = Vec::new();
+
+        for item in project_items {
+            let issue = match self.client.get_issue(item.issue_number).await {
+                Ok(issue) => issue,
+                Err(SymphonyError::GithubApiStatus { status: 404, .. }) => {
+                    tracing::debug!(
+                        issue_number = item.issue_number,
+                        "GitHub issue missing while reading Projects v2 state filter"
+                    );
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
+
+            if issue.pull_request.is_some() {
+                tracing::debug!(
+                    issue_number = issue.number,
+                    "Skipping GitHub pull request while filtering by Projects v2 state"
+                );
+                continue;
+            }
+
+            let issue_state = item.status.as_deref().unwrap_or_default();
+            issues.push(self.issue_to_domain_with_state(&issue, Some(issue_state)));
+        }
+
+        Ok(issues)
+    }
+
+    async fn fetch_issue_states_by_ids_labels(&self, issue_ids: &[String]) -> Result<Vec<Issue>> {
         let mut issues = Vec::new();
 
         for issue_id in issue_ids {
@@ -199,7 +425,147 @@ impl TrackerAdapter for GithubAdapter {
         Ok(issues)
     }
 
+    async fn fetch_issue_states_by_ids_projects(
+        &self,
+        _project_number: u64,
+        v2_client: &ProjectsV2Client,
+        issue_ids: &[String],
+    ) -> Result<Vec<Issue>> {
+        let status_field = self.ensure_status_field().await?;
+
+        let no_filter: Vec<String> = Vec::new();
+        let project_items = v2_client
+            .query_items_by_status(&status_field.project_id, &no_filter)
+            .await?;
+
+        let mut state_by_issue_number = HashMap::new();
+        for item in project_items {
+            if let Some(status) = item.status {
+                state_by_issue_number.insert(item.issue_number, status);
+            }
+        }
+
+        let mut issues = Vec::new();
+        for issue_id in issue_ids {
+            let Ok(number) = issue_id.parse::<u64>() else {
+                continue;
+            };
+
+            let Some(state) = state_by_issue_number.get(&number).cloned() else {
+                tracing::debug!(
+                    issue_number = number,
+                    "GitHub issue not on project board while fetching issue states"
+                );
+                continue;
+            };
+
+            match self.client.get_issue(number).await {
+                Ok(issue) => {
+                    if issue.pull_request.is_some() {
+                        tracing::debug!(
+                            issue_number = number,
+                            "Skipping GitHub pull request while fetching Projects v2 issue states"
+                        );
+                        continue;
+                    }
+
+                    issues.push(self.issue_to_domain_with_state(&issue, Some(&state)));
+                }
+                Err(SymphonyError::GithubApiStatus { status: 404, .. }) => {
+                    tracing::debug!(
+                        issue_number = number,
+                        "GitHub issue not found while polling Projects v2 state"
+                    );
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(issues)
+    }
+
+    async fn update_issue_state_projects(
+        &self,
+        project_number: u64,
+        v2_client: &ProjectsV2Client,
+        issue_number: u64,
+        state_name: &str,
+    ) -> Result<()> {
+        let status_field = self.ensure_status_field().await?;
+        let target_option = self.status_option_for_name(status_field, state_name)?;
+
+        let no_filter: Vec<String> = Vec::new();
+        let project_items = v2_client
+            .query_items_by_status(&status_field.project_id, &no_filter)
+            .await?;
+
+        let project_item = project_items
+            .into_iter()
+            .find(|item| item.issue_number == issue_number)
+            .ok_or_else(|| {
+                SymphonyError::GithubProjectsV2Error(format!(
+                    "issue #{issue_number} is not on project board #{project_number}"
+                ))
+            })?;
+
+        tracing::debug!(
+            issue_number,
+            item_id = %project_item.item_id,
+            "resolved project item for issue"
+        );
+
+        tracing::debug!(
+            issue_number,
+            option_id = %target_option.id,
+            state_name,
+            "updating Projects v2 status"
+        );
+
+        v2_client
+            .update_item_status(
+                &status_field.project_id,
+                &project_item.item_id,
+                &status_field.field_id,
+                &target_option.id,
+            )
+            .await
+    }
+}
+
+#[async_trait]
+impl TrackerAdapter for GithubAdapter {
+    async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>> {
+        match self.projects_mode() {
+            Some((project_number, v2_client)) => {
+                self.fetch_candidate_issues_projects(project_number, v2_client)
+                    .await
+            }
+            None => self.fetch_candidate_issues_labels().await,
+        }
+    }
+
+    async fn fetch_issues_by_states(&self, state_names: &[String]) -> Result<Vec<Issue>> {
+        match self.projects_mode() {
+            Some((project_number, v2_client)) => {
+                self.fetch_issues_by_states_projects(project_number, v2_client, state_names)
+                    .await
+            }
+            None => self.fetch_issues_by_states_labels(state_names).await,
+        }
+    }
+
+    async fn fetch_issue_states_by_ids(&self, issue_ids: &[String]) -> Result<Vec<Issue>> {
+        match self.projects_mode() {
+            Some((project_number, v2_client)) => {
+                self.fetch_issue_states_by_ids_projects(project_number, v2_client, issue_ids)
+                    .await
+            }
+            None => self.fetch_issue_states_by_ids_labels(issue_ids).await,
+        }
+    }
+
     async fn create_comment(&self, issue_id: &str, body: &str) -> Result<()> {
+        // Intentionally mode-independent: comments always use GitHub REST issue comments.
         let number = issue_id.parse::<u64>().map_err(|err| {
             SymphonyError::Other(format!(
                 "invalid GitHub issue id '{issue_id}' for create_comment: {err}"
@@ -216,53 +582,61 @@ impl TrackerAdapter for GithubAdapter {
             ))
         })?;
 
-        let issue = self.client.get_issue(number).await?;
-        let prefix = self.state_prefix();
+        match self.projects_mode() {
+            Some((project_number, v2_client)) => {
+                self.update_issue_state_projects(project_number, v2_client, number, state_name)
+                    .await
+            }
+            None => {
+                let issue = self.client.get_issue(number).await?;
+                let prefix = self.state_prefix();
 
-        let marker = format!("{}:", prefix.to_ascii_lowercase());
-        let old_labels: Vec<String> = issue
-            .labels
-            .iter()
-            .filter_map(|label| {
-                if label.name.to_ascii_lowercase().starts_with(&marker) {
-                    Some(label.name.clone())
-                } else {
-                    None
+                let marker = format!("{}:", prefix.to_ascii_lowercase());
+                let old_labels: Vec<String> = issue
+                    .labels
+                    .iter()
+                    .filter_map(|label| {
+                        if label.name.to_ascii_lowercase().starts_with(&marker) {
+                            Some(label.name.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                let new_label = format!("{prefix}:{}", normalize_state_for_label(state_name));
+
+                tracing::debug!(
+                    issue_number = number,
+                    old_labels = ?old_labels,
+                    new_label = %new_label,
+                    "Updating GitHub issue state via label swap"
+                );
+
+                for old in old_labels
+                    .iter()
+                    .filter(|old| old.as_str() != new_label.as_str())
+                {
+                    match self.client.remove_label(number, old).await {
+                        Ok(()) => {}
+                        Err(SymphonyError::GithubApiStatus { status: 404, .. }) => {
+                            tracing::debug!(
+                                issue_number = number,
+                                old_label = %old,
+                                "Old GitHub state label already absent"
+                            );
+                        }
+                        Err(err) => return Err(err),
+                    }
                 }
-            })
-            .collect();
 
-        let new_label = format!("{prefix}:{}", normalize_state_for_label(state_name));
-
-        tracing::debug!(
-            issue_number = number,
-            old_labels = ?old_labels,
-            new_label = %new_label,
-            "Updating GitHub issue state via label swap"
-        );
-
-        for old in old_labels
-            .iter()
-            .filter(|old| old.as_str() != new_label.as_str())
-        {
-            match self.client.remove_label(number, old).await {
-                Ok(()) => {}
-                Err(SymphonyError::GithubApiStatus { status: 404, .. }) => {
-                    tracing::debug!(
-                        issue_number = number,
-                        old_label = %old,
-                        "Old GitHub state label already absent"
-                    );
+                if !old_labels.iter().any(|label| label == &new_label) {
+                    self.client.add_label(number, &new_label).await?;
                 }
-                Err(err) => return Err(err),
+
+                Ok(())
             }
         }
-
-        if !old_labels.iter().any(|label| label == &new_label) {
-            self.client.add_label(number, &new_label).await?;
-        }
-
-        Ok(())
     }
 }
 
@@ -307,6 +681,16 @@ fn normalize_state_for_label(state_name: &str) -> String {
         .split_whitespace()
         .collect::<Vec<_>>()
         .join("-")
+}
+
+fn normalize_state_for_compare(state_name: &str) -> String {
+    state_name
+        .trim()
+        .to_ascii_lowercase()
+        .replace(['_', '-'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn denormalize_label_state(normalized: &str) -> String {

--- a/apps/symphony/src/github/adapter.rs
+++ b/apps/symphony/src/github/adapter.rs
@@ -516,6 +516,7 @@ impl GithubAdapter {
 
         tracing::debug!(
             issue_number,
+            project_number,
             option_id = %target_option.id,
             state_name,
             "updating Projects v2 status"

--- a/apps/symphony/src/github/adapter.rs
+++ b/apps/symphony/src/github/adapter.rs
@@ -264,7 +264,6 @@ impl GithubAdapter {
 
     async fn fetch_candidate_issues_projects(
         &self,
-        _project_number: u64,
         v2_client: &ProjectsV2Client,
     ) -> Result<Vec<Issue>> {
         let status_field = self.ensure_status_field().await?;
@@ -298,6 +297,15 @@ impl GithubAdapter {
                 tracing::debug!(
                     issue_number = issue.number,
                     "Skipping GitHub pull request from Projects v2 candidate issue set"
+                );
+                continue;
+            }
+
+            if !issue.state.eq_ignore_ascii_case("open") {
+                tracing::debug!(
+                    issue_number = issue.number,
+                    issue_state = %issue.state,
+                    "Skipping non-open GitHub issue from Projects v2 candidate issue set"
                 );
                 continue;
             }
@@ -348,7 +356,6 @@ impl GithubAdapter {
 
     async fn fetch_issues_by_states_projects(
         &self,
-        _project_number: u64,
         v2_client: &ProjectsV2Client,
         state_names: &[String],
     ) -> Result<Vec<Issue>> {
@@ -427,7 +434,6 @@ impl GithubAdapter {
 
     async fn fetch_issue_states_by_ids_projects(
         &self,
-        _project_number: u64,
         v2_client: &ProjectsV2Client,
         issue_ids: &[String],
     ) -> Result<Vec<Issue>> {
@@ -486,11 +492,19 @@ impl GithubAdapter {
 
     async fn update_issue_state_projects(
         &self,
-        project_number: u64,
         v2_client: &ProjectsV2Client,
         issue_number: u64,
         state_name: &str,
     ) -> Result<()> {
+        let project_number = self
+            .projects_mode()
+            .map(|(project_number, _)| project_number)
+            .ok_or_else(|| {
+                SymphonyError::GithubProjectsV2Error(
+                    "Projects v2 mode not enabled for this GitHub adapter".to_string(),
+                )
+            })?;
+
         let status_field = self.ensure_status_field().await?;
         let target_option = self.status_option_for_name(status_field, state_name)?;
 
@@ -537,18 +551,15 @@ impl GithubAdapter {
 impl TrackerAdapter for GithubAdapter {
     async fn fetch_candidate_issues(&self) -> Result<Vec<Issue>> {
         match self.projects_mode() {
-            Some((project_number, v2_client)) => {
-                self.fetch_candidate_issues_projects(project_number, v2_client)
-                    .await
-            }
+            Some((_, v2_client)) => self.fetch_candidate_issues_projects(v2_client).await,
             None => self.fetch_candidate_issues_labels().await,
         }
     }
 
     async fn fetch_issues_by_states(&self, state_names: &[String]) -> Result<Vec<Issue>> {
         match self.projects_mode() {
-            Some((project_number, v2_client)) => {
-                self.fetch_issues_by_states_projects(project_number, v2_client, state_names)
+            Some((_, v2_client)) => {
+                self.fetch_issues_by_states_projects(v2_client, state_names)
                     .await
             }
             None => self.fetch_issues_by_states_labels(state_names).await,
@@ -557,8 +568,8 @@ impl TrackerAdapter for GithubAdapter {
 
     async fn fetch_issue_states_by_ids(&self, issue_ids: &[String]) -> Result<Vec<Issue>> {
         match self.projects_mode() {
-            Some((project_number, v2_client)) => {
-                self.fetch_issue_states_by_ids_projects(project_number, v2_client, issue_ids)
+            Some((_, v2_client)) => {
+                self.fetch_issue_states_by_ids_projects(v2_client, issue_ids)
                     .await
             }
             None => self.fetch_issue_states_by_ids_labels(issue_ids).await,
@@ -584,8 +595,8 @@ impl TrackerAdapter for GithubAdapter {
         })?;
 
         match self.projects_mode() {
-            Some((project_number, v2_client)) => {
-                self.update_issue_state_projects(project_number, v2_client, number, state_name)
+            Some((_, v2_client)) => {
+                self.update_issue_state_projects(v2_client, number, state_name)
                     .await
             }
             None => {

--- a/apps/symphony/src/github/mod.rs
+++ b/apps/symphony/src/github/mod.rs
@@ -1,2 +1,3 @@
 pub mod adapter;
 pub mod client;
+pub mod projects_v2;

--- a/apps/symphony/src/github/projects_v2.rs
+++ b/apps/symphony/src/github/projects_v2.rs
@@ -17,7 +17,7 @@ query($projectNumber: Int!, $owner: String!) {
   user(login: $owner) {
     projectV2(number: $projectNumber) {
       id
-      field(name: \"Status\") {
+      field(name: "Status") {
         ... on ProjectV2SingleSelectField {
           id
           options {
@@ -31,7 +31,7 @@ query($projectNumber: Int!, $owner: String!) {
   organization(login: $owner) {
     projectV2(number: $projectNumber) {
       id
-      field(name: \"Status\") {
+      field(name: "Status") {
         ... on ProjectV2SingleSelectField {
           id
           options {
@@ -57,7 +57,7 @@ query($projectId: ID!, $first: Int!, $after: String) {
               number
             }
           }
-          fieldValueByName(name: \"Status\") {
+          fieldValueByName(name: "Status") {
             ... on ProjectV2ItemFieldSingleSelectValue {
               name
               optionId

--- a/apps/symphony/src/github/projects_v2.rs
+++ b/apps/symphony/src/github/projects_v2.rs
@@ -1,0 +1,425 @@
+use std::collections::HashSet;
+
+use reqwest::Method;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::error::{Result, SymphonyError};
+use crate::github::client::GithubClient;
+
+const MAX_PAGES: usize = 10;
+const PAGE_SIZE: usize = 100;
+const ERROR_BODY_PREVIEW_CHARS: usize = 200;
+
+pub const QUERY_PROJECT_FIELDS: &str = r#"
+query($projectNumber: Int!, $owner: String!) {
+  user(login: $owner) {
+    projectV2(number: $projectNumber) {
+      id
+      field(name: \"Status\") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+  organization(login: $owner) {
+    projectV2(number: $projectNumber) {
+      id
+      field(name: \"Status\") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+pub const QUERY_PROJECT_ITEMS: &str = r#"
+query($projectId: ID!, $first: Int!, $after: String) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: $first, after: $after) {
+        nodes {
+          id
+          content {
+            ... on Issue {
+              number
+            }
+          }
+          fieldValueByName(name: \"Status\") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name
+              optionId
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+"#;
+
+pub const MUTATION_UPDATE_STATUS: &str = r#"
+mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $singleSelectOptionId: String!) {
+  updateProjectV2ItemFieldValue(
+    input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $fieldId
+      value: { singleSelectOptionId: $singleSelectOptionId }
+    }
+  ) {
+    projectV2Item {
+      id
+    }
+  }
+}
+"#;
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct StatusOption {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct StatusFieldInfo {
+    pub project_id: String,
+    pub field_id: String,
+    pub options: Vec<StatusOption>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectItem {
+    pub item_id: String,
+    pub issue_number: u64,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectsV2Client {
+    github_client: GithubClient,
+}
+
+impl ProjectsV2Client {
+    pub fn new(github_client: GithubClient) -> Self {
+        Self { github_client }
+    }
+
+    pub async fn resolve_status_field(
+        &self,
+        owner: &str,
+        project_number: u64,
+    ) -> Result<StatusFieldInfo> {
+        let variables = json!({
+            "owner": owner,
+            "projectNumber": project_number as i64,
+        });
+
+        let data: ProjectFieldsData = self
+            .graphql_request(QUERY_PROJECT_FIELDS, variables)
+            .await?;
+
+        let project = data
+            .user
+            .and_then(|user| user.project_v2)
+            .or_else(|| data.organization.and_then(|org| org.project_v2))
+            .ok_or_else(|| {
+                SymphonyError::GithubProjectsV2Error(format!(
+                    "Project #{project_number} not found for owner '{owner}'"
+                ))
+            })?;
+
+        let Some(field) = project.field else {
+            tracing::warn!(project_number, owner, "Projects v2 status field not found");
+            return Err(SymphonyError::GithubProjectsV2Error(format!(
+                "Status field not found on project #{project_number}"
+            )));
+        };
+
+        tracing::debug!(
+            field_id = %field.id,
+            option_count = field.options.len(),
+            "Projects v2 status field resolved"
+        );
+
+        Ok(StatusFieldInfo {
+            project_id: project.id,
+            field_id: field.id,
+            options: field.options,
+        })
+    }
+
+    pub async fn query_items_by_status(
+        &self,
+        project_id: &str,
+        status_option_ids: &[String],
+    ) -> Result<Vec<ProjectItem>> {
+        let mut items = Vec::new();
+        let mut after: Option<String> = None;
+        let status_filter: Option<HashSet<&str>> = if status_option_ids.is_empty() {
+            None
+        } else {
+            Some(status_option_ids.iter().map(String::as_str).collect())
+        };
+
+        for _ in 0..MAX_PAGES {
+            let variables = json!({
+                "projectId": project_id,
+                "first": PAGE_SIZE,
+                "after": after,
+            });
+
+            let data: ProjectItemsData =
+                self.graphql_request(QUERY_PROJECT_ITEMS, variables).await?;
+            let node = data.node.ok_or_else(|| {
+                SymphonyError::GithubProjectsV2Error(format!(
+                    "Project node '{project_id}' not found"
+                ))
+            })?;
+
+            for node in node.items.nodes {
+                let Some(issue_number) = node.content.and_then(|content| content.number) else {
+                    continue;
+                };
+
+                let status_option_id = node
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.option_id.as_deref());
+                if let Some(filter) = &status_filter {
+                    let Some(option_id) = status_option_id else {
+                        continue;
+                    };
+                    if !filter.contains(option_id) {
+                        continue;
+                    }
+                }
+
+                items.push(ProjectItem {
+                    item_id: node.id,
+                    issue_number,
+                    status: node.status.and_then(|status| status.name),
+                });
+            }
+
+            tracing::debug!(item_count = items.len(), "Projects v2 items queried");
+
+            if node.items.page_info.has_next_page {
+                after = node.items.page_info.end_cursor;
+                if after.is_none() {
+                    return Err(SymphonyError::GithubProjectsV2Error(
+                        "Projects v2 query indicated next page but provided no cursor".to_string(),
+                    ));
+                }
+            } else {
+                after = None;
+                break;
+            }
+        }
+
+        if after.is_some() {
+            tracing::warn!(
+                max_pages = MAX_PAGES,
+                "Projects v2 item query truncated at page cap"
+            );
+        }
+
+        Ok(items)
+    }
+
+    pub async fn update_item_status(
+        &self,
+        project_id: &str,
+        item_id: &str,
+        field_id: &str,
+        option_id: &str,
+    ) -> Result<()> {
+        let variables = json!({
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "singleSelectOptionId": option_id,
+        });
+
+        let data: UpdateStatusData = self
+            .graphql_request(MUTATION_UPDATE_STATUS, variables)
+            .await?;
+
+        let mutation_result = data.update_project_item.ok_or_else(|| {
+            SymphonyError::GithubProjectsV2Error(
+                "Projects v2 status mutation did not return a result".to_string(),
+            )
+        })?;
+
+        if mutation_result.item.id.is_empty() {
+            return Err(SymphonyError::GithubProjectsV2Error(
+                "Projects v2 status mutation returned empty item id".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    async fn graphql_request<T: DeserializeOwned>(
+        &self,
+        query: &str,
+        variables: Value,
+    ) -> Result<T> {
+        let payload = json!({
+            "query": query,
+            "variables": variables,
+        });
+
+        let response = self
+            .github_client
+            .request(Method::POST, "/graphql", Some(&payload))
+            .await?;
+
+        let body = response.text().await.map_err(|err| {
+            SymphonyError::GithubProjectsV2Error(format!(
+                "Failed to read GraphQL response body: {err}"
+            ))
+        })?;
+
+        let envelope: GraphqlEnvelope<T> = serde_json::from_str(&body).map_err(|err| {
+            SymphonyError::GithubProjectsV2Error(format!(
+                "Failed to decode GraphQL response: {err}; body={}",
+                truncate_preview(&body)
+            ))
+        })?;
+
+        if let Some(errors) = envelope.errors.filter(|errors| !errors.is_empty()) {
+            let message = &errors[0].message;
+            return Err(SymphonyError::GithubProjectsV2Error(format!(
+                "{message}; response={}",
+                truncate_preview(&body)
+            )));
+        }
+
+        envelope.data.ok_or_else(|| {
+            SymphonyError::GithubProjectsV2Error(format!(
+                "GraphQL response missing data; body={}",
+                truncate_preview(&body)
+            ))
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlEnvelope<T> {
+    data: Option<T>,
+    #[serde(default)]
+    errors: Option<Vec<GraphqlError>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectFieldsData {
+    user: Option<ProjectOwner>,
+    organization: Option<ProjectOwner>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectOwner {
+    #[serde(rename = "projectV2")]
+    project_v2: Option<ProjectNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectNode {
+    id: String,
+    field: Option<ProjectStatusField>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectStatusField {
+    id: String,
+    #[serde(default)]
+    options: Vec<StatusOption>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectItemsData {
+    node: Option<ProjectItemsNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectItemsNode {
+    items: ProjectItemsConnection,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectItemsConnection {
+    nodes: Vec<ProjectItemNode>,
+    #[serde(rename = "pageInfo")]
+    page_info: PageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+struct PageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+    #[serde(rename = "endCursor")]
+    end_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectItemNode {
+    id: String,
+    content: Option<ProjectItemContent>,
+    #[serde(rename = "fieldValueByName")]
+    status: Option<ProjectItemStatus>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectItemContent {
+    number: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectItemStatus {
+    name: Option<String>,
+    #[serde(rename = "optionId")]
+    option_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateStatusData {
+    #[serde(rename = "updateProjectV2ItemFieldValue")]
+    update_project_item: Option<UpdateProjectItemMutation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateProjectItemMutation {
+    #[serde(rename = "projectV2Item")]
+    item: UpdateProjectItem,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateProjectItem {
+    id: String,
+}
+
+fn truncate_preview(body: &str) -> String {
+    body.chars().take(ERROR_BODY_PREVIEW_CHARS).collect()
+}

--- a/apps/symphony/tests/github_adapter_tests.rs
+++ b/apps/symphony/tests/github_adapter_tests.rs
@@ -166,6 +166,11 @@ fn issue_json(
     })
 }
 
+fn issue_state_json(mut issue: serde_json::Value, state: &str) -> serde_json::Value {
+    issue["state"] = json!(state);
+    issue
+}
+
 fn pull_request_json(mut issue: serde_json::Value) -> serde_json::Value {
     issue["pull_request"] = json!({
         "url": "https://api.github.com/repos/kata-sh/kata-mono/pulls/123"
@@ -787,6 +792,73 @@ async fn test_projects_v2_fetch_candidate_issues_queries_by_status() {
     assert_eq!(issues[0].state, "Todo");
     assert_eq!(issues[1].identifier, "#102");
     assert_eq!(issues[1].state, "In Progress");
+}
+
+#[tokio::test]
+async fn test_projects_v2_fetch_candidate_issues_skips_closed_issues() {
+    let mut server = Server::new_async().await;
+    let adapter = test_projects_adapter(&server, None, 42);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(projects_v2_status_field_payload().to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_v2_items_payload(&[
+                project_item_node("item_301", 301, "opt_todo", "Todo"),
+                project_item_node("item_302", 302, "opt_in_progress", "In Progress"),
+            ])
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issue_open = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/301")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(issue_json(301, &["symphony:todo"], "alice", &["alice"], None).to_string())
+        .create_async()
+        .await;
+
+    let issue_closed = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/302")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            issue_state_json(
+                issue_json(302, &["symphony:todo"], "bob", &["bob"], None),
+                "closed",
+            )
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let issues = adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("projects v2 fetch_candidate_issues should succeed");
+
+    fields_mock.assert_async().await;
+    items_mock.assert_async().await;
+    issue_open.assert_async().await;
+    issue_closed.assert_async().await;
+
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].identifier, "#301");
 }
 
 #[tokio::test]

--- a/apps/symphony/tests/github_adapter_tests.rs
+++ b/apps/symphony/tests/github_adapter_tests.rs
@@ -1,7 +1,8 @@
 use mockito::{Matcher, Server, ServerGuard};
 use serde_json::json;
 use symphony::domain::{ApiKey, TrackerConfig};
-use symphony::github::adapter::GithubAdapter;
+use symphony::error::SymphonyError;
+use symphony::github::adapter::{GithubAdapter, StateMode};
 use symphony::github::client::GithubClient;
 use symphony::linear::adapter::TrackerAdapter;
 
@@ -32,6 +33,113 @@ fn test_adapter(server: &ServerGuard, assignee: Option<&str>) -> GithubAdapter {
         server.url(),
     );
     GithubAdapter::new(client, test_config(assignee))
+}
+
+fn test_projects_adapter(
+    server: &ServerGuard,
+    assignee: Option<&str>,
+    project_number: u64,
+) -> GithubAdapter {
+    let mut config = test_config(assignee);
+    config.github_project_number = Some(project_number);
+
+    let client = GithubClient::with_base_url(
+        "test-token",
+        "kata-sh",
+        "kata-mono",
+        "symphony",
+        server.url(),
+    );
+
+    GithubAdapter::new(client, config)
+}
+
+fn projects_v2_status_field_payload() -> serde_json::Value {
+    json!({
+        "data": {
+            "user": {
+                "projectV2": {
+                    "id": "project_42",
+                    "field": {
+                        "id": "status_field",
+                        "options": [
+                            { "id": "opt_todo", "name": "Todo" },
+                            { "id": "opt_in_progress", "name": "In Progress" },
+                            { "id": "opt_done", "name": "Done" }
+                        ]
+                    }
+                }
+            },
+            "organization": null
+        }
+    })
+}
+
+fn projects_v2_items_payload(items: &[serde_json::Value]) -> serde_json::Value {
+    json!({
+        "data": {
+            "node": {
+                "items": {
+                    "nodes": items,
+                    "pageInfo": {
+                        "hasNextPage": false,
+                        "endCursor": null
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn project_item_node(
+    item_id: &str,
+    issue_number: u64,
+    option_id: &str,
+    status_name: &str,
+) -> serde_json::Value {
+    json!({
+        "id": item_id,
+        "content": { "number": issue_number },
+        "fieldValueByName": {
+            "name": status_name,
+            "optionId": option_id
+        }
+    })
+}
+
+async fn run_tracker_contract(
+    adapter: &GithubAdapter,
+    expected_state: &str,
+    transition_state: &str,
+) {
+    let candidates = adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("fetch_candidate_issues should succeed");
+    assert!(!candidates.is_empty(), "contract expects candidate issues");
+
+    let by_state = adapter
+        .fetch_issues_by_states(&[expected_state.to_string()])
+        .await
+        .expect("fetch_issues_by_states should succeed");
+    assert!(!by_state.is_empty(), "contract expects issues_by_states");
+
+    let issue_id = candidates[0].id.clone();
+    let issue_states = adapter
+        .fetch_issue_states_by_ids(std::slice::from_ref(&issue_id))
+        .await
+        .expect("fetch_issue_states_by_ids should succeed");
+    assert!(!issue_states.is_empty(), "contract expects issue_states");
+
+    adapter
+        .create_comment(&issue_id, "contract comment")
+        .await
+        .expect("create_comment should succeed");
+
+    adapter
+        .update_issue_state(&issue_id, transition_state)
+        .await
+        .expect("update_issue_state should succeed");
 }
 
 fn issue_json(
@@ -595,4 +703,498 @@ async fn test_issue_to_domain_extracts_state_from_label() {
     mock.assert_async().await;
     assert_eq!(issues.len(), 1);
     assert_eq!(issues[0].state, "In Progress");
+}
+
+#[tokio::test]
+async fn test_mode_detection_selects_projects_v2_when_project_number_set() {
+    let server = Server::new_async().await;
+    let adapter = test_projects_adapter(&server, None, 42);
+
+    assert!(matches!(
+        adapter.state_mode(),
+        StateMode::ProjectsV2 { project_number, .. } if *project_number == 42
+    ));
+}
+
+#[tokio::test]
+async fn test_mode_detection_selects_labels_when_project_number_absent() {
+    let server = Server::new_async().await;
+    let adapter = test_adapter(&server, None);
+
+    assert!(matches!(adapter.state_mode(), StateMode::Labels));
+}
+
+#[tokio::test]
+async fn test_projects_v2_fetch_candidate_issues_queries_by_status() {
+    let mut server = Server::new_async().await;
+    let adapter = test_projects_adapter(&server, None, 42);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(projects_v2_status_field_payload().to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_v2_items_payload(&[
+                project_item_node("item_101", 101, "opt_todo", "Todo"),
+                project_item_node("item_102", 102, "opt_in_progress", "In Progress"),
+                project_item_node("item_103", 103, "opt_done", "Done"),
+            ])
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issue_101 = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/101")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(issue_json(101, &["symphony:done"], "alice", &["alice"], None).to_string())
+        .create_async()
+        .await;
+
+    let issue_102 = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/102")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(issue_json(102, &["symphony:todo"], "bob", &["bob"], None).to_string())
+        .create_async()
+        .await;
+
+    let issues = adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("projects v2 fetch_candidate_issues should succeed");
+
+    fields_mock.assert_async().await;
+    items_mock.assert_async().await;
+    issue_101.assert_async().await;
+    issue_102.assert_async().await;
+
+    assert_eq!(issues.len(), 2);
+    assert_eq!(issues[0].identifier, "#101");
+    assert_eq!(issues[0].state, "Todo");
+    assert_eq!(issues[1].identifier, "#102");
+    assert_eq!(issues[1].state, "In Progress");
+}
+
+#[tokio::test]
+async fn test_projects_v2_fetch_issues_by_states() {
+    let mut server = Server::new_async().await;
+    let adapter = test_projects_adapter(&server, None, 42);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(projects_v2_status_field_payload().to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_v2_items_payload(&[
+                project_item_node("item_201", 201, "opt_todo", "Todo"),
+                project_item_node("item_202", 202, "opt_done", "Done"),
+            ])
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issue_202 = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/202")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(issue_json(202, &["symphony:todo"], "alice", &["alice"], None).to_string())
+        .create_async()
+        .await;
+
+    let issues = adapter
+        .fetch_issues_by_states(&["Done".to_string()])
+        .await
+        .expect("projects v2 fetch_issues_by_states should succeed");
+
+    fields_mock.assert_async().await;
+    items_mock.assert_async().await;
+    issue_202.assert_async().await;
+
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].identifier, "#202");
+    assert_eq!(issues[0].state, "Done");
+}
+
+#[tokio::test]
+async fn test_projects_v2_update_issue_state_mutates_status_field() {
+    let mut server = Server::new_async().await;
+    let adapter = test_projects_adapter(&server, None, 42);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(projects_v2_status_field_payload().to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_v2_items_payload(&[project_item_node("item_7", 7, "opt_todo", "Todo")])
+                .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mutation_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::AllOf(vec![
+            Matcher::Regex("updateProjectV2ItemFieldValue".to_string()),
+            Matcher::PartialJson(json!({
+                "variables": {
+                    "projectId": "project_42",
+                    "itemId": "item_7",
+                    "fieldId": "status_field",
+                    "singleSelectOptionId": "opt_done"
+                }
+            })),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "data": {
+                    "updateProjectV2ItemFieldValue": {
+                        "projectV2Item": { "id": "item_7" }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    adapter
+        .update_issue_state("7", "Done")
+        .await
+        .expect("projects v2 update_issue_state should succeed");
+
+    fields_mock.assert_async().await;
+    items_mock.assert_async().await;
+    mutation_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_projects_v2_update_issue_state_unknown_status_errors() {
+    let mut server = Server::new_async().await;
+    let adapter = test_projects_adapter(&server, None, 42);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(projects_v2_status_field_payload().to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let err = adapter
+        .update_issue_state("7", "Blocked")
+        .await
+        .expect_err("unknown status should fail");
+
+    fields_mock.assert_async().await;
+    match err {
+        SymphonyError::GithubProjectsV2Error(message) => {
+            assert!(message.contains("status option 'Blocked' not found"));
+            assert!(message.contains("Todo"));
+            assert!(message.contains("In Progress"));
+            assert!(message.contains("Done"));
+        }
+        other => panic!("expected GithubProjectsV2Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_projects_v2_update_issue_state_issue_not_on_board_errors() {
+    let mut server = Server::new_async().await;
+    let adapter = test_projects_adapter(&server, None, 42);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(projects_v2_status_field_payload().to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_v2_items_payload(&[project_item_node("item_99", 99, "opt_todo", "Todo")])
+                .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let err = adapter
+        .update_issue_state("7", "Done")
+        .await
+        .expect_err("missing project item should fail");
+
+    fields_mock.assert_async().await;
+    items_mock.assert_async().await;
+    match err {
+        SymphonyError::GithubProjectsV2Error(message) => {
+            assert!(message.contains("issue #7 is not on project board #42"));
+        }
+        other => panic!("expected GithubProjectsV2Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_projects_v2_fetch_issue_states_by_ids_reads_board_status() {
+    let mut server = Server::new_async().await;
+    let adapter = test_projects_adapter(&server, None, 42);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(projects_v2_status_field_payload().to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_v2_items_payload(&[project_item_node(
+                "item_55",
+                55,
+                "opt_in_progress",
+                "In Progress",
+            )])
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issue_mock = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/55")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(issue_json(55, &["symphony:todo"], "alice", &["alice"], None).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issues = adapter
+        .fetch_issue_states_by_ids(&["55".to_string()])
+        .await
+        .expect("projects v2 fetch_issue_states_by_ids should succeed");
+
+    fields_mock.assert_async().await;
+    items_mock.assert_async().await;
+    issue_mock.assert_async().await;
+
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].identifier, "#55");
+    assert_eq!(issues[0].state, "In Progress");
+}
+
+#[tokio::test]
+async fn test_contract_matrix_label_mode_all_methods() {
+    let mut server = Server::new_async().await;
+    let adapter = test_adapter(&server, None);
+
+    let issues_list_mock = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("state".into(), "open".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!([issue_json(7, &["symphony:todo"], "alice", &["alice"], None)]).to_string(),
+        )
+        .expect(2)
+        .create_async()
+        .await;
+
+    let issue_by_id_mock = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!([issue_json(7, &["symphony:todo"], "alice", &["alice"], None)])[0].to_string(),
+        )
+        .expect(2)
+        .create_async()
+        .await;
+
+    let comment_mock = server
+        .mock("POST", "/repos/kata-sh/kata-mono/issues/7/comments")
+        .match_body(Matcher::PartialJson(json!({ "body": "contract comment" })))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let remove_mock = server
+        .mock(
+            "DELETE",
+            "/repos/kata-sh/kata-mono/issues/7/labels/symphony:todo",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let add_mock = server
+        .mock("POST", "/repos/kata-sh/kata-mono/issues/7/labels")
+        .match_body(Matcher::PartialJson(
+            json!({ "labels": ["symphony:in-progress"] }),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("[]")
+        .expect(1)
+        .create_async()
+        .await;
+
+    run_tracker_contract(&adapter, "Todo", "In Progress").await;
+
+    issues_list_mock.assert_async().await;
+    issue_by_id_mock.assert_async().await;
+    comment_mock.assert_async().await;
+    remove_mock.assert_async().await;
+    add_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_contract_matrix_projects_v2_mode_all_methods() {
+    let mut server = Server::new_async().await;
+    let adapter = test_projects_adapter(&server, None, 42);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(projects_v2_status_field_payload().to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_v2_items_payload(&[project_item_node("item_7", 7, "opt_todo", "Todo")])
+                .to_string(),
+        )
+        .expect(4)
+        .create_async()
+        .await;
+
+    let issue_mock = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(issue_json(7, &["symphony:done"], "alice", &["alice"], None).to_string())
+        .expect(3)
+        .create_async()
+        .await;
+
+    let comment_mock = server
+        .mock("POST", "/repos/kata-sh/kata-mono/issues/7/comments")
+        .match_body(Matcher::PartialJson(json!({ "body": "contract comment" })))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mutation_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::AllOf(vec![
+            Matcher::Regex("updateProjectV2ItemFieldValue".to_string()),
+            Matcher::PartialJson(json!({
+                "variables": {
+                    "projectId": "project_42",
+                    "itemId": "item_7",
+                    "fieldId": "status_field",
+                    "singleSelectOptionId": "opt_done"
+                }
+            })),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "data": {
+                    "updateProjectV2ItemFieldValue": {
+                        "projectV2Item": { "id": "item_7" }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    run_tracker_contract(&adapter, "Todo", "Done").await;
+
+    fields_mock.assert_async().await;
+    items_mock.assert_async().await;
+    issue_mock.assert_async().await;
+    comment_mock.assert_async().await;
+    mutation_mock.assert_async().await;
 }

--- a/apps/symphony/tests/github_projects_v2_tests.rs
+++ b/apps/symphony/tests/github_projects_v2_tests.rs
@@ -1,0 +1,244 @@
+use mockito::{Matcher, Server, ServerGuard};
+use serde_json::json;
+use symphony::error::SymphonyError;
+use symphony::github::client::GithubClient;
+use symphony::github::projects_v2::ProjectsV2Client;
+
+fn test_client(server: &ServerGuard) -> ProjectsV2Client {
+    let github_client = GithubClient::with_base_url(
+        "test-token",
+        "kata-sh",
+        "kata-mono",
+        "symphony",
+        server.url(),
+    );
+    ProjectsV2Client::new(github_client)
+}
+
+#[tokio::test]
+async fn test_resolve_status_field_parses_options() {
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "data": {
+                    "user": null,
+                    "organization": {
+                        "projectV2": {
+                            "id": "project_42",
+                            "field": {
+                                "id": "status_field",
+                                "options": [
+                                    { "id": "opt_todo", "name": "Todo" },
+                                    { "id": "opt_in_progress", "name": "In Progress" },
+                                    { "id": "opt_done", "name": "Done" }
+                                ]
+                            }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let info = client
+        .resolve_status_field("kata-sh", 42)
+        .await
+        .expect("status field should parse");
+
+    mock.assert_async().await;
+    assert_eq!(info.project_id, "project_42");
+    assert_eq!(info.field_id, "status_field");
+    assert_eq!(info.options.len(), 3);
+    assert_eq!(info.options[0].id, "opt_todo");
+    assert_eq!(info.options[1].name, "In Progress");
+}
+
+#[tokio::test]
+async fn test_resolve_status_field_missing_status_errors() {
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "data": {
+                    "user": {
+                        "projectV2": {
+                            "id": "project_42",
+                            "field": null
+                        }
+                    },
+                    "organization": null
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let err = client
+        .resolve_status_field("kata-sh", 42)
+        .await
+        .expect_err("missing status field should error");
+
+    mock.assert_async().await;
+    match err {
+        SymphonyError::GithubProjectsV2Error(message) => {
+            assert!(message.contains("Status field not found on project #42"));
+        }
+        other => panic!("expected GithubProjectsV2Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_query_items_by_status_returns_matching_items() {
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "data": {
+                    "node": {
+                        "items": {
+                            "nodes": [
+                                {
+                                    "id": "item_1",
+                                    "content": { "number": 101 },
+                                    "fieldValueByName": {
+                                        "name": "Todo",
+                                        "optionId": "opt_todo"
+                                    }
+                                },
+                                {
+                                    "id": "item_2",
+                                    "content": { "number": 102 },
+                                    "fieldValueByName": {
+                                        "name": "Done",
+                                        "optionId": "opt_done"
+                                    }
+                                },
+                                {
+                                    "id": "item_3",
+                                    "content": { "number": 103 },
+                                    "fieldValueByName": null
+                                }
+                            ],
+                            "pageInfo": {
+                                "hasNextPage": false,
+                                "endCursor": null
+                            }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let items = client
+        .query_items_by_status("project_42", &["opt_todo".to_string()])
+        .await
+        .expect("item query should succeed");
+
+    mock.assert_async().await;
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].item_id, "item_1");
+    assert_eq!(items[0].issue_number, 101);
+    assert_eq!(items[0].status.as_deref(), Some("Todo"));
+}
+
+#[tokio::test]
+async fn test_update_item_status_sends_mutation() {
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::AllOf(vec![
+            Matcher::Regex("updateProjectV2ItemFieldValue".to_string()),
+            Matcher::PartialJson(json!({
+                "variables": {
+                    "projectId": "project_42",
+                    "itemId": "item_123",
+                    "fieldId": "status_field",
+                    "singleSelectOptionId": "opt_done"
+                }
+            })),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "data": {
+                    "updateProjectV2ItemFieldValue": {
+                        "projectV2Item": {
+                            "id": "item_123"
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    client
+        .update_item_status("project_42", "item_123", "status_field", "opt_done")
+        .await
+        .expect("status mutation should succeed");
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_graphql_error_produces_structured_error() {
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "errors": [
+                    { "message": "GraphQL exploded" }
+                ],
+                "data": null
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let err = client
+        .resolve_status_field("kata-sh", 42)
+        .await
+        .expect_err("graphql errors should be surfaced");
+
+    mock.assert_async().await;
+    match err {
+        SymphonyError::GithubProjectsV2Error(message) => {
+            assert!(message.contains("GraphQL exploded"));
+        }
+        other => panic!("expected GithubProjectsV2Error, got {other:?}"),
+    }
+}

--- a/apps/symphony/tests/github_projects_v2_tests.rs
+++ b/apps/symphony/tests/github_projects_v2_tests.rs
@@ -2,7 +2,7 @@ use mockito::{Matcher, Server, ServerGuard};
 use serde_json::json;
 use symphony::error::SymphonyError;
 use symphony::github::client::GithubClient;
-use symphony::github::projects_v2::ProjectsV2Client;
+use symphony::github::projects_v2::{ProjectsV2Client, QUERY_PROJECT_FIELDS, QUERY_PROJECT_ITEMS};
 
 fn test_client(server: &ServerGuard) -> ProjectsV2Client {
     let github_client = GithubClient::with_base_url(
@@ -206,6 +206,26 @@ async fn test_update_item_status_sends_mutation() {
         .expect("status mutation should succeed");
 
     mock.assert_async().await;
+}
+
+#[test]
+fn test_projects_v2_queries_use_plain_status_literal() {
+    assert!(
+        QUERY_PROJECT_FIELDS.contains("field(name: \"Status\")"),
+        "QUERY_PROJECT_FIELDS should use a plain GraphQL string literal"
+    );
+    assert!(
+        QUERY_PROJECT_ITEMS.contains("fieldValueByName(name: \"Status\")"),
+        "QUERY_PROJECT_ITEMS should use a plain GraphQL string literal"
+    );
+    assert!(
+        !QUERY_PROJECT_FIELDS.contains("\\\"Status\\\""),
+        "QUERY_PROJECT_FIELDS should not contain escaped quotes inside a raw string"
+    );
+    assert!(
+        !QUERY_PROJECT_ITEMS.contains("\\\"Status\\\""),
+        "QUERY_PROJECT_ITEMS should not contain escaped quotes inside a raw string"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add a dedicated `projects_v2` GraphQL client for GitHub Projects v2 status field resolution, item queries, and status mutations
- extend `GithubAdapter` with dual mode dispatch (`ProjectsV2` vs `Labels`) using config auto-detection from `github_project_number`
- add lazy Projects v2 status-field caching (`tokio::sync::OnceCell`) and Projects v2 paths for fetch + update methods
- add Projects v2 client tests plus expanded adapter tests (mode detection, Projects v2 read/write behavior, and dual-mode contract matrix over all 5 `TrackerAdapter` methods)

## Verification
- `cd apps/symphony && cargo test --test github_projects_v2_tests`
- `cd apps/symphony && cargo test --test github_adapter_tests`
- `cd apps/symphony && cargo test --test workflow_config_tests`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a dual-mode state management layer for the GitHub tracker adapter, allowing teams to drive issue state via either GitHub Projects v2 (single-select status field) or the existing label-based scheme. The core design is clean: a `StateMode` enum auto-detected from `github_project_number` drives dispatch across all five `TrackerAdapter` methods, a dedicated `ProjectsV2Client` handles the three GraphQL operations (field resolution, item query, status mutation), and a `tokio::sync::OnceCell` lazily caches the status field metadata per adapter instance. Test coverage is thorough, including a full dual-mode contract matrix.

**Key changes:**
- New `projects_v2.rs` — GraphQL client with paginated item queries (10 pages × 100 items = 1,000-item cap) and client-side `option_id` filtering
- `GithubAdapter` refactored with `StateMode` enum and `status_field_cache: OnceCell<StatusFieldInfo>`; all five `TrackerAdapter` methods now dispatch to `_projects` or `_labels` variants
- `fetch_issue_states_by_ids_projects` and `update_issue_state_projects` perform a **full-board scan** (empty status filter) to locate individual items — functional today but silently bounded at 1,000 items; a targeted `Issue.projectItems` GraphQL query would remove this limit
- Four `*_projects` helper methods carry an `_project_number` parameter that is never used inside the function (the project number is re-extracted internally via `ensure_status_field()`)
- Both GraphQL queries hard-code `"Status"` as the field name, restricting compatibility to projects that use that exact name

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/scalability suggestions that don't affect correctness within normal project board sizes.

All three open comments are P2: unused parameters (style noise, no behavioural impact), a 1,000-item pagination cap with an existing warn log (only a concern for unusually large boards), and a hardcoded field name (a documented limitation, not a regression). The dual-dispatch logic is correct, the OnceCell cache is properly scoped per adapter instance, error propagation is consistent, and the test suite is comprehensive with a full contract matrix across both modes.

apps/symphony/src/github/adapter.rs — unused `_project_number` parameters and full-board scan in update/fetch-by-ids paths; apps/symphony/src/github/projects_v2.rs — hardcoded "Status" field name.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/github/adapter.rs | Major refactor adding StateMode enum with dual-dispatch to ProjectsV2 / Labels paths; adds lazy OnceCell caching for status field. Four *_projects helpers accept an unused `_project_number` parameter; fetch_issue_states_by_ids_projects and update_issue_state_projects do full-board scans bounded at 1000 items. |
| apps/symphony/src/github/projects_v2.rs | New GraphQL client for GitHub Projects v2 — implements status-field resolution, paginated item queries (cap: 10 pages × 100 = 1000 items), and status mutations. Field name "Status" is hardcoded throughout. |
| apps/symphony/tests/github_adapter_tests.rs | Expands adapter tests: mode-detection, Projects v2 CRUD paths, and a full dual-mode contract matrix. Coverage is thorough; mock expectations align correctly with the caching/dispatch logic. |
| apps/symphony/tests/github_projects_v2_tests.rs | New unit tests for ProjectsV2Client: status-field resolution (user and org paths), item pagination, status mutation, and error cases. Well-structured and self-contained. |
| apps/symphony/src/error.rs | Adds GithubProjectsV2Error(String) variant — clean, consistent with existing error style. |
| apps/symphony/src/github/mod.rs | Trivial: exposes the new projects_v2 module. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GithubAdapter::new] --> B{config.github_project_number?}
    B -- Some(n) --> C[StateMode::ProjectsV2
project_number=n
v2_client=ProjectsV2Client]
    B -- None --> D[StateMode::Labels]
    E[TrackerAdapter call] --> F{projects_mode?}
    F -- Some --> G[*_projects path]
    F -- None --> H[*_labels path]
    G --> I[ensure_status_field
OnceCell — init once]
    I --> L[resolve_status_field
GQL: QUERY_PROJECT_FIELDS
user OR organization]
    G --> N[query_items_by_status
GQL: QUERY_PROJECT_ITEMS
paginated up to 10x100]
    N --> O[client-side filter by option_id]
    O --> P[get_issue per item
REST API]
    G --> Q[update: query ALL items
no filter — up to 1000]
    Q --> R[find item by issue_number]
    R --> S[update_item_status
GQL: MUTATION_UPDATE_STATUS]
    H --> T[list_issues REST
+ label-based filter]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/src/github/adapter.rs`, line 400-413 ([link](https://github.com/gannonh/kata/blob/6999623d1135c63fd443e44f2fffde952382a994/apps/symphony/src/github/adapter.rs#L400-L413)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Full-board item scan for a single-issue state update**

   `update_issue_state_projects` (and similarly `fetch_issue_states_by_ids_projects`) calls `query_items_by_status` with an **empty filter**, which fetches every item on the board (up to `MAX_PAGES × PAGE_SIZE = 1,000` items) just to locate one project item by issue number. For teams with boards approaching or exceeding that limit, valid issues that sort to a page beyond the cap will either be silently absent from `fetch_issue_states_by_ids` results or produce a hard "issue is not on project board" error from `update_issue_state`.

   The `tracing::warn!` on truncation is a helpful signal, but the bound itself means the methods are semantically broken once a board exceeds ~1,000 items. A targeted query using the `Issue.projectItems` GraphQL field (filtering by `projectId`) would eliminate the scan and remove the page-cap risk entirely.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/src/github/adapter.rs
   Line: 400-413

   Comment:
   **Full-board item scan for a single-issue state update**

   `update_issue_state_projects` (and similarly `fetch_issue_states_by_ids_projects`) calls `query_items_by_status` with an **empty filter**, which fetches every item on the board (up to `MAX_PAGES × PAGE_SIZE = 1,000` items) just to locate one project item by issue number. For teams with boards approaching or exceeding that limit, valid issues that sort to a page beyond the cap will either be silently absent from `fetch_issue_states_by_ids` results or produce a hard "issue is not on project board" error from `update_issue_state`.

   The `tracing::warn!` on truncation is a helpful signal, but the bound itself means the methods are semantically broken once a board exceeds ~1,000 items. A targeted query using the `Issue.projectItems` GraphQL field (filtering by `projectId`) would eliminate the scan and remove the page-cap risk entirely.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/github/adapter.rs
Line: 217-220

Comment:
**Unused `_project_number` parameter on all four `*_projects` helpers**

`fetch_candidate_issues_projects`, `fetch_issues_by_states_projects`, `fetch_issue_states_by_ids_projects`, and `update_issue_state_projects` all accept `_project_number: u64` but never use it (the `_` prefix suppresses the Rust warning intentionally). The project number is re-extracted internally via `ensure_status_field()` → `projects_mode()`. Carrying the parameter adds noise to the API surface without contributing any additional information to these functions. Consider dropping it from the signatures and relying on `ensure_status_field()` for the project context, consistent with how these methods already work.

The same unused parameter also appears at:
- `fetch_issues_by_states_projects` (~line 279)
- `fetch_issue_states_by_ids_projects` (~line 333)
- `update_issue_state_projects` (~line 392)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/github/adapter.rs
Line: 400-413

Comment:
**Full-board item scan for a single-issue state update**

`update_issue_state_projects` (and similarly `fetch_issue_states_by_ids_projects`) calls `query_items_by_status` with an **empty filter**, which fetches every item on the board (up to `MAX_PAGES × PAGE_SIZE = 1,000` items) just to locate one project item by issue number. For teams with boards approaching or exceeding that limit, valid issues that sort to a page beyond the cap will either be silently absent from `fetch_issue_states_by_ids` results or produce a hard "issue is not on project board" error from `update_issue_state`.

The `tracing::warn!` on truncation is a helpful signal, but the bound itself means the methods are semantically broken once a board exceeds ~1,000 items. A targeted query using the `Issue.projectItems` GraphQL field (filtering by `projectId`) would eliminate the scan and remove the page-cap risk entirely.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/github/projects_v2.rs
Line: 16-45

Comment:
**Hardcoded `"Status"` field name limits project compatibility**

Both `QUERY_PROJECT_FIELDS` and `QUERY_PROJECT_ITEMS` hard-code `field(name: \"Status\")` and `fieldValueByName(name: \"Status\")`. Any GitHub project that names its equivalent field differently (e.g., `"State"`, `"Column"`, `"Priority"`) will always produce a "Status field not found" error. If the field name should be configurable, adding an optional `status_field_name` key to `TrackerConfig` (defaulting to `"Status"`) would make this adapter usable for a wider set of project layouts.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/gannonh/kata/commit/6999623d1135c63fd443e44f2fffde952382a994) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26710365)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->