### PR TITLE
fix(symphony): don't kill sessions on transient API errors

### DIFF
--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -2678,27 +2678,35 @@ impl Orchestrator {
 
         if let Some(run_attempt) = self.state.running.get_mut(issue_id) {
             match event {
-                AgentEvent::TurnFailed { error, .. }
-                | AgentEvent::TurnEndedWithError { error, .. }
-                | AgentEvent::StartupFailed { error, .. } => {
+                AgentEvent::TurnFailed { error, .. } | AgentEvent::StartupFailed { error, .. } => {
                     run_attempt.status = "failed".to_string();
                     run_attempt.error = Some(error.clone());
                 }
                 AgentEvent::TurnCancelled { .. } => {
                     run_attempt.status = "cancelled".to_string();
                 }
+                // TurnEndedWithError is non-fatal: pi-agent retries internally.
+                // Don't mark the run as failed — just surface the error transiently.
                 _ => {}
             }
         }
 
         let event_error = match event {
-            AgentEvent::TurnFailed { error, .. }
-            | AgentEvent::TurnEndedWithError { error, .. }
-            | AgentEvent::StartupFailed { error, .. } => Some(error.as_str()),
+            AgentEvent::TurnFailed { error, .. } | AgentEvent::StartupFailed { error, .. } => {
+                Some(error.as_str())
+            }
             _ => None,
         };
 
         if let Some(error) = event_error {
+            if let Some(info) = self.worker_session_info.get_mut(issue_id) {
+                info.last_error = Some(format_rate_limit_error(error));
+            }
+        }
+
+        // TurnEndedWithError: surface the error transiently in the TUI
+        // but don't mark the run as failed — pi-agent retries internally.
+        if let AgentEvent::TurnEndedWithError { error, .. } = event {
             if let Some(info) = self.worker_session_info.get_mut(issue_id) {
                 info.last_error = Some(format_rate_limit_error(error));
             }

--- a/apps/symphony/src/pi_agent/rpc_bridge.rs
+++ b/apps/symphony/src/pi_agent/rpc_bridge.rs
@@ -899,6 +899,12 @@ pub async fn run_turn_with_followups(
                             None
                         };
 
+                        // Pi-agent retries transient API errors (connection errors,
+                        // overloaded, etc.) internally. A message_end with
+                        // stopReason="error" is NOT terminal — the agent will
+                        // retry and continue. Only agent_end signals a true
+                        // session end. Log the error and emit a TurnEndedWithError
+                        // notification, but keep the read loop alive.
                         tracing::warn!(
                             event = "turn_error_detected",
                             issue_id = %handle.issue_id,
@@ -906,7 +912,8 @@ pub async fn run_turn_with_followups(
                             error_type = %stop_reason,
                             message = %message_preview,
                             retry_after_ms,
-                            "pi-agent turn ended with stopReason=error"
+                            "pi-agent message ended with stopReason=error; \
+                             continuing read loop (agent retries internally)"
                         );
 
                         if has_rate_limit_hint(&error_text) {
@@ -920,15 +927,16 @@ pub async fn run_turn_with_followups(
                             );
                         }
 
-                        let failed = AgentEvent::TurnFailed {
+                        let error_event = AgentEvent::TurnEndedWithError {
                             timestamp: Utc::now(),
                             codex_app_server_pid: handle.pid.clone(),
                             turn_id: turn_id.clone(),
-                            error: error_text.clone(),
+                            error: error_text,
                         };
-                        event_callback(failed.clone());
-                        events.push(failed);
-                        return Err(SymphonyError::TurnFailed(error_text));
+                        event_callback(error_event.clone());
+                        events.push(error_event);
+                        // Do NOT return — let the loop continue so pi-agent
+                        // can retry the API call internally.
                     }
                 }
             }

--- a/apps/symphony/tests/pi_agent_tests.rs
+++ b/apps/symphony/tests/pi_agent_tests.rs
@@ -295,8 +295,12 @@ echo '{"type":"response","command":"get_state","success":true,"data":{"sessionId
 while read -r line; do
   if [[ "$line" == *'"type":"prompt"'* ]]; then
     echo '{"type":"response","command":"prompt","success":true}'
-    # Simulate a transient API error followed by agent retry and completion
+    # Simulate a transient API error followed by pi-agent internal retry and
+    # successful completion — mirrors what happens in production: message_end
+    # with stopReason="error" is intermediate, pi-agent retries, then emits a
+    # successful message_end before agent_end.
     echo '{"type":"message_end","message":{"stopReason":"error","errorMessage":"Rate limit exceeded. Retry after 12s.","content":[]}}'
+    echo '{"type":"message_end","message":{"stopReason":"toolUse","content":[{"type":"text","text":"retried successfully"}]}}'
     echo '{"type":"agent_end","messages":[]}'
   elif [[ "$line" == *'"type":"get_session_stats"'* ]]; then
     echo '{"type":"response","command":"get_session_stats","success":true,"data":{"session_id":"sess-error","tokens":{"input":5,"output":2,"total":7}}}'
@@ -682,6 +686,13 @@ async fn rpc_bridge_turn_continues_past_message_end_error_stop_reason() {
             .iter()
             .any(|event| matches!(event, symphony::domain::AgentEvent::TurnCompleted { .. })),
         "TurnCompleted event should be emitted after agent retry succeeds"
+    );
+
+    // output_text should come from the successful retry, not the failed attempt
+    assert_eq!(
+        result.output_text.as_deref(),
+        Some("retried successfully"),
+        "output_text should be captured from the successful retry message_end"
     );
 
     assert_eq!(result.total_tokens, 7, "tokens from stats response");

--- a/apps/symphony/tests/pi_agent_tests.rs
+++ b/apps/symphony/tests/pi_agent_tests.rs
@@ -295,8 +295,11 @@ echo '{"type":"response","command":"get_state","success":true,"data":{"sessionId
 while read -r line; do
   if [[ "$line" == *'"type":"prompt"'* ]]; then
     echo '{"type":"response","command":"prompt","success":true}'
+    # Simulate a transient API error followed by agent retry and completion
     echo '{"type":"message_end","message":{"stopReason":"error","errorMessage":"Rate limit exceeded. Retry after 12s.","content":[]}}'
     echo '{"type":"agent_end","messages":[]}'
+  elif [[ "$line" == *'"type":"get_session_stats"'* ]]; then
+    echo '{"type":"response","command":"get_session_stats","success":true,"data":{"session_id":"sess-error","tokens":{"input":5,"output":2,"total":7}}}'
   elif [[ "$line" == *'"type":"abort"'* ]]; then
     exit 0
   fi
@@ -616,7 +619,11 @@ async fn rpc_bridge_stop_session_handles_process_already_exited() {
 }
 
 #[tokio::test]
-async fn rpc_bridge_turn_fails_on_message_end_error_stop_reason() {
+async fn rpc_bridge_turn_continues_past_message_end_error_stop_reason() {
+    // Pi-agent retries transient API errors internally. A message_end with
+    // stopReason="error" is NOT fatal — the RPC bridge should continue the
+    // read loop until agent_end, emitting TurnEndedWithError as a non-fatal
+    // notification. The turn completes normally.
     let scripts_dir = tempfile::tempdir().expect("scripts dir");
     let root_dir = tempfile::tempdir().expect("root dir");
     let workspace = root_dir.path().join("workspace");
@@ -648,23 +655,36 @@ async fn rpc_bridge_turn_fails_on_message_end_error_stop_reason() {
     .expect("start_session succeeds");
 
     let mut events = Vec::new();
-    let err = rpc_bridge::run_turn(&mut handle, "hello", |event| events.push(event))
+    let result = rpc_bridge::run_turn(&mut handle, "hello", |event| events.push(event))
         .await
-        .expect_err("run_turn should fail on stopReason=error");
+        .expect("run_turn should succeed despite transient stopReason=error");
 
-    match err {
-        symphony::error::SymphonyError::TurnFailed(message) => {
-            assert!(message.contains("Rate limit exceeded"));
-        }
-        other => panic!("expected TurnFailed error, got {other:?}"),
-    }
+    // The transient error should be surfaced as TurnEndedWithError (non-fatal)
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            symphony::domain::AgentEvent::TurnEndedWithError { .. }
+        )),
+        "TurnEndedWithError event should be emitted for transient API errors"
+    );
 
+    // But the turn should NOT be treated as failed
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, symphony::domain::AgentEvent::TurnFailed { .. })),
+        "TurnFailed should NOT be emitted for transient API errors"
+    );
+
+    // The turn should complete normally after the agent retries internally
     assert!(
         events
             .iter()
-            .any(|event| matches!(event, symphony::domain::AgentEvent::TurnFailed { .. })),
-        "TurnFailed event should be emitted"
+            .any(|event| matches!(event, symphony::domain::AgentEvent::TurnCompleted { .. })),
+        "TurnCompleted event should be emitted after agent retry succeeds"
     );
