### PR TITLE
feat(desktop): implement app shell with CLI subprocess chat (KAT-2085)

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -1,0 +1,25 @@
+# Kata Desktop (apps/desktop)
+
+Fresh Electron shell for Kata Desktop.
+
+## Stack
+
+- Electron main + preload bundled with esbuild
+- Renderer: Vite + React 19 + Tailwind CSS v4 + Radix UI
+- State: Jotai
+- Agent runtime: `kata --mode rpc` subprocess managed by `PiAgentBridge`
+
+## Key files
+
+- `src/main/pi-agent-bridge.ts` — spawn/lifecycle + JSONL command/event bridge
+- `src/main/rpc-event-adapter.ts` — maps RPC events to renderer chat events
+- `src/main/ipc.ts` — `session:send`, `session:stop`, `session:events`
+- `src/shared/types.ts` — cross-process IPC and chat event contracts
+- `src/renderer/components/` — app shell + chat UI
+
+## Guardrails
+
+- Keep all product naming as **Kata Desktop**.
+- Never add legacy `@craft-*` imports in this app.
+- Never log API keys or auth file content.
+- Main process runs on Node.js (no Bun-only APIs).

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@kata/desktop",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/main.cjs",
+  "scripts": {
+    "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron",
+    "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload.cjs --external:electron",
+    "build:renderer": "vite build",
+    "build": "bun run build:main && bun run build:preload && bun run build:renderer",
+    "dev:main": "esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron --watch --sourcemap",
+    "dev:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload.cjs --external:electron --watch --sourcemap",
+    "dev:renderer": "vite dev --host 127.0.0.1 --port 5174 --strictPort",
+    "dev:electron": "wait-on tcp:5174 file:dist/main.cjs file:dist/preload.cjs && VITE_DEV_SERVER_URL=http://127.0.0.1:5174 electron .",
+    "desktop:dev": "concurrently -k -n MAIN,PRELOAD,RENDERER,ELECTRON -c green,cyan,magenta,yellow \"bun run dev:main\" \"bun run dev:preload\" \"bun run dev:renderer\" \"bun run dev:electron\"",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "dependencies": {
+    "@radix-ui/react-collapsible": "^1.1.12",
+    "electron-log": "^5.4.3",
+    "jotai": "^2.16.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-resizable-panels": "^4.6.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.18",
+    "@types/node": "^25.0.8",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "@vitejs/plugin-react": "^6.0.1",
+    "concurrently": "^9.2.1",
+    "electron": "^41.0.3",
+    "esbuild": "^0.27.4",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.0",
+    "vite": "^8.0.2",
+    "wait-on": "^8.0.1"
+  }
+}

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+import type { CommandResult } from '@shared/types'
+import { PiAgentBridge } from '../pi-agent-bridge'
+
+async function waitFor(condition: () => boolean, timeoutMs = 1_500): Promise<void> {
+  const startedAt = Date.now()
+
+  while (!condition()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(`Timed out waiting for condition after ${timeoutMs}ms`)
+    }
+
+    await Bun.sleep(25)
+  }
+}
+
+describe('PiAgentBridge', () => {
+  test('marks bridge as crashed and allows restart attempts after spawn error', async () => {
+    const bridge = new PiAgentBridge(process.cwd(), 'kata-command-that-does-not-exist')
+    const statusHistory: string[] = []
+
+    bridge.on('status', (status) => {
+      statusHistory.push(status.state)
+    })
+
+    await bridge.start()
+    await waitFor(() => statusHistory.includes('crashed'))
+
+    expect(bridge.getState().running).toBe(false)
+    expect(bridge.getState().status).toBe('crashed')
+
+    const crashedCount = statusHistory.filter((state) => state === 'crashed').length
+
+    await bridge.start()
+    await waitFor(() => statusHistory.filter((state) => state === 'crashed').length > crashedCount)
+
+    expect(bridge.getState().running).toBe(false)
+    expect(bridge.getState().status).toBe('crashed')
+  })
+
+  test('resolves oldest pending command when response id is omitted', () => {
+    const bridge = new PiAgentBridge(process.cwd()) as any
+
+    let resolved: CommandResult | undefined
+    bridge.pending.set('cmd-1', {
+      command: 'abort',
+      resolve: (result: CommandResult) => {
+        resolved = result
+      },
+      reject: () => {},
+    })
+
+    bridge.resolvePending({
+      type: 'response',
+      command: 'abort',
+      success: true,
+      data: { ok: true },
+    })
+
+    expect(bridge.pending.size).toBe(0)
+    expect(resolved?.id).toBe('cmd-1')
+    expect(resolved?.command).toBe('abort')
+    expect(resolved?.success).toBe(true)
+    expect(resolved?.data).toEqual({ ok: true })
+  })
+
+  test('rejects oldest pending command when id is omitted and response is a failure', () => {
+    const bridge = new PiAgentBridge(process.cwd()) as any
+
+    let rejectedMessage: string | undefined
+    bridge.pending.set('cmd-1', {
+      command: 'shutdown',
+      resolve: () => {},
+      reject: (error: Error) => {
+        rejectedMessage = error.message
+      },
+    })
+
+    bridge.resolvePending({
+      type: 'response',
+      command: 'shutdown',
+      success: false,
+      error: 'shutdown not allowed',
+    })
+
+    expect(bridge.pending.size).toBe(0)
+    expect(rejectedMessage).toBe('shutdown not allowed')
+  })
+})

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -38,6 +38,23 @@ describe('PiAgentBridge', () => {
     expect(bridge.getState().status).toBe('crashed')
   })
 
+  test('coalesces concurrent start calls into a single spawn attempt', async () => {
+    const bridge = new PiAgentBridge(process.cwd(), 'kata-command-that-does-not-exist')
+    const statusHistory: string[] = []
+
+    bridge.on('status', (status) => {
+      statusHistory.push(status.state)
+    })
+
+    await Promise.all([bridge.start(), bridge.start(), bridge.start()])
+    await waitFor(() => statusHistory.includes('crashed'))
+
+    expect(statusHistory.filter((state) => state === 'spawning').length).toBe(1)
+    expect(statusHistory.filter((state) => state === 'crashed').length).toBe(1)
+    expect(bridge.getState().running).toBe(false)
+    expect(bridge.getState().status).toBe('crashed')
+  })
+
   test('resolves oldest pending command when response id is omitted', () => {
     const bridge = new PiAgentBridge(process.cwd()) as any
 

--- a/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test'
+import { RpcEventAdapter } from '../rpc-event-adapter'
+
+describe('RpcEventAdapter', () => {
+  const adapter = new RpcEventAdapter()
+
+  test('maps lifecycle events', () => {
+    expect(adapter.adapt({ type: 'agent_start' })).toEqual([{ type: 'agent_start' }])
+    expect(adapter.adapt({ type: 'turn_start' })).toEqual([{ type: 'turn_start' }])
+    expect(adapter.adapt({ type: 'turn_end' })).toEqual([{ type: 'turn_end' }])
+    expect(adapter.adapt({ type: 'agent_end' })).toEqual([{ type: 'agent_end' }])
+  })
+
+  test('maps message start/update/end into chat events', () => {
+    expect(
+      adapter.adapt({
+        type: 'message_start',
+        message: { id: 'm1', role: 'assistant' },
+      }),
+    ).toEqual([
+      {
+        type: 'message_start',
+        messageId: 'm1',
+        role: 'assistant',
+      },
+    ])
+
+    expect(
+      adapter.adapt({
+        type: 'message_update',
+        message: { id: 'm1', role: 'assistant' },
+        assistantMessageEvent: { type: 'text_delta', delta: 'Hello ' },
+      }),
+    ).toEqual([
+      {
+        type: 'text_delta',
+        messageId: 'm1',
+        delta: 'Hello ',
+      },
+    ])
+
+    expect(
+      adapter.adapt({
+        type: 'message_end',
+        message: {
+          id: 'm1',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello world' }],
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'message_end',
+        messageId: 'm1',
+        text: 'Hello world',
+      },
+    ])
+  })
+
+  test('maps tool execution events', () => {
+    expect(
+      adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+        args: { command: 'ls -la' },
+      }),
+    ).toEqual([
+      {
+        type: 'tool_start',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+        args: { command: 'ls -la' },
+      },
+    ])
+
+    expect(
+      adapter.adapt({
+        type: 'tool_execution_update',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+        status: 'running',
+      }),
+    ).toEqual([
+      {
+        type: 'tool_update',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+        status: 'running',
+      },
+    ])
+
+    expect(
+      adapter.adapt({
+        type: 'tool_execution_end',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+        result: { stdout: 'README.md' },
+        isError: false,
+      }),
+    ).toEqual([
+      {
+        type: 'tool_end',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+        result: { stdout: 'README.md' },
+        isError: false,
+        error: undefined,
+      },
+    ])
+  })
+
+  test('maps extension errors and malformed payloads to agent_error', () => {
+    expect(
+      adapter.adapt({
+        type: 'extension_error',
+        error: 'extension exploded',
+      }),
+    ).toEqual([
+      {
+        type: 'agent_error',
+        message: 'extension exploded',
+      },
+    ])
+
+    expect(adapter.adapt('not-an-object')).toEqual([
+      {
+        type: 'agent_error',
+        message: 'Malformed RPC event payload',
+      },
+    ])
+  })
+
+  test('ignores unknown event types', () => {
+    expect(adapter.adapt({ type: 'totally_unknown' })).toEqual([])
+  })
+})

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { registerSessionIpc } from './ipc'
 
 let mainWindow: BrowserWindow | null = null
 let bridge: PiAgentBridge | null = null
+let unregisterSessionIpc: (() => void) | null = null
 
 function createWindow(): BrowserWindow {
   const window = new BrowserWindow({
@@ -39,9 +40,11 @@ app.whenReady().then(() => {
   bridge = new PiAgentBridge(workspacePath)
   mainWindow = createWindow()
 
-  registerSessionIpc({ bridge, window: mainWindow })
+  unregisterSessionIpc = registerSessionIpc({ bridge, window: mainWindow })
 
   mainWindow.on('closed', () => {
+    unregisterSessionIpc?.()
+    unregisterSessionIpc = null
     mainWindow = null
   })
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,0 +1,70 @@
+import path from 'node:path'
+import { app, BrowserWindow } from 'electron'
+import log from 'electron-log/main'
+import { PiAgentBridge } from './pi-agent-bridge'
+import { registerSessionIpc } from './ipc'
+
+let mainWindow: BrowserWindow | null = null
+let bridge: PiAgentBridge | null = null
+
+function createWindow(): BrowserWindow {
+  const window = new BrowserWindow({
+    width: 1400,
+    height: 900,
+    minWidth: 1024,
+    minHeight: 640,
+    title: 'Kata Desktop',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+    },
+  })
+
+  const devServerUrl = process.env.VITE_DEV_SERVER_URL
+  if (devServerUrl) {
+    void window.loadURL(devServerUrl)
+    window.webContents.openDevTools({ mode: 'detach' })
+  } else {
+    void window.loadFile(path.join(__dirname, 'renderer', 'index.html'))
+  }
+
+  return window
+}
+
+app.whenReady().then(() => {
+  const workspacePath = process.env.KATA_WORKSPACE_PATH || process.cwd()
+
+  bridge = new PiAgentBridge(workspacePath)
+  mainWindow = createWindow()
+
+  registerSessionIpc({ bridge, window: mainWindow })
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+
+  log.info('[desktop-main] ready', {
+    workspacePath,
+  })
+})
+
+app.on('before-quit', async (event) => {
+  if (!bridge) {
+    return
+  }
+
+  event.preventDefault()
+  try {
+    await bridge.shutdown()
+  } catch (error) {
+    log.error('[desktop-main] bridge shutdown failed', error)
+  } finally {
+    app.exit(0)
+  }
+})
+
+app.on('window-all-closed', () => {
+  app.quit()
+})

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { app, BrowserWindow } from 'electron'
-import log from 'electron-log/main'
+import log from './logger'
 import { PiAgentBridge } from './pi-agent-bridge'
 import { registerSessionIpc } from './ipc'
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -2,46 +2,54 @@ import { ipcMain, type BrowserWindow } from 'electron'
 import log from 'electron-log/main'
 import { PiAgentBridge } from './pi-agent-bridge'
 import { RpcEventAdapter } from './rpc-event-adapter'
-import {
-  IPC_CHANNELS,
-  type BridgeStatusEvent,
-  type ChatEvent,
-} from '../shared/types'
+import { IPC_CHANNELS, type BridgeStatusEvent, type ChatEvent } from '../shared/types'
 
 interface RegisterIpcOptions {
   bridge: PiAgentBridge
   window: BrowserWindow
 }
 
-export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): void {
+export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () => void {
   const adapter = new RpcEventAdapter()
 
+  const canSendToRenderer = (): boolean => !window.isDestroyed() && !window.webContents.isDestroyed()
+
   const sendEventToRenderer = (chatEvent: ChatEvent): void => {
+    if (!canSendToRenderer()) {
+      log.warn('[desktop-ipc] skipping event dispatch: renderer window is destroyed')
+      return
+    }
+
     window.webContents.send(IPC_CHANNELS.sessionEvents, chatEvent)
     log.debug('[desktop-ipc] outbound event', chatEvent)
   }
 
   const sendBridgeStatus = (status: BridgeStatusEvent): void => {
+    if (!canSendToRenderer()) {
+      log.warn('[desktop-ipc] skipping bridge status dispatch: renderer window is destroyed')
+      return
+    }
+
     window.webContents.send(IPC_CHANNELS.sessionBridgeStatus, status)
     log.debug('[desktop-ipc] bridge status', status)
   }
 
-  bridge.on('rpc-event', (rpcEvent) => {
+  const onRpcEvent = (rpcEvent: Record<string, unknown>): void => {
     log.debug('[desktop-ipc] inbound rpc event', rpcEvent)
     for (const chatEvent of adapter.adapt(rpcEvent)) {
       sendEventToRenderer(chatEvent)
     }
-  })
+  }
 
-  bridge.on('status', (status) => {
+  const onStatus = (status: BridgeStatusEvent): void => {
     sendBridgeStatus(status)
-  })
+  }
 
-  bridge.on('debug', (payload) => {
+  const onDebug = (payload: Record<string, unknown>): void => {
     log.debug('[desktop-ipc] bridge debug', payload)
-  })
+  }
 
-  bridge.on('crash', ({ exitCode, signal, stderrLines }) => {
+  const onCrash = ({ exitCode, signal, stderrLines }: { exitCode: number | null; signal: NodeJS.Signals | null; stderrLines: string[] }): void => {
     const lastLine = stderrLines[stderrLines.length - 1] ?? 'kata subprocess exited unexpectedly'
     sendEventToRenderer({
       type: 'subprocess_crash',
@@ -50,13 +58,24 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): void
       signal,
       stderrLines,
     })
-  })
+  }
 
+  bridge.on('rpc-event', onRpcEvent)
+  bridge.on('status', onStatus)
+  bridge.on('debug', onDebug)
+  bridge.on('crash', onCrash)
+
+  const initialState = bridge.getState()
   sendBridgeStatus({
-    state: bridge.getState().status,
-    pid: bridge.getState().pid,
+    state: initialState.status,
+    pid: initialState.pid,
     updatedAt: Date.now(),
   })
+
+  ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionRestart)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionGetBridgeState)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -73,6 +92,11 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): void
   })
 
   ipcMain.handle(IPC_CHANNELS.sessionStop, async () => {
+    const state = bridge.getState()
+    if (!state.running) {
+      return
+    }
+
     await bridge.abort()
   })
 
