### PR TITLE
chore: desktop planning artifacts and preferences

### DIFF
--- a/apps/desktop/.kata/preferences.md
+++ b/apps/desktop/.kata/preferences.md
@@ -1,0 +1,77 @@
+---
+version: 1
+workflow:
+  mode: linear
+linear:
+  teamKey: KAT
+  projectSlug: b0f5a7be6537
+pr:
+  enabled: false
+  auto_create: false
+  base_branch: main
+  review_on_create: false
+  linear_link: false
+always_use_skills: []
+prefer_skills: []
+avoid_skills: []
+skill_rules: []
+custom_instructions: []
+models: {}
+skill_discovery: suggest
+auto_supervisor: {}
+symphony: {}
+---
+
+# Kata Preferences
+
+> **Agent: do NOT overwrite this file.** Use `edit` to change individual fields. This file contains many settings — overwriting it with only the fields you care about destroys the rest.
+
+See `~/.kata-cli/agent/extensions/kata/docs/preferences-reference.md` for full field documentation and examples.
+
+## Quick start
+
+- `workflow.mode` is Linear-only. Keep `workflow.mode: linear`.
+- Fill in the `linear` block to bind this project to a Linear team/project.
+- Keep secrets out of this file. Store credentials in `~/.kata-cli/agent/auth.json` (preferred) or env vars (`LINEAR_API_KEY`, etc.). `.env` is optional.
+- Set `pr.enabled: true` to activate the PR lifecycle (create, review, address, merge via `gh` CLI).
+
+## Models example
+
+```yaml
+models:
+  research: claude-sonnet-4-6
+  planning: claude-opus-4-6     # Opus for architectural decisions
+  execution: claude-sonnet-4-6
+  completion: claude-sonnet-4-6
+  review: claude-sonnet-4-6     # Model for PR reviewer subagents
+```
+
+Omit any key to use the currently selected model.
+
+## PR lifecycle example
+
+```yaml
+pr:
+  enabled: true
+  auto_create: true      # auto-create PR after slice completes in auto-mode
+  base_branch: main      # target branch for PRs
+  review_on_create: false # auto-run parallel review after PR is created
+  linear_link: false      # add Linear issue references to PR body (requires linear mode)
+```
+
+## Symphony example
+
+```yaml
+symphony:
+  url: http://localhost:8080  # Symphony server URL (or set KATA_SYMPHONY_URL env var)
+```
+
+## Linear example
+
+```yaml
+workflow:
+  mode: linear
+linear:
+  teamKey: KAT
+  projectSlug: 459f9835e809   # from your Linear project URL (or use projectId for UUID)
+```

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -1,68 +1,143 @@
-# Kata Desktop (apps/desktop)
+# AGENTS.md — Kata Desktop
 
-Fresh Electron app for Kata Desktop (M001+), using the Kata CLI RPC runtime.
+This is a **fresh Electron application** being built from scratch. It is NOT the legacy `apps/electron/` (Craft Agents) app. Do not reference, import from, or depend on `@craft-agent/*` packages.
 
-## Runtime architecture
+## What This Is
 
-- **Main process**: `src/main/index.ts`
-  - creates the BrowserWindow
-  - registers IPC handlers (`registerSessionIpc`)
-  - persists model + workspace selections to `~/.kata-cli/agent/settings.json`
-- **Agent bridge**: `src/main/pi-agent-bridge.ts`
-  - spawns `kata --mode rpc --cwd <workspace>`
-  - adapts subprocess lifecycle to renderer-friendly status events
-  - binary discovery order:
-    1. bundled binary at `path.join(process.resourcesPath, 'kata')` when packaged
-    2. `KATA_BIN_PATH` when executable
-    3. `which kata` / `where kata`
-  - emits clear crash message when missing:
-    - `Kata CLI not found. Install via: npm install -g @kata-sh/cli`
-- **Renderer**: `src/renderer/`
-  - chat shell + onboarding + tool rendering UI
-  - split-pane layout (chat + contextual right pane)
+Kata Desktop is the native GUI for the Kata coding agent platform. It combines:
 
-## Build and packaging
+- **Chat pane (left):** A pi-coding-agent session — identical to Kata CLI but in a graphical interface
+- **Contextual right pane:** Planning artifact viewer during `/kata plan`, kanban board during execution
+- **Symphony operator surface:** Start/stop Symphony, monitor workers, handle escalations — all from the GUI
 
