### PR TITLE
feat(desktop): implement S04 session persistence

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -13,9 +13,10 @@ Fresh Electron shell for Kata Desktop.
 
 - `src/main/pi-agent-bridge.ts` — spawn/lifecycle + JSONL command/event bridge
 - `src/main/rpc-event-adapter.ts` — maps RPC events to renderer chat events
-- `src/main/ipc.ts` — `session:send`, `session:stop`, `session:events`
+- `src/main/ipc.ts` — session/chat/auth/workspace IPC handlers (`session:list`, `session:new`, `workspace:set`, etc.)
+- `src/main/session-manager.ts` — reads `~/.kata-cli/sessions/*.jsonl` and derives sidebar metadata
 - `src/shared/types.ts` — cross-process IPC and chat event contracts
-- `src/renderer/components/` — app shell + chat UI
+- `src/renderer/components/` — app shell + chat UI (`SessionSidebar`, `WorkspaceIndicator`)
 
 ## Guardrails
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { AuthBridge } from './auth-bridge'
 import log from './logger'
 import { PiAgentBridge } from './pi-agent-bridge'
 import { registerSessionIpc } from './ipc'
+import { DesktopSessionManager } from './session-manager'
 
 const SETTINGS_PATH = path.join(homedir(), '.kata-cli', 'agent', 'settings.json')
 
@@ -39,27 +40,63 @@ function createWindow(): BrowserWindow {
   return window
 }
 
-async function loadPersistedModel(): Promise<string | null> {
+async function isDirectory(targetPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(targetPath)
+    return stat.isDirectory()
+  } catch {
+    return false
+  }
+}
+
+async function readSettings(): Promise<Record<string, unknown>> {
   try {
     const raw = await fs.readFile(SETTINGS_PATH, 'utf8')
     if (!raw.trim()) {
-      return null
+      return {}
     }
 
-    const parsed = JSON.parse(raw) as Record<string, unknown>
-    const model = parsed.model
-    return typeof model === 'string' && model.trim() ? model.trim() : null
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {}
   } catch (error) {
-    if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: string }).code === 'ENOENT') {
-      return null
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: string }).code === 'ENOENT'
+    ) {
+      return {}
     }
 
-    log.warn('[desktop-main] failed to read settings model', {
+    log.warn('[desktop-main] failed to read settings', {
       path: SETTINGS_PATH,
       error: error instanceof Error ? error.message : String(error),
     })
-    return null
+    return {}
   }
+}
+
+async function writeSettings(updates: Record<string, unknown>): Promise<void> {
+  const settingsDir = path.dirname(SETTINGS_PATH)
+  await fs.mkdir(settingsDir, { recursive: true })
+
+  const current = await readSettings()
+  const next = {
+    ...current,
+    ...updates,
+  }
+
+  const tempPath = `${SETTINGS_PATH}.${process.pid}.${Date.now()}.tmp`
+  await fs.writeFile(tempPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 })
+  await fs.rename(tempPath, SETTINGS_PATH)
+}
+
+async function loadPersistedModel(): Promise<string | null> {
+  const settings = await readSettings()
+  const model = settings.model
+  return typeof model === 'string' && model.trim() ? model.trim() : null
 }
 
 async function persistSelectedModel(model: string): Promise<void> {
@@ -68,32 +105,7 @@ async function persistSelectedModel(model: string): Promise<void> {
     return
   }
 
-  const settingsDir = path.dirname(SETTINGS_PATH)
-  await fs.mkdir(settingsDir, { recursive: true })
-
-  let current: Record<string, unknown> = {}
-  try {
-    const raw = await fs.readFile(SETTINGS_PATH, 'utf8')
-    if (raw.trim()) {
-      const parsed = JSON.parse(raw)
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        current = parsed as Record<string, unknown>
-      }
-    }
-  } catch (error) {
-    if (!(typeof error === 'object' && error !== null && 'code' in error && (error as { code?: string }).code === 'ENOENT')) {
-      throw error
-    }
-  }
-
-  const next = {
-    ...current,
-    model: trimmedModel,
-  }
-
-  const tempPath = `${SETTINGS_PATH}.${process.pid}.${Date.now()}.tmp`
-  await fs.writeFile(tempPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 })
-  await fs.rename(tempPath, SETTINGS_PATH)
+  await writeSettings({ model: trimmedModel })
 
   log.info('[desktop-main] persisted model preference', {
     model: trimmedModel,
@@ -101,19 +113,66 @@ async function persistSelectedModel(model: string): Promise<void> {
   })
 }
 
+async function resolveInitialWorkspacePath(): Promise<string> {
+  const fallback = homedir()
+  const envWorkspacePath = process.env.KATA_WORKSPACE_PATH?.trim()
+
+  if (envWorkspacePath) {
+    const resolvedEnvPath = path.resolve(envWorkspacePath)
+    if (await isDirectory(resolvedEnvPath)) {
+      return resolvedEnvPath
+    }
+
+    log.warn('[desktop-main] KATA_WORKSPACE_PATH is not a directory, falling back', {
+      value: resolvedEnvPath,
+      fallback,
+    })
+  }
+
+  const settings = await readSettings()
+  const storedWorkspace = settings.lastWorkingDirectory
+
+  if (typeof storedWorkspace === 'string' && storedWorkspace.trim()) {
+    const resolvedStoredPath = path.resolve(storedWorkspace)
+    if (await isDirectory(resolvedStoredPath)) {
+      return resolvedStoredPath
+    }
+
+    log.warn('[desktop-main] stored workspace is missing, falling back to home directory', {
+      storedWorkspace: resolvedStoredPath,
+      fallback,
+    })
+  }
+
+  return fallback
+}
+
+async function persistWorkspacePath(workspacePath: string): Promise<void> {
+  const resolvedPath = path.resolve(workspacePath)
+  await writeSettings({ lastWorkingDirectory: resolvedPath })
+
+  log.info('[desktop-main] persisted workspace preference', {
+    workspacePath: resolvedPath,
+    path: SETTINGS_PATH,
+  })
+}
+
 app.whenReady().then(async () => {
-  const workspacePath = process.env.KATA_WORKSPACE_PATH || process.cwd()
+  const workspacePath = await resolveInitialWorkspacePath()
   const persistedModel = await loadPersistedModel()
 
   bridge = new PiAgentBridge(workspacePath, 'kata', 30_000, persistedModel)
   const authBridge = new AuthBridge()
+  const sessionManager = new DesktopSessionManager()
   mainWindow = createWindow()
 
   unregisterSessionIpc = registerSessionIpc({
     bridge,
     authBridge,
+    sessionManager,
     window: mainWindow,
     onModelSelected: persistSelectedModel,
+    onWorkspaceSelected: persistWorkspacePath,
   })
 
   mainWindow.on('closed', () => {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,8 +1,11 @@
-import { ipcMain, type BrowserWindow } from 'electron'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { dialog, ipcMain, type BrowserWindow } from 'electron'
 import log from './logger'
 import { AuthBridge } from './auth-bridge'
 import { PiAgentBridge } from './pi-agent-bridge'
 import { RpcEventAdapter } from './rpc-event-adapter'
+import { DesktopSessionManager } from './session-manager'
 import {
   IPC_CHANNELS,
   type AuthProvider,
@@ -14,23 +17,31 @@ import {
   type AuthSetKeyResponse,
   type AuthRemoveKeyResponse,
   type AuthValidationResult,
+  type CreateSessionResponse,
   type ExtensionUIRequest,
   type ExtensionUIResponse,
   type PermissionMode,
+  type SessionInfo,
+  type SessionListResponse,
+  type WorkspaceInfo,
 } from '../shared/types'
 
 interface RegisterIpcOptions {
   bridge: PiAgentBridge
   authBridge: AuthBridge
+  sessionManager: DesktopSessionManager
   window: BrowserWindow
   onModelSelected?: (model: string) => Promise<void> | void
+  onWorkspaceSelected?: (workspacePath: string) => Promise<void> | void
 }
 
 export function registerSessionIpc({
   bridge,
   authBridge,
+  sessionManager,
   window,
   onModelSelected,
+  onWorkspaceSelected,
 }: RegisterIpcOptions): () => void {
   const adapter = new RpcEventAdapter()
 
@@ -116,6 +127,12 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.sessionPermissionMode)
   ipcMain.removeHandler(IPC_CHANNELS.sessionGetAvailableModels)
   ipcMain.removeHandler(IPC_CHANNELS.sessionSetModel)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionList)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionNew)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionGetInfo)
+  ipcMain.removeHandler(IPC_CHANNELS.workspaceGet)
+  ipcMain.removeHandler(IPC_CHANNELS.workspaceSet)
+  ipcMain.removeHandler(IPC_CHANNELS.workspacePick)
   ipcMain.removeHandler(IPC_CHANNELS.authGetProviders)
   ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
   ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)
@@ -222,6 +239,136 @@ export function registerSessionIpc({
     }
   })
 