@@ -80,7 +104,17 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): void
     await bridge.restart()
   })
 
-  ipcMain.handle(IPC_CHANNELS.sessionGetBridgeState, async () => {
-    return bridge.getState()
-  })
+  ipcMain.handle(IPC_CHANNELS.sessionGetBridgeState, async () => bridge.getState())
+
+  return () => {
+    bridge.off('rpc-event', onRpcEvent)
+    bridge.off('status', onStatus)
+    bridge.off('debug', onDebug)
+    bridge.off('crash', onCrash)
+
+    ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionRestart)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionGetBridgeState)
+  }
 }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,0 +1,86 @@
+import { ipcMain, type BrowserWindow } from 'electron'
+import log from 'electron-log/main'
+import { PiAgentBridge } from './pi-agent-bridge'
+import { RpcEventAdapter } from './rpc-event-adapter'
+import {
+  IPC_CHANNELS,
+  type BridgeStatusEvent,
+  type ChatEvent,
+} from '../shared/types'
+
+interface RegisterIpcOptions {
+  bridge: PiAgentBridge
+  window: BrowserWindow
+}
+
+export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): void {
+  const adapter = new RpcEventAdapter()
+
+  const sendEventToRenderer = (chatEvent: ChatEvent): void => {
+    window.webContents.send(IPC_CHANNELS.sessionEvents, chatEvent)
+    log.debug('[desktop-ipc] outbound event', chatEvent)
+  }
+
+  const sendBridgeStatus = (status: BridgeStatusEvent): void => {
+    window.webContents.send(IPC_CHANNELS.sessionBridgeStatus, status)
+    log.debug('[desktop-ipc] bridge status', status)
+  }
+
+  bridge.on('rpc-event', (rpcEvent) => {
+    log.debug('[desktop-ipc] inbound rpc event', rpcEvent)
+    for (const chatEvent of adapter.adapt(rpcEvent)) {
+      sendEventToRenderer(chatEvent)
+    }
+  })
+
+  bridge.on('status', (status) => {
+    sendBridgeStatus(status)
+  })
+
+  bridge.on('debug', (payload) => {
+    log.debug('[desktop-ipc] bridge debug', payload)
+  })
+
+  bridge.on('crash', ({ exitCode, signal, stderrLines }) => {
+    const lastLine = stderrLines[stderrLines.length - 1] ?? 'kata subprocess exited unexpectedly'
+    sendEventToRenderer({
+      type: 'subprocess_crash',
+      message: lastLine,
+      exitCode,
+      signal,
+      stderrLines,
+    })
+  })
+
+  sendBridgeStatus({
+    state: bridge.getState().status,
+    pid: bridge.getState().pid,
+    updatedAt: Date.now(),
+  })
+
+  ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
+    if (!message?.trim()) {
+      return
+    }
+
+    void bridge.prompt(message).catch((error: unknown) => {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      sendEventToRenderer({
+        type: 'agent_error',
+        message: errorMessage,
+      })
+    })
+  })
+
+  ipcMain.handle(IPC_CHANNELS.sessionStop, async () => {
+    await bridge.abort()
+  })
+
+  ipcMain.handle(IPC_CHANNELS.sessionRestart, async () => {
+    await bridge.restart()
+  })
+
+  ipcMain.handle(IPC_CHANNELS.sessionGetBridgeState, async () => {
+    return bridge.getState()
+  })
+}

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,5 +1,5 @@
 import { ipcMain, type BrowserWindow } from 'electron'
-import log from 'electron-log/main'
+import log from './logger'
 import { PiAgentBridge } from './pi-agent-bridge'
 import { RpcEventAdapter } from './rpc-event-adapter'
 import { IPC_CHANNELS, type BridgeStatusEvent, type ChatEvent } from '../shared/types'

--- a/apps/desktop/src/main/logger.ts
+++ b/apps/desktop/src/main/logger.ts
@@ -1,0 +1,39 @@
+import { createRequire } from 'node:module'
+
+type Logger = {
+  info: (...args: unknown[]) => void
+  warn: (...args: unknown[]) => void
+  error: (...args: unknown[]) => void
+  debug: (...args: unknown[]) => void
+}
+
+const noop = (..._args: unknown[]): void => {}
+
+const fallbackLogger: Logger = {
+  info: noop,
+  warn: (...args) => console.warn(...args),
+  error: (...args) => console.error(...args),
+  debug: noop,
+}
+
+let resolvedLogger: Logger = fallbackLogger
+
+try {
+  const require = createRequire(import.meta.url)
+  const imported = require('electron-log/main') as { default?: Logger } | Logger
+  const candidate = (imported as { default?: Logger }).default ?? (imported as Logger)
+
+  if (
+    candidate &&
+    typeof candidate.info === 'function' &&
+    typeof candidate.warn === 'function' &&
+    typeof candidate.error === 'function' &&
+    typeof candidate.debug === 'function'
+  ) {
+    resolvedLogger = candidate
+  }
+} catch {
+  resolvedLogger = fallbackLogger
+}
+
+export default resolvedLogger

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import readline from 'node:readline'
-import log from 'electron-log/main'
+import log from './logger'
 import {
   type BridgeLifecycleState,
   type BridgeState,

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -132,30 +132,43 @@ export class PiAgentBridge extends EventEmitter {
       }
     })
 
-    child.on('error', (error) => {
-      const message = error instanceof Error ? error.message : String(error)
-      this.pushStderr(message)
-      log.error('[PiAgentBridge] subprocess error', error)
-      this.emit('debug', {
-        type: 'bridge:error',
-        message,
-      })
-    })
+    let finalizedTermination = false
 