-Desktop build and packaging are driven from `apps/desktop/package.json`:
+Desktop wraps the Kata CLI as a subprocess in JSON-RPC mode (`kata --mode rpc`). This means Desktop inherits all CLI capabilities: multi-provider support, extensions, skills, MCP, Linear/GitHub integration, and the Kata planning methodology.
 
-- `bun run desktop:build`
-  - `build:main` (esbuild)
-  - `build:preload` (esbuild)
-  - `build:renderer` (vite)
-- `bun run desktop:dist:mac`
-  - `bundle:cli` (`scripts/bundle-cli.sh`)
-  - `desktop:build`
-  - `prepare:builder-app` (`scripts/prepare-builder-app.sh`)
-  - package app (`scripts/package-mac.sh` + `electron-builder`)
+## Hard Rules
 
-### Bundled CLI resources (D004)
+- **Never use `git push --no-verify` or `git commit --no-verify`.** If the gate fails, fix the problem.
+- **Never import from `@craft-agent/*` packages.** This is a clean break. Use `packages/ui/` for shared React components. Use pi-coding-agent via the CLI subprocess, not as an embedded library.
+- **No "Craft Agents" naming anywhere.** The product name is "Kata Desktop". The package scope should use `@kata/desktop` or similar.
+- **Electron main process runs Node.js, not Bun.** Don't use `import.meta.dir` or Bun-only APIs in main process code. The CLI subprocess runs Bun, but the Electron process itself is Node.js.
 
-`bundle-cli.sh` creates app-local runtime assets in `apps/desktop/vendor/`:
+## Architecture
 
-- `vendor/kata` — launcher script invoked by `PiAgentBridge`
-- `vendor/bun/bun` — bundled Bun runtime used by launcher
-- `vendor/kata-runtime/` — bundled `@kata-sh/cli` dist/pkg/resources + production deps
+```
+apps/desktop/
+├── src/
+│   ├── main/                # Electron main process (Node.js)
+│   │   ├── index.ts         # App entry, window lifecycle
+│   │   ├── ipc.ts           # IPC handlers for renderer communication
+│   │   ├── pi-agent-bridge.ts   # Spawns `kata --mode rpc`, manages subprocess lifecycle
+│   │   └── rpc-event-adapter.ts # Maps pi-coding-agent RPC events → renderer types
+│   ├── preload/             # Context bridge (exposes IPC to renderer)
+│   └── renderer/            # React UI (Vite)
+│       ├── atoms/           # Jotai state atoms
+│       ├── components/      # React components
+│       │   ├── chat/        # Chat UI, message rendering, tool cards
+│       │   ├── app-shell/   # Layout, panels, navigation
+│       │   ├── onboarding/  # First-launch wizard
+│       │   ├── settings/    # Auth, model, preferences panels
+│       │   ├── planning/    # Right-pane planning artifact viewer (M002)
+│       │   ├── kanban/      # Right-pane kanban board (M003)
+│       │   └── symphony/    # Worker dashboard, escalation panel (M004)
+│       ├── hooks/           # Custom React hooks
+│       └── lib/             # Utilities
+├── e2e/                     # Playwright e2e tests
+├── package.json
+├── tsconfig.json
+└── AGENTS.md                # This file
+```
 
-`electron-builder.yml` copies these into packaged app resources:
+## Key Integration Points
 
-- `Contents/Resources/kata`
-- `Contents/Resources/bun/`
-- `Contents/Resources/kata-runtime/`
+### CLI Subprocess (pi-coding-agent)
 
-## Important file map
+The core integration. Desktop spawns `kata --mode rpc` as a child process:
 
-- `electron-builder.yml` — DMG config (`appId: sh.kata.desktop`, `productName: Kata Desktop`)
-- `scripts/bundle-cli.sh` — bundles CLI runtime and launcher
-- `scripts/prepare-builder-app.sh` — stages minimal `.bundle-app/` for packaging
-- `scripts/package-mac.sh` — creates packaged app + DMG
-- `src/main/pi-agent-bridge.ts` — subprocess discovery/spawn/restart/shutdown
-- `src/main/ipc.ts` — renderer/main IPC contract
-- `src/main/rpc-event-adapter.ts` — RPC event → UI chat/tool events
-- `src/main/session-manager.ts` — session persistence and list metadata
+- **Spawn:** `child_process.spawn()` with stdin/stdout for JSON-RPC
+- **Messages:** Send user messages, receive streaming events (text deltas, tool starts, tool results, errors, turn boundaries)
+- **Lifecycle:** Graceful shutdown on session close and app quit, crash detection with error surfaced to renderer
+- **Auth:** Reads `~/.kata-cli/agent/auth.json` — shared with CLI
+- **Model selection:** Passed via `--model` flag on spawn
 
