### PR TITLE
CLI v0.15.0 — M010 Preferences Config Editor

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.15.0
+
+### Features
+
+- **M010: Preferences Config Editor (`/kata config`)** — Interactive TUI editor for `.kata/preferences.md`. Section-based navigation across 8 sections (General, Workflow, Linear, PR, Models, Symphony, Skills, Auto Supervisor). Type-aware field editing (strings, numbers, booleans, enums, string arrays). Validation blocks invalid values before save. Cancel is safe — file is byte-identical. Reuses Symphony's `ConfigEditor` architecture with preferences-specific parser, writer, and validator. Creates preferences file from template if missing.
+  - **Preferences model** — Complete field model covering all `KataPreferences` fields with section definitions, type metadata, enum values, and descriptions. `buildPreferencesModel()` produces a `ConfigEditorModel` compatible with the shared `ConfigEditor` class.
+  - **Preferences parser & writer** — YAML frontmatter round-trip: parse → edit → write preserves markdown body unchanged. Handles BOM, CRLF, empty frontmatter. Parse errors include line numbers.
+  - **Preferences validator** — Catches invalid enum values, non-numeric/negative numbers, and non-boolean fields before save. Returns structured `ConfigValidationIssue[]`.
+  - **ConfigEditorModel generalization** — Symphony's `config-model.ts` types widened so non-Symphony section keys are valid. `ConfigSectionKey` accepts arbitrary strings. All existing Symphony code compiles unchanged.
+  - **134 new Vitest tests** across 5 test suites: model (39), parser (11), writer (17), validator (16), integration (4 + mock ConfigEditor pipeline).
+
+### Improvements
+
+- **Onboarding post-setup message** — After Linear configuration, shows both the confirmation and where preferences are saved: `Preferences saved: .kata/preferences.md (edit directly or with /kata config)`.
+- **Header padding** — Added top padding above the ASCII KATA logo.
+- **Auth storage documentation** — All docs now correctly describe `~/.kata-cli/agent/auth.json` as the primary credential store. Removed misleading guidance that implied `.env` files or manual env vars were required.
+- **`uat_dispatch` and `budget_ceiling` documented** — Both General-section fields now have full documentation in the preferences reference.
+- **`projectId` de-emphasized** — `linear.projectSlug` is the only publicly surfaced project identifier. `projectId` still works at runtime for backward compatibility but is removed from the config editor, docs, error messages, and templates.
+- **`teamKey` and `projectSlug` marked required** — Editor and docs reflect that Linear mode requires both fields.
+
 ## 0.14.0
 
 ### Features

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -318,10 +318,11 @@ Kata ships with built-in Linear support — 40 native tools for managing issues,
 ### Setup
 
 1. Create a [Linear personal API key](https://linear.app/settings/api)
-2. Start Kata and provide the key when prompted, or set it in your environment:
+2. Start Kata and provide the key when prompted (stored in `~/.kata-cli/agent/auth.json` and hydrated automatically). You can also set `LINEAR_API_KEY` manually in your environment if you prefer:
    ```bash
    LINEAR_API_KEY=lin_api_... npx @kata-sh/cli
    ```
+   `.env` is optional.
 3. Ask Kata to configure your project:
    ```
    Configure this project to use Linear
@@ -361,7 +362,7 @@ workflow:
   mode: linear
 linear:
   teamKey: KAT
-  projectId: <your-project-uuid>
+  projectSlug: <your-project-slug>
 ---
 ```
 

--- a/apps/cli/docs/uat/M010-UAT-PLAN.md
+++ b/apps/cli/docs/uat/M010-UAT-PLAN.md
@@ -1,0 +1,307 @@
+# M010 UAT Plan — Preferences Config Editor (`/kata config`)
+
+**Milestone:** [M010] Preferences Config Editor  
+**Branch:** `cli/uat/M010`  
+**Date:** 2026-03-30  
+**Status:** Plan ready (execution pending)
+
+---
+
+## 1) UAT Scope
+
+Validate that M010 shipped a production-ready, user-facing preferences editor for Kata CLI:
+
+- `/kata config` is discoverable and routable
+- editor loads `.kata/preferences.md` (creating it when missing)
+- all preferences fields are editable with correct type handling
+- save/cancel behavior is safe and predictable
+- validation blocks invalid config writes
+- YAML frontmatter + markdown body round-trip safely
+- existing `/kata` and Symphony config editor behavior remains intact
+
+---
+
+## 2) Ticket Review (M010)
+
+### Slices
+
+1. **KAT-1868 / S01 — Preferences model, parser, writer**
+   - Tasks: KAT-1870, KAT-1871, KAT-1872
+   - Delivered: preferences field model, parser, writer, and round-trip test coverage
+
+2. **KAT-1880 / S02 — Validator + ConfigEditor integration**
+   - Tasks: KAT-1881, KAT-1882
+   - Delivered: preferences validator and parse → edit → validate → write integration tests
+
+3. **KAT-1887 / S03 — `/kata config` command wiring**
+   - Tasks: KAT-1888, KAT-1890
+   - Delivered: command routing/completions, real TUI bridge, save/cancel + error handling
+
+### Key milestone decisions to verify in UAT
+
+- **D019:** Reuse Symphony ConfigEditor/model/render surfaces
+- **D020:** Project-scope editor only (`.kata/preferences.md`)
+- **D021:** Complex fields (`skill_rules`, `custom_instructions`) use text-editor fallback
+
+---
+
+## 3) Code Change Review (M010 commits)
+
+### Commit map
+
+- `6e475021` — S01 implementation
+- `52c9675f` — S02 implementation
+- `b1380731` — S03 implementation
+
+### New files
+
+- `src/resources/extensions/kata/prefs-model.ts`
+- `src/resources/extensions/kata/prefs-parser.ts`
+- `src/resources/extensions/kata/prefs-writer.ts`
+- `src/resources/extensions/kata/prefs-validator.ts`
+- `src/resources/extensions/kata/prefs-config-command.ts`
+- `src/resources/extensions/kata/tests/prefs-model.vitest.test.ts`
+- `src/resources/extensions/kata/tests/prefs-parser.vitest.test.ts`
+- `src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts`
+- `src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts`
+- `src/resources/extensions/kata/tests/prefs-integration.vitest.test.ts`
+
+### Modified files (M010-relevant)
+
+- `src/resources/extensions/kata/commands.ts` (subcommand + routing)
+- `src/resources/extensions/symphony/config-model.ts` (generic model support)
+- `src/resources/extensions/symphony/config-render.ts` (editor header options)
+- `src/resources/extensions/symphony/config-{parser,writer,validator}.ts` (type compatibility updates)
+- `src/resources/extensions/symphony/tests/symphony-config-editor.vitest.test.ts`
+- `src/tests/app-smoke.test.ts`
+- `vitest.config.ts`
+
+---
+
+## 4) Risks to prioritize during UAT
+
+1. **Data integrity risk:** frontmatter corruption or body loss on save
+2. **Validation UX risk:** invalid values allowed through or silently rewritten
+3. **Complex field UX risk:** `string[]` and `skill_rules` editing produces wrong serialization
+4. **Command discoverability risk:** `/kata config` route/completions missing in real TUI flow
+5. **Shared-component regression risk:** changes to Symphony config model/render break existing `/symphony config`
+
+---
+
+## 5) Environment Matrix
+
+Execute UAT in at least these environments:
+
+1. **Clean project** (no `.kata/preferences.md`)
+2. **Configured project** (valid existing `.kata/preferences.md`)
+3. **Malformed YAML project** (intentionally broken frontmatter)
+4. **Type-invalid values project** (syntactically valid YAML, semantically invalid values)
+
+Suggested setup:
+
+```bash
+cd apps/cli
+npm run build
+```
+
+For manual UAT, use an isolated temp project directory to avoid mutating real preferences unexpectedly.
+
+---
+
+## 6) UAT Execution Plan
+
+## Phase A — Automated confidence gate
+
+Run before manual acceptance:
+
+```bash
+cd apps/cli
+npx tsc --noEmit
+npx vitest run src/resources/extensions/kata/tests/prefs-model.vitest.test.ts
+npx vitest run src/resources/extensions/kata/tests/prefs-parser.vitest.test.ts
+npx vitest run src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts
+npx vitest run src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts
+npx vitest run src/resources/extensions/kata/tests/prefs-integration.vitest.test.ts
+npx vitest run src/resources/extensions/symphony/tests/symphony-config-editor.vitest.test.ts
+```
+
+Optional full confidence sweep:
+
+```bash
+bun run test
+```
+
+**Pass criteria:** all commands exit 0.
+
+---
+
+## Phase B — User-facing manual acceptance (primary)
+
+### UAT-M010-01 — Command discoverability
+
+- **Goal:** `/kata config` is visible and callable
+- **Steps:**
+  1. Start Kata CLI in a project
+  2. Enter `/kata` and inspect helper output/completions
+  3. Execute `/kata config`
+- **Expected:** editor opens (no unknown command warning)
+- **Covers:** KAT-1888
+
+### UAT-M010-02 — Missing preferences bootstrap
+
+- **Precondition:** `.kata/preferences.md` absent
+- **Steps:** run `/kata config`
+- **Expected:** file is auto-created from template, then editor opens
+- **Covers:** KAT-1890, D020
+
+### UAT-M010-03 — Editor header + structure
+
+- **Steps:** open editor and inspect top section
+- **Expected:**
+  - header includes `Kata Preferences Editor`
+  - file path is shown
+  - sections render correctly (General, Workflow, Linear, PR, Models, Symphony, Skills, Auto Supervisor)
+- **Covers:** KAT-1890, config-render updates
+
+### UAT-M010-04 — String field edit and persistence
+
+- **Steps:**
+  1. Edit `linear.teamKey`
+  2. Save
+  3. Re-open `/kata config`
+- **Expected:** new value persists in editor + file
+- **Covers:** KAT-1882, KAT-1890
+
+### UAT-M010-05 — Enum field edit and persistence
+
+- **Steps:** edit `skill_discovery` (`auto/suggest/off`) and save
+- **Expected:** enum selection persists and serializes correctly
+- **Covers:** KAT-1881, KAT-1882
+
+### UAT-M010-06 — Boolean and numeric field handling
+
+- **Steps:**
+  1. Toggle `pr.enabled`
+  2. Edit `auto_supervisor.soft_timeout_minutes`
+  3. Save and re-open
+- **Expected:**
+  - booleans stored as booleans
+  - numbers stored as numeric YAML values
+- **Covers:** KAT-1881
+
+### UAT-M010-07 — `string[]` fields and multiline behavior
+
+- **Steps:** edit `always_use_skills` and `custom_instructions` with multi-line input
+- **Expected:** values serialize to YAML arrays and rehydrate correctly in editor
+- **Covers:** KAT-1872, KAT-1890, D021
+
+### UAT-M010-08 — `skill_rules` text-editor fallback
+
+- **Steps:** edit `skill_rules` with multiple rule lines, save, reopen
+- **Expected:** values are preserved and editable through text fallback without corruption
+- **Covers:** D021
+
+### UAT-M010-09 — Cancel leaves file untouched
+
+- **Precondition:** capture checksum before open (`shasum .kata/preferences.md`)
+- **Steps:** open `/kata config`, make edits, cancel
+- **Expected:** checksum unchanged
+- **Covers:** success criterion + KAT-1890
+
+### UAT-M010-10 — Validation blocks bad enum values
+
+- **Precondition:** create syntactically valid but invalid value (e.g. `workflow.mode: file`)
+- **Steps:** open editor, attempt save
+- **Expected:** validation error shown; no write occurs
+- **Covers:** KAT-1881, KAT-1890
+
+### UAT-M010-11 — Validation blocks bad number/boolean values
+
+- **Precondition:** invalid values like string in numeric/boolean field
+- **Steps:** save through editor
+- **Expected:** specific issue list shown; no write occurs
+- **Covers:** KAT-1881
+
+### UAT-M010-12 — Parse error reporting quality
+
+- **Precondition:** malformed YAML frontmatter (syntax error)
+- **Steps:** run `/kata config`
+- **Expected:** parse error with line number (when available), no crash
+- **Covers:** KAT-1872, KAT-1890
+
+---
+
+## Phase C — Regression checks
+
+### UAT-M010-13 — `/kata prefs` unaffected
+
+- **Steps:** run `/kata prefs status`, `/kata prefs project`
+- **Expected:** existing behavior intact
+- **Covers:** command routing regression guard
+
+### UAT-M010-14 — Other `/kata` subcommands unaffected
+
+- **Steps:** smoke `/kata status`, `/kata plan` (or other normal subcommands)
+- **Expected:** no regressions from command handler changes
+- **Covers:** `commands.ts` integration safety
+
+### UAT-M010-15 — Symphony config editor still works
+
+- **Steps:** run `/symphony config`
+- **Expected:** header/rendering/functionality unaffected
+- **Covers:** shared `config-model` + `config-render` compatibility
+
+---
+
+## 7) Evidence capture checklist
+
+For each UAT case, capture:
+
+- terminal transcript snippet (or saved log)
+- before/after preference excerpts (for save cases)
+- checksum proof for cancel case
+- exact validation message text for failure-path cases
+- any screenshots for TUI visual structure (optional but recommended)
+
+Use this lightweight result template per case:
+
+```markdown
+### UAT-M010-XX — <name>
+- Result: Pass | Fail
+- Evidence:
+  - Command(s):
+  - Output snippet:
+  - File diff/checksum:
+- Notes:
+```
+
+---
+
+## 8) Exit criteria (GO / NO-GO)
+
+**GO requires all of the following:**
+
+- All Phase A checks pass
+- All Phase B user-facing cases pass
+- No data-loss/corruption defects in save/cancel/round-trip scenarios
+- Validation reliably blocks invalid enums, numbers, booleans
+- No regressions in `/kata prefs`, other `/kata` commands, or `/symphony config`
+
+**NO-GO triggers:**
+
+- any frontmatter/body corruption
+- cancel mutates file
+- invalid config can be saved
+- editor fails to open in supported baseline setup
+
+---
+
+## 9) Suggested execution order (fastest signal first)
+
+1. Phase A automated checks
+2. UAT-M010-02 (bootstrap) + 03 (structure)
+3. UAT-M010-04/05/06/07/08 (core editing)
+4. UAT-M010-09/10/11/12 (safety/failure paths)
+5. UAT-M010-13/14/15 (regression)
+
+This order surfaces high-severity issues early (routing, persistence, corruption) before lower-risk polish checks.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/resources/AGENTS.md
+++ b/apps/cli/src/resources/AGENTS.md
@@ -550,11 +550,11 @@ mcp({ connect: "linear" })               — force connect/reconnect a server
 
 ## Built-in Linear Integration
 
-Kata ships a built-in Linear extension with a custom GraphQL client — no MCP server required. It provides native tools that are always available when `LINEAR_API_KEY` is set.
+Kata ships a built-in Linear extension with a custom GraphQL client — no MCP server required. It provides native tools whenever a Linear API key is available in runtime env (typically hydrated from `~/.kata-cli/agent/auth.json`, or set manually as `LINEAR_API_KEY`).
 
 ### Setup
 
-Set `LINEAR_API_KEY` in your environment (a Linear personal API key). That's it — the tools are immediately available.
+Provide a Linear personal API key via Kata onboarding (stored in `~/.kata-cli/agent/auth.json`) or set `LINEAR_API_KEY` manually in your environment. `.env` is optional. Once the key is available at runtime, the tools are immediately available.
 
 ### Tools
 
@@ -593,7 +593,7 @@ workflow:
   mode: linear
 linear:
   teamKey: KAT
-  projectId: <project-uuid>
+  projectSlug: <project-slug>
 ```
 
 Use `linear_list_projects` to find the project UUID.

--- a/apps/cli/src/resources/extensions/kata/backend-factory.ts
+++ b/apps/cli/src/resources/extensions/kata/backend-factory.ts
@@ -37,7 +37,7 @@ export async function createBackend(basePath: string): Promise<KataBackend> {
   // Resolve projectId slug → UUID if needed (filter expressions require UUIDs).
   const projectResolution = await resolveConfiguredLinearProjectId(client, loadedPreferences);
   if (!projectResolution.projectId) {
-    throw new Error(projectResolution.error ?? "Linear project not configured. Set linear.projectSlug in .kata/preferences.md.");
+    throw new Error(projectResolution.error ?? "Linear project not configured \u2014 set linear.projectSlug in .kata/preferences.md.");
   }
   const projectId = projectResolution.projectId;
 

--- a/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
+++ b/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
@@ -9,7 +9,9 @@ Full documentation for `~/.kata-cli/preferences.md` (global) and `.kata/preferen
 - These preferences guide how Kata should route work and load skills.
 - Project preferences live at `.kata/preferences.md`.
 - Kata still reads the legacy `.kata/PREFERENCES.md` filename for backward compatibility, but new projects should use the lowercase canonical path.
-- Secrets stay in environment variables (`LINEAR_API_KEY`, provider keys, tokens). Do not store secrets in preferences files.
+- Do not store secrets in preferences files.
+- Kata stores provider credentials in `~/.kata-cli/agent/auth.json` (for example via onboarding prompts) and hydrates runtime env vars like `LINEAR_API_KEY` automatically.
+- Manually setting env vars is still supported, but `.env` is optional.
 
 ---
 
@@ -17,16 +19,21 @@ Full documentation for `~/.kata-cli/preferences.md` (global) and `.kata/preferen
 
 - `version`: schema version. Start at `1`.
 
+- `uat_dispatch`: boolean toggle for `/kata auto` UAT dispatch.
+  - When `true`, auto-mode dispatches `run-uat` for a completed slice when `Sxx-UAT` exists and `Sxx-UAT-RESULT` is still missing.
+  - For non-`artifact-driven` UAT types, auto-mode surfaces the result for human review and pauses.
+
+- `budget_ceiling`: optional numeric spend cap for auto-mode.
+  - When current tracked cost reaches/exceeds this value, auto-mode pauses and asks you to resume explicitly.
+
 - `workflow`: workflow-mode configuration.
   - `workflow.mode`: `linear`.
     - File mode has been removed; all Kata workflow state is Linear-backed.
 
-- `linear`: Linear binding configuration used when `workflow.mode: linear`.
-  - `linear.teamId`: optional Linear team UUID.
-  - `linear.teamKey`: optional Linear team key such as `KAT`.
-  - `linear.projectSlug`: optional Linear project slug ID (from the project URL, e.g. `459f9835e809`). Preferred over `linear.projectId` — shorter, human-readable, and matches the slug in Linear URLs and Symphony's `tracker.project_slug`.
-  - `linear.projectId`: optional Linear project UUID. Supported for backward compatibility; prefer `linear.projectSlug`.
-  - These fields identify which Linear team/project Kata should validate and operate against. When both `projectSlug` and `projectId` are set, `projectSlug` takes precedence.
+- `linear`: Linear binding configuration. Required for Linear mode.
+  - `linear.teamKey`: Linear team key such as `KAT`. Required.
+  - `linear.projectSlug`: Linear project slug from the project URL (e.g. `459f9835e809`). Required.
+  - `linear.teamId`: optional Linear team UUID (alternative to `teamKey`).
 
 - `pr`: PR lifecycle configuration. Controls whether and how Kata manages GitHub pull requests.
   - `pr.enabled`: set to `true` to activate the PR lifecycle. Requires `gh` CLI installed and authenticated.
@@ -110,7 +117,9 @@ Set pr.enabled: true in .kata/preferences.md to activate the PR workflow.
 - Prefer skill names for stable built-in skills.
 - Prefer absolute paths for local personal skills.
 - Use `linear.teamKey` when you want a readable binding; use `linear.teamId` when you already have the UUID.
-- Keep auth in env vars and config in preferences.
+- Keep config in preferences.
+- Keep credentials in `~/.kata-cli/agent/auth.json` (preferred) or env vars.
+- Never place API keys/tokens directly in preferences files.
 
 ---
 
@@ -151,7 +160,7 @@ custom_instructions:
 ---
 ```
 
-This opts the project into Linear mode without storing `LINEAR_API_KEY` in the preferences file. Use `projectSlug` (the short ID from your Linear project URL) instead of the full UUID.
+Kata typically hydrates `LINEAR_API_KEY` from `~/.kata-cli/agent/auth.json`; setting it manually in your shell/.env is optional.
 
 **PR lifecycle — auto-create PRs after each slice:**
 

--- a/apps/cli/src/resources/extensions/kata/header.ts
+++ b/apps/cli/src/resources/extensions/kata/header.ts
@@ -50,7 +50,7 @@ export function renderHeader(showHint: boolean): void {
     ? `\n\n  ${theme.fg("dim", "Run")} ${theme.fg("accent", "/kata")} ${theme.fg("dim", "to get started.")}`
     : "";
 
-  const headerContent = `${logoText}\n${titleLine}${hintLine}`;
+  const headerContent = `\n${logoText}\n${titleLine}${hintLine}`;
   _headerCtx.ui.setHeader((_ui: any, _theme: any) => new Text(headerContent, 1, 0));
 }
 

--- a/apps/cli/src/resources/extensions/kata/linear-config.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-config.ts
@@ -569,7 +569,12 @@ export function formatLinearConfigStatus(
     lines.push(`linear.teamKey: ${result.config.linear.teamKey}`);
   }
   if (result.config.linear.projectId) {
-    lines.push(`linear.projectSlug: ${result.config.linear.projectId}`);
+    // The normalized projectId may originate from projectSlug or legacy projectId.
+    // Use the value shape (UUIDs contain dashes) to display the correct field name.
+    const projectLabel = UUID_RE.test(result.config.linear.projectId)
+      ? "linear.projectId (legacy)"
+      : "linear.projectSlug";
+    lines.push(`${projectLabel}: ${result.config.linear.projectId}`);
   }
 
   lines.push(`validation: ${result.status}`);

--- a/apps/cli/src/resources/extensions/kata/linear-config.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-config.ts
@@ -260,7 +260,7 @@ export async function resolveConfiguredLinearProjectId(
     return {
       projectId: null,
       projectLookup: null,
-      error: "Linear project not configured — set linear.projectSlug (or linear.projectId) in kata preferences.",
+      error: "Linear project not configured — set linear.projectSlug in .kata/preferences.md.",
     };
   }
 
@@ -279,7 +279,7 @@ export async function resolveConfiguredLinearProjectId(
     return {
       projectId: null,
       projectLookup: rawProjectId,
-      error: `Linear project not found for "${rawProjectId}". Check linear.projectSlug (or linear.projectId) in preferences.`,
+      error: `Linear project not found for "${rawProjectId}". Check linear.projectSlug in .kata/preferences.md.`,
     };
   }
 
@@ -377,7 +377,7 @@ export async function validateLinearProjectConfig(
         return invalidResult(config, apiKeyPresent, [
           {
             code: "invalid_linear_project",
-            field: "linear.projectId",
+            field: "linear.projectSlug",
             message: `Configured Linear project could not be resolved: ${JSON.stringify(config.linear.projectId)}.`,
             retryable: false,
           },
@@ -569,7 +569,7 @@ export function formatLinearConfigStatus(
     lines.push(`linear.teamKey: ${result.config.linear.teamKey}`);
   }
   if (result.config.linear.projectId) {
-    lines.push(`linear.projectId: ${result.config.linear.projectId}`);
+    lines.push(`linear.projectSlug: ${result.config.linear.projectId}`);
   }
 
   lines.push(`validation: ${result.status}`);
@@ -626,7 +626,7 @@ function getLinearDiagnosticAction(
         ? "update linear.teamId to a valid Linear team." 
         : "update linear.teamKey to a valid Linear team.";
     case "invalid_linear_project":
-      return "update linear.projectId to a valid Linear project or remove it.";
+      return "update linear.projectSlug to a valid Linear project.";
     case "linear_auth_error":
       return "refresh LINEAR_API_KEY before retrying validation.";
     case "linear_network_error":

--- a/apps/cli/src/resources/extensions/kata/onboarding.ts
+++ b/apps/cli/src/resources/extensions/kata/onboarding.ts
@@ -536,7 +536,7 @@ export async function runOnboarding(
     try {
       updatePreferencesLinearConfig(basePath, pickerResult);
       ctx.ui.notify(
-        `✓ Linear configured: team=${pickerResult.teamKey}, project=${pickerResult.projectSlug}`,
+        `✓ Linear configured: team=${pickerResult.teamKey}, project=${pickerResult.projectSlug}\nPreferences saved: .kata/preferences.md (edit directly or with /kata config)`,
         "info",
       );
     } catch (err) {

--- a/apps/cli/src/resources/extensions/kata/prefs-model.ts
+++ b/apps/cli/src/resources/extensions/kata/prefs-model.ts
@@ -142,7 +142,6 @@ export const PREFS_FIELD_DEFINITIONS: readonly PrefsFieldDefinition[] = [
     label: "Team Key",
     path: ["linear", "teamKey"],
     type: "string",
-    required: true,
     description: "Linear team key such as KAT. Required for Linear mode.",
   },
   {
@@ -151,9 +150,8 @@ export const PREFS_FIELD_DEFINITIONS: readonly PrefsFieldDefinition[] = [
     label: "Project Slug",
     path: ["linear", "projectSlug"],
     type: "string",
-    required: true,
     description:
-      "Linear project slug (from the project URL, e.g. '459f9835e809'). Required for Linear mode.",
+      "Linear project slug from the project URL (e.g. '459f9835e809'). Required for Linear mode.",
   },
   {
     section: "linear",

--- a/apps/cli/src/resources/extensions/kata/prefs-model.ts
+++ b/apps/cli/src/resources/extensions/kata/prefs-model.ts
@@ -142,7 +142,8 @@ export const PREFS_FIELD_DEFINITIONS: readonly PrefsFieldDefinition[] = [
     label: "Team Key",
     path: ["linear", "teamKey"],
     type: "string",
-    description: "Linear team key such as KAT.",
+    required: true,
+    description: "Linear team key such as KAT. Required for Linear mode.",
   },
   {
     section: "linear",
@@ -150,8 +151,9 @@ export const PREFS_FIELD_DEFINITIONS: readonly PrefsFieldDefinition[] = [
     label: "Project Slug",
     path: ["linear", "projectSlug"],
     type: "string",
+    required: true,
     description:
-      "Linear project slug ID (from the project URL). Preferred over projectId.",
+      "Linear project slug (from the project URL, e.g. '459f9835e809'). Required for Linear mode.",
   },
   {
     section: "linear",
@@ -161,15 +163,7 @@ export const PREFS_FIELD_DEFINITIONS: readonly PrefsFieldDefinition[] = [
     type: "string",
     description: "Optional Linear team UUID.",
   },
-  {
-    section: "linear",
-    key: "projectId",
-    label: "Project ID",
-    path: ["linear", "projectId"],
-    type: "string",
-    description:
-      "Optional Linear project UUID. Supported for backward compatibility; prefer projectSlug.",
-  },
+  // projectId is still read at runtime for backward compat but hidden from the editor.
 
   // ── PR ────────────────────────────────────────────────────────────────────
   {

--- a/apps/cli/src/resources/extensions/kata/templates/preferences.md
+++ b/apps/cli/src/resources/extensions/kata/templates/preferences.md
@@ -30,7 +30,7 @@ See `~/.kata-cli/agent/extensions/kata/docs/preferences-reference.md` for full f
 
 - `workflow.mode` is Linear-only. Keep `workflow.mode: linear`.
 - Fill in the `linear` block to bind this project to a Linear team/project.
-- Keep secrets like `LINEAR_API_KEY` in environment variables, not in this file.
+- Keep secrets out of this file. Store credentials in `~/.kata-cli/agent/auth.json` (preferred) or env vars (`LINEAR_API_KEY`, etc.). `.env` is optional.
 - Set `pr.enabled: true` to activate the PR lifecycle (create, review, address, merge via `gh` CLI).
 
 ## Models example

--- a/apps/cli/src/resources/extensions/kata/tests/linear-config.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/linear-config.test.ts
@@ -210,7 +210,7 @@ test("validateLinearProjectConfig reports invalid project resolution", async () 
   assert.deepEqual(result.diagnostics, [
     {
       code: "invalid_linear_project",
-      field: "linear.projectId",
+      field: "linear.projectSlug",
       message: 'Configured Linear project could not be resolved: "project-456".',
       retryable: false,
     },

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-model.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-model.vitest.test.ts
@@ -21,7 +21,6 @@ const EXPECTED_PREFS_KEYS = [
   "linear.teamKey",
   "linear.projectSlug",
   "linear.teamId",
-  "linear.projectId",
   // PR
   "pr.enabled",
   "pr.auto_create",

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts
@@ -28,8 +28,8 @@ describe("applyPrefsModelToConfig", () => {
     const model = buildPreferencesModel({});
     const result = applyPrefsModelToConfig(model);
 
-    // Unset string fields should not appear
-    expect(result.linear).toBeUndefined();
+    // Required string fields (teamKey, projectSlug) produce empty strings,
+    // so the linear block exists but optional unrequired fields are absent.
     expect(result.pr).toBeUndefined();
     expect(result.models).toBeUndefined();
     expect(result.symphony).toBeUndefined();
@@ -308,25 +308,27 @@ Body.
     expect(output).toContain("version: abc");
   });
 
-  it("edit-then-write: clearing a value removes it", () => {
+  it("edit-then-write: clearing an optional value removes it", () => {
     const fixture = `---
 version: 1
 linear:
   teamKey: KAT
+  teamId: some-uuid
 ---
 Body.
 `;
     const { model, body } = parsePreferencesFile(fixture);
 
-    // Clear the value
+    // Clear the optional teamId value
     const linear = model.sections.find((s) => s.key === "linear")!;
-    const teamKeyField = linear.fields.find((f) => f.key === "teamKey")!;
-    teamKeyField.value = "";
+    const teamIdField = linear.fields.find((f) => f.key === "teamId")!;
+    teamIdField.value = "";
 
     const output = writePreferencesFile(model, body);
-    // teamKey should be removed since it's optional and empty
-    expect(output).not.toContain("teamKey");
-    // linear section should be removed since it's empty
-    expect(output).not.toContain("linear:");
+    // optional teamId should be removed since it's empty
+    expect(output).not.toContain("teamId");
+    // linear section remains because required fields exist
+    expect(output).toContain("linear:");
+    expect(output).toContain("teamKey: KAT");
   });
 });

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts
@@ -28,8 +28,8 @@ describe("applyPrefsModelToConfig", () => {
     const model = buildPreferencesModel({});
     const result = applyPrefsModelToConfig(model);
 
-    // Required string fields (teamKey, projectSlug) produce empty strings,
-    // so the linear block exists but optional unrequired fields are absent.
+    // All optional fields with empty/null values should be omitted.
+    expect(result.linear).toBeUndefined();
     expect(result.pr).toBeUndefined();
     expect(result.models).toBeUndefined();
     expect(result.symphony).toBeUndefined();

--- a/apps/cli/src/resources/extensions/linear/linear-tools.ts
+++ b/apps/cli/src/resources/extensions/linear/linear-tools.ts
@@ -916,7 +916,7 @@ export function registerLinearTools(pi: ExtensionAPI, client: LinearClient) {
           activeMilestone: null,
           activeSlice: null,
           activeTask: null,
-          blockers: ["Linear project not configured — set linear.projectSlug (or linear.projectId) in kata preferences"],
+          blockers: ["Linear project not configured — set linear.projectSlug in .kata/preferences.md"],
           recentDecisions: [],
           nextAction: "Run /kata prefs to configure the Linear project.",
           registry: [],


### PR DESCRIPTION
## CLI v0.15.0

### Features

- **M010: Preferences Config Editor (`/kata config`)** — Interactive TUI editor for `.kata/preferences.md`. Section-based navigation across 8 sections. Type-aware field editing (strings, numbers, booleans, enums, string arrays). Validation blocks invalid values before save. Cancel is safe. Reuses Symphony's `ConfigEditor` architecture with preferences-specific parser, writer, and validator. Creates preferences file from template if missing.
- **134 new Vitest tests** across 5 test suites (model, parser, writer, validator, integration).

### Improvements

- Onboarding post-setup message now shows where preferences are saved
- Header padding above ASCII logo
- Auth storage docs corrected (`auth.json` is primary, `.env` optional)
- `uat_dispatch` and `budget_ceiling` documented in preferences reference
- `projectId` de-emphasized — `projectSlug` is the only public-facing project identifier
- `teamKey` and `projectSlug` marked required in editor and docs
- Error messages normalized to reference `projectSlug` only

### Test Results

- TypeScript: clean
- Vitest: 396 passed (24 files)
- Bun: 249 passed (51 files)
- Coverage: 94% lines, 87% branches, 97% functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized messaging to prefer linear.projectSlug for Linear project config and diagnostics (legacy support retained)
  * Preferences editor now marks teamKey and projectSlug as required and shows an example slug
  * Onboarding success now notes preferences saved to .kata/preferences.md and how to edit them
  * CLI header rendering adjusted for improved visual spacing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers CLI v0.15.0 with the M010 Preferences Config Editor — an interactive TUI editor for `.kata/preferences.md` that reuses Symphony's `ConfigEditor` architecture. It also completes the `projectId` → `projectSlug` migration across error messages, docs, and the preferences model.

**Key changes:**
- New `prefs-model.ts` defines 8 editor sections and 30+ typed field definitions; `teamKey` and `projectSlug` marked `required`; `projectId` hidden from editor (preserved for runtime backward compat via `projectSlug ?? projectId` fallback in `loadEffectiveLinearProjectConfig`)
- `prefs-parser.ts` / `prefs-writer.ts` / `prefs-validator.ts` (not directly in this diff) provide YAML frontmatter round-trip with BOM, CRLF, and empty-frontmatter handling
- `linear-config.ts` error messages and `formatLinearConfigStatus` labels updated to reference `projectSlug` and canonical `.kata/preferences.md` path
- Onboarding notification augmented to show preferences file path and `/kata config` hint after Linear setup
- `AGENTS.md`, `README.md`, `preferences-reference.md`, and templates updated to correct auth storage docs (`auth.json` primary, `.env` optional)
- 134 new Vitest tests (model, parser, writer, validator, integration); reported 396 Vitest + 249 Bun passing

**Observations:**
- The `formatLinearConfigStatus` label change (line 572 of `linear-config.ts`) unconditionally emits `linear.projectSlug` for the normalized `config.linear.projectId` field, which could display misleadingly for legacy users who set only `linear.projectId`
- The `invalid_linear_project` diagnostic similarly points users at `linear.projectSlug` when the underlying value may have come from the legacy `linear.projectId` field
- One stale "project UUID" reference remains in `AGENTS.md` line 408 after the migration to `projectSlug`
- All remaining issues are P2 style/doc concerns with no functional impact on users who adopt `projectSlug`

<h3>Confidence Score: 5/5</h3>

- Safe to merge — no functional regressions or data-integrity issues; all findings are P2 style/doc improvements
- All critical paths are well-tested (134 new tests, 94% line coverage). The `projectSlug` migration is complete for new users; legacy `projectId` backward compatibility is preserved via the `projectSlug ?? projectId` fallback. The only remaining issues are cosmetic label inconsistencies in status output and one stale doc reference, neither of which affects runtime behavior or data integrity.
- `apps/cli/src/resources/extensions/kata/linear-config.ts` (status label and diagnostic field for legacy `projectId` users); `apps/cli/src/resources/AGENTS.md` (stale "project UUID" reference)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/linear-config.ts | Error messages and status labels updated to reference `projectSlug`; minor label inaccuracy for legacy `projectId` users in `formatLinearConfigStatus` and `validateLinearProjectConfig` diagnostics |
| apps/cli/src/resources/extensions/kata/prefs-model.ts | New preferences field model with 8 sections; `projectId` hidden from editor but preserved for runtime backward compat; `teamKey` and `projectSlug` correctly marked required |
| apps/cli/src/resources/extensions/kata/tests/prefs-model.vitest.test.ts | Comprehensive model test coverage; `linear.projectId` correctly removed from expected-keys list; coercion and compatibility tests look solid |
| apps/cli/src/resources/extensions/kata/tests/prefs-writer.vitest.test.ts | Writer tests correctly updated to reflect that required fields (teamKey, projectSlug) produce empty strings rather than being omitted; optional field removal behavior verified |
| apps/cli/src/resources/extensions/kata/tests/linear-config.test.ts | Diagnostic field updated from `linear.projectId` to `linear.projectSlug`; all existing tests maintained; backward compat tests still exercise `projectId` input path |
| apps/cli/src/resources/AGENTS.md | Auth storage docs corrected; `projectId` → `projectSlug` example updated; one stale reference to "project UUID" remains at line 408 |
| apps/cli/src/resources/extensions/kata/onboarding.ts | Post-setup notification updated to include preferences file path and `/kata config` hint; clean single-line change |
| apps/cli/src/resources/extensions/linear/linear-tools.ts | Blocker message updated to reference `projectSlug` and the canonical preferences path; no functional changes |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/kata config"] --> B{preferences.md exists?}
    B -- No --> C[Create from template]
    C --> D[Parse YAML frontmatter]
    B -- Yes --> D
    D --> E{Parse OK?}
    E -- Error --> F[Show parse error with line number]
    E -- OK --> G["buildPreferencesModel — prefs-model.ts"]
    G --> H["ConfigEditor TUI — 8 sections, typed fields"]
    H --> I{User action}
    I -- Cancel --> J[File unchanged]
    I -- Save --> K[prefs-validator]
    K --> L{Validation OK?}
    L -- Fail --> M[Show validation issues, no write]
    L -- Pass --> N["applyPrefsModelToConfig — prefs-writer.ts"]
    N --> O[writePreferencesFile]
    O --> P[.kata/preferences.md updated]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/cli/src/resources/AGENTS.md`, line 408 ([link](https://github.com/gannonh/kata/blob/7cc80c6597ec62fc0d3b37ffd8e93948a527ae45/apps/cli/src/resources/AGENTS.md#L408)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale "project UUID" reference after `projectSlug` migration**

   This line still instructs users to find the "project UUID" via `linear_list_projects`, but the surrounding context (and the rest of this PR) has been updated to use `projectSlug` (the short slug from the project URL) as the primary identifier. The instruction should be updated to guide users to the slug, not the UUID.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/AGENTS.md
   Line: 408

   Comment:
   **Stale "project UUID" reference after `projectSlug` migration**

   This line still instructs users to find the "project UUID" via `linear_list_projects`, but the surrounding context (and the rest of this PR) has been updated to use `projectSlug` (the short slug from the project URL) as the primary identifier. The instruction should be updated to guide users to the slug, not the UUID.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/cli/src/resources/extensions/kata/linear-config.ts`, line 376-384 ([link](https://github.com/gannonh/kata/blob/7cc80c6597ec62fc0d3b37ffd8e93948a527ae45/apps/cli/src/resources/extensions/kata/linear-config.ts#L376-L384)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Diagnostic `field` vs. `message` mismatch for legacy users**

   The error `field` is correctly updated to `"linear.projectSlug"`, but the `message` still reads `config.linear.projectId` — a normalized field that holds whatever the user actually configured (`projectSlug` *or* legacy `projectId` UUID). For a legacy user who only set `linear.projectId: "some-uuid"`, the diagnostic would read:

   > field: `linear.projectSlug`, message: `"…could not be resolved: "some-uuid""`

   This tells them to check `linear.projectSlug` when they never set that field, which can be confusing during debugging. Since `projectId` is still read at runtime for backward compatibility, it would be clearer to reference the actual source field in the message, or note that both field names are accepted.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/extensions/kata/linear-config.ts
   Line: 376-384

   Comment:
   **Diagnostic `field` vs. `message` mismatch for legacy users**

   The error `field` is correctly updated to `"linear.projectSlug"`, but the `message` still reads `config.linear.projectId` — a normalized field that holds whatever the user actually configured (`projectSlug` *or* legacy `projectId` UUID). For a legacy user who only set `linear.projectId: "some-uuid"`, the diagnostic would read:

   > field: `linear.projectSlug`, message: `"…could not be resolved: "some-uuid""`

   This tells them to check `linear.projectSlug` when they never set that field, which can be confusing during debugging. Since `projectId` is still read at runtime for backward compatibility, it would be clearer to reference the actual source field in the message, or note that both field names are accepted.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/linear-config.ts
Line: 571-573

Comment:
**Misleading status label for legacy `projectId` users**

`result.config.linear.projectId` holds a *normalized* value that is either the `projectSlug` or the legacy `projectId` UUID (see `loadEffectiveLinearProjectConfig`). Labelling it unconditionally as `linear.projectSlug` in the status output will confuse users who still have only `linear.projectId` set in their preferences — they would see `linear.projectSlug: <their-uuid>` in `/kata prefs status` even though they never set `projectSlug`.

Consider checking the raw preferences to emit the correct field name, or noting that the display value may originate from the legacy field:

```typescript
if (result.config.linear.projectId) {
  const label = result.config.linear.projectId.includes("-")
    ? "linear.projectId (legacy)"
    : "linear.projectSlug";
  lines.push(`${label}: ${result.config.linear.projectId}`);
}
```

Alternatively, expose `projectSlug` and `projectId` separately in `EffectiveLinearProjectConfig` so the display logic can be precise.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/AGENTS.md
Line: 408

Comment:
**Stale "project UUID" reference after `projectSlug` migration**

This line still instructs users to find the "project UUID" via `linear_list_projects`, but the surrounding context (and the rest of this PR) has been updated to use `projectSlug` (the short slug from the project URL) as the primary identifier. The instruction should be updated to guide users to the slug, not the UUID.

```suggestion
Use `linear_list_projects` to find the project slug.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/linear-config.ts
Line: 376-384

Comment:
**Diagnostic `field` vs. `message` mismatch for legacy users**

The error `field` is correctly updated to `"linear.projectSlug"`, but the `message` still reads `config.linear.projectId` — a normalized field that holds whatever the user actually configured (`projectSlug` *or* legacy `projectId` UUID). For a legacy user who only set `linear.projectId: "some-uuid"`, the diagnostic would read:

> field: `linear.projectSlug`, message: `"…could not be resolved: "some-uuid""`

This tells them to check `linear.projectSlug` when they never set that field, which can be confusing during debugging. Since `projectId` is still read at runtime for backward compatibility, it would be clearer to reference the actual source field in the message, or note that both field names are accepted.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): CLI v0.15.0 — M010 Prefe..."](https://github.com/gannonh/kata/commit/7cc80c6597ec62fc0d3b37ffd8e93948a527ae45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26802837)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->