-    child.on('exit', (exitCode, signal) => {
+    const finalizeTermination = (
+      cause: 'exit' | 'close' | 'error',
+      exitCode: number | null,
+      signal: NodeJS.Signals | null,
+      errorMessage?: string,
+    ): void => {
+      if (finalizedTermination) {
+        return
+      }
+
+      finalizedTermination = true
+
+      if (errorMessage) {
+        this.pushStderr(errorMessage)
+      }
+
       const stderrSnapshot = [...this.stderrLines]
       this.cleanupStreams()
-      this.child = null
+
+      if (this.child === child) {
+        this.child = null
+      }
+
       this.rejectPending(new Error('RPC subprocess exited before response was received'))
 
       if (!this.shuttingDown) {
         log.error('[PiAgentBridge] crash', {
+          cause,
           exitCode,
           signal,
           stderrLines: stderrSnapshot,
         })
         this.emit('debug', {
           type: 'bridge:crash',
+          cause,
           exitCode,
           signal,
           stderrLines: stderrSnapshot,
@@ -173,9 +186,10 @@ export class PiAgentBridge extends EventEmitter {
           signal,
         })
       } else {
-        log.info('[PiAgentBridge] shutdown complete', { exitCode, signal })
+        log.info('[PiAgentBridge] shutdown complete', { cause, exitCode, signal })
         this.emit('debug', {
           type: 'bridge:shutdown',
+          cause,
           exitCode,
           signal,
         })
@@ -186,6 +200,24 @@ export class PiAgentBridge extends EventEmitter {
           signal,
         })
       }
+    }
+
+    child.on('error', (error) => {
+      const message = error instanceof Error ? error.message : String(error)
+      log.error('[PiAgentBridge] subprocess error', error)
+      this.emit('debug', {
+        type: 'bridge:error',
+        message,
+      })
+      finalizeTermination('error', null, null, message)
+    })
+
+    child.on('exit', (exitCode, signal) => {
+      finalizeTermination('exit', exitCode, signal)
+    })
+
+    child.on('close', (exitCode, signal) => {
+      finalizeTermination('close', exitCode, signal)
     })
   }
 
@@ -317,16 +349,23 @@ export class PiAgentBridge extends EventEmitter {
 
   private resolvePending(response: RpcResponse): void {
     const id = response.id
-    if (!id) {
+
+    let pendingId: string | undefined = id
+    let pending = id ? this.pending.get(id) : undefined
+
+    if (!pending && !id) {
+      const firstPendingEntry = this.pending.entries().next()
+      if (!firstPendingEntry.done) {
+        pendingId = firstPendingEntry.value[0]
+        pending = firstPendingEntry.value[1]
+      }
+    }
+
+    if (!pending || !pendingId) {
       return
     }
 
-    const pending = this.pending.get(id)
-    if (!pending) {
-      return
-    }
-
-    this.pending.delete(id)
+    this.pending.delete(pendingId)
 
     if (!response.success) {
       pending.reject(new Error(response.error ?? `RPC command failed: ${pending.command}`))
@@ -334,7 +373,7 @@ export class PiAgentBridge extends EventEmitter {
     }
 
     pending.resolve({
-      id,
+      id: pendingId,
       command: response.command,
       success: true,
       data: response.data,
@@ -362,17 +401,19 @@ export class PiAgentBridge extends EventEmitter {
         resolve(false)
       }, timeoutMs)
 
-      const onExit = () => {
+      const onTerminated = () => {
         cleanup()
         resolve(true)
       }
 
       const cleanup = () => {
         clearTimeout(timer)
-        current.removeListener('exit', onExit)
+        current.removeListener('exit', onTerminated)
+        current.removeListener('close', onTerminated)
       }
 
-      current.once('exit', onExit)
+      current.once('exit', onTerminated)
+      current.once('close', onTerminated)
     })
   }
 

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -46,10 +46,12 @@ export class PiAgentBridge extends EventEmitter {
   private shuttingDown = false
   private resolvedCommand: string | null = null
   private status: BridgeLifecycleState = 'shutdown'
+  private startPromise: Promise<void> | null = null
 
   constructor(
     private readonly workspacePath: string,
     private readonly commandHint = 'kata',
+    private readonly commandTimeoutMs = 30_000,
   ) {
     super()
   }
@@ -76,6 +78,20 @@ export class PiAgentBridge extends EventEmitter {
       return
     }
 
+    if (this.startPromise) {
+      return this.startPromise
+    }
+
+    this.startPromise = this.startInternal()
+
+    try {
+      await this.startPromise
+    } finally {
+      this.startPromise = null
+    }
+  }
+
+  private async startInternal(): Promise<void> {
     this.shuttingDown = false
     this.stderrLines.length = 0
 
@@ -233,14 +249,26 @@ export class PiAgentBridge extends EventEmitter {
     const payload = { ...command, id }
 
     return new Promise<CommandResult>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`RPC command timed out: ${command.type}`))
+      }, this.commandTimeoutMs)
+
       this.pending.set(id, {
         command: command.type,
-        resolve,
-        reject,
+        resolve: (value) => {
+          clearTimeout(timeoutId)
+          resolve(value)
+        },
+        reject: (error) => {
+          clearTimeout(timeoutId)
+          reject(error)
+        },
       })
 
       child.stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
         if (error) {
+          clearTimeout(timeoutId)
           this.pending.delete(id)
           reject(error)
         }
@@ -284,7 +312,17 @@ export class PiAgentBridge extends EventEmitter {
     const exited = await this.waitForExit(timeoutMs)
     if (!exited && this.child && !this.child.killed) {
       this.child.kill('SIGTERM')
-      await this.waitForExit(timeoutMs)
+      const exitedAfterTerm = await this.waitForExit(timeoutMs)
+
+      if (!exitedAfterTerm && this.child && !this.child.killed && this.child.exitCode === null) {
+        log.warn('[PiAgentBridge] SIGTERM ignored, escalating to SIGKILL')
+        this.child.kill('SIGKILL')
+
+        const exitedAfterKill = await this.waitForExit(Math.min(timeoutMs, 500))
+        if (!exitedAfterKill) {
+          log.error('[PiAgentBridge] subprocess did not exit after SIGKILL')
+        }
+      }
     }
   }
 
@@ -294,13 +332,14 @@ export class PiAgentBridge extends EventEmitter {
       return fromEnv
     }
 
-    const whichResult = spawnSync('which', [this.commandHint], {
+    const lookupCommand = process.platform === 'win32' ? 'where' : 'which'
+    const whichResult = spawnSync(lookupCommand, [this.commandHint], {
       stdio: 'pipe',
       encoding: 'utf8',
     })
 
     if (whichResult.status === 0) {
-      const discovered = whichResult.stdout.trim()
+      const discovered = whichResult.stdout.trim().split(/\r?\n/)[0]?.trim()
       if (discovered) {
         return discovered
       }

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -1,0 +1,437 @@
+import { EventEmitter } from 'node:events'
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import readline from 'node:readline'
+import log from 'electron-log/main'
+import {
+  type BridgeLifecycleState,
+  type BridgeState,
+  type BridgeStatusEvent,
+  type CommandResult,
+  type RpcCommand,
+} from '../shared/types'
+
+interface PendingCommand {
+  command: string
+  resolve: (value: CommandResult) => void
+  reject: (error: Error) => void
+}
+
+interface RpcResponse {
+  type: 'response'
+  id?: string
+  command: string
+  success: boolean
+  data?: unknown
+  error?: string
+}
+
+interface RpcEnvelope {
+  type: 'event'
+  event: Record<string, unknown>
+}
+
+interface BridgeEvents {
+  'rpc-event': (event: Record<string, unknown>) => void
+  crash: (payload: { exitCode: number | null; signal: NodeJS.Signals | null; stderrLines: string[] }) => void
+  status: (payload: BridgeStatusEvent) => void
+  debug: (payload: Record<string, unknown>) => void
+}
+
+export class PiAgentBridge extends EventEmitter {
+  private child: ChildProcessWithoutNullStreams | null = null
+  private stdoutReader: readline.Interface | null = null
+  private readonly pending = new Map<string, PendingCommand>()
+  private readonly stderrLines: string[] = []
+  private commandCounter = 0
+  private shuttingDown = false
+  private resolvedCommand: string | null = null
+  private status: BridgeLifecycleState = 'shutdown'
+
+  constructor(
+    private readonly workspacePath: string,
+    private readonly commandHint = 'kata',
+  ) {
+    super()
+  }
+
+  override on<K extends keyof BridgeEvents>(event: K, listener: BridgeEvents[K]): this {
+    return super.on(event, listener)
+  }
+
+  override emit<K extends keyof BridgeEvents>(event: K, ...args: Parameters<BridgeEvents[K]>): boolean {
+    return super.emit(event, ...args)
+  }
+
+  public getState(): BridgeState {
+    return {
+      running: this.child !== null && !this.child.killed && this.status === 'running',
+      pid: this.child?.pid ?? null,
+      command: this.resolvedCommand,
+      status: this.status,
+    }
+  }
+
+  public async start(): Promise<void> {
+    if (this.child && !this.child.killed && this.status === 'running') {
+      return
+    }
+
+    this.shuttingDown = false
+    this.stderrLines.length = 0
+
+    const command = this.resolveCommand()
+    this.resolvedCommand = command
+
+    this.emitStatus({
+      state: 'spawning',
+      pid: null,
+    })
+
+    const args = ['--mode', 'rpc', '--cwd', this.workspacePath]
+    const child = spawn(command, args, {
+      cwd: this.workspacePath,
+      env: process.env,
+      stdio: 'pipe',
+    })
+
+    this.child = child
+    this.stdoutReader = readline.createInterface({ input: child.stdout })
+
+    log.info('[PiAgentBridge] spawn', {
+      command,
+      args,
+      cwd: this.workspacePath,
+      pid: child.pid,
+    })
+
+    this.emit('debug', {
+      type: 'bridge:spawn',
+      command,
+      args,
+      cwd: this.workspacePath,
+      pid: child.pid,
+    })
+
+    this.emitStatus({
+      state: 'running',
+      pid: child.pid ?? null,
+    })
+
+    this.stdoutReader.on('line', (line) => {
+      this.handleStdoutLine(line)
+    })
+
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      const text = chunk.toString()
+      for (const line of text.split('\n')) {
+        const trimmed = line.trim()
+        if (!trimmed) {
+          continue
+        }
+        this.pushStderr(trimmed)
+      }
+    })
+
+    child.on('error', (error) => {
+      const message = error instanceof Error ? error.message : String(error)
+      this.pushStderr(message)
+      log.error('[PiAgentBridge] subprocess error', error)
+      this.emit('debug', {
+        type: 'bridge:error',
+        message,
+      })
+    })
+
+    child.on('exit', (exitCode, signal) => {
+      const stderrSnapshot = [...this.stderrLines]
+      this.cleanupStreams()
+      this.child = null
+      this.rejectPending(new Error('RPC subprocess exited before response was received'))
+
+      if (!this.shuttingDown) {
+        log.error('[PiAgentBridge] crash', {
+          exitCode,
+          signal,
+          stderrLines: stderrSnapshot,
+        })
+        this.emit('debug', {
+          type: 'bridge:crash',
+          exitCode,
+          signal,
+          stderrLines: stderrSnapshot,
+        })
+        this.emit('crash', {
+          exitCode,
+          signal,
+          stderrLines: stderrSnapshot,
+        })
+        this.emitStatus({
+          state: 'crashed',
+          pid: null,
+          message: stderrSnapshot.at(-1) ?? 'kata subprocess exited unexpectedly',
+          exitCode,
+          signal,
+        })
+      } else {
+        log.info('[PiAgentBridge] shutdown complete', { exitCode, signal })
+        this.emit('debug', {
+          type: 'bridge:shutdown',
+          exitCode,
+          signal,
+        })
+        this.emitStatus({
+          state: 'shutdown',
+          pid: null,
+          exitCode,
+          signal,
+        })
+      }
+    })
+  }
+
+  public async send(command: RpcCommand): Promise<CommandResult> {
+    await this.start()
+
+    const child = this.child
+    if (!child || child.killed || !child.stdin.writable) {
+      throw new Error('RPC subprocess is not writable')
+    }
+
+    const id = command.id ?? `cmd-${++this.commandCounter}`
+    const payload = { ...command, id }
+
+    return new Promise<CommandResult>((resolve, reject) => {
+      this.pending.set(id, {
+        command: command.type,
+        resolve,
+        reject,
+      })
+
+      child.stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
+        if (error) {
+          this.pending.delete(id)
+          reject(error)
+        }
+      })
+    })
+  }
+
+  public prompt(message: string): Promise<CommandResult> {
+    return this.send({ type: 'prompt', message })
+  }
+
+  public abort(): Promise<CommandResult> {
+    return this.send({ type: 'abort' })
+  }
+
+  public async restart(): Promise<void> {
+    await this.shutdown()
+    await this.start()
+  }
+
+  public async shutdown(timeoutMs = 1_500): Promise<void> {
+    const child = this.child
+    if (!child) {
+      this.emitStatus({
+        state: 'shutdown',
+        pid: null,
+      })
+      return
+    }
+
+    this.shuttingDown = true
+
+    try {
+      await this.send({ type: 'shutdown' })
+    } catch (error) {
+      log.warn('[PiAgentBridge] shutdown command failed', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+
+    const exited = await this.waitForExit(timeoutMs)
+    if (!exited && this.child && !this.child.killed) {
+      this.child.kill('SIGTERM')
+      await this.waitForExit(timeoutMs)
+    }
+  }
+
+  private resolveCommand(): string {
+    const fromEnv = process.env.KATA_BIN_PATH?.trim()
+    if (fromEnv) {
+      return fromEnv
+    }
+
+    const whichResult = spawnSync('which', [this.commandHint], {
+      stdio: 'pipe',
+      encoding: 'utf8',
+    })
+
+    if (whichResult.status === 0) {
+      const discovered = whichResult.stdout.trim()
+      if (discovered) {
+        return discovered
+      }
+    }
+
+    return this.commandHint
+  }
+
+  private handleStdoutLine(line: string): void {
+    const trimmed = line.trim()
+    if (!trimmed) {
+      return
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      this.emit('rpc-event', {
+        type: 'agent_error',
+        message: 'Received non-JSON line from kata RPC subprocess',
+      })
+      return
+    }
+
+    if (this.isRpcResponse(parsed)) {
+      this.resolvePending(parsed)
+      return
+    }
+
+    if (this.isRpcEnvelope(parsed)) {
+      this.emit('rpc-event', parsed.event)
+      return
+    }
+
+    if (this.isRpcEvent(parsed)) {
+      this.emit('rpc-event', parsed)
+      return
+    }
+
+    this.emit('rpc-event', {
+      type: 'agent_error',
+      message: 'Received unrecognized RPC payload shape',
+    })
+  }
+
+  private resolvePending(response: RpcResponse): void {
+    const id = response.id
+    if (!id) {
+      return
+    }
+
+    const pending = this.pending.get(id)
+    if (!pending) {
+      return
+    }
+
+    this.pending.delete(id)
+
+    if (!response.success) {
+      pending.reject(new Error(response.error ?? `RPC command failed: ${pending.command}`))
+      return
+    }
+
+    pending.resolve({
+      id,
+      command: response.command,
+      success: true,
+      data: response.data,
+      error: response.error,
+    })
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      pending.reject(error)
+    }
+    this.pending.clear()
+  }
+
+  private waitForExit(timeoutMs: number): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const current = this.child
+      if (!current) {
+        resolve(true)
+        return
+      }
+
+      const timer = setTimeout(() => {
+        cleanup()
+        resolve(false)
+      }, timeoutMs)
+
+      const onExit = () => {
+        cleanup()
+        resolve(true)
+      }
+
+      const cleanup = () => {
+        clearTimeout(timer)
+        current.removeListener('exit', onExit)
+      }
+
+      current.once('exit', onExit)
+    })
+  }
+
+  private cleanupStreams(): void {
+    if (this.stdoutReader) {
+      this.stdoutReader.removeAllListeners()
+      this.stdoutReader.close()
+      this.stdoutReader = null
+    }
+  }
+
+  private pushStderr(line: string): void {
+    const sanitized = this.redactSensitiveTokens(line)
+    this.stderrLines.push(sanitized)
+
+    while (this.stderrLines.length > 5) {
+      this.stderrLines.shift()
+    }
+  }
+
+  private redactSensitiveTokens(value: string): string {
+    return value
+      .replace(/(sk-[A-Za-z0-9_-]{10,})/g, 'sk-***')
+      .replace(/(api[_-]?key\s*[=:]\s*)([^\s]+)/gi, '$1***')
+      .replace(/(token\s*[=:]\s*)([^\s]+)/gi, '$1***')
+  }
+
+  private emitStatus(event: Omit<BridgeStatusEvent, 'updatedAt'>): void {
+    this.status = event.state
+    this.emit('status', {
+      ...event,
+      updatedAt: Date.now(),
+    })
+  }
+
+  private isRpcResponse(value: unknown): value is RpcResponse {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    const candidate = value as Partial<RpcResponse>
+    return candidate.type === 'response' && typeof candidate.command === 'string'
+  }
+
+  private isRpcEnvelope(value: unknown): value is RpcEnvelope {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    const candidate = value as Partial<RpcEnvelope>
+    return candidate.type === 'event' && typeof candidate.event === 'object' && candidate.event !== null
+  }
+
+  private isRpcEvent(value: unknown): value is Record<string, unknown> {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    const candidate = value as Record<string, unknown>
+    return typeof candidate.type === 'string'
+  }
+}

