### PR TITLE
feat(desktop): rich tool rendering and permission modes (KAT-2090)

### DIFF
--- a/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
@@ -57,57 +57,239 @@ describe('RpcEventAdapter', () => {
     ])
   })
 
-  test('maps tool execution events', () => {
-    expect(
-      adapter.adapt({
-        type: 'tool_execution_start',
-        toolCallId: 'tool-1',
-        toolName: 'bash',
-        args: { command: 'ls -la' },
-      }),
-    ).toEqual([
-      {
-        type: 'tool_start',
-        toolCallId: 'tool-1',
-        toolName: 'bash',
-        args: { command: 'ls -la' },
+  test('extracts typed edit args and result metadata', () => {
+    const [startEvent] = adapter.adapt({
+      type: 'tool_execution_start',
+      toolCallId: 'tool-edit-1',
+      toolName: 'edit',
+      args: {
+        path: 'apps/desktop/src/main/index.ts',
+        edits: [
+          {
+            oldText: 'const a = 1\n',
+            newText: 'const a = 2\n',
+          },
+          {
+            oldText: 'const b = 1\n',
+            newText: 'const b = 3\n',
+          },
+        ],
       },
-    ])
+    })
 
-    expect(
-      adapter.adapt({
-        type: 'tool_execution_update',
-        toolCallId: 'tool-1',
-        toolName: 'bash',
-        status: 'running',
-      }),
-    ).toEqual([
-      {
-        type: 'tool_update',
-        toolCallId: 'tool-1',
-        toolName: 'bash',
-        status: 'running',
+    expect(startEvent).toEqual({
+      type: 'tool_start',
+      toolCallId: 'tool-edit-1',
+      toolName: 'edit',
+      args: {
+        path: 'apps/desktop/src/main/index.ts',
+        edits: [
+          {
+            oldText: 'const a = 1\n',
+            newText: 'const a = 2\n',
+          },
+          {
+            oldText: 'const b = 1\n',
+            newText: 'const b = 3\n',
+          },
+        ],
       },
-    ])
+    })
 
-    expect(
-      adapter.adapt({
-        type: 'tool_execution_end',
-        toolCallId: 'tool-1',
-        toolName: 'bash',
-        result: { stdout: 'README.md' },
-        isError: false,
-      }),
-    ).toEqual([
-      {
-        type: 'tool_end',
-        toolCallId: 'tool-1',
-        toolName: 'bash',
-        result: { stdout: 'README.md' },
-        isError: false,
-        error: undefined,
+    const [endEvent] = adapter.adapt({
+      type: 'tool_execution_end',
+      toolCallId: 'tool-edit-1',
+      toolName: 'edit',
+      args: {
+        path: 'apps/desktop/src/main/index.ts',
       },
-    ])
+      result: {
+        path: 'apps/desktop/src/main/index.ts',
+        diff: [
+          'diff --git a/apps/desktop/src/main/index.ts b/apps/desktop/src/main/index.ts',
+          '@@ -1,3 +1,3 @@',
+          '-const value = 1',
+          '+const value = 2',
+          ' export function boot() {}',
+        ].join('\n'),
+      },
+      isError: false,
+    })
+
+    expect(endEvent).toMatchObject({
+      type: 'tool_end',
+      toolCallId: 'tool-edit-1',
+      toolName: 'edit',
+      isError: false,
+      result: {
+        path: 'apps/desktop/src/main/index.ts',
+        linesAdded: 1,
+        linesRemoved: 1,
+        linesChanged: 2,
+      },
+    })
+  })
+
+  test('maps bash updates for streaming stdout and end result metadata', () => {
+    const [updateEvent] = adapter.adapt({
+      type: 'tool_execution_update',
+      toolCallId: 'tool-bash-1',
+      toolName: 'bash',
+      status: 'running',
+      result: {
+        stdout: '\u001b[32mline one\u001b[0m\n',
+      },
+    })
+
+    expect(updateEvent).toEqual({
+      type: 'tool_update',
+      toolCallId: 'tool-bash-1',
+      toolName: 'bash',
+      status: 'running',
+      partialStdout: '\u001b[32mline one\u001b[0m\n',
+    })
+
+    const [endEvent] = adapter.adapt({
+      type: 'tool_execution_end',
+      toolCallId: 'tool-bash-1',
+      toolName: 'bash',
+      args: {
+        command: 'ls -la --color=always',
+      },
+      result: {
+        stdout: '\u001b[34mapps\u001b[0m\n',
+        stderr: '',
+        exitCode: 0,
+      },
+      isError: false,
+    })
+
+    expect(endEvent).toEqual({
+      type: 'tool_end',
+      toolCallId: 'tool-bash-1',
+      toolName: 'bash',
+      isError: false,
+      error: undefined,
+      result: {
+        command: 'ls -la --color=always',
+        stdout: '\u001b[34mapps\u001b[0m\n',
+        stderr: '',
+        exitCode: 0,
+        raw: {
+          stdout: '\u001b[34mapps\u001b[0m\n',
+          stderr: '',
+          exitCode: 0,
+        },
+      },
+    })
+  })
+
+  test('extracts read metadata including language and truncation', () => {
+    const [endEvent] = adapter.adapt({
+      type: 'tool_execution_end',
+      toolCallId: 'tool-read-1',
+      toolName: 'read',
+      args: {
+        path: 'apps/desktop/package.json',
+      },
+      result: {
+        path: 'apps/desktop/package.json',
+        content: '{\n  "name": "@kata/desktop"\n}',
+        totalLines: 120,
+        truncated: true,
+      },
+      isError: false,
+    })
+
+    expect(endEvent).toEqual({
+      type: 'tool_end',
+      toolCallId: 'tool-read-1',
+      toolName: 'read',
+      isError: false,
+      error: undefined,
+      result: {
+        path: 'apps/desktop/package.json',
+        content: '{\n  "name": "@kata/desktop"\n}',
+        language: 'json',
+        totalLines: 120,
+        truncated: true,
+        raw: {
+          path: 'apps/desktop/package.json',
+          content: '{\n  "name": "@kata/desktop"\n}',
+          totalLines: 120,
+          truncated: true,
+        },
+      },
+    })
+  })
+
+  test('extracts write metadata and computes bytesWritten when omitted', () => {
+    const [endEvent] = adapter.adapt({
+      type: 'tool_execution_end',
+      toolCallId: 'tool-write-1',
+      toolName: 'write',
+      args: {
+        path: 'apps/desktop/tmp/test.txt',
+        content: 'hello\nworld',
+      },
+      result: {
+        path: 'apps/desktop/tmp/test.txt',
+      },
+      isError: false,
+    })
+
+    expect(endEvent).toEqual({
+      type: 'tool_end',
+      toolCallId: 'tool-write-1',
+      toolName: 'write',
+      isError: false,
+      error: undefined,
+      result: {
+        path: 'apps/desktop/tmp/test.txt',
+        content: 'hello\nworld',
+        bytesWritten: 11,
+        raw: {
+          path: 'apps/desktop/tmp/test.txt',
+        },
+      },
+    })
+  })
+
+  test('passes unknown tools through as raw args and result', () => {
+    const [startEvent] = adapter.adapt({
+      type: 'tool_execution_start',
+      toolCallId: 'tool-unknown-1',
+      toolName: 'browser_assert',
+      args: { checks: [{ kind: 'url_contains', value: 'localhost' }] },
+    })
+
+    expect(startEvent).toEqual({
+      type: 'tool_start',
+      toolCallId: 'tool-unknown-1',
+      toolName: 'browser_assert',
+      args: {
+        raw: { checks: [{ kind: 'url_contains', value: 'localhost' }] },
+      },
+    })
+
+    const [endEvent] = adapter.adapt({
+      type: 'tool_execution_end',
+      toolCallId: 'tool-unknown-1',
+      toolName: 'browser_assert',
+      result: { ok: true },
+      isError: false,
+    })
+
+    expect(endEvent).toEqual({
+      type: 'tool_end',
+      toolCallId: 'tool-unknown-1',
+      toolName: 'browser_assert',
+      isError: false,
+      error: undefined,
+      result: {
+        raw: { ok: true },
+      },
+    })
   })
 
   test('maps extension errors and malformed payloads to agent_error', () => {

--- a/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
@@ -136,7 +136,7 @@ describe('RpcEventAdapter', () => {
       toolCallId: 'tool-bash-1',
       toolName: 'bash',
       status: 'running',
-      result: {
+      partialResult: {
         stdout: '\u001b[32mline one\u001b[0m\n',
       },
     })
@@ -219,6 +219,40 @@ describe('RpcEventAdapter', () => {
           totalLines: 120,
           truncated: true,
         },
+      },
+    })
+  })
+
+  test('counts blank lines when edit result is reconstructed from edits array', () => {
+    const [endEvent] = adapter.adapt({
+      type: 'tool_execution_end',
+      toolCallId: 'tool-edit-blank-lines',
+      toolName: 'edit',
+      args: {
+        path: 'apps/desktop/src/main/index.ts',
+        edits: [
+          {
+            oldText: 'const value = 1\n',
+            newText: 'const value = 2\n\n',
+          },
+        ],
+      },
+      result: {
+        path: 'apps/desktop/src/main/index.ts',
+      },
+      isError: false,
+    })
+
+    expect(endEvent).toMatchObject({
+      type: 'tool_end',
+      toolCallId: 'tool-edit-blank-lines',
+      toolName: 'edit',
+      isError: false,
+      result: {
+        path: 'apps/desktop/src/main/index.ts',
+        linesAdded: 2,
+        linesRemoved: 1,
+        linesChanged: 3,
       },
     })
   })

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -2,7 +2,14 @@ import { ipcMain, type BrowserWindow } from 'electron'
 import log from './logger'
 import { PiAgentBridge } from './pi-agent-bridge'
 import { RpcEventAdapter } from './rpc-event-adapter'
-import { IPC_CHANNELS, type BridgeStatusEvent, type ChatEvent } from '../shared/types'
+import {
+  IPC_CHANNELS,
+  type BridgeStatusEvent,
+  type ChatEvent,
+  type ExtensionUIRequest,
+  type ExtensionUIResponse,
+  type PermissionMode,
+} from '../shared/types'
 
 interface RegisterIpcOptions {
   bridge: PiAgentBridge
@@ -41,6 +48,19 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () =
     }
   }
 
+  const onExtensionUiRequest = (request: ExtensionUIRequest): void => {
+    if (!canSendToRenderer()) {
+      log.warn('[desktop-ipc] skipping extension ui request dispatch: renderer window is destroyed')
+      return
+    }
+
+    window.webContents.send(IPC_CHANNELS.sessionExtensionUiRequest, request)
+    log.debug('[desktop-ipc] outbound extension ui request', {
+      id: request.id,
+      method: request.method,
+    })
+  }
+
   const onStatus = (status: BridgeStatusEvent): void => {
     sendBridgeStatus(status)
   }
@@ -61,6 +81,7 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () =
   }
 
   bridge.on('rpc-event', onRpcEvent)
+  bridge.on('extension-ui-request', onExtensionUiRequest)
   bridge.on('status', onStatus)
   bridge.on('debug', onDebug)
   bridge.on('crash', onCrash)
@@ -76,6 +97,8 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () =
   ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
   ipcMain.removeHandler(IPC_CHANNELS.sessionRestart)
   ipcMain.removeHandler(IPC_CHANNELS.sessionGetBridgeState)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionExtensionUiResponse)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionPermissionMode)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -106,8 +129,20 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () =
 
   ipcMain.handle(IPC_CHANNELS.sessionGetBridgeState, async () => bridge.getState())
 
+  ipcMain.handle(
+    IPC_CHANNELS.sessionExtensionUiResponse,
+    async (_event, id: string, response: ExtensionUIResponse) => {
+      await bridge.sendExtensionUIResponse(id, response)
+    },
+  )
+
+  ipcMain.handle(IPC_CHANNELS.sessionPermissionMode, async (_event, mode: PermissionMode) => {
+    bridge.setPermissionMode(mode)
+  })
+
   return () => {
     bridge.off('rpc-event', onRpcEvent)
+    bridge.off('extension-ui-request', onExtensionUiRequest)
     bridge.off('status', onStatus)
     bridge.off('debug', onDebug)
     bridge.off('crash', onCrash)
@@ -116,5 +151,7 @@ export function registerSessionIpc({ bridge, window }: RegisterIpcOptions): () =
     ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
     ipcMain.removeHandler(IPC_CHANNELS.sessionRestart)
     ipcMain.removeHandler(IPC_CHANNELS.sessionGetBridgeState)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionExtensionUiResponse)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionPermissionMode)
   }
 }

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -7,6 +7,9 @@ import {
   type BridgeState,
   type BridgeStatusEvent,
   type CommandResult,
+  type ExtensionUIRequest,
+  type ExtensionUIResponse,
+  type PermissionMode,
   type RpcCommand,
 } from '../shared/types'
 