+  ipcMain.handle(IPC_CHANNELS.sessionList, async (): Promise<SessionListResponse> => {
+    const workspacePath = bridge.getWorkspacePath()
+
+    try {
+      return await sessionManager.listSessions(workspacePath)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      log.error('[desktop-ipc] session list failed', {
+        workspacePath,
+        error: message,
+      })
+
+      throw new Error(`Unable to load sessions for ${workspacePath}: ${message}`)
+    }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.sessionNew, async (): Promise<CreateSessionResponse> => {
+    try {
+      const result = await bridge.send({ type: 'new_session' })
+      const payload = result.data
+      const sessionId =
+        payload &&
+        typeof payload === 'object' &&
+        'sessionId' in payload &&
+        typeof (payload as { sessionId?: unknown }).sessionId === 'string'
+          ? (payload as { sessionId: string }).sessionId
+          : payload &&
+                typeof payload === 'object' &&
+                'session_id' in payload &&
+                typeof (payload as { session_id?: unknown }).session_id === 'string'
+              ? (payload as { session_id: string }).session_id
+              : null
+
+      log.info('[desktop-ipc] new session created', {
+        sessionId,
+        workspacePath: bridge.getWorkspacePath(),
+      })
+
+      return {
+        success: true,
+        sessionId,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      log.error('[desktop-ipc] new session failed', {
+        workspacePath: bridge.getWorkspacePath(),
+        error: message,
+      })
+
+      return {
+        success: false,
+        sessionId: null,
+        error: message,
+      }
+    }
+  })
+
+  ipcMain.handle(
+    IPC_CHANNELS.sessionGetInfo,
+    async (_event, sessionPath: string): Promise<SessionInfo> => {
+      return sessionManager.getSessionInfo(sessionPath)
+    },
+  )
+
+  ipcMain.handle(IPC_CHANNELS.workspaceGet, async (): Promise<WorkspaceInfo> => {
+    return {
+      path: bridge.getWorkspacePath(),
+    }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.workspaceSet, async (_event, workspacePath: string): Promise<WorkspaceInfo> => {
+    const trimmedWorkspacePath = workspacePath?.trim()
+    if (!trimmedWorkspacePath) {
+      throw new Error('Workspace path is required')
+    }
+
+    const nextWorkspacePath = path.resolve(trimmedWorkspacePath)
+    const stat = await fs.stat(nextWorkspacePath)
+    if (!stat.isDirectory()) {
+      throw new Error(`Workspace path is not a directory: ${nextWorkspacePath}`)
+    }
+
+    const previousWorkspacePath = bridge.getWorkspacePath()
+
+    await bridge.switchWorkspace(nextWorkspacePath)
+
+    if (onWorkspaceSelected) {
+      try {
+        await onWorkspaceSelected(nextWorkspacePath)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.warn('[desktop-ipc] workspace persistence failed after switch', {
+          workspacePath: nextWorkspacePath,
+          error: message,
+        })
+      }
+    }
+
+    log.info('[desktop-ipc] workspace switched', {
+      previousWorkspacePath,
+      nextWorkspacePath,
+    })
+
+    return {
+      path: nextWorkspacePath,
+    }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.workspacePick, async (): Promise<WorkspaceInfo | null> => {
+    const result = await dialog.showOpenDialog(window, {
+      properties: ['openDirectory'],
+      defaultPath: bridge.getWorkspacePath(),
+      title: 'Select working directory',
+      buttonLabel: 'Use Directory',
+    })
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return null
+    }
+
+    const selectedPath = result.filePaths[0]
+    if (!selectedPath) {
+      return null
+    }
+
+    return {
+      path: selectedPath,
+    }
+  })
+
   ipcMain.handle(IPC_CHANNELS.authGetProviders, async (): Promise<AuthProvidersResponse> => {
     return authBridge.getProviders()
   })
@@ -288,6 +435,12 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.sessionPermissionMode)
     ipcMain.removeHandler(IPC_CHANNELS.sessionGetAvailableModels)
     ipcMain.removeHandler(IPC_CHANNELS.sessionSetModel)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionList)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionNew)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionGetInfo)
