### PR TITLE
CLI v0.15.1

### DIFF
--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -44,3 +44,6 @@ pkg/CHANGELOG.md
 
 # ── Kata baseline (auto-generated) ──
 dist/
+
+# ── Session exports ──
+kata-session-*.html

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.15.1
+
+### Bug Fixes
+
+- **Fix `/export` command failing with ENOENT** — The HTML export template (`template.html` and related assets) from `pi-coding-agent` was not being copied into `pkg/dist/core/export-html/` during build. Added `copy-export-html` build step so the export templates are included in published packages.
+- **Ignore exported session HTML files** — Added `kata-session-*.html` to `.gitignore` so session exports don't get committed.
+
 ## 0.15.0
 
 ### Features

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -30,9 +30,10 @@
     "node": ">=20.6.0"
   },
   "scripts": {
-    "build": "tsc && npm run copy-themes && npm run copy-changelog",
+    "build": "tsc && npm run copy-themes && npm run copy-export-html && npm run copy-changelog",
     "copy-changelog": "node -e \"require('fs').cpSync('CHANGELOG.md','pkg/CHANGELOG.md')\"",
     "copy-themes": "node -e \"const{mkdirSync,cpSync}=require('fs');const{resolve}=require('path');const candidates=[resolve(__dirname,'node_modules/@mariozechner/pi-coding-agent/dist/modes/interactive/theme'),resolve(__dirname,'..','..','node_modules/@mariozechner/pi-coding-agent/dist/modes/interactive/theme')];const src=candidates.find(p=>{try{require('fs').statSync(p);return true}catch{return false}});if(!src)throw new Error('theme dir not found');mkdirSync('pkg/dist/modes/interactive/theme',{recursive:true});cpSync(src,'pkg/dist/modes/interactive/theme',{recursive:true})\"",
+    "copy-export-html": "node -e \"const{mkdirSync,cpSync}=require('fs');const{resolve}=require('path');const candidates=[resolve(__dirname,'node_modules/@mariozechner/pi-coding-agent/dist/core/export-html'),resolve(__dirname,'..','..','node_modules/@mariozechner/pi-coding-agent/dist/core/export-html')];const src=candidates.find(p=>{try{require('fs').statSync(p);return true}catch{return false}});if(!src)throw new Error('export-html dir not found');mkdirSync('pkg/dist/core/export-html',{recursive:true});cpSync(src,'pkg/dist/core/export-html',{recursive:true})\"",
     "test": "bun test --path-ignore-patterns '**/*.vitest.test.ts' src/ && npx vitest run --coverage",
     "test:vitest": "npx vitest run",
     "test:coverage": "npx vitest run --coverage",


### PR DESCRIPTION
## CLI v0.15.1 — Patch Release

### Bug Fixes

- **Fix `/export` command failing with ENOENT** — The HTML export template (`template.html` and related assets) from `pi-coding-agent` was not being copied into `pkg/dist/core/export-html/` during build. Added `copy-export-html` build step so the export templates are included in published packages.
- **Ignore exported session HTML files** — Added `kata-session-*.html` to `.gitignore` so session exports don't get committed.

### Changes

- `apps/cli/package.json` — Added `copy-export-html` script, hooked into `build`, version bumped to `0.15.1`
- `apps/cli/.gitignore` — Added `kata-session-*.html`
- `apps/cli/CHANGELOG.md` — Added `0.15.1` entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Desktop application with chat messaging interface
- Real-time message streaming and agent response display
- Tool execution tracking with detailed results and error visualization
- Agent control functionality (stop and restart)
- Persistent window layout preservation
- Bridge status monitoring with lifecycle updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers two distinct changes: a focused CLI patch (v0.15.1) that fixes the `/export` command's `ENOENT` crash by adding a `copy-export-html` build step, and a brand-new `apps/desktop` Electron application — a React 19 + Jotai + Tailwind v4 chat shell that wraps the `kata --mode rpc` subprocess via a `PiAgentBridge` class.

**Key changes:**
- `apps/cli/package.json`: `copy-export-html` script added to the build pipeline, correctly mirroring the existing `copy-themes` path-resolution pattern. Version bumped to `0.15.1`.
- `apps/cli/.gitignore`: `kata-session-*.html` added to prevent accidental commits of exported sessions.
- `apps/desktop/`: Entire new Electron app scaffolded — main process (`PiAgentBridge`, IPC layer, preload), renderer (Jotai atoms, React components), shared types, tests, build config, and lockfile entries.
- **P1 bug found**: `PiAgentBridge` is instantiated in `apps/desktop/src/main/index.ts` but `bridge.start()` is never called. Because `ChatPanel` disables the input when `bridgeStatus.state !== 'running'`, and the `ErrorBanner` restart button only appears when there is an active error message, there is no UI path to transition the bridge out of its initial `shutdown` state. The desktop app is non-functional on first launch until `bridge.start()` is called (e.g. right after `registerSessionIpc()`).
- **P2 note**: `sandbox: false` is set in `BrowserWindow.webPreferences`; with `contextIsolation: true` the contextual boundary is intact, but OS-level sandbox is disabled — worth an explicit comment or justification in the codebase.

<h3>Confidence Score: 4/5</h3>

CLI patch is safe to merge; the new desktop app has a P1 bug that makes it non-functional on first launch.

The CLI v0.15.1 changes are minimal and correct. The desktop app is a large new addition with one confirmed P1 defect: `bridge.start()` is never called, so `bridgeStatus.state` stays `shutdown` permanently, the message input remains disabled, and no restart button is shown — the app cannot be used. This needs to be fixed before the desktop module is functional.

apps/desktop/src/main/index.ts — missing `bridge.start()` call makes the desktop app non-functional on first launch.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/index.ts | Electron main entry: bridge is created but never started, making the app unusable on first launch (P1 bug). Also uses `sandbox: false`. |
| apps/desktop/src/main/pi-agent-bridge.ts | Well-structured subprocess lifecycle manager with correct coalescing of concurrent `start()` calls, graceful shutdown with SIGTERM→SIGKILL escalation, and sensitive token redaction in stderr. |
| apps/desktop/src/main/ipc.ts | IPC handlers for session lifecycle are correctly implemented; existing handlers are removed before re-registration, and destroyed-window checks guard all renderer sends. |
| apps/desktop/src/main/rpc-event-adapter.ts | Robust RPC-to-ChatEvent translation layer with good defensive extraction helpers and malformed-payload handling. |
| apps/desktop/src/renderer/atoms/chat.ts | Jotai atoms correctly model full chat lifecycle; tool-call state and streaming flags are properly reset on new turns. |
| apps/desktop/src/renderer/components/chat/ChatPanel.tsx | Chat panel subscribes to bridge events and renders correctly; input disabled state is logically correct but depends on the bridge being started (see index.ts P1 bug). |
| apps/cli/package.json | Version bumped to 0.15.1; `copy-export-html` build step added with the same two-candidate path resolution pattern as `copy-themes` — correctly fixes the ENOENT regression. |
| apps/desktop/src/shared/types.ts | Shared IPC contracts and event types are well-typed; `DesktopApi` cleanly exposes the renderer-facing surface via `contextBridge`. |
| apps/desktop/src/preload/index.ts | Preload correctly uses `contextBridge.exposeInMainWorld`; listener unsubscribe functions are returned for cleanup. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as Electron Main
    participant Bridge as PiAgentBridge
    participant IPC as ipc.ts
    participant Preload as Preload
    participant Renderer as Renderer (ChatPanel)

    Main->>Bridge: new PiAgentBridge(workspacePath)
    Main->>IPC: registerSessionIpc({ bridge, window })
    Note over IPC: Sends initial 'shutdown' status to renderer
    Note over Main: bridge.start() never called here

    Renderer->>Preload: window.api.getBridgeState()
    Preload->>IPC: ipcRenderer.invoke('session:get-bridge-state')
    IPC-->>Renderer: { status: 'shutdown' }
    Note over Renderer: inputDisabled = true (bridge not 'running')<br/>ErrorBanner hidden (no error message)<br/>No way to start bridge from UI

    Note over Main,Renderer: With bridge.start() fix

    Main->>Bridge: bridge.start()
    Bridge->>Bridge: resolveCommand() then spawn kata --mode rpc
    Bridge-->>IPC: emit('status', { state: 'spawning' })
    IPC-->>Renderer: session:bridge-status state=spawning
    Bridge-->>IPC: emit('status', { state: 'running' })
    IPC-->>Renderer: session:bridge-status state=running
    Note over Renderer: inputDisabled = false, ready to send

    Renderer->>Preload: window.api.sendMessage(text)
    Preload->>IPC: invoke('session:send', text)
    IPC->>Bridge: bridge.prompt(text)
    Bridge->>Bridge: stdin.write(JSON payload)
    Bridge-->>IPC: emit('rpc-event', event)
    IPC-->>Renderer: session:events ChatEvent
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/main/index.ts`, line 37-54 ([link](https://github.com/gannonh/kata/blob/a36144798e771d85fbb7991c932ca8894983c31c/apps/desktop/src/main/index.ts#L37-L54)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Bridge never started — desktop app is unusable on first launch**

   `new PiAgentBridge(workspacePath)` creates the bridge but never calls `bridge.start()`. The renderer's `bridgeStatusAtom` initialises with `state: 'shutdown'`, and `ChatPanel.tsx` computes:

   ```ts
   const bridgeAvailable = bridgeStatus.state === 'running'
   const inputDisabled = isStreaming || !bridgeAvailable
   ```

   Because the bridge never transitions out of `shutdown`, the message input stays disabled indefinitely. The `ErrorBanner` (which holds the only "Restart" button) only renders when `errorMessage !== null`, but on a clean first launch both `error` and `bridgeStatus.message` are `null`. There is no UI path to start the bridge.

   The fix is to start the bridge after registering IPC (so the status events are captured and forwarded to the renderer):

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/index.ts
   Line: 37-54

   Comment:
   **Bridge never started — desktop app is unusable on first launch**

   `new PiAgentBridge(workspacePath)` creates the bridge but never calls `bridge.start()`. The renderer's `bridgeStatusAtom` initialises with `state: 'shutdown'`, and `ChatPanel.tsx` computes:

   ```ts
   const bridgeAvailable = bridgeStatus.state === 'running'
   const inputDisabled = isStreaming || !bridgeAvailable
   ```

   Because the bridge never transitions out of `shutdown`, the message input stays disabled indefinitely. The `ErrorBanner` (which holds the only "Restart" button) only renders when `errorMessage !== null`, but on a clean first launch both `error` and `bridgeStatus.message` are `null`. There is no UI path to start the bridge.

   The fix is to start the bridge after registering IPC (so the status events are captured and forwarded to the renderer):

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/desktop/src/main/index.ts`, line 22 ([link](https://github.com/gannonh/kata/blob/a36144798e771d85fbb7991c932ca8894983c31c/apps/desktop/src/main/index.ts#L22)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`sandbox: false` weakens process isolation**

   With `sandbox: false`, the renderer process runs without the Chromium sandbox (OS-level process isolation), even though `contextIsolation: true` and `nodeIntegration: false` are set. An XSS or malicious content in the renderer could exploit OS-level capabilities that the sandbox would otherwise block.

   If the preload script requires Node.js APIs (e.g. `require`), consider keeping `sandbox: false` but documenting the trade-off explicitly, or migrating the preload to avoid the need for it. If it is not required, consider removing this option or switching to `sandbox: true`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/index.ts
   Line: 22

   Comment:
   **`sandbox: false` weakens process isolation**

   With `sandbox: false`, the renderer process runs without the Chromium sandbox (OS-level process isolation), even though `contextIsolation: true` and `nodeIntegration: false` are set. An XSS or malicious content in the renderer could exploit OS-level capabilities that the sandbox would otherwise block.

   If the preload script requires Node.js APIs (e.g. `require`), consider keeping `sandbox: false` but documenting the trade-off explicitly, or migrating the preload to avoid the need for it. If it is not required, consider removing this option or switching to `sandbox: true`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/index.ts
Line: 37-54

Comment:
**Bridge never started — desktop app is unusable on first launch**

`new PiAgentBridge(workspacePath)` creates the bridge but never calls `bridge.start()`. The renderer's `bridgeStatusAtom` initialises with `state: 'shutdown'`, and `ChatPanel.tsx` computes:

```ts
const bridgeAvailable = bridgeStatus.state === 'running'
const inputDisabled = isStreaming || !bridgeAvailable
```

Because the bridge never transitions out of `shutdown`, the message input stays disabled indefinitely. The `ErrorBanner` (which holds the only "Restart" button) only renders when `errorMessage !== null`, but on a clean first launch both `error` and `bridgeStatus.message` are `null`. There is no UI path to start the bridge.

The fix is to start the bridge after registering IPC (so the status events are captured and forwarded to the renderer):

```suggestion
  unregisterSessionIpc = registerSessionIpc({ bridge, window: mainWindow })

  void bridge.start().catch((error: unknown) => {
    log.error('[desktop-main] bridge failed to start', error)
  })

  mainWindow.on('closed', () => {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/index.ts
Line: 22

Comment:
**`sandbox: false` weakens process isolation**

With `sandbox: false`, the renderer process runs without the Chromium sandbox (OS-level process isolation), even though `contextIsolation: true` and `nodeIntegration: false` are set. An XSS or malicious content in the renderer could exploit OS-level capabilities that the sandbox would otherwise block.

If the preload script requires Node.js APIs (e.g. `require`), consider keeping `sandbox: false` but documenting the trade-off explicitly, or migrating the preload to avoid the need for it. If it is not required, consider removing this option or switching to `sandbox: true`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump cli to 0.15.1"](https://github.com/gannonh/kata/commit/a36144798e771d85fbb7991c932ca8894983c31c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26956354)</sub>

<!-- /greptile_comment -->