### PR TITLE
[KAT-1894] Wire GitHub orchestrator port and tracker project URL integration

### DIFF
--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -1149,7 +1149,7 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
     if tracker_kind == "linear" {
         // tracker.api_key must be present and non-empty
         match config.tracker.api_key.as_deref() {
-            Some(k) if !k.is_empty() => {}
+            Some(k) if !k.trim().is_empty() => {}
             _ => {
                 return Err(SymphonyError::MissingLinearApiToken);
             }
@@ -1211,7 +1211,7 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
         }
 
         if let Some(project_number) = config.tracker.github_project_number {
-            tracing::info!(project_number, "Projects v2 mode active");
+            tracing::debug!(project_number, "Projects v2 mode active");
         }
     }
 

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -1146,19 +1146,15 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
         }
     };
 
-    // tracker.api_key must be present and non-empty
-    match config.tracker.api_key.as_deref() {
-        Some(k) if !k.is_empty() => {}
-        _ => {
-            return if tracker_kind == "github" {
-                Err(SymphonyError::MissingGithubApiToken)
-            } else {
-                Err(SymphonyError::MissingLinearApiToken)
-            };
-        }
-    }
-
     if tracker_kind == "linear" {
+        // tracker.api_key must be present and non-empty
+        match config.tracker.api_key.as_deref() {
+            Some(k) if !k.is_empty() => {}
+            _ => {
+                return Err(SymphonyError::MissingLinearApiToken);
+            }
+        }
+
         // tracker.project_slug must be present and non-empty
         match config.tracker.project_slug.as_deref() {
             Some(slug) if !slug.is_empty() => {}
@@ -1169,6 +1165,25 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
     }
 
     if tracker_kind == "github" {
+        let has_config_token = config
+            .tracker
+            .api_key
+            .as_deref()
+            .map(|key| !key.trim().is_empty())
+            .unwrap_or(false);
+        let has_env_token = ["GH_TOKEN", "GITHUB_TOKEN"].iter().any(|name| {
+            std::env::var(name)
+                .ok()
+                .map(|value| !value.trim().is_empty())
+                .unwrap_or(false)
+        });
+
+        if !(has_config_token || has_env_token) {
+            return Err(SymphonyError::InvalidWorkflowConfig(
+                "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github".to_string(),
+            ));
+        }
+
         if config
             .tracker
             .repo_owner
@@ -1193,6 +1208,10 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
             return Err(SymphonyError::InvalidWorkflowConfig(
                 "tracker.repo_name is required when tracker.kind is github".to_string(),
             ));
+        }
+
+        if let Some(project_number) = config.tracker.github_project_number {
+            tracing::info!(project_number, "Projects v2 mode active");
         }
     }
 

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -12,6 +12,7 @@ use crate::domain::{
     WorkspaceRepoStrategy,
 };
 use crate::error::SymphonyError;
+use crate::github::client::GithubClient;
 use crate::linear::adapter::TrackerAdapter;
 use crate::linear::client::LinearClient;
 use crate::notifications;