+    ipcMain.removeHandler(IPC_CHANNELS.workspaceGet)
+    ipcMain.removeHandler(IPC_CHANNELS.workspaceSet)
+    ipcMain.removeHandler(IPC_CHANNELS.workspacePick)
     ipcMain.removeHandler(IPC_CHANNELS.authGetProviders)
     ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
     ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -56,7 +56,7 @@ export class PiAgentBridge extends EventEmitter {
   private selectedModel: string | null
 
   constructor(
-    private readonly workspacePath: string,
+    private workspacePath: string,
     private readonly commandHint = 'kata',
     private readonly commandTimeoutMs = 30_000,
     initialModel: string | null = null,
@@ -360,6 +360,24 @@ export class PiAgentBridge extends EventEmitter {
 
   public getSelectedModel(): string | null {
     return this.selectedModel
+  }
+
+  public getWorkspacePath(): string {
+    return this.workspacePath
+  }
+
+  public async switchWorkspace(nextWorkspacePath: string): Promise<void> {
+    const normalized = nextWorkspacePath.trim()
+    if (!normalized) {
+      throw new Error('Workspace path is required')
+    }
+
+    if (normalized === this.workspacePath) {
+      return
+    }
+
+    this.workspacePath = normalized
+    await this.restart()
   }
 
   public async restart(): Promise<void> {

--- a/apps/desktop/src/main/session-manager.ts
+++ b/apps/desktop/src/main/session-manager.ts
@@ -147,7 +147,7 @@ export class DesktopSessionManager {
   public async listSessions(cwd: string): Promise<SessionListResponse> {
     const normalizedCwd = normalizePath(cwd)
 
-    let entries: Array<{ filePath: string; modified: number }> = []
+    let entries: Array<{ filePath: string }> = []
     const warnings: string[] = []
 
     try {
@@ -160,20 +160,9 @@ export class DesktopSessionManager {
 
         const filePath = path.join(this.sessionsDirectory, dirEntry.name)
 
-        try {
-          const stat = await fs.stat(filePath)
-          entries.push({
-            filePath,
-            modified: stat.mtimeMs,
-          })
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error)
-          warnings.push(`${path.basename(filePath)}: ${message}`)
-          log.warn('[desktop-session-manager] skipped unreadable session file', {
-            path: filePath,
-            error: message,
-          })
-        }
+        entries.push({
+          filePath,
+        })
       }
     } catch (error) {
       if (

--- a/apps/desktop/src/main/session-manager.ts
+++ b/apps/desktop/src/main/session-manager.ts
@@ -1,0 +1,435 @@
+import { promises as fs } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import log from './logger'
+import type {
+  SessionInfo,
+  SessionListItem,
+  SessionListResponse,
+  SessionTokenUsage,
+} from '../shared/types'
+
+interface ParsedSessionMetadata {
+  id: string
+  name: string | null
+  title: string
+  model: string | null
+  provider: string | null
+  created: string
+  modified: string
+  messageCount: number
+  firstMessagePreview: string | null
+  tokenUsage?: SessionTokenUsage
+}
+
+interface SessionHeader {
+  id?: string
+  timestamp?: string
+  cwd?: string
+}
+
+const HEADER_READ_SIZE_BYTES = 8 * 1024
+
+function normalizePath(value: string): string {
+  return path.resolve(value)
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value
+  }
+
+  return `${value.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`
+}
+
+function cleanText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function toIsoDate(value: Date): string {
+  return value.toISOString()
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function extractTokenUsage(candidate: unknown): SessionTokenUsage | undefined {
+  if (!candidate || typeof candidate !== 'object') {
+    return undefined
+  }
+
+  const value = candidate as Record<string, unknown>
+  const input = toOptionalNumber(value.input)
+  const output = toOptionalNumber(value.output)
+  const cacheRead = toOptionalNumber(value.cacheRead)
+  const cacheWrite = toOptionalNumber(value.cacheWrite)
+  const total = toOptionalNumber(value.total) ?? toOptionalNumber(value.totalTokens)
+
+  if (
+    input === undefined &&
+    output === undefined &&
+    cacheRead === undefined &&
+    cacheWrite === undefined &&
+    total === undefined
+  ) {
+    return undefined
+  }
+
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    total,
+  }
+}
+
+function extractSessionIdFromFilename(filePath: string): string {
+  const match = path.basename(filePath).match(/_([0-9a-fA-F-]{32,36})\.jsonl$/)
+  if (match?.[1]) {
+    return match[1]
+  }
+
+  return path.basename(filePath, '.jsonl')
+}
+
+function extractName(entry: Record<string, unknown>): string | null {
+  const candidates = [entry.name, entry.sessionName, entry.title]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim()
+    }
+  }
+
+  return null
+}
+
+function extractMessageText(message: unknown): string | null {
+  if (!message || typeof message !== 'object') {
+    return null
+  }
+
+  const payload = message as Record<string, unknown>
+  const content = payload.content
+
+  if (typeof content === 'string') {
+    const normalized = cleanText(content)
+    return normalized || null
+  }
+
+  if (!Array.isArray(content)) {
+    return null
+  }
+
+  const parts: string[] = []
+
+  for (const item of content) {
+    if (!item || typeof item !== 'object') {
+      continue
+    }
+
+    const block = item as Record<string, unknown>
+    if (typeof block.text === 'string' && block.text.trim()) {
+      parts.push(block.text)
+    }
+  }
+
+  const combined = cleanText(parts.join(' '))
+  return combined || null
+}
+
+export class DesktopSessionManager {
+  public constructor(
+    private readonly sessionsDirectory = path.join(homedir(), '.kata-cli', 'sessions'),
+  ) {}
+
+  public async listSessions(cwd: string): Promise<SessionListResponse> {
+    const normalizedCwd = normalizePath(cwd)
+
+    let entries: Array<{ filePath: string; modified: number }> = []
+    const warnings: string[] = []
+
+    try {
+      const dirEntries = await fs.readdir(this.sessionsDirectory, { withFileTypes: true })
+
+      entries = await Promise.all(
+        dirEntries
+          .filter((entry) => entry.isFile() && entry.name.endsWith('.jsonl'))
+          .map(async (entry) => {
+            const filePath = path.join(this.sessionsDirectory, entry.name)
+            const stat = await fs.stat(filePath)
+            return {
+              filePath,
+              modified: stat.mtimeMs,
+            }
+          }),
+      )
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error as { code?: string }).code === 'ENOENT'
+      ) {
+        log.info('[desktop-session-manager] sessions directory does not exist yet', {
+          directory: this.sessionsDirectory,
+          cwd: normalizedCwd,
+        })
+        return {
+          sessions: [],
+          warnings,
+          directory: this.sessionsDirectory,
+        }
+      }
+
+      throw error
+    }
+
+    const sessionItems: SessionListItem[] = []
+
+    for (const entry of entries) {
+      try {
+        const header = await this.readHeader(entry.filePath)
+
+        if (!header?.cwd || normalizePath(header.cwd) !== normalizedCwd) {
+          continue
+        }
+
+        const metadata = await this.parseSessionFile(entry.filePath)
+        sessionItems.push({
+          id: metadata.id,
+          path: entry.filePath,
+          name: metadata.name,
+          title: metadata.title,
+          model: metadata.model,
+          provider: metadata.provider,
+          created: metadata.created,
+          modified: metadata.modified,
+          messageCount: metadata.messageCount,
+          firstMessagePreview: metadata.firstMessagePreview,
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        warnings.push(`${path.basename(entry.filePath)}: ${message}`)
+        log.warn('[desktop-session-manager] skipped corrupted session file', {
+          path: entry.filePath,
+          error: message,
+        })
+      }
+    }
+
+    sessionItems.sort((a, b) => b.modified.localeCompare(a.modified))
+
+    log.info('[desktop-session-manager] loaded session list', {
+      directory: this.sessionsDirectory,
+      cwd: normalizedCwd,
+      count: sessionItems.length,
+      warningCount: warnings.length,
+    })
+
+    return {
+      sessions: sessionItems,
+      warnings,
+      directory: this.sessionsDirectory,
+    }
+  }
+
+  public async getSessionInfo(sessionPath: string): Promise<SessionInfo> {
+    const resolvedPath = this.resolveSessionPath(sessionPath)
+    const metadata = await this.parseSessionFile(resolvedPath)
+
+    return {
+      id: metadata.id,
+      path: resolvedPath,
+      name: metadata.name,
+      title: metadata.title,
+      model: metadata.model,
+      provider: metadata.provider,
+      created: metadata.created,
+      modified: metadata.modified,
+      messageCount: metadata.messageCount,
+      firstMessagePreview: metadata.firstMessagePreview,
+      tokenUsage: metadata.tokenUsage,
+    }
+  }
+
+  private resolveSessionPath(sessionPath: string): string {
+    const trimmed = sessionPath.trim()
+    if (!trimmed) {
+      throw new Error('Session path is required')
+    }
+
+    const candidate = path.isAbsolute(trimmed)
+      ? path.resolve(trimmed)
+      : path.resolve(this.sessionsDirectory, trimmed)
+
+    const relative = path.relative(this.sessionsDirectory, candidate)
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('Session path must be inside the sessions directory')
+    }
+
+    return candidate
+  }
+
+  private async readHeader(sessionFilePath: string): Promise<SessionHeader | null> {
+    const handle = await fs.open(sessionFilePath, 'r')
+
+    try {
+      const buffer = Buffer.alloc(HEADER_READ_SIZE_BYTES)
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0)
+
+      if (bytesRead <= 0) {
+        return null
+      }
+
+      const chunk = buffer.subarray(0, bytesRead).toString('utf8')
+      const newlineIndex = chunk.indexOf('\n')
+      const firstLine = (newlineIndex >= 0 ? chunk.slice(0, newlineIndex) : chunk).trim()
+
+      if (!firstLine) {
+        return null
+      }
+
+      const parsed = JSON.parse(firstLine)
+      if (!parsed || typeof parsed !== 'object') {
+        return null
+      }
+
+      const header = parsed as Record<string, unknown>
+      return {
+        id: typeof header.id === 'string' ? header.id : undefined,
+        timestamp: typeof header.timestamp === 'string' ? header.timestamp : undefined,
+        cwd: typeof header.cwd === 'string' ? header.cwd : undefined,
+      }
+    } finally {
+      await handle.close()
+    }
+  }
+
+  private async parseSessionFile(sessionFilePath: string): Promise<ParsedSessionMetadata> {
+    const raw = await fs.readFile(sessionFilePath, 'utf8')
+    const stat = await fs.stat(sessionFilePath)
+    const lines = raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+
+    if (lines.length === 0) {
+      throw new Error('Session file is empty')
+    }
+
+    const parsedLines = lines.map((line, index) => {
+      try {
+        return JSON.parse(line) as Record<string, unknown>
+      } catch (error) {
+        throw new Error(`Invalid JSON at line ${index + 1}: ${error instanceof Error ? error.message : String(error)}`)
+      }
+    })
+
+    const first = parsedLines[0]
+    if (!first) {
+      throw new Error('Missing session header')
+    }
+
+    const header: SessionHeader = {
+      id: typeof first.id === 'string' ? first.id : undefined,
+      timestamp: typeof first.timestamp === 'string' ? first.timestamp : undefined,
+      cwd: typeof first.cwd === 'string' ? first.cwd : undefined,
+    }
+
+    const fallbackId = extractSessionIdFromFilename(sessionFilePath)
+    const id = header.id ?? fallbackId
+
+    let name: string | null = null
+    let firstUserMessage: string | null = null
+    let provider: string | null = null
+    let model: string | null = null
+    let messageCount = 0
+    let tokenUsage: SessionTokenUsage | undefined
+
+    for (const entry of parsedLines) {
+      const type = typeof entry.type === 'string' ? entry.type : null
+
+      if (!name && type && (type === 'session_info' || type === 'session_name')) {
+        name = extractName(entry)
+      }
+
+      if (type === 'model_change') {
+        const providerCandidate = entry.provider
+        const modelCandidate = entry.modelId
+
+        if (typeof providerCandidate === 'string' && providerCandidate.trim()) {
+          provider = providerCandidate.trim()
+        }
+
+        if (typeof modelCandidate === 'string' && modelCandidate.trim()) {
+          const normalizedModel = modelCandidate.trim()
+          model = provider ? `${provider}/${normalizedModel}` : normalizedModel
+        }
+      }
+
+      if (type === 'message' && entry.message && typeof entry.message === 'object') {
+        const message = entry.message as Record<string, unknown>
+        const role = typeof message.role === 'string' ? message.role : null
+
+        if (role === 'user' || role === 'assistant') {
+          messageCount += 1
+        }
+
+        if (!firstUserMessage && role === 'user') {
+          firstUserMessage = extractMessageText(message)
+        }
+
+        if (!model) {
+          const modelCandidate = typeof message.model === 'string' ? message.model.trim() : ''
+          if (modelCandidate) {
+            model = modelCandidate
+          }
+        }
+
+        if (!provider) {
+          const providerCandidate =
+            typeof message.provider === 'string' ? message.provider.trim() : ''
+          if (providerCandidate) {
+            provider = providerCandidate
+          }
+        }
+
+        if (!tokenUsage && message.usage) {
+          tokenUsage = extractTokenUsage(message.usage)
+        }
+      }
+
+      if (!tokenUsage && type === 'session_stats') {
+        tokenUsage = extractTokenUsage(entry.tokens)
+      }
+
+      if (!tokenUsage && type === 'response') {
+        const data = entry.data
+        if (data && typeof data === 'object') {
+          tokenUsage = extractTokenUsage((data as Record<string, unknown>).tokens)
+        }
+      }
+    }
+
+    const firstMessagePreview = firstUserMessage ? truncate(firstUserMessage, 100) : null
+    const titleSource = name ?? firstMessagePreview ?? 'Untitled session'
+    const title = truncate(cleanText(titleSource), 100)
+    const created = header.timestamp ?? toIsoDate(stat.birthtime)
+    const modified = toIsoDate(stat.mtime)
+
+    return {
+      id,
+      name,
+      title,
+      model,
+      provider,
+      created,
+      modified,
+      messageCount,
+      firstMessagePreview,
+      tokenUsage,
+    }
+  }
+}

--- a/apps/desktop/src/main/session-manager.ts
+++ b/apps/desktop/src/main/session-manager.ts
@@ -153,18 +153,28 @@ export class DesktopSessionManager {
     try {
       const dirEntries = await fs.readdir(this.sessionsDirectory, { withFileTypes: true })
 
-      entries = await Promise.all(
-        dirEntries
-          .filter((entry) => entry.isFile() && entry.name.endsWith('.jsonl'))
-          .map(async (entry) => {
-            const filePath = path.join(this.sessionsDirectory, entry.name)
-            const stat = await fs.stat(filePath)
-            return {
-              filePath,
-              modified: stat.mtimeMs,
-            }
-          }),
-      )
+      for (const dirEntry of dirEntries) {
+        if (!dirEntry.isFile() || !dirEntry.name.endsWith('.jsonl')) {
+          continue
+        }
+
+        const filePath = path.join(this.sessionsDirectory, dirEntry.name)
+
+        try {
+          const stat = await fs.stat(filePath)
+          entries.push({
+            filePath,
+            modified: stat.mtimeMs,
+          })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          warnings.push(`${path.basename(filePath)}: ${message}`)
+          log.warn('[desktop-session-manager] skipped unreadable session file', {
+            path: filePath,
+            error: message,
+          })
+        }
+      }
     } catch (error) {
       if (
         typeof error === 'object' &&

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -70,6 +70,28 @@ const api: DesktopApi = {
   setModel: async (model: string) => {
     return ipcRenderer.invoke(IPC_CHANNELS.sessionSetModel, model)
   },
+  sessions: {
+    list: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.sessionList)
+    },
+    create: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.sessionNew)
+    },
+    getInfo: async (sessionPath: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.sessionGetInfo, sessionPath)
+    },
+  },
+  workspace: {
+    get: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workspaceGet)
+    },
+    set: async (workspacePath: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workspaceSet, workspacePath)
+    },
+    pick: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workspacePick)
+    },
+  },
   auth: {
     getProviders: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.authGetProviders)

