### PR TITLE
feat(desktop): planning artifact detection and right-pane rendering

### DIFF
--- a/apps/desktop/src/main/__tests__/auth-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/auth-bridge.test.ts
@@ -330,4 +330,44 @@ describe('AuthBridge', () => {
     expect(response.providers.openai.status).toBe('valid')
     expect(response.providers.openai.maskedKey).toBe('••••7890')
   })
+
+  test('getApiKey reads canonical and custom provider keys', async () => {
+    await fs.writeFile(
+      authFilePath,
+      JSON.stringify(
+        {
+          openai: { type: 'api_key', key: '  sk-openai-live  ' },
+          linear: { type: 'api_key', key: '  lin_api_test_123  ' },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    const bridge = new AuthBridge(authFilePath)
+
+    await expect(bridge.getApiKey('openai')).resolves.toBe('sk-openai-live')
+    await expect(bridge.getApiKey('linear')).resolves.toBe('lin_api_test_123')
+  })
+
+  test('getApiKey returns null for non-api-key records and missing provider names', async () => {
+    await fs.writeFile(
+      authFilePath,
+      JSON.stringify(
+        {
+          google: { type: 'oauth', access: 'token-123' },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    const bridge = new AuthBridge(authFilePath)
+
+    await expect(bridge.getApiKey('google')).resolves.toBeNull()
+    await expect(bridge.getApiKey('')).resolves.toBeNull()
+    await expect(bridge.getApiKey('linear')).resolves.toBeNull()
+  })
 })

--- a/apps/desktop/src/main/__tests__/linear-document-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-document-client.test.ts
@@ -95,7 +95,7 @@ describe('LinearDocumentClient', () => {
     await expect(client.fetchByTitle({ title: 'NOT-FOUND' })).resolves.toBeNull()
   })
 
-  test('maps unauthorized and rate limit failures to structured errors', async () => {
+  test('maps unauthorized, endpoint, and rate limit failures to structured errors', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 
     globalThis.fetch = (async () => new Response('{}', { status: 401 })) as unknown as typeof fetch
@@ -105,6 +105,13 @@ describe('LinearDocumentClient', () => {
     await expect(client.fetchByTitle({ title: 'M001-ROADMAP' })).rejects.toMatchObject({
       code: 'UNAUTHORIZED',
       status: 401,
+    })
+
+    globalThis.fetch = (async () => new Response('{}', { status: 404 })) as unknown as typeof fetch
+
+    await expect(client.fetchByTitle({ title: 'M001-ROADMAP' })).rejects.toMatchObject({
+      code: 'NETWORK',
+      status: 404,
     })
 
     globalThis.fetch = (async () => new Response('{}', { status: 429 })) as unknown as typeof fetch
@@ -131,6 +138,12 @@ describe('LinearDocumentClient', () => {
     expect(structured).toEqual({
       code: 'UNAUTHORIZED',
       message: 'bad key',
+    })
+
+    const transportError = LinearDocumentClient.toPlanningArtifactError(new TypeError('fetch failed'))
+    expect(transportError).toEqual({
+      code: 'NETWORK',
+      message: 'fetch failed',
     })
   })
 })

--- a/apps/desktop/src/main/__tests__/linear-document-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-document-client.test.ts
@@ -66,6 +66,7 @@ describe('LinearDocumentClient', () => {
 
     expect(artifact).toEqual({
       title: 'M001-ROADMAP',
+      artifactKey: 'project:project-123:M001-ROADMAP',
       content: '# Hello planning world',
       updatedAt: '2026-04-02T10:00:00.000Z',
       scope: 'project',

--- a/apps/desktop/src/main/__tests__/linear-document-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-document-client.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { LinearDocumentClient, LinearDocumentClientError } from '../linear-document-client'
+
+const originalFetch = globalThis.fetch
+const originalLinearApiKey = process.env.LINEAR_API_KEY
+
+describe('LinearDocumentClient', () => {
+  beforeEach(() => {
+    delete process.env.LINEAR_API_KEY
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalLinearApiKey) {
+      process.env.LINEAR_API_KEY = originalLinearApiKey
+    } else {
+      delete process.env.LINEAR_API_KEY
+    }
+  })
+
+  test('throws missing key error when no LINEAR_API_KEY is configured', async () => {
+    const authBridge = {
+      getApiKey: vi.fn(async () => null),
+    }
+
+    const client = new LinearDocumentClient(authBridge as never)
+
+    await expect(client.fetchByTitle({ title: 'M001-ROADMAP' })).rejects.toMatchObject({
+      code: 'MISSING_API_KEY',
+      message: expect.stringContaining('Linear API key required'),
+    })
+  })
+
+  test('fetches a document by title and returns planning artifact payload', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            documents: {
+              nodes: [
+                {
+                  title: 'M001-ROADMAP',
+                  content: '# Hello planning world',
+                  updatedAt: '2026-04-02T10:00:00.000Z',
+                  project: { id: 'project-123' },
+                  issue: null,
+                },
+              ],
+            },
+          },
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch
+
+    const authBridge = {
+      getApiKey: vi.fn(async () => null),
+    }
+
+    const client = new LinearDocumentClient(authBridge as never)
+    const artifact = await client.fetchByTitle({
+      title: 'M001-ROADMAP',
+      projectId: 'project-123',
+    })
+
+    expect(artifact).toEqual({
+      title: 'M001-ROADMAP',
+      content: '# Hello planning world',
+      updatedAt: '2026-04-02T10:00:00.000Z',
+      scope: 'project',
+      projectId: 'project-123',
+      issueId: undefined,
+    })
+  })
+
+  test('returns null when Linear responds with no matching documents', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            documents: {
+              nodes: [],
+            },
+          },
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch
+
+    const client = new LinearDocumentClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(client.fetchByTitle({ title: 'NOT-FOUND' })).resolves.toBeNull()
+  })
+
+  test('maps unauthorized and rate limit failures to structured errors', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = (async () => new Response('{}', { status: 401 })) as unknown as typeof fetch
+
+    const client = new LinearDocumentClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(client.fetchByTitle({ title: 'M001-ROADMAP' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+      status: 401,
+    })
+
+    globalThis.fetch = (async () => new Response('{}', { status: 429 })) as unknown as typeof fetch
+
+    await expect(client.fetchByTitle({ title: 'M001-ROADMAP' })).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+      status: 429,
+    })
+  })
+
+  test('converts arbitrary errors to planning artifact errors', () => {
+    const networkError = new Error('network down')
+    const converted = LinearDocumentClient.toPlanningArtifactError(networkError)
+
+    expect(converted).toEqual({
+      code: 'UNKNOWN',
+      message: 'network down',
+    })
+
+    const structured = LinearDocumentClient.toPlanningArtifactError(
+      new LinearDocumentClientError('UNAUTHORIZED', 'bad key', 401),
+    )
+
+    expect(structured).toEqual({
+      code: 'UNAUTHORIZED',
+      message: 'bad key',
+    })
+  })
+})

--- a/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
+++ b/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
@@ -35,6 +35,7 @@ describe('PlanningToolDetector', () => {
       toolCallId: 'tool-1',
       toolName: 'kata_write_document',
       title: 'M001-ROADMAP',
+      artifactKey: 'project:project-123:M001-ROADMAP',
       scope: 'project',
       action: 'updated',
       projectId: 'project-123',
@@ -42,48 +43,7 @@ describe('PlanningToolDetector', () => {
     })
   })
 
-  test('formats title and scope for kata_create_task events', () => {
-    const detector = new PlanningToolDetector()
-    const events: PlanningArtifactEvent[] = []
-
-    detector.on('artifact', (event) => {
-      events.push(event)
-    })
-
-    detector.handleChatEvent({
-      type: 'tool_start',
-      toolCallId: 'tool-2',
-      toolName: 'kata_create_task',
-      args: {
-        raw: {
-          kataId: 'T02',
-          title: 'Render markdown pane',
-          projectId: 'project-123',
-          sliceIssueId: 'issue-456',
-        },
-      },
-    })
-
-    detector.handleChatEvent({
-      type: 'tool_end',
-      toolCallId: 'tool-2',
-      toolName: 'kata_create_task',
-      isError: false,
-    })
-
-    expect(events).toHaveLength(1)
-    expect(events[0]).toEqual({
-      toolCallId: 'tool-2',
-      toolName: 'kata_create_task',
-      title: '[T02] Render markdown pane',
-      scope: 'issue',
-      action: 'created',
-      projectId: 'project-123',
-      issueId: 'issue-456',
-    })
-  })
-
-  test('emits for kata_read_document and ignores failed or unrelated tools', () => {
+  test('emits for kata_read_document and ignores failed, unrelated, or non-document planning tools', () => {
     const detector = new PlanningToolDetector()
     const events: PlanningArtifactEvent[] = []
 
@@ -132,10 +92,30 @@ describe('PlanningToolDetector', () => {
       isError: false,
     })
 
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-6',
+      toolName: 'kata_create_task',
+      args: {
+        raw: {
+          title: 'Should not emit as document artifact',
+          sliceIssueId: 'issue-should-not-fetch',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-6',
+      toolName: 'kata_create_task',
+      isError: false,
+    })
+
     expect(events).toHaveLength(1)
     expect(events[0]).toMatchObject({
       toolName: 'kata_read_document',
       title: 'DECISIONS',
+      artifactKey: 'issue:issue-789:DECISIONS',
       scope: 'issue',
       action: 'updated',
       issueId: 'issue-789',

--- a/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
+++ b/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'vitest'
+import { PlanningToolDetector } from '../planning-tool-detector'
+import type { PlanningArtifactEvent } from '../../shared/types'
+
+describe('PlanningToolDetector', () => {
+  test('emits planning artifact event for kata_write_document on tool_end', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-1',
+      toolName: 'kata_write_document',
+      args: {
+        raw: {
+          title: 'M001-ROADMAP',
+          projectId: 'project-123',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-1',
+      toolName: 'kata_write_document',
+      isError: false,
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({
+      toolCallId: 'tool-1',
+      toolName: 'kata_write_document',
+      title: 'M001-ROADMAP',
+      scope: 'project',
+      action: 'updated',
+      projectId: 'project-123',
+      issueId: undefined,
+    })
+  })
+
+  test('formats title and scope for kata_create_task events', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-2',
+      toolName: 'kata_create_task',
+      args: {
+        raw: {
+          kataId: 'T02',
+          title: 'Render markdown pane',
+          projectId: 'project-123',
+          sliceIssueId: 'issue-456',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-2',
+      toolName: 'kata_create_task',
+      isError: false,
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({
+      toolCallId: 'tool-2',
+      toolName: 'kata_create_task',
+      title: '[T02] Render markdown pane',
+      scope: 'issue',
+      action: 'created',
+      projectId: 'project-123',
+      issueId: 'issue-456',
+    })
+  })
+
+  test('emits for kata_read_document and ignores failed or unrelated tools', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-3',
+      toolName: 'kata_read_document',
+      args: {
+        raw: {
+          title: 'DECISIONS',
+          issueId: 'issue-789',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-3',
+      toolName: 'kata_read_document',
+      isError: false,
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-4',
+      toolName: 'kata_write_document',
+      args: { raw: { title: 'SHOULD-NOT-EMIT' } },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-4',
+      toolName: 'kata_write_document',
+      isError: true,
+      error: 'failed',
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-5',
+      toolName: 'bash',
+      isError: false,
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      toolName: 'kata_read_document',
+      title: 'DECISIONS',
+      scope: 'issue',
+      action: 'updated',
+      issueId: 'issue-789',
+    })
+  })
+})

--- a/apps/desktop/src/main/auth-bridge.ts
+++ b/apps/desktop/src/main/auth-bridge.ts
@@ -98,6 +98,34 @@ export class AuthBridge {
     return this.authFilePath
   }
 
+  public async getApiKey(provider: string): Promise<string | null> {
+    const normalizedProvider = provider.trim()
+    if (!normalizedProvider) {
+      return null
+    }
+
+    try {
+      const auth = await this.readAuthFile()
+
+      const record = ALL_AUTH_PROVIDERS.includes(normalizedProvider as AuthProvider)
+        ? this.resolveAuthRecord(auth, normalizedProvider as AuthProvider)
+        : auth[normalizedProvider]
+
+      if (record?.type !== 'api_key' || typeof record.key !== 'string') {
+        return null
+      }
+
+      const trimmedKey = record.key.trim()
+      return trimmedKey.length > 0 ? trimmedKey : null
+    } catch (error) {
+      log.warn('[auth-bridge] auth:get-api-key failed', {
+        provider: normalizedProvider,
+        error: this.toErrorMessage(error),
+      })
+      return null
+    }
+  }
+
   public async getProviders(): Promise<AuthProvidersResponse> {
     try {
       const auth = await this.readAuthFile()

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -23,6 +23,7 @@ import {
   type ExtensionUIRequest,
   type ExtensionUIResponse,
   type PermissionMode,
+  buildPlanningArtifactKey,
   type PlanningArtifact,
   type PlanningArtifactEvent,
   type PlanningArtifactFetchResponse,
@@ -55,8 +56,9 @@ export function registerSessionIpc({
   const planningToolDetector = new PlanningToolDetector()
   const linearDocumentClient = new LinearDocumentClient(authBridge)
 
-  const planningArtifactsByTitle = new Map<string, PlanningArtifact>()
-  const planningMetadataByTitle = new Map<string, PlanningArtifactEvent>()
+  const planningArtifactsByKey = new Map<string, PlanningArtifact>()
+  const planningMetadataByKey = new Map<string, PlanningArtifactEvent>()
+  const planningLatestKeyByTitle = new Map<string, string>()
 
   const canSendToRenderer = (): boolean => !window.isDestroyed() && !window.webContents.isDestroyed()
 
@@ -89,6 +91,7 @@ export function registerSessionIpc({
     window.webContents.send(IPC_CHANNELS.planningArtifactUpdated, artifact)
     log.debug('[desktop-ipc] planning artifact pushed', {
       title: artifact.title,
+      artifactKey: artifact.artifactKey,
       updatedAt: artifact.updatedAt,
       scope: artifact.scope,
       projectId: artifact.projectId,
@@ -96,8 +99,14 @@ export function registerSessionIpc({
     })
   }
 
-  const getPlanningFetchContext = (title: string): { projectId?: string; issueId?: string } => {
-    const metadata = planningMetadataByTitle.get(title)
+  const getPlanningFetchContext = (
+    title: string,
+    artifactKey?: string,
+  ): { projectId?: string; issueId?: string } => {
+    const metadata =
+      (artifactKey ? planningMetadataByKey.get(artifactKey) : undefined) ??
+      planningMetadataByKey.get(planningLatestKeyByTitle.get(title) ?? '')
+
     if (!metadata) {
       return {}
     }
@@ -115,6 +124,7 @@ export function registerSessionIpc({
       issueId?: string
       pushUpdate?: boolean
       scope?: PlanningArtifact['scope']
+      artifactKey?: string
     },
   ): Promise<PlanningArtifactFetchResponse> => {
     const trimmedTitle = title.trim()
@@ -145,12 +155,25 @@ export function registerSessionIpc({
         }
       }
 
+      const scope = options?.scope ?? fetchedArtifact.scope
+      const artifactKey =
+        options?.artifactKey ??
+        fetchedArtifact.artifactKey ??
+        buildPlanningArtifactKey({
+          title: fetchedArtifact.title,
+          scope,
+          projectId: fetchedArtifact.projectId,
+          issueId: fetchedArtifact.issueId,
+        })
+
       const artifact: PlanningArtifact = {
         ...fetchedArtifact,
-        scope: options?.scope ?? fetchedArtifact.scope,
+        scope,
+        artifactKey,
       }
 
-      planningArtifactsByTitle.set(trimmedTitle, artifact)
+      planningArtifactsByKey.set(artifactKey, artifact)
+      planningLatestKeyByTitle.set(trimmedTitle, artifactKey)
 
       if (options?.pushUpdate) {
         sendPlanningArtifactToRenderer(artifact)
@@ -169,12 +192,14 @@ export function registerSessionIpc({
   }
 
   const onPlanningArtifactEvent = (planningEvent: PlanningArtifactEvent): void => {
-    planningMetadataByTitle.set(planningEvent.title, planningEvent)
+    planningMetadataByKey.set(planningEvent.artifactKey, planningEvent)
+    planningLatestKeyByTitle.set(planningEvent.title, planningEvent.artifactKey)
 
     void fetchPlanningArtifact(planningEvent.title, {
       projectId: planningEvent.projectId,
       issueId: planningEvent.issueId,
       scope: planningEvent.scope,
+      artifactKey: planningEvent.artifactKey,
       pushUpdate: true,
     })
   }
@@ -563,17 +588,18 @@ export function registerSessionIpc({
 
   ipcMain.handle(
     IPC_CHANNELS.planningFetchArtifact,
-    async (_event, title: string): Promise<PlanningArtifactFetchResponse> => {
-      const context = getPlanningFetchContext(title)
+    async (_event, title: string, artifactKey?: string): Promise<PlanningArtifactFetchResponse> => {
+      const context = getPlanningFetchContext(title, artifactKey)
       return fetchPlanningArtifact(title, {
         ...context,
+        artifactKey,
         pushUpdate: false,
       })
     },
   )
 
   ipcMain.handle(IPC_CHANNELS.planningListArtifacts, async (): Promise<PlanningArtifactListResponse> => {
-    const artifacts = Array.from(planningArtifactsByTitle.values()).sort((left, right) => {
+    const artifacts = Array.from(planningArtifactsByKey.values()).sort((left, right) => {
       return Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
     })
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -3,7 +3,9 @@ import path from 'node:path'
 import { dialog, ipcMain, type BrowserWindow } from 'electron'
 import log from './logger'
 import { AuthBridge } from './auth-bridge'
+import { LinearDocumentClient } from './linear-document-client'
 import { PiAgentBridge } from './pi-agent-bridge'
+import { PlanningToolDetector } from './planning-tool-detector'
 import { RpcEventAdapter } from './rpc-event-adapter'
 import { DesktopSessionManager } from './session-manager'
 import {
@@ -21,6 +23,10 @@ import {
   type ExtensionUIRequest,
   type ExtensionUIResponse,
   type PermissionMode,
+  type PlanningArtifact,
+  type PlanningArtifactEvent,
+  type PlanningArtifactFetchResponse,
+  type PlanningArtifactListResponse,
   type SessionInfo,
   type SessionListResponse,
   type SetThinkingLevelResponse,
@@ -46,6 +52,11 @@ export function registerSessionIpc({
   onWorkspaceSelected,
 }: RegisterIpcOptions): () => void {
   const adapter = new RpcEventAdapter()
+  const planningToolDetector = new PlanningToolDetector()
+  const linearDocumentClient = new LinearDocumentClient(authBridge)
+
+  const planningArtifactsByTitle = new Map<string, PlanningArtifact>()
+  const planningMetadataByTitle = new Map<string, PlanningArtifactEvent>()
 
   const canSendToRenderer = (): boolean => !window.isDestroyed() && !window.webContents.isDestroyed()
 
@@ -69,10 +80,112 @@ export function registerSessionIpc({
     log.debug('[desktop-ipc] bridge status', status)
   }
 
+  const sendPlanningArtifactToRenderer = (artifact: PlanningArtifact): void => {
+    if (!canSendToRenderer()) {
+      log.warn('[desktop-ipc] skipping planning artifact dispatch: renderer window is destroyed')
+      return
+    }
+
+    window.webContents.send(IPC_CHANNELS.planningArtifactUpdated, artifact)
+    log.debug('[desktop-ipc] planning artifact pushed', {
+      title: artifact.title,
+      updatedAt: artifact.updatedAt,
+      scope: artifact.scope,
+      projectId: artifact.projectId,
+      issueId: artifact.issueId,
+    })
+  }
+
+  const getPlanningFetchContext = (title: string): { projectId?: string; issueId?: string } => {
+    const metadata = planningMetadataByTitle.get(title)
+    if (!metadata) {
+      return {}
+    }
+
+    return {
+      projectId: metadata.projectId,
+      issueId: metadata.issueId,
+    }
+  }
+
+  const fetchPlanningArtifact = async (
+    title: string,
+    options?: {
+      projectId?: string
+      issueId?: string
+      pushUpdate?: boolean
+      scope?: PlanningArtifact['scope']
+    },
+  ): Promise<PlanningArtifactFetchResponse> => {
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle) {
+      return {
+        success: false,
+        error: {
+          code: 'UNKNOWN',
+          message: 'Artifact title is required',
+        },
+      }
+    }
+
+    try {
+      const fetchedArtifact = await linearDocumentClient.fetchByTitle({
+        title: trimmedTitle,
+        projectId: options?.projectId,
+        issueId: options?.issueId,
+      })
+
+      if (!fetchedArtifact) {
+        return {
+          success: false,
+          error: {
+            code: 'NOT_FOUND',
+            message: `Artifact "${trimmedTitle}" not found`,
+          },
+        }
+      }
+
+      const artifact: PlanningArtifact = {
+        ...fetchedArtifact,
+        scope: options?.scope ?? fetchedArtifact.scope,
+      }
+
+      planningArtifactsByTitle.set(trimmedTitle, artifact)
+
+      if (options?.pushUpdate) {
+        sendPlanningArtifactToRenderer(artifact)
+      }
+
+      return {
+        success: true,
+        artifact,
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: LinearDocumentClient.toPlanningArtifactError(error),
+      }
+    }
+  }
+
+  const onPlanningArtifactEvent = (planningEvent: PlanningArtifactEvent): void => {
+    planningMetadataByTitle.set(planningEvent.title, planningEvent)
+
+    void fetchPlanningArtifact(planningEvent.title, {
+      projectId: planningEvent.projectId,
+      issueId: planningEvent.issueId,
+      scope: planningEvent.scope,
+      pushUpdate: true,
+    })
+  }
+
+  planningToolDetector.on('artifact', onPlanningArtifactEvent)
+
   const onRpcEvent = (rpcEvent: Record<string, unknown>): void => {
     log.debug('[desktop-ipc] inbound rpc event', rpcEvent)
     for (const chatEvent of adapter.adapt(rpcEvent)) {
       sendEventToRenderer(chatEvent)
+      planningToolDetector.handleChatEvent(chatEvent)
     }
   }
 
@@ -140,6 +253,8 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
   ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)
   ipcMain.removeHandler(IPC_CHANNELS.authValidateKey)
+  ipcMain.removeHandler(IPC_CHANNELS.planningFetchArtifact)
+  ipcMain.removeHandler(IPC_CHANNELS.planningListArtifacts)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -446,12 +561,35 @@ export function registerSessionIpc({
     },
   )
 
+  ipcMain.handle(
+    IPC_CHANNELS.planningFetchArtifact,
+    async (_event, title: string): Promise<PlanningArtifactFetchResponse> => {
+      const context = getPlanningFetchContext(title)
+      return fetchPlanningArtifact(title, {
+        ...context,
+        pushUpdate: false,
+      })
+    },
+  )
+
+  ipcMain.handle(IPC_CHANNELS.planningListArtifacts, async (): Promise<PlanningArtifactListResponse> => {
+    const artifacts = Array.from(planningArtifactsByTitle.values()).sort((left, right) => {
+      return Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+    })
+
+    return {
+      success: true,
+      artifacts,
+    }
+  })
+
   return () => {
     bridge.off('rpc-event', onRpcEvent)
     bridge.off('extension-ui-request', onExtensionUiRequest)
     bridge.off('status', onStatus)
     bridge.off('debug', onDebug)
     bridge.off('crash', onCrash)
+    planningToolDetector.off('artifact', onPlanningArtifactEvent)
 
     ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
     ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
@@ -472,5 +610,7 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
     ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)
     ipcMain.removeHandler(IPC_CHANNELS.authValidateKey)
+    ipcMain.removeHandler(IPC_CHANNELS.planningFetchArtifact)
+    ipcMain.removeHandler(IPC_CHANNELS.planningListArtifacts)
   }
 }

--- a/apps/desktop/src/main/linear-document-client.ts
+++ b/apps/desktop/src/main/linear-document-client.ts
@@ -1,0 +1,274 @@
+import { AuthBridge } from './auth-bridge'
+import log from './logger'
+import {
+  type PlanningArtifact,
+  type PlanningArtifactError,
+  type PlanningArtifactErrorCode,
+  type PlanningArtifactScope,
+} from '../shared/types'
+
+const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql'
+
+interface FetchByTitleOptions {
+  title: string
+  projectId?: string
+  issueId?: string
+}
+
+interface LinearDocumentNode {
+  title?: string
+  content?: string
+  updatedAt?: string
+  project?: {
+    id?: string
+  } | null
+  issue?: {
+    id?: string
+  } | null
+}
+
+interface GraphQLResponse<TData> {
+  data?: TData
+  errors?: Array<{
+    message?: string
+  }>
+}
+
+interface DocumentsQueryData {
+  documents?: {
+    nodes?: LinearDocumentNode[]
+  }
+}
+
+export class LinearDocumentClientError extends Error {
+  constructor(
+    public readonly code: PlanningArtifactErrorCode,
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message)
+    this.name = 'LinearDocumentClientError'
+  }
+}
+
+export class LinearDocumentClient {
+  constructor(
+    private readonly authBridge: AuthBridge,
+    private readonly apiUrl = LINEAR_GRAPHQL_URL,
+  ) {}
+
+  public async fetchByTitle(options: FetchByTitleOptions): Promise<PlanningArtifact | null> {
+    const title = options.title.trim()
+    if (!title) {
+      throw new LinearDocumentClientError('UNKNOWN', 'Document title is required')
+    }
+
+    const startedAt = Date.now()
+
+    try {
+      const apiKey = await this.resolveApiKey()
+      if (!apiKey) {
+        throw new LinearDocumentClientError(
+          'MISSING_API_KEY',
+          'Linear API key required. Configure provider "linear" in auth.json or set LINEAR_API_KEY.',
+        )
+      }
+
+      const variables: Record<string, string> = {
+        title,
+      }
+
+      const filterConditions: string[] = ['title: { eq: $title }']
+
+      if (options.projectId) {
+        variables.projectId = options.projectId
+        filterConditions.push('project: { id: { eq: $projectId } }')
+      }
+
+      if (options.issueId) {
+        variables.issueId = options.issueId
+        filterConditions.push('issue: { id: { eq: $issueId } }')
+      }
+
+      const variableDefinitions = [
+        '$title: String!',
+        options.projectId ? '$projectId: ID!' : null,
+        options.issueId ? '$issueId: ID!' : null,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .join(', ')
+
+      const query = `
+        query PlanningDocumentByTitle(${variableDefinitions}) {
+          documents(first: 20, filter: { ${filterConditions.join(', ')} }) {
+            nodes {
+              title
+              content
+              updatedAt
+              project {
+                id
+              }
+              issue {
+                id
+              }
+            }
+          }
+        }
+      `
+
+      const response = await fetch(this.apiUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: apiKey,
+        },
+        body: JSON.stringify({
+          query,
+          variables,
+        }),
+      })
+
+      if (response.status === 401 || response.status === 403) {
+        throw new LinearDocumentClientError('UNAUTHORIZED', 'Invalid Linear API key', response.status)
+      }
+
+      if (response.status === 404) {
+        throw new LinearDocumentClientError('NOT_FOUND', `Artifact "${title}" not found`, response.status)
+      }
+
+      if (response.status === 429) {
+        throw new LinearDocumentClientError('RATE_LIMITED', 'Linear API rate limit exceeded', response.status)
+      }
+
+      const payload = (await response.json()) as GraphQLResponse<DocumentsQueryData>
+
+      if (!response.ok) {
+        const firstErrorMessage = payload.errors?.[0]?.message
+        if (firstErrorMessage) {
+          throw new LinearDocumentClientError('GRAPHQL', firstErrorMessage, response.status)
+        }
+
+        throw new LinearDocumentClientError(
+          'NETWORK',
+          `Linear API request failed with status ${response.status}`,
+          response.status,
+        )
+      }
+
+      if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        const firstErrorMessage = payload.errors[0]?.message ?? 'Unknown GraphQL error'
+        if (/rate\s*limit/i.test(firstErrorMessage)) {
+          throw new LinearDocumentClientError('RATE_LIMITED', firstErrorMessage, response.status)
+        }
+
+        throw new LinearDocumentClientError('GRAPHQL', firstErrorMessage, response.status)
+      }
+
+      const nodes = payload.data?.documents?.nodes ?? []
+      if (nodes.length === 0) {
+        log.info('[linear-document-client] planning:fetch', {
+          title,
+          status: 'not_found',
+          latencyMs: Date.now() - startedAt,
+          projectId: options.projectId,
+          issueId: options.issueId,
+        })
+        return null
+      }
+
+      const exactMatches = nodes.filter((node) => node.title === title)
+      const selectedNode = (exactMatches.length > 0 ? exactMatches : nodes)
+        .slice()
+        .sort((a, b) => toTimestamp(b.updatedAt) - toTimestamp(a.updatedAt))[0]
+
+      if (!selectedNode?.title) {
+        log.info('[linear-document-client] planning:fetch', {
+          title,
+          status: 'not_found',
+          latencyMs: Date.now() - startedAt,
+          projectId: options.projectId,
+          issueId: options.issueId,
+        })
+        return null
+      }
+
+      const artifact: PlanningArtifact = {
+        title: selectedNode.title,
+        content: selectedNode.content ?? '',
+        updatedAt: selectedNode.updatedAt ?? new Date().toISOString(),
+        scope: this.resolveScope(options, selectedNode),
+        projectId: options.projectId ?? selectedNode.project?.id,
+        issueId: options.issueId ?? selectedNode.issue?.id,
+      }
+
+      log.info('[linear-document-client] planning:fetch', {
+        title,
+        status: 'ok',
+        latencyMs: Date.now() - startedAt,
+        projectId: artifact.projectId,
+        issueId: artifact.issueId,
+      })
+
+      return artifact
+    } catch (error) {
+      const clientError = toLinearDocumentClientError(error)
+
+      log.warn('[linear-document-client] planning:fetch', {
+        title,
+        status: clientError.code.toLowerCase(),
+        latencyMs: Date.now() - startedAt,
+        projectId: options.projectId,
+        issueId: options.issueId,
+        error: clientError.message,
+      })
+
+      throw clientError
+    }
+  }
+
+  public static toPlanningArtifactError(error: unknown): PlanningArtifactError {
+    const clientError = toLinearDocumentClientError(error)
+    return {
+      code: clientError.code,
+      message: clientError.message,
+    }
+  }
+
+  private async resolveApiKey(): Promise<string | null> {
+    const envKey = process.env.LINEAR_API_KEY?.trim()
+    if (envKey) {
+      return envKey
+    }
+
+    return this.authBridge.getApiKey('linear')
+  }
+
+  private resolveScope(options: FetchByTitleOptions, node: LinearDocumentNode): PlanningArtifactScope {
+    if (options.issueId || node.issue?.id) {
+      return 'issue'
+    }
+
+    return 'project'
+  }
+}
+
+function toTimestamp(value: string | undefined): number {
+  if (!value) {
+    return 0
+  }
+
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+function toLinearDocumentClientError(error: unknown): LinearDocumentClientError {
+  if (error instanceof LinearDocumentClientError) {
+    return error
+  }
+
+  if (error instanceof Error) {
+    return new LinearDocumentClientError('UNKNOWN', error.message)
+  }
+
+  return new LinearDocumentClientError('UNKNOWN', String(error))
+}

--- a/apps/desktop/src/main/linear-document-client.ts
+++ b/apps/desktop/src/main/linear-document-client.ts
@@ -9,6 +9,7 @@ import {
 } from '../shared/types'
 
 const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql'
+const LINEAR_REQUEST_TIMEOUT_MS = 10_000
 
 interface FetchByTitleOptions {
   title: string
@@ -56,6 +57,7 @@ export class LinearDocumentClient {
   constructor(
     private readonly authBridge: AuthBridge,
     private readonly apiUrl = LINEAR_GRAPHQL_URL,
+    private readonly requestTimeoutMs = LINEAR_REQUEST_TIMEOUT_MS,
   ) {}
 
   public async fetchByTitle(options: FetchByTitleOptions): Promise<PlanningArtifact | null> {
@@ -117,31 +119,48 @@ export class LinearDocumentClient {
         }
       `
 
-      const response = await fetch(this.apiUrl, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          authorization: apiKey,
-        },
-        body: JSON.stringify({
-          query,
-          variables,
-        }),
-      })
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => {
+        controller.abort()
+      }, this.requestTimeoutMs)
+
+      let response: Response
+      try {
+        response = await fetch(this.apiUrl, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: apiKey,
+          },
+          signal: controller.signal,
+          body: JSON.stringify({
+            query,
+            variables,
+          }),
+        })
+      } finally {
+        clearTimeout(timeoutId)
+      }
 
       if (response.status === 401 || response.status === 403) {
         throw new LinearDocumentClientError('UNAUTHORIZED', 'Invalid Linear API key', response.status)
       }
 
       if (response.status === 404) {
-        throw new LinearDocumentClientError('NOT_FOUND', `Artifact "${title}" not found`, response.status)
+        throw new LinearDocumentClientError(
+          'NETWORK',
+          'Linear API endpoint not found (HTTP 404). Verify endpoint configuration.',
+          response.status,
+        )
       }
 
       if (response.status === 429) {
         throw new LinearDocumentClientError('RATE_LIMITED', 'Linear API rate limit exceeded', response.status)
       }
 
-      const payload = (await response.json()) as GraphQLResponse<DocumentsQueryData>
+      const payload = (await response
+        .json()
+        .catch(() => ({}))) as GraphQLResponse<DocumentsQueryData>
 
       if (!response.ok) {
         const firstErrorMessage = payload.errors?.[0]?.message
@@ -275,6 +294,14 @@ function toTimestamp(value: string | undefined): number {
 function toLinearDocumentClientError(error: unknown): LinearDocumentClientError {
   if (error instanceof LinearDocumentClientError) {
     return error
+  }
+
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return new LinearDocumentClientError('NETWORK', 'Linear API request timed out')
+  }
+
+  if (error instanceof TypeError) {
+    return new LinearDocumentClientError('NETWORK', error.message)
   }
 
   if (error instanceof Error) {

--- a/apps/desktop/src/main/linear-document-client.ts
+++ b/apps/desktop/src/main/linear-document-client.ts
@@ -1,6 +1,7 @@
 import { AuthBridge } from './auth-bridge'
 import log from './logger'
 import {
+  buildPlanningArtifactKey,
   type PlanningArtifact,
   type PlanningArtifactError,
   type PlanningArtifactErrorCode,
@@ -192,13 +193,23 @@ export class LinearDocumentClient {
         return null
       }
 
+      const scope = this.resolveScope(options, selectedNode)
+      const projectId = options.projectId ?? selectedNode.project?.id
+      const issueId = options.issueId ?? selectedNode.issue?.id
+
       const artifact: PlanningArtifact = {
         title: selectedNode.title,
+        artifactKey: buildPlanningArtifactKey({
+          title: selectedNode.title,
+          scope,
+          projectId,
+          issueId,
+        }),
         content: selectedNode.content ?? '',
         updatedAt: selectedNode.updatedAt ?? new Date().toISOString(),
-        scope: this.resolveScope(options, selectedNode),
-        projectId: options.projectId ?? selectedNode.project?.id,
-        issueId: options.issueId ?? selectedNode.issue?.id,
+        scope,
+        projectId,
+        issueId,
       }
 
       log.info('[linear-document-client] planning:fetch', {

--- a/apps/desktop/src/main/planning-tool-detector.ts
+++ b/apps/desktop/src/main/planning-tool-detector.ts
@@ -1,0 +1,194 @@
+import { EventEmitter } from 'node:events'
+import log from './logger'
+import {
+  type ChatEvent,
+  type PlanningArtifactAction,
+  type PlanningArtifactEvent,
+  type PlanningArtifactScope,
+  type ToolArgs,
+} from '../shared/types'
+
+interface PendingToolCall {
+  toolName: string
+  args: ToolArgs
+}
+
+interface PlanningToolDetectorEvents {
+  artifact: (event: PlanningArtifactEvent) => void
+}
+
+const PLANNING_TOOL_NAMES = new Set([
+  'kata_write_document',
+  'kata_create_milestone',
+  'kata_create_slice',
+  'kata_create_task',
+  'kata_read_document',
+])
+
+export class PlanningToolDetector extends EventEmitter {
+  private readonly pendingToolCalls = new Map<string, PendingToolCall>()
+
+  override on<K extends keyof PlanningToolDetectorEvents>(
+    event: K,
+    listener: PlanningToolDetectorEvents[K],
+  ): this {
+    return super.on(event, listener)
+  }
+
+  override emit<K extends keyof PlanningToolDetectorEvents>(
+    event: K,
+    ...args: Parameters<PlanningToolDetectorEvents[K]>
+  ): boolean {
+    return super.emit(event, ...args)
+  }
+
+  public handleChatEvent(event: ChatEvent): void {
+    if (event.type === 'tool_start') {
+      this.pendingToolCalls.set(event.toolCallId, {
+        toolName: event.toolName,
+        args: event.args,
+      })
+      return
+    }
+
+    if (event.type !== 'tool_end') {
+      return
+    }
+
+    const pending = this.pendingToolCalls.get(event.toolCallId)
+    this.pendingToolCalls.delete(event.toolCallId)
+
+    if (!PLANNING_TOOL_NAMES.has(event.toolName) || event.isError) {
+      return
+    }
+
+    const artifactEvent = this.toPlanningArtifactEvent(
+      event.toolCallId,
+      event.toolName,
+      pending?.args,
+    )
+
+    if (!artifactEvent) {
+      return
+    }
+
+    log.info('[planning-tool-detector] planning:tool-detected', {
+      toolName: artifactEvent.toolName,
+      documentTitle: artifactEvent.title,
+      scope: artifactEvent.scope,
+      action: artifactEvent.action,
+      projectId: artifactEvent.projectId,
+      issueId: artifactEvent.issueId,
+    })
+
+    this.emit('artifact', artifactEvent)
+  }
+
+  private toPlanningArtifactEvent(
+    toolCallId: string,
+    toolName: string,
+    toolArgs: ToolArgs | undefined,
+  ): PlanningArtifactEvent | null {
+    const args = this.extractRawArgs(toolArgs)
+    const title = this.extractTitle(toolName, args)
+
+    if (!title) {
+      return null
+    }
+
+    const issueId = this.extractIssueId(args)
+    const projectId = asString(args.projectId)
+
+    return {
+      toolCallId,
+      toolName,
+      title,
+      scope: this.extractScope(args),
+      action: this.extractAction(toolName),
+      projectId,
+      issueId,
+    }
+  }
+
+  private extractRawArgs(toolArgs: ToolArgs | undefined): Record<string, unknown> {
+    if (!toolArgs) {
+      return {}
+    }
+
+    if ('raw' in toolArgs && isRecord(toolArgs.raw)) {
+      return toolArgs.raw
+    }
+
+    if (isRecord(toolArgs)) {
+      return toolArgs
+    }
+
+    return {}
+  }
+
+  private extractTitle(toolName: string, args: Record<string, unknown>): string | null {
+    const directTitle = asString(args.title)
+
+    if (toolName === 'kata_write_document' || toolName === 'kata_read_document') {
+      if (directTitle) {
+        return directTitle
+      }
+
+      if (Array.isArray(args.args) && typeof args.args[0] === 'string') {
+        return args.args[0]
+      }
+
+      return null
+    }
+
+    const kataId = asString(args.kataId)
+
+    if (kataId && directTitle) {
+      return `[${kataId}] ${directTitle}`
+    }
+
+    return directTitle ?? kataId ?? null
+  }
+
+  private extractScope(args: Record<string, unknown>): PlanningArtifactScope {
+    return this.extractIssueId(args) ? 'issue' : 'project'
+  }
+
+  private extractIssueId(args: Record<string, unknown>): string | undefined {
+    const issueId = asString(args.issueId)
+    if (issueId) {
+      return issueId
+    }
+
+    const sliceIssueId = asString(args.sliceIssueId)
+    if (sliceIssueId) {
+      return sliceIssueId
+    }
+
+    const parentId = asString(args.parentId)
+    if (parentId) {
+      return parentId
+    }
+
+    return undefined
+  }
+
+  private extractAction(toolName: string): PlanningArtifactAction {
+    switch (toolName) {
+      case 'kata_create_milestone':
+      case 'kata_create_slice':
+      case 'kata_create_task':
+        return 'created'
+      default:
+        return 'updated'
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}

--- a/apps/desktop/src/main/planning-tool-detector.ts
+++ b/apps/desktop/src/main/planning-tool-detector.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'node:events'
 import log from './logger'
 import {
+  buildPlanningArtifactKey,
   type ChatEvent,
-  type PlanningArtifactAction,
   type PlanningArtifactEvent,
   type PlanningArtifactScope,
   type ToolArgs,
@@ -19,9 +19,6 @@ interface PlanningToolDetectorEvents {
 
 const PLANNING_TOOL_NAMES = new Set([
   'kata_write_document',
-  'kata_create_milestone',
-  'kata_create_slice',
-  'kata_create_task',
   'kata_read_document',
 ])
 
@@ -98,13 +95,20 @@ export class PlanningToolDetector extends EventEmitter {
 
     const issueId = this.extractIssueId(args)
     const projectId = asString(args.projectId)
+    const scope = this.extractScope(args)
 
     return {
       toolCallId,
       toolName,
       title,
-      scope: this.extractScope(args),
-      action: this.extractAction(toolName),
+      artifactKey: buildPlanningArtifactKey({
+        title,
+        scope,
+        projectId,
+        issueId,
+      }),
+      scope,
+      action: 'updated',
       projectId,
       issueId,
     }
@@ -126,28 +130,17 @@ export class PlanningToolDetector extends EventEmitter {
     return {}
   }
 
-  private extractTitle(toolName: string, args: Record<string, unknown>): string | null {
+  private extractTitle(_toolName: string, args: Record<string, unknown>): string | null {
     const directTitle = asString(args.title)
-
-    if (toolName === 'kata_write_document' || toolName === 'kata_read_document') {
-      if (directTitle) {
-        return directTitle
-      }
-
-      if (Array.isArray(args.args) && typeof args.args[0] === 'string') {
-        return args.args[0]
-      }
-
-      return null
+    if (directTitle) {
+      return directTitle
     }
 
-    const kataId = asString(args.kataId)
-
-    if (kataId && directTitle) {
-      return `[${kataId}] ${directTitle}`
+    if (Array.isArray(args.args) && typeof args.args[0] === 'string') {
+      return args.args[0]
     }
 
-    return directTitle ?? kataId ?? null
+    return null
   }
 
   private extractScope(args: Record<string, unknown>): PlanningArtifactScope {
@@ -173,16 +166,6 @@ export class PlanningToolDetector extends EventEmitter {
     return undefined
   }
 
-  private extractAction(toolName: string): PlanningArtifactAction {
-    switch (toolName) {
-      case 'kata_create_milestone':
-      case 'kata_create_slice':
-      case 'kata_create_task':
-        return 'created'
-      default:
-        return 'updated'
-    }
-  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -123,8 +123,8 @@ const api: DesktopApi = {
         ipcRenderer.removeListener(IPC_CHANNELS.planningArtifactUpdated, wrapped)
       }
     },
-    fetchArtifact: async (title: string) => {
-      return ipcRenderer.invoke(IPC_CHANNELS.planningFetchArtifact, title)
+    fetchArtifact: async (title: string, artifactKey?: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.planningFetchArtifact, title, artifactKey)
     },
     listArtifacts: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.planningListArtifacts)

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -7,6 +7,7 @@ import {
   type DesktopApi,
   type ExtensionUIRequest,
   type PermissionMode,
+  type PlanningArtifact,
   type ThinkingLevel,
 } from '../shared/types'
 
@@ -108,6 +109,25 @@ const api: DesktopApi = {
     },
     validateKey: async (provider: AuthProvider, key: string) => {
       return ipcRenderer.invoke(IPC_CHANNELS.authValidateKey, provider, key)
+    },
+  },
+  planning: {
+    onArtifactUpdated: (listener: (artifact: PlanningArtifact) => void) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, artifact: PlanningArtifact) => {
+        listener(artifact)
+      }
+
+      ipcRenderer.on(IPC_CHANNELS.planningArtifactUpdated, wrapped)
+
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.planningArtifactUpdated, wrapped)
+      }
+    },
+    fetchArtifact: async (title: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.planningFetchArtifact, title)
+    },
+    listArtifacts: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.planningListArtifacts)
     },
   },
 }

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -2,10 +2,13 @@ import { useAtomValue } from 'jotai'
 import { onboardingCompleteAtom } from './atoms/onboarding'
 import { AppShell } from './components/app-shell/AppShell'
 import { OnboardingWizard } from './components/onboarding/OnboardingWizard'
+import { usePlanningArtifactBridge } from '@/atoms/planning'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
 export default function App() {
   const onboardingComplete = useAtomValue(onboardingCompleteAtom)
+
+  usePlanningArtifactBridge()
 
   return (
     <TooltipProvider>

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -88,14 +88,20 @@ export function usePlanningArtifactBridge(): void {
           }
         }
 
-        setArtifacts(nextArtifacts)
+        setArtifacts((currentArtifacts) => ({
+          ...nextArtifacts,
+          ...currentArtifacts,
+        }))
 
         const mostRecentArtifact = response.artifacts[0]
         if (mostRecentArtifact) {
-          setActiveArtifactTitle({
-            artifactKey: mostRecentArtifact.artifactKey,
-            title: mostRecentArtifact.title,
-          })
+          setActiveArtifactTitle(
+            (currentActiveArtifact) =>
+              currentActiveArtifact ?? {
+                artifactKey: mostRecentArtifact.artifactKey,
+                title: mostRecentArtifact.title,
+              },
+          )
         }
       })
       .catch((error: unknown) => {

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -6,6 +6,8 @@ import type { PlanningArtifact } from '@shared/types'
 export const RIGHT_PANE_MODE_STORAGE_KEY = 'kata-desktop:right-pane-mode'
 
 export interface PlanningArtifactState {
+  artifactKey: string
+  title: string
   content: string
   updatedAt: string
   scope: PlanningArtifact['scope']
@@ -15,8 +17,13 @@ export interface PlanningArtifactState {
 
 export type PlanningArtifactsMap = Record<string, PlanningArtifactState>
 
+export interface ActivePlanningArtifactRef {
+  artifactKey: string
+  title: string
+}
+
 export const planningArtifactsAtom = atom<PlanningArtifactsMap>({})
-export const activePlanningArtifactAtom = atom<string | null>(null)
+export const activePlanningArtifactAtom = atom<ActivePlanningArtifactRef | null>(null)
 export const rightPaneModeAtom = atomWithStorage<'planning' | 'default'>(
   RIGHT_PANE_MODE_STORAGE_KEY,
   'default',
@@ -27,7 +34,9 @@ export const planningErrorAtom = atom<string | null>(null)
 export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: PlanningArtifact) => {
   set(planningArtifactsAtom, {
     ...get(planningArtifactsAtom),
-    [artifact.title]: {
+    [artifact.artifactKey]: {
+      artifactKey: artifact.artifactKey,
+      title: artifact.title,
       content: artifact.content,
       updatedAt: artifact.updatedAt,
       scope: artifact.scope,
@@ -35,7 +44,10 @@ export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: Plannin
       issueId: artifact.issueId,
     },
   })
-  set(activePlanningArtifactAtom, artifact.title)
+  set(activePlanningArtifactAtom, {
+    artifactKey: artifact.artifactKey,
+    title: artifact.title,
+  })
   set(rightPaneModeAtom, 'planning')
   set(planningLoadingAtom, false)
   set(planningErrorAtom, null)
@@ -66,7 +78,9 @@ export function usePlanningArtifactBridge(): void {
 
         const nextArtifacts: PlanningArtifactsMap = {}
         for (const artifact of response.artifacts) {
-          nextArtifacts[artifact.title] = {
+          nextArtifacts[artifact.artifactKey] = {
+            artifactKey: artifact.artifactKey,
+            title: artifact.title,
             content: artifact.content,
             updatedAt: artifact.updatedAt,
             scope: artifact.scope,
@@ -79,7 +93,10 @@ export function usePlanningArtifactBridge(): void {
 
         const mostRecentArtifact = response.artifacts[0]
         if (mostRecentArtifact) {
-          setActiveArtifactTitle(mostRecentArtifact.title)
+          setActiveArtifactTitle({
+            artifactKey: mostRecentArtifact.artifactKey,
+            title: mostRecentArtifact.title,
+          })
         }
       })
       .catch((error: unknown) => {

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -72,7 +72,6 @@ export function usePlanningArtifactBridge(): void {
         }
 
         if (response.artifacts.length === 0) {
-          setLoading(false)
           return
         }
 

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -1,0 +1,101 @@
+import { atom, useSetAtom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+import { useEffect } from 'react'
+import type { PlanningArtifact } from '@shared/types'
+
+export const RIGHT_PANE_MODE_STORAGE_KEY = 'kata-desktop:right-pane-mode'
+
+export interface PlanningArtifactState {
+  content: string
+  updatedAt: string
+  scope: PlanningArtifact['scope']
+  projectId?: string
+  issueId?: string
+}
+
+export type PlanningArtifactsMap = Record<string, PlanningArtifactState>
+
+export const planningArtifactsAtom = atom<PlanningArtifactsMap>({})
+export const activePlanningArtifactAtom = atom<string | null>(null)
+export const rightPaneModeAtom = atomWithStorage<'planning' | 'default'>(
+  RIGHT_PANE_MODE_STORAGE_KEY,
+  'default',
+)
+export const planningLoadingAtom = atom<boolean>(false)
+export const planningErrorAtom = atom<string | null>(null)
+
+export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: PlanningArtifact) => {
+  set(planningArtifactsAtom, {
+    ...get(planningArtifactsAtom),
+    [artifact.title]: {
+      content: artifact.content,
+      updatedAt: artifact.updatedAt,
+      scope: artifact.scope,
+      projectId: artifact.projectId,
+      issueId: artifact.issueId,
+    },
+  })
+  set(activePlanningArtifactAtom, artifact.title)
+  set(rightPaneModeAtom, 'planning')
+  set(planningLoadingAtom, false)
+  set(planningErrorAtom, null)
+})
+
+export function usePlanningArtifactBridge(): void {
+  const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
+  const setArtifacts = useSetAtom(planningArtifactsAtom)
+  const setActiveArtifactTitle = useSetAtom(activePlanningArtifactAtom)
+  const setLoading = useSetAtom(planningLoadingAtom)
+  const setError = useSetAtom(planningErrorAtom)
+
+  useEffect(() => {
+    setLoading(true)
+
+    void window.api.planning
+      .listArtifacts()
+      .then((response) => {
+        if (!response.success) {
+          setError(response.error?.message ?? 'Unable to list planning artifacts')
+          return
+        }
+
+        if (response.artifacts.length === 0) {
+          setLoading(false)
+          return
+        }
+
+        const nextArtifacts: PlanningArtifactsMap = {}
+        for (const artifact of response.artifacts) {
+          nextArtifacts[artifact.title] = {
+            content: artifact.content,
+            updatedAt: artifact.updatedAt,
+            scope: artifact.scope,
+            projectId: artifact.projectId,
+            issueId: artifact.issueId,
+          }
+        }
+
+        setArtifacts(nextArtifacts)
+
+        const mostRecentArtifact = response.artifacts[0]
+        if (mostRecentArtifact) {
+          setActiveArtifactTitle(mostRecentArtifact.title)
+        }
+      })
+      .catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error)
+        setError(message)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+
+    const unsubscribe = window.api.planning.onArtifactUpdated((artifact) => {
+      applyPlanningArtifact(artifact)
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [applyPlanningArtifact, setActiveArtifactTitle, setArtifacts, setError, setLoading])
+}

--- a/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
@@ -1,6 +1,15 @@
+import { useAtomValue } from 'jotai'
+import { rightPaneModeAtom } from '@/atoms/planning'
+import { PlanningPane } from '@/components/planning/PlanningPane'
 import { Separator } from '@/components/ui/separator'
 
 export function RightPane() {
+  const rightPaneMode = useAtomValue(rightPaneModeAtom)
+
+  if (rightPaneMode === 'planning') {
+    return <PlanningPane />
+  }
+
   return (
     <aside className="flex h-full flex-col bg-muted/40">
       <div className="flex h-14 items-center px-4">

--- a/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
@@ -23,7 +23,7 @@ export function RightPane() {
       <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
         <div className="flex flex-col gap-2">
           <p className="font-medium text-foreground">Kata Desktop</p>
-          <p>Planning and kanban views are coming in M002/M003.</p>
+          <p>Planning artifacts appear here during /kata plan. Kanban view is coming in M003.</p>
         </div>
       </div>
     </aside>

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -13,7 +13,7 @@ import { Separator } from '@/components/ui/separator'
 
 export function PlanningPane() {
   const artifacts = useAtomValue(planningArtifactsAtom)
-  const activeArtifactTitle = useAtomValue(activePlanningArtifactAtom)
+  const activeArtifactRef = useAtomValue(activePlanningArtifactAtom)
   const loading = useAtomValue(planningLoadingAtom)
   const error = useAtomValue(planningErrorAtom)
 
@@ -22,19 +22,19 @@ export function PlanningPane() {
   const setPlanningError = useSetAtom(planningErrorAtom)
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
-  const scrollPositionsByTitleRef = useRef<Record<string, number>>({})
+  const scrollPositionsByKeyRef = useRef<Record<string, number>>({})
 
-  const activeArtifact = activeArtifactTitle ? artifacts[activeArtifactTitle] : null
+  const activeArtifact = activeArtifactRef ? artifacts[activeArtifactRef.artifactKey] : null
 
   useEffect(() => {
-    if (!activeArtifactTitle || activeArtifact) {
+    if (!activeArtifactRef || activeArtifact) {
       return
     }
 
     setPlanningLoading(true)
 
     void window.api.planning
-      .fetchArtifact(activeArtifactTitle)
+      .fetchArtifact(activeArtifactRef.title, activeArtifactRef.artifactKey)
       .then((response) => {
         if (!response.success || !response.artifact) {
           setPlanningError(response.error?.message ?? 'Unable to fetch artifact')
@@ -50,10 +50,10 @@ export function PlanningPane() {
       .finally(() => {
         setPlanningLoading(false)
       })
-  }, [activeArtifact, activeArtifactTitle, applyPlanningArtifact, setPlanningError, setPlanningLoading])
+  }, [activeArtifact, activeArtifactRef, applyPlanningArtifact, setPlanningError, setPlanningLoading])
 
   useEffect(() => {
-    if (!activeArtifactTitle) {
+    if (!activeArtifactRef) {
       return
     }
 
@@ -62,15 +62,16 @@ export function PlanningPane() {
       return
     }
 
-    container.scrollTop = scrollPositionsByTitleRef.current[activeArtifactTitle] ?? 0
-  }, [activeArtifactTitle])
+    container.scrollTop = scrollPositionsByKeyRef.current[activeArtifactRef.artifactKey] ?? 0
+  }, [activeArtifactRef])
 
   const handleScroll = (): void => {
-    if (!activeArtifactTitle || !scrollContainerRef.current) {
+    if (!activeArtifactRef || !scrollContainerRef.current) {
       return
     }
 
-    scrollPositionsByTitleRef.current[activeArtifactTitle] = scrollContainerRef.current.scrollTop
+    scrollPositionsByKeyRef.current[activeArtifactRef.artifactKey] =
+      scrollContainerRef.current.scrollTop
   }
 
   return (
@@ -81,7 +82,7 @@ export function PlanningPane() {
             Planning View
           </h2>
           <p className="truncate text-sm font-medium text-foreground">
-            {activeArtifactTitle ?? 'No active artifact'}
+            {activeArtifact?.title ?? activeArtifactRef?.title ?? 'No active artifact'}
           </p>
         </div>
 

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -31,12 +31,18 @@ export function PlanningPane() {
       return
     }
 
+    let cancelled = false
+
     setPlanningLoading(true)
     setPlanningError(null)
 
     void window.api.planning
       .fetchArtifact(activeArtifactRef.title, activeArtifactRef.artifactKey)
       .then((response) => {
+        if (cancelled) {
+          return
+        }
+
         if (!response.success || !response.artifact) {
           setPlanningError(response.error?.message ?? 'Unable to fetch artifact')
           return
@@ -45,12 +51,24 @@ export function PlanningPane() {
         applyPlanningArtifact(response.artifact)
       })
       .catch((fetchError: unknown) => {
+        if (cancelled) {
+          return
+        }
+
         const message = fetchError instanceof Error ? fetchError.message : String(fetchError)
         setPlanningError(message)
       })
       .finally(() => {
+        if (cancelled) {
+          return
+        }
+
         setPlanningLoading(false)
       })
+
+    return () => {
+      cancelled = true
+    }
   }, [activeArtifact, activeArtifactRef, applyPlanningArtifact, setPlanningError, setPlanningLoading])
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -1,0 +1,130 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import { Loader2 } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { Markdown } from '@kata-ui/components/markdown/Markdown'
+import {
+  activePlanningArtifactAtom,
+  applyPlanningArtifactAtom,
+  planningArtifactsAtom,
+  planningErrorAtom,
+  planningLoadingAtom,
+} from '@/atoms/planning'
+import { Separator } from '@/components/ui/separator'
+
+export function PlanningPane() {
+  const artifacts = useAtomValue(planningArtifactsAtom)
+  const activeArtifactTitle = useAtomValue(activePlanningArtifactAtom)
+  const loading = useAtomValue(planningLoadingAtom)
+  const error = useAtomValue(planningErrorAtom)
+
+  const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
+  const setPlanningLoading = useSetAtom(planningLoadingAtom)
+  const setPlanningError = useSetAtom(planningErrorAtom)
+
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const scrollPositionsByTitleRef = useRef<Record<string, number>>({})
+
+  const activeArtifact = activeArtifactTitle ? artifacts[activeArtifactTitle] : null
+
+  useEffect(() => {
+    if (!activeArtifactTitle || activeArtifact) {
+      return
+    }
+
+    setPlanningLoading(true)
+
+    void window.api.planning
+      .fetchArtifact(activeArtifactTitle)
+      .then((response) => {
+        if (!response.success || !response.artifact) {
+          setPlanningError(response.error?.message ?? 'Unable to fetch artifact')
+          return
+        }
+
+        applyPlanningArtifact(response.artifact)
+      })
+      .catch((fetchError: unknown) => {
+        const message = fetchError instanceof Error ? fetchError.message : String(fetchError)
+        setPlanningError(message)
+      })
+      .finally(() => {
+        setPlanningLoading(false)
+      })
+  }, [activeArtifact, activeArtifactTitle, applyPlanningArtifact, setPlanningError, setPlanningLoading])
+
+  useEffect(() => {
+    if (!activeArtifactTitle) {
+      return
+    }
+
+    const container = scrollContainerRef.current
+    if (!container) {
+      return
+    }
+
+    container.scrollTop = scrollPositionsByTitleRef.current[activeArtifactTitle] ?? 0
+  }, [activeArtifactTitle])
+
+  const handleScroll = (): void => {
+    if (!activeArtifactTitle || !scrollContainerRef.current) {
+      return
+    }
+
+    scrollPositionsByTitleRef.current[activeArtifactTitle] = scrollContainerRef.current.scrollTop
+  }
+
+  return (
+    <aside className="flex h-full flex-col bg-muted/20">
+      <div className="flex h-14 items-center justify-between px-4">
+        <div className="flex min-w-0 flex-col">
+          <h2 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">
+            Planning View
+          </h2>
+          <p className="truncate text-sm font-medium text-foreground">
+            {activeArtifactTitle ?? 'No active artifact'}
+          </p>
+        </div>
+
+        {activeArtifact ? (
+          <span className="text-xs text-muted-foreground">
+            {new Date(activeArtifact.updatedAt).toLocaleTimeString()}
+          </span>
+        ) : null}
+      </div>
+
+      <Separator />
+
+      {error ? (
+        <div className="border-b border-border bg-destructive/10 px-4 py-3 text-xs text-destructive">
+          Unable to fetch artifact: {error}
+        </div>
+      ) : null}
+
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-auto px-4 py-3"
+      >
+        {loading && !activeArtifact ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+            <Loader2 className="size-5 animate-spin" />
+            <p>Loading planning artifact…</p>
+          </div>
+        ) : null}
+
+        {!loading && !activeArtifact ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">No artifacts yet</p>
+            <p>Start a planning session with `/kata plan` to populate this pane.</p>
+          </div>
+        ) : null}
+
+        {activeArtifact ? (
+          <Markdown mode="full" className="text-sm leading-relaxed">
+            {activeArtifact.content}
+          </Markdown>
+        ) : null}
+      </div>
+    </aside>
+  )
+}

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -32,6 +32,7 @@ export function PlanningPane() {
     }
 
     setPlanningLoading(true)
+    setPlanningError(null)
 
     void window.api.planning
       .fetchArtifact(activeArtifactRef.title, activeArtifactRef.artifactKey)

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -21,6 +21,9 @@ export const IPC_CHANNELS = {
   authSetKey: 'auth:set-key',
   authRemoveKey: 'auth:remove-key',
   authValidateKey: 'auth:validate-key',
+  planningArtifactUpdated: 'planning:artifact-updated',
+  planningFetchArtifact: 'planning:fetch-artifact',
+  planningListArtifacts: 'planning:list-artifacts',
 } as const
 
 export type PermissionMode = 'explore' | 'ask' | 'auto'
@@ -376,6 +379,55 @@ export interface BridgeState {
   selectedModel: string | null
 }
 
+export type PlanningArtifactScope = 'project' | 'issue'
+
+export type PlanningArtifactAction = 'created' | 'updated'
+
+export type PlanningArtifactErrorCode =
+  | 'MISSING_API_KEY'
+  | 'UNAUTHORIZED'
+  | 'NOT_FOUND'
+  | 'RATE_LIMITED'
+  | 'NETWORK'
+  | 'GRAPHQL'
+  | 'UNKNOWN'
+
+export interface PlanningArtifactError {
+  code: PlanningArtifactErrorCode
+  message: string
+}
+
+export interface PlanningArtifactEvent {
+  toolName: string
+  toolCallId: string
+  title: string
+  scope: PlanningArtifactScope
+  action: PlanningArtifactAction
+  projectId?: string
+  issueId?: string
+}
+
+export interface PlanningArtifact {
+  title: string
+  content: string
+  updatedAt: string
+  scope: PlanningArtifactScope
+  projectId?: string
+  issueId?: string
+}
+
+export interface PlanningArtifactFetchResponse {
+  success: boolean
+  artifact?: PlanningArtifact
+  error?: PlanningArtifactError
+}
+
+export interface PlanningArtifactListResponse {
+  success: boolean
+  artifacts: PlanningArtifact[]
+  error?: PlanningArtifactError
+}
+
 export interface DesktopApi {
   sendMessage: (message: string) => Promise<void>
   stopAgent: () => Promise<void>
@@ -404,6 +456,11 @@ export interface DesktopApi {
     setKey: (provider: AuthProvider, key: string) => Promise<AuthSetKeyResponse>
     removeKey: (provider: AuthProvider) => Promise<AuthRemoveKeyResponse>
     validateKey: (provider: AuthProvider, key: string) => Promise<AuthValidationResult>
+  }
+  planning: {
+    onArtifactUpdated: (listener: (artifact: PlanningArtifact) => void) => () => void
+    fetchArtifact: (title: string) => Promise<PlanningArtifactFetchResponse>
+    listArtifacts: () => Promise<PlanningArtifactListResponse>
   }
 }
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -401,6 +401,7 @@ export interface PlanningArtifactEvent {
   toolName: string
   toolCallId: string
   title: string
+  artifactKey: string
   scope: PlanningArtifactScope
   action: PlanningArtifactAction
   projectId?: string
@@ -409,11 +410,32 @@ export interface PlanningArtifactEvent {
 
 export interface PlanningArtifact {
   title: string
+  artifactKey: string
   content: string
   updatedAt: string
   scope: PlanningArtifactScope
   projectId?: string
   issueId?: string
+}
+
+export function buildPlanningArtifactKey({
+  title,
+  scope,
+  projectId,
+  issueId,
+}: {
+  title: string
+  scope: PlanningArtifactScope
+  projectId?: string
+  issueId?: string
+}): string {
+  const normalizedTitle = title.trim()
+
+  if (scope === 'issue') {
+    return `issue:${issueId?.trim() || projectId?.trim() || 'unknown'}:${normalizedTitle}`
+  }
+
+  return `project:${projectId?.trim() || 'global'}:${normalizedTitle}`
 }
 
 export interface PlanningArtifactFetchResponse {
@@ -459,7 +481,7 @@ export interface DesktopApi {
   }
   planning: {
     onArtifactUpdated: (listener: (artifact: PlanningArtifact) => void) => () => void
-    fetchArtifact: (title: string) => Promise<PlanningArtifactFetchResponse>
+    fetchArtifact: (title: string, artifactKey?: string) => Promise<PlanningArtifactFetchResponse>
     listArtifacts: () => Promise<PlanningArtifactListResponse>
   }
 }


### PR DESCRIPTION
## Summary
- add a main-process PlanningToolDetector that watches tool execution events and emits normalized planning artifact events
- add LinearDocumentClient with auth lookup (LINEAR_API_KEY env or auth.json linear) and structured Linear GraphQL fetch error handling
- wire planning IPC channels (planning:artifact-updated, planning:fetch-artifact, planning:list-artifacts) through main, preload, and shared Desktop API types
- add renderer planning atoms + PlanningPane markdown view and switch RightPane between default and planning modes

## Validation
- cd apps/desktop && bun run typecheck
- cd apps/desktop && bun run test
- cd apps/desktop && bun run build:main && bun run build:preload
- cd apps/desktop && bun -e "LinearDocumentClient fetchByTitle runtime proof against Linear"
- cd apps/desktop && env -u LINEAR_API_KEY bun -e "LinearDocumentClient missing-key error path proof"

Closes KAT-2141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added planning artifact panel to display and manage project planning documents
  * Integrated Linear document fetching with artifact management
  * Added real-time artifact updates and caching for planning workflows
  * Enhanced authentication to support multiple API key providers
  * Added automatic detection and tracking of planning tool actions

* **Tests**
  * Comprehensive test coverage for authentication, document fetching, and planning tool detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds end-to-end planning artifact detection and display: a `PlanningToolDetector` watches `tool_start`/`tool_end` chat events in the main process and triggers a `LinearDocumentClient` fetch when planning tools fire successfully, pushing updates to the renderer via IPC and rendering them in a new markdown `PlanningPane`. The IPC surface (`planning:artifact-updated` push + `planning:fetch-artifact` / `planning:list-artifacts` handlers), Jotai atoms, preload wiring, and auth-bridge extension are all consistent and well-tested.

<h3>Confidence Score: 5/5</h3>

Safe to merge; both findings are minor UX polish items that do not affect correctness or data integrity.

No P0/P1 issues found. The two P2 comments are a stale error banner during re-fetch and a redundant atom update — neither affects functional behavior or data integrity. The main-process code, IPC wiring, Linear client error handling, and auth-bridge extension are all correct.

apps/desktop/src/renderer/components/planning/PlanningPane.tsx and apps/desktop/src/renderer/atoms/planning.ts have the minor UX items noted above.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/planning-tool-detector.ts | New EventEmitter-based detector that maps tool_start/tool_end ChatEvent pairs to PlanningArtifactEvents; logic for title extraction, scope, and action is clean and well-tested. |
| apps/desktop/src/main/linear-document-client.ts | New Linear GraphQL client with structured error codes, API key resolution from env/auth.json, exact-title match with recency fallback, and correct 200-with-errors handling. |
| apps/desktop/src/main/ipc.ts | Wires PlanningToolDetector and LinearDocumentClient into the IPC layer; adds three planning channels (push, fetch, list) with correct handler registration/cleanup pattern. |
| apps/desktop/src/main/auth-bridge.ts | Adds generic getApiKey(provider) that handles both canonical and custom providers (e.g. "linear"), trims values, and returns null for non-api_key record types. |
| apps/desktop/src/renderer/atoms/planning.ts | New Jotai atoms for planning state plus usePlanningArtifactBridge hook; stale error state not cleared on re-fetch and minor redundant setLoading(false) in empty-artifacts branch. |
| apps/desktop/src/renderer/components/planning/PlanningPane.tsx | New markdown pane with scroll-position memory per artifact; stale planningErrorAtom not cleared before triggering a fresh fetchArtifact, causing an old error banner to show during the new load. |
| apps/desktop/src/renderer/components/app-shell/RightPane.tsx | Switches between default Context Pane and PlanningPane based on persisted rightPaneModeAtom; straightforward conditional render. |
| apps/desktop/src/shared/types.ts | Adds IPC channel constants, full planning type hierarchy (artifact, event, error codes, fetch/list responses), and DesktopApi.planning namespace; types are consistent with implementations. |
| apps/desktop/src/preload/index.ts | Exposes planning.onArtifactUpdated, fetchArtifact, listArtifacts through contextBridge following the same listener-wrapping pattern as existing channels. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as AI Agent
    participant RpcAdapter as RpcEventAdapter
    participant Detector as PlanningToolDetector
    participant IPC as ipc.ts (main)
    participant Linear as LinearDocumentClient
    participant Renderer as Renderer (planning atoms)

    Agent->>RpcAdapter: rpc-event (tool_start: kata_write_document)
    RpcAdapter->>IPC: ChatEvent (tool_start)
    IPC->>Detector: handleChatEvent(tool_start)
    Note over Detector: stores in pendingToolCalls

    Agent->>RpcAdapter: rpc-event (tool_end: kata_write_document)
    RpcAdapter->>IPC: ChatEvent (tool_end)
    IPC->>Detector: handleChatEvent(tool_end)
    Detector-->>IPC: emit('artifact', PlanningArtifactEvent)
    IPC->>Linear: fetchByTitle(title, {projectId, issueId})
    Linear->>Linear: resolveApiKey (env → auth.json)
    Linear-->>IPC: PlanningArtifact
    IPC->>IPC: planningArtifactsByTitle.set(title, artifact)
    IPC->>Renderer: webContents.send(planning:artifact-updated, artifact)
    Renderer->>Renderer: applyPlanningArtifactAtom → rightPaneModeAtom='planning'

    Renderer->>IPC: invoke(planning:list-artifacts)
    IPC-->>Renderer: PlanningArtifactListResponse

    Renderer->>IPC: invoke(planning:fetch-artifact, title)
    IPC->>Linear: fetchByTitle(title, context)
    Linear-->>IPC: PlanningArtifact
    IPC-->>Renderer: PlanningArtifactFetchResponse
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/planning/PlanningPane.tsx
Line: 34-53

Comment:
**Stale error banner persists during re-fetch**

`planningErrorAtom` is not cleared before `setPlanningLoading(true)`, so if a prior fetch left an error (e.g. "Unable to fetch artifact"), the red banner remains visible while the new request is in flight. Adding `setPlanningError(null)` before kicking off the fetch keeps the UX consistent.

```suggestion
    setPlanningLoading(true)
    setPlanningError(null)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/planning.ts
Line: 62-65

Comment:
**Redundant `setLoading(false)` in empty-artifacts branch**

The `.finally()` callback on line 89 unconditionally calls `setLoading(false)`, so the explicit call inside this `if` block is never needed — it only produces an extra Jotai atom update. Removing it simplifies the control flow.

```suggestion
        if (response.artifacts.length === 0) {
          return
        }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): prevent planning artifact ..."](https://github.com/gannonh/kata/commit/15c0123c8ca65bc41159ddde3529c35d2f97eec7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27186704)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->