### PR TITLE
KAT-1898: GitHub dashboard parity, doctor checks, and e2e verification

### DIFF
--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -174,6 +174,52 @@ Complete the task described in the issue.
 
 The YAML front-matter is configuration. Everything below the `---` is a [Liquid template](https://shopify.github.io/liquid/) rendered as the prompt for each agent session, with `{{ issue.* }}` and `{{ workspace.* }}` variables available.
 
+### GitHub Issues Backend
+
+Symphony can use **GitHub Issues** as a tracker backend (`tracker.kind: github`) instead of Linear.
+
+Minimal GitHub tracker configuration:
+
+```yaml
+tracker:
+  kind: github
+  api_key: $GH_TOKEN          # or $GITHUB_TOKEN
+  repo_owner: your-org
+  repo_name: your-repo
+
+  # Optional: Projects v2 mode (board status drives state mapping)
+  # github_project_number: 7
+
+  # Optional: label mode prefix when github_project_number is omitted
+  # label_prefix: symphony
+
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+```
+
+Authentication:
+
+- Use a GitHub **PAT** (personal access token) via `GH_TOKEN` or `GITHUB_TOKEN`.
+- `tracker.api_key` supports `$VAR` indirection like other secrets.
+
+State management modes:
+
+- **Projects v2 mode**: set `tracker.github_project_number`.
+  - Symphony reads/writes state from the project's `Status` single-select field.
+- **Label mode**: omit `tracker.github_project_number`.
+  - Symphony reads/writes state labels using `{label_prefix}:{state}` (default prefix: `symphony`).
+
+Operational notes:
+
+- Issue identifiers are rendered as GitHub-style `#N`.
+- Dashboard/TUI/Slack links use GitHub issue URLs.
+- `/api/v1/state` emits GitHub identifiers and URLs for running sessions.
+- GitHub's standard REST rate limit is typically `5000` requests/hour per authenticated user/token.
+- `symphony doctor` validates GitHub PAT auth, repository access, Projects v2 availability (when configured), and label presence (label mode).
+
 ### 3. Run Symphony
 
 ```bash
@@ -220,7 +266,9 @@ Symphony Doctor
 Checks currently cover:
 
 - Workflow parse/validation, `$ENV_VAR` resolution, prompt path existence, notification event names
-- Linear auth/project/workflow-state/assignee checks
+- Tracker checks:
+  - Linear: auth/project/workflow-state/assignee checks
+  - GitHub: PAT auth, repo access, Projects v2 status field check (when configured), label presence check (label mode)
 - Agent backend command handshake (`--version`)
 - Workspace root/repo/git strategy/docker daemon checks
 - Orphan workspace detection under `workspace.root`

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -27,7 +27,10 @@
 #
 # Current check groups:
 #   - Config: parse + validate + env-var resolution + prompt file paths + Slack event names
-#   - Linear: auth (viewer), project slug resolution, workflow state alignment, assignee lookup
+#   - Tracker:
+#       Linear: auth (viewer), project slug resolution, workflow state alignment, assignee lookup
+#       GitHub: PAT auth, repo access, Projects v2 check (when github_project_number is set),
+#               label presence checks (label mode)
 #   - Backend: configured backend command present on PATH and responds to `--version`
 #   - Workspace: root path writable/creatable, repo reference sanity, git strategy compatibility,
 #                Docker daemon availability when isolation=docker
@@ -42,26 +45,46 @@
 # ─── Tracker ──────────────────────────────────────────────────────────────────
 # Configures which issue tracker to poll and how to filter issues.
 tracker:
-  # Tracker backend. Currently only "linear" is supported.
+  # Tracker backend: "linear" or "github".
   kind: linear
 
-  # Linear personal API key. Use $VAR indirection to avoid committing secrets.
+  # Tracker API token (supports $VAR indirection).
+  # - Linear: personal API key (for example $LINEAR_API_KEY)
+  # - GitHub: PAT (for example $GH_TOKEN or $GITHUB_TOKEN)
   api_key: $LINEAR_API_KEY
 
-  # Linear project URL slug or slugId. Found in the project URL:
+  # Optional tracker endpoint override.
+  # - Linear default: https://api.linear.app/graphql
+  # - GitHub default: https://api.github.com
+  # endpoint: https://api.linear.app/graphql
+
+  # Linear-only: project URL slug or slugId from
   # https://linear.app/<workspace>/project/<slug>
   project_slug: "89d4761fddf0"
 
-  # Optional: Linear workspace slug for dashboard project links.
+  # Linear-only: workspace slug used for dashboard project links.
   # When omitted, Symphony falls back to "kata-sh".
   # workspace_slug: kata-sh
 
-  # Optional: Linear GraphQL endpoint. Override for self-hosted Linear.
-  # endpoint: https://api.linear.app/graphql
+  # GitHub-only: repository owner and repository name.
+  # Required when kind: github.
+  # repo_owner: kata-sh
+  # repo_name: kata-mono
 
-  # Optional: filter candidate issues to this Linear username.
-  # When set, only issues assigned to this user are dispatched.
-  # When omitted, ALL issues in the project matching active_states are eligible.
+  # GitHub-only: Projects v2 project number.
+  # - Set this for Projects v2 mode (state from Status field)
+  # - Omit for label mode (state from labels)
+  # github_project_number: 7
+
+  # GitHub-only (label mode): prefix for state labels.
+  # Labels are expected as {label_prefix}:{normalized-state}.
+  # Default: symphony
+  # label_prefix: symphony
+
+  # Optional: filter candidate issues to this assignee.
+  # - Linear: username/display name/email/user id lookup
+  # - GitHub: login match against assignee/assignees
+  # When omitted, ALL issues in the project/repository matching active_states are eligible.
   # Supports $VAR indirection.
   # assignee: alice
 
@@ -94,6 +117,32 @@ tracker:
   # Default: [] (no issues excluded by label).
   # exclude_labels:
   #   - kata:task
+
+# GitHub label mode example (omit github_project_number):
+# tracker:
+#   kind: github
+#   api_key: $GH_TOKEN
+#   repo_owner: kata-sh
+#   repo_name: kata-mono
+#   label_prefix: symphony
+#   active_states:
+#     - Todo
+#     - In Progress
+#   terminal_states:
+#     - Done
+#
+# GitHub Projects v2 example (set github_project_number):
+# tracker:
+#   kind: github
+#   api_key: $GH_TOKEN
+#   repo_owner: kata-sh
+#   repo_name: kata-mono
+#   github_project_number: 7
+#   active_states:
+#     - Todo
+#     - In Progress
+#   terminal_states:
+#     - Done
 
 # ─── Polling ──────────────────────────────────────────────────────────────────
 # Controls how frequently Symphony polls the tracker for new/changed issues.

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -394,18 +394,14 @@ pub async fn check_github(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
             Err(SymphonyError::GithubApiStatus { status, .. }) => {
                 results.push(DoctorCheckResult::warning(
                     "GitHub Repo",
-                    format!(
-                        "Repository {repo_owner}/{repo_name} check returned HTTP {status}"
-                    ),
+                    format!("Repository {repo_owner}/{repo_name} check returned HTTP {status}"),
                 ));
                 false
             }
             Err(err) => {
                 results.push(DoctorCheckResult::warning(
                     "GitHub Repo",
-                    format!(
-                        "Repository {repo_owner}/{repo_name} check failed: {err}"
-                    ),
+                    format!("Repository {repo_owner}/{repo_name} check failed: {err}"),
                 ));
                 false
             }

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -437,7 +437,12 @@ pub async fn check_github(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
                 }
                 Err(err) => {
                     let err_text = err.to_string();
-                    let message = if err_text.to_ascii_lowercase().contains("not found") {
+                    let err_lower = err_text.to_ascii_lowercase();
+                    let message = if err_lower.contains("status field") {
+                        format!(
+                            "Project #{project_number} found but Status field is missing or inaccessible"
+                        )
+                    } else if err_lower.contains("not found") {
                         format!("Project #{project_number} not found or not accessible")
                     } else {
                         format!(

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use reqwest::Method;
 use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
 
@@ -13,6 +14,7 @@ use crate::domain::{
 };
 use crate::error::SymphonyError;
 use crate::github::client::GithubClient;
+use crate::github::projects_v2::ProjectsV2Client;
 use crate::linear::adapter::TrackerAdapter;
 use crate::linear::client::LinearClient;
 use crate::notifications;
@@ -269,7 +271,7 @@ pub async fn check_github(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
 
     let Some(token) = token else {
         results.push(DoctorCheckResult::error(
-            "GitHub Auth",
+            "GitHub PAT",
             "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github",
         ));
         return results;
@@ -323,24 +325,206 @@ pub async fn check_github(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
         endpoint,
     );
 
-    match client.list_labels().await {
-        Ok(labels) => {
-            results.push(DoctorCheckResult::pass(
-                "GitHub Auth",
-                "Authenticated with GitHub API",
+    let pat_ok = match client.request(Method::GET, "/user", None).await {
+        Ok(response) => {
+            match response.json::<JsonValue>().await {
+                Ok(payload) => {
+                    let login = payload
+                        .get("login")
+                        .and_then(|value| value.as_str())
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .unwrap_or("authenticated");
+                    results.push(DoctorCheckResult::pass(
+                        "GitHub PAT",
+                        format!("PAT authenticated as {login}"),
+                    ));
+                }
+                Err(err) => {
+                    results.push(DoctorCheckResult::warning(
+                        "GitHub PAT",
+                        format!(
+                            "PAT authenticated but doctor could not decode /user response: {err}"
+                        ),
+                    ));
+                }
+            }
+            true
+        }
+        Err(SymphonyError::GithubApiStatus { status: 401, .. }) => {
+            results.push(DoctorCheckResult::error(
+                "GitHub PAT",
+                "PAT authentication failed (HTTP 401)",
             ));
-            results.push(DoctorCheckResult::pass(
-                "GitHub Repo",
-                format!(
-                    "Resolved repository '{repo_owner}/{repo_name}' ({} labels visible)",
-                    labels.len()
-                ),
+            false
+        }
+        Err(SymphonyError::GithubApiStatus { status, .. }) => {
+            results.push(DoctorCheckResult::warning(
+                "GitHub PAT",
+                format!("PAT authentication check returned HTTP {status}"),
             ));
+            false
         }
         Err(err) => {
-            results.push(DoctorCheckResult::error(
-                "GitHub Auth",
-                format!("Failed to authenticate with GitHub: {err}"),
+            results.push(DoctorCheckResult::warning(
+                "GitHub PAT",
+                format!("PAT authentication check failed: {err}"),
+            ));
+            false
+        }
+    };
+
+    let repo_ok = if pat_ok {
+        let repo_path = format!("/repos/{repo_owner}/{repo_name}");
+        match client.request(Method::GET, &repo_path, None).await {
+            Ok(_) => {
+                results.push(DoctorCheckResult::pass(
+                    "GitHub Repo",
+                    format!("Repository {repo_owner}/{repo_name} accessible"),
+                ));
+                true
+            }
+            Err(SymphonyError::GithubApiStatus { status: 404, .. }) => {
+                results.push(DoctorCheckResult::error(
+                    "GitHub Repo",
+                    format!("Repository {repo_owner}/{repo_name} not found (HTTP 404)"),
+                ));
+                false
+            }
+            Err(SymphonyError::GithubApiStatus { status, .. }) => {
+                results.push(DoctorCheckResult::warning(
+                    "GitHub Repo",
+                    format!(
+                        "Repository {repo_owner}/{repo_name} check returned HTTP {status}"
+                    ),
+                ));
+                false
+            }
+            Err(err) => {
+                results.push(DoctorCheckResult::warning(
+                    "GitHub Repo",
+                    format!(
+                        "Repository {repo_owner}/{repo_name} check failed: {err}"
+                    ),
+                ));
+                false
+            }
+        }
+    } else {
+        results.push(DoctorCheckResult::skipped(
+            "GitHub Repo",
+            "Skipped because PAT authentication failed",
+        ));
+        false
+    };
+
+    if let Some(project_number) = config.github_project_number {
+        if !pat_ok {
+            results.push(DoctorCheckResult::skipped(
+                "GitHub Project",
+                "Skipped because PAT authentication failed",
+            ));
+        } else {
+            let projects_client = ProjectsV2Client::new(client.clone());
+            match projects_client
+                .resolve_status_field(repo_owner, project_number)
+                .await
+            {
+                Ok(status_field) => {
+                    results.push(DoctorCheckResult::pass(
+                        "GitHub Project",
+                        format!(
+                            "Project #{project_number} found with Status field ({} options)",
+                            status_field.options.len()
+                        ),
+                    ));
+                }
+                Err(err) => {
+                    let err_text = err.to_string();
+                    let message = if err_text.to_ascii_lowercase().contains("not found") {
+                        format!("Project #{project_number} not found or not accessible")
+                    } else {
+                        format!(
+                            "Project #{project_number} not found or not accessible ({err_text})"
+                        )
+                    };
+                    results.push(DoctorCheckResult::error("GitHub Project", message));
+                }
+            }
+        }
+
+        results.push(DoctorCheckResult::skipped(
+            "GitHub Labels",
+            "Projects v2 mode configured (github_project_number set)",
+        ));
+        return results;
+    }
+
+    results.push(DoctorCheckResult::skipped(
+        "GitHub Project",
+        "No github_project_number configured — label mode assumed",
+    ));
+
+    if !pat_ok {
+        results.push(DoctorCheckResult::skipped(
+            "GitHub Labels",
+            "Skipped because PAT authentication failed",
+        ));
+        return results;
+    }
+
+    if !repo_ok {
+        results.push(DoctorCheckResult::skipped(
+            "GitHub Labels",
+            "Skipped because repository check failed",
+        ));
+        return results;
+    }
+
+    match client.list_labels().await {
+        Ok(labels) => {
+            let normalized_labels: BTreeSet<String> = labels
+                .iter()
+                .map(|label| label.name.trim().to_ascii_lowercase())
+                .filter(|label| !label.is_empty())
+                .collect();
+
+            let expected_labels: BTreeSet<String> = config
+                .active_states
+                .iter()
+                .chain(config.terminal_states.iter())
+                .map(|state| normalize_state_for_label(state))
+                .filter(|state| !state.is_empty())
+                .map(|state| format!("{label_prefix}:{state}"))
+                .collect();
+
+            let mut missing_labels = Vec::new();
+            for expected in expected_labels {
+                if !normalized_labels.contains(&expected.to_ascii_lowercase()) {
+                    missing_labels.push(expected);
+                }
+            }
+
+            if missing_labels.is_empty() {
+                results.push(DoctorCheckResult::pass(
+                    "GitHub Labels",
+                    "All configured state labels exist on repository",
+                ));
+            } else {
+                for missing in missing_labels {
+                    results.push(DoctorCheckResult::warning(
+                        "GitHub Labels",
+                        format!(
+                            "Label {missing} not found on repository — create it before running Symphony"
+                        ),
+                    ));
+                }
+            }
+        }
+        Err(err) => {
+            results.push(DoctorCheckResult::warning(
+                "GitHub Labels",
+                format!("Failed to list repository labels: {err}"),
             ));
         }
     }
@@ -1063,6 +1247,16 @@ async fn resolve_assignee(
     }
 
     Ok(None)
+}
+
+fn normalize_state_for_label(state_name: &str) -> String {
+    state_name
+        .trim()
+        .to_ascii_lowercase()
+        .replace('_', "-")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 fn collect_unresolved_env_refs(value: &YamlValue) -> Vec<EnvReferenceIssue> {

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -900,7 +900,29 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       return Number.isNaN(parsed.getTime()) ? String(value) : parsed.toISOString();
     }}
 
-    function renderRunningTable(running, sessionInfoByIssue) {{
+    function issueNumberFromIdentifier(identifier) {{
+      const match = String(identifier || '').match(/(\d+)/);
+      return match ? match[1] : null;
+    }}
+
+    function buildIssueUrl(issueIdentifier, issueUrl, trackerProjectUrl) {{
+      if (typeof issueUrl === 'string' && issueUrl.trim().length > 0) {{
+        return issueUrl.trim();
+      }}
+
+      if (typeof trackerProjectUrl !== 'string' || trackerProjectUrl.trim().length === 0) {{
+        return null;
+      }}
+
+      const issueNumber = issueNumberFromIdentifier(issueIdentifier);
+      if (!issueNumber) {{
+        return null;
+      }}
+
+      return trackerProjectUrl.replace(/\/+$/, '') + '/' + issueNumber;
+    }}
+
+    function renderRunningTable(running, sessionInfoByIssue, trackerProjectUrl) {{
       const rows = Object.entries(running || {{}}).sort(function(a, b) {{
         return String(a[1].issue_identifier || '').localeCompare(String(b[1].issue_identifier || ''));
       }});
@@ -936,12 +958,17 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         const toolName = sessionInfo.current_tool_name || '';
         const toolArgs = sessionInfo.current_tool_args_preview || '';
         const activityLabel = toolName ? 'tool: ' + toolName + (toolArgs ? ' (' + toolArgs + ')' : '') : '-';
+        const issueIdentifier = run.issue_identifier || '-';
+        const issueUrl = buildIssueUrl(issueIdentifier, run.issue_url, trackerProjectUrl);
+        const issueCell = issueUrl
+          ? '<a href="' + escapeHtml(issueUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(issueIdentifier) + '</a>'
+          : escapeHtml(issueIdentifier);
         const errorValue = sessionInfo.last_error;
         const errorCell = errorValue
           ? '<td class="mono error-text">' + escapeHtml(errorValue) + '</td>'
           : '<td class="muted">-</td>';
         return '<tr>' +
-          '<td class="mono">' + escapeHtml(run.issue_identifier || '-') + '</td>' +
+          '<td class="mono">' + issueCell + '</td>' +
           '<td>' + escapeHtml(run.linear_state || '-') + '</td>' +
           '<td>' + escapeHtml(run.status || '-') + '</td>' +
           '<td class="mono">' + escapeHtml(activityLabel) + '</td>' +
@@ -958,8 +985,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }}).join('');
     }}
 
-    function renderEscalationTable(escalations, running) {{
-      const rows = Array.isArray(escalations) ? escalations.slice() : [];
+    function renderEscalationTable(escalations, running) {{      const rows = Array.isArray(escalations) ? escalations.slice() : [];
       const runningRows = running && typeof running === 'object' ? Object.values(running) : [];
 
       rows.sort(function(a, b) {{
@@ -1025,7 +1051,7 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }}).join('');
     }}
 
-    function renderCompleted(completed) {{
+    function renderCompleted(completed, trackerProjectUrl) {{
       const items = Array.isArray(completed) ? completed : [];
       if (items.length === 0) {{
         return '<li class="muted">No completed issues yet.</li>';
@@ -1033,11 +1059,15 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
 
       return items.map(function(entry) {{
         const id = entry.identifier || entry.issue_id || '-';
+        const issueUrl = buildIssueUrl(id, entry.issue_url, trackerProjectUrl);
+        const idLabel = issueUrl
+          ? '<a href="' + escapeHtml(issueUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(id) + '</a>'
+          : escapeHtml(id);
         const title = entry.title || '';
         const date = entry.completed_at ? new Date(entry.completed_at).toLocaleString() : '';
-        const label = title ? id + ' — ' + title : id;
+        const titleSuffix = title ? ' — ' + escapeHtml(title) : '';
         const suffix = date ? ' <span class="muted" style="font-size:12px">(' + escapeHtml(date) + ')</span>' : '';
-        return '<li class="mono">' + escapeHtml(label) + suffix + '</li>';
+        return '<li class="mono">' + idLabel + titleSuffix + suffix + '</li>';
       }}).join('');
     }}
 
@@ -1184,7 +1214,8 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
           renderTrackerProjectCard(state.tracker_project_url);
         document.getElementById('running-table-body').innerHTML = renderRunningTable(
           running,
-          state.running_session_info || {{}}
+          state.running_session_info || {{}},
+          state.tracker_project_url
         );
         document.getElementById('escalation-table-body').innerHTML = renderEscalationTable(pendingEscalations, running);
         document.getElementById('retry-table-body').innerHTML = renderRetryTable(retryQueue);
@@ -1203,7 +1234,10 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
           blockedSection.style.display = 'none';
         }}
 
-        document.getElementById('completed-list').innerHTML = renderCompleted(completed);
+        document.getElementById('completed-list').innerHTML = renderCompleted(
+          completed,
+          state.tracker_project_url
+        );
         updateSharedContextSection(sharedContextEntries);
         updateSupervisor(state.supervisor || {{}});
         document.getElementById('token-input').textContent = state.codex_totals?.input_tokens ?? 0;

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -914,12 +914,17 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
         return null;
       }}
 
+      const projectBase = trackerProjectUrl.trim();
+      if (!projectBase.includes('/issues')) {{
+        return null;
+      }}
+
       const issueNumber = issueNumberFromIdentifier(issueIdentifier);
       if (!issueNumber) {{
         return null;
       }}
 
-      return trackerProjectUrl.replace(/\/+$/, '') + '/' + issueNumber;
+      return projectBase.replace(/\/+$/, '') + '/' + issueNumber;
     }}
 
     function renderRunningTable(running, sessionInfoByIssue, trackerProjectUrl) {{
@@ -985,7 +990,8 @@ async fn get_dashboard(State(state): State<HttpServerState>) -> impl IntoRespons
       }}).join('');
     }}
 
-    function renderEscalationTable(escalations, running) {{      const rows = Array.isArray(escalations) ? escalations.slice() : [];
+    function renderEscalationTable(escalations, running) {{
+      const rows = Array.isArray(escalations) ? escalations.slice() : [];
       const runningRows = running && typeof running === 'object' ? Object.values(running) : [];
 
       rows.sort(function(a, b) {{

--- a/apps/symphony/src/notifications.rs
+++ b/apps/symphony/src/notifications.rs
@@ -256,6 +256,22 @@ mod tests {
         assert!(!is_supported_slack_event("staleled"));
     }
 
+    #[test]
+    fn test_slack_message_formats_github_url() {
+        let message = format_slack_message(
+            "in_progress",
+            "#42",
+            "Fix login bug",
+            "Moved to In Progress",
+            Some("https://github.com/owner/repo/issues/42"),
+        );
+
+        assert!(
+            message.contains("<https://github.com/owner/repo/issues/42|#42>"),
+            "expected github issue to be rendered as Slack mrkdwn link"
+        );
+    }
+
     #[tokio::test]
     async fn test_notification_dispatch_formats_slack_message() {
         let mut server = Server::new_async().await;

--- a/apps/symphony/src/tui.rs
+++ b/apps/symphony/src/tui.rs
@@ -1287,6 +1287,46 @@ mod tests {
     }
 
     #[test]
+    fn test_tui_renders_github_identifier() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 22, 16, 10, 0)
+            .single()
+            .expect("valid fixture timestamp");
+        let mut snapshot = snapshot_fixture(0, None);
+        let issue_id = "issue-github".to_string();
+
+        snapshot.running.insert(
+            issue_id.clone(),
+            crate::domain::RunAttempt {
+                issue_id: issue_id.clone(),
+                issue_identifier: "#42".to_string(),
+                issue_title: Some("GitHub parity issue".to_string()),
+                attempt: Some(1),
+                workspace_path: "/tmp/workspace-github".to_string(),
+                started_at: now,
+                status: "running".to_string(),
+                error: None,
+                worker_host: None,
+                model: None,
+                linear_state: Some("In Progress".to_string()),
+                issue_url: Some("https://github.com/owner/repo/issues/42".to_string()),
+            },
+        );
+
+        let backend = TestBackend::new(180, 30);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| draw_dashboard(frame, &snapshot, now, "Throughput: 0.0 tps ▁▁▁▁▁▁▁▁"))
+            .expect("dashboard draw should succeed");
+
+        let rendered = render_text(terminal.backend());
+        assert!(
+            rendered.contains("#42"),
+            "running table should render github issue identifiers verbatim, got:\n{rendered}"
+        );
+    }
+
+    #[test]
     fn status_color_respects_event_mapping_and_staleness() {
         let now = Utc
             .with_ymd_and_hms(2026, 3, 22, 15, 0, 0)

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -608,6 +608,193 @@ fn test_check_workspace_root_nonexistent_and_not_creatable() {
         .any(|result| { result.status == CheckStatus::Error && result.name == "Workspace Root" }));
 }
 
+fn github_tracker_config(endpoint: String) -> TrackerConfig {
+    TrackerConfig {
+        kind: Some("github".to_string()),
+        endpoint,
+        api_key: Some(ApiKey::new("github-test-token")),
+        project_slug: None,
+        workspace_slug: None,
+        repo_owner: Some("test-owner".to_string()),
+        repo_name: Some("test-repo".to_string()),
+        github_project_number: None,
+        label_prefix: Some("symphony".to_string()),
+        assignee: None,
+        active_states: vec!["Todo".to_string(), "In Progress".to_string()],
+        terminal_states: vec!["Done".to_string()],
+        exclude_labels: vec![],
+    }
+}
+
+#[tokio::test]
+async fn test_doctor_github_pat_valid() {
+    let mut server = Server::new_async().await;
+    let _user_mock = server
+        .mock("GET", "/user")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"login":"octocat"}"#)
+        .create_async()
+        .await;
+    let _repo_mock = server
+        .mock("GET", "/repos/test-owner/test-repo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"test-repo"}"#)
+        .create_async()
+        .await;
+    let _labels_mock = server
+        .mock("GET", "/repos/test-owner/test-repo/labels")
+        .match_query(Matcher::UrlEncoded("per_page".to_string(), "100".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"[{"name":"symphony:todo"},{"name":"symphony:in-progress"},{"name":"symphony:done"}]"#,
+        )
+        .create_async()
+        .await;
+
+    let config = github_tracker_config(server.url());
+    let results = doctor::check_github(&config).await;
+
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Pass
+            && result.name == "GitHub PAT"
+            && result.message.contains("PAT authenticated")
+    }));
+}
+
+#[tokio::test]
+async fn test_doctor_github_pat_invalid() {
+    let mut server = Server::new_async().await;
+    let _user_mock = server
+        .mock("GET", "/user")
+        .with_status(401)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"message":"Bad credentials"}"#)
+        .create_async()
+        .await;
+
+    let config = github_tracker_config(server.url());
+    let results = doctor::check_github(&config).await;
+
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Error
+            && result.name == "GitHub PAT"
+            && result.message.contains("PAT authentication failed (HTTP 401)")
+    }));
+}
+
+#[tokio::test]
+async fn test_doctor_github_repo_not_found() {
+    let mut server = Server::new_async().await;
+    let _user_mock = server
+        .mock("GET", "/user")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"login":"octocat"}"#)
+        .create_async()
+        .await;
+    let _repo_mock = server
+        .mock("GET", "/repos/test-owner/test-repo")
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"message":"Not Found"}"#)
+        .create_async()
+        .await;
+
+    let config = github_tracker_config(server.url());
+    let results = doctor::check_github(&config).await;
+
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Error
+            && result.name == "GitHub Repo"
+            && result
+                .message
+                .contains("Repository test-owner/test-repo not found (HTTP 404)")
+    }));
+}
+
+#[tokio::test]
+async fn test_doctor_github_project_found() {
+    let mut server = Server::new_async().await;
+    let _user_mock = server
+        .mock("GET", "/user")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"login":"octocat"}"#)
+        .create_async()
+        .await;
+    let _repo_mock = server
+        .mock("GET", "/repos/test-owner/test-repo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"test-repo"}"#)
+        .create_async()
+        .await;
+    let _graphql_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"data":{"user":{"projectV2":{"id":"PVT_kwDOA","field":{"id":"PVTSSF_kwDOA","options":[{"id":"opt_todo","name":"Todo"},{"id":"opt_done","name":"Done"}]}}},"organization":null}}"#,
+        )
+        .create_async()
+        .await;
+
+    let mut config = github_tracker_config(server.url());
+    config.github_project_number = Some(7);
+
+    let results = doctor::check_github(&config).await;
+
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Pass
+            && result.name == "GitHub Project"
+            && result
+                .message
+                .contains("Project #7 found with Status field")
+    }));
+}
+
+#[tokio::test]
+async fn test_doctor_github_labels_missing_warning() {
+    let mut server = Server::new_async().await;
+    let _user_mock = server
+        .mock("GET", "/user")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"login":"octocat"}"#)
+        .create_async()
+        .await;
+    let _repo_mock = server
+        .mock("GET", "/repos/test-owner/test-repo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"test-repo"}"#)
+        .create_async()
+        .await;
+    let _labels_mock = server
+        .mock("GET", "/repos/test-owner/test-repo/labels")
+        .match_query(Matcher::UrlEncoded("per_page".to_string(), "100".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"[{"name":"symphony:todo"}]"#)
+        .create_async()
+        .await;
+
+    let config = github_tracker_config(server.url());
+    let results = doctor::check_github(&config).await;
+
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Warning
+            && result.name == "GitHub Labels"
+            && result
+                .message
+                .contains("Label symphony:in-progress not found on repository")
+    }));
+}
+
 #[tokio::test]
 async fn test_check_linear_auth_failure() {
     let mut server = Server::new_async().await;

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -760,6 +760,46 @@ async fn test_doctor_github_project_found() {
 }
 
 #[tokio::test]
+async fn test_doctor_github_project_status_field_missing_message() {
+    let mut server = Server::new_async().await;
+    let _user_mock = server
+        .mock("GET", "/user")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"login":"octocat"}"#)
+        .create_async()
+        .await;
+    let _repo_mock = server
+        .mock("GET", "/repos/test-owner/test-repo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"test-repo"}"#)
+        .create_async()
+        .await;
+    let _graphql_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"data":{"user":{"projectV2":{"id":"PVT_kwDOA","field":null}},"organization":null}}"#)
+        .create_async()
+        .await;
+
+    let mut config = github_tracker_config(server.url());
+    config.github_project_number = Some(7);
+
+    let results = doctor::check_github(&config).await;
+
+    assert!(results.iter().any(|result| {
+        result.status == CheckStatus::Error
+            && result.name == "GitHub Project"
+            && result
+                .message
+                .contains("Project #7 found but Status field is missing or inaccessible")
+    }));
+}
+
+#[tokio::test]
 async fn test_doctor_github_labels_missing_warning() {
     let mut server = Server::new_async().await;
     let _user_mock = server

--- a/apps/symphony/tests/cli_tests.rs
+++ b/apps/symphony/tests/cli_tests.rs
@@ -681,7 +681,9 @@ async fn test_doctor_github_pat_invalid() {
     assert!(results.iter().any(|result| {
         result.status == CheckStatus::Error
             && result.name == "GitHub PAT"
-            && result.message.contains("PAT authentication failed (HTTP 401)")
+            && result
+                .message
+                .contains("PAT authentication failed (HTTP 401)")
     }));
 }
 
@@ -776,7 +778,10 @@ async fn test_doctor_github_labels_missing_warning() {
         .await;
     let _labels_mock = server
         .mock("GET", "/repos/test-owner/test-repo/labels")
-        .match_query(Matcher::UrlEncoded("per_page".to_string(), "100".to_string()))
+        .match_query(Matcher::UrlEncoded(
+            "per_page".to_string(),
+            "100".to_string(),
+        ))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"[{"name":"symphony:todo"}]"#)

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -175,7 +175,8 @@ fn github_snapshot() -> OrchestratorSnapshot {
         .expect("fixture timestamp should be valid");
 
     let mut snapshot = fixture_snapshot();
-    snapshot.tracker_project_url = Some("https://github.com/test-owner/test-repo/issues".to_string());
+    snapshot.tracker_project_url =
+        Some("https://github.com/test-owner/test-repo/issues".to_string());
     snapshot.running = BTreeMap::from([(
         "gh-42".to_string(),
         RunAttempt {

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -168,6 +168,40 @@ fn fixture_snapshot() -> OrchestratorSnapshot {
     }
 }
 
+fn github_snapshot() -> OrchestratorSnapshot {
+    let started_at = Utc
+        .with_ymd_and_hms(2026, 3, 19, 12, 0, 0)
+        .single()
+        .expect("fixture timestamp should be valid");
+
+    let mut snapshot = fixture_snapshot();
+    snapshot.tracker_project_url = Some("https://github.com/test-owner/test-repo/issues".to_string());
+    snapshot.running = BTreeMap::from([(
+        "gh-42".to_string(),
+        RunAttempt {
+            issue_id: "gh-42".to_string(),
+            issue_identifier: "#42".to_string(),
+            issue_title: Some("GitHub issue parity".to_string()),
+            attempt: Some(1),
+            workspace_path: "/tmp/symphony/gh-42".to_string(),
+            started_at,
+            status: "running".to_string(),
+            error: None,
+            worker_host: Some("worker-a".to_string()),
+            model: None,
+            linear_state: Some("In Progress".to_string()),
+            issue_url: Some("https://github.com/test-owner/test-repo/issues/42".to_string()),
+        },
+    )]);
+    snapshot.completed = vec![CompletedEntry {
+        issue_id: "gh-42".to_string(),
+        identifier: "#42".to_string(),
+        title: "GitHub issue parity".to_string(),
+        completed_at: Some(started_at),
+    }];
+    snapshot
+}
+
 fn test_router() -> axum::Router {
     test_router_with_steer_sender(None)
 }
@@ -346,6 +380,66 @@ async fn test_get_root_returns_html_dashboard_shell_with_structured_sections() {
     assert!(
         !body.contains("Live state"),
         "dashboard shell should no longer expose the raw live-state section"
+    );
+}
+
+#[tokio::test]
+async fn test_dashboard_renders_github_identifiers() {
+    let app = build_router(HttpServerState::new(
+        Arc::new(StaticSnapshotSource {
+            snapshot: github_snapshot(),
+        }),
+        Arc::new(FakeRefreshControl::default()),
+        symphony::orchestrator::EscalationRegistry::default(),
+    ));
+
+    let dashboard_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+
+    let dashboard_html = body_text(dashboard_response).await;
+
+    assert!(
+        dashboard_html.contains("https://github.com/test-owner/test-repo/issues"),
+        "dashboard should render GitHub tracker project URL card"
+    );
+    assert!(
+        dashboard_html.contains("buildIssueUrl(issueIdentifier, run.issue_url, trackerProjectUrl)"),
+        "running table rendering should resolve issue links using run.issue_url first"
+    );
+    assert!(
+        dashboard_html.contains("trackerProjectUrl.replace(/\\/+$/, '') + '/' + issueNumber"),
+        "running/completed link rendering should fall back to tracker_project_url + issue number"
+    );
+
+    let state_response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v1/state")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+
+    let payload = body_json(state_response).await;
+    assert_eq!(payload["running"]["gh-42"]["issue_identifier"], "#42");
+    assert_eq!(
+        payload["running"]["gh-42"]["issue_url"],
+        "https://github.com/test-owner/test-repo/issues/42"
+    );
+    assert_eq!(
+        payload["tracker_project_url"],
+        "https://github.com/test-owner/test-repo/issues"
     );
 }
 

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -417,8 +417,12 @@ async fn test_dashboard_renders_github_identifiers() {
         "running table rendering should resolve issue links using run.issue_url first"
     );
     assert!(
-        dashboard_html.contains("trackerProjectUrl.replace(/\\/+$/, '') + '/' + issueNumber"),
-        "running/completed link rendering should fall back to tracker_project_url + issue number"
+        dashboard_html.contains("if (!projectBase.includes('/issues'))"),
+        "running/completed link fallback should only activate for GitHub-style /issues base URLs"
+    );
+    assert!(
+        dashboard_html.contains("projectBase.replace(/\\/+$/, '') + '/' + issueNumber"),
+        "running/completed link rendering should append numeric issue ids to GitHub issue base URLs"
     );
 
     let state_response = app
@@ -441,6 +445,33 @@ async fn test_dashboard_renders_github_identifiers() {
     assert_eq!(
         payload["tracker_project_url"],
         "https://github.com/test-owner/test-repo/issues"
+    );
+}
+
+#[tokio::test]
+async fn test_dashboard_does_not_fallback_issue_links_for_linear_project_urls() {
+    let app = test_router();
+
+    let dashboard_response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond");
+
+    let dashboard_html = body_text(dashboard_response).await;
+
+    assert!(
+        dashboard_html.contains("if (!projectBase.includes('/issues'))"),
+        "dashboard JS should guard numeric issue-url fallback so Linear project URLs are not treated like issue bases"
+    );
+    assert!(
+        !dashboard_html.contains("trackerProjectUrl.replace(/\\/+$/, '') + '/' + issueNumber"),
+        "dashboard JS should no longer append issue numbers to arbitrary tracker project URLs"
     );
 }
 

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -4610,7 +4610,10 @@ fn test_e2e_github_snapshot_state_json_complete() {
         running_snapshot["tracker_project_url"],
         "https://github.com/test-owner/test-repo/issues"
     );
-    assert_eq!(running_snapshot["running"]["gh-42"]["issue_identifier"], "#42");
+    assert_eq!(
+        running_snapshot["running"]["gh-42"]["issue_identifier"],
+        "#42"
+    );
     assert_eq!(
         running_snapshot["running"]["gh-42"]["issue_url"],
         "https://github.com/test-owner/test-repo/issues/42"
@@ -4632,7 +4635,9 @@ fn test_e2e_github_snapshot_state_json_complete() {
     assert!(
         completed_entries.iter().any(|entry| {
             entry["identifier"] == "#42"
-                && entry["title"].as_str().is_some_and(|title| !title.is_empty())
+                && entry["title"]
+                    .as_str()
+                    .is_some_and(|title| !title.is_empty())
         }),
         "completed snapshot should include github identifier and title"
     );

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -4491,6 +4491,153 @@ fn test_github_snapshot_contains_tracker_project_url() {
     );
 }
 
+#[test]
+fn test_e2e_github_label_mode_full_lifecycle() {
+    let mut orchestrator = Orchestrator::new(github_test_config(1), String::new());
+
+    let mut dispatch_port = FakePort {
+        candidate_issues: vec![github_issue("gh-42", 42, "Todo", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut dispatch_port)
+        .expect("dispatch tick should succeed");
+
+    let running_issue = orchestrator
+        .state()
+        .running
+        .get("gh-42")
+        .expect("issue should be tracked as running after dispatch");
+    assert_eq!(running_issue.issue_identifier, "#42");
+
+    let mut in_progress_port = FakePort {
+        reconciled_issues: vec![github_issue("gh-42", 42, "In Progress", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut in_progress_port)
+        .expect("reconcile in-progress tick should succeed");
+    assert!(
+        orchestrator.state().running.contains_key("gh-42"),
+        "issue should remain in running while state is active"
+    );
+
+    let mut done_port = FakePort {
+        reconciled_issues: vec![github_issue("gh-42", 42, "Done", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut done_port)
+        .expect("reconcile done tick should succeed");
+
+    assert!(
+        !orchestrator.state().running.contains_key("gh-42"),
+        "done issue should be removed from running set"
+    );
+
+    let completed = orchestrator
+        .state()
+        .completed
+        .get("gh-42")
+        .expect("done issue should be tracked as completed");
+    assert_eq!(completed.identifier, "#42");
+}
+
+#[test]
+fn test_e2e_github_projects_v2_mode_full_lifecycle() {
+    let mut config = github_test_config(1);
+    config.tracker.github_project_number = Some(7);
+
+    let mut orchestrator = Orchestrator::new(config, String::new());
+
+    let mut dispatch_port = FakePort {
+        candidate_issues: vec![github_issue("gh-84", 84, "Todo", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut dispatch_port)
+        .expect("dispatch tick should succeed");
+    assert!(
+        orchestrator.state().running.contains_key("gh-84"),
+        "projects-v2 mode should dispatch github issues the same as label mode"
+    );
+
+    let mut in_progress_port = FakePort {
+        reconciled_issues: vec![github_issue("gh-84", 84, "In Progress", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut in_progress_port)
+        .expect("reconcile in-progress tick should succeed");
+    assert!(
+        orchestrator.state().running.contains_key("gh-84"),
+        "active issue should remain running"
+    );
+
+    let mut done_port = FakePort {
+        reconciled_issues: vec![github_issue("gh-84", 84, "Done", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut done_port)
+        .expect("reconcile done tick should succeed");
+
+    assert!(
+        !orchestrator.state().running.contains_key("gh-84"),
+        "terminal issue should leave running set"
+    );
+    assert!(
+        orchestrator.state().completed.contains_key("gh-84"),
+        "terminal issue should be recorded as completed"
+    );
+}
+
+#[test]
+fn test_e2e_github_snapshot_state_json_complete() {
+    let mut orchestrator = Orchestrator::new(github_test_config(1), String::new());
+
+    let mut dispatch_port = FakePort {
+        candidate_issues: vec![github_issue("gh-42", 42, "Todo", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut dispatch_port)
+        .expect("dispatch tick should succeed");
+
+    let running_snapshot = serde_json::to_value(orchestrator.snapshot(0))
+        .expect("running snapshot should serialize to JSON");
+    assert_eq!(
+        running_snapshot["tracker_project_url"],
+        "https://github.com/test-owner/test-repo/issues"
+    );
+    assert_eq!(running_snapshot["running"]["gh-42"]["issue_identifier"], "#42");
+    assert_eq!(
+        running_snapshot["running"]["gh-42"]["issue_url"],
+        "https://github.com/test-owner/test-repo/issues/42"
+    );
+
+    let mut done_port = FakePort {
+        reconciled_issues: vec![github_issue("gh-42", 42, "Done", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut done_port)
+        .expect("reconcile done tick should succeed");
+
+    let final_snapshot = serde_json::to_value(orchestrator.snapshot(0))
+        .expect("final snapshot should serialize to JSON");
+    let completed_entries = final_snapshot["completed"]
+        .as_array()
+        .expect("completed should serialize as an array");
+    assert!(
+        completed_entries.iter().any(|entry| {
+            entry["identifier"] == "#42"
+                && entry["title"].as_str().is_some_and(|title| !title.is_empty())
+        }),
+        "completed snapshot should include github identifier and title"
+    );
+}
+
 // Covered by test_execute_worker_attempt_runs_multiple_turns_in_one_session:
 // same-state (In Progress → In Progress) continues normally for 2+ turns.
 // The Todo→In Progress auto-transition sets issue.state = effective_state in


### PR DESCRIPTION
## Summary
- add GitHub-aware dashboard link rendering for running/completed entries with `issue_url` + `tracker_project_url` fallback logic
- add explicit TUI and Slack formatting tests to verify `#N` identifiers and GitHub issue links render unchanged
- implement `doctor::check_github` PAT/repo/project/label checks with pass/warn/error/skip outcomes and add mockito coverage
- add end-to-end GitHub orchestration lifecycle tests for label mode + Projects v2 mode and snapshot JSON assertions
- document GitHub backend configuration and doctor behavior in `README.md` and `docs/WORKFLOW-REFERENCE.md`

## Validation
- `cd apps/symphony && cargo test --test http_server_tests github`
- `cd apps/symphony && cargo test tui_renders_github`
- `cd apps/symphony && cargo test slack_message_formats_github`
- `cd apps/symphony && cargo test doctor_github`
- `cd apps/symphony && cargo test --test orchestrator_tests e2e_github`
- `cd apps/symphony && cargo test`
- `cd apps/symphony && cargo clippy -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub Projects v2 mode support for enhanced project tracking
  * Enhanced GitHub authentication validation with explicit Personal Access Token (PAT) verification
  * Dashboard now automatically generates clickable issue links from identifiers when direct URLs unavailable

* **Improvements**
  * Improved state label normalization and validation
  * Enhanced error reporting distinguishing between authentication failures, missing repositories, and other API issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds GitHub Issues backend parity to the Symphony dashboard, extends `doctor` with granular GitHub PAT/repo/project/label checks, and introduces comprehensive e2e and unit test coverage for GitHub orchestration. The bulk of the changes are additive (new tests, documentation, doctor logic) and are well-implemented — one functional regression in the dashboard URL-rendering layer needs attention before merge.

**Key changes:**
- `buildIssueUrl` JS helper added to `http_server.rs` resolves issue links from `run.issue_url` first, falling back to `trackerProjectUrl + '/' + issueNumber` — but this fallback is only semantically correct for GitHub. For Linear, `tracker_project_url` is a project-level URL (e.g. `https://linear.app/workspace/project/slug`) and `issue_url` is typically `None`, so the fallback constructs broken href values for every Linear running and completed entry.
- `doctor::check_github` is a clean rewrite: granular PAT → repo → project/labels cascade with appropriate skip propagation and mockito test coverage.
- Three new e2e orchestrator tests exercise the full label-mode and Projects v2 lifecycle, plus snapshot JSON assertion.
- A formatting nit was introduced in `renderEscalationTable` (function signature and first statement merged onto one line).
- Several `http_server_tests` assertions compare verbatim JS source snippets rather than rendered HTML output, making them fragile to refactoring.

<h3>Confidence Score: 4/5</h3>

One P1 regression: `buildIssueUrl` fallback produces broken links for Linear entries; should be fixed before merge.

The doctor and e2e test additions are solid, but the `buildIssueUrl` fallback in `http_server.rs` introduces a present behavioral defect for Linear users — it renders every running/completed issue as a clickable link pointing to an invalid URL when `issue_url` is `None` and `tracker_project_url` is a Linear project URL. The fix is small and targeted, warranting a 4 rather than 5.

`apps/symphony/src/http_server.rs` — both the running table and completed list use `buildIssueUrl` with the Linear `tracker_project_url` fallback.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/symphony/src/http_server.rs | Adds `buildIssueUrl` helper and `trackerProjectUrl` argument to running/completed render functions; the fallback URL construction works correctly for GitHub but produces broken links for Linear entries where `issue_url` is `None`. |
| apps/symphony/src/doctor.rs | Rewrites `check_github` to run granular PAT/repo/project/label checks with proper skip propagation; logic is correct and well-structured. |
| apps/symphony/tests/http_server_tests.rs | Adds `github_snapshot` fixture and `test_dashboard_renders_github_identifiers`; some assertions test JS source text verbatim rather than rendered output, making them fragile to refactoring. |
| apps/symphony/tests/cli_tests.rs | Adds five mockito-backed doctor tests covering PAT valid/invalid, repo not found, project found, and missing labels; coverage is solid and the mocks are correctly scoped. |
| apps/symphony/tests/orchestrator_tests.rs | Adds three e2e lifecycle tests for label mode, Projects v2 mode, and full JSON snapshot assertions; all look correct and well-structured. |
| apps/symphony/src/tui.rs | Adds a TUI test verifying `#42` GitHub identifier renders verbatim in the running table; straightforward and correct. |
| apps/symphony/src/notifications.rs | Adds a Slack formatting test verifying GitHub issue links render as mrkdwn `<url|#N>`; test is correct and passes existing `format_slack_message` logic. |
| apps/symphony/README.md | Adds GitHub Issues backend documentation section covering configuration, authentication, state modes, and doctor behavior; content is accurate. |
| apps/symphony/docs/WORKFLOW-REFERENCE.md | Extends reference config with GitHub-only fields and example stanzas for both label mode and Projects v2 mode; content is well-organized. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildIssueUrl called] --> B{issue_url set?}
    B -- Yes --> C[Return issue_url directly ✅]
    B -- No --> D{trackerProjectUrl set?}
    D -- No --> E[Return null — no link]
    D -- Yes --> F[Extract digits from identifier]
    F --> G{issueNumber found?}
    G -- No --> E
    G -- Yes --> H[Return trackerProjectUrl + / + issueNumber]
    H --> I{Tracker kind?}
    I -- GitHub: .../issues/N --> J[✅ Valid GitHub issue URL]
    I -- Linear: .../project/slug/N --> K[❌ Broken Linear URL]

    style K fill:#f88,stroke:#c00
    style J fill:#8f8,stroke:#080
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/symphony/tests/http_server_tests.rs`, line 911-917 ([link](https://github.com/gannonh/kata/blob/7a29b7471f95ca8529a93bf30552566d3729e126/apps/symphony/tests/http_server_tests.rs#L911-L917)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Assertions test JS source text verbatim, making them brittle**

   The assertions at lines 911–917 check for exact JavaScript source snippets like `"buildIssueUrl(issueIdentifier, run.issue_url, trackerProjectUrl)"` and `"trackerProjectUrl.replace(/\\/+$/, '') + '/' + issueNumber"`. Because these strings are embedded inside the Rust format string that builds the dashboard HTML, any refactoring of the JS (renaming a parameter, adding whitespace, splitting an expression) will cause these tests to fail without any actual behavioral change.

   Consider asserting on observable behavior instead — e.g. that the rendered HTML for the known running entry contains the expected `<a href="...">` tag with the correct URL — which is both more meaningful and more resilient to internal JS refactoring.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/symphony/tests/http_server_tests.rs
   Line: 911-917

   Comment:
   **Assertions test JS source text verbatim, making them brittle**

   The assertions at lines 911–917 check for exact JavaScript source snippets like `"buildIssueUrl(issueIdentifier, run.issue_url, trackerProjectUrl)"` and `"trackerProjectUrl.replace(/\\/+$/, '') + '/' + issueNumber"`. Because these strings are embedded inside the Rust format string that builds the dashboard HTML, any refactoring of the JS (renaming a parameter, adding whitespace, splitting an expression) will cause these tests to fail without any actual behavioral change.

   Consider asserting on observable behavior instead — e.g. that the rendered HTML for the known running entry contains the expected `<a href="...">` tag with the correct URL — which is both more meaningful and more resilient to internal JS refactoring.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 962-966

Comment:
**`buildIssueUrl` fallback constructs broken URLs for Linear entries**

The `buildIssueUrl` fallback path — `trackerProjectUrl.replace(/\/+$/, '') + '/' + issueNumber` — is semantically correct only for GitHub, where `tracker_project_url` is `https://github.com/{owner}/{repo}/issues` and issue URLs are `https://github.com/{owner}/{repo}/issues/{number}`.