@@ -237,6 +238,109 @@ pub fn check_config(workflow_path: &Path) -> Vec<DoctorCheckResult> {
             results.push(DoctorCheckResult::pass(
                 "Config Prompts",
                 "All configured prompt files exist",
+            ));
+        }
+    }
+
+    results
+}
+
+pub async fn check_github(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
+    let mut results = Vec::new();
+
+    let token = config
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            std::env::var("GH_TOKEN")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .or_else(|| {
+            std::env::var("GITHUB_TOKEN")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        });
+
+    let Some(token) = token else {
+        results.push(DoctorCheckResult::error(
+            "GitHub Auth",
+            "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github",
+        ));
+        return results;
+    };
+
+    let Some(repo_owner) = config
+        .repo_owner
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        results.push(DoctorCheckResult::error(
+            "GitHub Repo",
+            "tracker.repo_owner is required when tracker.kind is github",
+        ));
+        return results;
+    };
+
+    let Some(repo_name) = config
+        .repo_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        results.push(DoctorCheckResult::error(
+            "GitHub Repo",
+            "tracker.repo_name is required when tracker.kind is github",
+        ));
+        return results;
+    };
+
+    let label_prefix = config
+        .label_prefix
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("symphony");
+
+    let endpoint = config.endpoint.trim();
+    let endpoint = if endpoint.is_empty() {
+        "https://api.github.com"
+    } else {
+        endpoint
+    };
+
+    let client = GithubClient::with_base_url(
+        token,
+        repo_owner.to_string(),
+        repo_name.to_string(),
+        label_prefix.to_string(),
+        endpoint,
+    );
+
+    match client.list_labels().await {
+        Ok(labels) => {
+            results.push(DoctorCheckResult::pass(
+                "GitHub Auth",
+                "Authenticated with GitHub API",
+            ));
+            results.push(DoctorCheckResult::pass(
+                "GitHub Repo",
+                format!(
+                    "Resolved repository '{repo_owner}/{repo_name}' ({} labels visible)",
+                    labels.len()
+                ),
+            ));
+        }
+        Err(err) => {
+            results.push(DoctorCheckResult::error(
+                "GitHub Auth",
+                format!("Failed to authenticate with GitHub: {err}"),
             ));
         }
     }

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -530,12 +530,31 @@ impl Default for TrackerConfig {
 }
 
 impl TrackerConfig {
-    /// Build a browser URL for the configured Linear project.
+    /// Build a browser URL for the configured tracker project.
     ///
-    /// The project slug comes from workflow config (`tracker.project_slug`).
-    /// Workspace slug can come from `tracker.workspace_slug`, with a fallback
-    /// to Kata's default workspace for backward compatibility.
-    pub fn linear_project_url(&self) -> Option<String> {
+    /// - GitHub kind: `https://github.com/{owner}/{repo}/issues`
+    /// - Linear kind (or default): `https://linear.app/{workspace}/project/{slug}`
+    pub fn tracker_project_url(&self) -> Option<String> {
+        match self
+            .kind
+            .as_deref()
+            .map(str::trim)
+            .filter(|kind| !kind.is_empty())
+        {
+            Some(kind) if kind.eq_ignore_ascii_case("github") => {
+                let owner = self.repo_owner.as_deref()?.trim();
+                let repo = self.repo_name.as_deref()?.trim();
+                if owner.is_empty() || repo.is_empty() {
+                    return None;
+                }
+
+                Some(format!("https://github.com/{owner}/{repo}/issues"))
+            }
+            _ => self.build_linear_url(),
+        }
+    }
+
+    fn build_linear_url(&self) -> Option<String> {
         let project_slug = self.project_slug.as_deref()?.trim();
         if project_slug.is_empty() {
             return None;
@@ -1171,7 +1190,7 @@ pub struct OrchestratorSnapshot {
     pub poll_interval_ms: u64,
     pub max_concurrent_agents: u32,
     #[serde(default)]
-    pub linear_project_url: Option<String>,
+    pub tracker_project_url: Option<String>,
     pub running: BTreeMap<String, RunAttempt>,
     #[serde(default)]
     pub running_sessions: BTreeMap<String, RunningSessionSnapshot>,

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -297,7 +297,7 @@ struct ApiError {
 struct StateResponse {
     poll_interval_ms: u64,
     max_concurrent_agents: u32,
-    linear_project_url: Option<String>,
+    tracker_project_url: Option<String>,
     running: std::collections::BTreeMap<String, RunAttempt>,
     running_sessions: std::collections::BTreeMap<String, RunningSessionSnapshot>,
     running_session_info: std::collections::BTreeMap<String, WorkerSessionInfo>,
@@ -614,17 +614,17 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         .map(|timestamp| timestamp.to_rfc3339())
         .map(|value| escape_html(&value))
         .unwrap_or_else(|| "n/a".to_string());
-    let linear_project_card = snapshot
-        .linear_project_url
+    let tracker_project_card = snapshot
+        .tracker_project_url
         .as_deref()
         .map(|url| {
             let escaped_url = escape_html(url);
             format!(
-                r#"<section class="card"><div class="label">linear project</div><div class="mono"><a id="linear-project-link" href="{escaped_url}" target="_blank" rel="noopener noreferrer">{escaped_url}</a></div></section>"#
+                r#"<section class="card"><div class="label">project</div><div class="mono"><a id="tracker-project-link" href="{escaped_url}" target="_blank" rel="noopener noreferrer">{escaped_url}</a></div></section>"#
             )
         })
         .unwrap_or_else(|| {
-            r#"<section class="card"><div class="label">linear project</div><div class="mono muted">n/a</div></section>"#
+            r#"<section class="card"><div class="label">project</div><div class="mono muted">n/a</div></section>"#
                 .to_string()
         });
 
@@ -684,7 +684,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     <section class="card"><div class="label">claimed</div><div class="value" id="claimed-count">{claimed_count}</div></section>
     <section class="card"><div class="label">completed</div><div class="value" id="completed-count">{completed_count}</div></section>
     <section class="card"><div class="label">supervisor</div><div class="mono" id="supervisor-status">{supervisor_status_label}</div></section>
-    <div id="linear-project-card">{linear_project_card}</div>
+    <div id="linear-project-card">{tracker_project_card}</div>
   </div>
 
   <section class="card section">
@@ -1102,12 +1102,12 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }}
     }}
 
-    function renderLinearProjectCard(url) {{
+    function renderTrackerProjectCard(url) {{
       if (!url) {{
-        return '<section class="card"><div class="label">linear project</div><div class="mono muted">n/a</div></section>';
+        return '<section class="card"><div class="label">project</div><div class="mono muted">n/a</div></section>';
       }}
       const escaped = escapeHtml(url);
-      return '<section class="card"><div class="label">linear project</div><div class="mono"><a id="linear-project-link" href="' +
+      return '<section class="card"><div class="label">project</div><div class="mono"><a id="tracker-project-link" href="' +
         escaped +
         '" target="_blank" rel="noopener noreferrer">' +
         escaped +
@@ -1181,7 +1181,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         document.getElementById('claimed-count').textContent = (state.claimed || []).length;
         document.getElementById('completed-count').textContent = completed.length;
         document.getElementById('linear-project-card').innerHTML =
-          renderLinearProjectCard(state.linear_project_url);
+          renderTrackerProjectCard(state.tracker_project_url);
         document.getElementById('running-table-body').innerHTML = renderRunningTable(
           running,
           state.running_session_info || {{}}
@@ -1232,7 +1232,7 @@ async fn get_state(State(state): State<HttpServerState>) -> impl IntoResponse {
     Json(StateResponse {
         poll_interval_ms: snapshot.poll_interval_ms,
         max_concurrent_agents: snapshot.max_concurrent_agents,
-        linear_project_url: snapshot.linear_project_url,
+        tracker_project_url: snapshot.tracker_project_url,
         running: snapshot.running,
         running_sessions: snapshot.running_sessions,
         running_session_info: snapshot.running_session_info,

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -684,7 +684,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
     <section class="card"><div class="label">claimed</div><div class="value" id="claimed-count">{claimed_count}</div></section>
     <section class="card"><div class="label">completed</div><div class="value" id="completed-count">{completed_count}</div></section>
     <section class="card"><div class="label">supervisor</div><div class="mono" id="supervisor-status">{supervisor_status_label}</div></section>
-    <div id="linear-project-card">{tracker_project_card}</div>
+    <div id="tracker-project-card">{tracker_project_card}</div>
   </div>
 
   <section class="card section">
@@ -1180,7 +1180,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         document.getElementById('retry-count').textContent = retryQueue.length;
         document.getElementById('claimed-count').textContent = (state.claimed || []).length;
         document.getElementById('completed-count').textContent = completed.length;
-        document.getElementById('linear-project-card').innerHTML =
+        document.getElementById('tracker-project-card').innerHTML =
           renderTrackerProjectCard(state.tracker_project_url);
         document.getElementById('running-table-body').innerHTML = renderRunningTable(
           running,

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -24,6 +24,10 @@ use std::time::Duration;
 #[cfg(not(test))]
 use symphony::domain::Issue;
 #[cfg(not(test))]
+use symphony::github::adapter::GithubAdapter;
+#[cfg(not(test))]
+use symphony::github::client::GithubClient;
+#[cfg(not(test))]
 use symphony::http_server::{
     bind_http_listener_with_fallback, start_http_server, HttpServerState, HTTP_PORT_RETRY_LIMIT,
 };
@@ -175,6 +179,130 @@ impl OrchestratorPort for LinearOrchestratorPort {
 }
 
 #[cfg(not(test))]
+struct GithubOrchestratorPort {
+    workflow_store: Arc<WorkflowStore>,
+}
+
+#[cfg(not(test))]
+impl GithubOrchestratorPort {
+    fn new(workflow_store: Arc<WorkflowStore>) -> Self {
+        Self { workflow_store }
+    }
+
+    fn block_on<T>(&self, future: impl Future<Output = error::Result<T>>) -> error::Result<T> {
+        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
+    }
+
+    fn tracker_adapter(&self) -> error::Result<GithubAdapter> {
+        let (_, effective_config) = self.workflow_store.effective_config();
+        let tracker = effective_config.tracker;
+
+        let token = tracker
+            .api_key
+            .as_ref()
+            .map(|api_key| api_key.as_str().to_string())
+            .or_else(|| {
+                std::env::var("GH_TOKEN")
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty())
+            })
+            .or_else(|| {
+                std::env::var("GITHUB_TOKEN")
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty())
+            })
+            .ok_or_else(|| {
+                error::SymphonyError::InvalidWorkflowConfig(
+                    "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github"
+                        .to_string(),
+                )
+            })?;
+
+        let repo_owner = tracker
+            .repo_owner
+            .clone()
+            .map(|owner| owner.trim().to_string())
+            .filter(|owner| !owner.is_empty())
+            .ok_or_else(|| {
+                error::SymphonyError::InvalidWorkflowConfig(
+                    "tracker.repo_owner is required when tracker.kind is github".to_string(),
+                )
+            })?;
+
+        let repo_name = tracker
+            .repo_name
+            .clone()
+            .map(|repo| repo.trim().to_string())
+            .filter(|repo| !repo.is_empty())
+            .ok_or_else(|| {
+                error::SymphonyError::InvalidWorkflowConfig(
+                    "tracker.repo_name is required when tracker.kind is github".to_string(),
+                )
+            })?;
+
+        let label_prefix = tracker
+            .label_prefix
+            .clone()
+            .map(|prefix| prefix.trim().to_string())
+            .filter(|prefix| !prefix.is_empty())
+            .unwrap_or_else(|| "symphony".to_string());
+
+        let client = GithubClient::with_base_url(
+            token,
+            repo_owner,
+            repo_name,
+            label_prefix,
+            "https://api.github.com",
+        );
+
+        Ok(GithubAdapter::new(client, tracker))
+    }
+}
+
+#[cfg(not(test))]
+impl OrchestratorPort for GithubOrchestratorPort {
+    fn startup_terminal_issues(&mut self, terminal_states: &[String]) -> error::Result<Vec<Issue>> {
+        let adapter = self.tracker_adapter()?;
+        self.block_on(adapter.fetch_issues_by_states(terminal_states))
+    }
+
+    fn reconcile_running_issues(
+        &mut self,
+        running_issue_ids: &[String],
+    ) -> error::Result<Vec<Issue>> {
+        if running_issue_ids.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let adapter = self.tracker_adapter()?;
+        self.block_on(adapter.fetch_issue_states_by_ids(running_issue_ids))
+    }
+
+    fn validate_dispatch_preflight(&mut self, config: &ServiceConfig) -> error::Result<()> {
+        config::validate(config).map(|_| ())
+    }
+
+    fn fetch_candidate_issues(&mut self) -> error::Result<Vec<Issue>> {
+        let adapter = self.tracker_adapter()?;
+        self.block_on(adapter.fetch_candidate_issues())
+    }
+
+    fn refresh_issue(&mut self, issue_id: &str) -> error::Result<Option<Issue>> {
+        let adapter = self.tracker_adapter()?;
+        let issue_ids = vec![issue_id.to_string()];
+        let issues = self.block_on(adapter.fetch_issue_states_by_ids(&issue_ids))?;
+        Ok(issues.into_iter().next())
+    }
+
+    fn update_issue_state(&mut self, issue_id: &str, state_name: &str) -> error::Result<()> {
+        let adapter = self.tracker_adapter()?;
+        self.block_on(adapter.update_issue_state(issue_id, state_name))
+    }
+}
+
+#[cfg(not(test))]
 #[derive(Default)]
 pub struct RuntimeBootstrapDeps {
     startup_context: Option<StartupContext>,
@@ -260,8 +388,22 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
             );
         }
 
+        let tracker_kind = context
+            .effective_config
+            .tracker
+            .kind
+            .clone()
+            .unwrap_or_else(|| "linear".to_string());
+
         let workflow_store = Arc::new(context.workflow_store);
-        let mut tracker_port = LinearOrchestratorPort::new(Arc::clone(&workflow_store));
+        let mut tracker_port: Box<dyn OrchestratorPort> = if tracker_kind == "github" {
+            Box::new(GithubOrchestratorPort::new(Arc::clone(&workflow_store)))
+        } else {
+            Box::new(LinearOrchestratorPort::new(Arc::clone(&workflow_store)))
+        };
+
+        tracing::info!(tracker_kind = %tracker_kind, "orchestrator port selected");
+
         let server_port_override = prepared_http_server
             .as_ref()
             .map(|server| server.bound_port)
@@ -331,7 +473,7 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
 
         let runtime_result = run_runtime_until_shutdown(
             &mut orchestrator,
-            &mut tracker_port,
+            &mut *tracker_port,
             workflow_path,
             prepared_http_server,
             http_state,

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -215,8 +215,7 @@ impl GithubOrchestratorPort {
             })
             .ok_or_else(|| {
                 error::SymphonyError::InvalidWorkflowConfig(
-                    "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github"
-                        .to_string(),
+                    "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github".to_string(),
                 )
             })?;
 

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -200,7 +200,8 @@ impl GithubOrchestratorPort {
         let token = tracker
             .api_key
             .as_ref()
-            .map(|api_key| api_key.as_str().to_string())
+            .map(|api_key| api_key.as_str().trim().to_string())
+            .filter(|value| !value.is_empty())
             .or_else(|| {
                 std::env::var("GH_TOKEN")
                     .ok()
@@ -248,13 +249,15 @@ impl GithubOrchestratorPort {
             .filter(|prefix| !prefix.is_empty())
             .unwrap_or_else(|| "symphony".to_string());
 
-        let client = GithubClient::with_base_url(
-            token,
-            repo_owner,
-            repo_name,
-            label_prefix,
-            "https://api.github.com",
-        );
+        let endpoint = tracker.endpoint.trim();
+        let endpoint = if endpoint.is_empty() {
+            "https://api.github.com"
+        } else {
+            endpoint
+        };
+
+        let client =
+            GithubClient::with_base_url(token, repo_owner, repo_name, label_prefix, endpoint);
 
         Ok(GithubAdapter::new(client, tracker))
     }

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -179,87 +179,161 @@ impl OrchestratorPort for LinearOrchestratorPort {
 }
 
 #[cfg(not(test))]
+struct GithubAdapterInputs {
+    token: String,
+    repo_owner: String,
+    repo_name: String,
+    label_prefix: String,
+    endpoint: String,
+}
+
+#[cfg(not(test))]
+fn github_adapter_inputs(
+    tracker: &symphony::domain::TrackerConfig,
+) -> error::Result<GithubAdapterInputs> {
+    let token = tracker
+        .api_key
+        .as_ref()
+        .map(|api_key| api_key.as_str().trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::env::var("GH_TOKEN")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .or_else(|| {
+            std::env::var("GITHUB_TOKEN")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .ok_or_else(|| {
+            error::SymphonyError::InvalidWorkflowConfig(
+                "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github".to_string(),
+            )
+        })?;
+
+    let repo_owner = tracker
+        .repo_owner
+        .clone()
+        .map(|owner| owner.trim().to_string())
+        .filter(|owner| !owner.is_empty())
+        .ok_or_else(|| {
+            error::SymphonyError::InvalidWorkflowConfig(
+                "tracker.repo_owner is required when tracker.kind is github".to_string(),
+            )
+        })?;
+
+    let repo_name = tracker
+        .repo_name
+        .clone()
+        .map(|repo| repo.trim().to_string())
+        .filter(|repo| !repo.is_empty())
+        .ok_or_else(|| {
+            error::SymphonyError::InvalidWorkflowConfig(
+                "tracker.repo_name is required when tracker.kind is github".to_string(),
+            )
+        })?;
+
+    let label_prefix = tracker
+        .label_prefix
+        .clone()
+        .map(|prefix| prefix.trim().to_string())
+        .filter(|prefix| !prefix.is_empty())
+        .unwrap_or_else(|| "symphony".to_string());
+
+    let endpoint = tracker.endpoint.trim();
+    let endpoint = if endpoint.is_empty() {
+        "https://api.github.com".to_string()
+    } else {
+        endpoint.to_string()
+    };
+
+    Ok(GithubAdapterInputs {
+        token,
+        repo_owner,
+        repo_name,
+        label_prefix,
+        endpoint,
+    })
+}
+
+#[cfg(not(test))]
 struct GithubOrchestratorPort {
     workflow_store: Arc<WorkflowStore>,
+    cached_adapter: Option<GithubAdapter>,
+    adapter_cache_key: Option<String>,
 }
 
 #[cfg(not(test))]
 impl GithubOrchestratorPort {
     fn new(workflow_store: Arc<WorkflowStore>) -> Self {
-        Self { workflow_store }
+        Self {
+            workflow_store,
+            cached_adapter: None,
+            adapter_cache_key: None,
+        }
     }
 
-    fn block_on<T>(&self, future: impl Future<Output = error::Result<T>>) -> error::Result<T> {
+    fn block_on<T>(future: impl Future<Output = error::Result<T>>) -> error::Result<T> {
         tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
     }
 
-    fn tracker_adapter(&self) -> error::Result<GithubAdapter> {
+    fn build_adapter_cache_key(
+        tracker: &symphony::domain::TrackerConfig,
+        token: &str,
+        repo_owner: &str,
+        repo_name: &str,
+        label_prefix: &str,
+        endpoint: &str,
+    ) -> String {
+        format!(
+            "{token}\u{1e}{repo_owner}\u{1e}{repo_name}\u{1e}{label_prefix}\u{1e}{endpoint}\u{1e}{project_number}\u{1e}{assignee}\u{1e}{active_states}\u{1e}{terminal_states}\u{1e}{exclude_labels}",
+            project_number = tracker
+                .github_project_number
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+            assignee = tracker.assignee.as_deref().unwrap_or_default(),
+            active_states = tracker.active_states.join("\u{1f}"),
+            terminal_states = tracker.terminal_states.join("\u{1f}"),
+            exclude_labels = tracker.exclude_labels.join("\u{1f}"),
+        )
+    }
+
+    fn tracker_adapter(&mut self) -> error::Result<&GithubAdapter> {
         let (_, effective_config) = self.workflow_store.effective_config();
         let tracker = effective_config.tracker;
 
-        let token = tracker
-            .api_key
-            .as_ref()
-            .map(|api_key| api_key.as_str().trim().to_string())
-            .filter(|value| !value.is_empty())
-            .or_else(|| {
-                std::env::var("GH_TOKEN")
-                    .ok()
-                    .map(|value| value.trim().to_string())
-                    .filter(|value| !value.is_empty())
-            })
-            .or_else(|| {
-                std::env::var("GITHUB_TOKEN")
-                    .ok()
-                    .map(|value| value.trim().to_string())
-                    .filter(|value| !value.is_empty())
-            })
-            .ok_or_else(|| {
-                error::SymphonyError::InvalidWorkflowConfig(
-                    "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github".to_string(),
-                )
-            })?;
+        let inputs = github_adapter_inputs(&tracker)?;
 
-        let repo_owner = tracker
-            .repo_owner
-            .clone()
-            .map(|owner| owner.trim().to_string())
-            .filter(|owner| !owner.is_empty())
-            .ok_or_else(|| {
-                error::SymphonyError::InvalidWorkflowConfig(
-                    "tracker.repo_owner is required when tracker.kind is github".to_string(),
-                )
-            })?;
+        let cache_key = Self::build_adapter_cache_key(
+            &tracker,
+            &inputs.token,
+            &inputs.repo_owner,
+            &inputs.repo_name,
+            &inputs.label_prefix,
+            inputs.endpoint.as_str(),
+        );
 
-        let repo_name = tracker
-            .repo_name
-            .clone()
-            .map(|repo| repo.trim().to_string())
-            .filter(|repo| !repo.is_empty())
-            .ok_or_else(|| {
-                error::SymphonyError::InvalidWorkflowConfig(
-                    "tracker.repo_name is required when tracker.kind is github".to_string(),
-                )
-            })?;
+        let should_refresh = self.adapter_cache_key.as_deref() != Some(cache_key.as_str());
+        if should_refresh {
+            let client = GithubClient::with_base_url(
+                inputs.token,
+                inputs.repo_owner,
+                inputs.repo_name,
+                inputs.label_prefix,
+                inputs.endpoint.as_str(),
+            );
+            self.cached_adapter = Some(GithubAdapter::new(client, tracker));
+            self.adapter_cache_key = Some(cache_key);
+        }
 
-        let label_prefix = tracker
-            .label_prefix
-            .clone()
-            .map(|prefix| prefix.trim().to_string())
-            .filter(|prefix| !prefix.is_empty())
-            .unwrap_or_else(|| "symphony".to_string());
-
-        let endpoint = tracker.endpoint.trim();
-        let endpoint = if endpoint.is_empty() {
-            "https://api.github.com"
-        } else {
-            endpoint
-        };
-
-        let client =
-            GithubClient::with_base_url(token, repo_owner, repo_name, label_prefix, endpoint);
-
-        Ok(GithubAdapter::new(client, tracker))
+        self.cached_adapter.as_ref().ok_or_else(|| {
+            error::SymphonyError::InvalidWorkflowConfig(
+                "failed to initialize github tracker adapter".to_string(),
+            )
+        })
     }
 }
 
@@ -267,7 +341,7 @@ impl GithubOrchestratorPort {
 impl OrchestratorPort for GithubOrchestratorPort {
     fn startup_terminal_issues(&mut self, terminal_states: &[String]) -> error::Result<Vec<Issue>> {
         let adapter = self.tracker_adapter()?;
-        self.block_on(adapter.fetch_issues_by_states(terminal_states))
+        Self::block_on(adapter.fetch_issues_by_states(terminal_states))
     }
 
     fn reconcile_running_issues(
@@ -279,7 +353,7 @@ impl OrchestratorPort for GithubOrchestratorPort {
         }
 
         let adapter = self.tracker_adapter()?;
-        self.block_on(adapter.fetch_issue_states_by_ids(running_issue_ids))
+        Self::block_on(adapter.fetch_issue_states_by_ids(running_issue_ids))
     }
 
     fn validate_dispatch_preflight(&mut self, config: &ServiceConfig) -> error::Result<()> {
@@ -288,19 +362,19 @@ impl OrchestratorPort for GithubOrchestratorPort {
 
     fn fetch_candidate_issues(&mut self) -> error::Result<Vec<Issue>> {
         let adapter = self.tracker_adapter()?;
-        self.block_on(adapter.fetch_candidate_issues())
+        Self::block_on(adapter.fetch_candidate_issues())
     }
 
     fn refresh_issue(&mut self, issue_id: &str) -> error::Result<Option<Issue>> {
         let adapter = self.tracker_adapter()?;
         let issue_ids = vec![issue_id.to_string()];
-        let issues = self.block_on(adapter.fetch_issue_states_by_ids(&issue_ids))?;
+        let issues = Self::block_on(adapter.fetch_issue_states_by_ids(&issue_ids))?;
         Ok(issues.into_iter().next())
     }
 
     fn update_issue_state(&mut self, issue_id: &str, state_name: &str) -> error::Result<()> {
         let adapter = self.tracker_adapter()?;
-        self.block_on(adapter.update_issue_state(issue_id, state_name))
+        Self::block_on(adapter.update_issue_state(issue_id, state_name))
     }
 }
 
@@ -697,19 +771,60 @@ fn run_doctor(workflow_path: &Path) -> Result<i32, String> {
                 let runtime = tokio::runtime::Handle::try_current()
                     .map_err(|err| format!("missing tokio runtime for doctor checks: {err}"))?;
 
-                let linear_results = tokio::task::block_in_place(|| {
-                    runtime.block_on(doctor::check_linear(&service_config.tracker))
-                });
-                results.extend(linear_results);
+                let tracker_kind = service_config.tracker.kind.as_deref().unwrap_or("linear");
 
-                results.extend(doctor::check_backend(&service_config));
-                results.extend(doctor::check_workspace(&service_config.workspace));
+                if tracker_kind == "github" {
+                    let github_results = tokio::task::block_in_place(|| {
+                        runtime.block_on(doctor::check_github(&service_config.tracker))
+                    });
+                    results.extend(github_results);
 
-                let adapter = LinearAdapter::new(LinearClient::new(service_config.tracker.clone()));
-                let orphan_results = tokio::task::block_in_place(|| {
-                    runtime.block_on(doctor::check_orphans(&service_config, &adapter))
-                });
-                results.extend(orphan_results);
+                    results.extend(doctor::check_backend(&service_config));
+                    results.extend(doctor::check_workspace(&service_config.workspace));
+
+                    match github_adapter_inputs(&service_config.tracker) {
+                        Ok(inputs) => {
+                            let client = GithubClient::with_base_url(
+                                inputs.token,
+                                inputs.repo_owner,
+                                inputs.repo_name,
+                                inputs.label_prefix,
+                                inputs.endpoint.as_str(),
+                            );
+                            let adapter =
+                                GithubAdapter::new(client, service_config.tracker.clone());
+                            let orphan_results = tokio::task::block_in_place(|| {
+                                runtime.block_on(doctor::check_orphans(&service_config, &adapter))
+                            });
+                            results.extend(orphan_results);
+                        }
+                        Err(err) => {
+                            results.push(doctor::DoctorCheckResult {
+                                name: "Orphans".to_string(),
+                                status: doctor::CheckStatus::Error,
+                                message: format!(
+                                    "Failed to initialize GitHub adapter for orphan checks: {err}"
+                                ),
+                                details: None,
+                            });
+                        }
+                    }
+                } else {
+                    let linear_results = tokio::task::block_in_place(|| {
+                        runtime.block_on(doctor::check_linear(&service_config.tracker))
+                    });
+                    results.extend(linear_results);
+
+                    results.extend(doctor::check_backend(&service_config));
+                    results.extend(doctor::check_workspace(&service_config.workspace));
+
+                    let adapter =
+                        LinearAdapter::new(LinearClient::new(service_config.tracker.clone()));
+                    let orphan_results = tokio::task::block_in_place(|| {
+                        runtime.block_on(doctor::check_orphans(&service_config, &adapter))
+                    });
+                    results.extend(orphan_results);
+                }
             }
             Err(err) => results.push(doctor::DoctorCheckResult {
                 name: "Config Parse".to_string(),

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -3937,7 +3937,7 @@ impl Orchestrator {
         OrchestratorSnapshot {
             poll_interval_ms: self.state.poll_interval_ms,
             max_concurrent_agents: self.state.max_concurrent_agents,
-            linear_project_url: self.config.tracker.linear_project_url(),
+            tracker_project_url: self.config.tracker.tracker_project_url(),
             running,
             running_sessions,
             blocked: self.blocked_issues.clone(),

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -427,8 +427,8 @@ fn build_summary_lines(snapshot: &OrchestratorSnapshot, throughput_line: &str) -
     let mut lines = vec![counts.join("  |  "), throughput_line.to_string()];
     lines.push(supervisor_summary_line(snapshot));
 
-    if let Some(project_url) = snapshot.linear_project_url.as_deref() {
-        lines.push(format!("Linear Project: {project_url}"));
+    if let Some(project_url) = snapshot.tracker_project_url.as_deref() {
+        lines.push(format!("Project: {project_url}"));
     }
 
     lines
@@ -1057,12 +1057,12 @@ mod tests {
 
     fn snapshot_fixture(
         total_tokens: u64,
-        linear_project_url: Option<&str>,
+        tracker_project_url: Option<&str>,
     ) -> OrchestratorSnapshot {
         OrchestratorSnapshot {
             poll_interval_ms: REFRESH_INTERVAL_MS,
             max_concurrent_agents: 1,
-            linear_project_url: linear_project_url.map(ToString::to_string),
+            tracker_project_url: tracker_project_url.map(ToString::to_string),
             running: BTreeMap::new(),
             running_sessions: BTreeMap::new(),
             running_session_info: BTreeMap::new(),
@@ -1346,7 +1346,7 @@ mod tests {
     }
 
     #[test]
-    fn build_summary_lines_includes_linear_project_url_when_available() {
+    fn build_summary_lines_includes_tracker_project_url_when_available() {
         let snapshot = snapshot_fixture(1_337, Some("https://linear.app/kata-sh/project/symphony"));
         let throughput_line = "Throughput: 42.3 tps ▁▂▃▄▅▆▇█";
         let lines = build_summary_lines(&snapshot, throughput_line);
@@ -1358,8 +1358,8 @@ mod tests {
         assert!(
             lines
                 .iter()
-                .any(|line| line == "Linear Project: https://linear.app/kata-sh/project/symphony"),
-            "summary lines should include the linear project URL when configured"
+                .any(|line| line == "Project: https://linear.app/kata-sh/project/symphony"),
+            "summary lines should include the tracker project URL when configured"
         );
     }
 

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -7,6 +7,7 @@ use std::{fs, io};
 
 use main_bin::{BootstrapDeps, Cli, CliCommand};
 use mockito::{Matcher, Server};
+use symphony::config::validate;
 use symphony::doctor::{self, CheckStatus};
 use symphony::domain::{
     AgentBackend, ApiKey, ServiceConfig, TrackerConfig, WorkspaceConfig, WorkspaceIsolation,
@@ -114,6 +115,31 @@ fn test_run_subcommand_backward_compat() {
         "default invocation should not select a subcommand"
     );
     assert_eq!(parsed.workflow_path, "WORKFLOW.md");
+}
+
+#[test]
+fn test_github_tracker_kind_accepted() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let workflow_path = temp_dir.path().join("WORKFLOW.md");
+
+    fs::write(
+        &workflow_path,
+        format!(
+            "---\ntracker:\n  kind: github\n  api_key: test-token\n  repo_owner: kata-sh\n  repo_name: kata-mono\nworkspace:\n  root: {}\n---\nPrompt\n",
+            workspace_root.display()
+        ),
+    )
+    .expect("workflow fixture should be written");
+
+    let service_config =
+        doctor::load_service_config(&workflow_path).expect("github workflow should parse");
+
+    assert_eq!(service_config.tracker.kind.as_deref(), Some("github"));
+    assert!(
+        validate(&service_config).is_ok(),
+        "github tracker config should validate"
+    );
 }
 
 #[test]

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -160,22 +160,37 @@ fn test_service_config_defaults_match_spec() {
 }
 
 #[test]
-fn test_tracker_linear_project_url_uses_project_and_workspace_slug() {
+fn test_tracker_project_url_uses_linear_project_and_workspace_slug() {
     let mut tracker = TrackerConfig::default();
     tracker.project_slug = Some("symphony".to_string());
     assert_eq!(
-        tracker.linear_project_url().as_deref(),
+        tracker.tracker_project_url().as_deref(),
         Some("https://linear.app/kata-sh/project/symphony")
     );
 
     tracker.workspace_slug = Some("acme".to_string());
     assert_eq!(
-        tracker.linear_project_url().as_deref(),
+        tracker.tracker_project_url().as_deref(),
         Some("https://linear.app/acme/project/symphony")
     );
 
     tracker.project_slug = None;
-    assert_eq!(tracker.linear_project_url(), None);
+    assert_eq!(tracker.tracker_project_url(), None);
+}
+
+#[test]
+fn test_tracker_project_url_uses_github_repo_path_for_github_kind() {
+    let tracker = TrackerConfig {
+        kind: Some("github".to_string()),
+        repo_owner: Some("kata-sh".to_string()),
+        repo_name: Some("kata-mono".to_string()),
+        ..TrackerConfig::default()
+    };
+
+    assert_eq!(
+        tracker.tracker_project_url().as_deref(),
+        Some("https://github.com/kata-sh/kata-mono/issues")
+    );
 }
 
 // ── ServerConfig default fix (T01 must-have) ───────────────────────────
@@ -285,7 +300,7 @@ fn test_orchestrator_snapshot_serializes() {
     let snap = OrchestratorSnapshot {
         poll_interval_ms: 30_000,
         max_concurrent_agents: 5,
-        linear_project_url: Some("https://linear.app/kata-sh/project/symphony".to_string()),
+        tracker_project_url: Some("https://linear.app/kata-sh/project/symphony".to_string()),
         running: {
             let mut m = BTreeMap::new();
             m.insert(
@@ -407,7 +422,7 @@ fn test_orchestrator_snapshot_serializes() {
     assert!(val.get("poll_interval_ms").is_some());
     assert!(val.get("max_concurrent_agents").is_some());
     assert_eq!(
-        val.get("linear_project_url").and_then(|v| v.as_str()),
+        val.get("tracker_project_url").and_then(|v| v.as_str()),
         Some("https://linear.app/kata-sh/project/symphony")
     );
     assert!(val.get("running").is_some());

--- a/apps/symphony/tests/escalation_tests.rs
+++ b/apps/symphony/tests/escalation_tests.rs
@@ -41,7 +41,7 @@ fn empty_snapshot() -> OrchestratorSnapshot {
     OrchestratorSnapshot {
         poll_interval_ms: 30_000,
         max_concurrent_agents: 4,
-        linear_project_url: None,
+        tracker_project_url: None,
         running: BTreeMap::new(),
         running_sessions: BTreeMap::new(),
         running_session_info: BTreeMap::new(),

--- a/apps/symphony/tests/event_stream_tests.rs
+++ b/apps/symphony/tests/event_stream_tests.rs
@@ -48,7 +48,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
     OrchestratorSnapshot {
         poll_interval_ms: 30_000,
         max_concurrent_agents: 4,
-        linear_project_url: Some("https://linear.app/kata-sh/project/symphony".to_string()),
+        tracker_project_url: Some("https://linear.app/kata-sh/project/symphony".to_string()),
         running: BTreeMap::from([(
             "issue-920".to_string(),
             RunAttempt {

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -62,7 +62,7 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
     OrchestratorSnapshot {
         poll_interval_ms: 30_000,
         max_concurrent_agents: 4,
-        linear_project_url: Some("https://linear.app/kata-sh/project/symphony".to_string()),
+        tracker_project_url: Some("https://linear.app/kata-sh/project/symphony".to_string()),
         running: {
             let mut running = BTreeMap::new();
             running.insert(
@@ -320,12 +320,12 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
         "dashboard shell should include token summary section"
     );
     assert!(
-        body.contains(r#"id="linear-project-link""#),
-        "dashboard shell should include clickable Linear project link in summary section"
+        body.contains(r#"id="tracker-project-link""#),
+        "dashboard shell should include clickable tracker project link in summary section"
     );
     assert!(
         body.contains("https://linear.app/kata-sh/project/symphony"),
-        "dashboard shell should render the configured Linear project URL"
+        "dashboard shell should render the configured tracker project URL"
     );
     assert!(
         body.contains("Polling"),
@@ -545,7 +545,7 @@ async fn test_get_api_state_returns_snapshot_projection() {
     assert_eq!(payload["codex_totals"]["total_tokens"], 200);
     assert_eq!(payload["codex_rate_limits"]["remaining"], 88);
     assert_eq!(
-        payload["linear_project_url"],
+        payload["tracker_project_url"],
         "https://linear.app/kata-sh/project/symphony"
     );
     assert_eq!(payload["polling"]["next_poll_in_ms"], 5_000);

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -113,6 +113,26 @@ fn test_config(max_concurrent_agents: u32) -> ServiceConfig {
     config
 }
 
+fn github_test_config(max_concurrent_agents: u32) -> ServiceConfig {
+    let mut config = ServiceConfig::default();
+    config.tracker = TrackerConfig {
+        kind: Some("github".to_string()),
+        api_key: Some("github-test-token".into()),
+        repo_owner: Some("test-owner".to_string()),
+        repo_name: Some("test-repo".to_string()),
+        active_states: vec!["Todo".to_string(), "In Progress".to_string()],
+        terminal_states: vec!["Done".to_string(), "Canceled".to_string()],
+        ..TrackerConfig::default()
+    };
+    config.agent = AgentConfig {
+        max_concurrent_agents,
+        max_turns: 20,
+        max_retry_backoff_ms: 60_000,
+        escalation_timeout_ms: 300_000,
+    };
+    config
+}
+
 fn with_slack_notifications(
     mut config: ServiceConfig,
     webhook_url: String,
@@ -155,6 +175,30 @@ fn issue(
         state: state.to_string(),
         branch_name: None,
         url: None,
+        assignee_id: None,
+        labels: vec![],
+        blocked_by: vec![],
+        assigned_to_worker: true,
+        created_at: Some(Utc::now() + Duration::seconds(created_at_offset_secs)),
+        updated_at: Some(Utc::now()),
+        children_count: 0,
+        parent_identifier: None,
+    }
+}
+
+fn github_issue(id: &str, number: u64, state: &str, created_at_offset_secs: i64) -> Issue {
+    let identifier = format!("#{number}");
+    Issue {
+        id: id.to_string(),
+        identifier: identifier.clone(),
+        title: format!("GitHub issue {identifier}"),
+        description: Some("orchestrator github test issue".to_string()),
+        priority: Some(1),
+        state: state.to_string(),
+        branch_name: None,
+        url: Some(format!(
+            "https://github.com/test-owner/test-repo/issues/{number}"
+        )),
         assignee_id: None,
         labels: vec![],
         blocked_by: vec![],
@@ -4377,6 +4421,73 @@ async fn test_execute_worker_attempt_shared_context_is_injected_into_prompt() {
     assert!(
         first_prompt.contains("Decision: using Zod for validation"),
         "first worker prompt should include the shared context decision"
+    );
+}
+
+#[test]
+fn test_github_port_dispatch_cycle() {
+    let mut orchestrator = Orchestrator::new(github_test_config(2), String::new());
+    let mut port = FakePort {
+        candidate_issues: vec![
+            github_issue("gh-42", 42, "Todo", -30),
+            github_issue("gh-43", 43, "Todo", -20),
+        ],
+        ..FakePort::default()
+    };
+
+    let tick = orchestrator.tick(&mut port).expect("tick should succeed");
+
+    assert_eq!(tick.dispatched_issue_ids.len(), 2);
+    assert!(orchestrator.state().running.contains_key("gh-42"));
+    assert!(orchestrator.state().running.contains_key("gh-43"));
+    assert!(
+        port.call_history()
+            .iter()
+            .any(|call| call == "fetch_candidate_issues"),
+        "github dispatch cycle should fetch candidates from the tracker port"
+    );
+}
+
+#[test]
+fn test_github_port_reconciliation() {
+    let mut orchestrator = Orchestrator::new(github_test_config(1), String::new());
+    let mut dispatch_port = FakePort {
+        candidate_issues: vec![github_issue("gh-42", 42, "Todo", -30)],
+        ..FakePort::default()
+    };
+
+    orchestrator
+        .tick(&mut dispatch_port)
+        .expect("dispatch tick should succeed");
+    assert!(orchestrator.state().running.contains_key("gh-42"));
+
+    let mut reconcile_port = FakePort {
+        reconciled_issues: vec![github_issue("gh-42", 42, "Done", -30)],
+        ..FakePort::default()
+    };
+
+    orchestrator
+        .tick(&mut reconcile_port)
+        .expect("reconcile tick should succeed");
+
+    assert!(
+        !orchestrator.state().running.contains_key("gh-42"),
+        "done issue should be removed from running map"
+    );
+    assert!(
+        orchestrator.state().completed.contains_key("gh-42"),
+        "done issue should be tracked as completed"
+    );
+}
+
+#[test]
+fn test_github_snapshot_contains_tracker_project_url() {
+    let orchestrator = Orchestrator::new(github_test_config(1), String::new());
+
+    let snapshot = orchestrator.snapshot(0);
+    assert_eq!(
+        snapshot.tracker_project_url.as_deref(),
+        Some("https://github.com/test-owner/test-repo/issues")
     );
 }
 

--- a/apps/symphony/tests/pi_agent_tests.rs
+++ b/apps/symphony/tests/pi_agent_tests.rs
@@ -229,6 +229,22 @@ fn write_script(dir: &Path, name: &str, content: &str) -> std::path::PathBuf {
     path
 }
 
+fn make_rpc_test_config(
+    script_path: &Path,
+    read_timeout_ms: u64,
+    stall_timeout_ms: u64,
+) -> PiAgentConfig {
+    PiAgentConfig {
+        command: vec![
+            "bash".to_string(),
+            script_path.to_string_lossy().to_string(),
+        ],
+        read_timeout_ms,
+        stall_timeout_ms,
+        ..PiAgentConfig::default()
+    }
+}
+
 fn make_test_issue() -> Issue {
     Issue {
         id: "issue-test-1".to_string(),
@@ -369,12 +385,7 @@ async fn rpc_bridge_start_turn_stop_smoke() {
     std::fs::create_dir_all(&workspace).expect("workspace");
 
     let script_path = write_script(scripts_dir.path(), "fake-kata.sh", SCRIPT_BASIC_RPC);
-    let config = PiAgentConfig {
-        command: vec![script_path.to_string_lossy().to_string()],
-        read_timeout_ms: 5_000,
-        stall_timeout_ms: 10_000,
-        ..PiAgentConfig::default()
-    };
+    let config = make_rpc_test_config(&script_path, 5_000, 10_000);
 
     let issue = make_test_issue();
 
@@ -428,12 +439,7 @@ async fn rpc_bridge_run_turn_handles_stdin_write_failure() {
         "fake-kata-close-stdin-after-handshake.sh",
         SCRIPT_CLOSE_STDIN_AFTER_HANDSHAKE_RPC,
     );
-    let config = PiAgentConfig {
-        command: vec![script_path.to_string_lossy().to_string()],
-        read_timeout_ms: 5_000,
-        stall_timeout_ms: 10_000,
-        ..PiAgentConfig::default()
-    };
+    let config = make_rpc_test_config(&script_path, 5_000, 10_000);
 
     let issue = make_test_issue();
     let (escalation_tx, _escalation_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -486,12 +492,7 @@ async fn rpc_bridge_run_turn_handles_agent_end_before_message_end() {
         "fake-kata-agent-end-first.sh",
         SCRIPT_AGENT_END_BEFORE_MESSAGE_END_RPC,
     );
-    let config = PiAgentConfig {
-        command: vec![script_path.to_string_lossy().to_string()],
-        read_timeout_ms: 5_000,
-        stall_timeout_ms: 10_000,
-        ..PiAgentConfig::default()
-    };
+    let config = make_rpc_test_config(&script_path, 5_000, 10_000);
 
     let issue = make_test_issue();
     let (escalation_tx, _escalation_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -537,12 +538,7 @@ async fn rpc_bridge_run_turn_surfaces_stall_timeout() {
         "fake-kata-stall.sh",
         SCRIPT_STALL_AFTER_PROMPT_RPC,
     );
-    let config = PiAgentConfig {
-        command: vec![script_path.to_string_lossy().to_string()],
-        read_timeout_ms: 50,
-        stall_timeout_ms: 150,
-        ..PiAgentConfig::default()
-    };
+    let config = make_rpc_test_config(&script_path, 50, 150);
 
     let issue = make_test_issue();
     let (escalation_tx, _escalation_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -593,12 +589,7 @@ async fn rpc_bridge_stop_session_handles_process_already_exited() {
         "fake-kata-stop-after-exit.sh",
         SCRIPT_EXIT_AFTER_HANDSHAKE_RPC,
     );
-    let config = PiAgentConfig {
-        command: vec![script_path.to_string_lossy().to_string()],
-        read_timeout_ms: 5_000,
-        stall_timeout_ms: 10_000,
-        ..PiAgentConfig::default()
-    };
+    let config = make_rpc_test_config(&script_path, 5_000, 10_000);
 
     let issue = make_test_issue();
     let (escalation_tx, _escalation_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -636,12 +627,7 @@ async fn rpc_bridge_turn_fails_on_message_end_error_stop_reason() {
         "fake-kata-error-stop-reason.sh",
         SCRIPT_ERROR_STOP_REASON_RPC,
     );
-    let config = PiAgentConfig {
-        command: vec![script_path.to_string_lossy().to_string()],
-        read_timeout_ms: 5_000,
-        stall_timeout_ms: 10_000,
-        ..PiAgentConfig::default()
-    };
+    let config = make_rpc_test_config(&script_path, 5_000, 10_000);
 
     let issue = make_test_issue();
     let (escalation_tx, _escalation_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -697,12 +683,7 @@ async fn rpc_bridge_escalation_holds_and_resumes_with_response() {
         "fake-kata-escalation.sh",
         SCRIPT_ESCALATION_RPC,
     );
-    let config = PiAgentConfig {
-        command: vec![script_path.to_string_lossy().to_string()],
-        read_timeout_ms: 5_000,
-        stall_timeout_ms: 10_000,
-        ..PiAgentConfig::default()
-    };
+    let config = make_rpc_test_config(&script_path, 5_000, 10_000);
 
     let issue = make_test_issue();
     let (escalation_tx, mut escalation_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -802,12 +783,7 @@ async fn rpc_bridge_escalation_times_out_and_falls_back() {
         "fake-kata-escalation-timeout.sh",
         SCRIPT_ESCALATION_RPC,
     );
-    let config = PiAgentConfig {
-        command: vec![script_path.to_string_lossy().to_string()],
-        read_timeout_ms: 5_000,
-        stall_timeout_ms: 10_000,
-        ..PiAgentConfig::default()
-    };
+    let config = make_rpc_test_config(&script_path, 5_000, 10_000);
 
     let issue = make_test_issue();
     let (escalation_tx, mut escalation_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -863,12 +839,7 @@ async fn rpc_bridge_escalation_channel_close_emits_cancelled() {
         "fake-kata-escalation-channel-closed.sh",
         SCRIPT_ESCALATION_RPC,
     );
-    let config = PiAgentConfig {
-        command: vec![script_path.to_string_lossy().to_string()],
-        read_timeout_ms: 5_000,
-        stall_timeout_ms: 10_000,
-        ..PiAgentConfig::default()
-    };
+    let config = make_rpc_test_config(&script_path, 5_000, 10_000);
 
     let issue = make_test_issue();
     let (escalation_tx, mut escalation_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -1393,7 +1393,13 @@ fn test_config_validation_github_valid() {
 }
 
 #[test]
-fn test_config_validation_github_missing_api_key() {
+#[serial]
+fn test_config_validation_github_missing_token_errors() {
+    let previous_gh_token = std::env::var("GH_TOKEN").ok();
+    let previous_github_token = std::env::var("GITHUB_TOKEN").ok();
+    std::env::remove_var("GH_TOKEN");
+    std::env::remove_var("GITHUB_TOKEN");
+
     let config = ServiceConfig {
         tracker: TrackerConfig {
             kind: Some("github".to_string()),
@@ -1407,14 +1413,23 @@ fn test_config_validation_github_missing_api_key() {
 
     let result = validate(&config);
     assert!(
-        matches!(result, Err(SymphonyError::MissingGithubApiToken)),
-        "missing github api_key should return MissingGithubApiToken, got: {:?}",
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg == "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github"),
+        "missing github token should return descriptive validation error, got: {:?}",
         result
     );
+
+    match previous_gh_token {
+        Some(value) => std::env::set_var("GH_TOKEN", value),
+        None => std::env::remove_var("GH_TOKEN"),
+    }
+    match previous_github_token {
+        Some(value) => std::env::set_var("GITHUB_TOKEN", value),
+        None => std::env::remove_var("GITHUB_TOKEN"),
+    }
 }
 
 #[test]
-fn test_config_validation_github_missing_repo_owner() {
+fn test_config_validation_github_missing_repo_owner_errors() {
     let config = ServiceConfig {
         tracker: TrackerConfig {
             kind: Some("github".to_string()),
@@ -1430,6 +1445,27 @@ fn test_config_validation_github_missing_repo_owner() {
     assert!(
         matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg == "tracker.repo_owner is required when tracker.kind is github"),
         "missing github repo_owner should fail validation, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_config_validation_github_missing_repo_name_errors() {
+    let config = ServiceConfig {
+        tracker: TrackerConfig {
+            kind: Some("github".to_string()),
+            api_key: Some("test-key".into()),
+            repo_owner: Some("kata-sh".to_string()),
+            repo_name: None,
+            ..TrackerConfig::default()
+        },
+        ..ServiceConfig::default()
+    };
+
+    let result = validate(&config);
+    assert!(
+        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg == "tracker.repo_name is required when tracker.kind is github"),
+        "missing github repo_name should fail validation, got: {:?}",
         result
     );
 }

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -1412,10 +1412,10 @@ fn test_config_validation_github_missing_token_errors() {
     };
 
     let result = validate(&config);
-    assert!(
-        matches!(result, Err(SymphonyError::InvalidWorkflowConfig(ref msg)) if msg == "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github"),
-        "missing github token should return descriptive validation error, got: {:?}",
-        result
+    let validation_failed_for_missing_token = matches!(
+        result,
+        Err(SymphonyError::InvalidWorkflowConfig(ref msg))
+            if msg == "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github"
     );
 
     match previous_gh_token {
@@ -1426,6 +1426,12 @@ fn test_config_validation_github_missing_token_errors() {
         Some(value) => std::env::set_var("GITHUB_TOKEN", value),
         None => std::env::remove_var("GITHUB_TOKEN"),
     }
+
+    assert!(
+        validation_failed_for_missing_token,
+        "missing github token should return descriptive validation error, got: {:?}",
+        result
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- rename snapshot/project surfaces from `linear_project_url` to `tracker_project_url` and add tracker-aware URL building for both Linear and GitHub
- add `GithubOrchestratorPort` in `main.rs` and select tracker port at startup based on `tracker.kind`
- extend GitHub validation to require token/repo fields and add GitHub orchestration loop coverage tests

## Validation
- `cd apps/symphony && cargo test --test orchestrator_tests github`
- `cd apps/symphony && cargo test --test http_server_tests`
- `cd apps/symphony && cargo test --test cli_tests`
- `cd apps/symphony && cargo test --test workflow_config_tests github`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`
- `cd apps/symphony && grep -R "linear_project_url" src/ tests/`

Closes KAT-1894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub as a supported tracker backend (configure via tracker.kind=github); accepts API key or GH_TOKEN/GITHUB_TOKEN and requires repo owner/name for linking.

* **Updates**
  * UI, API and CLI now use a generic "Project" label and expose tracker_project_url for GitHub and Linear.
  * Tracker validation now enforces credentials per-tracker and provides clearer error messages.
  * Runtime selects tracker backend dynamically at startup.

* **Tests**
  * Expanded test coverage for GitHub tracker behavior and updated fixtures/assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the GitHub orchestrator path end-to-end: it adds `GithubOrchestratorPort` in `main.rs`, selects the correct port at startup based on `tracker.kind`, renames the `linear_project_url` surface to the tracker-agnostic `tracker_project_url` across the snapshot, HTTP API, dashboard, and TUI layers, and strengthens GitHub validation to require a token (config or env) plus `repo_owner`/`repo_name`. Three new orchestrator tests and several updated config/domain tests cover the added behaviour.

- **`main.rs`**: New `GithubOrchestratorPort` mirrors `LinearOrchestratorPort` structure; token resolution follows `api_key` → env vars; port is boxed as `dyn OrchestratorPort` and selected at startup.
- **`domain.rs`**: `linear_project_url()` renamed to `tracker_project_url()`; GitHub kind returns `https://github.com/{owner}/{repo}/issues`; Linear path extracted to private `build_linear_url()`.
- **`config.rs`**: API-key check moved inside `if tracker_kind == \"linear\"` block; GitHub block gains explicit token + env-var validation and new `repo_name` required check.
- **`http_server.rs`**: `linear_project_url` → `tracker_project_url` in `StateResponse`, dashboard HTML, and polling JS; inner link ID updated to `tracker-project-link` but the outer wrapper `div` retains the stale `id=\"linear-project-card\"` (noted in inline comment).
- **Tests**: GitHub dispatch cycle, reconciliation, and snapshot URL tests added; `test_config_validation_github_missing_token_errors` correctly uses `#[serial]` for env-var isolation, though cleanup ordering is not panic-safe (noted in inline comment)."

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/cleanup items with no impact on runtime correctness.

All 422 lines of additions pass the full test suite (200+ tests). The two flagged issues are a stale HTML element ID (cosmetic, JS still resolves correctly) and non-panic-safe env var teardown in a single test (risk is limited to that one serial test sequence). No logic errors, data-integrity issues, or security concerns were found.

apps/symphony/src/http_server.rs (stale outer div ID), apps/symphony/tests/workflow_config_tests.rs (env var cleanup ordering)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/config.rs | GitHub token validation refactored: api_key check moved into tracker-specific branches; new env-var fallback added for GitHub; Projects v2 info log added. |
| apps/symphony/src/domain.rs | Renames linear_project_url → tracker_project_url; adds GitHub URL variant (repo/issues path); Linear URL logic extracted to private build_linear_url helper. |
| apps/symphony/src/http_server.rs | Renames linear_project_url → tracker_project_url in StateResponse and dashboard HTML/JS; inner link ID updated to tracker-project-link but outer wrapper div retains stale id="linear-project-card". |
| apps/symphony/src/main.rs | Adds GithubOrchestratorPort implementing OrchestratorPort; selects tracker port at startup based on tracker.kind; mirrors LinearOrchestratorPort structure with env-var token resolution. |
| apps/symphony/src/orchestrator.rs | One-line rename: linear_project_url() call replaced with tracker_project_url() in snapshot builder. |
| apps/symphony/src/tui.rs | Renames linear_project_url field reference and display label to tracker_project_url / "Project:" in TUI summary. |
| apps/symphony/tests/orchestrator_tests.rs | Adds github_test_config, github_issue helpers and three new GitHub orchestrator tests: dispatch cycle, reconciliation, and snapshot URL verification. |
| apps/symphony/tests/workflow_config_tests.rs | Updates GitHub validation tests; new missing-token test uses #[serial] for env var isolation but cleanup code is not panic-safe (runs after assert, skipped on panic). |
| apps/symphony/tests/cli_tests.rs | Adds test_github_tracker_kind_accepted to verify github tracker parses and validates successfully end-to-end. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[startup: read tracker.kind] --> B{kind == github?}
    B -- yes --> C[GithubOrchestratorPort]
    B -- no --> D[LinearOrchestratorPort]
    C --> E[tracker_adapter: resolves auth token from config or env]
    E --> F[GithubAdapter]
    D --> G[LinearAdapter]
    F & G --> H[OrchestratorPort trait]
    H --> I[Orchestrator.tick]
    I --> J[OrchestratorSnapshot: tracker_project_url]
    J --> K[HTTP API /state]
    J --> L[TUI display]
    J --> M[Dashboard HTML]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 687

Comment:
**Stale outer div ID after rename**

The inner card content was renamed from `linear-project-card` / `linear-project-link` to `tracker-project-card` / `tracker-project-link`, but the outer wrapper `div` ID was not updated. It still reads `id="linear-project-card"`, which the JavaScript at line 1183 relies on (`document.getElementById('linear-project-card')`). Functionally this works, but the stale "linear" name in the wrapper ID is inconsistent with the tracker-agnostic rename applied everywhere else.

```suggestion
    <div id="tracker-project-card">{tracker_project_card}</div>
```

The corresponding JS reference on line 1183 would also need to be updated:
```js
document.getElementById('tracker-project-card').innerHTML =
  renderTrackerProjectCard(state.tracker_project_url);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/tests/workflow_config_tests.rs
Line: 1398-1430

Comment:
**Env var cleanup not panic-safe**

The cleanup code that restores the two env vars runs at the end of the function body, after the `assert!` call. If the assertion panics (i.e., the test fails), the test framework catches the panic and moves on — but the cleanup block is never reached, leaving those env vars permanently unset for subsequent tests in the same `#[serial]` sequence.

A simple fix is to perform the restoration *before* the final assertion, capturing the result in a local variable first, then asserting after cleanup is done. Alternatively, a small RAII guard type or `std::panic::catch_unwind` can guarantee cleanup regardless of how the test exits.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(symphony): format main startup wir..."](https://github.com/gannonh/kata/commit/80de1a47fe8cd6c4ca415fc0513371ed0db65bad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26715315)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->