+
+    assert_eq!(result.total_tokens, 7, "tokens from stats response");
 
     rpc_bridge::stop_session(handle)
         .await


### PR DESCRIPTION
## Problem

The RPC bridge treated `message_end` with `stopReason="error"` as a fatal session-ending event. But pi-agent retries transient API errors (connection errors, rate limits, overloaded) internally — `message_end` is just an intermediate event, not terminal. Only `agent_end` signals a true session end.

This caused Symphony to kill and restart sessions on every transient API error, losing all context and progress. Workers would churn through dozens of fresh sessions making no progress.

**Evidence from session logs:** In interactive kata-cli, connection errors appear as `stopReason: "error"` in the JSONL, and the very next line is a successful `stopReason: "toolUse"` — pi-agent retried and continued. Symphony was killing the session on that intermediate event.

- KAT-2098 burned through **290 sessions** in 3 hours with zero task completions
- After the fix, it completed all 3 tasks in a single session (with 5 transient errors that all recovered)

## Changes

- **`rpc_bridge.rs`**: `MessageEnd` with `stopReason=error` now emits `TurnEndedWithError` (non-fatal notification) and continues the read loop instead of returning `Err(TurnFailed)`
- **`orchestrator.rs`**: `TurnEndedWithError` no longer marks the run as `"failed"`. The error is surfaced transiently in the TUI via `last_error`, but the worker keeps running
- **`pi_agent_tests.rs`**: Updated test to verify the new non-fatal behavior — turn completes successfully despite transient `stopReason=error`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Certain agent error conditions are now treated as non-fatal: turns can continue after transient errors while those errors are surfaced for logging and session status without marking the run as failed.

