### PR TITLE
feat(desktop): implement S03 multi-provider auth, onboarding, and model selection

### DIFF
--- a/apps/desktop/src/main/__tests__/auth-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/auth-bridge.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { AuthBridge } from '../auth-bridge'
+
+const originalFetch = globalThis.fetch
+
+describe('AuthBridge', () => {
+  let tempDir: string
+  let authFilePath: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'kata-desktop-auth-bridge-'))
+    authFilePath = path.join(tempDir, 'auth.json')
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test('returns missing provider status when auth file does not exist', async () => {
+    const bridge = new AuthBridge(authFilePath)
+
+    const response = await bridge.getProviders()
+
+    expect(response.success).toBe(true)
+    expect(response.providers.openai.status).toBe('missing')
+    expect(response.providers.anthropic.status).toBe('missing')
+  })
+
+  test('validates and saves provider keys with masking', async () => {
+    globalThis.fetch = (async () => new Response('{}', { status: 200 })) as unknown as typeof fetch
+
+    const bridge = new AuthBridge(authFilePath)
+    const result = await bridge.setProviderKey('openai', 'sk-test-1234567890')
+
+    expect(result.success).toBe(true)
+    expect(result.providerInfo?.status).toBe('valid')
+    expect(result.providerInfo?.maskedKey).toBe('••••7890')
+
+    const file = await fs.readFile(authFilePath, 'utf8')
+    expect(file).toContain('"openai"')
+    expect(file).toContain('"type": "api_key"')
+
+    const providers = await bridge.getProviders()
+    expect(providers.providers.openai.status).toBe('valid')
+    expect(providers.providers.openai.maskedKey).toBe('••••7890')
+  })
+
+  test('returns structured validation errors for invalid keys', async () => {
+    globalThis.fetch = (async () => new Response('{}', { status: 401 })) as unknown as typeof fetch
+
+    const bridge = new AuthBridge(authFilePath)
+    const result = await bridge.setProviderKey('openai', 'sk-invalid')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Invalid OpenAI API key')
+
+    const exists = await fs
+      .access(authFilePath)
+      .then(() => true)
+      .catch(() => false)
+
+    expect(exists).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/auth-bridge.ts
+++ b/apps/desktop/src/main/auth-bridge.ts
@@ -1,0 +1,401 @@
+import { promises as fs } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import log from './logger'
+import {
+  ALL_AUTH_PROVIDERS,
+  type AuthProvider,
+  type AuthProvidersResponse,
+  type AuthRecord,
+  type AuthRecordEntry,
+  type AuthSetKeyResponse,
+  type AuthRemoveKeyResponse,
+  type AuthValidationResult,
+  type ProviderInfo,
+  type ProviderStatusMap,
+} from '../shared/types'
+
+const DEFAULT_AUTH_PATH = path.join(homedir(), '.kata-cli', 'agent', 'auth.json')
+
+interface ValidationConfig {
+  url: (key: string) => string
+  init: (key: string) => RequestInit
+  validStatusCodes: Set<number>
+  invalidStatusCodes: Set<number>
+  invalidMessage: string
+}
+
+const VALIDATION_TIMEOUT_MS = 10_000
+
+const PROVIDER_VALIDATION_CONFIG: Partial<Record<AuthProvider, ValidationConfig>> = {
+  anthropic: {
+    url: () => 'https://api.anthropic.com/v1/messages',
+    init: (key) => ({
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': key,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({}),
+    }),
+    validStatusCodes: new Set([200, 400, 429]),
+    invalidStatusCodes: new Set([401, 403]),
+    invalidMessage: 'Invalid Anthropic API key',
+  },
+  openai: {
+    url: () => 'https://api.openai.com/v1/models',
+    init: (key) => ({
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${key}`,
+      },
+    }),
+    validStatusCodes: new Set([200, 429]),
+    invalidStatusCodes: new Set([401, 403]),
+    invalidMessage: 'Invalid OpenAI API key',
+  },
+  google: {
+    url: (key) => `https://generativelanguage.googleapis.com/v1/models?key=${encodeURIComponent(key)}`,
+    init: () => ({
+      method: 'GET',
+    }),
+    validStatusCodes: new Set([200, 429]),
+    invalidStatusCodes: new Set([400, 401, 403]),
+    invalidMessage: 'Invalid Google API key',
+  },
+  mistral: {
+    url: () => 'https://api.mistral.ai/v1/models',
+    init: (key) => ({
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${key}`,
+      },
+    }),
+    validStatusCodes: new Set([200, 429]),
+    invalidStatusCodes: new Set([401, 403]),
+    invalidMessage: 'Invalid Mistral API key',
+  },
+}
+
+const UNSUPPORTED_PROVIDER_MESSAGES: Partial<Record<AuthProvider, string>> = {
+  bedrock: 'AWS Bedrock validation requires AWS credentials and region configuration',
+  azure: 'Azure validation requires both API key and Azure endpoint configuration',
+}
+
+export class AuthBridge {
+  constructor(private readonly authFilePath = DEFAULT_AUTH_PATH) {}
+
+  public async getProviders(): Promise<AuthProvidersResponse> {
+    try {
+      const auth = await this.readAuthFile()
+      const providers = this.toProviderStatusMap(auth)
+
+      log.info('[auth-bridge] auth:read', {
+        path: this.authFilePath,
+        success: true,
+      })
+
+      return {
+        success: true,
+        providers,
+      }
+    } catch (error) {
+      const message = this.toErrorMessage(error)
+      log.error('[auth-bridge] auth:read', {
+        path: this.authFilePath,
+        success: false,
+        error: message,
+      })
+
+      return {
+        success: false,
+        providers: this.emptyProviderStatusMap(),
+        error: `Unable to load credentials from ${this.authFilePath}: ${message}`,
+      }
+    }
+  }
+
+  public async validateKey(provider: AuthProvider, key: string): Promise<AuthValidationResult> {
+    const trimmedKey = key.trim()
+    if (!trimmedKey) {
+      return {
+        valid: false,
+        error: 'API key is required',
+      }
+    }
+
+    const unsupportedMessage = UNSUPPORTED_PROVIDER_MESSAGES[provider]
+    if (unsupportedMessage) {
+      log.info('[auth-bridge] auth:validate', {
+        provider,
+        success: false,
+        reason: 'unsupported-provider-validation',
+      })
+      return {
+        valid: false,
+        error: unsupportedMessage,
+      }
+    }
+
+    const config = PROVIDER_VALIDATION_CONFIG[provider]
+    if (!config) {
+      return {
+        valid: false,
+        error: `Unsupported provider: ${provider}`,
+      }
+    }
+
+    const abortController = new AbortController()
+    const timeout = setTimeout(() => abortController.abort(), VALIDATION_TIMEOUT_MS)
+
+    try {
+      const response = await fetch(config.url(trimmedKey), {
+        ...config.init(trimmedKey),
+        signal: abortController.signal,
+      })
+
+      if (config.validStatusCodes.has(response.status)) {
+        log.info('[auth-bridge] auth:validate', {
+          provider,
+          success: true,
+          status: response.status,
+        })
+        return { valid: true }
+      }
+
+      if (config.invalidStatusCodes.has(response.status)) {
+        log.info('[auth-bridge] auth:validate', {
+          provider,
+          success: false,
+          status: response.status,
+        })
+        return {
+          valid: false,
+          error: config.invalidMessage,
+        }
+      }
+
+      log.warn('[auth-bridge] auth:validate unexpected status', {
+        provider,
+        status: response.status,
+      })
+      return {
+        valid: false,
+        error: `Validation request failed with status ${response.status}`,
+      }
+    } catch (error) {
+      const message = this.toErrorMessage(error)
+      log.error('[auth-bridge] auth:validate', {
+        provider,
+        success: false,
+        error: message,
+      })
+      return {
+        valid: false,
+        error: `Unable to validate ${provider} key: ${message}`,
+      }
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  public async setProviderKey(provider: AuthProvider, key: string): Promise<AuthSetKeyResponse> {
+    const validation = await this.validateKey(provider, key)
+    if (!validation.valid) {
+      return {
+        success: false,
+        provider,
+        error: validation.error ?? 'Invalid API key',
+      }
+    }
+
+    const trimmedKey = key.trim()
+
+    try {
+      const auth = await this.readAuthFile()
+      auth[provider] = {
+        type: 'api_key',
+        key: trimmedKey,
+      }
+
+      await this.writeAuthFile(auth)
+
+      const providerInfo = this.toProviderInfo(provider, auth[provider])
+
+      log.info('[auth-bridge] auth:write', {
+        provider,
+        success: true,
+        operation: 'set',
+      })
+
+      return {
+        success: true,
+        provider,
+        providerInfo,
+      }
+    } catch (error) {
+      const message = this.toErrorMessage(error)
+      log.error('[auth-bridge] auth:write', {
+        provider,
+        success: false,
+        operation: 'set',
+        error: message,
+      })
+      return {
+        success: false,
+        provider,
+        error: `Unable to save ${provider} credentials: ${message}`,
+      }
+    }
+  }
+
+  public async removeProviderKey(provider: AuthProvider): Promise<AuthRemoveKeyResponse> {
+    try {
+      const auth = await this.readAuthFile()
+      delete auth[provider]
+      await this.writeAuthFile(auth)
+
+      log.info('[auth-bridge] auth:write', {
+        provider,
+        success: true,
+        operation: 'remove',
+      })
+
+      return {
+        success: true,
+        provider,
+        providerInfo: this.toProviderInfo(provider, undefined),
+      }
+    } catch (error) {
+      const message = this.toErrorMessage(error)
+      log.error('[auth-bridge] auth:write', {
+        provider,
+        success: false,
+        operation: 'remove',
+        error: message,
+      })
+      return {
+        success: false,
+        provider,
+        error: `Unable to remove ${provider} credentials: ${message}`,
+      }
+    }
+  }
+
+  private async readAuthFile(): Promise<AuthRecord> {
+    try {
+      const content = await fs.readFile(this.authFilePath, 'utf8')
+      if (!content.trim()) {
+        return {}
+      }
+
+      const parsed = JSON.parse(content) as AuthRecord
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('auth.json must contain a JSON object')
+      }
+
+      return parsed
+    } catch (error) {
+      if (this.isFileNotFoundError(error)) {
+        return {}
+      }
+
+      throw error
+    }
+  }
+
+  private async writeAuthFile(auth: AuthRecord): Promise<void> {
+    const directory = path.dirname(this.authFilePath)
+    await fs.mkdir(directory, { recursive: true })
+
+    const tempPath = path.join(
+      directory,
+      `${path.basename(this.authFilePath)}.${process.pid}.${Date.now()}.tmp`,
+    )
+
+    const serialized = `${JSON.stringify(auth, null, 2)}\n`
+    await fs.writeFile(tempPath, serialized, { mode: 0o600 })
+    await fs.rename(tempPath, this.authFilePath)
+  }
+
+  private toProviderStatusMap(auth: AuthRecord): ProviderStatusMap {
+    const entries = ALL_AUTH_PROVIDERS.map((provider) => [
+      provider,
+      this.toProviderInfo(provider, auth[provider]),
+    ])
+
+    return Object.fromEntries(entries) as ProviderStatusMap
+  }
+
+  private emptyProviderStatusMap(): ProviderStatusMap {
+    const entries = ALL_AUTH_PROVIDERS.map((provider) => [
+      provider,
+      this.toProviderInfo(provider, undefined),
+    ])
+
+    return Object.fromEntries(entries) as ProviderStatusMap
+  }
+
+  private toProviderInfo(provider: AuthProvider, record: AuthRecordEntry | undefined): ProviderInfo {
+    if (!record) {
+      return {
+        provider,
+        status: 'missing',
+      }
+    }
+
+    if (record.type === 'api_key') {
+      return {
+        provider,
+        authType: 'api_key',
+        status: record.key ? 'valid' : 'missing',
+        maskedKey: this.maskKey(record.key),
+      }
+    }
+
+    if (record.type === 'oauth') {
+      const expiresAt = record.expires ? Number(record.expires) : null
+      const isExpired = Number.isFinite(expiresAt) && expiresAt !== null && expiresAt <= Date.now()
+
+      return {
+        provider,
+        authType: 'oauth',
+        status: isExpired ? 'expired' : 'valid',
+        maskedKey: this.maskKey(record.access),
+      }
+    }
+
+    return {
+      provider,
+      status: 'invalid',
+    }
+  }
+
+  private maskKey(value: string | undefined): string | undefined {
+    if (!value) {
+      return undefined
+    }
+
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return undefined
+    }
+
+    const suffix = trimmed.slice(-4)
+    return `••••${suffix}`
+  }
+
+  private isFileNotFoundError(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: string }).code === 'ENOENT'
+    )
+  }
+
+  private toErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error)
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,8 +1,13 @@
+import { promises as fs } from 'node:fs'
+import { homedir } from 'node:os'
 import path from 'node:path'
 import { app, BrowserWindow } from 'electron'
+import { AuthBridge } from './auth-bridge'
 import log from './logger'
 import { PiAgentBridge } from './pi-agent-bridge'
 import { registerSessionIpc } from './ipc'
+
+const SETTINGS_PATH = path.join(homedir(), '.kata-cli', 'agent', 'settings.json')
 
 let mainWindow: BrowserWindow | null = null
 let bridge: PiAgentBridge | null = null
@@ -34,13 +39,82 @@ function createWindow(): BrowserWindow {
   return window
 }
 
-app.whenReady().then(() => {
-  const workspacePath = process.env.KATA_WORKSPACE_PATH || process.cwd()
+async function loadPersistedModel(): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(SETTINGS_PATH, 'utf8')
+    if (!raw.trim()) {
+      return null
+    }
 
-  bridge = new PiAgentBridge(workspacePath)
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const model = parsed.model
+    return typeof model === 'string' && model.trim() ? model.trim() : null
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: string }).code === 'ENOENT') {
+      return null
+    }
+
+    log.warn('[desktop-main] failed to read settings model', {
+      path: SETTINGS_PATH,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+async function persistSelectedModel(model: string): Promise<void> {
+  const trimmedModel = model.trim()
+  if (!trimmedModel) {
+    return
+  }
+
+  const settingsDir = path.dirname(SETTINGS_PATH)
+  await fs.mkdir(settingsDir, { recursive: true })
+
+  let current: Record<string, unknown> = {}
+  try {
+    const raw = await fs.readFile(SETTINGS_PATH, 'utf8')
+    if (raw.trim()) {
+      const parsed = JSON.parse(raw)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        current = parsed as Record<string, unknown>
+      }
+    }
+  } catch (error) {
+    if (!(typeof error === 'object' && error !== null && 'code' in error && (error as { code?: string }).code === 'ENOENT')) {
+      throw error
+    }
+  }
+
+  const next = {
+    ...current,
+    model: trimmedModel,
+  }
+
+  const tempPath = `${SETTINGS_PATH}.${process.pid}.${Date.now()}.tmp`
+  await fs.writeFile(tempPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 })
+  await fs.rename(tempPath, SETTINGS_PATH)
+
+  log.info('[desktop-main] persisted model preference', {
+    model: trimmedModel,
+    path: SETTINGS_PATH,
+  })
+}
+
+app.whenReady().then(async () => {
+  const workspacePath = process.env.KATA_WORKSPACE_PATH || process.cwd()
+  const persistedModel = await loadPersistedModel()
+
+  bridge = new PiAgentBridge(workspacePath, 'kata', 30_000, persistedModel)
+  const authBridge = new AuthBridge()
   mainWindow = createWindow()
 
-  unregisterSessionIpc = registerSessionIpc({ bridge, window: mainWindow })
+  unregisterSessionIpc = registerSessionIpc({
+    bridge,
+    authBridge,
+    window: mainWindow,
+    onModelSelected: persistSelectedModel,
+  })
 
   mainWindow.on('closed', () => {
     unregisterSessionIpc?.()
@@ -50,6 +124,7 @@ app.whenReady().then(() => {
 
   log.info('[desktop-main] ready', {
     workspacePath,
+    model: persistedModel,
   })
 })
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -158,8 +158,17 @@ export function registerSessionIpc({
 
     try {
       await bridge.setModel(model)
+
       if (onModelSelected) {
-        await onModelSelected(model)
+        try {
+          await onModelSelected(model)
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          log.warn('[desktop-ipc] model persistence failed after runtime switch', {
+            model,
+            error: message,
+          })
+        }
       }
 
       log.info('[desktop-ipc] model switch', {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,15 +1,34 @@
 import { ipcMain, type BrowserWindow } from 'electron'
 import log from './logger'
+import { AuthBridge } from './auth-bridge'
 import { PiAgentBridge } from './pi-agent-bridge'
 import { RpcEventAdapter } from './rpc-event-adapter'
-import { IPC_CHANNELS, type BridgeStatusEvent, type ChatEvent } from '../shared/types'
+import {
+  IPC_CHANNELS,
+  type AuthProvider,
+  type BridgeStatusEvent,
+  type ChatEvent,
+  type AvailableModelsResponse,
+  type SetModelResponse,
+  type AuthProvidersResponse,
+  type AuthSetKeyResponse,
+  type AuthRemoveKeyResponse,
+  type AuthValidationResult,
+} from '../shared/types'
 
 interface RegisterIpcOptions {
   bridge: PiAgentBridge
+  authBridge: AuthBridge
   window: BrowserWindow
+  onModelSelected?: (model: string) => Promise<void> | void
 }
 
-export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () => void {
+export function registerSessionIpc({
+  bridge,
+  authBridge,
+  window,
+  onModelSelected,
+}: RegisterIpcOptions): () => void {
   const adapter = new RpcEventAdapter()
 
   const canSendToRenderer = (): boolean => !window.isDestroyed() && !window.webContents.isDestroyed()
@@ -76,6 +95,12 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () =
   ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
   ipcMain.removeHandler(IPC_CHANNELS.sessionRestart)
   ipcMain.removeHandler(IPC_CHANNELS.sessionGetBridgeState)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionGetAvailableModels)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionSetModel)
+  ipcMain.removeHandler(IPC_CHANNELS.authGetProviders)
+  ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
+  ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)
+  ipcMain.removeHandler(IPC_CHANNELS.authValidateKey)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -106,6 +131,109 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () =
 
   ipcMain.handle(IPC_CHANNELS.sessionGetBridgeState, async () => bridge.getState())
 
+  ipcMain.handle(IPC_CHANNELS.sessionGetAvailableModels, async (): Promise<AvailableModelsResponse> => {
+    try {
+      const models = await bridge.getAvailableModels()
+      return {
+        success: true,
+        models,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return {
+        success: false,
+        models: [],
+        error: message,
+      }
+    }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.sessionSetModel, async (_event, model: string): Promise<SetModelResponse> => {
+    if (!model?.trim()) {
+      return {
+        success: false,
+        error: 'Model is required',
+      }
+    }
+
+    try {
+      await bridge.setModel(model)
+      if (onModelSelected) {
+        await onModelSelected(model)
+      }
+
+      log.info('[desktop-ipc] model switch', {
+        model,
+      })
+
+      return {
+        success: true,
+        model,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      log.error('[desktop-ipc] model switch failed', {
+        model,
+        error: message,
+      })
+      return {
+        success: false,
+        error: message,
+      }
+    }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.authGetProviders, async (): Promise<AuthProvidersResponse> => {
+    return authBridge.getProviders()
+  })
+
+  ipcMain.handle(
+    IPC_CHANNELS.authSetKey,
+    async (_event, provider: AuthProvider, key: string): Promise<AuthSetKeyResponse> => {
+      try {
+        return await authBridge.setProviderKey(provider, key)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          success: false,
+          provider,
+          error: message,
+        }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.authRemoveKey,
+    async (_event, provider: AuthProvider): Promise<AuthRemoveKeyResponse> => {
+      try {
+        return await authBridge.removeProviderKey(provider)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          success: false,
+          provider,
+          error: message,
+        }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.authValidateKey,
+    async (_event, provider: AuthProvider, key: string): Promise<AuthValidationResult> => {
+      try {
+        return await authBridge.validateKey(provider, key)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          valid: false,
+          error: message,
+        }
+      }
+    },
+  )
+
   return () => {
     bridge.off('rpc-event', onRpcEvent)
     bridge.off('status', onStatus)
@@ -116,5 +244,11 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () =
     ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
     ipcMain.removeHandler(IPC_CHANNELS.sessionRestart)
     ipcMain.removeHandler(IPC_CHANNELS.sessionGetBridgeState)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionGetAvailableModels)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionSetModel)
+    ipcMain.removeHandler(IPC_CHANNELS.authGetProviders)
+    ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
+    ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)
+    ipcMain.removeHandler(IPC_CHANNELS.authValidateKey)
   }
 }

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -74,6 +74,7 @@ export class PiAgentBridge extends EventEmitter {
       pid: this.child?.pid ?? null,
       command: this.resolvedCommand,
       status: this.status,
+      selectedModel: this.selectedModel,
     }
   }
 

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -3,6 +3,7 @@ import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:chil
 import readline from 'node:readline'
 import log from './logger'
 import {
+  type AvailableModel,
   type BridgeLifecycleState,
   type BridgeState,
   type BridgeStatusEvent,
@@ -47,13 +48,16 @@ export class PiAgentBridge extends EventEmitter {
   private resolvedCommand: string | null = null
   private status: BridgeLifecycleState = 'shutdown'
   private startPromise: Promise<void> | null = null
+  private selectedModel: string | null
 
   constructor(
     private readonly workspacePath: string,
     private readonly commandHint = 'kata',
     private readonly commandTimeoutMs = 30_000,
+    initialModel: string | null = null,
   ) {
     super()
+    this.selectedModel = initialModel?.trim() ? initialModel.trim() : null
   }
 
   override on<K extends keyof BridgeEvents>(event: K, listener: BridgeEvents[K]): this {
@@ -104,6 +108,9 @@ export class PiAgentBridge extends EventEmitter {
     })
 
     const args = ['--mode', 'rpc', '--cwd', this.workspacePath]
+    if (this.selectedModel) {
+      args.push('--model', this.selectedModel)
+    }
     const child = spawn(command, args, {
       cwd: this.workspacePath,
       env: process.env,
@@ -282,6 +289,52 @@ export class PiAgentBridge extends EventEmitter {
 
   public abort(): Promise<CommandResult> {
     return this.send({ type: 'abort' })
+  }
+
+  public async getAvailableModels(): Promise<AvailableModel[]> {
+    const result = await this.send({ type: 'get_available_models' })
+    const payload = result.data
+
+    if (!Array.isArray(payload)) {
+      return []
+    }
+
+    const models: AvailableModel[] = []
+
+    for (const entry of payload) {
+      if (!entry || typeof entry !== 'object') {
+        continue
+      }
+
+      const candidate = entry as Partial<AvailableModel>
+      if (typeof candidate.provider !== 'string' || typeof candidate.id !== 'string') {
+        continue
+      }
+
+      models.push({
+        provider: candidate.provider,
+        id: candidate.id,
+        contextWindow:
+          typeof candidate.contextWindow === 'number' ? candidate.contextWindow : undefined,
+        reasoning: typeof candidate.reasoning === 'boolean' ? candidate.reasoning : undefined,
+      })
+    }
+
+    return models
+  }
+
+  public async setModel(model: string): Promise<void> {
+    const trimmed = model.trim()
+    if (!trimmed) {
+      throw new Error('Model is required')
+    }
+
+    await this.send({ type: 'set_model', model: trimmed })
+    this.selectedModel = trimmed
+  }
+
+  public getSelectedModel(): string | null {
+    return this.selectedModel
   }
 
   public async restart(): Promise<void> {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import {
   IPC_CHANNELS,
+  type AuthProvider,
   type BridgeStatusEvent,
   type ChatEvent,
   type DesktopApi,
@@ -40,6 +41,26 @@ const api: DesktopApi = {
   },
   getBridgeState: async () => {
     return ipcRenderer.invoke(IPC_CHANNELS.sessionGetBridgeState)
+  },
+  getAvailableModels: async () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.sessionGetAvailableModels)
+  },
+  setModel: async (model: string) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.sessionSetModel, model)
+  },
+  auth: {
+    getProviders: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.authGetProviders)
+    },
+    setKey: async (provider: AuthProvider, key: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.authSetKey, provider, key)
+    },
+    removeKey: async (provider: AuthProvider) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.authRemoveKey, provider)
+    },
+    validateKey: async (provider: AuthProvider, key: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.authValidateKey, provider, key)
+    },
   },
 }
 

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,5 +1,15 @@
+import { useAtomValue } from 'jotai'
+import { onboardingCompleteAtom } from './atoms/onboarding'
 import { AppShell } from './components/app-shell/AppShell'
+import { OnboardingWizard } from './components/onboarding/OnboardingWizard'
 
 export default function App() {
-  return <AppShell />
+  const onboardingComplete = useAtomValue(onboardingCompleteAtom)
+
+  return (
+    <>
+      <AppShell />
+      {!onboardingComplete && <OnboardingWizard />}
+    </>
+  )
 }

--- a/apps/desktop/src/renderer/atoms/model.ts
+++ b/apps/desktop/src/renderer/atoms/model.ts
@@ -1,0 +1,14 @@
+import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+import type { AvailableModel } from '@shared/types'
+
+export const SELECTED_MODEL_STORAGE_KEY = 'kata-desktop:selected-model'
+
+export const selectedModelAtom = atomWithStorage<string | null>(
+  SELECTED_MODEL_STORAGE_KEY,
+  null,
+)
+
+export const availableModelsAtom = atom<AvailableModel[]>([])
+export const modelLoadingAtom = atom<boolean>(false)
+export const modelErrorAtom = atom<string | null>(null)

--- a/apps/desktop/src/renderer/atoms/onboarding.ts
+++ b/apps/desktop/src/renderer/atoms/onboarding.ts
@@ -1,0 +1,8 @@
+import { atomWithStorage } from 'jotai/utils'
+
+export const ONBOARDING_COMPLETE_STORAGE_KEY = 'kata-desktop:onboarding-complete'
+
+export const onboardingCompleteAtom = atomWithStorage<boolean>(
+  ONBOARDING_COMPLETE_STORAGE_KEY,
+  false,
+)

--- a/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
@@ -1,12 +1,31 @@
+import { useState } from 'react'
+import { SettingsPanel } from '../settings/SettingsPanel'
 import { ChatPanel } from '../chat/ChatPanel'
+import { ModelSelector } from './ModelSelector'
 
 export function LeftPane() {
+  const [settingsOpen, setSettingsOpen] = useState(false)
+
   return (
     <section className="h-full border-r border-slate-800 bg-slate-950">
-      <div className="flex h-14 items-center border-b border-slate-800 px-4">
+      <div className="flex h-14 items-center justify-between gap-3 border-b border-slate-800 px-4">
         <h1 className="text-sm font-semibold tracking-wide uppercase text-slate-200">Kata Desktop</h1>
+
+        <div className="flex flex-1 items-center justify-end gap-3">
+          <ModelSelector />
+          <button
+            type="button"
+            onClick={() => setSettingsOpen(true)}
+            className="inline-flex h-8 items-center rounded-md border border-slate-700 px-3 text-xs text-slate-200 hover:bg-slate-800"
+          >
+            ⚙ Settings
+          </button>
+        </div>
       </div>
+
       <ChatPanel />
+
+      <SettingsPanel open={settingsOpen} onOpenChange={setSettingsOpen} />
     </section>
   )
 }

--- a/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
@@ -43,13 +43,20 @@ export function ModelSelector() {
         return
       }
 
+      const bridgeState = await window.api.getBridgeState()
+      const bridgeModel = bridgeState.selectedModel?.trim() || null
+      const activeModel = selectedModel ?? bridgeModel
+
       const currentExists =
-        !!selectedModel &&
+        !!activeModel &&
         response.models.some(
-          (model) => toModelIdentifier(model.provider, model.id) === selectedModel,
+          (model) => toModelIdentifier(model.provider, model.id) === activeModel,
         )
 
       if (currentExists) {
+        if (activeModel !== selectedModel) {
+          setSelectedModel(activeModel)
+        }
         return
       }
 

--- a/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useMemo } from 'react'
+import { useAtom } from 'jotai'
+import {
+  availableModelsAtom,
+  modelErrorAtom,
+  modelLoadingAtom,
+  selectedModelAtom,
+} from '@/atoms/model'
+import { MODELS_REFRESH_EVENT, PROVIDER_METADATA } from '@/constants/providers'
+
+function toModelIdentifier(provider: string, id: string): string {
+  return `${provider}/${id}`
+}
+
+function formatProviderLabel(provider: string): string {
+  const normalized = provider.toLowerCase() as keyof typeof PROVIDER_METADATA
+  const metadata = PROVIDER_METADATA[normalized]
+  return metadata?.name ?? provider
+}
+
+export function ModelSelector() {
+  const [selectedModel, setSelectedModel] = useAtom(selectedModelAtom)
+  const [availableModels, setAvailableModels] = useAtom(availableModelsAtom)
+  const [loading, setLoading] = useAtom(modelLoadingAtom)
+  const [error, setError] = useAtom(modelErrorAtom)
+
+  const refreshModels = useCallback(async () => {
+    setLoading(true)
+
+    try {
+      const response = await window.api.getAvailableModels()
+
+      if (!response.success) {
+        setAvailableModels([])
+        setError(response.error ?? 'Unable to load models')
+        return
+      }
+
+      setAvailableModels(response.models)
+      setError(null)
+
+      if (response.models.length === 0) {
+        return
+      }
+
+      const currentExists =
+        !!selectedModel &&
+        response.models.some(
+          (model) => toModelIdentifier(model.provider, model.id) === selectedModel,
+        )
+
+      if (currentExists) {
+        return
+      }
+
+      const first = response.models[0]
+      if (!first) {
+        return
+      }
+
+      const fallbackModel = toModelIdentifier(first.provider, first.id)
+      const setResult = await window.api.setModel(fallbackModel)
+      if (!setResult.success) {
+        setError(setResult.error ?? 'Unable to set default model')
+        return
+      }
+
+      setSelectedModel(fallbackModel)
+    } catch (refreshError) {
+      setError(refreshError instanceof Error ? refreshError.message : String(refreshError))
+    } finally {
+      setLoading(false)
+    }
+  }, [selectedModel, setAvailableModels, setError, setLoading, setSelectedModel])
+
+  useEffect(() => {
+    void refreshModels()
+
+    const listener = () => {
+      void refreshModels()
+    }
+
+    window.addEventListener(MODELS_REFRESH_EVENT, listener)
+
+    return () => {
+      window.removeEventListener(MODELS_REFRESH_EVENT, listener)
+    }
+  }, [refreshModels])
+
+  const groupedModels = useMemo(() => {
+    const groups = new Map<string, { provider: string; id: string }[]>()
+
+    for (const model of availableModels) {
+      const key = model.provider.toLowerCase()
+      const existing = groups.get(key)
+      const value = { provider: model.provider, id: model.id }
+
+      if (existing) {
+        existing.push(value)
+      } else {
+        groups.set(key, [value])
+      }
+    }
+
+    return Array.from(groups.entries())
+  }, [availableModels])
+
+  const handleChange = async (nextModel: string): Promise<void> => {
+    if (!nextModel || nextModel === selectedModel) {
+      return
+    }
+
+    const response = await window.api.setModel(nextModel)
+    if (!response.success) {
+      setError(response.error ?? 'Unable to switch model')
+      return
+    }
+
+    setSelectedModel(nextModel)
+    setError(null)
+  }
+
+  return (
+    <div className="flex min-w-[16rem] flex-col gap-1">
+      <label className="text-[10px] uppercase tracking-wide text-slate-400">Model</label>
+
+      <select
+        value={selectedModel ?? ''}
+        disabled={loading || availableModels.length === 0}
+        onChange={(event) => {
+          void handleChange(event.target.value)
+        }}
+        className="h-8 rounded-md border border-slate-700 bg-slate-900 px-2 text-xs text-slate-100 focus:border-slate-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {availableModels.length === 0 && (
+          <option value="">{loading ? 'Loading models…' : 'No models available'}</option>
+        )}
+
+        {groupedModels.map(([provider, models]) => (
+          <optgroup key={provider} label={formatProviderLabel(provider)}>
+            {models.map((model) => {
+              const value = toModelIdentifier(model.provider, model.id)
+              return (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              )
+            })}
+          </optgroup>
+        ))}
+      </select>
+
+      {error && <p className="text-[11px] text-rose-300">{error}</p>}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/onboarding/CompletionStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/CompletionStep.tsx
@@ -1,0 +1,48 @@
+interface CompletionStepProps {
+  selectedModel: string | null
+  onBack: () => void
+  onFinish: () => void
+}
+
+export function CompletionStep({ selectedModel, onBack, onFinish }: CompletionStepProps) {
+  return (
+    <div className="flex h-full flex-col justify-between">
+      <div>
+        <h2 className="text-3xl font-semibold text-slate-100">You're all set!</h2>
+        <p className="mt-2 text-sm text-slate-300">
+          Your provider credentials are configured and shared with Kata CLI.
+        </p>
+
+        <div className="mt-5 rounded-lg border border-slate-700 bg-slate-900/80 p-4">
+          <p className="text-xs uppercase tracking-wide text-slate-400">Default model</p>
+          <p className="mt-1 text-sm font-semibold text-slate-100">
+            {selectedModel ?? 'No model selected yet'}
+          </p>
+          {!selectedModel && (
+            <p className="mt-2 text-xs text-slate-400">
+              You can choose a model anytime from the toolbar model picker.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-6 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="rounded-md border border-slate-600 px-3 py-1.5 text-xs text-slate-200"
+        >
+          Back
+        </button>
+
+        <button
+          type="button"
+          onClick={onFinish}
+          className="rounded-md bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900"
+        >
+          Start chatting
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
@@ -30,12 +30,6 @@ export function KeyInputStep({ provider, onBack, onSaved, onSkip }: KeyInputStep
     setSuccessMessage(null)
 
     try {
-      const validation = await window.api.auth.validateKey(provider, trimmed)
-      if (!validation.valid) {
-        setError(validation.error ?? 'Invalid API key')
-        return
-      }
-
       const saveResult = await window.api.auth.setKey(provider, trimmed)
       if (!saveResult.success) {
         setError(saveResult.error ?? 'Unable to save API key')
@@ -43,7 +37,13 @@ export function KeyInputStep({ provider, onBack, onSaved, onSkip }: KeyInputStep
       }
 
       setSuccessMessage(`${metadata.name} key validated and saved`)
-      await onSaved(provider)
+
+      try {
+        await onSaved(provider)
+      } catch (savedError) {
+        setSuccessMessage(null)
+        setError(savedError instanceof Error ? savedError.message : String(savedError))
+      }
     } finally {
       setBusy(false)
     }

--- a/apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react'
+import type { AuthProvider } from '@shared/types'
+import { PROVIDER_METADATA } from '@/constants/providers'
+
+interface KeyInputStepProps {
+  provider: AuthProvider
+  onBack: () => void
+  onSaved: (provider: AuthProvider) => Promise<void>
+  onSkip: () => void
+}
+
+export function KeyInputStep({ provider, onBack, onSaved, onSkip }: KeyInputStepProps) {
+  const [keyValue, setKeyValue] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const metadata = PROVIDER_METADATA[provider]
+
+  const validateAndSave = async (): Promise<void> => {
+    const trimmed = keyValue.trim()
+    if (!trimmed) {
+      setError('API key is required')
+      setSuccessMessage(null)
+      return
+    }
+
+    setBusy(true)
+    setError(null)
+    setSuccessMessage(null)
+
+    try {
+      const validation = await window.api.auth.validateKey(provider, trimmed)
+      if (!validation.valid) {
+        setError(validation.error ?? 'Invalid API key')
+        return
+      }
+
+      const saveResult = await window.api.auth.setKey(provider, trimmed)
+      if (!saveResult.success) {
+        setError(saveResult.error ?? 'Unable to save API key')
+        return
+      }
+
+      setSuccessMessage(`${metadata.name} key validated and saved`)
+      await onSaved(provider)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col justify-between">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-100">Add your {metadata.name} key</h2>
+        <p className="mt-2 text-sm text-slate-300">
+          Keys are stored in <code className="rounded bg-slate-800 px-1">~/.kata-cli/agent/auth.json</code>{' '}
+          and shared with Kata CLI.
+        </p>
+
+        <div className="mt-4 space-y-2">
+          <label className="text-xs uppercase tracking-wide text-slate-400">API key</label>
+          <input
+            type="password"
+            value={keyValue}
+            onChange={(event) => {
+              setKeyValue(event.target.value)
+              setError(null)
+              setSuccessMessage(null)
+            }}
+            placeholder={`Enter ${metadata.shortName} API key`}
+            className="h-10 w-full rounded-md border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 outline-none focus:border-slate-500"
+          />
+        </div>
+
+        {busy && <p className="mt-3 text-xs text-slate-300">Validating key…</p>}
+        {error && <p className="mt-3 text-xs text-rose-300">{error}</p>}
+        {successMessage && <p className="mt-3 text-xs text-emerald-300">{successMessage}</p>}
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="rounded-md border border-slate-600 px-3 py-1.5 text-xs text-slate-200"
+        >
+          Back
+        </button>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-xs text-slate-400 underline-offset-2 hover:underline"
+          >
+            Skip for now
+          </button>
+
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => {
+              void validateAndSave()
+            }}
+            className="rounded-md bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900 disabled:opacity-60"
+          >
+            {busy ? 'Validating…' : 'Validate & Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSetAtom } from 'jotai'
+import {
+  ALL_AUTH_PROVIDERS,
+  type AuthProvider,
+  type ProviderStatusMap,
+} from '@shared/types'
+import { onboardingCompleteAtom } from '@/atoms/onboarding'
+import { selectedModelAtom } from '@/atoms/model'
+import { MODELS_REFRESH_EVENT } from '@/constants/providers'
+import { CompletionStep } from './CompletionStep'
+import { KeyInputStep } from './KeyInputStep'
+import { ProviderStep } from './ProviderStep'
+import { WelcomeStep } from './WelcomeStep'
+
+type OnboardingStep = 'welcome' | 'provider' | 'key' | 'complete'
+
+function createMissingProviderMap(): ProviderStatusMap {
+  const entries = ALL_AUTH_PROVIDERS.map((provider) => [
+    provider,
+    {
+      provider,
+      status: 'missing' as const,
+    },
+  ])
+
+  return Object.fromEntries(entries) as ProviderStatusMap
+}
+
+export function OnboardingWizard() {
+  const setOnboardingComplete = useSetAtom(onboardingCompleteAtom)
+  const setSelectedModel = useSetAtom(selectedModelAtom)
+
+  const [step, setStep] = useState<OnboardingStep>('welcome')
+  const [providers, setProviders] = useState<ProviderStatusMap>(createMissingProviderMap)
+  const [selectedProvider, setSelectedProvider] = useState<AuthProvider | null>('openai')
+  const [providersLoading, setProvidersLoading] = useState(false)
+  const [providersError, setProvidersError] = useState<string | null>(null)
+  const [resolvedModel, setResolvedModel] = useState<string | null>(null)
+
+  const loadProviders = useCallback(async () => {
+    setProvidersLoading(true)
+
+    try {
+      const response = await window.api.auth.getProviders()
+      setProviders(response.providers)
+      setProvidersError(response.success ? null : response.error ?? 'Unable to load credentials')
+
+      if (!selectedProvider) {
+        const firstValid = ALL_AUTH_PROVIDERS.find(
+          (provider) => response.providers[provider].status === 'valid',
+        )
+
+        setSelectedProvider(firstValid ?? 'openai')
+      }
+    } catch (error) {
+      setProviders(createMissingProviderMap())
+      setProvidersError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setProvidersLoading(false)
+    }
+  }, [selectedProvider])
+
+  useEffect(() => {
+    void loadProviders()
+  }, [loadProviders])
+
+  const progress = useMemo(() => {
+    const steps: OnboardingStep[] = ['welcome', 'provider', 'key', 'complete']
+    return Math.max(1, steps.indexOf(step) + 1)
+  }, [step])
+
+  const selectModelForProvider = useCallback(
+    async (provider: AuthProvider): Promise<string | null> => {
+      const modelResponse = await window.api.getAvailableModels()
+      if (!modelResponse.success || modelResponse.models.length === 0) {
+        return null
+      }
+
+      const preferred =
+        modelResponse.models.find((model) => model.provider.toLowerCase() === provider) ??
+        modelResponse.models[0]
+
+      if (!preferred) {
+        return null
+      }
+
+      const nextModel = `${preferred.provider}/${preferred.id}`
+      const setResult = await window.api.setModel(nextModel)
+      if (!setResult.success) {
+        throw new Error(setResult.error ?? 'Unable to set model')
+      }
+
+      setSelectedModel(nextModel)
+      window.dispatchEvent(new Event(MODELS_REFRESH_EVENT))
+      return nextModel
+    },
+    [setSelectedModel],
+  )
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/85 p-6 backdrop-blur-sm">
+      <div className="flex h-[min(42rem,92vh)] w-[min(56rem,94vw)] flex-col rounded-2xl border border-slate-700 bg-slate-900 p-6 shadow-2xl">
+        <div className="mb-5">
+          <div className="mb-3 flex items-center justify-between text-xs text-slate-400">
+            <span>Onboarding</span>
+            <span>Step {progress} of 4</span>
+          </div>
+
+          <div className="grid grid-cols-4 gap-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={index}
+                className={`h-1.5 rounded-full ${index < progress ? 'bg-slate-200' : 'bg-slate-700'}`}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto">
+          {step === 'welcome' && <WelcomeStep onNext={() => setStep('provider')} />}
+
+          {step === 'provider' && (
+            <ProviderStep
+              providers={providers}
+              selectedProvider={selectedProvider}
+              loadError={providersError}
+              loading={providersLoading}
+              onBack={() => setStep('welcome')}
+              onSelect={setSelectedProvider}
+              onContinue={() => {
+                if (selectedProvider) {
+                  setStep('key')
+                }
+              }}
+            />
+          )}
+
+          {step === 'key' && selectedProvider && (
+            <KeyInputStep
+              provider={selectedProvider}
+              onBack={() => setStep('provider')}
+              onSaved={async (provider) => {
+                await loadProviders()
+                const model = await selectModelForProvider(provider)
+                setResolvedModel(model)
+                setStep('complete')
+              }}
+              onSkip={() => setStep('complete')}
+            />
+          )}
+
+          {step === 'complete' && (
+            <CompletionStep
+              selectedModel={resolvedModel}
+              onBack={() => setStep(selectedProvider ? 'key' : 'provider')}
+              onFinish={() => setOnboardingComplete(true)}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -45,21 +45,13 @@ export function OnboardingWizard() {
       const response = await window.api.auth.getProviders()
       setProviders(response.providers)
       setProvidersError(response.success ? null : response.error ?? 'Unable to load credentials')
-
-      if (!selectedProvider) {
-        const firstValid = ALL_AUTH_PROVIDERS.find(
-          (provider) => response.providers[provider].status === 'valid',
-        )
-
-        setSelectedProvider(firstValid ?? 'openai')
-      }
     } catch (error) {
       setProviders(createMissingProviderMap())
       setProvidersError(error instanceof Error ? error.message : String(error))
     } finally {
       setProvidersLoading(false)
     }
-  }, [selectedProvider])
+  }, [])
 
   useEffect(() => {
     void loadProviders()

--- a/apps/desktop/src/renderer/components/onboarding/ProviderStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/ProviderStep.tsx
@@ -1,0 +1,96 @@
+import type { AuthProvider, ProviderStatusMap } from '@shared/types'
+import { ONBOARDING_PROVIDER_IDS, PROVIDER_METADATA } from '@/constants/providers'
+
+interface ProviderStepProps {
+  providers: ProviderStatusMap
+  selectedProvider: AuthProvider | null
+  loadError: string | null
+  loading: boolean
+  onBack: () => void
+  onSelect: (provider: AuthProvider) => void
+  onContinue: () => void
+}
+
+export function ProviderStep({
+  providers,
+  selectedProvider,
+  loadError,
+  loading,
+  onBack,
+  onSelect,
+  onContinue,
+}: ProviderStepProps) {
+  return (
+    <div className="flex h-full flex-col justify-between">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-100">Choose a provider</h2>
+        <p className="mt-2 text-sm text-slate-300">
+          You can add more providers later in Settings. Start with one that already has a key.
+        </p>
+
+        {loadError && (
+          <div className="mt-3 rounded-md border border-rose-500/50 bg-rose-950/40 px-3 py-2 text-xs text-rose-200">
+            {loadError}
+          </div>
+        )}
+
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {ONBOARDING_PROVIDER_IDS.map((provider) => {
+            const metadata = PROVIDER_METADATA[provider]
+            const info = providers[provider]
+            const configured = info.status === 'valid'
+
+            return (
+              <button
+                key={provider}
+                type="button"
+                onClick={() => onSelect(provider)}
+                className={`rounded-lg border p-3 text-left transition ${
+                  selectedProvider === provider
+                    ? 'border-slate-400 bg-slate-800/80'
+                    : 'border-slate-700 bg-slate-900/70 hover:border-slate-600'
+                }`}
+              >
+                <div className="flex items-start justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-slate-100">{metadata.name}</p>
+                    <p className="mt-1 text-xs text-slate-400">{metadata.description}</p>
+                  </div>
+
+                  <span
+                    className={`ml-3 rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                      configured
+                        ? 'bg-emerald-500/20 text-emerald-200'
+                        : 'bg-slate-700 text-slate-300'
+                    }`}
+                  >
+                    {configured ? 'Configured' : 'Add key'}
+                  </span>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="mt-6 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="rounded-md border border-slate-600 px-3 py-1.5 text-xs text-slate-200"
+        >
+          Back
+        </button>
+
+        <button
+          type="button"
+          disabled={!selectedProvider || loading}
+          onClick={onContinue}
+          className="rounded-md bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900 disabled:opacity-60"
+        >
+          {loading ? 'Loading…' : 'Continue'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/onboarding/WelcomeStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/WelcomeStep.tsx
@@ -1,0 +1,28 @@
+interface WelcomeStepProps {
+  onNext: () => void
+}
+
+export function WelcomeStep({ onNext }: WelcomeStepProps) {
+  return (
+    <div className="flex h-full flex-col justify-between">
+      <div>
+        <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Kata Desktop</p>
+        <h2 className="mt-3 text-3xl font-semibold text-slate-100">Welcome to your coding co-pilot</h2>
+        <p className="mt-3 max-w-xl text-sm text-slate-300">
+          Connect an AI provider, pick a model, and start chatting in under a minute.
+        </p>
+      </div>
+
+      <div className="mt-8 flex items-center justify-between">
+        <p className="text-xs text-slate-400">Step 1 of 4</p>
+        <button
+          type="button"
+          onClick={onNext}
+          className="rounded-md bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900"
+        >
+          Get started
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { AuthProvider, ProviderInfo, ProviderStatusMap } from '@shared/types'
+import { MODELS_REFRESH_EVENT, PROVIDER_METADATA } from '@/constants/providers'
+
+const AUTH_FILE_DISPLAY_PATH = '~/.kata-cli/agent/auth.json'
+
+const PROVIDER_ORDER: AuthProvider[] = [
+  'anthropic',
+  'openai',
+  'google',
+  'mistral',
+  'bedrock',
+  'azure',
+]
+
+function statusDotClass(status: ProviderInfo['status']): string {
+  if (status === 'valid') {
+    return 'bg-emerald-400'
+  }
+  if (status === 'expired' || status === 'invalid') {
+    return 'bg-rose-400'
+  }
+  return 'bg-slate-500'
+}
+
+export function ProviderAuthPanel() {
+  const [providers, setProviders] = useState<ProviderStatusMap | null>(null)
+  const [loading, setLoading] = useState<boolean>(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [activeProvider, setActiveProvider] = useState<AuthProvider>('anthropic')
+  const [apiKeyInput, setApiKeyInput] = useState('')
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const loadProviders = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await window.api.auth.getProviders()
+      setProviders(response.providers)
+      setLoadError(response.success ? null : response.error ?? 'Unable to load credentials')
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : String(error))
+      setProviders(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadProviders()
+  }, [loadProviders])
+
+  const activeInfo = providers?.[activeProvider]
+
+  const providerRows = useMemo(() => {
+    if (!providers) {
+      return []
+    }
+
+    return PROVIDER_ORDER.map((provider) => {
+      const metadata = PROVIDER_METADATA[provider]
+      const info = providers[provider]
+      return {
+        provider,
+        metadata,
+        info,
+      }
+    })
+  }, [providers])
+
+  const handleSave = async () => {
+    const trimmed = apiKeyInput.trim()
+    if (!trimmed) {
+      setActionError('API key is required')
+      setActionSuccess(null)
+      return
+    }
+
+    setSubmitting(true)
+    setActionError(null)
+    setActionSuccess(null)
+
+    try {
+      const validation = await window.api.auth.validateKey(activeProvider, trimmed)
+      if (!validation.valid) {
+        setActionError(validation.error ?? 'Invalid API key')
+        return
+      }
+
+      const setResult = await window.api.auth.setKey(activeProvider, trimmed)
+      if (!setResult.success) {
+        setActionError(setResult.error ?? 'Unable to save API key')
+        return
+      }
+
+      setActionSuccess(`${PROVIDER_METADATA[activeProvider].name} key saved`)
+      setApiKeyInput('')
+      await loadProviders()
+      window.dispatchEvent(new Event(MODELS_REFRESH_EVENT))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleRemove = async () => {
+    setSubmitting(true)
+    setActionError(null)
+    setActionSuccess(null)
+
+    try {
+      const result = await window.api.auth.removeKey(activeProvider)
+      if (!result.success) {
+        setActionError(result.error ?? 'Unable to remove API key')
+        return
+      }
+
+      setActionSuccess(`${PROVIDER_METADATA[activeProvider].name} key removed`)
+      setApiKeyInput('')
+      await loadProviders()
+      window.dispatchEvent(new Event(MODELS_REFRESH_EVENT))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      {loadError && (
+        <div className="rounded-md border border-rose-500/40 bg-rose-950/40 px-3 py-2 text-xs text-rose-200">
+          <p className="font-semibold">Unable to load credentials</p>
+          <p className="mt-1">{loadError}</p>
+          <p className="mt-1 text-rose-300">
+            Check file: <span className="font-mono">{AUTH_FILE_DISPLAY_PATH}</span>
+          </p>
+        </div>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.3fr)]">
+        <div className="space-y-2 rounded-lg border border-slate-700 bg-slate-950/50 p-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-300">Providers</h3>
+
+          {loading && <p className="text-xs text-slate-400">Loading providers…</p>}
+
+          {!loading && providerRows.length === 0 && (
+            <p className="text-xs text-slate-400">No providers available</p>
+          )}
+
+          {providerRows.map(({ provider, metadata, info }) => (
+            <button
+              key={provider}
+              type="button"
+              onClick={() => {
+                setActiveProvider(provider)
+                setActionError(null)
+                setActionSuccess(null)
+                setApiKeyInput('')
+              }}
+              className={`flex w-full items-center justify-between rounded-md border px-2 py-2 text-left text-xs transition ${
+                activeProvider === provider
+                  ? 'border-slate-500 bg-slate-800/70'
+                  : 'border-slate-700 bg-slate-900/60 hover:border-slate-600'
+              }`}
+            >
+              <span>
+                <span className="block font-medium text-slate-100">{metadata.name}</span>
+                <span className="block text-slate-400">{info.maskedKey ?? 'Not configured'}</span>
+              </span>
+              <span className={`h-2.5 w-2.5 rounded-full ${statusDotClass(info.status)}`} />
+            </button>
+          ))}
+        </div>
+
+        <div className="space-y-3 rounded-lg border border-slate-700 bg-slate-950/50 p-3">
+          <h3 className="text-sm font-semibold text-slate-100">{PROVIDER_METADATA[activeProvider].name}</h3>
+          <p className="text-xs text-slate-400">{PROVIDER_METADATA[activeProvider].description}</p>
+
+          <div className="text-xs text-slate-300">
+            Status:{' '}
+            <span className="font-semibold capitalize text-slate-100">
+              {activeInfo?.status ?? 'missing'}
+            </span>
+          </div>
+
+          {activeInfo?.maskedKey ? (
+            <div className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-300">
+              <p>
+                Saved key: <span className="font-mono text-slate-100">{activeInfo.maskedKey}</span>
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-wide text-slate-400">API key</label>
+              <input
+                type="password"
+                value={apiKeyInput}
+                onChange={(event) => setApiKeyInput(event.target.value)}
+                placeholder={`Enter ${PROVIDER_METADATA[activeProvider].shortName} key`}
+                className="h-9 w-full rounded-md border border-slate-700 bg-slate-900 px-3 text-xs text-slate-100 outline-none focus:border-slate-500"
+              />
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            {!activeInfo?.maskedKey && (
+              <button
+                type="button"
+                disabled={submitting}
+                onClick={() => {
+                  void handleSave()
+                }}
+                className="rounded-md bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-900 disabled:opacity-60"
+              >
+                {submitting ? 'Validating…' : 'Validate & Save'}
+              </button>
+            )}
+
+            {activeInfo?.maskedKey && (
+              <button
+                type="button"
+                disabled={submitting}
+                onClick={() => {
+                  void handleRemove()
+                }}
+                className="rounded-md border border-rose-400/60 px-3 py-1.5 text-xs text-rose-200 disabled:opacity-60"
+              >
+                {submitting ? 'Removing…' : 'Remove key'}
+              </button>
+            )}
+          </div>
+
+          {actionError && <p className="text-xs text-rose-300">{actionError}</p>}
+          {actionSuccess && <p className="text-xs text-emerald-300">{actionSuccess}</p>}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
@@ -82,12 +82,6 @@ export function ProviderAuthPanel() {
     setActionSuccess(null)
 
     try {
-      const validation = await window.api.auth.validateKey(activeProvider, trimmed)
-      if (!validation.valid) {
-        setActionError(validation.error ?? 'Invalid API key')
-        return
-      }
-
       const setResult = await window.api.auth.setKey(activeProvider, trimmed)
       if (!setResult.success) {
         setActionError(setResult.error ?? 'Unable to save API key')

--- a/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { ProviderAuthPanel } from './ProviderAuthPanel'
+
+type SettingsTab = 'providers' | 'general' | 'appearance'
+
+interface SettingsPanelProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
+  const [activeTab, setActiveTab] = useState<SettingsTab>('providers')
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-6 backdrop-blur-sm">
+      <div className="flex h-[min(48rem,90vh)] w-[min(70rem,95vw)] flex-col rounded-xl border border-slate-700 bg-slate-900 shadow-2xl">
+        <header className="flex items-center justify-between border-b border-slate-700 px-5 py-3">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-100">Settings</h2>
+            <p className="text-xs text-slate-400">Manage providers, preferences, and desktop defaults.</p>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="rounded-md border border-slate-600 px-3 py-1 text-xs text-slate-200 hover:bg-slate-800"
+          >
+            Close
+          </button>
+        </header>
+
+        <div className="grid flex-1 overflow-hidden md:grid-cols-[12rem_minmax(0,1fr)]">
+          <nav className="border-r border-slate-700 bg-slate-950/40 p-3">
+            <div className="space-y-1 text-xs">
+              {[
+                { id: 'providers', label: 'Providers' },
+                { id: 'general', label: 'General' },
+                { id: 'appearance', label: 'Appearance' },
+              ].map((tab) => {
+                const id = tab.id as SettingsTab
+                const active = activeTab === id
+
+                return (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    onClick={() => setActiveTab(id)}
+                    className={`w-full rounded-md px-3 py-2 text-left transition ${
+                      active
+                        ? 'bg-slate-800 text-slate-100'
+                        : 'text-slate-300 hover:bg-slate-800/50'
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                )
+              })}
+            </div>
+          </nav>
+
+          <section className="overflow-auto p-4">
+            {activeTab === 'providers' && <ProviderAuthPanel />}
+
+            {activeTab === 'general' && (
+              <div className="rounded-lg border border-slate-700 bg-slate-950/40 p-4 text-sm text-slate-300">
+                <p className="font-semibold text-slate-100">General settings</p>
+                <p className="mt-2 text-xs text-slate-400">Additional preferences will be added in a future slice.</p>
+              </div>
+            )}
+
+            {activeTab === 'appearance' && (
+              <div className="rounded-lg border border-slate-700 bg-slate-950/40 p-4 text-sm text-slate-300">
+                <p className="font-semibold text-slate-100">Appearance</p>
+                <p className="mt-2 text-xs text-slate-400">Theme and typography controls are coming in a future slice.</p>
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/constants/providers.ts
+++ b/apps/desktop/src/renderer/constants/providers.ts
@@ -1,0 +1,56 @@
+import type { AuthProvider } from '@shared/types'
+
+export interface ProviderMetadata {
+  id: AuthProvider
+  name: string
+  shortName: string
+  description: string
+}
+
+export const PROVIDER_METADATA: Record<AuthProvider, ProviderMetadata> = {
+  anthropic: {
+    id: 'anthropic',
+    name: 'Anthropic',
+    shortName: 'Claude',
+    description: 'Claude 4 family models',
+  },
+  openai: {
+    id: 'openai',
+    name: 'OpenAI',
+    shortName: 'GPT',
+    description: 'GPT-4o and reasoning models',
+  },
+  google: {
+    id: 'google',
+    name: 'Google',
+    shortName: 'Gemini',
+    description: 'Gemini models via Google AI Studio',
+  },
+  mistral: {
+    id: 'mistral',
+    name: 'Mistral',
+    shortName: 'Mistral',
+    description: 'Mistral large and small models',
+  },
+  bedrock: {
+    id: 'bedrock',
+    name: 'AWS Bedrock',
+    shortName: 'Bedrock',
+    description: 'Provider currently requires AWS credentials',
+  },
+  azure: {
+    id: 'azure',
+    name: 'Azure OpenAI',
+    shortName: 'Azure',
+    description: 'Provider currently requires endpoint + key',
+  },
+}
+
+export const ONBOARDING_PROVIDER_IDS: AuthProvider[] = [
+  'anthropic',
+  'openai',
+  'google',
+  'mistral',
+]
+
+export const MODELS_REFRESH_EVENT = 'kata-desktop:models-refresh'

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -165,6 +165,7 @@ export interface BridgeState {
   pid: number | null
   command: string | null
   status: BridgeLifecycleState
+  selectedModel: string | null
 }
 
 export interface DesktopApi {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -5,7 +5,97 @@ export const IPC_CHANNELS = {
   sessionEvents: 'session:events',
   sessionBridgeStatus: 'session:bridge-status',
   sessionGetBridgeState: 'session:get-bridge-state',
+  sessionGetAvailableModels: 'session:get-available-models',
+  sessionSetModel: 'session:set-model',
+  authGetProviders: 'auth:get-providers',
+  authSetKey: 'auth:set-key',
+  authRemoveKey: 'auth:remove-key',
+  authValidateKey: 'auth:validate-key',
 } as const
+
+export const ALL_AUTH_PROVIDERS = [
+  'anthropic',
+  'openai',
+  'google',
+  'mistral',
+  'bedrock',
+  'azure',
+] as const
+
+export type AuthProvider = (typeof ALL_AUTH_PROVIDERS)[number]
+
+export type ProviderStatus = 'valid' | 'missing' | 'expired' | 'invalid'
+
+export type ProviderAuthType = 'api_key' | 'oauth'
+
+export interface ProviderInfo {
+  provider: AuthProvider
+  status: ProviderStatus
+  authType?: ProviderAuthType
+  maskedKey?: string
+}
+
+export type ProviderStatusMap = Record<AuthProvider, ProviderInfo>
+
+export interface AuthProvidersResponse {
+  success: boolean
+  providers: ProviderStatusMap
+  error?: string
+}
+
+export interface AuthValidationResult {
+  valid: boolean
+  error?: string
+}
+
+export interface AuthSetKeyResponse {
+  success: boolean
+  provider: AuthProvider
+  providerInfo?: ProviderInfo
+  error?: string
+}
+
+export interface AuthRemoveKeyResponse {
+  success: boolean
+  provider: AuthProvider
+  providerInfo?: ProviderInfo
+  error?: string
+}
+
+export interface ApiKeyAuthRecordEntry {
+  type: 'api_key'
+  key: string
+}
+
+export interface OAuthAuthRecordEntry {
+  type: 'oauth'
+  access: string
+  refresh?: string
+  expires?: string | number
+}
+
+export type AuthRecordEntry = ApiKeyAuthRecordEntry | OAuthAuthRecordEntry
+
+export type AuthRecord = Record<string, AuthRecordEntry>
+
+export interface AvailableModel {
+  provider: string
+  id: string
+  contextWindow?: number
+  reasoning?: boolean
+}
+
+export interface AvailableModelsResponse {
+  success: boolean
+  models: AvailableModel[]
+  error?: string
+}
+
+export interface SetModelResponse {
+  success: boolean
+  model?: string
+  error?: string
+}
 
 export type RpcCommandType =
   | 'prompt'
@@ -14,11 +104,14 @@ export type RpcCommandType =
   | 'get_state'
   | 'get_session_stats'
   | 'follow_up'
+  | 'get_available_models'
+  | 'set_model'
 
 export interface RpcCommand {
   type: RpcCommandType
   id?: string
   message?: string
+  model?: string
 }
 
 export interface CommandResult {
@@ -81,6 +174,14 @@ export interface DesktopApi {
   onChatEvent: (listener: (event: ChatEvent) => void) => () => void
   onBridgeStatus: (listener: (status: BridgeStatusEvent) => void) => () => void
   getBridgeState: () => Promise<BridgeState>
+  getAvailableModels: () => Promise<AvailableModelsResponse>
+  setModel: (model: string) => Promise<SetModelResponse>
+  auth: {
+    getProviders: () => Promise<AuthProvidersResponse>
+    setKey: (provider: AuthProvider, key: string) => Promise<AuthSetKeyResponse>
+    removeKey: (provider: AuthProvider) => Promise<AuthRemoveKeyResponse>
+    validateKey: (provider: AuthProvider, key: string) => Promise<AuthValidationResult>
+  }
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- add a main-process AuthBridge for ~/.kata-cli/agent/auth.json with atomic writes, provider status masking, and provider key validation
- expose auth + model IPC/preload APIs for provider management and model switching
- implement first-launch onboarding wizard with provider selection, key validation/save, and completion persistence
- add toolbar model selector with provider-grouped models and persistent selected model
- add settings modal with provider auth panel, status indicators, add/remove flows, and credential load error banner
- persist selected model in ~/.kata-cli/agent/settings.json and pass --model on bridge spawn

## Validation
- bun run --filter @kata/desktop typecheck
- bun run --filter @kata/desktop test
- bun run --filter @kata/desktop build

## Linear
- KAT-2094
- KAT-2097
- KAT-2096
- KAT-2095

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a complete multi-provider auth system for the Kata Desktop app, including an `AuthBridge` for managing `~/.kata-cli/agent/auth.json` with atomic writes and key masking, IPC/preload bindings for all auth and model operations, a first-launch onboarding wizard, a toolbar model selector, and a settings panel with provider management. The auth layer is well-structured — atomic temp-file renames, 0o600 file permissions, provider key masking in logs, and live HTTP validation against each provider's API are all correctly implemented. The main-process model persistence in `settings.json` and the `--model` flag pass-through on bridge spawn also look solid.

Key findings:
- **`KeyInputStep` silently drops `onSaved` errors**: if model selection throws after a successful key save, the wizard stalls on the key step with a misleading \"validated and saved\" success message and no error shown to the user.
- **Double provider validation on every save**: both `KeyInputStep` and `ProviderAuthPanel` call `validateKey` explicitly then immediately call `setKey`, which calls `validateKey` internally — resulting in two live HTTP calls to the provider's API per save.
- **Unnecessary `selectedProvider` dep in `loadProviders` `useCallback`**: since `selectedProvider` starts as `'openai'` (never `null`), the auto-select branch is dead code; including it in deps causes an extra IPC round-trip to read auth state on every provider tile click in the onboarding wizard.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the onSaved error-propagation bug in KeyInputStep, which can leave the onboarding wizard in a stuck state.

One P1 defect: unhandled onSaved rejection in KeyInputStep leaves the wizard stuck with a false-positive success message if model selection fails after key save. The two P2 findings (double validation, spurious useCallback dep) don't block functionality but are worth cleaning up.

apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx (P1 error-propagation bug), apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx (spurious useCallback dep), apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx (double validation)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/auth-bridge.ts | New AuthBridge class: reads/writes auth.json with atomic rename + 0o600 perms, validates keys via live HTTP for 4 providers, masks stored keys; clean error handling throughout. |
| apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx | Key input step: onSaved() throw is not caught, leaving wizard stuck with a misleading success message; also double-validates the key on each save (two live API calls). |
| apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx | Onboarding flow orchestrator: selectedProvider dep in loadProviders useCallback causes spurious IPC round-trips on every provider tile click; flow logic otherwise correct. |
| apps/desktop/src/main/ipc.ts | IPC handler registration: adds auth + model channels with proper handler removal; correctly delegates to AuthBridge and PiAgentBridge. |
| apps/desktop/src/main/index.ts | App entry: loads persisted model from settings.json on startup, passes it to PiAgentBridge, wires onModelSelected persistence; atomic writes for settings. |
| apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx | Settings provider panel: same double-validation pattern as KeyInputStep (validateKey then setKey); bedrock/azure always fail silently from UI perspective. |
| apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx | Toolbar model selector: loads and groups models by provider, auto-falls back to first model if selected is gone, listens for MODELS_REFRESH_EVENT. |
| apps/desktop/src/shared/types.ts | Shared types: adds auth provider types, IPC channels, AuthRecord entry variants, and DesktopApi interface extension for auth and model operations. |
| apps/desktop/src/preload/index.ts | Preload: exposes auth and model IPC methods via contextBridge using the existing DesktopApi interface; straightforward pass-through. |
| apps/desktop/src/renderer/atoms/model.ts | New jotai atoms: selectedModel persisted to localStorage, plus transient availableModels, modelLoading, and modelError atoms. |
| apps/desktop/src/renderer/atoms/onboarding.ts | New jotai atom: onboardingComplete persisted to localStorage; drives the App.tsx conditional render for the wizard overlay. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer (React)
    participant P as Preload (contextBridge)
    participant I as IPC (ipcMain)
    participant AB as AuthBridge
    participant PB as PiAgentBridge
    participant FS as ~/.kata-cli/agent/

    Note over R: First launch — OnboardingWizard shown
    R->>P: auth.getProviders()
    P->>I: authGetProviders
    I->>AB: getProviders()
    AB->>FS: readFile(auth.json)
    FS-->>AB: AuthRecord (or ENOENT → {})
    AB-->>I: ProviderStatusMap (keys masked)
    I-->>R: AuthProvidersResponse

    R->>P: auth.validateKey(provider, key)
    P->>I: authValidateKey
    I->>AB: validateKey()
    AB->>AB: HTTP → provider API
    AB-->>R: AuthValidationResult

    R->>P: auth.setKey(provider, key)
    P->>I: authSetKey
    I->>AB: setProviderKey()
    AB->>AB: validateKey() [2nd HTTP call]
    AB->>FS: atomic write auth.json (0o600)
    AB-->>R: AuthSetKeyResponse

    Note over R: Model auto-selection after key save
    R->>P: getAvailableModels()
    P->>I: sessionGetAvailableModels
    I->>PB: getAvailableModels()
    PB-->>R: AvailableModel[]

    R->>P: setModel(model)
    P->>I: sessionSetModel
    I->>PB: setModel() — RPC to subprocess
    I->>I: onModelSelected callback
    I->>FS: atomic write settings.json
    PB-->>R: SetModelResponse
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
Line: 46-47

Comment:
**Unhandled `onSaved` rejection leaves wizard stuck**

`onSaved` can throw — `selectModelForProvider` in `OnboardingWizard` throws if `window.api.setModel` returns `success: false`. When that happens, the success message (`"key validated and saved"`) is already displayed, `setBusy(false)` still fires from the `finally` block, but `setStep('complete')` never runs. The user is left on the key step with a "success" indicator and no way to understand what went wrong. The outer `void validateAndSave()` discards the rejected promise, so the error is silently swallowed.

```suggestion
      setSuccessMessage(`${metadata.name} key validated and saved`)
      try {
        await onSaved(provider)
      } catch (savedError) {
        setError(savedError instanceof Error ? savedError.message : String(savedError))
      }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
Line: 33-43

Comment:
**Double provider validation on every save**

`validateKey` is called explicitly here, then `setKey` is called immediately after — but `AuthBridge.setProviderKey` already calls `validateKey` internally before writing. This results in **two** live HTTP requests to the provider's endpoint for every save, doubling latency and rate-limit exposure.

The same pattern appears in `ProviderAuthPanel.tsx` lines 85–93.

Consider removing the explicit `validateKey` + guard here (and in `ProviderAuthPanel`) and relying on the error returned by `setKey`, or expose a `setKeyWithoutValidation` path in the bridge if pre-flight UI feedback is needed without the double call.

```suggestion
      const saveResult = await window.api.auth.setKey(provider, trimmed)
      if (!saveResult.success) {
        setError(saveResult.error ?? 'Unable to save API key')
        return
      }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
Line: 41-62

Comment:
**`selectedProvider` in `useCallback` deps causes spurious provider reloads**

`loadProviders` depends on `selectedProvider` only to auto-select the first valid provider when `selectedProvider` is `null`. However, `selectedProvider` is initialized as `'openai'` (never `null`), so the `if (!selectedProvider)` branch is effectively dead code. Including it in the `useCallback` deps means the function is recreated — and the `useEffect` re-fires, issuing a new IPC call to read auth state — every time the user clicks a different provider tile in `ProviderStep`.

Remove `selectedProvider` from the dependency array (or restructure to avoid the dead-code branch):

```suggestion
  const loadProviders = useCallback(async () => {
    setProvidersLoading(true)

    try {
      const response = await window.api.auth.getProviders()
      setProviders(response.providers)
      setProvidersError(response.success ? null : response.error ?? 'Unable to load credentials')
    } catch (error) {
      setProviders(createMissingProviderMap())
      setProvidersError(error instanceof Error ? error.message : String(error))
    } finally {
      setProvidersLoading(false)
    }
  }, [])
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/gannonh/kata/commit/8f74527dc003cd8d69d6362c3aee407f687df7ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26957674)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->