### PR TITLE
chore(symphony): update Cargo.lock for v2.2.0

### DIFF
--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -2187,7 +2187,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphony"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Cargo.lock version bump missed in the v2.2.0 PR. One-line change: symphony version 2.1.0 → 2.2.0 in the lockfile.