* **Tests**
  * Updated tests to expect continuation past message-end errors, to verify transient-error events are emitted, successful turn completion, and correct token accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a session-churn bug in Symphony where `message_end` events carrying `stopReason=error` were treated as fatal, causing the orchestrator to kill and restart sessions on every transient API error. The fix correctly models the pi-agent's internal retry semantics: `message_end` is intermediate, only `agent_end` is terminal.

**Key changes:**
- `rpc_bridge.rs`: `stopReason=error` on `MessageEnd` now emits `TurnEndedWithError` and continues the read loop instead of returning `Err(TurnFailed)`. The existing `stall_timeout_ms` guard prevents infinite loops if `agent_end` never arrives.
- `orchestrator.rs`: `TurnEndedWithError` no longer sets `run_attempt.status = "failed"`. The error is surfaced transiently via `last_error` (which is already cleared on `TurnCompleted` at line 2790), keeping the TUI informative without breaking the worker.
- `pi_agent_tests.rs`: Test correctly inverted from `expect_err` to `expect` and now asserts all three key properties — `TurnEndedWithError` emitted, `TurnFailed` not emitted, `TurnCompleted` emitted.

**One minor gap:** the mock script in the test jumps directly from `stopReason=error` to `agent_end`, so the path where the agent retries and emits a successful `message_end` (the actual production scenario) is not covered. This doesn't affect correctness of the fix but leaves a small branch untested.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the fix is correct, well-scoped, and well-commented with no P0/P1 issues.
- All three files change in a self-consistent, minimal way. The core loop already has stall_timeout_ms protection, last_error is cleared on TurnCompleted, and TurnEndedWithError was already handled correctly throughout the rest of the orchestrator (severity, tool-activity, event naming). The only finding is a P2 test-coverage gap (missing the "retry produced content" script path), which does not affect production correctness.
- apps/symphony/tests/pi_agent_tests.rs — mock script could be extended to cover the retry-with-content path, but this is non-blocking.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/pi_agent/rpc_bridge.rs | Core fix: MessageEnd with stopReason=error now emits TurnEndedWithError and continues the read loop instead of returning Err(TurnFailed). The loop already has stall_timeout_ms protection, so there's no infinite-loop risk if agent_end never arrives. |
| apps/symphony/src/orchestrator.rs | TurnEndedWithError is correctly decoupled from the "failed" run status. last_error is set for TUI visibility and is already cleared on TurnCompleted (line 2790), ensuring transient display only. |
| apps/symphony/tests/pi_agent_tests.rs | Test correctly inverts the old expect_err to expect and asserts the three key properties (TurnEndedWithError emitted, TurnFailed not emitted, TurnCompleted emitted). Mock script goes directly from error → agent_end without an intermediate successful message_end, so the "agent retried and produced content" path is not exercised. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant R as rpc_bridge
    participant P as pi-agent process

    O->>R: run_turn("hello", callback)
    R->>P: send prompt command

    Note over P: transient API error occurs

    P-->>R: message_end {stopReason: "error"}
    R->>O: callback(TurnEndedWithError)
    Note over R: ⚡ BEFORE: return Err(TurnFailed)<br/>✅ AFTER: continue read loop

    Note over O: BEFORE: run_attempt.status = "failed"<br/>✅ AFTER: set last_error only (TUI transient display)

    Note over P: pi-agent retries API call internally

    P-->>R: agent_end
    R->>O: callback(TurnCompleted)
    R->>P: get_session_stats
    P-->>R: stats response
    R-->>O: Ok(TurnResult)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/tests/pi_agent_tests.rs
