### PR TITLE
KAT-2144: Rich structured rendering for planning artifacts

### DIFF
--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -34,10 +34,10 @@ export const lastViewedPlanningArtifactAtom = atom<Record<string, string>>({})
 
 export const markPlanningArtifactViewedAtom = atom(
   null,
-  (get, set, artifact: { title: string; updatedAt: string }) => {
+  (get, set, artifact: { artifactKey: string; updatedAt: string }) => {
     set(lastViewedPlanningArtifactAtom, {
       ...get(lastViewedPlanningArtifactAtom),
-      [artifact.title]: artifact.updatedAt,
+      [artifact.artifactKey]: artifact.updatedAt,
     })
   },
 )

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -30,9 +30,20 @@ export const rightPaneModeAtom = atomWithStorage<'planning' | 'default'>(
 )
 export const planningLoadingAtom = atom<boolean>(false)
 export const planningErrorAtom = atom<string | null>(null)
+export const lastViewedPlanningArtifactAtom = atom<Record<string, string>>({})
+
+export const markPlanningArtifactViewedAtom = atom(
+  null,
+  (get, set, artifact: { title: string; updatedAt: string }) => {
+    set(lastViewedPlanningArtifactAtom, {
+      ...get(lastViewedPlanningArtifactAtom),
+      [artifact.title]: artifact.updatedAt,
+    })
+  },
+)
 
 export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: PlanningArtifact) => {
-  set(planningArtifactsAtom, {
+  const nextArtifacts: PlanningArtifactsMap = {
     ...get(planningArtifactsAtom),
     [artifact.artifactKey]: {
       artifactKey: artifact.artifactKey,
@@ -43,11 +54,18 @@ export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: Plannin
       projectId: artifact.projectId,
       issueId: artifact.issueId,
     },
-  })
-  set(activePlanningArtifactAtom, {
-    artifactKey: artifact.artifactKey,
-    title: artifact.title,
-  })
+  }
+
+  set(planningArtifactsAtom, nextArtifacts)
+
+  const currentActiveArtifact = get(activePlanningArtifactAtom)
+  if (!currentActiveArtifact || !nextArtifacts[currentActiveArtifact.artifactKey]) {
+    set(activePlanningArtifactAtom, {
+      artifactKey: artifact.artifactKey,
+      title: artifact.title,
+    })
+  }
+
   set(rightPaneModeAtom, 'planning')
   set(planningLoadingAtom, false)
   set(planningErrorAtom, null)

--- a/apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx
+++ b/apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx
@@ -5,7 +5,7 @@ import { detectArtifactType } from '@/lib/artifact-parser'
 export interface ArtifactTabsProps {
   artifacts: PlanningArtifactState[]
   activeArtifactKey: string | null
-  hasUnviewedUpdatesByTitle: Record<string, boolean>
+  hasUnviewedUpdatesByKey: Record<string, boolean>
   onSelect: (artifact: PlanningArtifactState) => void
 }
 
@@ -19,7 +19,7 @@ const TYPE_SORT_ORDER: Record<string, number> = {
 export function ArtifactTabs({
   artifacts,
   activeArtifactKey,
-  hasUnviewedUpdatesByTitle,
+  hasUnviewedUpdatesByKey,
   onSelect,
 }: ArtifactTabsProps) {
   const sortedArtifacts = [...artifacts].sort((left, right) => {
@@ -40,7 +40,7 @@ export function ArtifactTabs({
     <div className="flex min-h-10 items-end gap-1 overflow-x-auto px-4 pb-2">
       {sortedArtifacts.map((artifact) => {
         const isActive = artifact.artifactKey === activeArtifactKey
-        const hasUnviewedUpdate = hasUnviewedUpdatesByTitle[artifact.title] === true
+        const hasUnviewedUpdate = hasUnviewedUpdatesByKey[artifact.artifactKey] === true
 
         return (
           <button

--- a/apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx
+++ b/apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx
@@ -16,6 +16,13 @@ const TYPE_SORT_ORDER: Record<string, number> = {
   context: 3,
 }
 
+const TYPE_LABEL: Record<string, string> = {
+  roadmap: 'Roadmap',
+  requirements: 'Requirements',
+  decisions: 'Decisions',
+  context: 'Context',
+}
+
 export function ArtifactTabs({
   artifacts,
   activeArtifactKey,
@@ -36,8 +43,16 @@ export function ArtifactTabs({
     return left.title.localeCompare(right.title)
   })
 
+  const typeCounts = sortedArtifacts.reduce<Record<string, number>>((result, artifact) => {
+    const type = detectArtifactType(artifact.title)
+    if (type) {
+      result[type] = (result[type] ?? 0) + 1
+    }
+    return result
+  }, {})
+
   return (
-    <div className="flex min-h-10 items-end gap-1 overflow-x-auto px-4 pb-2">
+    <div role="tablist" className="flex min-h-10 items-end gap-1 overflow-x-auto px-4 pb-2">
       {sortedArtifacts.map((artifact) => {
         const isActive = artifact.artifactKey === activeArtifactKey
         const hasUnviewedUpdate = hasUnviewedUpdatesByKey[artifact.artifactKey] === true
@@ -46,13 +61,18 @@ export function ArtifactTabs({
           <button
             key={artifact.artifactKey}
             type="button"
+            role="tab"
+            aria-selected={isActive}
+            id={`tab-${artifact.artifactKey}`}
+            aria-controls={`panel-${artifact.artifactKey}`}
+            tabIndex={isActive ? 0 : -1}
             onClick={() => onSelect(artifact)}
             className={cn(
               'relative shrink-0 rounded-t-md border border-transparent px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground',
               isActive && 'border-border border-b-background bg-background text-foreground',
             )}
           >
-            <span>{formatArtifactTitle(artifact.title)}</span>
+            <span>{formatArtifactTitle(artifact.title, typeCounts)}</span>
             {hasUnviewedUpdate ? (
               <span className="absolute top-1 right-1 size-1.5 rounded-full bg-primary" aria-label="updated" />
             ) : null}
@@ -63,24 +83,15 @@ export function ArtifactTabs({
   )
 }
 
-function formatArtifactTitle(title: string): string {
+function formatArtifactTitle(title: string, typeCounts: Record<string, number>): string {
   const detectedType = detectArtifactType(title)
-
-  if (detectedType === 'roadmap') {
-    return 'Roadmap'
+  if (!detectedType) {
+    return title
   }
 
-  if (detectedType === 'requirements') {
-    return 'Requirements'
+  if ((typeCounts[detectedType] ?? 0) > 1) {
+    return title
   }
 
-  if (detectedType === 'decisions') {
-    return 'Decisions'
-  }
-
-  if (detectedType === 'context') {
-    return 'Context'
-  }
-
-  return title
+  return TYPE_LABEL[detectedType] ?? title
 }

--- a/apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx
+++ b/apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx
@@ -1,0 +1,86 @@
+import type { PlanningArtifactState } from '@/atoms/planning'
+import { cn } from '@/lib/utils'
+import { detectArtifactType } from '@/lib/artifact-parser'
+
+export interface ArtifactTabsProps {
+  artifacts: PlanningArtifactState[]
+  activeArtifactKey: string | null
+  hasUnviewedUpdatesByTitle: Record<string, boolean>
+  onSelect: (artifact: PlanningArtifactState) => void
+}
+
+const TYPE_SORT_ORDER: Record<string, number> = {
+  roadmap: 0,
+  requirements: 1,
+  decisions: 2,
+  context: 3,
+}
+
+export function ArtifactTabs({
+  artifacts,
+  activeArtifactKey,
+  hasUnviewedUpdatesByTitle,
+  onSelect,
+}: ArtifactTabsProps) {
+  const sortedArtifacts = [...artifacts].sort((left, right) => {
+    const leftType = detectArtifactType(left.title)
+    const rightType = detectArtifactType(right.title)
+
+    const leftOrder = TYPE_SORT_ORDER[leftType ?? ''] ?? 99
+    const rightOrder = TYPE_SORT_ORDER[rightType ?? ''] ?? 99
+
+    if (leftOrder !== rightOrder) {
+      return leftOrder - rightOrder
+    }
+
+    return left.title.localeCompare(right.title)
+  })
+
+  return (
+    <div className="flex min-h-10 items-end gap-1 overflow-x-auto px-4 pb-2">
+      {sortedArtifacts.map((artifact) => {
+        const isActive = artifact.artifactKey === activeArtifactKey
+        const hasUnviewedUpdate = hasUnviewedUpdatesByTitle[artifact.title] === true
+
+        return (
+          <button
+            key={artifact.artifactKey}
+            type="button"
+            onClick={() => onSelect(artifact)}
+            className={cn(
+              'relative shrink-0 rounded-t-md border border-transparent px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground',
+              isActive && 'border-border border-b-background bg-background text-foreground',
+            )}
+          >
+            <span>{formatArtifactTitle(artifact.title)}</span>
+            {hasUnviewedUpdate ? (
+              <span className="absolute top-1 right-1 size-1.5 rounded-full bg-primary" aria-label="updated" />
+            ) : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function formatArtifactTitle(title: string): string {
+  const detectedType = detectArtifactType(title)
+
+  if (detectedType === 'roadmap') {
+    return 'Roadmap'
+  }
+
+  if (detectedType === 'requirements') {
+    return 'Requirements'
+  }
+
+  if (detectedType === 'decisions') {
+    return 'Decisions'
+  }
+
+  if (detectedType === 'context') {
+    return 'Context'
+  }
+
+  return title
+}

--- a/apps/desktop/src/renderer/components/planning/ContextView.tsx
+++ b/apps/desktop/src/renderer/components/planning/ContextView.tsx
@@ -11,9 +11,9 @@ export interface ContextViewProps {
 export function ContextView({ context }: ContextViewProps) {
   return (
     <div className="space-y-3">
-      {context.sections.map((section) => (
+      {context.sections.map((section, index) => (
         <Collapsible
-          key={`${section.level}-${section.heading}`}
+          key={`context-section-${index}`}
           defaultOpen
           className="group/section overflow-hidden rounded-lg border border-border"
         >

--- a/apps/desktop/src/renderer/components/planning/ContextView.tsx
+++ b/apps/desktop/src/renderer/components/planning/ContextView.tsx
@@ -1,0 +1,46 @@
+import { ChevronDown } from 'lucide-react'
+import type { ParsedContext } from '@shared/types'
+import { Markdown } from '@kata-ui/components/markdown/Markdown'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { cn } from '@/lib/utils'
+
+export interface ContextViewProps {
+  context: ParsedContext
+}
+
+export function ContextView({ context }: ContextViewProps) {
+  return (
+    <div className="space-y-3">
+      {context.sections.map((section) => (
+        <Collapsible
+          key={`${section.level}-${section.heading}`}
+          defaultOpen
+          className="group/section overflow-hidden rounded-lg border border-border"
+        >
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                'flex w-full items-center justify-between gap-2 bg-muted/30 px-3 py-2 text-left text-sm font-medium',
+                section.level === 3 && 'pl-5 text-muted-foreground',
+              )}
+            >
+              <span>{section.heading}</span>
+              <ChevronDown className="size-4 transition-transform group-data-[state=open]/section:rotate-180" />
+            </button>
+          </CollapsibleTrigger>
+
+          <CollapsibleContent className="border-t border-border bg-background px-3 py-2">
+            {section.content ? (
+              <Markdown mode="full" className="text-sm leading-relaxed">
+                {section.content}
+              </Markdown>
+            ) : (
+              <p className="text-xs text-muted-foreground">No content</p>
+            )}
+          </CollapsibleContent>
+        </Collapsible>
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/planning/ContextView.tsx
+++ b/apps/desktop/src/renderer/components/planning/ContextView.tsx
@@ -9,9 +9,23 @@ export interface ContextViewProps {
 }
 
 export function ContextView({ context }: ContextViewProps) {
+  const sectionGroups = context.sections.reduce<
+    Array<{ parent: ParsedContext['sections'][number]; children: ParsedContext['sections'][number][] }>
+  >((groups, section) => {
+    const currentGroup = groups[groups.length - 1]
+
+    if (section.level === 2 || !currentGroup) {
+      groups.push({ parent: section, children: [] })
+      return groups
+    }
+
+    currentGroup.children.push(section)
+    return groups
+  }, [])
+
   return (
     <div className="space-y-3">
-      {context.sections.map((section, index) => (
+      {sectionGroups.map((group, index) => (
         <Collapsible
           key={`context-section-${index}`}
           defaultOpen
@@ -22,22 +36,56 @@ export function ContextView({ context }: ContextViewProps) {
               type="button"
               className={cn(
                 'flex w-full items-center justify-between gap-2 bg-muted/30 px-3 py-2 text-left text-sm font-medium',
-                section.level === 3 && 'pl-5 text-muted-foreground',
+                group.parent.level === 3 && 'pl-5 text-muted-foreground',
               )}
             >
-              <span>{section.heading}</span>
+              <span>{group.parent.heading}</span>
               <ChevronDown className="size-4 transition-transform group-data-[state=open]/section:rotate-180" />
             </button>
           </CollapsibleTrigger>
 
-          <CollapsibleContent className="border-t border-border bg-background px-3 py-2">
-            {section.content ? (
+          <CollapsibleContent className="space-y-2 border-t border-border bg-background px-3 py-2">
+            {group.parent.content ? (
               <Markdown mode="full" className="text-sm leading-relaxed">
-                {section.content}
+                {group.parent.content}
               </Markdown>
-            ) : (
+            ) : null}
+
+            {group.children.length > 0 ? (
+              <div className="space-y-2">
+                {group.children.map((child, childIndex) => (
+                  <Collapsible
+                    key={`context-child-${index}-${childIndex}`}
+                    defaultOpen
+                    className="group/child overflow-hidden rounded-md border border-border"
+                  >
+                    <CollapsibleTrigger asChild>
+                      <button
+                        type="button"
+                        className="flex w-full items-center justify-between gap-2 bg-muted/20 px-3 py-2 text-left text-sm font-medium text-muted-foreground"
+                      >
+                        <span>{child.heading}</span>
+                        <ChevronDown className="size-4 transition-transform group-data-[state=open]/child:rotate-180" />
+                      </button>
+                    </CollapsibleTrigger>
+
+                    <CollapsibleContent className="border-t border-border bg-background px-3 py-2">
+                      {child.content ? (
+                        <Markdown mode="full" className="text-sm leading-relaxed">
+                          {child.content}
+                        </Markdown>
+                      ) : (
+                        <p className="text-xs text-muted-foreground">No content</p>
+                      )}
+                    </CollapsibleContent>
+                  </Collapsible>
+                ))}
+              </div>
+            ) : null}
+
+            {!group.parent.content && group.children.length === 0 ? (
               <p className="text-xs text-muted-foreground">No content</p>
-            )}
+            ) : null}
           </CollapsibleContent>
         </Collapsible>
       ))}

--- a/apps/desktop/src/renderer/components/planning/DecisionsView.tsx
+++ b/apps/desktop/src/renderer/components/planning/DecisionsView.tsx
@@ -1,0 +1,165 @@
+import { ArrowUpDown } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { ParsedDecision, ParsedDecisions } from '@shared/types'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+type DecisionSortColumn = 'id' | 'when' | 'scope' | 'decision' | 'choice' | 'revisable'
+type DecisionSortDirection = 'asc' | 'desc'
+
+interface DecisionSort {
+  column: DecisionSortColumn
+  direction: DecisionSortDirection
+}
+
+const DEFAULT_SORT: DecisionSort = {
+  column: 'id',
+  direction: 'asc',
+}
+
+export interface DecisionsViewProps {
+  decisions: ParsedDecisions
+}
+
+export function DecisionsView({ decisions }: DecisionsViewProps) {
+  const [sort, setSort] = useState<DecisionSort>(DEFAULT_SORT)
+
+  const sortedRows = useMemo(() => {
+    return [...decisions.rows].sort((left, right) => {
+      const sortMultiplier = sort.direction === 'asc' ? 1 : -1
+      const leftValue = getSortValue(left, sort.column)
+      const rightValue = getSortValue(right, sort.column)
+
+      return leftValue.localeCompare(rightValue, undefined, { numeric: true }) * sortMultiplier
+    })
+  }, [decisions.rows, sort])
+
+  const toggleSort = (column: DecisionSortColumn) => {
+    setSort((currentSort) => {
+      if (currentSort.column !== column) {
+        return {
+          column,
+          direction: 'asc',
+        }
+      }
+
+      return {
+        column,
+        direction: currentSort.direction === 'asc' ? 'desc' : 'asc',
+      }
+    })
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-border text-left text-sm">
+          <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
+            <tr>
+              <SortableHeader label="#" column="id" activeSort={sort} onToggleSort={toggleSort} />
+              <SortableHeader label="When" column="when" activeSort={sort} onToggleSort={toggleSort} />
+              <SortableHeader label="Scope" column="scope" activeSort={sort} onToggleSort={toggleSort} />
+              <SortableHeader
+                label="Decision"
+                column="decision"
+                activeSort={sort}
+                onToggleSort={toggleSort}
+              />
+              <SortableHeader label="Choice" column="choice" activeSort={sort} onToggleSort={toggleSort} />
+              <SortableHeader
+                label="Revisable"
+                column="revisable"
+                activeSort={sort}
+                onToggleSort={toggleSort}
+              />
+            </tr>
+          </thead>
+
+          <tbody className="divide-y divide-border">
+            {sortedRows.map((row, rowIndex) => (
+              <tr key={row.id} className={cn(rowIndex % 2 === 1 && 'bg-muted/20')}>
+                <td className="px-3 py-2 font-medium">{row.id}</td>
+                <td className="px-3 py-2 text-muted-foreground">{row.when || '—'}</td>
+                <td className="px-3 py-2 text-muted-foreground">{row.scope || '—'}</td>
+                <td className="px-3 py-2">
+                  <p className="font-medium">{row.decision}</p>
+                  {row.rationale ? (
+                    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{row.rationale}</p>
+                  ) : null}
+                </td>
+                <td className="px-3 py-2 text-muted-foreground">{row.choice || '—'}</td>
+                <td className="px-3 py-2">{renderRevisableBadge(row)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function renderRevisableBadge(row: ParsedDecision) {
+  if (row.revisable === false) {
+    return (
+      <Badge className="bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+        No
+      </Badge>
+    )
+  }
+
+  if (row.revisable === true) {
+    return (
+      <Badge className="bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">
+        {row.revisableCondition ? `Yes — ${row.revisableCondition}` : 'Yes'}
+      </Badge>
+    )
+  }
+
+  return <Badge variant="outline">{row.revisableLabel || 'Unknown'}</Badge>
+}
+
+function SortableHeader({
+  label,
+  column,
+  activeSort,
+  onToggleSort,
+}: {
+  label: string
+  column: DecisionSortColumn
+  activeSort: DecisionSort
+  onToggleSort: (column: DecisionSortColumn) => void
+}) {
+  const isActive = activeSort.column === column
+
+  return (
+    <th className="px-3 py-2 font-medium">
+      <button
+        type="button"
+        onClick={() => onToggleSort(column)}
+        className={cn(
+          'inline-flex items-center gap-1 transition-colors hover:text-foreground',
+          isActive && 'text-foreground',
+        )}
+      >
+        {label}
+        <ArrowUpDown className="size-3" />
+      </button>
+    </th>
+  )
+}
+
+function getSortValue(row: ParsedDecision, column: DecisionSortColumn): string {
+  if (column === 'revisable') {
+    if (row.revisable === true) {
+      return `1-${row.revisableCondition ?? ''}`
+    }
+
+    if (row.revisable === false) {
+      return '0'
+    }
+
+    return `2-${row.revisableLabel}`
+  }
+
+  return row[column] ?? ''
+}

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -277,7 +277,12 @@ export function PlanningPane() {
         ) : null}
 
         {activeArtifact ? (
-          <div className="text-sm leading-relaxed">
+          <div
+            role="tabpanel"
+            id={`panel-${activeArtifact.artifactKey}`}
+            aria-labelledby={`tab-${activeArtifact.artifactKey}`}
+            className="text-sm leading-relaxed"
+          >
             {parsedArtifact?.type === 'roadmap' && parsedArtifact.parsed ? (
               <RoadmapView roadmap={parsedArtifact.parsed as ParsedRoadmap} />
             ) : parsedArtifact?.type === 'requirements' && parsedArtifact.parsed ? (

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -1,30 +1,55 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { Loader2 } from 'lucide-react'
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
+import type {
+  ParsedContext,
+  ParsedDecisions,
+  ParsedRequirements,
+  ParsedRoadmap,
+} from '@shared/types'
 import { Markdown } from '@kata-ui/components/markdown/Markdown'
 import {
   activePlanningArtifactAtom,
   applyPlanningArtifactAtom,
+  lastViewedPlanningArtifactAtom,
+  markPlanningArtifactViewedAtom,
   planningArtifactsAtom,
   planningErrorAtom,
   planningLoadingAtom,
 } from '@/atoms/planning'
+import { ArtifactTabs } from '@/components/planning/ArtifactTabs'
+import { ContextView } from '@/components/planning/ContextView'
+import { DecisionsView } from '@/components/planning/DecisionsView'
+import { RequirementsView } from '@/components/planning/RequirementsView'
+import { RoadmapView } from '@/components/planning/RoadmapView'
 import { Separator } from '@/components/ui/separator'
+import {
+  detectArtifactType,
+  parseContext,
+  parseDecisions,
+  parseRequirements,
+  parseRoadmap,
+} from '@/lib/artifact-parser'
 
 export function PlanningPane() {
-  const artifacts = useAtomValue(planningArtifactsAtom)
+  const artifactsByKey = useAtomValue(planningArtifactsAtom)
   const activeArtifactRef = useAtomValue(activePlanningArtifactAtom)
   const loading = useAtomValue(planningLoadingAtom)
   const error = useAtomValue(planningErrorAtom)
+  const lastViewedByTitle = useAtomValue(lastViewedPlanningArtifactAtom)
 
   const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
+  const setActiveArtifact = useSetAtom(activePlanningArtifactAtom)
+  const markPlanningArtifactViewed = useSetAtom(markPlanningArtifactViewedAtom)
   const setPlanningLoading = useSetAtom(planningLoadingAtom)
   const setPlanningError = useSetAtom(planningErrorAtom)
+
+  const artifacts = useMemo(() => Object.values(artifactsByKey), [artifactsByKey])
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const scrollPositionsByKeyRef = useRef<Record<string, number>>({})
 
-  const activeArtifact = activeArtifactRef ? artifacts[activeArtifactRef.artifactKey] : null
+  const activeArtifact = activeArtifactRef ? artifactsByKey[activeArtifactRef.artifactKey] : null
 
   useEffect(() => {
     if (!activeArtifactRef || activeArtifact) {
@@ -84,6 +109,80 @@ export function PlanningPane() {
     container.scrollTop = scrollPositionsByKeyRef.current[activeArtifactRef.artifactKey] ?? 0
   }, [activeArtifactRef])
 
+  useEffect(() => {
+    if (!activeArtifact) {
+      return
+    }
+
+    markPlanningArtifactViewed({
+      title: activeArtifact.title,
+      updatedAt: activeArtifact.updatedAt,
+    })
+  }, [activeArtifact, markPlanningArtifactViewed])
+
+  const parsedArtifact = useMemo(() => {
+    if (!activeArtifact) {
+      return null
+    }
+
+    const type = detectArtifactType(activeArtifact.title)
+
+    if (type === 'roadmap') {
+      return {
+        type,
+        parsed: parseRoadmap(activeArtifact.content) as ParsedRoadmap | null,
+      }
+    }
+
+    if (type === 'requirements') {
+      return {
+        type,
+        parsed: parseRequirements(activeArtifact.content) as ParsedRequirements | null,
+      }
+    }
+
+    if (type === 'decisions') {
+      return {
+        type,
+        parsed: parseDecisions(activeArtifact.content) as ParsedDecisions | null,
+      }
+    }
+
+    if (type === 'context') {
+      return {
+        type,
+        parsed: parseContext(activeArtifact.content) as ParsedContext | null,
+      }
+    }
+
+    return {
+      type: null,
+      parsed: null,
+    }
+  }, [activeArtifact])
+
+  const parseFailed = Boolean(activeArtifact && parsedArtifact?.type && !parsedArtifact.parsed)
+
+  useEffect(() => {
+    if (!activeArtifact || !parseFailed || !parsedArtifact?.type) {
+      return
+    }
+
+    console.warn('Unable to parse planning artifact as structured view', {
+      title: activeArtifact.title,
+      expectedFormat: parsedArtifact.type,
+      sample: activeArtifact.content.slice(0, 280),
+    })
+  }, [activeArtifact, parseFailed, parsedArtifact])
+
+  const hasUnviewedUpdatesByTitle = useMemo(() => {
+    return artifacts.reduce<Record<string, boolean>>((result, artifact) => {
+      const viewedAt = lastViewedByTitle[artifact.title]
+      result[artifact.title] = !viewedAt || new Date(artifact.updatedAt).getTime() > new Date(viewedAt).getTime()
+      return result
+    }, {})
+  }, [artifacts, lastViewedByTitle])
+
   const handleScroll = (): void => {
     if (!activeArtifactRef || !scrollContainerRef.current) {
       return
@@ -93,22 +192,53 @@ export function PlanningPane() {
       scrollContainerRef.current.scrollTop
   }
 
+  const handleArtifactSelect = (artifactKey: string, title: string): void => {
+    if (!activeArtifactRef || !scrollContainerRef.current) {
+      setActiveArtifact({ artifactKey, title })
+      return
+    }
+
+    scrollPositionsByKeyRef.current[activeArtifactRef.artifactKey] = scrollContainerRef.current.scrollTop
+
+    if (artifactKey === activeArtifactRef.artifactKey) {
+      return
+    }
+
+    console.debug('Planning tab switched', {
+      from: activeArtifactRef.title,
+      to: title,
+    })
+
+    setActiveArtifact({ artifactKey, title })
+  }
+
   return (
     <aside className="flex h-full flex-col bg-muted/20">
-      <div className="flex h-14 items-center justify-between px-4">
-        <div className="flex min-w-0 flex-col">
-          <h2 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">
-            Planning View
-          </h2>
-          <p className="truncate text-sm font-medium text-foreground">
-            {activeArtifact?.title ?? activeArtifactRef?.title ?? 'No active artifact'}
-          </p>
+      <div className="flex flex-col py-2">
+        <div className="flex items-center justify-between px-4">
+          <div className="flex min-w-0 flex-col">
+            <h2 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">
+              Planning View
+            </h2>
+            <p className="truncate text-sm font-medium text-foreground">
+              {activeArtifact?.title ?? activeArtifactRef?.title ?? 'No active artifact'}
+            </p>
+          </div>
+
+          {activeArtifact ? (
+            <span className="text-xs text-muted-foreground">
+              {new Date(activeArtifact.updatedAt).toLocaleTimeString()}
+            </span>
+          ) : null}
         </div>
 
-        {activeArtifact ? (
-          <span className="text-xs text-muted-foreground">
-            {new Date(activeArtifact.updatedAt).toLocaleTimeString()}
-          </span>
+        {artifacts.length > 0 ? (
+          <ArtifactTabs
+            artifacts={artifacts}
+            activeArtifactKey={activeArtifactRef?.artifactKey ?? null}
+            hasUnviewedUpdatesByTitle={hasUnviewedUpdatesByTitle}
+            onSelect={(artifact) => handleArtifactSelect(artifact.artifactKey, artifact.title)}
+          />
         ) : null}
       </div>
 
@@ -117,6 +247,12 @@ export function PlanningPane() {
       {error ? (
         <div className="border-b border-border bg-destructive/10 px-4 py-3 text-xs text-destructive">
           Unable to fetch artifact: {error}
+        </div>
+      ) : null}
+
+      {parseFailed ? (
+        <div className="border-b border-border bg-amber-100/60 px-4 py-3 text-xs text-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+          Unable to parse as structured view. Displaying raw markdown fallback.
         </div>
       ) : null}
 
@@ -140,9 +276,21 @@ export function PlanningPane() {
         ) : null}
 
         {activeArtifact ? (
-          <Markdown mode="full" className="text-sm leading-relaxed">
-            {activeArtifact.content}
-          </Markdown>
+          <div className="text-sm leading-relaxed">
+            {parsedArtifact?.type === 'roadmap' && parsedArtifact.parsed ? (
+              <RoadmapView roadmap={parsedArtifact.parsed as ParsedRoadmap} />
+            ) : parsedArtifact?.type === 'requirements' && parsedArtifact.parsed ? (
+              <RequirementsView requirements={parsedArtifact.parsed as ParsedRequirements} />
+            ) : parsedArtifact?.type === 'decisions' && parsedArtifact.parsed ? (
+              <DecisionsView decisions={parsedArtifact.parsed as ParsedDecisions} />
+            ) : parsedArtifact?.type === 'context' && parsedArtifact.parsed ? (
+              <ContextView context={parsedArtifact.parsed as ParsedContext} />
+            ) : (
+              <Markdown mode="full" className="text-sm leading-relaxed">
+                {activeArtifact.content}
+              </Markdown>
+            )}
+          </div>
         ) : null}
       </div>
     </aside>

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -36,7 +36,7 @@ export function PlanningPane() {
   const activeArtifactRef = useAtomValue(activePlanningArtifactAtom)
   const loading = useAtomValue(planningLoadingAtom)
   const error = useAtomValue(planningErrorAtom)
-  const lastViewedByTitle = useAtomValue(lastViewedPlanningArtifactAtom)
+  const lastViewedByArtifactKey = useAtomValue(lastViewedPlanningArtifactAtom)
 
   const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
   const setActiveArtifact = useSetAtom(activePlanningArtifactAtom)
@@ -115,7 +115,7 @@ export function PlanningPane() {
     }
 
     markPlanningArtifactViewed({
-      title: activeArtifact.title,
+      artifactKey: activeArtifact.artifactKey,
       updatedAt: activeArtifact.updatedAt,
     })
   }, [activeArtifact, markPlanningArtifactViewed])
@@ -175,13 +175,14 @@ export function PlanningPane() {
     })
   }, [activeArtifact, parseFailed, parsedArtifact])
 
-  const hasUnviewedUpdatesByTitle = useMemo(() => {
+  const hasUnviewedUpdatesByKey = useMemo(() => {
     return artifacts.reduce<Record<string, boolean>>((result, artifact) => {
-      const viewedAt = lastViewedByTitle[artifact.title]
-      result[artifact.title] = !viewedAt || new Date(artifact.updatedAt).getTime() > new Date(viewedAt).getTime()
+      const viewedAt = lastViewedByArtifactKey[artifact.artifactKey]
+      result[artifact.artifactKey] =
+        !viewedAt || new Date(artifact.updatedAt).getTime() > new Date(viewedAt).getTime()
       return result
     }, {})
-  }, [artifacts, lastViewedByTitle])
+  }, [artifacts, lastViewedByArtifactKey])
 
   const handleScroll = (): void => {
     if (!activeArtifactRef || !scrollContainerRef.current) {
@@ -236,7 +237,7 @@ export function PlanningPane() {
           <ArtifactTabs
             artifacts={artifacts}
             activeArtifactKey={activeArtifactRef?.artifactKey ?? null}
-            hasUnviewedUpdatesByTitle={hasUnviewedUpdatesByTitle}
+            hasUnviewedUpdatesByKey={hasUnviewedUpdatesByKey}
             onSelect={(artifact) => handleArtifactSelect(artifact.artifactKey, artifact.title)}
           />
         ) : null}

--- a/apps/desktop/src/renderer/components/planning/RequirementsView.tsx
+++ b/apps/desktop/src/renderer/components/planning/RequirementsView.tsx
@@ -1,0 +1,118 @@
+import type { ParsedRequirement, ParsedRequirements, RequirementStatus } from '@shared/types'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+interface RequirementSectionConfig {
+  key: RequirementStatus
+  label: string
+  headingClassName: string
+}
+
+const SECTION_CONFIG: RequirementSectionConfig[] = [
+  {
+    key: 'active',
+    label: 'Active',
+    headingClassName: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300',
+  },
+  {
+    key: 'validated',
+    label: 'Validated',
+    headingClassName: 'bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300',
+  },
+  {
+    key: 'deferred',
+    label: 'Deferred',
+    headingClassName: 'bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300',
+  },
+  {
+    key: 'outOfScope',
+    label: 'Out of Scope',
+    headingClassName: 'bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300',
+  },
+]
+
+export interface RequirementsViewProps {
+  requirements: ParsedRequirements
+}
+
+export function RequirementsView({ requirements }: RequirementsViewProps) {
+  const coverageTotal =
+    requirements.active.length +
+    requirements.validated.length +
+    requirements.deferred.length +
+    requirements.outOfScope.length
+
+  return (
+    <div className="space-y-4">
+      {SECTION_CONFIG.map((section) => {
+        const sectionRequirements = requirements[section.key]
+        if (sectionRequirements.length === 0) {
+          return null
+        }
+
+        return (
+          <section key={section.key} className="overflow-hidden rounded-lg border border-border">
+            <div className={cn('flex items-center justify-between px-3 py-2 text-xs font-semibold', section.headingClassName)}>
+              <span>{section.label}</span>
+              <span>{sectionRequirements.length}</span>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-border text-left text-sm">
+                <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Requirement</th>
+                    <th className="px-3 py-2 font-medium">Class</th>
+                    <th className="px-3 py-2 font-medium">Status</th>
+                    <th className="px-3 py-2 font-medium">Owning Slice</th>
+                  </tr>
+                </thead>
+
+                <tbody className="divide-y divide-border">
+                  {sectionRequirements.map((requirement) => (
+                    <RequirementRow key={requirement.id} requirement={requirement} sectionLabel={section.label} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )
+      })}
+
+      <div className="rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        Traceability summary: {coverageTotal} requirements rendered ({requirements.active.length} active,{' '}
+        {requirements.validated.length} validated, {requirements.deferred.length} deferred,{' '}
+        {requirements.outOfScope.length} out of scope).
+      </div>
+    </div>
+  )
+}
+
+function RequirementRow({
+  requirement,
+  sectionLabel,
+}: {
+  requirement: ParsedRequirement
+  sectionLabel: string
+}) {
+  return (
+    <tr className="align-top">
+      <td className="space-y-1 px-3 py-2">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="secondary">{requirement.id}</Badge>
+          <span className="font-medium text-foreground">{requirement.title}</span>
+        </div>
+        {requirement.description ? (
+          <p className="text-xs leading-relaxed text-muted-foreground">{requirement.description}</p>
+        ) : null}
+      </td>
+      <td className="px-3 py-2">
+        {requirement.class ? <Badge variant="outline">{requirement.class}</Badge> : <span>—</span>}
+      </td>
+      <td className="px-3 py-2">
+        <Badge variant="outline">{requirement.status || sectionLabel.toLowerCase()}</Badge>
+      </td>
+      <td className="px-3 py-2 text-xs text-muted-foreground">{requirement.owner || '—'}</td>
+    </tr>
+  )
+}

--- a/apps/desktop/src/renderer/components/planning/RoadmapView.tsx
+++ b/apps/desktop/src/renderer/components/planning/RoadmapView.tsx
@@ -36,8 +36,8 @@ export function RoadmapView({ roadmap }: RoadmapViewProps) {
             Success Criteria
           </p>
           <ul className="mt-2 list-disc space-y-1 pl-4 text-sm">
-            {roadmap.successCriteria.map((criterion) => (
-              <li key={criterion}>{criterion}</li>
+            {roadmap.successCriteria.map((criterion, index) => (
+              <li key={`criterion-${index}`}>{criterion}</li>
             ))}
           </ul>
         </section>
@@ -99,8 +99,8 @@ export function RoadmapView({ roadmap }: RoadmapViewProps) {
           </CollapsibleTrigger>
 
           <CollapsibleContent className="space-y-2 border-t border-border px-3 py-2">
-            {roadmap.boundaryMap.map((section) => (
-              <div key={section.heading} className="space-y-1">
+            {roadmap.boundaryMap.map((section, index) => (
+              <div key={`boundary-${index}`} className="space-y-1">
                 <p className="text-sm font-medium">{section.heading}</p>
                 <pre className="overflow-x-auto whitespace-pre-wrap text-xs text-muted-foreground">
                   {section.content}

--- a/apps/desktop/src/renderer/components/planning/RoadmapView.tsx
+++ b/apps/desktop/src/renderer/components/planning/RoadmapView.tsx
@@ -1,0 +1,115 @@
+import type { ParsedRoadmap, ParsedRoadmapSlice } from '@shared/types'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { cn } from '@/lib/utils'
+
+function riskBadgeClass(risk: ParsedRoadmapSlice['risk']): string {
+  if (risk === 'high') {
+    return 'bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300'
+  }
+
+  if (risk === 'medium') {
+    return 'bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300'
+  }
+
+  return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300'
+}
+
+export interface RoadmapViewProps {
+  roadmap: ParsedRoadmap
+}
+
+export function RoadmapView({ roadmap }: RoadmapViewProps) {
+  return (
+    <div className="space-y-4">
+      {roadmap.vision ? (
+        <section className="rounded-lg border border-border bg-background px-3 py-2">
+          <p className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">Vision</p>
+          <p className="mt-1 text-sm leading-relaxed">{roadmap.vision}</p>
+        </section>
+      ) : null}
+
+      {roadmap.successCriteria.length > 0 ? (
+        <section className="rounded-lg border border-border bg-background px-3 py-2">
+          <p className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">
+            Success Criteria
+          </p>
+          <ul className="mt-2 list-disc space-y-1 pl-4 text-sm">
+            {roadmap.successCriteria.map((criterion) => (
+              <li key={criterion}>{criterion}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className="space-y-3">
+        {roadmap.slices.map((slice) => (
+          <Card
+            key={slice.id}
+            size="sm"
+            className={cn(slice.done && 'border-dashed bg-muted/40 text-muted-foreground')}
+          >
+            <CardHeader className="gap-2">
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={slice.done}
+                    readOnly
+                    aria-label={`${slice.id} completion state`}
+                    className="mt-0.5 size-4 rounded border-border"
+                  />
+                  <Badge variant="secondary">{slice.id}</Badge>
+                  <CardTitle className={cn('text-sm', slice.done && 'line-through')}>
+                    {slice.title}
+                  </CardTitle>
+                </div>
+
+                <Badge className={cn('capitalize', riskBadgeClass(slice.risk))}>{slice.risk} risk</Badge>
+              </div>
+
+              {slice.depends.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {slice.depends.map((dependency) => (
+                    <Badge key={`${slice.id}-${dependency}`} variant="outline">
+                      depends: {dependency}
+                    </Badge>
+                  ))}
+                </div>
+              ) : null}
+            </CardHeader>
+
+            {slice.demo ? (
+              <CardContent className="pt-0 text-sm italic text-muted-foreground">{slice.demo}</CardContent>
+            ) : null}
+          </Card>
+        ))}
+      </section>
+
+      {roadmap.boundaryMap.length > 0 ? (
+        <Collapsible defaultOpen={false} className="rounded-lg border border-border bg-background">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center justify-between px-3 py-2 text-left text-xs font-semibold tracking-wide uppercase text-muted-foreground"
+            >
+              Boundary Map
+            </button>
+          </CollapsibleTrigger>
+
+          <CollapsibleContent className="space-y-2 border-t border-border px-3 py-2">
+            {roadmap.boundaryMap.map((section) => (
+              <div key={section.heading} className="space-y-1">
+                <p className="text-sm font-medium">{section.heading}</p>
+                <pre className="overflow-x-auto whitespace-pre-wrap text-xs text-muted-foreground">
+                  {section.content}
+                </pre>
+              </div>
+            ))}
+          </CollapsibleContent>
+        </Collapsible>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts
@@ -194,6 +194,12 @@ describe('artifact-parser', () => {
       revisable: false,
       revisableCondition: null,
     })
+
+    expect(parsed?.rows[2]).toMatchObject({
+      id: 'D010',
+      revisable: true,
+      revisableCondition: 'if auto-switch is disruptive',
+    })
   })
 
   test('parseContext returns section objects for ## and ### headings', () => {

--- a/apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from 'vitest'
+import {
+  detectArtifactType,
+  parseContext,
+  parseDecisions,
+  parseRequirements,
+  parseRoadmap,
+} from '../artifact-parser'
+
+const ROADMAP_SAMPLE = `# M002: Planning View
+
+**Vision:** When a user runs /kata plan in the Desktop chat, the right pane comes alive.
+
+## Success Criteria
+
+* ROADMAP renders with slice cards showing checkboxes, colored risk badges, dependency tags, and demo lines
+* REQUIREMENTS renders as a structured table with status badges
+
+## Slices
+
+- [ ] **S01: Artifact Detection and Linear API Bridge** \`risk:high\` \`depends:[]\`
+
+  > After this: the pane detects planning tool calls and fetches docs from Linear.
+- [x] **S02: Rich Structured Rendering for Planning Artifacts** \`risk:medium\` \`depends:[S01]\`
+
+  > After this: ROADMAP, REQUIREMENTS, DECISIONS, and CONTEXT have rich structured renderers.
+- [ ] **S03: Auto-Switch, Navigation, and Integration Polish** \`risk:low\` \`depends:[S01,S02]\`
+
+  > After this: right pane auto-switching and smooth updates are complete.
+
+## Boundary Map
+
+### S01 → S02, S03
+
+Produces:
+
+* PlanningPane shell
+* planningArtifactsAtom + activePlanningArtifactAtom
+`
+
+const REQUIREMENTS_SAMPLE = `# Requirements
+
+## Active
+
+### R009 — Live rendering of planning artifacts in right pane
+
+* Class: primary-user-loop
+* Status: active
+* Description: During /kata plan sessions, the right pane renders ROADMAP, REQUIREMENTS, DECISIONS, CONTEXT as structured docs.
+* Primary owning slice: M002/S01
+* Validation: unmapped
+
+### R010 — Contextual right-pane switching
+
+* Class: primary-user-loop
+* Status: active
+* Description: Right pane switches between planning and kanban contexts.
+* Primary owning slice: M003/S01
+* Validation: unmapped
+
+## Validated
+
+### R001 — pi-coding-agent as agent runtime
+
+* Class: core-capability
+* Status: validated
+* Description: Desktop runs pi-coding-agent via kata --mode rpc.
+* Primary owning slice: M001/S01
+* Validation: e2e
+
+## Deferred
+
+### R021 — Standalone local-only task tracker
+
+* Class: core-capability
+* Status: deferred
+* Description: Built-in local backend for teams without Linear/GitHub.
+* Primary owning slice: none
+* Validation: unmapped
+
+## Out of Scope
+
+### R022 — Legacy daemon integrations
+
+* Class: anti-feature
+* Status: out-of-scope
+* Description: Legacy daemon channels are intentionally excluded.
+* Primary owning slice: none
+* Validation: n/a
+`
+
+const DECISIONS_SAMPLE = `# Decisions Register
+
+| \\# | When | Scope | Decision | Choice | Rationale | Revisable? |
+| -- | -- | -- | -- | -- | -- | -- |
+| D008 | M002 | arch | Planning artifact detection | Intercept tool calls from RPC event stream | Event-driven and deterministic | Yes — add polling fallback if tool names change |
+| D009 | M002 | arch | Planning artifact rendering | Rich structured components, not raw markdown | Artifacts are easier to scan and action | No |
+| D010 | M002 | arch | Right pane auto-switch | Auto-switch with manual override | Reduces friction while preserving control | Yes - if auto-switch is disruptive |
+`
+
+const CONTEXT_SAMPLE = `# M002: Planning View — Context
+
+## Project Description
+
+Add a right-pane planning artifact viewer to Kata Desktop.
+
+## Why This Milestone
+
+Planning is a core Kata workflow and should be visible live in the app.
+
+## Integration Points
+
+### CLI subprocess RPC events
+
+Detect kata_write_document and related tools.
+
+### Linear API
+
+Read document content for rendering.
+`
+
+describe('artifact-parser', () => {
+  test('detectArtifactType matches known artifact titles', () => {
+    expect(detectArtifactType('M002-ROADMAP')).toBe('roadmap')
+    expect(detectArtifactType('REQUIREMENTS')).toBe('requirements')
+    expect(detectArtifactType('DECISIONS')).toBe('decisions')
+    expect(detectArtifactType('M002-CONTEXT')).toBe('context')
+    expect(detectArtifactType('PROJECT')).toBeNull()
+  })
+
+  test('parseRoadmap parses real roadmap markdown patterns', () => {
+    const parsed = parseRoadmap(ROADMAP_SAMPLE)
+
+    expect(parsed).not.toBeNull()
+    expect(parsed?.vision).toContain('right pane comes alive')
+    expect(parsed?.successCriteria).toHaveLength(2)
+    expect(parsed?.slices).toHaveLength(3)
+
+    expect(parsed?.slices[0]).toEqual({
+      id: 'S01',
+      title: 'Artifact Detection and Linear API Bridge',
+      risk: 'high',
+      depends: [],
+      demo: 'After this: the pane detects planning tool calls and fetches docs from Linear.',
+      done: false,
+    })
+
+    expect(parsed?.slices[1]?.done).toBe(true)
+    expect(parsed?.slices[1]?.depends).toEqual(['S01'])
+    expect(parsed?.slices[2]?.depends).toEqual(['S01', 'S02'])
+    expect(parsed?.boundaryMap[0]?.heading).toBe('S01 → S02, S03')
+    expect(parsed?.boundaryMap[0]?.content).toContain('PlanningPane shell')
+  })
+
+  test('parseRequirements groups requirements by section headings', () => {
+    const parsed = parseRequirements(REQUIREMENTS_SAMPLE)
+
+    expect(parsed).not.toBeNull()
+    expect(parsed?.active).toHaveLength(2)
+    expect(parsed?.validated).toHaveLength(1)
+    expect(parsed?.deferred).toHaveLength(1)
+    expect(parsed?.outOfScope).toHaveLength(1)
+
+    expect(parsed?.active[0]).toMatchObject({
+      id: 'R009',
+      class: 'primary-user-loop',
+      status: 'active',
+      owner: 'M002/S01',
+    })
+
+    expect(parsed?.outOfScope[0]).toMatchObject({
+      id: 'R022',
+      status: 'out-of-scope',
+      validation: 'n/a',
+    })
+  })
+
+  test('parseDecisions parses markdown table rows and revisability', () => {
+    const parsed = parseDecisions(DECISIONS_SAMPLE)
+
+    expect(parsed).not.toBeNull()
+    expect(parsed?.rows).toHaveLength(3)
+
+    expect(parsed?.rows[0]).toMatchObject({
+      id: 'D008',
+      when: 'M002',
+      scope: 'arch',
+      revisable: true,
+      revisableCondition: 'add polling fallback if tool names change',
+    })
+
+    expect(parsed?.rows[1]).toMatchObject({
+      id: 'D009',
+      revisable: false,
+      revisableCondition: null,
+    })
+  })
+
+  test('parseContext returns section objects for ## and ### headings', () => {
+    const parsed = parseContext(CONTEXT_SAMPLE)
+
+    expect(parsed).not.toBeNull()
+    expect(parsed?.sections.map((section) => section.heading)).toEqual([
+      'Project Description',
+      'Why This Milestone',
+      'Integration Points',
+      'CLI subprocess RPC events',
+      'Linear API',
+    ])
+    expect(parsed?.sections[0]).toMatchObject({ level: 2 })
+    expect(parsed?.sections[3]).toMatchObject({ level: 3 })
+  })
+
+  test('all parsers fail safely on malformed markdown', () => {
+    const malformed = 'just some notes without artifact structure'
+
+    expect(parseRoadmap(malformed)).toBeNull()
+    expect(parseRequirements(malformed)).toBeNull()
+    expect(parseDecisions(malformed)).toBeNull()
+    expect(parseContext(malformed)).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/lib/artifact-parser.ts
+++ b/apps/desktop/src/renderer/lib/artifact-parser.ts
@@ -399,17 +399,18 @@ function buildHeaderIndexMap(headers: string[]): Map<string, number> {
 }
 
 function parseRevisableCell(value: string): { value: boolean | null; condition: string | null } {
-  const normalized = value.toLowerCase()
+  const trimmed = value.trim()
+  const normalized = trimmed.toLowerCase()
 
   if (normalized.startsWith('no')) {
     return { value: false, condition: null }
   }
 
   if (normalized.startsWith('yes')) {
-    const condition = value.split(/[—-]/).slice(1).join('—').trim()
+    const conditionMatch = trimmed.match(/^yes\s*[—-]\s*(.+)$/i)
     return {
       value: true,
-      condition: condition || null,
+      condition: conditionMatch?.[1]?.trim() || null,
     }
   }
 

--- a/apps/desktop/src/renderer/lib/artifact-parser.ts
+++ b/apps/desktop/src/renderer/lib/artifact-parser.ts
@@ -1,0 +1,448 @@
+import type {
+  ArtifactType,
+  ParsedContext,
+  ParsedContextSection,
+  ParsedDecision,
+  ParsedDecisions,
+  ParsedRequirement,
+  ParsedRequirements,
+  ParsedRoadmap,
+  ParsedRoadmapBoundarySection,
+  ParsedRoadmapSlice,
+  RequirementStatus,
+  RoadmapRisk,
+} from '@shared/types'
+
+const SECTION_HEADING_PATTERN = /^##(?!#)\s+(.+)$/gm
+const CONTEXT_HEADING_PATTERN = /^(#{2,3})\s+(.+)$/gm
+
+export function detectArtifactType(title: string): ArtifactType | null {
+  const normalized = title.trim().toUpperCase()
+
+  if (/-ROADMAP(?:\b|$)/.test(normalized) || normalized === 'ROADMAP') {
+    return 'roadmap'
+  }
+
+  if (normalized === 'REQUIREMENTS' || /-REQUIREMENTS(?:\b|$)/.test(normalized)) {
+    return 'requirements'
+  }
+
+  if (normalized === 'DECISIONS' || /-DECISIONS(?:\b|$)/.test(normalized)) {
+    return 'decisions'
+  }
+
+  if (/-CONTEXT(?:\b|$)/.test(normalized) || normalized === 'CONTEXT') {
+    return 'context'
+  }
+
+  return null
+}
+
+export function parseRoadmap(markdown: string): ParsedRoadmap | null {
+  const slicesSection = extractSection(markdown, 'Slices')
+  if (!slicesSection) {
+    return null
+  }
+
+  const lines = slicesSection.split('\n')
+  const slices: ParsedRoadmapSlice[] = []
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex] ?? ''
+    const parsedSlice = parseRoadmapSliceLine(line)
+    if (!parsedSlice) {
+      continue
+    }
+
+    const demo = findDemoLine(lines, lineIndex + 1)
+    slices.push({
+      ...parsedSlice,
+      demo,
+    })
+  }
+
+  if (slices.length === 0) {
+    return null
+  }
+
+  return {
+    vision: parseVision(markdown),
+    successCriteria: parseRoadmapSuccessCriteria(markdown),
+    slices,
+    boundaryMap: parseBoundaryMap(markdown),
+  }
+}
+
+export function parseRequirements(markdown: string): ParsedRequirements | null {
+  const parsed: ParsedRequirements = {
+    active: parseRequirementSection(markdown, 'Active', 'active'),
+    validated: parseRequirementSection(markdown, 'Validated', 'validated'),
+    deferred: parseRequirementSection(markdown, 'Deferred', 'deferred'),
+    outOfScope: parseRequirementSection(markdown, 'Out of Scope', 'outOfScope'),
+  }
+
+  const requirementCount =
+    parsed.active.length +
+    parsed.validated.length +
+    parsed.deferred.length +
+    parsed.outOfScope.length
+
+  if (requirementCount === 0) {
+    return null
+  }
+
+  return parsed
+}
+
+export function parseDecisions(markdown: string): ParsedDecisions | null {
+  const tableLines = markdown
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('|'))
+
+  if (tableLines.length < 3) {
+    return null
+  }
+
+  const header = splitTableRow(tableLines[0] ?? '')
+  const headerIndexByName = buildHeaderIndexMap(header)
+
+  const idIndex = headerIndexByName.get('#') ?? headerIndexByName.get('id')
+  const whenIndex = headerIndexByName.get('when')
+  const scopeIndex = headerIndexByName.get('scope')
+  const decisionIndex = headerIndexByName.get('decision')
+  const choiceIndex = headerIndexByName.get('choice')
+  const rationaleIndex = headerIndexByName.get('rationale')
+  const revisableIndex = headerIndexByName.get('revisable')
+
+  if (
+    idIndex === undefined ||
+    whenIndex === undefined ||
+    scopeIndex === undefined ||
+    decisionIndex === undefined ||
+    choiceIndex === undefined ||
+    revisableIndex === undefined
+  ) {
+    return null
+  }
+
+  const rows: ParsedDecision[] = []
+
+  for (const tableLine of tableLines.slice(2)) {
+    const cells = splitTableRow(tableLine)
+    const id = cells[idIndex]?.trim() ?? ''
+    if (!id) {
+      continue
+    }
+
+    const revisableLabel = (cells[revisableIndex] ?? '').trim()
+    const revisable = parseRevisableCell(revisableLabel)
+
+    rows.push({
+      id,
+      when: (cells[whenIndex] ?? '').trim(),
+      scope: (cells[scopeIndex] ?? '').trim(),
+      decision: (cells[decisionIndex] ?? '').trim(),
+      choice: (cells[choiceIndex] ?? '').trim(),
+      rationale: rationaleIndex === undefined ? '' : (cells[rationaleIndex] ?? '').trim(),
+      revisable: revisable.value,
+      revisableCondition: revisable.condition,
+      revisableLabel,
+    })
+  }
+
+  if (rows.length === 0) {
+    return null
+  }
+
+  return { rows }
+}
+
+export function parseContext(markdown: string): ParsedContext | null {
+  const matches = Array.from(markdown.matchAll(CONTEXT_HEADING_PATTERN))
+  const sections: ParsedContextSection[] = []
+
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index]
+    const nextMatch = matches[index + 1]
+
+    if (!match || match.index === undefined) {
+      continue
+    }
+
+    const level = match[1]?.length ?? 2
+    const heading = (match[2] ?? '').trim()
+
+    if (!heading) {
+      continue
+    }
+
+    const start = match.index + match[0].length
+    const end = nextMatch?.index ?? markdown.length
+    const content = markdown.slice(start, end).trim()
+
+    sections.push({
+      heading,
+      content,
+      level,
+    })
+  }
+
+  if (sections.length === 0) {
+    return null
+  }
+
+  return { sections }
+}
+
+function parseVision(markdown: string): string | null {
+  const visionMatch = markdown.match(/\*\*Vision:\*\*\s*(.+)/i)
+  return visionMatch?.[1]?.trim() || null
+}
+
+function parseRoadmapSuccessCriteria(markdown: string): string[] {
+  const successCriteriaSection = extractSection(markdown, 'Success Criteria')
+  if (!successCriteriaSection) {
+    return []
+  }
+
+  return successCriteriaSection
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /^[-*]\s+/.test(line))
+    .map((line) => line.replace(/^[-*]\s+/, '').trim())
+    .filter(Boolean)
+}
+
+function parseRoadmapSliceLine(line: string): Omit<ParsedRoadmapSlice, 'demo'> | null {
+  const sliceMatch = line.match(/^\s*[-*]\s*\[( |x|X)\]\s*\*\*S(\d+):\s*(.+?)\*\*(.*)$/)
+  if (!sliceMatch) {
+    return null
+  }
+
+  const done = (sliceMatch[1] ?? '').toLowerCase() === 'x'
+  const id = `S${sliceMatch[2]}`
+  const title = (sliceMatch[3] ?? '').trim()
+  const metadata = sliceMatch[4] ?? ''
+
+  const tags = Array.from(metadata.matchAll(/`([^`]+)`/g)).map((match) => match[1] ?? '')
+
+  const riskTag = tags.find((tag) => tag.toLowerCase().startsWith('risk:')) ?? 'risk:low'
+  const risk = normalizeRoadmapRisk(riskTag.split(':')[1])
+
+  const dependsTag = tags.find((tag) => tag.toLowerCase().startsWith('depends:'))
+  const depends = parseDependsValue(dependsTag)
+
+  return {
+    id,
+    title,
+    risk,
+    depends,
+    done,
+  }
+}
+
+function normalizeRoadmapRisk(value?: string): RoadmapRisk {
+  const normalized = value?.trim().toLowerCase()
+  if (normalized === 'high' || normalized === 'medium' || normalized === 'low') {
+    return normalized
+  }
+
+  return 'low'
+}
+
+function parseDependsValue(dependsTag?: string): string[] {
+  if (!dependsTag) {
+    return []
+  }
+
+  const dependsMatch = dependsTag.match(/depends:\[([^\]]*)\]/i)
+  const dependsValue = dependsMatch?.[1]?.trim() ?? ''
+
+  if (!dependsValue) {
+    return []
+  }
+
+  return dependsValue
+    .split(',')
+    .map((dependency) => dependency.trim())
+    .filter(Boolean)
+}
+
+function findDemoLine(lines: string[], startIndex: number): string | null {
+  for (let lineIndex = startIndex; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex]?.trim() ?? ''
+
+    if (!line) {
+      continue
+    }
+
+    if (/^[-*]\s*\[( |x|X)\]\s*\*\*S\d+:/.test(line)) {
+      break
+    }
+
+    if (line.startsWith('>')) {
+      return line.replace(/^>\s*/, '').trim()
+    }
+  }
+
+  return null
+}
+
+function parseBoundaryMap(markdown: string): ParsedRoadmapBoundarySection[] {
+  const boundaryMapSection = extractSection(markdown, 'Boundary Map')
+  if (!boundaryMapSection) {
+    return []
+  }
+
+  const lines = boundaryMapSection.split('\n')
+  const sections: ParsedRoadmapBoundarySection[] = []
+  let currentSection: ParsedRoadmapBoundarySection | null = null
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^###\s+(.+)$/)
+    if (headingMatch) {
+      currentSection = {
+        heading: headingMatch[1]?.trim() ?? 'Boundary',
+        content: '',
+      }
+      sections.push(currentSection)
+      continue
+    }
+
+    if (!currentSection) {
+      continue
+    }
+
+    currentSection.content = [currentSection.content, line]
+      .filter((chunk) => chunk.length > 0)
+      .join('\n')
+      .trim()
+  }
+
+  return sections.filter((section) => section.content.length > 0)
+}
+
+function parseRequirementSection(
+  markdown: string,
+  sectionHeading: string,
+  fallbackStatus: RequirementStatus,
+): ParsedRequirement[] {
+  const section = extractSection(markdown, sectionHeading)
+  if (!section) {
+    return []
+  }
+
+  const requirementHeadingPattern = /^###\s+R(\d+)\s+[—-]\s+(.+)$/gm
+  const headingMatches = Array.from(section.matchAll(requirementHeadingPattern))
+  const requirements: ParsedRequirement[] = []
+
+  for (let index = 0; index < headingMatches.length; index += 1) {
+    const match = headingMatches[index]
+    const nextMatch = headingMatches[index + 1]
+
+    if (!match || match.index === undefined) {
+      continue
+    }
+
+    const id = `R${match[1]}`
+    const title = (match[2] ?? '').trim()
+    const blockStart = match.index + match[0].length
+    const blockEnd = nextMatch?.index ?? section.length
+    const block = section.slice(blockStart, blockEnd)
+
+    requirements.push({
+      id,
+      title,
+      class: parseRequirementField(block, 'Class'),
+      status: parseRequirementField(block, 'Status') || fallbackStatus,
+      description: parseRequirementField(block, 'Description'),
+      owner: parseRequirementField(block, 'Primary owning slice'),
+      validation: parseRequirementField(block, 'Validation'),
+    })
+  }
+
+  return requirements
+}
+
+function parseRequirementField(block: string, fieldName: string): string {
+  const escapedFieldName = escapeRegExp(fieldName)
+  const matcher = new RegExp(`^[*-]\\s*${escapedFieldName}:\\s*(.+)$`, 'im')
+  const fieldMatch = block.match(matcher)
+  return fieldMatch?.[1]?.trim() ?? ''
+}
+
+function splitTableRow(line: string): string[] {
+  return line
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((cell) => cell.trim())
+}
+
+function buildHeaderIndexMap(headers: string[]): Map<string, number> {
+  const headerMap = new Map<string, number>()
+
+  headers.forEach((header, index) => {
+    const normalized = header
+      .toLowerCase()
+      .replace(/\\#/g, '#')
+      .replace(/\?/g, '')
+      .trim()
+
+    if (normalized) {
+      headerMap.set(normalized, index)
+    }
+  })
+
+  return headerMap
+}
+
+function parseRevisableCell(value: string): { value: boolean | null; condition: string | null } {
+  const normalized = value.toLowerCase()
+
+  if (normalized.startsWith('no')) {
+    return { value: false, condition: null }
+  }
+
+  if (normalized.startsWith('yes')) {
+    const condition = value.split(/[—-]/).slice(1).join('—').trim()
+    return {
+      value: true,
+      condition: condition || null,
+    }
+  }
+
+  return { value: null, condition: null }
+}
+
+function extractSection(markdown: string, heading: string): string | null {
+  const headingMatches = Array.from(markdown.matchAll(SECTION_HEADING_PATTERN))
+
+  for (let index = 0; index < headingMatches.length; index += 1) {
+    const match = headingMatches[index]
+    if (!match || match.index === undefined) {
+      continue
+    }
+
+    if ((match[1] ?? '').trim().toLowerCase() !== heading.toLowerCase()) {
+      continue
+    }
+
+    const nextMatch = headingMatches[index + 1]
+    const start = match.index + match[0].length
+    const end = nextMatch?.index ?? markdown.length
+
+    return markdown.slice(start, end).trim() || null
+  }
+
+  return null
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function listTopLevelSections(markdown: string): string[] {
+  return Array.from(markdown.matchAll(SECTION_HEADING_PATTERN)).map((match) => match[1]?.trim() ?? '')
+}

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -450,6 +450,76 @@ export interface PlanningArtifactListResponse {
   error?: PlanningArtifactError
 }
 
+export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context'
+
+export type RoadmapRisk = 'high' | 'medium' | 'low'
+
+export interface ParsedRoadmapSlice {
+  id: string
+  title: string
+  risk: RoadmapRisk
+  depends: string[]
+  demo: string | null
+  done: boolean
+}
+
+export interface ParsedRoadmapBoundarySection {
+  heading: string
+  content: string
+}
+
+export interface ParsedRoadmap {
+  vision: string | null
+  successCriteria: string[]
+  slices: ParsedRoadmapSlice[]
+  boundaryMap: ParsedRoadmapBoundarySection[]
+}
+
+export type RequirementStatus = 'active' | 'validated' | 'deferred' | 'outOfScope'
+
+export interface ParsedRequirement {
+  id: string
+  title: string
+  class: string
+  status: string
+  description: string
+  owner: string
+  validation: string
+}
+
+export interface ParsedRequirements {
+  active: ParsedRequirement[]
+  validated: ParsedRequirement[]
+  deferred: ParsedRequirement[]
+  outOfScope: ParsedRequirement[]
+}
+
+export interface ParsedDecision {
+  id: string
+  when: string
+  scope: string
+  decision: string
+  choice: string
+  rationale: string
+  revisable: boolean | null
+  revisableCondition: string | null
+  revisableLabel: string
+}
+
+export interface ParsedDecisions {
+  rows: ParsedDecision[]
+}
+
+export interface ParsedContextSection {
+  heading: string
+  content: string
+  level: number
+}
+
+export interface ParsedContext {
+  sections: ParsedContextSection[]
+}
+
 export interface DesktopApi {
   sendMessage: (message: string) => Promise<void>
   stopAgent: () => Promise<void>


### PR DESCRIPTION
## Summary
- add artifact-parser with dedicated parsers for ROADMAP, REQUIREMENTS, DECISIONS, and CONTEXT plus artifact type detection
- add rich planning artifact renderer components (RoadmapView, RequirementsView, DecisionsView, ContextView) and structured/fallback rendering in PlanningPane
- add planning artifact tab navigation (ArtifactTabs) with fixed ordering, active state, per-artifact scroll restore, and unseen update indicators backed by lastViewedPlanningArtifactAtom

## Validation
- bun test apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts
- bun run --cwd apps/desktop test
- bun run --cwd apps/desktop typecheck
- bun run --cwd apps/desktop build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured, typed views for roadmaps, requirements, decisions and context with tables, cards and collapsibles.
  * Horizontal artifact tabs with normalized labels and update-dot indicators for unviewed changes.
  * View-tracking per artifact so previously viewed timestamps are remembered; scroll positions are preserved when switching.
  * Amber banner and raw-markdown fallback when structured parsing fails.

* **Bug Fixes**
  * Preserve current active artifact selection when appropriate instead of always overwriting.

* **Tests**
  * New parser test suite validating artifact detection and parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements structured rendering for four planning artifact types (ROADMAP, REQUIREMENTS, DECISIONS, CONTEXT) in the Kata Desktop right pane, replacing raw markdown rendering with dedicated view components.

**Key changes:**
- **`artifact-parser.ts`** — New library with `detectArtifactType`, `parseRoadmap`, `parseRequirements`, `parseDecisions`, `parseContext`, and `listTopLevelSections`. Well-tested with representative markdown fixtures.
- **`PlanningPane.tsx`** — Adds tab navigation (via new `ArtifactTabs`), per-artifact scroll restore using a `useRef`-backed map, "unseen update" indicator computation, and structured-vs-fallback rendering dispatch.
- **`ArtifactTabs.tsx`** — New component rendering sorted, labeled tabs with a dot indicator for unviewed updates.
- **View components** (`RoadmapView`, `RequirementsView`, `DecisionsView`, `ContextView`) — Each renders its parsed structure with Tailwind styling; `DecisionsView` adds sortable columns.
- **`planning.ts`** — Adds `lastViewedPlanningArtifactAtom` / `markPlanningArtifactViewedAtom` for tracking unseen updates, and changes `applyPlanningArtifactAtom` to preserve the user's currently active tab instead of always switching to the latest incoming artifact.
- **`types.ts`** — New shared type definitions for all parsed artifact structures.

**Issues found:**
- The "last viewed" tracking atom is keyed by `artifact.title` rather than `artifact.artifactKey`, which can cause incorrect dot-indicator state when two artifacts from different scopes (project vs. issue) share the same title string.
- `RoadmapView` uses criterion text as a React list key, which can produce duplicate-key warnings if two success criteria share identical text.
- `ContextView` uses a `level-heading` composite key that can collide when the same heading appears at the same level more than once in a document.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one title-keyed tracking bug that can cause incorrect dot indicators for same-name multi-scope artifacts.

The parser, view components, and atom logic are solid and well-tested. The main concern is that lastViewedPlanningArtifactAtom and hasUnviewedUpdatesByTitle both key on artifact.title rather than artifact.artifactKey, which can produce incorrect unseen update state when project-scope and issue-scope artifacts share the same title string. The two React key fragility issues in RoadmapView and ContextView are low-impact style concerns. No runtime crashes, no data loss, no security issues.

apps/desktop/src/renderer/atoms/planning.ts and the corresponding hasUnviewedUpdatesByTitle computation in PlanningPane.tsx — the title-based tracking key should be reviewed against multi-scope artifact scenarios.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/lib/artifact-parser.ts | New parsing library with clean section extraction, regex-based slice/requirement/decision parsing, and safe null returns; logic is correct and well-tested. |
| apps/desktop/src/renderer/atoms/planning.ts | Adds lastViewedPlanningArtifactAtom (keyed by title, not artifactKey) and a write-only marker atom; applyPlanningArtifactAtom now preserves active tab selection correctly. |
| apps/desktop/src/renderer/components/planning/PlanningPane.tsx | Orchestrates tabs, scroll restore, unseen-update tracking, and structured/fallback dispatch; the title-keyed unviewed tracking inherits the same scope-collision risk from the atom. |
| apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx | Fixed-order tab component with dot indicator; sort and label logic are correct. |
| apps/desktop/src/renderer/components/planning/RoadmapView.tsx | Renders slice cards with checkboxes, risk badges, and dependency tags; uses criterion text as React key, which can produce duplicate-key warnings. |
| apps/desktop/src/renderer/components/planning/ContextView.tsx | Collapsible section renderer backed by Markdown; composite level-heading key can collide for duplicate headings at the same depth. |
| apps/desktop/src/renderer/components/planning/DecisionsView.tsx | Sortable decision table with inline rationale sub-row; sort logic and badge rendering are correct. |
| apps/desktop/src/renderer/components/planning/RequirementsView.tsx | Grouped requirements table with status badge and traceability summary; logic is correct. |
| apps/desktop/src/shared/types.ts | Adds ArtifactType union and all ParsedXxx interfaces; new types are clean and match parser outputs. |
| apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts | Tests cover happy-path parsing and malformed-input fallback for all four parsers; fixture data is realistic and edge cases are exercised. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PlanningArtifact arrives via IPC / listArtifacts] --> B[applyPlanningArtifactAtom]
    B --> C{activeArtifact already set?}
    C -- No --> D[Set activePlanningArtifactAtom to incoming artifact]
    C -- Yes --> E[Keep current active tab]
    D & E --> F[planningArtifactsAtom updated]
    F --> G[PlanningPane renders]
    G --> H[detectArtifactType on title]
    H --> I{Known type?}
    I -- roadmap --> J[parseRoadmap to RoadmapView]
    I -- requirements --> K[parseRequirements to RequirementsView]
    I -- decisions --> L[parseDecisions to DecisionsView]
    I -- context --> M[parseContext to ContextView]
    I -- unknown or parse failed --> N[Markdown fallback]
    G --> O[ArtifactTabs renders sorted tabs]
    O --> P{hasUnviewedUpdatesByTitle computed from lastViewedByTitle}
    P -- unseen --> Q[dot indicator shown]
    P -- seen --> R[no indicator]
    G --> S[markPlanningArtifactViewed on activeArtifact change]
    S --> T[lastViewedPlanningArtifactAtom updated by title]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/planning.ts
Line: 35-43

Comment:
**Unviewed-update tracking keyed by title, not artifactKey**

`lastViewedPlanningArtifactAtom` uses `artifact.title` as the map key. `buildPlanningArtifactKey` (in `types.ts`) produces distinct keys for the same title at different scopes — e.g. `project:abc:M002-ROADMAP` vs `issue:xyz:M002-ROADMAP`. Because both artifacts share the same `.title` string, marking the project-scope artifact as viewed will suppress the dot indicator on the issue-scope artifact (and vice versa), even though the user may never have opened it.

Using `artifactKey` throughout (atom, marker, and `hasUnviewedUpdatesByTitle` computation in `PlanningPane.tsx`) would eliminate the collision. The `markPlanningArtifactViewed` call at line 117 of `PlanningPane.tsx` would pass `artifactKey` instead of `title`, and the `hasUnviewedUpdatesByTitle` reduce at line 179 would key on `artifact.artifactKey` as well.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/planning/RoadmapView.tsx
Line: 39-41

Comment:
**Fragile React key using criterion text**

Using the criterion string as a `key` will trigger a React duplicate-key warning if two success criteria happen to share identical text. An index-based key (e.g. using the second map callback argument) is safer here since the list order is stable and parsed sequentially from markdown.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/planning/ContextView.tsx
Line: 14-16

Comment:
**Composite key can collide for repeated headings**

The key `${section.level}-${section.heading}` will produce the same string if a document repeats the same heading at the same depth (e.g. two `## Overview` sections). Because sections are parsed in strict document order, using the array index (via the second `.map()` callback argument) as the key is both unique and stable.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): KAT-2145 KAT-2146 add str..."](https://github.com/gannonh/kata/commit/46bef02e73eae9fcfce5ad303e3d7370ed6d4960) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27194495)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->