@@ -32,6 +35,7 @@ interface RpcEnvelope {
 
 interface BridgeEvents {
   'rpc-event': (event: Record<string, unknown>) => void
+  'extension-ui-request': (request: ExtensionUIRequest) => void
   crash: (payload: { exitCode: number | null; signal: NodeJS.Signals | null; stderrLines: string[] }) => void
   status: (payload: BridgeStatusEvent) => void
   debug: (payload: Record<string, unknown>) => void
@@ -47,6 +51,7 @@ export class PiAgentBridge extends EventEmitter {
   private resolvedCommand: string | null = null
   private status: BridgeLifecycleState = 'shutdown'
   private startPromise: Promise<void> | null = null
+  private permissionMode: PermissionMode = 'ask'
 
   constructor(
     private readonly workspacePath: string,
@@ -70,6 +75,7 @@ export class PiAgentBridge extends EventEmitter {
       pid: this.child?.pid ?? null,
       command: this.resolvedCommand,
       status: this.status,
+      permissionMode: this.permissionMode,
     }
   }
 
@@ -266,14 +272,32 @@ export class PiAgentBridge extends EventEmitter {
         },
       })
 
-      child.stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
-        if (error) {
-          clearTimeout(timeoutId)
-          this.pending.delete(id)
-          reject(error)
-        }
+      this.writeJsonLine(payload).catch((error: unknown) => {
+        clearTimeout(timeoutId)
+        this.pending.delete(id)
+        reject(error instanceof Error ? error : new Error(String(error)))
       })
     })
+  }
+
+  public setPermissionMode(mode: PermissionMode): void {
+    this.permissionMode = mode
+    this.emit('debug', {
+      type: 'bridge:permission-mode',
+      mode,
+    })
+  }
+
+  public async sendExtensionUIResponse(id: string, response: ExtensionUIResponse): Promise<void> {
+    await this.start()
+
+    const payload = {
+      type: 'extension_ui_response',
+      id,
+      ...response,
+    }
+
+    await this.writeJsonLine(payload)
   }
 
   public prompt(message: string): Promise<CommandResult> {
@@ -326,6 +350,25 @@ export class PiAgentBridge extends EventEmitter {
     }
   }
 
+  private writeJsonLine(payload: Record<string, unknown>): Promise<void> {
+    const child = this.child
+    if (!child || child.killed || !child.stdin.writable) {
+      return Promise.reject(new Error('RPC subprocess is not writable'))
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const line = `${JSON.stringify(payload)}\n`
+      child.stdin.write(line, (error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve()
+      })
+    })
+  }
+
   private resolveCommand(): string {
     const fromEnv = process.env.KATA_BIN_PATH?.trim()
     if (fromEnv) {
@@ -371,12 +414,12 @@ export class PiAgentBridge extends EventEmitter {
     }
 
     if (this.isRpcEnvelope(parsed)) {
-      this.emit('rpc-event', parsed.event)
+      this.dispatchRpcEvent(parsed.event)
       return
     }
 
     if (this.isRpcEvent(parsed)) {
-      this.emit('rpc-event', parsed)
+      this.dispatchRpcEvent(parsed)
       return
     }
 
@@ -384,6 +427,39 @@ export class PiAgentBridge extends EventEmitter {
       type: 'agent_error',
       message: 'Received unrecognized RPC payload shape',
     })
+  }
+
+  private dispatchRpcEvent(event: Record<string, unknown>): void {
+    if (event.type === 'extension_ui_request') {
+      const request = this.extractExtensionUIRequest(event)
+      if (!request) {
+        this.emit('rpc-event', {
+          type: 'agent_error',
+          message: 'Received malformed extension_ui_request payload',
+        })
+        return
+      }
+
+      this.emit('extension-ui-request', request)
+      return
+    }
+
+    this.emit('rpc-event', event)
+  }
+
+  private extractExtensionUIRequest(event: Record<string, unknown>): ExtensionUIRequest | null {
+    const id = event.id
+    const method = event.method
+
+    if (typeof id !== 'string' || id.length === 0) {
+      return null
+    }
+
+    if (typeof method !== 'string' || method.length === 0) {
+      return null
+    }
+
+    return event as ExtensionUIRequest
   }
 
   private resolvePending(response: RpcResponse): void {

--- a/apps/desktop/src/main/rpc-event-adapter.ts
+++ b/apps/desktop/src/main/rpc-event-adapter.ts
@@ -1,4 +1,16 @@
-import { type ChatEvent } from '../shared/types'
+import {
+  type BashArgs,
+  type BashResult,
+  type ChatEvent,
+  type EditArgs,
+  type EditResult,
+  type ReadArgs,
+  type ReadResult,
+  type ToolArgs,
+  type ToolResult,
+  type WriteArgs,
+  type WriteResult,
+} from '../shared/types'
 
 interface AssistantMessageEvent {
   type?: string
@@ -17,6 +29,33 @@ interface RpcEvent {
   isError?: boolean
   error?: string
   status?: string
+  stdout?: unknown
+}
+
+const LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'typescript',
+  js: 'javascript',
+  jsx: 'javascript',
+  json: 'json',
+  md: 'markdown',
+  py: 'python',
+  rb: 'ruby',
+  rs: 'rust',
+  go: 'go',
+  java: 'java',
+  kt: 'kotlin',
+  swift: 'swift',
+  css: 'css',
+  scss: 'scss',
+  html: 'html',
+  xml: 'xml',
+  yaml: 'yaml',
+  yml: 'yaml',
+  sh: 'shell',
+  bash: 'shell',
+  sql: 'sql',
+  toml: 'toml',
 }
 
 export class RpcEventAdapter {
@@ -85,35 +124,44 @@ export class RpcEventAdapter {
           },
         ]
 
-      case 'tool_execution_start':
+      case 'tool_execution_start': {
+        const toolName = this.extractToolName(event)
         return [
           {
             type: 'tool_start',
             toolCallId: this.extractToolCallId(event),
-            toolName: this.extractToolName(event),
-            args: event.args ?? {},
+            toolName,
+            args: this.extractToolArgs(toolName, event.args),
           },
         ]
+      }
 
-      case 'tool_execution_update':
+      case 'tool_execution_update': {
+        const toolName = this.extractToolName(event)
+
         return [
           {
             type: 'tool_update',
             toolCallId: this.extractToolCallId(event),
-            toolName: this.extractToolName(event),
+            toolName,
             status: typeof event.status === 'string' ? event.status : undefined,
+            partialStdout: toolName === 'bash' ? this.extractPartialStdout(event) : undefined,
           },
         ]
+      }
 
       case 'tool_execution_end': {
-        const result = event.result ?? event.message?.result
+        const toolName = this.extractToolName(event)
+        const args = this.extractToolArgs(toolName, event.args)
+        const rawResult = event.result ?? event.message?.result
+        const result = this.extractToolResult(toolName, args, rawResult)
         const error = typeof event.error === 'string' ? event.error : this.extractToolError(event.message)
 
         return [
           {
             type: 'tool_end',
             toolCallId: this.extractToolCallId(event),
-            toolName: this.extractToolName(event),
+            toolName,
             result,
             isError: Boolean(event.isError || error),
             error: error ?? undefined,
@@ -132,6 +180,190 @@ export class RpcEventAdapter {
       default:
         return []
     }
+  }
+
+  private extractToolArgs(toolName: string, args: unknown): ToolArgs {
+    const argRecord = asRecord(args)
+
+    switch (toolName) {
+      case 'edit': {
+        const typed: EditArgs = {
+          path: asString(argRecord?.path) ?? 'unknown-file',
+        }
+
+        if (typeof argRecord?.oldText === 'string') {
+          typed.oldText = argRecord.oldText
+        }
+
+        if (typeof argRecord?.newText === 'string') {
+          typed.newText = argRecord.newText
+        }
+
+        const edits = toEditsArray(argRecord?.edits)
+        if (edits.length > 0) {
+          typed.edits = edits
+        }
+
+        return typed
+      }
+
+      case 'bash':
+        return {
+          command: asString(argRecord?.command) ?? '',
+          timeout: asNumber(argRecord?.timeout),
+        } satisfies BashArgs
+
+      case 'read':
+        return {
+          path: asString(argRecord?.path) ?? 'unknown-file',
+          offset: asNumber(argRecord?.offset),
+          limit: asNumber(argRecord?.limit),
+        } satisfies ReadArgs
+
+      case 'write':
+        return {
+          path: asString(argRecord?.path) ?? 'unknown-file',
+          content: asString(argRecord?.content) ?? '',
+        } satisfies WriteArgs
+
+      default:
+        return {
+          raw: args,
+        }
+    }
+  }
+
+  private extractToolResult(toolName: string, args: ToolArgs, result: unknown): ToolResult {
+    switch (toolName) {
+      case 'edit':
+        return this.extractEditResult(args, result)
+      case 'bash':
+        return this.extractBashResult(args, result)
+      case 'read':
+        return this.extractReadResult(args, result)
+      case 'write':
+        return this.extractWriteResult(args, result)
+      default:
+        return {
+          raw: result,
+        }
+    }
+  }
+
+  private extractEditResult(args: ToolArgs, result: unknown): EditResult {
+    const argRecord = asRecord(args)
+    const resultRecord = asRecord(result)
+
+    const path = asString(resultRecord?.path) ?? asString(argRecord?.path) ?? 'unknown-file'
+    const diff = asString(resultRecord?.diff) ?? asString(resultRecord?.content) ?? ''
+
+    const { additions, deletions } = diff ? countDiffLines(diff) : countFromEdits(toEditsArray(argRecord?.edits))
+
+    const linesAdded = asNumber(resultRecord?.linesAdded) ?? additions
+    const linesRemoved = asNumber(resultRecord?.linesRemoved) ?? deletions
+
+    const parsed: EditResult = {
+      path,
+      diff,
+      linesAdded,
+      linesRemoved,
+      linesChanged: linesAdded + linesRemoved,
+      original: asString(resultRecord?.original),
+      modified: asString(resultRecord?.modified),
+      raw: result,
+    }
+
+    if (!diff) {
+      parsed.parseError = 'No diff returned by edit tool result'
+    }
+
+    return parsed
+  }
+
+  private extractBashResult(args: ToolArgs, result: unknown): BashResult {
+    const argRecord = asRecord(args)
+    const resultRecord = asRecord(result)
+
+    const stdout = stringifyField(resultRecord?.stdout) ?? stringifyField(resultRecord?.output) ?? ''
+    const stderr = stringifyField(resultRecord?.stderr) ?? ''
+
+    return {
+      command: asString(argRecord?.command) ?? asString(resultRecord?.command) ?? 'bash',
+      stdout,
+      stderr,
+      exitCode: asNumber(resultRecord?.exitCode),
+      raw: result,
+    }
+  }
+
+  private extractReadResult(args: ToolArgs, result: unknown): ReadResult {
+    const argRecord = asRecord(args)
+    const resultRecord = asRecord(result)
+
+    const path = asString(resultRecord?.path) ?? asString(argRecord?.path) ?? 'unknown-file'
+    const content =
+      asString(resultRecord?.content) ??
+      asString(resultRecord?.text) ??
+      asString(asRecord(resultRecord?.file)?.content) ??
+      stringifyField(result) ??
+      ''
+
+    const contentLines = content.length > 0 ? content.split('\n').length : 0
+    const totalLines =
+      asNumber(resultRecord?.totalLines) ??
+      asNumber(asRecord(resultRecord?.file)?.totalLines) ??
+      asNumber(resultRecord?.numLines) ??
+      contentLines
+
+    const truncated =
+      asBoolean(resultRecord?.truncated) ??
+      asBoolean(asRecord(resultRecord?.file)?.truncated) ??
+      (totalLines > contentLines && contentLines > 0)
+
+    return {
+      path,
+      content,
+      language: detectLanguage(path),
+      totalLines,
+      truncated,
+      raw: result,
+    }
+  }
+
+  private extractWriteResult(args: ToolArgs, result: unknown): WriteResult {
+    const argRecord = asRecord(args)
+    const resultRecord = asRecord(result)
+
+    const path = asString(resultRecord?.path) ?? asString(argRecord?.path) ?? 'unknown-file'
+    const content = asString(resultRecord?.content) ?? asString(argRecord?.content) ?? ''
+
+    return {
+      path,
+      content,
+      bytesWritten: asNumber(resultRecord?.bytesWritten) ?? byteLength(content),
+      raw: result,
+    }
+  }
+
+  private extractPartialStdout(event: RpcEvent): string | undefined {
+    const fromTopLevel = stringifyField(event.stdout)
+    if (fromTopLevel) {
+      return fromTopLevel
+    }
+
+    const resultRecord = asRecord(event.result)
+    const fromResult = stringifyField(resultRecord?.stdout)
+    if (fromResult) {
+      return fromResult
+    }
+
+    const messageRecord = event.message
+    const fromMessage = stringifyField(messageRecord?.stdout)
+    if (fromMessage) {
+      return fromMessage
+    }
+
+    return undefined
   }
 
   private extractTextDelta(event: RpcEvent): string {
@@ -266,4 +498,117 @@ export class RpcEventAdapter {
 
     return 'Unknown extension error'
   }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function stringifyField(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => stringifyField(entry) ?? '').join('\n')
+  }
+
+  if (value && typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, 2)
+    } catch {
+      return String(value)
+    }
+  }
+
+  if (value === undefined || value === null) {
+    return undefined
+  }
+
+  return String(value)
+}
+
+function toEditsArray(value: unknown): Array<{ oldText: string; newText: string }> {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((item) => {
+      const record = asRecord(item)
+      const oldText = asString(record?.oldText)
+      const newText = asString(record?.newText)
+
+      if (!oldText && !newText) {
+        return null
+      }
+
+      return {
+        oldText: oldText ?? '',
+        newText: newText ?? '',
+      }
+    })
+    .filter((item): item is { oldText: string; newText: string } => item !== null)
+}
+
+function countDiffLines(diff: string): { additions: number; deletions: number } {
+  const lines = diff.split('\n')
+  let additions = 0
+  let deletions = 0
+
+  for (const line of lines) {
+    if (line.startsWith('+++ ') || line.startsWith('--- ') || line.startsWith('diff --git')) {
+      continue
+    }
+
+    if (line.startsWith('+')) {
+      additions += 1
+    } else if (line.startsWith('-')) {
+      deletions += 1
+    }
+  }
+
+  return { additions, deletions }
+}
+
+function countFromEdits(edits: Array<{ oldText: string; newText: string }>): {
+  additions: number
+  deletions: number
+} {
+  return edits.reduce(
+    (totals, edit) => {
+      totals.additions += edit.newText.split('\n').filter(Boolean).length
+      totals.deletions += edit.oldText.split('\n').filter(Boolean).length
+      return totals
+    },
+    {
+      additions: 0,
+      deletions: 0,
+    },
+  )
+}
+
+function detectLanguage(path: string): string {
+  const extension = path.split('.').pop()?.toLowerCase() ?? ''
+  return LANGUAGE_BY_EXTENSION[extension] ?? 'text'
+}
+
+function byteLength(input: string): number {
+  return new TextEncoder().encode(input).byteLength
 }