--- a/apps/desktop/src/main/rpc-event-adapter.ts
+++ b/apps/desktop/src/main/rpc-event-adapter.ts
@@ -1,0 +1,269 @@
+import { type ChatEvent } from '../shared/types'
+
+interface AssistantMessageEvent {
+  type?: string
+  delta?: string
+  text?: string
+}
+
+interface RpcEvent {
+  type?: string
+  message?: Record<string, unknown>
+  assistantMessageEvent?: AssistantMessageEvent
+  toolCallId?: string
+  toolName?: string
+  args?: unknown
+  result?: unknown
+  isError?: boolean
+  error?: string
+  status?: string
+}
+
+export class RpcEventAdapter {
+  public adapt(input: unknown): ChatEvent[] {
+    if (!input || typeof input !== 'object') {
+      return [
+        {
+          type: 'agent_error',
+          message: 'Malformed RPC event payload',
+        },
+      ]
+    }
+
+    const event = input as RpcEvent
+    const type = event.type
+
+    switch (type) {
+      case 'agent_start':
+        return [{ type: 'agent_start' }]
+
+      case 'agent_end':
+        return [{ type: 'agent_end' }]
+
+      case 'turn_start':
+        return [{ type: 'turn_start' }]
+
+      case 'turn_end':
+        return [{ type: 'turn_end' }]
+
+      case 'message_start': {
+        const role = this.extractRole(event.message)
+        if (role !== 'assistant' && role !== 'user') {
+          return []
+        }
+
+        return [
+          {
+            type: 'message_start',
+            role,
+            messageId: this.extractMessageId(event.message),
+          },
+        ]
+      }
+
+      case 'message_update': {
+        const delta = this.extractTextDelta(event)
+        if (!delta) {
+          return []
+        }
+
+        return [
+          {
+            type: 'text_delta',
+            messageId: this.extractMessageId(event.message),
+            delta,
+          },
+        ]
+      }
+
+      case 'message_end':
+        return [
+          {
+            type: 'message_end',
+            messageId: this.extractMessageId(event.message),
+            text: this.extractText(event.message),
+          },
+        ]
+
+      case 'tool_execution_start':
+        return [
+          {
+            type: 'tool_start',
+            toolCallId: this.extractToolCallId(event),
+            toolName: this.extractToolName(event),
+            args: event.args ?? {},
+          },
+        ]
+
+      case 'tool_execution_update':
+        return [
+          {
+            type: 'tool_update',
+            toolCallId: this.extractToolCallId(event),
+            toolName: this.extractToolName(event),
+            status: typeof event.status === 'string' ? event.status : undefined,
+          },
+        ]
+
+      case 'tool_execution_end': {
+        const result = event.result ?? event.message?.result
+        const error = typeof event.error === 'string' ? event.error : this.extractToolError(event.message)
+
+        return [
+          {
+            type: 'tool_end',
+            toolCallId: this.extractToolCallId(event),
+            toolName: this.extractToolName(event),
+            result,
+            isError: Boolean(event.isError || error),
+            error: error ?? undefined,
+          },
+        ]
+      }
+
+      case 'extension_error':
+        return [
+          {
+            type: 'agent_error',
+            message: this.extractErrorMessage(event),
+          },
+        ]
+
+      default:
+        return []
+    }
+  }
+
+  private extractTextDelta(event: RpcEvent): string {
+    const assistantMessageEvent = event.assistantMessageEvent
+    if (
+      assistantMessageEvent &&
+      assistantMessageEvent.type === 'text_delta' &&
+      typeof assistantMessageEvent.delta === 'string'
+    ) {
+      return assistantMessageEvent.delta
+    }
+
+    if (assistantMessageEvent && typeof assistantMessageEvent.text === 'string') {
+      return assistantMessageEvent.text
+    }
+
+    const fromMessage = this.extractText(event.message)
+    return fromMessage ?? ''
+  }
+
+  private extractText(message?: Record<string, unknown>): string | undefined {
+    if (!message) {
+      return undefined
+    }
+
+    const directText = message.text
+    if (typeof directText === 'string') {
+      return directText
+    }
+
+    const content = message.content
+    if (!Array.isArray(content)) {
+      return undefined
+    }
+
+    const textChunks = content
+      .map((chunk) => {
+        if (!chunk || typeof chunk !== 'object') {
+          return ''
+        }
+
+        const typedChunk = chunk as Record<string, unknown>
+        if (typedChunk.type === 'text' && typeof typedChunk.text === 'string') {
+          return typedChunk.text
+        }
+
+        return ''
+      })
+      .filter(Boolean)
+
+    if (textChunks.length === 0) {
+      return undefined
+    }
+
+    return textChunks.join('')
+  }
+
+  private extractRole(message?: Record<string, unknown>): 'assistant' | 'user' | undefined {
+    if (!message) {
+      return undefined
+    }
+
+    const role = message.role
+    if (role === 'assistant' || role === 'user') {
+      return role
+    }
+
+    return undefined
+  }
+
+  private extractMessageId(message?: Record<string, unknown>): string {
+    if (!message) {
+      return 'message:unknown'
+    }
+
+    const id = message.id
+    if (typeof id === 'string' && id.length > 0) {
+      return id
+    }
+
+    return 'message:unknown'
+  }
+
+  private extractToolCallId(event: RpcEvent): string {
+    if (typeof event.toolCallId === 'string' && event.toolCallId.length > 0) {
+      return event.toolCallId
+    }
+
+    const message = event.message
+    if (message && typeof message.toolCallId === 'string' && message.toolCallId.length > 0) {
+      return message.toolCallId
+    }
+
+    return 'tool:unknown'
+  }
+
+  private extractToolName(event: RpcEvent): string {
+    if (typeof event.toolName === 'string' && event.toolName.length > 0) {
+      return event.toolName
+    }
+
+    const message = event.message
+    if (message && typeof message.toolName === 'string' && message.toolName.length > 0) {
+      return message.toolName
+    }
+
+    return 'unknown_tool'
+  }
+
+  private extractToolError(message?: Record<string, unknown>): string | undefined {
+    if (!message) {
+      return undefined
+    }
+
+    const value = message.error
+    if (typeof value === 'string' && value.length > 0) {
+      return value
+    }
+
+    return undefined
+  }
+
+  private extractErrorMessage(event: RpcEvent): string {
+    if (typeof event.error === 'string' && event.error.length > 0) {
+      return event.error
+    }
+
+    const message = event.message
+    if (message && typeof message.error === 'string' && message.error.length > 0) {
+      return message.error
+    }
+
+    return 'Unknown extension error'
+  }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,0 +1,46 @@
+import { contextBridge, ipcRenderer } from 'electron'
+import {
+  IPC_CHANNELS,
+  type BridgeStatusEvent,
+  type ChatEvent,
+  type DesktopApi,
+} from '../shared/types'
+
+const api: DesktopApi = {
+  sendMessage: async (message: string) => {
+    await ipcRenderer.invoke(IPC_CHANNELS.sessionSend, message)
+  },
+  stopAgent: async () => {
+    await ipcRenderer.invoke(IPC_CHANNELS.sessionStop)
+  },
+  restartAgent: async () => {
+    await ipcRenderer.invoke(IPC_CHANNELS.sessionRestart)
+  },
+  onChatEvent: (listener: (event: ChatEvent) => void) => {
+    const wrapped = (_event: Electron.IpcRendererEvent, chatEvent: ChatEvent) => {
+      listener(chatEvent)
+    }
+
+    ipcRenderer.on(IPC_CHANNELS.sessionEvents, wrapped)
+
+    return () => {
+      ipcRenderer.removeListener(IPC_CHANNELS.sessionEvents, wrapped)
+    }
+  },
+  onBridgeStatus: (listener: (status: BridgeStatusEvent) => void) => {
+    const wrapped = (_event: Electron.IpcRendererEvent, status: BridgeStatusEvent) => {
+      listener(status)
+    }
+
+    ipcRenderer.on(IPC_CHANNELS.sessionBridgeStatus, wrapped)
+
+    return () => {
+      ipcRenderer.removeListener(IPC_CHANNELS.sessionBridgeStatus, wrapped)
+    }
+  },
+  getBridgeState: async () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.sessionGetBridgeState)
+  },
+}
+
+contextBridge.exposeInMainWorld('api', api)

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from './components/app-shell/AppShell'
+
+export default function App() {
+  return <AppShell />
+}

--- a/apps/desktop/src/renderer/atoms/chat.ts
+++ b/apps/desktop/src/renderer/atoms/chat.ts
@@ -65,6 +65,7 @@ export const applyBridgeStatusAtom = atom(null, (_get, set, status: BridgeStatus
 
   if (status.state === 'running') {
     set(errorAtom, null)
+    set(toolCallsAtom, [])
   }
 })
 