For Linear, `tracker_project_url` resolves to `https://linear.app/{workspace}/project/{slug}`, and issue URLs have the completely different form `https://linear.app/{workspace}/issue/{TEAM-NUMBER}`. Because `RunAttempt.issue_url` is `None` for Linear (the Linear adapter does not populate `issue.url`), the running table will now render every Linear issue as a clickable link pointing to a non-existent URL such as `https://linear.app/kata-sh/project/symphony/123` instead of plain text.

The `fixture_snapshot()` test helper already exercises this combination (`tracker_project_url = "https://linear.app/kata-sh/project/symphony"`, `issue_url = None`), but none of the existing tests assert on the rendered href, so the regression goes undetected.

The same logic applies to `renderCompleted` (line 1062): `CompletedEntry` has no `issue_url` field, so the fallback will always fire for Linear completed entries when `tracker_project_url` is set.

A minimal fix is to only apply the `trackerProjectUrl` fallback when the URL looks like a GitHub issues base (e.g. `trackerProjectUrl.includes('/issues')`), or to expose a `tracker_kind` field on the snapshot and gate the fallback on it:

```
function buildIssueUrl(issueIdentifier, issueUrl, trackerProjectUrl) {
  if (typeof issueUrl === 'string' && issueUrl.trim().length > 0) {
    return issueUrl.trim();
  }

  // Only apply the numeric-fallback for GitHub-style issue base URLs
  if (
    typeof trackerProjectUrl !== 'string' ||
    trackerProjectUrl.trim().length === 0 ||
    !trackerProjectUrl.includes('/issues')
  ) {
    return null;
  }

  const issueNumber = issueNumberFromIdentifier(issueIdentifier);
  if (!issueNumber) {
    return null;
  }

  return trackerProjectUrl.replace(/\/+$/, '') + '/' + issueNumber;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/http_server.rs
Line: 988

Comment:
**Missing newline after `renderEscalationTable` opening brace**

A newline was accidentally dropped between the function signature's opening brace and the first `const rows` declaration. The generated JavaScript still executes correctly (JS is not whitespace-sensitive here), but the source is hard to read and differs from the style of every other function in this block.

```suggestion
    function renderEscalationTable(escalations, running) {{
      const rows = Array.isArray(escalations) ? escalations.slice() : [];
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/tests/http_server_tests.rs
Line: 911-917

Comment:
**Assertions test JS source text verbatim, making them brittle**

The assertions at lines 911–917 check for exact JavaScript source snippets like `"buildIssueUrl(issueIdentifier, run.issue_url, trackerProjectUrl)"` and `"trackerProjectUrl.replace(/\\/+$/, '') + '/' + issueNumber"`. Because these strings are embedded inside the Rust format string that builds the dashboard HTML, any refactoring of the JS (renaming a parameter, adding whitespace, splitting an expression) will cause these tests to fail without any actual behavioral change.

Consider asserting on observable behavior instead — e.g. that the rendered HTML for the known running entry contains the expected `<a href="...">` tag with the correct URL — which is both more meaningful and more resilient to internal JS refactoring.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style(symphony): format github parity sl..."](https://github.com/gannonh/kata/commit/7a29b7471f95ca8529a93bf30552566d3729e126) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26718057)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->