--- a/apps/desktop/src/main/rpc-event-adapter.ts
+++ b/apps/desktop/src/main/rpc-event-adapter.ts
@@ -30,6 +30,7 @@ interface RpcEvent {
   error?: string
   status?: string
   stdout?: unknown
+  partialResult?: unknown
 }
 
 const LANGUAGE_BY_EXTENSION: Record<string, string> = {
@@ -351,16 +352,37 @@ export class RpcEventAdapter {
       return fromTopLevel
     }
 
+    const topLevelPartialRecord = asRecord(event.partialResult)
+    const fromTopLevelPartial =
+      stringifyField(topLevelPartialRecord?.stdout) ?? stringifyField(topLevelPartialRecord?.output)
+    if (fromTopLevelPartial) {
+      return fromTopLevelPartial
+    }
+
     const resultRecord = asRecord(event.result)
-    const fromResult = stringifyField(resultRecord?.stdout)
+    const fromResult = stringifyField(resultRecord?.stdout) ?? stringifyField(resultRecord?.output)
     if (fromResult) {
       return fromResult
     }
 
+    const resultPartialRecord = asRecord(resultRecord?.partialResult)
+    const fromResultPartial =
+      stringifyField(resultPartialRecord?.stdout) ?? stringifyField(resultPartialRecord?.output)
+    if (fromResultPartial) {
+      return fromResultPartial
+    }
+
     const messageRecord = event.message
-    const fromMessage = stringifyField(messageRecord?.stdout)
+    const fromMessage = stringifyField(messageRecord?.stdout) ?? stringifyField(messageRecord?.output)
     if (fromMessage) {
       return fromMessage
+    }
+
+    const messagePartialRecord = asRecord(messageRecord?.partialResult)
+    const fromMessagePartial =
+      stringifyField(messagePartialRecord?.stdout) ?? stringifyField(messagePartialRecord?.output)
+    if (fromMessagePartial) {
+      return fromMessagePartial
     }
 
     return undefined
@@ -593,8 +615,8 @@ function countFromEdits(edits: Array<{ oldText: string; newText: string }>): {
 } {
   return edits.reduce(
     (totals, edit) => {
-      totals.additions += edit.newText.split('\n').filter(Boolean).length
-      totals.deletions += edit.oldText.split('\n').filter(Boolean).length
+      totals.additions += countTextLines(edit.newText)
+      totals.deletions += countTextLines(edit.oldText)
       return totals
     },
     {
@@ -602,6 +624,17 @@ function countFromEdits(edits: Array<{ oldText: string; newText: string }>): {
       deletions: 0,
     },
   )
+}
+
+function countTextLines(value: string): number {
+  if (value.length === 0) {
+    return 0
+  }
+
+  const normalized = value.replace(/\r\n/g, '\n')
+  const lineCount = normalized.split('\n').length
+
+  return normalized.endsWith('\n') ? Math.max(0, lineCount - 1) : lineCount
 }
 
 function detectLanguage(path: string): string {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -4,6 +4,8 @@ import {
   type BridgeStatusEvent,
   type ChatEvent,
   type DesktopApi,
+  type ExtensionUIRequest,
+  type PermissionMode,
 } from '../shared/types'
 
 const api: DesktopApi = {
@@ -40,6 +42,23 @@ const api: DesktopApi = {
   },
   getBridgeState: async () => {
     return ipcRenderer.invoke(IPC_CHANNELS.sessionGetBridgeState)
+  },
+  onExtensionUIRequest: (listener: (event: ExtensionUIRequest) => void) => {
+    const wrapped = (_event: Electron.IpcRendererEvent, request: ExtensionUIRequest) => {
+      listener(request)
+    }
+
+    ipcRenderer.on(IPC_CHANNELS.sessionExtensionUiRequest, wrapped)
+
+    return () => {
+      ipcRenderer.removeListener(IPC_CHANNELS.sessionExtensionUiRequest, wrapped)
+    }
+  },
+  sendExtensionUIResponse: async (id: string, response: Parameters<DesktopApi['sendExtensionUIResponse']>[1]) => {
+    await ipcRenderer.invoke(IPC_CHANNELS.sessionExtensionUiResponse, id, response)
+  },
+  setPermissionMode: async (mode: PermissionMode) => {
+    await ipcRenderer.invoke(IPC_CHANNELS.sessionPermissionMode, mode)
   },
 }
 

--- a/apps/desktop/src/renderer/atoms/chat.ts
+++ b/apps/desktop/src/renderer/atoms/chat.ts
@@ -3,15 +3,18 @@ import {
   type BridgeStatusEvent,
   type BridgeLifecycleState,
   type ChatEvent,
+  type ToolArgs,
+  type ToolResult,
 } from '@shared/types'
 
 export interface ToolCallView {
   id: string
   name: string
-  args: unknown
+  args: ToolArgs
   status: 'running' | 'done' | 'error'
-  result?: unknown
+  result?: ToolResult
   error?: string
+  partialStdout?: string
 }
 
 export interface ChatMessageView {
@@ -184,15 +187,20 @@ export const applyChatEventAtom = atom(null, (get, set, event: ChatEvent) => {
     case 'tool_update': {
       set(
         toolCallsAtom,
-        get(toolCallsAtom).map((tool) =>
-          tool.id === event.toolCallId
-            ? {
-                ...tool,
-                name: event.toolName,
-                status: event.status === 'error' ? 'error' : tool.status,
-              }
-            : tool,
-        ),
+        get(toolCallsAtom).map((tool) => {
+          if (tool.id !== event.toolCallId) {
+            return tool
+          }
+
+          return {
+            ...tool,
+            name: event.toolName,
+            status: event.status === 'error' ? 'error' : tool.status,
+            partialStdout: event.partialStdout
+              ? `${tool.partialStdout ?? ''}${event.partialStdout}`
+              : tool.partialStdout,
+          }
+        }),
       )
       return
     }
@@ -208,6 +216,7 @@ export const applyChatEventAtom = atom(null, (get, set, event: ChatEvent) => {
                 status: event.isError ? 'error' : 'done',
                 result: event.result,
                 error: event.error,
+                partialStdout: undefined,
               }
             : tool,
         ),

--- a/apps/desktop/src/renderer/atoms/permissions.ts
+++ b/apps/desktop/src/renderer/atoms/permissions.ts
@@ -1,0 +1,4 @@
+import { atom } from 'jotai'
+import type { PermissionMode } from '@shared/types'
+
+export const permissionModeAtom = atom<PermissionMode>('ask')

--- a/apps/desktop/src/renderer/components/chat/BashOutputCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/BashOutputCard.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import * as Collapsible from '@radix-ui/react-collapsible'
 import { TerminalOutput } from '@kata-ui/components/terminal/TerminalOutput'
 import type { ToolCallView } from '@/atoms/chat'
+import { asNumber, asRecord, asString } from './toolCardUtils'
 
 interface BashOutputCardProps {
   tool: ToolCallView
@@ -13,46 +14,6 @@ interface BashViewModel {
   stderr: string
   output: string
   exitCode?: number
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return null
-  }
-
-  return value as Record<string, unknown>
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
-}
-
-function toText(value: unknown): string {
-  if (typeof value === 'string') {
-    return value
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((entry) => toText(entry)).join('\n')
-  }
-
-  if (value && typeof value === 'object') {
-    try {
-      return JSON.stringify(value, null, 2)
-    } catch {
-      return String(value)
-    }
-  }
-
-  if (value === null || value === undefined) {
-    return ''
-  }
-
-  return String(value)
 }
 
 function buildBashViewModel(tool: ToolCallView): BashViewModel {

--- a/apps/desktop/src/renderer/components/chat/BashOutputCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/BashOutputCard.tsx
@@ -1,0 +1,134 @@
+import { useMemo, useState } from 'react'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import { TerminalOutput } from '@kata-ui/components/terminal/TerminalOutput'
+import type { ToolCallView } from '@/atoms/chat'
+
+interface BashOutputCardProps {
+  tool: ToolCallView
+}
+
+interface BashViewModel {
+  command: string
+  stdout: string
+  stderr: string
+  output: string
+  exitCode?: number
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function toText(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => toText(entry)).join('\n')
+  }
+
+  if (value && typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, 2)
+    } catch {
+      return String(value)
+    }
+  }
+
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  return String(value)
+}
+
+function buildBashViewModel(tool: ToolCallView): BashViewModel {
+  const args = asRecord(tool.args)
+  const result = asRecord(tool.result)
+
+  const command = asString(result?.command) ?? asString(args?.command) ?? 'bash'
+
+  const stdout =
+    asString(result?.stdout) ??
+    asString(result?.output) ??
+    asString(tool.partialStdout) ??
+    (tool.status === 'running' ? asString(result?.content) : undefined) ??
+    ''
+
+  const stderr = asString(result?.stderr) ?? ''
+
+  const output = [stdout, stderr].filter(Boolean).join(stdout && stderr ? '\n' : '')
+
+  const exitCode = asNumber(result?.exitCode)
+
+  return {
+    command,
+    stdout,
+    stderr,
+    output,
+    exitCode,
+  }
+}
+
+export function BashOutputCard({ tool }: BashOutputCardProps) {
+  const [isOpen, setIsOpen] = useState(tool.status !== 'done')
+  const view = useMemo(() => buildBashViewModel(tool), [tool])
+
+  const statusClass =
+    tool.status === 'error'
+      ? 'border-red-500/40 bg-red-500/20 text-red-100'
+      : tool.status === 'done'
+        ? 'border-emerald-500/40 bg-emerald-500/20 text-emerald-100'
+        : 'border-amber-500/40 bg-amber-500/20 text-amber-100'
+
+  const exitClass =
+    view.exitCode === undefined || view.exitCode === 0
+      ? 'border-emerald-500/40 bg-emerald-500/15 text-emerald-200'
+      : 'border-red-500/40 bg-red-500/15 text-red-200'
+
+  return (
+    <Collapsible.Root
+      className="rounded-md border border-slate-700 bg-slate-900/60"
+      open={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      <Collapsible.Trigger className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-semibold text-slate-100">bash · {view.command}</p>
+          <div className="mt-1 flex items-center gap-2">
+            {view.exitCode !== undefined && (
+              <span className={`rounded border px-1.5 py-0.5 text-[10px] ${exitClass}`}>
+                exit {view.exitCode}
+              </span>
+            )}
+            <span className="text-[11px] text-slate-400">
+              {(view.output || '').split('\n').filter(Boolean).length} lines
+            </span>
+          </div>
+        </div>
+        <span className={`rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide ${statusClass}`}>
+          {tool.status}
+        </span>
+      </Collapsible.Trigger>
+
+      <Collapsible.Content className="border-t border-slate-700 px-3 py-2">
+        <div className="max-h-[24rem] overflow-auto rounded border border-slate-700 bg-slate-950">
+          <TerminalOutput command={view.command} output={view.output} exitCode={view.exitCode} theme="dark" toolType="bash" />
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -11,8 +11,10 @@ import {
   toolCallsAtom,
 } from '@/atoms/chat'
 import { ErrorBanner } from './ErrorBanner'
+import { ExtensionUIHandler } from './ExtensionUIHandler'
 import { MessageInput } from './MessageInput'
 import { MessageList } from './MessageList'
+import { PermissionModeSelector } from './PermissionModeSelector'
 
 export function ChatPanel() {
   const messages = useAtomValue(messagesAtom)
@@ -64,7 +66,9 @@ export function ChatPanel() {
   const errorTitle = bridgeStatus.state === 'crashed' ? 'Agent process crashed' : 'Agent error'
 
   return (
-    <div className="flex h-[calc(100%-3.5rem)] flex-col">
+    <div className="relative flex h-[calc(100%-3.5rem)] flex-col">
+      <ExtensionUIHandler />
+
       {errorMessage && (
         <ErrorBanner
           title={errorTitle}
@@ -72,6 +76,11 @@ export function ChatPanel() {
           onRestart={bridgeStatus.state !== 'spawning' ? () => window.api.restartAgent() : undefined}
         />
       )}
+
+      <div className="flex items-center justify-between border-b border-slate-800 px-4 py-2">
+        <p className="text-[11px] uppercase tracking-wide text-slate-400">Permission mode</p>
+        <PermissionModeSelector />
+      </div>
 
       <div ref={scrollRef} className="flex-1 overflow-auto">
         <MessageList messages={messages} tools={tools} />

--- a/apps/desktop/src/renderer/components/chat/ExtensionUIHandler.tsx
+++ b/apps/desktop/src/renderer/components/chat/ExtensionUIHandler.tsx
@@ -40,6 +40,12 @@ function isInputRequest(request: ExtensionUIRequest): request is ExtensionUIInpu
   return request.method === 'input'
 }
 
+function isSupportedInteractiveRequest(
+  request: ExtensionUIRequest,
+): request is ExtensionUIConfirmRequest | ExtensionUISelectRequest | ExtensionUIInputRequest {
+  return isConfirmRequest(request) || isSelectRequest(request) || isInputRequest(request)
+}
+
 function isNotifyLevel(value: unknown): value is ToastItem['level'] {
   return value === 'info' || value === 'success' || value === 'warning' || value === 'error'
 }
@@ -112,10 +118,11 @@ export function ExtensionUIHandler() {
     window.setTimeout(() => dismissToast(id), 4_500)
   }
 
-  const sendResponse = async (requestId: string, response: ExtensionUIResponse): Promise<void> => {
+  const sendResponse = async (requestId: string, response: ExtensionUIResponse): Promise<boolean> => {
     try {
       await window.api.sendExtensionUIResponse(requestId, response)
       console.debug('[ExtensionUIHandler] extension_ui_response sent', { requestId, response })
+      return true
     } catch (error) {
       console.error('[ExtensionUIHandler] failed to send extension_ui_response', {
         requestId,
@@ -125,9 +132,11 @@ export function ExtensionUIHandler() {
 
       pushToast({
         title: 'Response failed',
-        message: 'Could not send extension_ui_response to the agent subprocess.',
+        message: 'Could not send extension_ui_response to the agent subprocess. Request remains open for retry.',
         level: 'error',
       })
+
+      return false
     }
   }
 
@@ -149,6 +158,15 @@ export function ExtensionUIHandler() {
         const level = isNotifyLevel(request.level) ? request.level : 'info'
 
         pushToast({ title, message, level })
+        return
+      }
+
+      if (!isSupportedInteractiveRequest(request)) {
+        console.warn('[ExtensionUIHandler] unsupported extension_ui_request method; auto-cancelling', {
+          id: request.id,
+          method: request.method,
+        })
+        void sendResponse(request.id, { cancelled: true })
         return
       }
 
@@ -207,14 +225,23 @@ export function ExtensionUIHandler() {
       return
     }
 
+    const requestId = activeRequest.id
+    const requestMethod = activeRequest.method
+
     const timeoutId = window.setTimeout(() => {
-      void sendResponse(activeRequest.id, { cancelled: true })
-      pushToast({
-        title: 'Request timed out',
-        message: `${activeRequest.method} request expired without input.`,
-        level: 'warning',
-      })
-      setActiveRequest(null)
+      void (async () => {
+        const sent = await sendResponse(requestId, { cancelled: true })
+        if (!sent) {
+          return
+        }
+
+        pushToast({
+          title: 'Request timed out',
+          message: `${requestMethod} request expired without input.`,
+          level: 'warning',
+        })
+        setActiveRequest((current) => (current?.id === requestId ? null : current))
+      })()
     }, getTimeoutMs(activeRequest))
 
     return () => window.clearTimeout(timeoutId)
@@ -239,21 +266,35 @@ export function ExtensionUIHandler() {
         open={Boolean(activeConfirmRequest)}
         request={activeConfirmRequest}
         onApprove={(requestId) => {
-          void sendResponse(requestId, { confirmed: true })
-          setActiveRequest(null)
+          void (async () => {
+            const sent = await sendResponse(requestId, { confirmed: true })
+            if (sent) {
+              setActiveRequest((current) => (current?.id === requestId ? null : current))
+            }
+          })()
         }}
         onReject={(requestId) => {
-          void sendResponse(requestId, { confirmed: false })
-          setActiveRequest(null)
+          void (async () => {
+            const sent = await sendResponse(requestId, { confirmed: false })
+            if (sent) {
+              setActiveRequest((current) => (current?.id === requestId ? null : current))
+            }
+          })()
         }}
         onTimeout={(requestId) => {
-          void sendResponse(requestId, { confirmed: false })
-          pushToast({
-            title: 'Approval timed out',
-            message: 'Tool request was rejected after timeout.',
-            level: 'warning',
-          })
-          setActiveRequest(null)
+          void (async () => {
+            const sent = await sendResponse(requestId, { confirmed: false })
+            if (!sent) {
+              return
+            }
+
+            pushToast({
+              title: 'Approval timed out',
+              message: 'Tool request was rejected after timeout.',
+              level: 'warning',
+            })
+            setActiveRequest((current) => (current?.id === requestId ? null : current))
+          })()
         }}
       />
 
@@ -302,8 +343,13 @@ export function ExtensionUIHandler() {
                 type="button"
                 className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-800"
                 onClick={() => {
-                  void sendResponse(activeSelectRequest.id, { cancelled: true })
-                  setActiveRequest(null)
+                  void (async () => {
+                    const requestId = activeSelectRequest.id
+                    const sent = await sendResponse(requestId, { cancelled: true })
+                    if (sent) {
+                      setActiveRequest((current) => (current?.id === requestId ? null : current))
+                    }
+                  })()
                 }}
               >
                 Cancel
@@ -312,8 +358,13 @@ export function ExtensionUIHandler() {
                 type="button"
                 className="rounded border border-emerald-500/50 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-100 hover:bg-emerald-500/20"
                 onClick={() => {
-                  void sendResponse(activeSelectRequest.id, { value: selectedValue })
-                  setActiveRequest(null)
+                  void (async () => {
+                    const requestId = activeSelectRequest.id
+                    const sent = await sendResponse(requestId, { value: selectedValue })
+                    if (sent) {
+                      setActiveRequest((current) => (current?.id === requestId ? null : current))
+                    }
+                  })()
                 }}
                 disabled={!selectedValue}
               >
@@ -348,8 +399,13 @@ export function ExtensionUIHandler() {
                 type="button"
                 className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-800"
                 onClick={() => {
-                  void sendResponse(activeInputRequest.id, { cancelled: true })
-                  setActiveRequest(null)
+                  void (async () => {
+                    const requestId = activeInputRequest.id
+                    const sent = await sendResponse(requestId, { cancelled: true })
+                    if (sent) {
+                      setActiveRequest((current) => (current?.id === requestId ? null : current))
+                    }
+                  })()
                 }}
               >
                 Cancel
@@ -358,8 +414,13 @@ export function ExtensionUIHandler() {
                 type="button"
                 className="rounded border border-emerald-500/50 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-100 hover:bg-emerald-500/20"
                 onClick={() => {
-                  void sendResponse(activeInputRequest.id, { value: inputValue })
-                  setActiveRequest(null)
+                  void (async () => {
+                    const requestId = activeInputRequest.id
+                    const sent = await sendResponse(requestId, { value: inputValue })
+                    if (sent) {
+                      setActiveRequest((current) => (current?.id === requestId ? null : current))
+                    }
+                  })()
                 }}
               >
                 Submit

--- a/apps/desktop/src/renderer/components/chat/ExtensionUIHandler.tsx
+++ b/apps/desktop/src/renderer/components/chat/ExtensionUIHandler.tsx
@@ -1,0 +1,395 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useAtomValue } from 'jotai'
+import {
+  type ExtensionUIConfirmRequest,
+  type ExtensionUIInputRequest,
+  type ExtensionUIRequest,
+  type ExtensionUIResponse,
+  type ExtensionUISelectRequest,
+} from '@shared/types'
+import { permissionModeAtom } from '@/atoms/permissions'
+import { ToolApprovalDialog } from './ToolApprovalDialog'
+
+interface ToastItem {
+  id: string
+  title: string
+  message: string
+  level: 'info' | 'success' | 'warning' | 'error'
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
+
+function getTimeoutMs(request: ExtensionUIRequest): number {
+  const value = request.timeoutMs ?? request.timeout_ms
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value
+  }
+
+  return DEFAULT_TIMEOUT_MS
+}
+
+function isConfirmRequest(request: ExtensionUIRequest): request is ExtensionUIConfirmRequest {
+  return request.method === 'confirm'
+}
+
+function isSelectRequest(request: ExtensionUIRequest): request is ExtensionUISelectRequest {
+  return request.method === 'select'
+}
+
+function isInputRequest(request: ExtensionUIRequest): request is ExtensionUIInputRequest {
+  return request.method === 'input'
+}
+
+function isNotifyLevel(value: unknown): value is ToastItem['level'] {
+  return value === 'info' || value === 'success' || value === 'warning' || value === 'error'
+}
+
+function normalizeOptions(request: ExtensionUISelectRequest): Array<{ label: string; value: string; description?: string }> {
+  if (!Array.isArray(request.options)) {
+    return []
+  }
+
+  const options: Array<{ label: string; value: string; description?: string }> = []
+
+  request.options.forEach((option, index) => {
+    if (typeof option === 'string') {
+      options.push({
+        label: option,
+        value: option,
+      })
+      return
+    }
+
+    if (!option || typeof option !== 'object') {
+      return
+    }
+
+    const record = option as Record<string, unknown>
+    const label = typeof record.label === 'string' ? record.label : `Option ${index + 1}`
+    const value = typeof record.value === 'string' ? record.value : label
+    const description = typeof record.description === 'string' ? record.description : undefined
+
+    options.push({
+      label,
+      value,
+      description,
+    })
+  })
+
+  return options
+}
+
+function makeToastId(prefix: string): string {
+  return `${prefix}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`
+}
+
+export function ExtensionUIHandler() {
+  const permissionMode = useAtomValue(permissionModeAtom)
+  const permissionModeRef = useRef(permissionMode)
+  const [queue, setQueue] = useState<ExtensionUIRequest[]>([])
+  const [activeRequest, setActiveRequest] = useState<ExtensionUIRequest | null>(null)
+  const [inputValue, setInputValue] = useState('')
+  const [selectedValue, setSelectedValue] = useState('')
+  const [toasts, setToasts] = useState<ToastItem[]>([])
+
+  useEffect(() => {
+    permissionModeRef.current = permissionMode
+  }, [permissionMode])
+
+  const enqueue = (request: ExtensionUIRequest) => {
+    setQueue((current) => [...current, request])
+  }
+
+  const dismissToast = (id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id))
+  }
+
+  const pushToast = (toast: Omit<ToastItem, 'id'>) => {
+    const id = makeToastId('toast')
+    const next: ToastItem = { id, ...toast }
+
+    setToasts((current) => [...current, next])
+    window.setTimeout(() => dismissToast(id), 4_500)
+  }
+
+  const sendResponse = async (requestId: string, response: ExtensionUIResponse): Promise<void> => {
+    try {
+      await window.api.sendExtensionUIResponse(requestId, response)
+      console.debug('[ExtensionUIHandler] extension_ui_response sent', { requestId, response })
+    } catch (error) {
+      console.error('[ExtensionUIHandler] failed to send extension_ui_response', {
+        requestId,
+        response,
+        error,
+      })
+
+      pushToast({
+        title: 'Response failed',
+        message: 'Could not send extension_ui_response to the agent subprocess.',
+        level: 'error',
+      })
+    }
+  }
+
+  useEffect(() => {
+    const unsubscribe = window.api.onExtensionUIRequest((request) => {
+      console.debug('[ExtensionUIHandler] extension_ui_request received', {
+        id: request.id,
+        method: request.method,
+      })
+
+      if (request.method === 'notify') {
+        const title = typeof request.title === 'string' ? request.title : 'Notification'
+        const message =
+          typeof request.message === 'string'
+            ? request.message
+            : typeof request.description === 'string'
+              ? request.description
+              : 'Agent emitted a notification.'
+        const level = isNotifyLevel(request.level) ? request.level : 'info'
+
+        pushToast({ title, message, level })
+        return
+      }
+
+      if (isConfirmRequest(request)) {
+        const mode = permissionModeRef.current
+
+        if (mode === 'auto') {
+          void sendResponse(request.id, { confirmed: true })
+          return
+        }
+
+        if (mode === 'explore') {
+          void sendResponse(request.id, { confirmed: false })
+          return
+        }
+      }
+
+      enqueue(request)
+    })
+
+    return unsubscribe
+  }, [])
+
+  useEffect(() => {
+    if (activeRequest || queue.length === 0) {
+      return
+    }
+
+    const [next, ...rest] = queue
+    setActiveRequest(next ?? null)
+    setQueue(rest)
+  }, [activeRequest, queue])
+
+  useEffect(() => {
+    if (!activeRequest) {
+      return
+    }
+
+    if (isInputRequest(activeRequest)) {
+      setInputValue(typeof activeRequest.defaultValue === 'string' ? activeRequest.defaultValue : '')
+      return
+    }
+
+    if (isSelectRequest(activeRequest)) {
+      const options = normalizeOptions(activeRequest)
+      setSelectedValue(options[0]?.value ?? '')
+      return
+    }
+
+    setInputValue('')
+    setSelectedValue('')
+  }, [activeRequest])
+
+  useEffect(() => {
+    if (!activeRequest || isConfirmRequest(activeRequest)) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      void sendResponse(activeRequest.id, { cancelled: true })
+      pushToast({
+        title: 'Request timed out',
+        message: `${activeRequest.method} request expired without input.`,
+        level: 'warning',
+      })
+      setActiveRequest(null)
+    }, getTimeoutMs(activeRequest))
+
+    return () => window.clearTimeout(timeoutId)
+  }, [activeRequest])
+
+  const activeConfirmRequest =
+    activeRequest && isConfirmRequest(activeRequest) ? activeRequest : null
+  const activeSelectRequest = activeRequest && isSelectRequest(activeRequest) ? activeRequest : null
+  const activeInputRequest = activeRequest && isInputRequest(activeRequest) ? activeRequest : null
+
+  const selectOptions = useMemo(() => {
+    if (!activeSelectRequest) {
+      return []
+    }
+
+    return normalizeOptions(activeSelectRequest)
+  }, [activeSelectRequest])
+
+  return (
+    <>
+      <ToolApprovalDialog
+        open={Boolean(activeConfirmRequest)}
+        request={activeConfirmRequest}
+        onApprove={(requestId) => {
+          void sendResponse(requestId, { confirmed: true })
+          setActiveRequest(null)
+        }}
+        onReject={(requestId) => {
+          void sendResponse(requestId, { confirmed: false })
+          setActiveRequest(null)
+        }}
+        onTimeout={(requestId) => {
+          void sendResponse(requestId, { confirmed: false })
+          pushToast({
+            title: 'Approval timed out',
+            message: 'Tool request was rejected after timeout.',
+            level: 'warning',
+          })
+          setActiveRequest(null)
+        }}
+      />
+
+      {activeSelectRequest && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/65 px-4">
+          <div className="w-full max-w-xl rounded-xl border border-slate-700 bg-slate-900 shadow-2xl">
+            <header className="border-b border-slate-700 px-4 py-3">
+              <p className="text-[11px] uppercase tracking-wide text-slate-400">Select value</p>
+              <h2 className="mt-1 text-sm font-semibold text-slate-100">
+                {activeSelectRequest.title ?? activeSelectRequest.message ?? 'Choose an option'}
+              </h2>
+            </header>
+
+            <div className="max-h-72 space-y-2 overflow-auto p-4">
+              {selectOptions.length === 0 && (
+                <p className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-xs text-slate-300">
+                  No options were provided for this select request.
+                </p>
+              )}
+
+              {selectOptions.map((option) => (
+                <label
+                  key={option.value}
+                  className="flex cursor-pointer items-start gap-2 rounded border border-slate-700 bg-slate-950 px-3 py-2"
+                >
+                  <input
+                    type="radio"
+                    name={`extension-select-${activeSelectRequest.id}`}
+                    value={option.value}
+                    checked={selectedValue === option.value}
+                    onChange={(event) => setSelectedValue(event.target.value)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <span className="block text-sm text-slate-100">{option.label}</span>
+                    {option.description && (
+                      <span className="block text-xs text-slate-400">{option.description}</span>
+                    )}
+                  </span>
+                </label>
+              ))}
+            </div>
+
+            <footer className="flex items-center justify-end gap-2 border-t border-slate-700 px-4 py-3">
+              <button
+                type="button"
+                className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-800"
+                onClick={() => {
+                  void sendResponse(activeSelectRequest.id, { cancelled: true })
+                  setActiveRequest(null)
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="rounded border border-emerald-500/50 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-100 hover:bg-emerald-500/20"
+                onClick={() => {
+                  void sendResponse(activeSelectRequest.id, { value: selectedValue })
+                  setActiveRequest(null)
+                }}
+                disabled={!selectedValue}
+              >
+                Submit
+              </button>
+            </footer>
+          </div>
+        </div>
+      )}
+
+      {activeInputRequest && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/65 px-4">
+          <div className="w-full max-w-xl rounded-xl border border-slate-700 bg-slate-900 shadow-2xl">
+            <header className="border-b border-slate-700 px-4 py-3">
+              <p className="text-[11px] uppercase tracking-wide text-slate-400">Input requested</p>
+              <h2 className="mt-1 text-sm font-semibold text-slate-100">
+                {activeInputRequest.title ?? activeInputRequest.message ?? 'Provide input'}
+              </h2>
+            </header>
+
+            <div className="space-y-2 p-4">
+              <textarea
+                value={inputValue}
+                onChange={(event) => setInputValue(event.target.value)}
+                placeholder={typeof activeInputRequest.placeholder === 'string' ? activeInputRequest.placeholder : 'Type a response...'}
+                className="h-28 w-full resize-none rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 outline-none focus:border-slate-500"
+              />
+            </div>
+
+            <footer className="flex items-center justify-end gap-2 border-t border-slate-700 px-4 py-3">
+              <button
+                type="button"
+                className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-800"
+                onClick={() => {
+                  void sendResponse(activeInputRequest.id, { cancelled: true })
+                  setActiveRequest(null)
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="rounded border border-emerald-500/50 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-100 hover:bg-emerald-500/20"
+                onClick={() => {
+                  void sendResponse(activeInputRequest.id, { value: inputValue })
+                  setActiveRequest(null)
+                }}
+              >
+                Submit
+              </button>
+            </footer>
+          </div>
+        </div>
+      )}
+
+      {toasts.length > 0 && (
+        <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex w-96 max-w-[calc(100vw-2rem)] flex-col gap-2">
+          {toasts.map((toast) => {
+            const levelClass =
+              toast.level === 'error'
+                ? 'border-red-500/50 bg-red-500/20 text-red-100'
+                : toast.level === 'warning'
+                  ? 'border-amber-500/50 bg-amber-500/20 text-amber-100'
+                  : toast.level === 'success'
+                    ? 'border-emerald-500/50 bg-emerald-500/20 text-emerald-100'
+                    : 'border-slate-600 bg-slate-800/95 text-slate-100'
+
+            return (
+              <div key={toast.id} className={`rounded border px-3 py-2 text-xs shadow-xl ${levelClass}`}>
+                <p className="font-semibold">{toast.title}</p>
+                <p className="mt-0.5 text-[11px] opacity-90">{toast.message}</p>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/FileEditCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/FileEditCard.tsx
@@ -3,6 +3,7 @@ import * as Collapsible from '@radix-ui/react-collapsible'
 import { ShikiDiffViewer } from '@kata-ui/components/code-viewer/ShikiDiffViewer'
 import { getLanguageFromPath, truncateFilePath } from '@kata-ui/components/code-viewer/language-map'
 import type { ToolCallView } from '@/atoms/chat'
+import { asNumber, asRecord, asString, countTextLines } from './toolCardUtils'
 
 interface FileEditCardProps {
   tool: ToolCallView
@@ -15,21 +16,6 @@ interface DiffViewModel {
   additions: number
   deletions: number
   parseError?: string
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return null
-  }
-  return value as Record<string, unknown>
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 function parseUnifiedDiff(diffText: string): Omit<DiffViewModel, 'filePath'> | null {
@@ -131,8 +117,8 @@ function buildFromEditsArray(edits: unknown): Omit<DiffViewModel, 'filePath'> | 
     originalChunks.push(oldText)
     modifiedChunks.push(newText)
 
-    additions += newText.split('\n').filter(Boolean).length
-    deletions += oldText.split('\n').filter(Boolean).length
+    additions += countTextLines(newText)
+    deletions += countTextLines(oldText)
   })
 
   return {
@@ -163,8 +149,8 @@ function createDiffViewModel(tool: ToolCallView): DiffViewModel {
       filePath,
       original: explicitOriginal,
       modified: explicitModified,
-      additions: asNumber(result?.linesAdded) ?? explicitModified.split('\n').filter(Boolean).length,
-      deletions: asNumber(result?.linesRemoved) ?? explicitOriginal.split('\n').filter(Boolean).length,
+      additions: asNumber(result?.linesAdded) ?? countTextLines(explicitModified),
+      deletions: asNumber(result?.linesRemoved) ?? countTextLines(explicitOriginal),
     }
   }
 

--- a/apps/desktop/src/renderer/components/chat/FileEditCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/FileEditCard.tsx
@@ -1,0 +1,265 @@
+import { useMemo, useState } from 'react'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import { ShikiDiffViewer } from '@kata-ui/components/code-viewer/ShikiDiffViewer'
+import { getLanguageFromPath, truncateFilePath } from '@kata-ui/components/code-viewer/language-map'
+import type { ToolCallView } from '@/atoms/chat'
+
+interface FileEditCardProps {
+  tool: ToolCallView
+}
+
+interface DiffViewModel {
+  filePath: string
+  original: string
+  modified: string
+  additions: number
+  deletions: number
+  parseError?: string
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function parseUnifiedDiff(diffText: string): Omit<DiffViewModel, 'filePath'> | null {
+  const rawLines = diffText
+    .replace(/^```diff\n?/i, '')
+    .replace(/```\s*$/i, '')
+    .split('\n')
+
+  const original: string[] = []
+  const modified: string[] = []
+  let additions = 0
+  let deletions = 0
+  let inHunk = false
+
+  for (const line of rawLines) {
+    if (
+      line.startsWith('diff --git') ||
+      line.startsWith('index ') ||
+      line.startsWith('--- ') ||
+      line.startsWith('+++ ')
+    ) {
+      continue
+    }
+
+    if (line.startsWith('@@')) {
+      inHunk = true
+      continue
+    }
+
+    if (!inHunk) {
+      continue
+    }
+
+    if (line.startsWith('\\ No newline at end of file')) {
+      continue
+    }
+
+    if (line.startsWith('+')) {
+      modified.push(line.slice(1))
+      additions += 1
+      continue
+    }
+
+    if (line.startsWith('-')) {
+      original.push(line.slice(1))
+      deletions += 1
+      continue
+    }
+
+    if (line.startsWith(' ')) {
+      const content = line.slice(1)
+      original.push(content)
+      modified.push(content)
+      continue
+    }
+
+    // Graceful fallback for malformed hunks.
+    original.push(line)
+    modified.push(line)
+  }
+
+  if (!inHunk) {
+    return null
+  }
+
+  return {
+    original: original.join('\n'),
+    modified: modified.join('\n'),
+    additions,
+    deletions,
+  }
+}
+
+function buildFromEditsArray(edits: unknown): Omit<DiffViewModel, 'filePath'> | null {
+  if (!Array.isArray(edits) || edits.length === 0) {
+    return null
+  }
+
+  const originalChunks: string[] = []
+  const modifiedChunks: string[] = []
+  let additions = 0
+  let deletions = 0
+
+  edits.forEach((editEntry, index) => {
+    const editRecord = asRecord(editEntry)
+    if (!editRecord) {
+      return
+    }
+
+    const oldText = asString(editRecord.oldText) ?? ''
+    const newText = asString(editRecord.newText) ?? ''
+
+    const separator = `\n// --- edit ${index + 1} ---\n`
+    if (originalChunks.length > 0) {
+      originalChunks.push(separator)
+      modifiedChunks.push(separator)
+    }
+
+    originalChunks.push(oldText)
+    modifiedChunks.push(newText)
+
+    additions += newText.split('\n').filter(Boolean).length
+    deletions += oldText.split('\n').filter(Boolean).length
+  })
+
+  return {
+    original: originalChunks.join(''),
+    modified: modifiedChunks.join(''),
+    additions,
+    deletions,
+  }
+}
+
+function createDiffViewModel(tool: ToolCallView): DiffViewModel {
+  const args = asRecord(tool.args)
+  const result = asRecord(tool.result)
+
+  const filePath =
+    asString(result?.path) ??
+    asString(args?.path) ??
+    asString(result?.filePath) ??
+    asString(args?.filePath) ??
+    'unknown-file'
+
+  const diff = asString(result?.diff)
+  const explicitOriginal = asString(result?.original)
+  const explicitModified = asString(result?.modified)
+
+  if (explicitOriginal !== undefined && explicitModified !== undefined) {
+    return {
+      filePath,
+      original: explicitOriginal,
+      modified: explicitModified,
+      additions: asNumber(result?.linesAdded) ?? explicitModified.split('\n').filter(Boolean).length,
+      deletions: asNumber(result?.linesRemoved) ?? explicitOriginal.split('\n').filter(Boolean).length,
+    }
+  }
+
+  if (diff) {
+    const parsed = parseUnifiedDiff(diff)
+    if (parsed) {
+      return {
+        filePath,
+        original: parsed.original,
+        modified: parsed.modified,
+        additions: asNumber(result?.linesAdded) ?? parsed.additions,
+        deletions: asNumber(result?.linesRemoved) ?? parsed.deletions,
+      }
+    }
+  }
+
+  const fromEdits = buildFromEditsArray(args?.edits)
+  if (fromEdits) {
+    return {
+      filePath,
+      original: fromEdits.original,
+      modified: fromEdits.modified,
+      additions: fromEdits.additions,
+      deletions: fromEdits.deletions,
+      parseError: diff ? 'Unable to parse unified diff; showing reconstructed edit preview.' : undefined,
+    }
+  }
+
+  return {
+    filePath,
+    original: '',
+    modified: '',
+    additions: 0,
+    deletions: 0,
+    parseError: 'Diff payload missing or malformed. Falling back to raw tool payload.',
+  }
+}
+
+export function FileEditCard({ tool }: FileEditCardProps) {
+  const diffModel = useMemo(() => createDiffViewModel(tool), [tool])
+  const [isOpen, setIsOpen] = useState(tool.status !== 'done')
+
+  const statusClass =
+    tool.status === 'error'
+      ? 'border-red-500/40 bg-red-500/20 text-red-100'
+      : tool.status === 'done'
+        ? 'border-emerald-500/40 bg-emerald-500/20 text-emerald-100'
+        : 'border-amber-500/40 bg-amber-500/20 text-amber-100'
+
+  const fileLabel = truncateFilePath(diffModel.filePath, 68)
+  const language = getLanguageFromPath(diffModel.filePath)
+
+  return (
+    <Collapsible.Root
+      className="rounded-md border border-slate-700 bg-slate-900/60"
+      open={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      <Collapsible.Trigger className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-semibold text-slate-100">edit · {fileLabel}</p>
+          <p className="text-[11px] text-slate-400">
+            +{diffModel.additions} / -{diffModel.deletions} · {language}
+          </p>
+        </div>
+        <span className={`rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide ${statusClass}`}>
+          {tool.status}
+        </span>
+      </Collapsible.Trigger>
+
+      <Collapsible.Content className="space-y-2 border-t border-slate-700 px-3 py-2">
+        {diffModel.parseError && (
+          <p className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-xs text-amber-200">
+            rendering failed: {diffModel.parseError}
+          </p>
+        )}
+
+        {diffModel.original || diffModel.modified ? (
+          <div className="h-[20rem] overflow-hidden rounded border border-slate-700 bg-slate-950">
+            <ShikiDiffViewer
+              filePath={diffModel.filePath}
+              language={language}
+              original={diffModel.original}
+              modified={diffModel.modified}
+              diffStyle="unified"
+              theme="dark"
+              disableFileHeader={false}
+            />
+          </div>
+        ) : (
+          <pre className="max-h-60 overflow-auto rounded bg-slate-950 p-2 text-xs text-slate-200">
+            {JSON.stringify({ args: tool.args, result: tool.result, error: tool.error }, null, 2)}
+          </pre>
+        )}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/FileReadCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/FileReadCard.tsx
@@ -3,6 +3,7 @@ import * as Collapsible from '@radix-ui/react-collapsible'
 import { ShikiCodeViewer } from '@kata-ui/components/code-viewer/ShikiCodeViewer'
 import { getLanguageFromPath, truncateFilePath } from '@kata-ui/components/code-viewer/language-map'
 import type { ToolCallView } from '@/atoms/chat'
+import { asBoolean, asNumber, asRecord, asString } from './toolCardUtils'
 
 interface FileReadCardProps {
   tool: ToolCallView
@@ -14,26 +15,6 @@ interface ReadViewModel {
   language: string
   totalLines: number
   truncated: boolean
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return null
-  }
-
-  return value as Record<string, unknown>
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined
-}
-
-function asBoolean(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 function buildReadViewModel(tool: ToolCallView): ReadViewModel {

--- a/apps/desktop/src/renderer/components/chat/FileReadCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/FileReadCard.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from 'react'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import { ShikiCodeViewer } from '@kata-ui/components/code-viewer/ShikiCodeViewer'
+import { getLanguageFromPath, truncateFilePath } from '@kata-ui/components/code-viewer/language-map'
+import type { ToolCallView } from '@/atoms/chat'
+
+interface FileReadCardProps {
+  tool: ToolCallView
+}
+
+interface ReadViewModel {
+  filePath: string
+  content: string
+  language: string
+  totalLines: number
+  truncated: boolean
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function buildReadViewModel(tool: ToolCallView): ReadViewModel {
+  const args = asRecord(tool.args)
+  const result = asRecord(tool.result)
+
+  const filePath = asString(result?.path) ?? asString(args?.path) ?? 'unknown-file'
+  const content = asString(result?.content) ?? asString(result?.text) ?? ''
+  const lineCount = asNumber(result?.totalLines) ?? content.split('\n').length
+  const language = asString(result?.language) ?? getLanguageFromPath(filePath)
+  const truncated = asBoolean(result?.truncated) ?? false
+
+  return {
+    filePath,
+    content,
+    language,
+    totalLines: lineCount,
+    truncated,
+  }
+}
+
+export function FileReadCard({ tool }: FileReadCardProps) {
+  const view = useMemo(() => buildReadViewModel(tool), [tool])
+  const isLongFile = view.totalLines > 80
+  const [isOpen, setIsOpen] = useState(!isLongFile || tool.status !== 'done')
+
+  const statusClass =
+    tool.status === 'error'
+      ? 'border-red-500/40 bg-red-500/20 text-red-100'
+      : tool.status === 'done'
+        ? 'border-emerald-500/40 bg-emerald-500/20 text-emerald-100'
+        : 'border-amber-500/40 bg-amber-500/20 text-amber-100'
+
+  return (
+    <Collapsible.Root
+      className="rounded-md border border-slate-700 bg-slate-900/60"
+      open={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      <Collapsible.Trigger className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-semibold text-slate-100">read · {truncateFilePath(view.filePath, 68)}</p>
+          <p className="text-[11px] text-slate-400">
+            {view.language} · {view.totalLines} lines{view.truncated ? ' · truncated' : ''}
+          </p>
+        </div>
+        <span className={`rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide ${statusClass}`}>
+          {tool.status}
+        </span>
+      </Collapsible.Trigger>
+
+      <Collapsible.Content className="space-y-2 border-t border-slate-700 px-3 py-2">
+        {view.truncated && (
+          <p className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-xs text-amber-200">
+            File output was truncated by the tool.
+          </p>
+        )}
+
+        <div className="h-[22rem] overflow-hidden rounded border border-slate-700 bg-slate-950">
+          <ShikiCodeViewer
+            code={view.content}
+            language={view.language}
+            filePath={view.filePath}
+            theme="dark"
+          />
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/PermissionModeSelector.tsx
+++ b/apps/desktop/src/renderer/components/chat/PermissionModeSelector.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from 'react'
+import { useAtom } from 'jotai'
+import type { PermissionMode } from '@shared/types'
+import { permissionModeAtom } from '@/atoms/permissions'
+
+const OPTIONS: Array<{
+  value: PermissionMode
+  label: string
+  icon: string
+  description: string
+}> = [
+  {
+    value: 'explore',
+    label: 'Explore',
+    icon: '🔍',
+    description: 'Block file-changing confirms',
+  },
+  {
+    value: 'ask',
+    label: 'Ask',
+    icon: '❓',
+    description: 'Prompt for confirm requests',
+  },
+  {
+    value: 'auto',
+    label: 'Auto',
+    icon: '⚡',
+    description: 'Auto-approve confirm requests',
+  },
+]
+
+export function PermissionModeSelector() {
+  const [mode, setMode] = useAtom(permissionModeAtom)
+
+  useEffect(() => {
+    void window.api.setPermissionMode(mode).catch((error: unknown) => {
+      console.error('[PermissionModeSelector] failed to update bridge permission mode', error)
+    })
+  }, [mode])
+
+  return (
+    <div className="inline-flex rounded-lg border border-slate-700 bg-slate-900 p-1" role="radiogroup" aria-label="Permission mode">
+      {OPTIONS.map((option) => {
+        const selected = option.value === mode
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            title={option.description}
+            onClick={() => setMode(option.value)}
+            className={`rounded px-2.5 py-1 text-xs transition ${
+              selected
+                ? 'bg-slate-100 text-slate-900'
+                : 'text-slate-300 hover:bg-slate-800 hover:text-slate-100'
+            }`}
+          >
+            <span className="mr-1" aria-hidden="true">
+              {option.icon}
+            </span>
+            {option.label}
+          </button>
+        )}
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/ToolApprovalDialog.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolApprovalDialog.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { ExtensionUIConfirmRequest } from '@shared/types'
+
+interface ToolApprovalDialogProps {
+  request: ExtensionUIConfirmRequest | null
+  open: boolean
+  onApprove: (requestId: string) => void
+  onReject: (requestId: string) => void
+  onTimeout: (requestId: string) => void
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+function truncateString(value: string, limit = 180): string {
+  if (value.length <= limit) {
+    return value
+  }
+
+  return `${value.slice(0, limit)}… [truncated ${value.length - limit} chars]`
+}
+
+function redactLargeContent(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return truncateString(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactLargeContent(entry))
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+
+  const record = value as Record<string, unknown>
+  const output: Record<string, unknown> = {}
+
+  for (const [key, entry] of Object.entries(record)) {
+    if (typeof entry === 'string' && /content|oldText|newText|diff/i.test(key)) {
+      output[key] = truncateString(entry, 120)
+      continue
+    }
+
+    output[key] = redactLargeContent(entry)
+  }
+
+  return output
+}
+
+function formatArgs(args: unknown): string {
+  try {
+    return JSON.stringify(redactLargeContent(args), null, 2)
+  } catch {
+    return String(args)
+  }
+}
+
+function formatTime(ms: number): string {
+  const clamped = Math.max(ms, 0)
+  const totalSeconds = Math.floor(clamped / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}
+
+export function ToolApprovalDialog({
+  request,
+  open,
+  onApprove,
+  onReject,
+  onTimeout,
+}: ToolApprovalDialogProps) {
+  const timeoutMs = useMemo(() => {
+    if (!request) {
+      return DEFAULT_TIMEOUT_MS
+    }
+
+    return asNumber(request.timeoutMs) ?? asNumber(request.timeout_ms) ?? DEFAULT_TIMEOUT_MS
+  }, [request])
+
+  const [deadlineAt, setDeadlineAt] = useState<number>(Date.now() + timeoutMs)
+  const [remainingMs, setRemainingMs] = useState<number>(timeoutMs)
+
+  useEffect(() => {
+    if (!open || !request) {
+      return
+    }
+
+    const deadline = Date.now() + timeoutMs
+    setDeadlineAt(deadline)
+    setRemainingMs(timeoutMs)
+  }, [open, request, timeoutMs])
+
+  useEffect(() => {
+    if (!open || !request) {
+      return
+    }
+
+    const interval = setInterval(() => {
+      const now = Date.now()
+      const next = Math.max(0, deadlineAt - now)
+      setRemainingMs(next)
+
+      if (next <= 0) {
+        clearInterval(interval)
+        onTimeout(request.id)
+      }
+    }, 250)
+
+    return () => clearInterval(interval)
+  }, [deadlineAt, onTimeout, open, request])
+
+  if (!open || !request) {
+    return null
+  }
+
+  const toolName = request.toolName ?? 'tool'
+  const message = request.message ?? request.title ?? 'Approve this tool action?'
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/65 px-4">
+      <div className="w-full max-w-2xl rounded-xl border border-slate-700 bg-slate-900 shadow-2xl">
+        <header className="border-b border-slate-700 px-4 py-3">
+          <p className="text-[11px] uppercase tracking-wide text-slate-400">Tool approval requested</p>
+          <h2 className="mt-1 text-sm font-semibold text-slate-100">{toolName}</h2>
+          <p className="mt-1 text-xs text-slate-300">{message}</p>
+        </header>
+
+        <div className="space-y-3 p-4">
+          <div>
+            <p className="mb-1 text-[11px] uppercase tracking-wide text-slate-400">Arguments</p>
+            <pre className="max-h-56 overflow-auto rounded border border-slate-700 bg-slate-950 p-3 text-xs text-slate-200">
+              {formatArgs(request.args ?? {})}
+            </pre>
+          </div>
+
+          <p className="text-xs text-amber-200">Auto-rejects in {formatTime(remainingMs)}</p>
+        </div>
+
+        <footer className="flex items-center justify-end gap-2 border-t border-slate-700 px-4 py-3">
+          <button
+            type="button"
+            className="rounded border border-red-500/50 bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-100 hover:bg-red-500/20"
+            onClick={() => onReject(request.id)}
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            className="rounded border border-emerald-500/50 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-100 hover:bg-emerald-500/20"
+            onClick={() => onApprove(request.id)}
+          >
+            Approve
+          </button>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
@@ -36,8 +36,8 @@ function GenericToolCallCard({ tool }: ToolCallCardProps) {
       <Collapsible.Trigger className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left">
         <div className="flex min-w-0 items-center gap-2">
           <span className="truncate text-xs font-medium text-slate-100">{tool.name}</span>
-          <span className="rounded border border-amber-500/40 bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-200">
-            rendering failed
+          <span className="rounded border border-slate-600 bg-slate-700/30 px-1.5 py-0.5 text-[10px] text-slate-400">
+            generic
           </span>
         </div>
         <span className={`rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide ${badgeClass}`}>

--- a/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
@@ -1,5 +1,9 @@
 import * as Collapsible from '@radix-ui/react-collapsible'
 import type { ToolCallView } from '@/atoms/chat'
+import { BashOutputCard } from './BashOutputCard'
+import { FileEditCard } from './FileEditCard'
+import { FileReadCard } from './FileReadCard'
+import { WriteCard } from './WriteCard'
 
 interface ToolCallCardProps {
   tool: ToolCallView
@@ -14,7 +18,7 @@ function formatJson(value: unknown): string {
   }
 }
 
-export function ToolCallCard({ tool }: ToolCallCardProps) {
+function GenericToolCallCard({ tool }: ToolCallCardProps) {
   const badgeClass =
     tool.status === 'error'
       ? 'bg-red-500/20 text-red-200 border-red-500/40'
@@ -30,7 +34,12 @@ export function ToolCallCard({ tool }: ToolCallCardProps) {
   return (
     <Collapsible.Root className="rounded-md border border-slate-700 bg-slate-900/60">
       <Collapsible.Trigger className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left">
-        <span className="text-xs font-medium text-slate-100">{tool.name}</span>
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-xs font-medium text-slate-100">{tool.name}</span>
+          <span className="rounded border border-amber-500/40 bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-200">
+            rendering failed
+          </span>
+        </div>
         <span className={`rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide ${badgeClass}`}>
           {tool.status}
         </span>
@@ -53,4 +62,19 @@ export function ToolCallCard({ tool }: ToolCallCardProps) {
       </Collapsible.Content>
     </Collapsible.Root>
   )
+}
+
+export function ToolCallCard({ tool }: ToolCallCardProps) {
+  switch (tool.name) {
+    case 'edit':
+      return <FileEditCard tool={tool} />
+    case 'bash':
+      return <BashOutputCard tool={tool} />
+    case 'read':
+      return <FileReadCard tool={tool} />
+    case 'write':
+      return <WriteCard tool={tool} />
+    default:
+      return <GenericToolCallCard tool={tool} />
+  }
 }

--- a/apps/desktop/src/renderer/components/chat/WriteCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/WriteCard.tsx
@@ -1,0 +1,109 @@
+import { useMemo, useState } from 'react'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import { ShikiCodeViewer } from '@kata-ui/components/code-viewer/ShikiCodeViewer'
+import { getLanguageFromPath, truncateFilePath } from '@kata-ui/components/code-viewer/language-map'
+import type { ToolCallView } from '@/atoms/chat'
+
+interface WriteCardProps {
+  tool: ToolCallView
+}
+
+interface WriteViewModel {
+  filePath: string
+  content: string
+  bytesWritten?: number
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function buildWriteViewModel(tool: ToolCallView): WriteViewModel {
+  const args = asRecord(tool.args)
+  const result = asRecord(tool.result)
+
+  return {
+    filePath: asString(result?.path) ?? asString(args?.path) ?? 'unknown-file',
+    content: asString(result?.content) ?? asString(args?.content) ?? '',
+    bytesWritten: asNumber(result?.bytesWritten),
+  }
+}
+
+function toPreview(content: string, lines = 20): string {
+  const split = content.split('\n')
+  if (split.length <= lines) {
+    return content
+  }
+
+  return `${split.slice(0, lines).join('\n')}\n… (${split.length - lines} more lines)`
+}
+
+export function WriteCard({ tool }: WriteCardProps) {
+  const view = useMemo(() => buildWriteViewModel(tool), [tool])
+  const [isOpen, setIsOpen] = useState(tool.status !== 'done')
+  const [showFullContent, setShowFullContent] = useState(false)
+
+  const statusClass =
+    tool.status === 'error'
+      ? 'border-red-500/40 bg-red-500/20 text-red-100'
+      : tool.status === 'done'
+        ? 'border-emerald-500/40 bg-emerald-500/20 text-emerald-100'
+        : 'border-amber-500/40 bg-amber-500/20 text-amber-100'
+
+  const isLarge = view.content.split('\n').length > 20
+  const language = getLanguageFromPath(view.filePath)
+  const contentToShow = showFullContent ? view.content : toPreview(view.content, 20)
+
+  return (
+    <Collapsible.Root
+      className="rounded-md border border-slate-700 bg-slate-900/60"
+      open={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      <Collapsible.Trigger className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-semibold text-slate-100">write · {truncateFilePath(view.filePath, 68)}</p>
+          <p className="text-[11px] text-slate-400">
+            {tool.status === 'done' ? 'created/overwritten' : 'pending write'}
+            {view.bytesWritten !== undefined ? ` · ${view.bytesWritten} bytes` : ''}
+          </p>
+        </div>
+        <span className={`rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide ${statusClass}`}>
+          {tool.status}
+        </span>
+      </Collapsible.Trigger>
+
+      <Collapsible.Content className="space-y-2 border-t border-slate-700 px-3 py-2">
+        <div className="h-[18rem] overflow-hidden rounded border border-slate-700 bg-slate-950">
+          <ShikiCodeViewer
+            code={contentToShow}
+            language={language}
+            filePath={view.filePath}
+            theme="dark"
+          />
+        </div>
+
+        {isLarge && (
+          <button
+            type="button"
+            className="text-xs text-slate-300 underline decoration-dotted underline-offset-2 hover:text-slate-100"
+            onClick={() => setShowFullContent((value) => !value)}
+          >
+            {showFullContent ? 'Show preview' : 'Show full content'}
+          </button>
+        )}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/WriteCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/WriteCard.tsx
@@ -3,6 +3,7 @@ import * as Collapsible from '@radix-ui/react-collapsible'
 import { ShikiCodeViewer } from '@kata-ui/components/code-viewer/ShikiCodeViewer'
 import { getLanguageFromPath, truncateFilePath } from '@kata-ui/components/code-viewer/language-map'
 import type { ToolCallView } from '@/atoms/chat'
+import { asNumber, asRecord, asString } from './toolCardUtils'
 
 interface WriteCardProps {
   tool: ToolCallView
@@ -12,21 +13,6 @@ interface WriteViewModel {
   filePath: string
   content: string
   bytesWritten?: number
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return null
-  }
-  return value as Record<string, unknown>
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 function buildWriteViewModel(tool: ToolCallView): WriteViewModel {

--- a/apps/desktop/src/renderer/components/chat/toolCardUtils.ts
+++ b/apps/desktop/src/renderer/components/chat/toolCardUtils.ts
@@ -1,0 +1,30 @@
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  return value as Record<string, unknown>
+}
+
+export function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+export function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+export function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+export function countTextLines(value: string): number {
+  if (value.length === 0) {
+    return 0
+  }
+
+  const normalized = value.replace(/\r\n/g, '\n')
+  const lineCount = normalized.split('\n').length
+
+  return normalized.endsWith('\n') ? Math.max(0, lineCount - 1) : lineCount
+}

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -5,7 +5,12 @@ export const IPC_CHANNELS = {
   sessionEvents: 'session:events',
   sessionBridgeStatus: 'session:bridge-status',
   sessionGetBridgeState: 'session:get-bridge-state',
+  sessionExtensionUiRequest: 'session:extension-ui-request',
+  sessionExtensionUiResponse: 'session:extension-ui-response',
+  sessionPermissionMode: 'session:permission-mode',
 } as const
+
+export type PermissionMode = 'explore' | 'ask' | 'auto'
 
 export type RpcCommandType =
   | 'prompt'
@@ -40,6 +45,137 @@ export interface BridgeStatusEvent {
   updatedAt: number
 }
 
+export interface EditArgs {
+  path: string
+  oldText?: string
+  newText?: string
+  edits?: Array<{
+    oldText: string
+    newText: string
+  }>
+}
+
+export interface BashArgs {
+  command: string
+  timeout?: number
+}
+
+export interface ReadArgs {
+  path: string
+  offset?: number
+  limit?: number
+}
+
+export interface WriteArgs {
+  path: string
+  content: string
+}
+
+export interface UnknownToolArgs {
+  raw: unknown
+}
+
+export type ToolArgs = EditArgs | BashArgs | ReadArgs | WriteArgs | UnknownToolArgs
+
+export interface EditResult {
+  path: string
+  diff: string
+  linesAdded: number
+  linesRemoved: number
+  linesChanged: number
+  original?: string
+  modified?: string
+  parseError?: string
+  raw?: unknown
+}
+
+export interface BashResult {
+  command: string
+  stdout: string
+  stderr: string
+  exitCode?: number
+  raw?: unknown
+}
+
+export interface ReadResult {
+  path: string
+  content: string
+  language: string
+  totalLines: number
+  truncated: boolean
+  raw?: unknown
+}
+
+export interface WriteResult {
+  path: string
+  content: string
+  bytesWritten: number
+  raw?: unknown
+}
+
+export interface UnknownToolResult {
+  raw: unknown
+  parseError?: string
+}
+
+export type ToolResult = EditResult | BashResult | ReadResult | WriteResult | UnknownToolResult
+
+export interface ExtensionUIRequestBase {
+  id: string
+  method: string
+  timeoutMs?: number
+  [key: string]: unknown
+}
+
+export interface ExtensionUIConfirmRequest extends ExtensionUIRequestBase {
+  method: 'confirm'
+  title?: string
+  message?: string
+  toolName?: string
+  args?: unknown
+}
+
+export interface ExtensionUISelectRequest extends ExtensionUIRequestBase {
+  method: 'select'
+  title?: string
+  message?: string
+  options?: Array<{
+    label: string
+    value?: string
+    description?: string
+  }>
+}
+
+export interface ExtensionUIInputRequest extends ExtensionUIRequestBase {
+  method: 'input'
+  title?: string
+  message?: string
+  placeholder?: string
+  defaultValue?: string
+}
+
+export interface ExtensionUINotifyRequest extends ExtensionUIRequestBase {
+  method: 'notify'
+  title?: string
+  message?: string
+  level?: 'info' | 'success' | 'warning' | 'error'
+}
+
+export type ExtensionUIRequest =
+  | ExtensionUIConfirmRequest
+  | ExtensionUISelectRequest
+  | ExtensionUIInputRequest
+  | ExtensionUINotifyRequest
+  | ExtensionUIRequestBase
+
+export interface ExtensionUIResponse {
+  confirmed?: boolean
+  cancelled?: boolean
+  value?: string
+  values?: string[]
+  [key: string]: unknown
+}
+
 export type ChatEvent =
   | { type: 'agent_start' }
   | { type: 'agent_end' }
@@ -48,13 +184,19 @@ export type ChatEvent =
   | { type: 'message_start'; messageId: string; role: 'assistant' | 'user' }
   | { type: 'text_delta'; messageId: string; delta: string }
   | { type: 'message_end'; messageId: string; text?: string }
-  | { type: 'tool_start'; toolCallId: string; toolName: string; args: unknown }
-  | { type: 'tool_update'; toolCallId: string; toolName: string; status?: string }
+  | { type: 'tool_start'; toolCallId: string; toolName: string; args: ToolArgs }
+  | {
+      type: 'tool_update'
+      toolCallId: string
+      toolName: string
+      status?: string
+      partialStdout?: string
+    }
   | {
       type: 'tool_end'
       toolCallId: string
       toolName: string
-      result?: unknown
+      result?: ToolResult
       isError: boolean
       error?: string
     }
@@ -72,6 +214,7 @@ export interface BridgeState {
   pid: number | null
   command: string | null
   status: BridgeLifecycleState
+  permissionMode: PermissionMode
 }
 
 export interface DesktopApi {
@@ -81,6 +224,9 @@ export interface DesktopApi {
   onChatEvent: (listener: (event: ChatEvent) => void) => () => void
   onBridgeStatus: (listener: (status: BridgeStatusEvent) => void) => () => void
   getBridgeState: () => Promise<BridgeState>
+  onExtensionUIRequest: (listener: (event: ExtensionUIRequest) => void) => () => void
+  sendExtensionUIResponse: (id: string, response: ExtensionUIResponse) => Promise<void>
+  setPermissionMode: (mode: PermissionMode) => Promise<void>
 }
 
 declare global {


### PR DESCRIPTION
## Summary

Implements S02 for Kata Desktop with three focused commits:

- **KAT-2091**: Replaced generic tool cards with specialized rich renderers:
  - `FileEditCard` (Shiki diff rendering + diff stats + parse fallback)
  - `BashOutputCard` (ANSI terminal rendering + exit code status)
  - `FileReadCard` (syntax-highlighted file content + line metadata)
  - `WriteCard` (file preview with expandable full content)
  - `ToolCallCard` now dispatches by tool name and falls back to generic JSON
- **KAT-2092**: Extended `RpcEventAdapter` + shared types with structured tool args/results:
  - typed extraction for `edit`, `bash`, `read`, `write`
  - unknown tool passthrough without crashes
  - bash `tool_execution_update` support with `partialStdout`
  - expanded adapter tests with sample payloads and edge cases
- **KAT-2093**: Added permission modes + extension UI request/response bridge:
  - `permissionModeAtom` + `PermissionModeSelector` (`Explore` / `Ask` / `Auto`)
  - `PiAgentBridge` intercepts `extension_ui_request` and sends `extension_ui_response`
  - IPC + preload channels for extension UI and permission-mode updates
  - `ExtensionUIHandler` routes `confirm/select/input/notify`
  - `ToolApprovalDialog` with approve/reject and timeout auto-reject

## Validation

- `bun test apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts`
- `bun test apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && bun run test`
- `cd apps/desktop && bun run build`

## Notes

- `pi-agent-bridge` tests intentionally exercise spawn-failure behavior; expected crash-path log output appears while tests still pass.
- Child tasks moved directly from Backlog to Done:
  - KAT-2091
  - KAT-2092
  - KAT-2093

Closes KAT-2090

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements S02 for Kata Desktop across three focused sub-tasks: rich per-tool UI cards (KAT-2091), typed tool metadata extraction in the RPC adapter (KAT-2092), and a full extension UI request/response bridge with per-mode permission handling (KAT-2093). The changes are well-scoped and the key data paths are thoroughly tested.

**Highlights:**
- `ToolCallCard` now dispatches to specialized renderers (`FileEditCard`, `BashOutputCard`, `FileReadCard`, `WriteCard`) and falls back gracefully to generic JSON; `GenericToolCallCard` uses a "rendering failed" badge for all unrecognized tools, which is semantically misleading since no failure occurred — consider "generic" or "no renderer" instead
- `RpcEventAdapter` adds typed extraction with safe null-coalescing helpers; `countFromEdits` uses `filter(Boolean)` when tallying lines, silently dropping blank lines and understating the addition/deletion counts
- `ExtensionUIHandler` correctly handles the 'auto'/'explore'/'ask' modes using a `permissionModeRef` to avoid stale-closure bugs; the request-queue and timeout logic is sound
- `ToolApprovalDialog` uses an absolute deadline timestamp so interval restarts caused by prop reference churn are harmless
- Utility helpers (`asRecord`, `asString`, `asNumber`) are duplicated verbatim across all four new card components and already exist in `rpc-event-adapter.ts` — worth extracting to a shared module
- `PermissionModeSelector`'s `useEffect` fires on mount, sending an unnecessary `setPermissionMode('ask')` IPC call on every panel mount

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/quality suggestions with no blocking correctness issues

No P0 or P1 issues found. The IPC lifecycle, stdin write guarding, stale-closure handling, and timeout countdown logic are all correct. The four findings are improvements to UX labelling, line-count accuracy, an unnecessary mount-time IPC call, and code duplication — none of which affect correctness or reliability of the feature.

No files require special attention; the "rendering failed" label in `ToolCallCard.tsx` and the `filter(Boolean)` in `rpc-event-adapter.ts` are the most visible items to address in a follow-up

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/rpc-event-adapter.ts | Major expansion: adds typed extraction for edit/bash/read/write tools, language detection, and diff-line counting; `countFromEdits` uses `filter(Boolean)` which skips blank lines and slightly undercounts additions/deletions |
| apps/desktop/src/main/pi-agent-bridge.ts | Adds `extension_ui_request` interception via `dispatchRpcEvent`, `writeJsonLine` helper, `setPermissionMode`, and `sendExtensionUIResponse`; logic is sound with proper stdin writability checks |
| apps/desktop/src/main/ipc.ts | Wires up IPC handlers for extension UI request/response bridge and permission mode; clean cleanup in teardown and proper guard against destroyed renderer |
| apps/desktop/src/shared/types.ts | Adds well-structured typed interfaces for all tool args/results, ExtensionUIRequest subtypes, PermissionMode, and new IPC channels |
| apps/desktop/src/renderer/components/chat/ExtensionUIHandler.tsx | New component handling extension UI requests queue, per-mode auto-approve/reject, input/select modals, and toast notifications; `sendResponse`/`pushToast` in stale closure are safe due to functional state updaters |
| apps/desktop/src/renderer/components/chat/ToolApprovalDialog.tsx | Countdown timer dialog for confirm requests; interval uses absolute deadline so restarts from `onTimeout` prop changes are harmless, but a narrow race between user action and timeout expiry could send two responses for the same request |
| apps/desktop/src/renderer/components/chat/ToolCallCard.tsx | Now dispatches to specialized renderers; generic fallback shows "rendering failed" badge for any unrecognized tool, which is semantically misleading |
| apps/desktop/src/renderer/components/chat/FileEditCard.tsx | New component with three-tier diff rendering (explicit original/modified → parsed unified diff → reconstructed from edits array); parse fallback is well-thought-out |
| apps/desktop/src/renderer/components/chat/BashOutputCard.tsx | New component with ANSI terminal rendering, streaming partial stdout accumulation, and exit code display; utility helpers are duplicated from other card components |
| apps/desktop/src/renderer/components/chat/PermissionModeSelector.tsx | Three-mode toggle (Explore/Ask/Auto) synced to bridge via IPC; `useEffect` fires on mount sending a redundant `setPermissionMode('ask')` call |
| apps/desktop/src/renderer/atoms/chat.ts | Adds `partialStdout` accumulation on `tool_update` and clears it on `tool_end`; `ToolCallView` now uses typed `ToolArgs`/`ToolResult` |
| apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts | Comprehensive new tests for edit/bash/read/write typed extraction, unknown tool passthrough, and streaming stdout; good coverage of edge cases |
| apps/desktop/src/preload/index.ts | Exposes three new IPC APIs (`onExtensionUIRequest`, `sendExtensionUIResponse`, `setPermissionMode`) through `contextBridge` with proper listener cleanup |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Agent Subprocess
    participant Bridge as PiAgentBridge
    participant IPC as IPC Layer
    participant Renderer as ExtensionUIHandler
    participant Dialog as ToolApprovalDialog

    Note over Agent,Dialog: Normal tool execution flow
    Agent->>Bridge: tool_execution_start/update/end (JSON line)
    Bridge->>Bridge: dispatchRpcEvent()
    Bridge-->>IPC: emit('rpc-event', event)
    IPC->>Renderer: webContents.send(session:events)
    Renderer->>Renderer: applyChatEventAtom (accumulate partialStdout)

    Note over Agent,Dialog: Extension UI request flow
    Agent->>Bridge: extension_ui_request {id, method}
    Bridge->>Bridge: extractExtensionUIRequest()
    Bridge-->>IPC: emit('extension-ui-request', request)
    IPC->>Renderer: webContents.send(session:extension-ui-request)
    
    alt method == 'notify'
        Renderer->>Renderer: pushToast()
    else method == 'confirm' + mode == 'auto'
        Renderer->>IPC: sendExtensionUIResponse(id, {confirmed:true})
        IPC->>Bridge: ipcMain.handle(session:extension-ui-response)
        Bridge->>Agent: extension_ui_response (JSON line)
    else method == 'confirm' + mode == 'explore'
        Renderer->>IPC: sendExtensionUIResponse(id, {confirmed:false})
        IPC->>Bridge: ipcMain.handle
        Bridge->>Agent: extension_ui_response
    else method == 'confirm' + mode == 'ask'
        Renderer->>Dialog: open=true (queued confirm request)
        Dialog->>Dialog: countdown timer (5 min default)
        alt User approves
            Dialog->>Renderer: onApprove(id)
            Renderer->>IPC: sendExtensionUIResponse(id, {confirmed:true})
        else User rejects / timeout
            Dialog->>Renderer: onReject/onTimeout(id)
            Renderer->>IPC: sendExtensionUIResponse(id, {confirmed:false})
        end
        IPC->>Bridge: ipcMain.handle
        Bridge->>Agent: extension_ui_response
    else method == 'select' / 'input'
        Renderer->>Renderer: show modal (always, regardless of mode)
        Renderer->>IPC: sendExtensionUIResponse(id, {value})
        IPC->>Bridge: ipcMain.handle
        Bridge->>Agent: extension_ui_response
    end

    Note over Renderer,Dialog: Permission mode change
    Renderer->>IPC: ipcRenderer.invoke(session:permission-mode, mode)
    IPC->>Bridge: setPermissionMode(mode)
    Bridge->>Bridge: update in-memory permissionMode
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/chat/PermissionModeSelector.tsx`, line 665-669 ([link](https://github.com/gannonh/kata/blob/a902188f2bc6635b3ddeee29c285e071a86b02bc/apps/desktop/src/renderer/components/chat/PermissionModeSelector.tsx#L665-L669)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`setPermissionMode` fires redundantly on mount**

   The `useEffect` with `[mode]` as its dependency also fires on the initial render, sending a `setPermissionMode('ask')` IPC call even though the bridge defaults to `'ask'`. This is a harmless extra round-trip, but it means every time the `ChatPanel` mounts a spurious IPC call is made. Consider skipping the sync on initial mount:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/chat/PermissionModeSelector.tsx
   Line: 665-669

   Comment:
   **`setPermissionMode` fires redundantly on mount**

   The `useEffect` with `[mode]` as its dependency also fires on the initial render, sending a `setPermissionMode('ask')` IPC call even though the bridge defaults to `'ask'`. This is a harmless extra round-trip, but it means every time the `ChatPanel` mounts a spurious IPC call is made. Consider skipping the sync on initial mount:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
Line: 37-41

Comment:
**"rendering failed" label applied to all unrecognized tools**

The `GenericToolCallCard` always renders a `rendering failed` badge, but no actual rendering failure has occurred — there's simply no specialized renderer registered for the tool. Future tools like `grep`, `glob`, `computer_use`, etc. would all display this badge while functioning correctly. Consider a label like `generic` or `no renderer` to distinguish the "fallback" case from an actual render error.

```suggestion
          <span className="rounded border border-slate-600 bg-slate-700/30 px-1.5 py-0.5 text-[10px] text-slate-400">
            generic
          </span>
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/rpc-event-adapter.ts
Line: 579-583

Comment:
**`filter(Boolean)` skips blank lines, undercounting additions/deletions**

`edit.newText.split('\n').filter(Boolean)` discards empty strings, so any blank lines in the edited content are silently excluded from the count. For example, adding a blank line at the end of a function would count as 0 additions. The same issue exists in `FileEditCard.tsx` in `buildFromEditsArray`.

```suggestion
      totals.additions += edit.newText.split('\n').length
      totals.deletions += edit.oldText.split('\n').length
```

If trailing newlines need to be excluded, consider using `.trimEnd().split('\n')` instead of `filter(Boolean)`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/PermissionModeSelector.tsx
Line: 665-669

Comment:
**`setPermissionMode` fires redundantly on mount**

The `useEffect` with `[mode]` as its dependency also fires on the initial render, sending a `setPermissionMode('ask')` IPC call even though the bridge defaults to `'ask'`. This is a harmless extra round-trip, but it means every time the `ChatPanel` mounts a spurious IPC call is made. Consider skipping the sync on initial mount:

```suggestion
  const isMounted = useRef(false)

  useEffect(() => {
    if (!isMounted.current) {
      isMounted.current = true
      return
    }
    void window.api.setPermissionMode(mode).catch((error: unknown) => {
      console.error('[PermissionModeSelector] failed to update bridge permission mode', error)
    })
  }, [mode])
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/BashOutputCard.tsx
Line: 19-53

Comment:
**Utility helpers duplicated across all four card components**

`asRecord`, `asString`, and `asNumber` are defined identically (or near-identically) in `BashOutputCard.tsx`, `FileEditCard.tsx`, `FileReadCard.tsx`, and `WriteCard.tsx`, and the same helpers already exist in `rpc-event-adapter.ts`. Extracting them to a shared module (e.g., `@/lib/type-guards` or a co-located `card-utils.ts`) would eliminate ~40 lines of duplication and make future changes easier.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/gannonh/kata/commit/a902188f2bc6635b3ddeee29c285e071a86b02bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26958318)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added permission mode selector to control how the agent handles interactive requests (explore, ask, or auto modes).
  * Added support for interactive extension UI dialogs, notifications, and input forms.
  * Enhanced tool output visualization with specialized displays for bash commands, file edits, reads, and writes.

* **UI Improvements**
  * Tool execution outputs now display with structured formatting, including command previews, file diffs, and line change summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->