--- a/apps/desktop/src/renderer/atoms/chat.ts
+++ b/apps/desktop/src/renderer/atoms/chat.ts
@@ -70,6 +70,12 @@ export const applyBridgeStatusAtom = atom(null, (_get, set, status: BridgeStatus
 
 export const applyChatEventAtom = atom(null, (get, set, event: ChatEvent) => {
   switch (event.type) {
+    case 'agent_start': {
+      set(toolCallsAtom, [])
+      set(errorAtom, null)
+      return
+    }
+
     case 'message_start': {
       if (event.role !== 'assistant') {
         return

--- a/apps/desktop/src/renderer/atoms/chat.ts
+++ b/apps/desktop/src/renderer/atoms/chat.ts
@@ -1,0 +1,226 @@
+import { atom } from 'jotai'
+import {
+  type BridgeStatusEvent,
+  type BridgeLifecycleState,
+  type ChatEvent,
+} from '@shared/types'
+
+export interface ToolCallView {
+  id: string
+  name: string
+  args: unknown
+  status: 'running' | 'done' | 'error'
+  result?: unknown
+  error?: string
+}
+
+export interface ChatMessageView {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  streaming: boolean
+}
+
+export interface BridgeStatusView {
+  state: BridgeLifecycleState
+  pid: number | null
+  message?: string
+  updatedAt: number
+}
+
+export const messagesAtom = atom<ChatMessageView[]>([])
+export const toolCallsAtom = atom<ToolCallView[]>([])
+export const isStreamingAtom = atom<boolean>(false)
+export const errorAtom = atom<string | null>(null)
+export const bridgeStatusAtom = atom<BridgeStatusView>({
+  state: 'shutdown',
+  pid: null,
+  updatedAt: Date.now(),
+})
+
+export const appendUserMessageAtom = atom(null, (get, set, content: string) => {
+  const trimmed = content.trim()
+  if (!trimmed) {
+    return
+  }
+
+  set(messagesAtom, [
+    ...get(messagesAtom),
+    {
+      id: `user:${Date.now()}`,
+      role: 'user',
+      content: trimmed,
+      streaming: false,
+    },
+  ])
+})
+
+export const applyBridgeStatusAtom = atom(null, (_get, set, status: BridgeStatusEvent) => {
+  set(bridgeStatusAtom, {
+    state: status.state,
+    pid: status.pid,
+    message: status.message,
+    updatedAt: status.updatedAt,
+  })
+
+  if (status.state === 'running') {
+    set(errorAtom, null)
+  }
+})
+
+export const applyChatEventAtom = atom(null, (get, set, event: ChatEvent) => {
+  switch (event.type) {
+    case 'message_start': {
+      if (event.role !== 'assistant') {
+        return
+      }
+
+      const existing = get(messagesAtom).some((message) => message.id === event.messageId)
+      if (existing) {
+        return
+      }
+
+      set(messagesAtom, [
+        ...get(messagesAtom),
+        {
+          id: event.messageId,
+          role: 'assistant',
+          content: '',
+          streaming: true,
+        },
+      ])
+      set(isStreamingAtom, true)
+      set(errorAtom, null)
+      return
+    }
+
+    case 'text_delta': {
+      const messages = get(messagesAtom)
+      const index = messages.findIndex((message) => message.id === event.messageId)
+
+      if (index >= 0) {
+        const existing = messages[index]
+        if (!existing) {
+          return
+        }
+
+        const updated = [...messages]
+        updated[index] = {
+          ...existing,
+          content: `${existing.content}${event.delta}`,
+          streaming: true,
+        }
+        set(messagesAtom, updated)
+      } else {
+        set(messagesAtom, [
+          ...messages,
+          {
+            id: event.messageId,
+            role: 'assistant',
+            content: event.delta,
+            streaming: true,
+          },
+        ])
+      }
+
+      set(isStreamingAtom, true)
+      return
+    }
+
+    case 'message_end': {
+      set(
+        messagesAtom,
+        get(messagesAtom).map((message) =>
+          message.id === event.messageId
+            ? {
+                ...message,
+                content: event.text ?? message.content,
+                streaming: false,
+              }
+            : message,
+        ),
+      )
+      return
+    }
+
+    case 'turn_end':
+    case 'agent_end': {
+      set(isStreamingAtom, false)
+      set(
+        messagesAtom,
+        get(messagesAtom).map((message) =>
+          message.streaming
+            ? {
+                ...message,
+                streaming: false,
+              }
+            : message,
+        ),
+      )
+      return
+    }
+
+    case 'tool_start': {
+      const withoutOld = get(toolCallsAtom).filter((tool) => tool.id !== event.toolCallId)
+      set(toolCallsAtom, [
+        ...withoutOld,
+        {
+          id: event.toolCallId,
+          name: event.toolName,
+          args: event.args,
+          status: 'running',
+        },
+      ])
+      return
+    }
+
+    case 'tool_update': {
+      set(
+        toolCallsAtom,
+        get(toolCallsAtom).map((tool) =>
+          tool.id === event.toolCallId
+            ? {
+                ...tool,
+                name: event.toolName,
+                status: event.status === 'error' ? 'error' : tool.status,
+              }
+            : tool,
+        ),
+      )
+      return
+    }
+
+    case 'tool_end': {
+      set(
+        toolCallsAtom,
+        get(toolCallsAtom).map((tool) =>
+          tool.id === event.toolCallId
+            ? {
+                ...tool,
+                name: event.toolName,
+                status: event.isError ? 'error' : 'done',
+                result: event.result,
+                error: event.error,
+              }
+            : tool,
+        ),
+      )
+      return
+    }
+
+    case 'agent_error': {
+      set(errorAtom, event.message)
+      set(isStreamingAtom, false)
+      return
+    }
+
+    case 'subprocess_crash': {
+      set(errorAtom, event.message)
+      set(isStreamingAtom, false)
+      return
+    }
+
+    default:
+      return
+  }
+})

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react'
+import { Group, Panel, Separator, type Layout } from 'react-resizable-panels'
+import { LeftPane } from './LeftPane'
+import { RightPane } from './RightPane'
+
+const LAYOUT_STORAGE_KEY = 'kata-desktop:app-shell-layout'
+const LEFT_PANEL_ID = 'chat-pane'
+const RIGHT_PANEL_ID = 'context-pane'
+const DEFAULT_LAYOUT: Layout = {
+  [LEFT_PANEL_ID]: 64,
+  [RIGHT_PANEL_ID]: 36,
+}
+
+function readInitialLayout(): Layout {
+  if (typeof window === 'undefined') {
+    return DEFAULT_LAYOUT
+  }
+
+  const value = window.localStorage.getItem(LAYOUT_STORAGE_KEY)
+  if (!value) {
+    return DEFAULT_LAYOUT
+  }
+
+  try {
+    const parsed = JSON.parse(value)
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof parsed[LEFT_PANEL_ID] === 'number' &&
+      typeof parsed[RIGHT_PANEL_ID] === 'number'
+    ) {
+      return {
+        [LEFT_PANEL_ID]: parsed[LEFT_PANEL_ID],
+        [RIGHT_PANEL_ID]: parsed[RIGHT_PANEL_ID],
+      }
+    }
+  } catch {
+    // Ignore malformed local storage data.
+  }
+
+  return DEFAULT_LAYOUT
+}
+
+export function AppShell() {
+  const defaultLayout = useMemo(readInitialLayout, [])
+
+  return (
+    <main className="h-full w-full bg-slate-950 text-slate-100">
+      <Group
+        orientation="horizontal"
+        className="h-full"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={(layout) => {
+          window.localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layout))
+        }}
+      >
+        <Panel id={LEFT_PANEL_ID} defaultSize={defaultLayout[LEFT_PANEL_ID]} minSize={45}>
+          <LeftPane />
+        </Panel>
+
+        <Separator className="w-px bg-slate-800 hover:bg-slate-600 transition-colors" />
+
+        <Panel id={RIGHT_PANEL_ID} defaultSize={defaultLayout[RIGHT_PANEL_ID]} minSize={20}>
+          <RightPane />
+        </Panel>
+      </Group>
+    </main>
+  )
+}

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -23,15 +23,20 @@ function readInitialLayout(): Layout {
 
   try {
     const parsed = JSON.parse(value)
+    const left = parsed?.[LEFT_PANEL_ID]
+    const right = parsed?.[RIGHT_PANEL_ID]
+
     if (
       parsed &&
       typeof parsed === 'object' &&
-      typeof parsed[LEFT_PANEL_ID] === 'number' &&
-      typeof parsed[RIGHT_PANEL_ID] === 'number'
+      Number.isFinite(left) &&
+      Number.isFinite(right) &&
+      left > 0 &&
+      right > 0
     ) {
       return {
-        [LEFT_PANEL_ID]: parsed[LEFT_PANEL_ID],
-        [RIGHT_PANEL_ID]: parsed[RIGHT_PANEL_ID],
+        [LEFT_PANEL_ID]: left,
+        [RIGHT_PANEL_ID]: right,
       }
     }
   } catch {
@@ -51,7 +56,11 @@ export function AppShell() {
         className="h-full"
         defaultLayout={defaultLayout}
         onLayoutChanged={(layout) => {
-          window.localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layout))
+          try {
+            window.localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layout))
+          } catch {
+            // Ignore storage persistence failures.
+          }
         }}
       >
         <Panel id={LEFT_PANEL_ID} defaultSize={defaultLayout[LEFT_PANEL_ID]} minSize={45}>

--- a/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
@@ -1,0 +1,12 @@
+import { ChatPanel } from '../chat/ChatPanel'
+
+export function LeftPane() {
+  return (
+    <section className="h-full border-r border-slate-800 bg-slate-950">
+      <div className="flex h-14 items-center border-b border-slate-800 px-4">
+        <h1 className="text-sm font-semibold tracking-wide uppercase text-slate-200">Kata Desktop</h1>
+      </div>
+      <ChatPanel />
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
@@ -1,0 +1,16 @@
+export function RightPane() {
+  return (
+    <aside className="flex h-full flex-col bg-slate-900/60">
+      <div className="flex h-14 items-center border-b border-slate-800 px-4">
+        <h2 className="text-sm font-semibold tracking-wide uppercase text-slate-300">Context Pane</h2>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-slate-400">
+        <div>
+          <p className="font-medium text-slate-200">Kata Desktop</p>
+          <p className="mt-2">Planning and kanban views are coming in M002/M003.</p>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -61,11 +61,13 @@ export function ChatPanel() {
   const inputDisabled = isStreaming || !bridgeAvailable
   const stopDisabled = !isStreaming || !bridgeAvailable
   const errorMessage = error ?? bridgeStatus.message ?? null
+  const errorTitle = bridgeStatus.state === 'crashed' ? 'Agent process crashed' : 'Agent error'
 
   return (
     <div className="flex h-[calc(100%-3.5rem)] flex-col">
       {errorMessage && (
         <ErrorBanner
+          title={errorTitle}
           message={errorMessage}
           onRestart={bridgeStatus.state !== 'spawning' ? () => window.api.restartAgent() : undefined}
         />
@@ -80,7 +82,16 @@ export function ChatPanel() {
         stopDisabled={stopDisabled}
         onSubmit={async (value) => {
           appendUserMessage(value)
-          await window.api.sendMessage(value)
+
+          try {
+            await window.api.sendMessage(value)
+          } catch (sendError) {
+            const message = sendError instanceof Error ? sendError.message : String(sendError)
+            applyChatEvent({
+              type: 'agent_error',
+              message,
+            })
+          }
         }}
         onStop={async () => {
           await window.api.stopAgent()

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import {
+  appendUserMessageAtom,
+  applyBridgeStatusAtom,
+  applyChatEventAtom,
+  bridgeStatusAtom,
+  errorAtom,
+  isStreamingAtom,
+  messagesAtom,
+  toolCallsAtom,
+} from '@/atoms/chat'
+import { ErrorBanner } from './ErrorBanner'
+import { MessageInput } from './MessageInput'
+import { MessageList } from './MessageList'
+
+export function ChatPanel() {
+  const messages = useAtomValue(messagesAtom)
+  const tools = useAtomValue(toolCallsAtom)
+  const error = useAtomValue(errorAtom)
+  const isStreaming = useAtomValue(isStreamingAtom)
+  const bridgeStatus = useAtomValue(bridgeStatusAtom)
+
+  const appendUserMessage = useSetAtom(appendUserMessageAtom)
+  const applyChatEvent = useSetAtom(applyChatEventAtom)
+  const applyBridgeStatus = useSetAtom(applyBridgeStatusAtom)
+
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const unsubscribeChatEvents = window.api.onChatEvent((event) => {
+      applyChatEvent(event)
+    })
+
+    const unsubscribeBridgeStatus = window.api.onBridgeStatus((status) => {
+      applyBridgeStatus(status)
+    })
+
+    void window.api.getBridgeState().then((state) => {
+      applyBridgeStatus({
+        state: state.status,
+        pid: state.pid,
+        updatedAt: Date.now(),
+      })
+    })
+
+    return () => {
+      unsubscribeChatEvents()
+      unsubscribeBridgeStatus()
+    }
+  }, [applyBridgeStatus, applyChatEvent])
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({
+      top: scrollRef.current.scrollHeight,
+      behavior: 'smooth',
+    })
+  }, [messages, tools])
+
+  const bridgeAvailable = bridgeStatus.state === 'running'
+  const inputDisabled = isStreaming || !bridgeAvailable
+  const errorMessage = error ?? bridgeStatus.message ?? null
+
+  return (
+    <div className="flex h-[calc(100%-3.5rem)] flex-col">
+      {errorMessage && (
+        <ErrorBanner
+          message={errorMessage}
+          onRestart={bridgeStatus.state !== 'spawning' ? () => window.api.restartAgent() : undefined}
+        />
+      )}
+
+      <div ref={scrollRef} className="flex-1 overflow-auto">
+        <MessageList messages={messages} tools={tools} />
+      </div>
+
+      <MessageInput
+        disabled={inputDisabled}
+        onSubmit={async (value) => {
+          appendUserMessage(value)
+          await window.api.sendMessage(value)
+        }}
+        onStop={async () => {
+          await window.api.stopAgent()
+        }}
+      />
+
+      <div className="border-t border-slate-800 px-4 py-2 text-[11px] text-slate-500">
+        {isStreaming
+          ? 'Streaming response…'
+          : bridgeStatus.state === 'running'
+            ? 'Ready'
+            : `Bridge ${bridgeStatus.state}`}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -59,6 +59,7 @@ export function ChatPanel() {
 
   const bridgeAvailable = bridgeStatus.state === 'running'
   const inputDisabled = isStreaming || !bridgeAvailable
+  const stopDisabled = !isStreaming || !bridgeAvailable
   const errorMessage = error ?? bridgeStatus.message ?? null
 
   return (
@@ -76,6 +77,7 @@ export function ChatPanel() {
 
       <MessageInput
         disabled={inputDisabled}
+        stopDisabled={stopDisabled}
         onSubmit={async (value) => {
           appendUserMessage(value)
           await window.api.sendMessage(value)

--- a/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
@@ -1,13 +1,14 @@
 interface ErrorBannerProps {
+  title?: string
   message: string
   onRestart?: () => Promise<void> | void
 }
 
-export function ErrorBanner({ message, onRestart }: ErrorBannerProps) {
+export function ErrorBanner({ title = 'Agent error', message, onRestart }: ErrorBannerProps) {
   return (
     <div className="mx-4 mb-3 rounded-md border border-red-500/50 bg-red-500/10 px-3 py-2 text-sm text-red-200">
       <div className="flex items-center justify-between gap-3">
-        <p className="font-medium">Agent process crashed</p>
+        <p className="font-medium">{title}</p>
         {onRestart && (
           <button
             type="button"

--- a/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
@@ -1,0 +1,26 @@
+interface ErrorBannerProps {
+  message: string
+  onRestart?: () => Promise<void> | void
+}
+
+export function ErrorBanner({ message, onRestart }: ErrorBannerProps) {
+  return (
+    <div className="mx-4 mb-3 rounded-md border border-red-500/50 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+      <div className="flex items-center justify-between gap-3">
+        <p className="font-medium">Agent process crashed</p>
+        {onRestart && (
+          <button
+            type="button"
+            onClick={() => {
+              void onRestart()
+            }}
+            className="rounded border border-red-300/60 px-2 py-1 text-xs font-medium text-red-100 hover:bg-red-500/20"
+          >
+            Restart
+          </button>
+        )}
+      </div>
+      <p className="mt-1 text-red-100/90">{message}</p>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react'
 
 interface MessageInputProps {
   disabled?: boolean
+  stopDisabled?: boolean
   onSubmit: (value: string) => Promise<void>
   onStop: () => Promise<void>
 }
 
-export function MessageInput({ disabled = false, onSubmit, onStop }: MessageInputProps) {
+export function MessageInput({ disabled = false, stopDisabled = disabled, onSubmit, onStop }: MessageInputProps) {
   const [value, setValue] = useState('')
   const [submitting, setSubmitting] = useState(false)
 
@@ -46,7 +47,7 @@ export function MessageInput({ disabled = false, onSubmit, onStop }: MessageInpu
           <button
             type="button"
             onClick={() => void onStop()}
-            disabled={disabled}
+            disabled={stopDisabled || submitting}
             className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-800 disabled:opacity-50"
           >
             Stop

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -26,6 +26,18 @@ export function MessageInput({ disabled = false, stopDisabled = disabled, onSubm
     }
   }
 
+  const handleSend = (): void => {
+    void send().catch((error: unknown) => {
+      console.error('[MessageInput] failed to send message', error)
+    })
+  }
+
+  const handleStop = (): void => {
+    void onStop().catch((error: unknown) => {
+      console.error('[MessageInput] failed to stop session', error)
+    })
+  }
+
   return (
     <div className="border-t border-slate-800 p-4">
       <div className="rounded-lg border border-slate-700 bg-slate-900 p-2">
@@ -35,7 +47,7 @@ export function MessageInput({ disabled = false, stopDisabled = disabled, onSubm
           onKeyDown={(event) => {
             if (event.key === 'Enter' && !event.shiftKey) {
               event.preventDefault()
-              void send()
+              handleSend()
             }
           }}
           className="h-20 w-full resize-none border-none bg-transparent text-sm text-slate-100 outline-none disabled:opacity-50"
@@ -46,8 +58,8 @@ export function MessageInput({ disabled = false, stopDisabled = disabled, onSubm
         <div className="mt-2 flex justify-end gap-2">
           <button
             type="button"
-            onClick={() => void onStop()}
-            disabled={stopDisabled || submitting}
+            onClick={handleStop}
+            disabled={stopDisabled}
             className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-800 disabled:opacity-50"
           >
             Stop
@@ -55,7 +67,7 @@ export function MessageInput({ disabled = false, stopDisabled = disabled, onSubm
 
           <button
             type="button"
-            onClick={() => void send()}
+            onClick={handleSend}
             disabled={disabled || submitting}
             className="rounded bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-900 disabled:opacity-50"
           >

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 interface MessageInputProps {
   disabled?: boolean
@@ -10,18 +10,21 @@ interface MessageInputProps {
 export function MessageInput({ disabled = false, stopDisabled = disabled, onSubmit, onStop }: MessageInputProps) {
   const [value, setValue] = useState('')
   const [submitting, setSubmitting] = useState(false)
+  const sendingRef = useRef(false)
 
   const send = async (): Promise<void> => {
     const trimmed = value.trim()
-    if (!trimmed || submitting || disabled) {
+    if (!trimmed || disabled || submitting || sendingRef.current) {
       return
     }
 
+    sendingRef.current = true
     setSubmitting(true)
     try {
       await onSubmit(trimmed)
       setValue('')
     } finally {
+      sendingRef.current = false
       setSubmitting(false)
     }
   }
@@ -45,6 +48,10 @@ export function MessageInput({ disabled = false, stopDisabled = disabled, onSubm
           value={value}
           onChange={(event) => setValue(event.target.value)}
           onKeyDown={(event) => {
+            if (event.nativeEvent.isComposing) {
+              return
+            }
+
             if (event.key === 'Enter' && !event.shiftKey) {
               event.preventDefault()
               handleSend()

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+
+interface MessageInputProps {
+  disabled?: boolean
+  onSubmit: (value: string) => Promise<void>
+  onStop: () => Promise<void>
+}
+
+export function MessageInput({ disabled = false, onSubmit, onStop }: MessageInputProps) {
+  const [value, setValue] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const send = async (): Promise<void> => {
+    const trimmed = value.trim()
+    if (!trimmed || submitting || disabled) {
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await onSubmit(trimmed)
+      setValue('')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="border-t border-slate-800 p-4">
+      <div className="rounded-lg border border-slate-700 bg-slate-900 p-2">
+        <textarea
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+              event.preventDefault()
+              void send()
+            }
+          }}
+          className="h-20 w-full resize-none border-none bg-transparent text-sm text-slate-100 outline-none disabled:opacity-50"
+          placeholder="Ask Kata to help with your code..."
+          disabled={disabled || submitting}
+        />
+
+        <div className="mt-2 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => void onStop()}
+            disabled={disabled}
+            className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-800 disabled:opacity-50"
+          >
+            Stop
+          </button>
+
+          <button
+            type="button"
+            onClick={() => void send()}
+            disabled={disabled || submitting}
+            className="rounded bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-900 disabled:opacity-50"
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/MessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageList.tsx
@@ -1,0 +1,35 @@
+import type { ChatMessageView, ToolCallView } from '@/atoms/chat'
+import { StreamingMessage } from './StreamingMessage'
+import { ToolCallCard } from './ToolCallCard'
+
+interface MessageListProps {
+  messages: ChatMessageView[]
+  tools: ToolCallView[]
+}
+
+export function MessageList({ messages, tools }: MessageListProps) {
+  return (
+    <div className="space-y-4 px-4 py-4">
+      {messages.map((message) => (
+        <article key={message.id} className="space-y-1">
+          <p className="text-[11px] uppercase tracking-wide text-slate-400">{message.role}</p>
+
+          {message.role === 'assistant' ? (
+            <StreamingMessage content={message.content} isStreaming={message.streaming} />
+          ) : (
+            <div className="rounded-lg bg-slate-700/80 px-3 py-2 text-sm text-slate-100">{message.content}</div>
+          )}
+        </article>
+      ))}
+
+      {tools.length > 0 && (
+        <section className="space-y-2">
+          <p className="text-[11px] uppercase tracking-wide text-slate-400">Tool calls</p>
+          {tools.map((tool) => (
+            <ToolCallCard key={tool.id} tool={tool} />
+          ))}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/StreamingMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/StreamingMessage.tsx
@@ -1,0 +1,15 @@
+import { Markdown } from '@kata-ui/components/markdown/Markdown'
+
+interface StreamingMessageProps {
+  content: string
+  isStreaming: boolean
+}
+
+export function StreamingMessage({ content, isStreaming }: StreamingMessageProps) {
+  return (
+    <div className="rounded-lg bg-slate-800/70 px-3 py-2 text-sm text-slate-100">
+      <Markdown mode="minimal">{content || (isStreaming ? '…' : '')}</Markdown>
+      {isStreaming && <span className="ml-1 inline-block h-3 w-1 animate-pulse rounded bg-slate-300 align-middle" />}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
@@ -1,0 +1,55 @@
+import * as Collapsible from '@radix-ui/react-collapsible'
+import type { ToolCallView } from '@/atoms/chat'
+
+interface ToolCallCardProps {
+  tool: ToolCallView
+}
+
+function formatJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+export function ToolCallCard({ tool }: ToolCallCardProps) {
+  const badgeClass =
+    tool.status === 'error'
+      ? 'bg-red-500/20 text-red-200 border-red-500/40'
+      : tool.status === 'done'
+        ? 'bg-emerald-500/20 text-emerald-100 border-emerald-500/40'
+        : 'bg-amber-500/20 text-amber-100 border-amber-500/40'
+
+  const resultClass =
+    tool.status === 'error'
+      ? 'max-h-48 overflow-auto rounded border border-red-500/40 bg-red-950/30 p-2 text-xs text-red-100'
+      : 'max-h-48 overflow-auto rounded bg-slate-950 p-2 text-xs text-slate-200'
+
+  return (
+    <Collapsible.Root className="rounded-md border border-slate-700 bg-slate-900/60">
+      <Collapsible.Trigger className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left">
+        <span className="text-xs font-medium text-slate-100">{tool.name}</span>
+        <span className={`rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide ${badgeClass}`}>
+          {tool.status}
+        </span>
+      </Collapsible.Trigger>
+
+      <Collapsible.Content className="space-y-2 border-t border-slate-700 px-3 py-2">
+        <div>
+          <p className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">Args</p>
+          <pre className="max-h-40 overflow-auto rounded bg-slate-950 p-2 text-xs text-slate-200">
+            {formatJson(tool.args)}
+          </pre>
+        </div>
+
+        {(tool.result !== undefined || tool.error) && (
+          <div>
+            <p className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">Result</p>
+            <pre className={resultClass}>{tool.error ?? formatJson(tool.result)}</pre>
+          </div>
+        )}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
@@ -7,7 +7,8 @@ interface ToolCallCardProps {
 
 function formatJson(value: unknown): string {
   try {
-    return JSON.stringify(value, null, 2)
+    const serialized = JSON.stringify(value, null, 2)
+    return serialized ?? String(value)
   } catch {
     return String(value)
   }

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kata Desktop</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws://127.0.0.1:* ws://localhost:* http://127.0.0.1:* http://localhost:*; frame-src 'none'; object-src 'none'; base-uri 'self';"
+    />
     <title>Kata Desktop</title>
   </head>
   <body>

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,0 +1,15 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './styles.css'
+
+const rootElement = document.getElementById('root')
+if (!rootElement) {
+  throw new Error('Missing #root container')
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -1,0 +1,18 @@
+@import "tailwindcss";
+
+:root {
+  color-scheme: dark;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: #0b0f1a;
+  color: #f8fafc;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1,0 +1,90 @@
+export const IPC_CHANNELS = {
+  sessionSend: 'session:send',
+  sessionStop: 'session:stop',
+  sessionRestart: 'session:restart',
+  sessionEvents: 'session:events',
+  sessionBridgeStatus: 'session:bridge-status',
+  sessionGetBridgeState: 'session:get-bridge-state',
+} as const
+
+export type RpcCommandType =
+  | 'prompt'
+  | 'abort'
+  | 'shutdown'
+  | 'get_state'
+  | 'get_session_stats'
+  | 'follow_up'
+
+export interface RpcCommand {
+  type: RpcCommandType
+  id?: string
+  message?: string
+}
+
+export interface CommandResult {
+  id?: string
+  success: boolean
+  command: string
+  data?: unknown
+  error?: string
+}
+
+export type BridgeLifecycleState = 'spawning' | 'running' | 'crashed' | 'shutdown'
+
+export interface BridgeStatusEvent {
+  state: BridgeLifecycleState
+  pid: number | null
+  message?: string
+  exitCode?: number | null
+  signal?: NodeJS.Signals | null
+  updatedAt: number
+}
+
+export type ChatEvent =
+  | { type: 'agent_start' }
+  | { type: 'agent_end' }
+  | { type: 'turn_start' }
+  | { type: 'turn_end' }
+  | { type: 'message_start'; messageId: string; role: 'assistant' | 'user' }
+  | { type: 'text_delta'; messageId: string; delta: string }
+  | { type: 'message_end'; messageId: string; text?: string }
+  | { type: 'tool_start'; toolCallId: string; toolName: string; args: unknown }
+  | { type: 'tool_update'; toolCallId: string; toolName: string; status?: string }
+  | {
+      type: 'tool_end'
+      toolCallId: string
+      toolName: string
+      result?: unknown
+      isError: boolean
+      error?: string
+    }
+  | { type: 'agent_error'; message: string }
+  | {
+      type: 'subprocess_crash'
+      message: string
+      exitCode: number | null
+      signal: NodeJS.Signals | null
+      stderrLines: string[]
+    }
+
+export interface BridgeState {
+  running: boolean
+  pid: number | null
+  command: string | null
+  status: BridgeLifecycleState
+}
+
+export interface DesktopApi {
+  sendMessage: (message: string) => Promise<void>
+  stopAgent: () => Promise<void>
+  restartAgent: () => Promise<void>
+  onChatEvent: (listener: (event: ChatEvent) => void) => () => void
+  onBridgeStatus: (listener: (status: BridgeStatusEvent) => void) => () => void
+  getBridgeState: () => Promise<BridgeState>
+}
+
+declare global {
+  interface Window {
+    api: DesktopApi
+  }
+}

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["node", "vite/client", "electron", "react", "react-dom", "bun"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/renderer/*"],
+      "@shared/*": ["src/shared/*"],
+      "@kata-ui/*": ["../../packages/ui/src/*"]
+    }
+  },
+  "include": ["src/**/*", "vite.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,0 +1,28 @@
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'vite'
+
+const rootDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineConfig({
+  root: path.join(rootDir, 'src/renderer'),
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': path.join(rootDir, 'src/renderer'),
+      '@shared': path.join(rootDir, 'src/shared'),
+      '@kata-ui': path.join(rootDir, '../../packages/ui/src'),
+    },
+  },
+  server: {
+    host: '127.0.0.1',
+    port: 5174,
+    strictPort: true,
+  },
+  build: {
+    outDir: path.join(rootDir, 'dist/renderer'),
+    emptyOutDir: true,
+  },
+})

--- a/bun.lock
+++ b/bun.lock
@@ -131,6 +131,32 @@
         "vitest": "^4.1.0",
       },
     },
+    "apps/desktop": {
+      "name": "@kata/desktop",
+      "version": "0.0.0",
+      "dependencies": {
+        "@radix-ui/react-collapsible": "^1.1.12",
+        "electron-log": "^5.4.3",
+        "jotai": "^2.16.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "react-resizable-panels": "^4.6.3",
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.1.18",
+        "@types/node": "^25.0.8",
+        "@types/react": "^19.1.0",
+        "@types/react-dom": "^19.1.0",
+        "@vitejs/plugin-react": "^6.0.1",
+        "concurrently": "^9.2.1",
+        "electron": "^41.0.3",
+        "esbuild": "^0.27.4",
+        "tailwindcss": "^4.1.18",
+        "typescript": "^5.9.0",
+        "vite": "^8.0.2",
+        "wait-on": "^8.0.1",
+      },
+    },
     "apps/electron": {
       "name": "@kata-sh/desktop",
       "version": "0.6.2",
@@ -643,9 +669,19 @@
 
     "@google/genai": ["@google/genai@1.44.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A=="],
 
+    "@hapi/address": ["@hapi/address@5.1.1", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA=="],
+
     "@hapi/boom": ["@hapi/boom@10.0.1", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA=="],
 
+    "@hapi/formula": ["@hapi/formula@3.0.2", "", {}, "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw=="],
+
     "@hapi/hoek": ["@hapi/hoek@11.0.7", "", {}, "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ=="],
+
+    "@hapi/pinpoint": ["@hapi/pinpoint@2.0.1", "", {}, "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q=="],
+
+    "@hapi/tlds": ["@hapi/tlds@1.1.6", "", {}, "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw=="],
+
+    "@hapi/topo": ["@hapi/topo@6.0.2", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
@@ -738,6 +774,8 @@
     "@kata-sh/orc": ["@kata-sh/orc@workspace:apps/orchestrator"],
 
     "@kata/context": ["@kata/context@workspace:apps/context"],
+
+    "@kata/desktop": ["@kata/desktop@workspace:apps/desktop"],
 
     "@kata/online-docs": ["@kata/online-docs@workspace:apps/online-docs"],
 
@@ -2377,6 +2415,8 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "joi": ["joi@18.1.2", "", { "dependencies": { "@hapi/address": "^5.1.1", "@hapi/formula": "^3.0.2", "@hapi/hoek": "^11.0.7", "@hapi/pinpoint": "^2.0.1", "@hapi/tlds": "^1.1.1", "@hapi/topo": "^6.0.2", "@standard-schema/spec": "^1.1.0" } }, "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA=="],
+
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
     "jotai": ["jotai@2.16.2", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-DH0lBiTXvewsxtqqwjDW6Hg9JPTDnq9LcOsXSFWCAUEt+qj5ohl9iRVX9zQXPPHKLXCdH+5mGvM28fsXMl17/g=="],
@@ -3437,6 +3477,8 @@
 
     "vlq": ["vlq@0.2.3", "", {}, "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="],
 
+    "wait-on": ["wait-on@8.0.5", "", { "dependencies": { "axios": "^1.12.1", "joi": "^18.0.1", "lodash": "^4.17.21", "minimist": "^1.2.8", "rxjs": "^7.8.2" }, "bin": { "wait-on": "bin/wait-on" } }, "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag=="],
+
     "warning": ["warning@4.0.3", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
@@ -3722,6 +3764,10 @@
     "@kata/context/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
     "@kata/context/vitest": ["vitest@4.1.0", "", { "dependencies": { "@vitest/expect": "4.1.0", "@vitest/mocker": "4.1.0", "@vitest/pretty-format": "4.1.0", "@vitest/runner": "4.1.0", "@vitest/snapshot": "4.1.0", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.0", "@vitest/browser-preview": "4.1.0", "@vitest/browser-webdriverio": "4.1.0", "@vitest/ui": "4.1.0", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw=="],
+
+    "@kata/desktop/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@kata/desktop/tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 
     "@kata/online-docs/postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
@@ -4372,6 +4418,8 @@
     "@kata/context/vitest/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "@kata/context/vitest/vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+
+    "@kata/desktop/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@mariozechner/pi-ai/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "electron:build": "bun run electron:build:main && bun run electron:build:preload && bun run electron:build:renderer && bun run electron:build:resources && bun run electron:build:assets",
     "electron:start": "bun run electron:build && electron apps/electron",
     "electron:dev": "bun run scripts/electron-dev.ts",
+    "desktop:dev": "cd apps/desktop && bun run desktop:dev",
     "electron:dev:terminal": "bun run scripts/electron-dev.ts --terminal",
     "electron:dev:menu": "bash scripts/electron-dev.sh",
     "electron:dev:logs": "pgrep -f 'tail -f.*Craft Agents/main.log' > /dev/null || osascript -e \"tell application \\\"Terminal\\\" to do script \\\"$PWD/scripts/tail-electron-logs.sh\\\"\"",

--- a/turbo.json
+++ b/turbo.json
@@ -42,6 +42,10 @@
     "dev": {
       "cache": false,
       "persistent": true
+    },
+    "desktop:dev": {
+      "cache": false,
+      "persistent": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- scaffold a new `apps/desktop` Electron app (`@kata/desktop`) with esbuild main/preload + Vite React renderer
- add `PiAgentBridge` to spawn `kata --mode rpc`, stream JSONL events, map RPC events, and emit bridge lifecycle/crash status
- wire main ↔ preload ↔ renderer IPC for `session:send`, `session:stop`, `session:events`, `session:bridge-status`, and restart/get-state helpers
- implement streaming chat UI with markdown assistant rendering, tool call cards, crash banner + restart action, and split-pane shell with persisted layout
- add RpcEventAdapter unit tests and root scripts (`desktop:dev`) for development workflow

## Validation
- `bun test apps/desktop/`
- `cd apps/desktop && bun run typecheck`
- `bun run desktop:dev` (process reached ready state; Electron main logs confirmed window bootstrap)
- `grep -R "craft-agent\|CraftAgent\|Craft Agents" apps/desktop/ || true`

## Linear
Closes KAT-2085
Closes KAT-2086
Closes KAT-2087
Closes KAT-2088
Closes KAT-2089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Electron desktop app: chat UI, resizable split panes, persisted layout, secure preload API, CSP, and bundled styling.
  * Real-time streaming assistant responses with auto-scroll and incremental updates.
  * Tool execution view with collapsible details and formatted results.
  * Agent controls: send, stop, restart; crash detection with error banner and one-click restart; live bridge status.

* **Tests**
  * Added test suites covering event adaptation and subprocess bridge behavior.

* **Chores**
  * Added desktop dev/build scripts and TypeScript/Vite config for the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the `apps/desktop` Electron application — a new chat shell that spawns `kata --mode rpc` as a subprocess, streams JSONL events over a readline bridge, and renders a streaming chat UI with markdown rendering and tool-call cards. The architecture is well-layered (main → preload → renderer via `contextBridge`) and the `RpcEventAdapter` is cleanly designed with solid unit test coverage.

Three P1 issues need attention before merge:

- **Stop button is always disabled during streaming** (`MessageInput.tsx`): both the textarea and the Stop button share the same `disabled` prop (`isStreaming || !bridgeAvailable`). When the agent is actively streaming, `isStreaming=true` makes `disabled=true`, so the user has no way to abort an in-progress run.
- **Concurrent `start()` calls can spawn duplicate child processes** (`PiAgentBridge.start()`): the early-return guard is not idempotent under concurrent callers; a coalescing promise pattern is needed.
- **`sessionStop` IPC handler re-launches a crashed bridge** (`ipc.ts`): `bridge.abort()` → `bridge.send()` → `bridge.start()`, so invoking stop when the bridge is down unexpectedly spawns a new subprocess. A `state.running` guard on the handler is sufficient.

Smaller P2 items:
- `ErrorBanner` hardcodes \"Agent process crashed\" for all error conditions including non-crash `agent_error` events.
- `toolCallsAtom` is never cleared on `agent_start`, so tool calls from previous turns accumulate across restarts.
- `sandbox: false` in the main `BrowserWindow` reduces renderer-level process isolation; worth revisiting given that LLM-generated content is rendered via `rehype-raw`.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is — the Stop button is unconditionally disabled during streaming, making agent abort impossible from the UI.

Three P1 defects exist on the changed path: (1) the Stop button shares the same disabled condition as the text input, rendering it inoperable during streaming; (2) concurrent start() calls lack a coalescing guard; (3) the sessionStop IPC handler can unintentionally re-spawn a crashed bridge. All three are straightforward fixes but affect the primary user interaction loop. Architecture and event adapter quality are high, and the RpcEventAdapter has good test coverage.

apps/desktop/src/renderer/components/chat/MessageInput.tsx (Stop button disabled logic), apps/desktop/src/main/pi-agent-bridge.ts (concurrent start guard), apps/desktop/src/main/ipc.ts (sessionStop guard)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/MessageInput.tsx | Chat input and Stop button share the same disabled prop; when isStreaming=true both are disabled, making it impossible to abort a running agent. |
| apps/desktop/src/main/pi-agent-bridge.ts | Core bridge class spawning the kata RPC subprocess; contains a concurrent-start race condition and the lazy-start design causes abort/stop to unintentionally re-spawn the process. |
| apps/desktop/src/main/ipc.ts | Wires bridge events to IPC channels; sessionStop handler can inadvertently re-launch a crashed bridge via bridge.abort() → send() → start(). |
| apps/desktop/src/renderer/atoms/chat.ts | Jotai atoms handling all chat state; toolCallsAtom is never cleared on agent_start or restart, causing stale tool call UI across sessions. |
| apps/desktop/src/main/rpc-event-adapter.ts | Maps raw RPC events from the subprocess to typed ChatEvents; well-structured with thorough extraction helpers and good unit test coverage. |
| apps/desktop/src/renderer/components/chat/ErrorBanner.tsx | Crash/error banner component; title is hardcoded to "Agent process crashed" which misleadingly appears for non-crash agent_error events too. |
| apps/desktop/src/main/index.ts | Electron main entry; solid before-quit / window-all-closed lifecycle, but sandbox: false weakens renderer isolation for LLM-rendered HTML content. |
| apps/desktop/src/shared/types.ts | Clean shared type definitions for IPC channels, RPC commands, ChatEvent union, and DesktopApi; well-typed cross-process contract. |
| apps/desktop/src/preload/index.ts | Preload script exposing DesktopApi via contextBridge with correct listener cleanup patterns. |
| apps/desktop/src/renderer/components/chat/ChatPanel.tsx | Main chat panel wiring IPC subscriptions to Jotai atoms; propagates the shared disabled flag that inadvertently disables the Stop button during streaming. |
| apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts | Good unit test coverage of RpcEventAdapter covering lifecycle events, message streaming, tool execution, and error/malformed payload handling. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer (React/Jotai)
    participant P as Preload (contextBridge)
    participant I as Main: ipc.ts
    participant B as PiAgentBridge
    participant K as kata --mode rpc

    R->>P: window.api.sendMessage(text)
    P->>I: ipcRenderer.invoke("session:send", text)
    I->>B: bridge.prompt(message)
    B->>B: start() → spawn kata if needed
    B->>K: stdin write JSON {"type":"prompt","message":"..."}
    K-->>B: stdout JSONL events
    B-->>I: emit("rpc-event", event)
    I->>I: RpcEventAdapter.adapt(rpcEvent)
    I-->>P: webContents.send("session:events", chatEvent)
    P-->>R: listener(chatEvent) → applyChatEvent atom

    Note over B,K: On crash
    K-->>B: exit(code, signal)
    B-->>I: emit("crash", {...})
    B-->>I: emit("status", {state:"crashed"})
    I-->>P: send("session:events", subprocess_crash)
    I-->>P: send("session:bridge-status", crashed)
    P-->>R: errorAtom set, bridgeStatusAtom updated
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/index.ts`, line 245-251 ([link](https://github.com/gannonh/kata/blob/4e02dc20e65714baa728667016321f1f7ae63c5e/apps/desktop/src/main/index.ts#L245-L251)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`sandbox: false` weakens renderer process isolation**

   Disabling the sandbox (`sandbox: false`) means the renderer process runs without Chromium's process-level sandbox. While `contextIsolation: true` and `nodeIntegration: false` prevent direct Node.js access, the lack of OS-level sandboxing increases the blast radius of any XSS or renderer-side exploit (especially relevant since `StreamingMessage` renders assistant Markdown through `rehype-raw`, which allows raw HTML pass-through).

   If the preload script is the only reason `sandbox` is disabled, consider whether the Node.js APIs used there (`contextBridge`, `ipcRenderer`) can be satisfied with `sandbox: true` — they can in modern Electron. Enabling the sandbox would add a meaningful defence-in-depth layer for LLM-rendered content.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/index.ts
   Line: 245-251

   Comment:
   **`sandbox: false` weakens renderer process isolation**

   Disabling the sandbox (`sandbox: false`) means the renderer process runs without Chromium's process-level sandbox. While `contextIsolation: true` and `nodeIntegration: false` prevent direct Node.js access, the lack of OS-level sandboxing increases the blast radius of any XSS or renderer-side exploit (especially relevant since `StreamingMessage` renders assistant Markdown through `rehype-raw`, which allows raw HTML pass-through).

   If the preload script is the only reason `sandbox` is disabled, consider whether the Node.js APIs used there (`contextBridge`, `ipcRenderer`) can be satisfied with `sandbox: true` — they can in modern Electron. Enabling the sandbox would add a meaningful defence-in-depth layer for LLM-rendered content.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/MessageInput.tsx
Line: 48-53

Comment:
**Stop button disabled during streaming**

The `disabled` prop for both the textarea and the Stop button comes from the same `inputDisabled` expression (`isStreaming || !bridgeAvailable`). When the agent IS actively streaming, `isStreaming=true` → `inputDisabled=true` → the Stop button is disabled. This means the user has no way to abort an in-progress agent run.

The intent should be the inverse: disable the Stop button when there's **nothing to stop**, and keep it enabled when the agent is streaming.

```suggestion
          <button
            type="button"
            onClick={() => void onStop()}
            disabled={!isStreaming || !bridgeAvailable}
            className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-800 disabled:opacity-50"
          >
            Stop
          </button>
```

This requires `MessageInput` to receive (or derive) `isStreaming` separately from the `disabled` prop that controls the textarea. One approach is to split `disabled` into two props (`inputDisabled` and `stopDisabled`), or pass `isStreaming` directly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/pi-agent-bridge.ts
Line: 74-78

Comment:
**Concurrent `start()` calls may spawn multiple processes**

Because `send()` calls `await this.start()`, and `start()` is an `async` function, two concurrent `send()` calls can both pass the early-return guard simultaneously (before either has assigned `this.child`). The guard:

```ts
if (this.child && !this.child.killed && this.status === 'running') {
  return
}
```

is evaluated at the top of an `async` function. Two callers can enter `start()` before `this.child` is set, both pass the guard, and both `spawn()` a child process. The second child then clobbers `this.child`, leaving an orphaned subprocess with no exit listener.

Although `start()` has no internal `await` (so this is a narrower race than it looks), the correct safeguard is to store the in-flight start promise and return it to all callers:

```ts
private startPromise: Promise<void> | null = null

public async start(): Promise<void> {
  if (this.child && !this.child.killed && this.status === 'running') {
    return
  }
  if (this.startPromise) {
    return this.startPromise
  }
  this.startPromise = this._doStart().finally(() => {
    this.startPromise = null
  })
  return this.startPromise
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/ipc.ts
Line: 75-77

Comment:
**`sessionStop` re-launches the bridge if it is not running**

`bridge.abort()` delegates to `bridge.send({ type: 'abort' })`, which internally calls `bridge.start()`. If the bridge is currently crashed or shut down (`this.child === null`), calling `abort()` will **spawn a new child process** just to send an abort command to it — an unintended side effect of the lazy-start design.

While `inputDisabled` in the renderer normally prevents sending while the bridge is down, IPC is still invokable directly (e.g., rapid clicks, race on bridge status propagation). A guard is needed:

```ts
ipcMain.handle(IPC_CHANNELS.sessionStop, async () => {
  const state = bridge.getState()
  if (!state.running) {
    return
  }
  await bridge.abort()
})
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
Line: 9-11

Comment:
**Hardcoded "Agent process crashed" title shown for non-crash errors**

`ChatPanel` feeds `errorMessage` to `ErrorBanner` from two distinct sources: the `errorAtom` (which is set by `agent_error` events — normal runtime errors, not crashes) and `bridgeStatus.message` (which IS crash-related). Both result in the same "Agent process crashed" heading, which will be misleading for ordinary agent errors.

Consider accepting an optional `title` prop (defaulting to "Agent error") so that the crash case can pass a more specific title, or derive the title from the `bridgeStatus.state`:

```tsx
<p className="font-medium">{title ?? 'Agent error'}</p>
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/chat.ts
Line: 146-161

Comment:
**Tool calls accumulate across turns and survive agent restarts**

The `toolCallsAtom` is only modified (not cleared) by `tool_start`, `tool_update`, and `tool_end` events. There is no path that empties it on `agent_start`, `turn_start`, or bridge restart. After each restart the user sees all tool calls from every previous turn stacked in the "Tool calls" section, even though the restarted agent has no memory of them.

Consider resetting `toolCallsAtom` (and possibly `messagesAtom`) on `agent_start`:

```ts
case 'agent_start': {
  set(toolCallsAtom, [])
  return
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/index.ts
Line: 245-251

Comment:
**`sandbox: false` weakens renderer process isolation**

Disabling the sandbox (`sandbox: false`) means the renderer process runs without Chromium's process-level sandbox. While `contextIsolation: true` and `nodeIntegration: false` prevent direct Node.js access, the lack of OS-level sandboxing increases the blast radius of any XSS or renderer-side exploit (especially relevant since `StreamingMessage` renders assistant Markdown through `rehype-raw`, which allows raw HTML pass-through).

If the preload script is the only reason `sandbox` is disabled, consider whether the Node.js APIs used there (`contextBridge`, `ipcRenderer`) can be satisfied with `sandbox: true` — they can in modern Electron. Enabling the sandbox would add a meaningful defence-in-depth layer for LLM-rendered content.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): add split-pane shell and ..."](https://github.com/gannonh/kata/commit/4e02dc20e65714baa728667016321f1f7ae63c5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26943991)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->