-## Guardrails
+Reference: `apps/cli/src/cli.ts` (RPC mode entry), `apps/electron/src/main/daemon-manager.ts` (subprocess lifecycle pattern)
 
-- Product naming must remain **Kata Desktop**.
-- Do not reintroduce any legacy Craft-era naming or package namespaces.
-- Do not log provider keys or auth file contents.
-- Main process code must stay Node-compatible (no Bun-only APIs).
+### Symphony API
+
+Desktop connects directly to Symphony's HTTP/WS API:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/v1/state` | Full orchestrator snapshot (workers, queue, completions) |
+| `GET /api/v1/events` | WebSocket live event stream |
+| `GET /api/v1/escalations` | Pending escalation list |
+| `POST /api/v1/escalations/{id}/respond` | Resolve an escalation |
+| `POST /api/v1/steer` | Send steering instruction to a worker |
+| `POST /api/v1/refresh` | Trigger immediate poll |
+
+Reference: `apps/cli/src/resources/extensions/symphony/client.ts` (SymphonyHttpClient — directly reusable)
+
+### Linear / GitHub (Workflow State)
+
+Desktop reads workflow state from Linear or GitHub to render the kanban board:
+
+- **Linear:** GraphQL API for milestones, issues (slices), sub-issues (tasks), workflow states
+- **GitHub:** REST/GraphQL API for issues, Projects v2 status, labels
+
+Reference: `apps/cli/src/resources/extensions/linear/` (Linear client), `apps/symphony/src/github/` (GitHub adapter)
+
+## Tech Stack
+
+- **Runtime:** Electron (Node.js main process, Chromium renderer)
+- **UI:** React 19 + Vite + Tailwind CSS v4 + Radix UI + Jotai
+- **Shared components:** `packages/ui/` (chat, markdown, code-viewer, terminal)
+- **Diagrams:** `packages/mermaid/` (Mermaid → SVG)
+- **Build:** esbuild (main/preload) + Vite (renderer) + electron-builder (distribution)
+- **Tests:** Bun test (unit), Playwright (e2e)
+
+## Reusable Assets from Legacy Desktop
+
+Borrow patterns and components selectively. **Import from shared packages**, not from `apps/electron/`:
+
+| Asset | Location | What to borrow |
+|-------|----------|---------------|
+| Chat components | `packages/ui/src/components/chat/` | SessionViewer, TurnCard patterns |
+| Markdown renderer | `packages/ui/src/components/markdown/` | Shiki-based rendering |
+| Code viewer | `packages/ui/src/components/code-viewer/` | Syntax highlighting |
+| Terminal output | `packages/ui/src/components/terminal/` | ANSI color rendering |
+| Mermaid diagrams | `packages/mermaid/` | Diagram → SVG |
+| Symphony client | `apps/cli/src/resources/extensions/symphony/client.ts` | HTTP/WS client (copy, not import) |
+| Subprocess lifecycle | `apps/electron/src/main/daemon-manager.ts` | Pattern reference for spawn/crash/restart |
+
+## Project Management
+
+- **Linear Project:** Kata Desktop
+- **Project ID:** `ffaf4986-8e29-4178-85b1-91a58a0c34b2`
+- **Team:** Kata-sh (ID: `a47bcacd-54f3-4472-a4b4-d6933248b605`)
+- **Issue prefix:** KAT
+- **Workflow mode:** Linear-backed Kata workflow (milestones → slices → tasks)
+
+## Milestone Sequence
+
+| Milestone | Title | Intent |
+|-----------|-------|--------|
+| M001 | Chat Foundation | Fresh Electron app, pi-coding-agent runtime, streaming chat, tool rendering, auth, sessions, onboarding |
+| M002 | Planning View | Right-pane live rendering of planning artifacts (ROADMAP, REQUIREMENTS, DECISIONS) |
+| M003 | Workflow Kanban | Right-pane kanban view of Linear/GitHub execution state |
+| M004 | Symphony Integration | Start/stop Symphony from GUI, worker dashboard, escalation handling |
+| M005 | Interactive Workflow | Read-write kanban, MCP management UI, UX polish |
+| M006 | Integrated Beta | End-to-end hardening, reliability, packaged .dmg perfection |
+
+## Key Decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D001 | Agent runtime | pi-coding-agent via CLI subprocess in RPC mode |
+| D002 | Build strategy | Fresh app at `apps/desktop/`, borrow selectively from legacy |
+| D003 | Auth storage | Shared `~/.kata-cli/agent/auth.json` with CLI |
+| D004 | CLI packaging | Bundle `kata` binary inside .dmg |
+| D005 | Session migration | Clean break — no legacy session migration |
+| D006 | Product naming | "Kata Desktop" — all Craft naming removed |
+| D007 | Right pane | Split-pane layout with contextual right pane (planning view, kanban) |
+
+See the `DECISIONS` document in Linear for full rationale and revisability notes.