--- a/apps/desktop/src/renderer/atoms/chat.ts
+++ b/apps/desktop/src/renderer/atoms/chat.ts
@@ -58,6 +58,13 @@ export const appendUserMessageAtom = atom(null, (get, set, content: string) => {
   ])
 })
 
+export const resetChatStateAtom = atom(null, (_get, set) => {
+  set(messagesAtom, [])
+  set(toolCallsAtom, [])
+  set(isStreamingAtom, false)
+  set(errorAtom, null)
+})
+
 export const applyBridgeStatusAtom = atom(null, (_get, set, status: BridgeStatusEvent) => {
   set(bridgeStatusAtom, {
     state: status.state,

--- a/apps/desktop/src/renderer/atoms/session.ts
+++ b/apps/desktop/src/renderer/atoms/session.ts
@@ -1,0 +1,115 @@
+import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+import type { SessionListResponse, SessionListItem } from '@shared/types'
+import { resetChatStateAtom } from './chat'
+
+const CURRENT_SESSION_STORAGE_KEY = 'kata-desktop:current-session-id'
+const WORKING_DIRECTORY_STORAGE_KEY = 'kata-desktop:working-directory'
+const SESSION_SIDEBAR_OPEN_STORAGE_KEY = 'kata-desktop:session-sidebar-open'
+
+export const sessionListAtom = atom<SessionListItem[]>([])
+export const sessionWarningsAtom = atom<string[]>([])
+export const sessionDirectoryAtom = atom<string>('')
+export const sessionListLoadingAtom = atom<boolean>(false)
+export const sessionListErrorAtom = atom<string | null>(null)
+
+export const currentSessionIdAtom = atomWithStorage<string | null>(
+  CURRENT_SESSION_STORAGE_KEY,
+  null,
+)
+
+export const workingDirectoryAtom = atomWithStorage<string>(
+  WORKING_DIRECTORY_STORAGE_KEY,
+  '',
+)
+
+export const sessionSidebarOpenAtom = atomWithStorage<boolean>(
+  SESSION_SIDEBAR_OPEN_STORAGE_KEY,
+  true,
+)
+
+const applySessionListResponseAtom = atom(
+  null,
+  (get, set, response: SessionListResponse) => {
+    set(sessionListAtom, response.sessions)
+    set(sessionWarningsAtom, response.warnings)
+    set(sessionDirectoryAtom, response.directory)
+
+    const existingSessionId = get(currentSessionIdAtom)
+    if (
+      existingSessionId &&
+      response.sessions.some((session) => session.id === existingSessionId)
+    ) {
+      return
+    }
+
+    set(currentSessionIdAtom, response.sessions[0]?.id ?? null)
+  },
+)
+
+export const refreshSessionListAtom = atom(null, async (_get, set) => {
+  set(sessionListLoadingAtom, true)
+  set(sessionListErrorAtom, null)
+
+  try {
+    const response = await window.api.sessions.list()
+    set(applySessionListResponseAtom, response)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    set(sessionListErrorAtom, message)
+  } finally {
+    set(sessionListLoadingAtom, false)
+  }
+})
+
+export const initializeSessionsAtom = atom(null, async (_get, set) => {
+  set(sessionListLoadingAtom, true)
+  set(sessionListErrorAtom, null)
+
+  try {
+    const workspace = await window.api.workspace.get()
+    set(workingDirectoryAtom, workspace.path)
+
+    const response = await window.api.sessions.list()
+    set(applySessionListResponseAtom, response)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    set(sessionListErrorAtom, message)
+  } finally {
+    set(sessionListLoadingAtom, false)
+  }
+})
+
+export const createSessionAtom = atom(null, async (_get, set) => {
+  set(sessionListErrorAtom, null)
+
+  const response = await window.api.sessions.create()
+  if (!response.success) {
+    set(sessionListErrorAtom, response.error ?? 'Unable to create session')
+    return
+  }
+
+  set(resetChatStateAtom)
+
+  await set(refreshSessionListAtom)
+
+  if (response.sessionId) {
+    set(currentSessionIdAtom, response.sessionId)
+  }
+})
+
+export const selectSessionAtom = atom(null, (_get, set, sessionId: string) => {
+  set(currentSessionIdAtom, sessionId)
+})
+
+export const pickWorkspaceAtom = atom(null, async () => {
+  return window.api.workspace.pick()
+})
+
+export const switchWorkspaceAtom = atom(null, async (_get, set, workspacePath: string) => {
+  const response = await window.api.workspace.set(workspacePath)
+  set(workingDirectoryAtom, response.path)
+  set(currentSessionIdAtom, null)
+  set(resetChatStateAtom)
+  await set(refreshSessionListAtom)
+})

--- a/apps/desktop/src/renderer/atoms/session.ts
+++ b/apps/desktop/src/renderer/atoms/session.ts
@@ -12,6 +12,7 @@ export const sessionWarningsAtom = atom<string[]>([])
 export const sessionDirectoryAtom = atom<string>('')
 export const sessionListLoadingAtom = atom<boolean>(false)
 export const sessionListErrorAtom = atom<string | null>(null)
+export const sessionCreatingAtom = atom<boolean>(false)
 
 export const currentSessionIdAtom = atomWithStorage<string | null>(
   CURRENT_SESSION_STORAGE_KEY,
@@ -80,26 +81,31 @@ export const initializeSessionsAtom = atom(null, async (_get, set) => {
   }
 })
 
-export const createSessionAtom = atom(null, async (_get, set) => {
-  set(sessionListErrorAtom, null)
-
-  const response = await window.api.sessions.create()
-  if (!response.success) {
-    set(sessionListErrorAtom, response.error ?? 'Unable to create session')
+export const createSessionAtom = atom(null, async (get, set) => {
+  if (get(sessionCreatingAtom)) {
     return
   }
 
-  set(resetChatStateAtom)
+  set(sessionCreatingAtom, true)
+  set(sessionListErrorAtom, null)
 
-  await set(refreshSessionListAtom)
+  try {
+    const response = await window.api.sessions.create()
+    if (!response.success) {
+      set(sessionListErrorAtom, response.error ?? 'Unable to create session')
+      return
+    }
 
-  if (response.sessionId) {
-    set(currentSessionIdAtom, response.sessionId)
+    set(resetChatStateAtom)
+
+    await set(refreshSessionListAtom)
+
+    if (response.sessionId) {
+      set(currentSessionIdAtom, response.sessionId)
+    }
+  } finally {
+    set(sessionCreatingAtom, false)
   }
-})
-
-export const selectSessionAtom = atom(null, (_get, set, sessionId: string) => {
-  set(currentSessionIdAtom, sessionId)
 })
 
 export const pickWorkspaceAtom = atom(null, async () => {
@@ -107,9 +113,16 @@ export const pickWorkspaceAtom = atom(null, async () => {
 })
 
 export const switchWorkspaceAtom = atom(null, async (_get, set, workspacePath: string) => {
-  const response = await window.api.workspace.set(workspacePath)
-  set(workingDirectoryAtom, response.path)
-  set(currentSessionIdAtom, null)
-  set(resetChatStateAtom)
-  await set(refreshSessionListAtom)
+  set(sessionListErrorAtom, null)
+
+  try {
+    const response = await window.api.workspace.set(workspacePath)
+    set(workingDirectoryAtom, response.path)
+    set(currentSessionIdAtom, null)
+    set(resetChatStateAtom)
+    await set(refreshSessionListAtom)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    set(sessionListErrorAtom, `Unable to switch workspace to ${workspacePath}: ${message}`)
+  }
 })

--- a/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
@@ -1,15 +1,37 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useAtom, useSetAtom } from 'jotai'
+import { initializeSessionsAtom, sessionSidebarOpenAtom } from '@/atoms/session'
 import { SettingsPanel } from '../settings/SettingsPanel'
 import { ChatPanel } from '../chat/ChatPanel'
 import { ModelSelector } from './ModelSelector'
+import { SessionSidebar } from './SessionSidebar'
+import { WorkspaceIndicator } from './WorkspaceIndicator'
 
 export function LeftPane() {
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [sessionSidebarOpen, setSessionSidebarOpen] = useAtom(sessionSidebarOpenAtom)
+  const initializeSessions = useSetAtom(initializeSessionsAtom)
+
+  useEffect(() => {
+    void initializeSessions()
+  }, [initializeSessions])
 
   return (
-    <section className="h-full border-r border-slate-800 bg-slate-950">
-      <div className="flex h-14 items-center justify-between gap-3 border-b border-slate-800 px-4">
-        <h1 className="text-sm font-semibold tracking-wide uppercase text-slate-200">Kata Desktop</h1>
+    <section className="flex h-full flex-col border-r border-slate-800 bg-slate-950">
+      <div className="flex h-14 items-center justify-between gap-3 border-b border-slate-800 px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setSessionSidebarOpen((open) => !open)}
+            className="inline-flex h-8 items-center rounded-md border border-slate-700 px-2 text-xs text-slate-200 hover:bg-slate-800"
+            title={sessionSidebarOpen ? 'Hide session history' : 'Show session history'}
+          >
+            ☰
+          </button>
+
+          <h1 className="text-sm font-semibold tracking-wide uppercase text-slate-200">Kata Desktop</h1>
+          <WorkspaceIndicator />
+        </div>
 
         <div className="flex flex-1 items-center justify-end gap-3">
           <ModelSelector />
@@ -23,7 +45,13 @@ export function LeftPane() {
         </div>
       </div>
 
-      <ChatPanel />
+      <div className="flex min-h-0 flex-1">
+        <SessionSidebar open={sessionSidebarOpen} />
+
+        <div className="min-h-0 min-w-0 flex-1">
+          <ChatPanel />
+        </div>
+      </div>
 
       <SettingsPanel open={settingsOpen} onOpenChange={setSettingsOpen} />
     </section>

--- a/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
@@ -1,0 +1,111 @@
+import type { SessionListItem as SessionListItemType } from '@shared/types'
+
+interface SessionListItemProps {
+  session: SessionListItemType
+  isCurrent: boolean
+  onSelect: (sessionId: string) => void
+}
+
+function formatRelativeTime(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown'
+  }
+
+  const now = Date.now()
+  const deltaMs = date.getTime() - now
+  const absDeltaMs = Math.abs(deltaMs)
+
+  const minute = 60_000
+  const hour = 60 * minute
+  const day = 24 * hour
+
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+
+  if (absDeltaMs < hour) {
+    return rtf.format(Math.round(deltaMs / minute), 'minute')
+  }
+
+  if (absDeltaMs < day) {
+    return rtf.format(Math.round(deltaMs / hour), 'hour')
+  }
+
+  if (absDeltaMs < 7 * day) {
+    return rtf.format(Math.round(deltaMs / day), 'day')
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(date)
+}
+
+function sessionModelLabel(session: SessionListItemType): string {
+  if (session.model) {
+    return session.model
+  }
+
+  if (session.provider) {
+    return session.provider
+  }
+
+  return 'Unknown model'
+}
+
+export function SessionListItem({ session, isCurrent, onSelect }: SessionListItemProps) {
+  const model = sessionModelLabel(session)
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(session.id)}
+      title={session.title}
+      className={`w-full rounded-md border px-2 py-2 text-left transition ${
+        isCurrent
+          ? 'border-sky-500/80 bg-sky-500/15'
+          : 'border-slate-800 bg-slate-900/70 hover:border-slate-700 hover:bg-slate-800/70'
+      }`}
+    >
+      <div className="space-y-1.5">
+        <p
+          className="text-xs font-medium text-slate-100"
+          style={{
+            display: '-webkit-box',
+            overflow: 'hidden',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+          }}
+        >
+          {session.title}
+        </p>
+
+        {session.firstMessagePreview && (
+          <p
+            className="text-[11px] text-slate-400"
+            style={{
+              display: '-webkit-box',
+              overflow: 'hidden',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+            }}
+          >
+            {session.firstMessagePreview}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="max-w-[9rem] truncate rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-300">
+            {model}
+          </span>
+
+          <span className="text-[10px] text-slate-400">{formatRelativeTime(session.modified)}</span>
+        </div>
+
+        <div className="flex items-center justify-between text-[10px] text-slate-400">
+          <span>{session.provider ?? 'provider: n/a'}</span>
+          <span>{session.messageCount} msgs</span>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
@@ -3,7 +3,6 @@ import type { SessionListItem as SessionListItemType } from '@shared/types'
 interface SessionListItemProps {
   session: SessionListItemType
   isCurrent: boolean
-  onSelect: (sessionId: string) => void
 }
 
 function formatRelativeTime(value: string): string {
@@ -52,18 +51,16 @@ function sessionModelLabel(session: SessionListItemType): string {
   return 'Unknown model'
 }
 
-export function SessionListItem({ session, isCurrent, onSelect }: SessionListItemProps) {
+export function SessionListItem({ session, isCurrent }: SessionListItemProps) {
   const model = sessionModelLabel(session)
 
   return (
-    <button
-      type="button"
-      onClick={() => onSelect(session.id)}
+    <div
       title={session.title}
-      className={`w-full rounded-md border px-2 py-2 text-left transition ${
+      className={`w-full rounded-md border px-2 py-2 text-left ${
         isCurrent
           ? 'border-sky-500/80 bg-sky-500/15'
-          : 'border-slate-800 bg-slate-900/70 hover:border-slate-700 hover:bg-slate-800/70'
+          : 'border-slate-800 bg-slate-900/70'
       }`}
     >
       <div className="space-y-1.5">
@@ -106,6 +103,6 @@ export function SessionListItem({ session, isCurrent, onSelect }: SessionListIte
           <span>{session.messageCount} msgs</span>
         </div>
       </div>
-    </button>
+    </div>
   )
 }

--- a/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
@@ -1,0 +1,92 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import {
+  createSessionAtom,
+  currentSessionIdAtom,
+  refreshSessionListAtom,
+  selectSessionAtom,
+  sessionListAtom,
+  sessionListErrorAtom,
+  sessionListLoadingAtom,
+  sessionWarningsAtom,
+} from '@/atoms/session'
+import { SessionListItem } from './SessionListItem'
+
+interface SessionSidebarProps {
+  open: boolean
+}
+
+export function SessionSidebar({ open }: SessionSidebarProps) {
+  const sessions = useAtomValue(sessionListAtom)
+  const currentSessionId = useAtomValue(currentSessionIdAtom)
+  const loading = useAtomValue(sessionListLoadingAtom)
+  const error = useAtomValue(sessionListErrorAtom)
+  const warnings = useAtomValue(sessionWarningsAtom)
+
+  const createSession = useSetAtom(createSessionAtom)
+  const selectSession = useSetAtom(selectSessionAtom)
+  const refreshSessions = useSetAtom(refreshSessionListAtom)
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <aside className="flex h-full w-[16rem] shrink-0 flex-col border-r border-slate-800 bg-slate-950/80">
+      <div className="border-b border-slate-800 p-3">
+        <button
+          type="button"
+          onClick={() => {
+            void createSession()
+          }}
+          className="inline-flex w-full items-center justify-center rounded-md bg-slate-100 px-2 py-1.5 text-xs font-medium text-slate-900 hover:bg-white"
+        >
+          + New Session
+        </button>
+
+        <div className="mt-2 flex items-center justify-between text-[10px] text-slate-400">
+          <span>{sessions.length} sessions</span>
+          <button
+            type="button"
+            onClick={() => {
+              void refreshSessions()
+            }}
+            className="rounded border border-slate-700 px-1.5 py-0.5 hover:bg-slate-800"
+          >
+            Refresh
+          </button>
+        </div>
+
+        {warnings.length > 0 && (
+          <p className="mt-2 rounded border border-amber-500/50 bg-amber-500/10 px-2 py-1 text-[10px] text-amber-200">
+            {warnings.length} corrupted session file{warnings.length === 1 ? '' : 's'} skipped
+          </p>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {loading && <p className="p-2 text-xs text-slate-400">Loading sessions…</p>}
+
+        {!loading && error && (
+          <p className="rounded border border-rose-500/40 bg-rose-500/10 p-2 text-xs text-rose-200">
+            Unable to load sessions: {error}
+          </p>
+        )}
+
+        {!loading && !error && sessions.length === 0 && (
+          <p className="p-2 text-xs text-slate-400">No sessions for this workspace yet.</p>
+        )}
+
+        <div className="space-y-2">
+          {sessions.map((session) => (
+            <SessionListItem
+              key={session.id}
+              session={session}
+              isCurrent={session.id === currentSessionId}
+              onSelect={selectSession}
+            />
+          ))}
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
@@ -3,7 +3,6 @@ import {
   createSessionAtom,
   currentSessionIdAtom,
   refreshSessionListAtom,
-  selectSessionAtom,
   sessionListAtom,
   sessionListErrorAtom,
   sessionListLoadingAtom,
@@ -23,7 +22,6 @@ export function SessionSidebar({ open }: SessionSidebarProps) {
   const warnings = useAtomValue(sessionWarningsAtom)
 
   const createSession = useSetAtom(createSessionAtom)
-  const selectSession = useSetAtom(selectSessionAtom)
   const refreshSessions = useSetAtom(refreshSessionListAtom)
 
   if (!open) {
@@ -56,6 +54,8 @@ export function SessionSidebar({ open }: SessionSidebarProps) {
           </button>
         </div>
 
+        <p className="mt-2 text-[10px] text-slate-500">Session switching is not available yet in Desktop.</p>
+
         {warnings.length > 0 && (
           <p className="mt-2 rounded border border-amber-500/50 bg-amber-500/10 px-2 py-1 text-[10px] text-amber-200">
             {warnings.length} corrupted session file{warnings.length === 1 ? '' : 's'} skipped
@@ -82,7 +82,6 @@ export function SessionSidebar({ open }: SessionSidebarProps) {
               key={session.id}
               session={session}
               isCurrent={session.id === currentSessionId}
-              onSelect={selectSession}
             />
           ))}
         </div>

--- a/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
@@ -3,6 +3,7 @@ import {
   createSessionAtom,
   currentSessionIdAtom,
   refreshSessionListAtom,
+  sessionCreatingAtom,
   sessionListAtom,
   sessionListErrorAtom,
   sessionListLoadingAtom,
@@ -18,6 +19,7 @@ export function SessionSidebar({ open }: SessionSidebarProps) {
   const sessions = useAtomValue(sessionListAtom)
   const currentSessionId = useAtomValue(currentSessionIdAtom)
   const loading = useAtomValue(sessionListLoadingAtom)
+  const creatingSession = useAtomValue(sessionCreatingAtom)
   const error = useAtomValue(sessionListErrorAtom)
   const warnings = useAtomValue(sessionWarningsAtom)
 
@@ -36,9 +38,10 @@ export function SessionSidebar({ open }: SessionSidebarProps) {
           onClick={() => {
             void createSession()
           }}
-          className="inline-flex w-full items-center justify-center rounded-md bg-slate-100 px-2 py-1.5 text-xs font-medium text-slate-900 hover:bg-white"
+          disabled={creatingSession}
+          className="inline-flex w-full items-center justify-center rounded-md bg-slate-100 px-2 py-1.5 text-xs font-medium text-slate-900 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
         >
-          + New Session
+          {creatingSession ? 'Creating…' : '+ New Session'}
         </button>
 
         <div className="mt-2 flex items-center justify-between text-[10px] text-slate-400">

--- a/apps/desktop/src/renderer/components/app-shell/WorkspaceIndicator.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/WorkspaceIndicator.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import {
   pickWorkspaceAtom,
+  sessionListErrorAtom,
   switchWorkspaceAtom,
   workingDirectoryAtom,
 } from '@/atoms/session'
@@ -25,6 +26,7 @@ export function WorkspaceIndicator() {
   const workingDirectory = useAtomValue(workingDirectoryAtom)
   const pickWorkspace = useSetAtom(pickWorkspaceAtom)
   const switchWorkspace = useSetAtom(switchWorkspaceAtom)
+  const setSessionError = useSetAtom(sessionListErrorAtom)
 
   const workspaceLabel = useMemo(
     () => formatWorkspaceLabel(workingDirectory),
@@ -32,12 +34,17 @@ export function WorkspaceIndicator() {
   )
 
   const handlePickWorkspace = async (): Promise<void> => {
-    const selected = await pickWorkspace()
-    if (!selected) {
-      return
-    }
+    try {
+      const selected = await pickWorkspace()
+      if (!selected) {
+        return
+      }
 
-    await switchWorkspace(selected.path)
+      await switchWorkspace(selected.path)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setSessionError(`Unable to switch workspace: ${message}`)
+    }
   }
 
   return (

--- a/apps/desktop/src/renderer/components/app-shell/WorkspaceIndicator.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/WorkspaceIndicator.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import {
+  pickWorkspaceAtom,
+  switchWorkspaceAtom,
+  workingDirectoryAtom,
+} from '@/atoms/session'
+
+function formatWorkspaceLabel(workspacePath: string): string {
+  if (!workspacePath) {
+    return 'Select workspace'
+  }
+
+  const segments = workspacePath.split('/').filter(Boolean)
+  const tail = segments.slice(-2)
+
+  if (tail.length === 0) {
+    return workspacePath
+  }
+
+  return tail.join(' / ')
+}
+
+export function WorkspaceIndicator() {
+  const workingDirectory = useAtomValue(workingDirectoryAtom)
+  const pickWorkspace = useSetAtom(pickWorkspaceAtom)
+  const switchWorkspace = useSetAtom(switchWorkspaceAtom)
+
+  const workspaceLabel = useMemo(
+    () => formatWorkspaceLabel(workingDirectory),
+    [workingDirectory],
+  )
+
+  const handlePickWorkspace = async (): Promise<void> => {
+    const selected = await pickWorkspace()
+    if (!selected) {
+      return
+    }
+
+    await switchWorkspace(selected.path)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void handlePickWorkspace()
+      }}
+      title={workingDirectory || 'Select working directory'}
+      className="max-w-[18rem] truncate rounded border border-slate-700 px-2 py-1 text-xs text-slate-300 hover:bg-slate-800"
+    >
+      📁 {workspaceLabel}
+    </button>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -10,6 +10,7 @@ import {
   messagesAtom,
   toolCallsAtom,
 } from '@/atoms/chat'
+import { refreshSessionListAtom } from '@/atoms/session'
 import { ErrorBanner } from './ErrorBanner'
 import { ExtensionUIHandler } from './ExtensionUIHandler'
 import { MessageInput } from './MessageInput'
@@ -26,12 +27,17 @@ export function ChatPanel() {
   const appendUserMessage = useSetAtom(appendUserMessageAtom)
   const applyChatEvent = useSetAtom(applyChatEventAtom)
   const applyBridgeStatus = useSetAtom(applyBridgeStatusAtom)
+  const refreshSessions = useSetAtom(refreshSessionListAtom)
 
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     const unsubscribeChatEvents = window.api.onChatEvent((event) => {
       applyChatEvent(event)
+
+      if (event.type === 'agent_end') {
+        void refreshSessions()
+      }
     })
 
     const unsubscribeBridgeStatus = window.api.onBridgeStatus((status) => {
@@ -50,7 +56,7 @@ export function ChatPanel() {
       unsubscribeChatEvents()
       unsubscribeBridgeStatus()
     }
-  }, [applyBridgeStatus, applyChatEvent])
+  }, [applyBridgeStatus, applyChatEvent, refreshSessions])
 
   useEffect(() => {
     scrollRef.current?.scrollTo({
@@ -66,7 +72,7 @@ export function ChatPanel() {
   const errorTitle = bridgeStatus.state === 'crashed' ? 'Agent process crashed' : 'Agent error'
 
   return (
-    <div className="relative flex h-[calc(100%-3.5rem)] flex-col">
+    <div className="relative flex h-full min-h-0 flex-col">
       <ExtensionUIHandler />
 
       {errorMessage && (

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -10,6 +10,12 @@ export const IPC_CHANNELS = {
   sessionPermissionMode: 'session:permission-mode',
   sessionGetAvailableModels: 'session:get-available-models',
   sessionSetModel: 'session:set-model',
+  sessionList: 'session:list',
+  sessionNew: 'session:new',
+  sessionGetInfo: 'session:get-info',
+  workspaceGet: 'workspace:get',
+  workspaceSet: 'workspace:set',
+  workspacePick: 'workspace:pick',
   authGetProviders: 'auth:get-providers',
   authSetKey: 'auth:set-key',
   authRemoveKey: 'auth:remove-key',
@@ -102,12 +108,54 @@ export interface SetModelResponse {
   error?: string
 }
 
+export interface SessionTokenUsage {
+  input?: number
+  output?: number
+  cacheRead?: number
+  cacheWrite?: number
+  total?: number
+}
+
+export interface SessionListItem {
+  id: string
+  path: string
+  name: string | null
+  title: string
+  model: string | null
+  provider: string | null
+  created: string
+  modified: string
+  messageCount: number
+  firstMessagePreview: string | null
+}
+
+export interface SessionInfo extends SessionListItem {
+  tokenUsage?: SessionTokenUsage
+}
+
+export interface SessionListResponse {
+  sessions: SessionListItem[]
+  warnings: string[]
+  directory: string
+}
+
+export interface CreateSessionResponse {
+  success: boolean
+  sessionId: string | null
+  error?: string
+}
+
+export interface WorkspaceInfo {
+  path: string
+}
+
 export type RpcCommandType =
   | 'prompt'
   | 'abort'
   | 'shutdown'
   | 'get_state'
   | 'get_session_stats'
+  | 'new_session'
   | 'follow_up'
   | 'get_available_models'
   | 'set_model'
@@ -323,6 +371,16 @@ export interface DesktopApi {
   setPermissionMode: (mode: PermissionMode) => Promise<void>
   getAvailableModels: () => Promise<AvailableModelsResponse>
   setModel: (model: string) => Promise<SetModelResponse>
+  sessions: {
+    list: () => Promise<SessionListResponse>
+    create: () => Promise<CreateSessionResponse>
+    getInfo: (sessionPath: string) => Promise<SessionInfo>
+  }
+  workspace: {
+    get: () => Promise<WorkspaceInfo>
+    set: (workspacePath: string) => Promise<WorkspaceInfo>
+    pick: () => Promise<WorkspaceInfo | null>
+  }
   auth: {
     getProviders: () => Promise<AuthProvidersResponse>
     setKey: (provider: AuthProvider, key: string) => Promise<AuthSetKeyResponse>


### PR DESCRIPTION
## Summary
- add `DesktopSessionManager` to parse `~/.kata-cli/sessions/*.jsonl` and expose session metadata
- add session/workspace IPC + preload APIs (`session:list/new/get-info`, `workspace:get/set/pick`)
- add renderer session state atoms, sidebar UI, new-session flow, and current session highlighting
- add workspace picker + persisted last working directory and bridge restart on workspace switch

## Linked work
- KAT-2098
- KAT-2101
- KAT-2099
- KAT-2100

## Validation
- `bun run --cwd apps/desktop typecheck`
- `bun run --cwd apps/desktop test`
- `bun run --cwd apps/desktop build`
- `bun -e "import { DesktopSessionManager } from './apps/desktop/src/main/session-manager.ts'; const mgr=new DesktopSessionManager(); const res=await mgr.listSessions(process.cwd()); console.log('session_count',res.sessions.length,'warnings',res.warnings.length,'directory',res.directory);"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session history sidebar to view, create, and switch between previous conversations with details like message count and timestamps
  * Added workspace/working directory switching with integrated directory picker
  * Sessions and working directory preferences now persist across app restarts
  * Added workspace indicator in the app header for quick reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements S04 session persistence for the Kata Desktop app, introducing a `DesktopSessionManager` that parses `~/.kata-cli/sessions/*.jsonl` files to surface session metadata, new IPC channels for session and workspace management, renderer Jotai atoms, a `SessionSidebar`, a `WorkspaceIndicator`, and persisted last-working-directory support with bridge restart on workspace switch.

The overall architecture is clean — the main-process changes are well-decomposed (`readSettings`/`writeSettings` helpers, `resolveInitialWorkspacePath` fallback chain), the path-traversal guard in `resolveSessionPath` is solid, and the IPC cleanup is symmetric. Key issues found:

- **Silent error swallowing in `WorkspaceIndicator`**: `void handlePickWorkspace()` discards the promise, so a failed bridge restart or `fs.stat` error produces no user-visible feedback and leaves the UI in a stale state.
- **Dead `fs.stat` call in `listSessions`**: `stat.mtimeMs` is collected via `Promise.all` for every `.jsonl` file but never read; the final sort uses the ISO-string `modified` field from `parseSessionFile` instead.
- **Double header parse**: For workspace-matched sessions, `readHeader` (8 KB read) is immediately followed by `parseSessionFile` which re-reads and re-parses the same first line.
- **No in-flight guard on `createSessionAtom`**: Rapid clicks can dispatch multiple concurrent `new_session` commands to the bridge.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the silent workspace-switch error handling; remaining findings are P2 quality improvements.
- One P1 issue exists: errors from workspace switching are silently discarded in WorkspaceIndicator, which could leave the bridge in a crashed/inconsistent state with no user feedback. The remaining three findings are P2 (dead code, minor inefficiency, missing debounce) and do not block functionality.
- apps/desktop/src/renderer/components/app-shell/WorkspaceIndicator.tsx (P1 silent error), apps/desktop/src/main/session-manager.ts (P2 dead stat call + double header parse)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/session-manager.ts | New class: reads ~/.kata-cli/sessions/*.jsonl, filters by cwd, extracts metadata. Path-traversal guard in resolveSessionPath is solid; minor inefficiencies (dead stat call, double header parse). |
| apps/desktop/src/main/ipc.ts | Adds session:list/new/get-info and workspace:get/set/pick IPC handlers; workspaceSet correctly validates path before switching bridge; cleanup handlers are symmetric. |
| apps/desktop/src/main/index.ts | Refactors settings into shared readSettings/writeSettings helpers; adds resolveInitialWorkspacePath with env-var and persisted-path fallback chain; clean decomposition. |
| apps/desktop/src/renderer/atoms/session.ts | New Jotai atoms for session list, workspace, and sidebar state; createSessionAtom lacks an in-flight guard; switchWorkspaceAtom has no error handling. |
| apps/desktop/src/renderer/components/app-shell/WorkspaceIndicator.tsx | New component for workspace display and picker; handlePickWorkspace errors are silently discarded via void, leaving no user feedback on switch failures. |
| apps/desktop/src/main/pi-agent-bridge.ts | Adds getWorkspacePath() and switchWorkspace() methods; workspacePath changed from readonly to mutable; restart() called correctly on switch. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Renderer (WorkspaceIndicator / SessionSidebar)
    participant Atoms as Jotai Atoms
    participant Preload as Preload Bridge
    participant IPC as Main IPC (ipc.ts)
    participant SM as DesktopSessionManager
    participant Bridge as PiAgentBridge
    participant FS as File System

    Note over UI,FS: Session list load on startup
    UI->>Atoms: initializeSessionsAtom
    Atoms->>Preload: workspace.get()
    Preload->>IPC: workspaceGet
    IPC->>Bridge: getWorkspacePath()
    Bridge-->>IPC: path
    IPC-->>Atoms: WorkspaceInfo
    Atoms->>Preload: sessions.list()
    Preload->>IPC: sessionList
    IPC->>SM: listSessions(cwd)
    SM->>FS: readdir(~/.kata-cli/sessions)
    SM->>FS: readHeader(file) × N
    SM->>FS: parseSessionFile(file) × matched
    SM-->>IPC: SessionListResponse
    IPC-->>Atoms: sessions[]
    Atoms-->>UI: render sidebar

    Note over UI,FS: New session flow
    UI->>Atoms: createSessionAtom
    Atoms->>Preload: sessions.create()
    Preload->>IPC: sessionNew
    IPC->>Bridge: send({type:'new_session'})
    Bridge-->>IPC: CreateSessionResponse
    IPC-->>Atoms: {success, sessionId}
    Atoms->>Atoms: resetChatStateAtom
    Atoms->>SM: refreshSessionListAtom

    Note over UI,FS: Workspace switch flow
    UI->>Atoms: pickWorkspaceAtom
    Atoms->>Preload: workspace.pick()
    Preload->>IPC: workspacePick → dialog
    IPC-->>Atoms: WorkspaceInfo | null
    Atoms->>Preload: workspace.set(path)
    Preload->>IPC: workspaceSet
    IPC->>FS: stat(path)
    IPC->>Bridge: switchWorkspace(path)
    Bridge->>Bridge: shutdown() + start()
    IPC->>FS: writeSettings(lastWorkingDirectory)
    IPC-->>Atoms: WorkspaceInfo
    Atoms->>Atoms: workingDirectoryAtom, resetChatState, refreshSessions
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/app-shell/WorkspaceIndicator.tsx
Line: 39-47

Comment:
**Silent error swallowing on workspace switch**

`void handlePickWorkspace()` discards the returned promise, meaning any errors thrown inside — including a failed `bridge.switchWorkspace` / `bridge.restart()` — are silently swallowed. The user receives zero feedback if the workspace switch or bridge restart fails, and the UI is left in a stale state (sidebar still shows old workspace label, no error banner).

`switchWorkspaceAtom` also has no `try/catch`, so the unhandled rejection has nowhere to surface. Consider adding error handling in the component or the atom:

```tsx
onClick={() => {
  void handlePickWorkspace().catch((err) => {
    console.error('[WorkspaceIndicator] workspace switch failed', err)
    // surface error via a toast / error atom
  })
}}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/session-manager.ts
Line: 173-190

Comment:
**Unnecessary `fs.stat` call — `modified` field is unused**

`stat.mtimeMs` is stored in the `entries` array but is never read anywhere in the method. The sort at the bottom of `listSessions` operates on `sessionItem.modified` (an ISO string produced inside `parseSessionFile`), not on `entry.modified`. The `fs.stat` call here adds one syscall per `.jsonl` file for zero benefit.

```ts
entries = await Promise.all(
  dirEntries
    .filter((entry) => entry.isFile() && entry.name.endsWith('.jsonl'))
    .map(async (entry) => {
      const filePath = path.join(this.sessionsDirectory, entry.name)
-       const stat = await fs.stat(filePath)
      return {
        filePath,
-         modified: stat.mtimeMs,
      }
    }),
)
```

Change the mapped type to `Array<{ filePath: string }>` and remove the `stat` call.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/session.ts
Line: 86-100

Comment:
**No loading guard on `createSessionAtom`**

If the user clicks "+ New Session" rapidly (or it's triggered twice before the first `bridge.send` resolves), multiple concurrent `new_session` commands are sent to the bridge. There's no in-flight flag to debounce this.

Consider setting a dedicated loading atom (e.g. `sessionCreatingAtom`) at the start of `createSessionAtom` and clearing it in `finally`, and disabling the button while it's true.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/session-manager.ts
Line: 231-257

Comment:
**Double-read of session header for matched files**

For every session whose `cwd` matches, `readHeader` (8 KB read) is followed immediately by `parseSessionFile` which calls `fs.readFile` on the entire file and re-parses the same first line as a header. The header is parsed twice.

A simple optimisation is to pass the already-resolved header into `parseSessionFile` (or merge the two methods for the "full parse" path):

```ts
const header = await this.readHeader(entry.filePath)
if (!header?.cwd || normalizePath(header.cwd) !== normalizedCwd) continue

// pass `header` to avoid re-reading/re-parsing line 1
const metadata = await this.parseSessionFile(entry.filePath, header)
```

This is low-impact for small session counts but will matter as the sessions directory grows.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): persist workspace and res..."](https://github.com/gannonh/kata/commit/9360898abf8b640c2397a84818b30fa27c9b1e23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26980239)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->