### PR TITLE
Fix CLI test failures and release build

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -95,7 +95,7 @@ jobs:
         run: bun install
 
       - name: Build
-        run: cd apps/cli && npx tsc && npm run copy-themes && npm run copy-export-html
+        run: cd apps/cli && npm run build
 
       - name: Publish to npm
         run: cd apps/cli && npm publish --access public

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -95,7 +95,7 @@ jobs:
         run: bun install
 
       - name: Build
-        run: cd apps/cli && npx tsc && npm run copy-themes
+        run: cd apps/cli && npx tsc && npm run copy-themes && npm run copy-export-html
 
       - name: Publish to npm
         run: cd apps/cli && npm publish --access public

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-status.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-status.test.ts
@@ -142,7 +142,7 @@ test("buildPrefsStatusReport reports Linear mode identifiers and validation summ
   assert.match(report.message, /^mode: linear$/m);
   assert.match(report.message, /^LINEAR_API_KEY: present$/m);
   assert.match(report.message, /^linear\.teamKey: KAT$/m);
-  assert.match(report.message, /^linear\.projectId: project-456$/m);
+  assert.match(report.message, /^linear\.projectSlug: project-456$/m);
   assert.match(report.message, /^validation: valid$/m);
   assert.match(report.message, /^resolved team: Kata \(KAT · team-123\)$/m);
   assert.match(report.message, /^resolved project: CLI \(project-456 · started\)$/m);


### PR DESCRIPTION
## Fixes

- **`prefs-status.test.ts`** — Test asserted `linear.projectId` but the output now shows `linear.projectSlug` (after the projectId→projectSlug rename). Updated assertion.
- **`cli-release.yml`** — The publish build step ran `copy-themes` but not `copy-export-html`, so published packages were still missing the export templates. Added `npm run copy-export-html` to the build step.

Note: The `show-plan.vitest.test.ts` `vi.hoisted` CI annotation appears to be a non-blocking warning from bun's test runner. The file is correctly excluded via `--path-ignore-patterns` and all vitest tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTML export generation to the build process.

* **Bug Fixes**
  * Updated Linear integration to use project slug identifiers instead of project IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent issues that were causing CLI test failures and an incomplete release build.

- **Test fix** (`prefs-status.test.ts`): The assertion was checking for `linear.projectId` in the status report, but `formatLinearConfigStatus` in `linear-config.ts` uses the value's shape to determine the display label — non-UUID slugs are labelled `linear.projectSlug` while UUID values are labelled `linear.projectId (legacy)`. Since the test fixture uses `\"project-456\"` (not a UUID), the correct label is `linear.projectSlug: project-456`. The fix correctly aligns the assertion with the label-selection logic.

- **Workflow fix** (`cli-release.yml`): The explicit `Build` step was running `npx tsc && npm run copy-themes` but was missing `npm run copy-export-html`. This step is meant to mirror `npm run build` (which includes all four steps: `tsc`, `copy-themes`, `copy-export-html`, `copy-changelog`) and serve as an early-fail gate before publish. Worth noting that `prepublishOnly` in `package.json` runs the full `npm run build`, so the published package would have received the export templates anyway — but the explicit step was inconsistent. This PR corrects that inconsistency for `copy-export-html`; `copy-changelog` still remains absent from the explicit Build step (see inline comment).

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are minimal, targeted bug fixes with no runtime risk.

The test assertion fix is verified correct against formatLinearConfigStatus's UUID-detection label logic. The workflow fix adds a missing build step that was already covered by the prepublishOnly hook, so there is no regression risk. The only remaining finding is a P2 style suggestion about copy-changelog still being absent from the explicit Build step, which does not block merge.

No files require special attention. The P2 note on .github/workflows/cli-release.yml is a non-blocking consistency suggestion.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/cli-release.yml | Adds `npm run copy-export-html` to the explicit publish build step, aligning it with `package.json`'s `build` script; `copy-changelog` is still absent from this step but covered by `prepublishOnly`. |
| apps/cli/src/resources/extensions/kata/tests/prefs-status.test.ts | Updates assertion from `linear.projectId` to `linear.projectSlug` to match `formatLinearConfigStatus`'s label selection logic (non-UUID values are labeled `linear.projectSlug`). |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main with apps/cli changes] --> B[check-version job]
    B -->|should_release=true| C[test job]
    B -->|should_release=false| Z[Skip release]
    C --> D[publish job]
    D --> E[bun install]
    E --> F["Build step\nnpx tsc\n+ copy-themes\n+ copy-export-html ✅ added"]
    F --> G["npm publish\n↳ prepublishOnly hook\n  → sync-pkg-version\n  → npm run build\n    (tsc + all copy-* steps)"]
    G --> H[Create Git tag]
    H --> I[Extract changelog]
    I --> J[Create GitHub Release]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/cli-release.yml
Line: 98

Comment:
**Build step still diverges from `npm run build`**

The full `build` script in `package.json` is:
```
tsc && npm run copy-themes && npm run copy-export-html && npm run copy-changelog
```

This PR adds `copy-export-html`, but `copy-changelog` is still absent from the workflow's explicit Build step. Note that `prepublishOnly` triggers `npm run build` when `npm publish` runs, so the published package is ultimately complete. However, the explicit Build step exists for early failure detection — keeping it in sync with `npm run build` would make that intent clearer and would catch a missing `CHANGELOG.md` at build time rather than silently skipping it.

```suggestion
        run: cd apps/cli && npx tsc && npm run copy-themes && npm run copy-export-html && npm run copy-changelog
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): fix prefs-status test and cli-..."](https://github.com/gannonh/kata/commit/95ff94f6d49ca9f82a921372ade247f59a2c523a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26958310)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->