Line: 296-300

Comment:
**Test script doesn't cover the "retry produced content" path**

The comment says _"Simulate a transient API error followed by agent retry and completion"_, but the script goes directly `message_end(stopReason=error)` → `agent_end` without emitting a second `message_end` carrying actual content. In the real scenario described in the PR ("the very next line is a successful `stopReason: toolUse`"), the flow looks like:

```
message_end  stopReason=error      # transient failure
message_end  stopReason=toolUse    # agent retried, produced content
agent_end
```

The current mock skips the intermediate successful `message_end`, so the `output_text` path after a retry is never exercised. The test still validates the critical behavioral change (non-fatal vs fatal), but consider adding a second variant that includes the successful `message_end` to ensure `output_text` is captured correctly after a retry:

```bash
# Simulate a transient API error followed by agent retry and completion
echo '{"type":"message_end","message":{"stopReason":"error","errorMessage":"Rate limit exceeded. Retry after 12s.","content":[]}}'
echo '{"type":"message_end","message":{"stopReason":"toolUse","content":[{"type":"text","text":"retried successfully"}]}}'
echo '{"type":"agent_end","messages":[]}'
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(symphony): don&#39;t kill sessions on tr..."](https://github.com/gannonh/kata/commit/b6408305bca8f6f86b5f3ff999f907eed665ad3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26980561)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->