--- a/apps/electron/.gitignore
+++ b/apps/electron/.gitignore
@@ -4,3 +4,36 @@
 # These directories are created by CI before packaging and are never committed.
 release/
 node_modules/@anthropic-ai/
+
+# ── Kata baseline (auto-generated) ──
+.kata/activity/
+.kata/runtime/
+.kata/auto.lock
+.kata/debug.log
+.kata/metrics.json
+.kata/STATE.md
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+*.code-workspace
+.env
+.env.*
+!.env.example
+node_modules/
+.next/
+dist/
+build/
+__pycache__/
+*.pyc
+.venv/
+venv/
+target/
+vendor/
+*.log
+coverage/
+.cache/
+tmp/

--- a/apps/electron/.kata/preferences.md
+++ b/apps/electron/.kata/preferences.md
@@ -1,0 +1,77 @@
+---
+version: 1
+workflow:
+  mode: linear
+linear:
+  teamKey: KAT
+  projectSlug: b0f5a7be6537
+pr:
+  enabled: false
+  auto_create: false
+  base_branch: main
+  review_on_create: false
+  linear_link: false
+always_use_skills: []
+prefer_skills: []
+avoid_skills: []
+skill_rules: []
+custom_instructions: []
+models: {}
+skill_discovery: suggest
+auto_supervisor: {}
+symphony: {}
+---
+
+# Kata Preferences
+
+> **Agent: do NOT overwrite this file.** Use `edit` to change individual fields. This file contains many settings — overwriting it with only the fields you care about destroys the rest.
+
+See `~/.kata-cli/agent/extensions/kata/docs/preferences-reference.md` for full field documentation and examples.
+
+## Quick start
+
+- `workflow.mode` is Linear-only. Keep `workflow.mode: linear`.
+- Fill in the `linear` block to bind this project to a Linear team/project.
+- Keep secrets out of this file. Store credentials in `~/.kata-cli/agent/auth.json` (preferred) or env vars (`LINEAR_API_KEY`, etc.). `.env` is optional.
+- Set `pr.enabled: true` to activate the PR lifecycle (create, review, address, merge via `gh` CLI).
+
+## Models example
+
+```yaml
+models:
+  research: claude-sonnet-4-6
+  planning: claude-opus-4-6     # Opus for architectural decisions
+  execution: claude-sonnet-4-6
+  completion: claude-sonnet-4-6
+  review: claude-sonnet-4-6     # Model for PR reviewer subagents
+```
+
+Omit any key to use the currently selected model.
+
+## PR lifecycle example
+
+```yaml
+pr:
+  enabled: true
+  auto_create: true      # auto-create PR after slice completes in auto-mode
+  base_branch: main      # target branch for PRs
+  review_on_create: false # auto-run parallel review after PR is created
+  linear_link: false      # add Linear issue references to PR body (requires linear mode)
+```
+
+## Symphony example
+
+```yaml
+symphony:
+  url: http://localhost:8080  # Symphony server URL (or set KATA_SYMPHONY_URL env var)
+```
+
+## Linear example
+
+```yaml
+workflow:
+  mode: linear
+linear:
+  teamKey: KAT
+  projectSlug: 459f9835e809   # from your Linear project URL (or use projectId for UUID)
+```


### PR DESCRIPTION
Planning artifacts for Kata Desktop direction pivot:

- `apps/desktop/AGENTS.md` updated with project context
- `apps/electron/.kata/preferences.md` for Desktop configuration

All planning state lives in Linear (PROJECT, REQUIREMENTS, DECISIONS, M001-M006 CONTEXT/ROADMAP documents, slice and task issues). These local files provide agent context for execution.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds planning artifacts for the Kata Desktop direction pivot: an updated `apps/desktop/AGENTS.md` with comprehensive architecture context, milestone roadmap, and tech stack decisions, plus Kata preferences files for both the new `apps/desktop/` and legacy `apps/electron/` apps. A Kata baseline block was also auto-generated into `apps/electron/.gitignore`.

**Key findings:**
- `apps/desktop/.kata/preferences.md` contains an incorrect Linear `projectSlug` (`b0f5a7be6537`), which belongs to the Cloud Agents / legacy electron project rather than the new Kata Desktop project. The file appears to be a verbatim copy of `apps/electron/.kata/preferences.md` that was never updated with the Desktop project's slug. Agents working in `apps/desktop/` will link work to the wrong Linear project until this is corrected.
- The new entries in `apps/electron/.gitignore` are mostly redundant with rules already present in the root `.gitignore` — harmless but noisy.
- `apps/desktop/AGENTS.md` is well-structured and thorough, no issues.

<h3>Confidence Score: 4/5</h3>

Safe to merge after correcting the Kata Desktop Linear project slug in apps/desktop/.kata/preferences.md.

One P1 finding: the desktop preferences file carries the wrong Linear project slug, copied verbatim from the electron app. Until fixed, any agent operating in apps/desktop/ will track issues against the Cloud Agents project instead of Kata Desktop. All other findings are P2 or lower.

apps/desktop/.kata/preferences.md — the linear.projectSlug must be updated to the Kata Desktop project slug before agents start executing work.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/.kata/preferences.md | New Kata preferences file for the desktop app, but contains an incorrect Linear projectSlug copied from the Cloud Agents project; agents using this file will target the wrong Linear project. |
| apps/desktop/AGENTS.md | Comprehensive rewrite providing architecture context, tech stack, milestone sequence, and key decisions for the fresh Kata Desktop Electron app — no issues found. |
| apps/electron/.gitignore | Auto-generated Kata baseline entries added; most are already covered by the root .gitignore, introducing harmless but noisy redundancy. |
| apps/electron/.kata/preferences.md | New Kata preferences file for the legacy electron app with the correct Cloud Agents project slug — correctly scoped to its Linear project. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph desktop["apps/desktop/ (new)"]
        DA["AGENTS.md\n(architecture context)"]
        DP[".kata/preferences.md\nprojectSlug: b0f5a7be6537 ⚠️"]
    end

    subgraph electron["apps/electron/ (legacy)"]
        EG[".gitignore\n(Kata baseline added)"]
        EP[".kata/preferences.md\nprojectSlug: b0f5a7be6537 ✅"]
    end

    subgraph linear["Linear Projects"]
        LA["Kata Cloud Agents\nslug: b0f5a7be6537"]
        LD["Kata Desktop\nID: ffaf4986-..."]
    end

    EP -->|"correctly targets"| LA
    DP -->|"incorrectly targets"| LA
    DP -.->|"should target"| LD
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/.kata/preferences.md
Line: 9-10

Comment:
**Wrong Linear project slug for Kata Desktop**

The `projectSlug: b0f5a7be6537` used here belongs to the **Kata Cloud Agents** project (the legacy `apps/electron/` app). Per `apps/electron/AGENTS.md`, the full URL for Cloud Agents is `https://linear.app/kata-sh/project/kata-cloud-agents-b0f5a7be6537`.

`apps/desktop/AGENTS.md` identifies the Desktop project with a separate project UUID. Any Kata agent operating inside `apps/desktop/` will create and link issues against the Cloud Agents project rather than the Kata Desktop project, silently mixing execution history between the two.

This file also appears to be a verbatim copy of `apps/electron/.kata/preferences.md` — both files are identical byte-for-byte. The desktop preferences should reference the correct Desktop project slug before agents start using it.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/electron/.gitignore
Line: 7-36

Comment:
**Redundant entries already covered by root `.gitignore`**

Many of the newly added entries are already present in the root `.gitignore`, creating unnecessary duplication:

- `.DS_Store`, `.idea/`, `.env`, `.env.*`, `!.env.example` — all in root
- `node_modules/`, `dist/`, `build/`, `coverage/`, `.cache/`, `*.log`, `tmp/` — all in root
- `.kata/activity/`, `.kata/runtime/`, `.kata/auto.lock`, `.kata/debug.log`, `.kata/metrics.json`, `.kata/STATE.md` — already in the root "Kata baseline" block

The only genuinely new, non-redundant addition is `vendor/` (though `apps/electron/vendor` is also excluded from the root). This is not a blocking issue — redundant gitignore rules are harmless — but it adds noise and could cause confusion about which file is authoritative.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add preferences.md for Kata Deskto..."](https://github.com/gannonh/kata/commit/bfc7bc8bdf74cf5eeb317d198b6b5b8d3d36b38f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27034803)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->