### PR TITLE
KAT-2148: polish planning pane auto-switch, loading, and transitions

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -27,6 +27,7 @@ import {
   type PlanningArtifact,
   type PlanningArtifactEvent,
   type PlanningArtifactFetchResponse,
+  type PlanningArtifactFetchStateEvent,
   type PlanningArtifactListResponse,
   type SessionInfo,
   type SessionListResponse,
@@ -97,6 +98,16 @@ export function registerSessionIpc({
       projectId: artifact.projectId,
       issueId: artifact.issueId,
     })
+  }
+
+  const sendPlanningFetchStateToRenderer = (event: PlanningArtifactFetchStateEvent): void => {
+    if (!canSendToRenderer()) {
+      log.warn('[desktop-ipc] skipping planning fetch state dispatch: renderer window is destroyed')
+      return
+    }
+
+    window.webContents.send(IPC_CHANNELS.planningArtifactFetchState, event)
+    log.debug('[desktop-ipc] planning fetch state', event)
   }
 
   const getPlanningFetchContext = (
@@ -195,13 +206,39 @@ export function registerSessionIpc({
     planningMetadataByKey.set(planningEvent.artifactKey, planningEvent)
     planningLatestKeyByTitle.set(planningEvent.title, planningEvent.artifactKey)
 
-    void fetchPlanningArtifact(planningEvent.title, {
-      projectId: planningEvent.projectId,
-      issueId: planningEvent.issueId,
-      scope: planningEvent.scope,
+    sendPlanningFetchStateToRenderer({
+      state: 'start',
+      title: planningEvent.title,
       artifactKey: planningEvent.artifactKey,
-      pushUpdate: true,
+      toolName: planningEvent.toolName,
     })
+
+    void (async () => {
+      const response = await fetchPlanningArtifact(planningEvent.title, {
+        projectId: planningEvent.projectId,
+        issueId: planningEvent.issueId,
+        scope: planningEvent.scope,
+        artifactKey: planningEvent.artifactKey,
+        pushUpdate: true,
+      })
+
+      sendPlanningFetchStateToRenderer({
+        state: 'end',
+        title: planningEvent.title,
+        artifactKey: planningEvent.artifactKey,
+        toolName: planningEvent.toolName,
+        error: response.success ? undefined : response.error,
+      })
+
+      if (!response.success) {
+        log.warn('[desktop-ipc] planning artifact fetch failed', {
+          title: planningEvent.title,
+          artifactKey: planningEvent.artifactKey,
+          toolName: planningEvent.toolName,
+          error: response.error,
+        })
+      }
+    })()
   }
 
   planningToolDetector.on('artifact', onPlanningArtifactEvent)

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -8,6 +8,7 @@ import {
   type ExtensionUIRequest,
   type PermissionMode,
   type PlanningArtifact,
+  type PlanningArtifactFetchStateEvent,
   type ThinkingLevel,
 } from '../shared/types'
 
@@ -121,6 +122,17 @@ const api: DesktopApi = {
 
       return () => {
         ipcRenderer.removeListener(IPC_CHANNELS.planningArtifactUpdated, wrapped)
+      }
+    },
+    onArtifactFetchState: (listener: (event: PlanningArtifactFetchStateEvent) => void) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, event: PlanningArtifactFetchStateEvent) => {
+        listener(event)
+      }
+
+      ipcRenderer.on(IPC_CHANNELS.planningArtifactFetchState, wrapped)
+
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.planningArtifactFetchState, wrapped)
       }
     },
     fetchArtifact: async (title: string, artifactKey?: string) => {

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -1,6 +1,6 @@
-import { atom, useSetAtom } from 'jotai'
+import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { PlanningArtifact } from '@shared/types'
 
 export const RIGHT_PANE_MODE_STORAGE_KEY = 'kata-desktop:right-pane-mode'
@@ -28,7 +28,9 @@ export const rightPaneModeAtom = atomWithStorage<'planning' | 'default'>(
   RIGHT_PANE_MODE_STORAGE_KEY,
   'default',
 )
+export const autoSwitchTriggeredAtom = atom<boolean>(false)
 export const planningLoadingAtom = atom<boolean>(false)
+export const isFetchingAtom = atom<boolean>(false)
 export const planningErrorAtom = atom<string | null>(null)
 export const lastViewedPlanningArtifactAtom = atom<Record<string, string>>({})
 
@@ -41,6 +43,16 @@ export const markPlanningArtifactViewedAtom = atom(
     })
   },
 )
+
+export const resetPlanningSessionStateAtom = atom(null, (_get, set) => {
+  set(planningArtifactsAtom, {})
+  set(activePlanningArtifactAtom, null)
+  set(autoSwitchTriggeredAtom, false)
+  set(planningLoadingAtom, false)
+  set(isFetchingAtom, false)
+  set(planningErrorAtom, null)
+  set(lastViewedPlanningArtifactAtom, {})
+})
 
 export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: PlanningArtifact) => {
   const nextArtifacts: PlanningArtifactsMap = {
@@ -66,16 +78,22 @@ export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: Plannin
     })
   }
 
-  set(rightPaneModeAtom, 'planning')
   set(planningLoadingAtom, false)
   set(planningErrorAtom, null)
 })
 
 export function usePlanningArtifactBridge(): void {
+  const rightPaneMode = useAtomValue(rightPaneModeAtom)
+  const autoSwitchTriggered = useAtomValue(autoSwitchTriggeredAtom)
+
   const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
   const setArtifacts = useSetAtom(planningArtifactsAtom)
+  const pendingTriggerToolNameByArtifactKeyRef = useRef<Record<string, string>>({})
   const setActiveArtifactTitle = useSetAtom(activePlanningArtifactAtom)
+  const setRightPaneMode = useSetAtom(rightPaneModeAtom)
+  const setAutoSwitchTriggered = useSetAtom(autoSwitchTriggeredAtom)
   const setLoading = useSetAtom(planningLoadingAtom)
+  const setIsFetching = useSetAtom(isFetchingAtom)
   const setError = useSetAtom(planningErrorAtom)
 
   useEffect(() => {
@@ -130,12 +148,54 @@ export function usePlanningArtifactBridge(): void {
         setLoading(false)
       })
 
-    const unsubscribe = window.api.planning.onArtifactUpdated((artifact) => {
+    const unsubscribeFetchState = window.api.planning.onArtifactFetchState((event) => {
+      if (event.state === 'start') {
+        setIsFetching(true)
+        setError(null)
+        pendingTriggerToolNameByArtifactKeyRef.current[event.artifactKey] =
+          event.toolName ?? 'unknown'
+        return
+      }
+
+      setIsFetching(false)
+      delete pendingTriggerToolNameByArtifactKeyRef.current[event.artifactKey]
+
+      if (event.error) {
+        setError(event.error.message)
+      }
+    })
+
+    const unsubscribeArtifactUpdated = window.api.planning.onArtifactUpdated((artifact) => {
+      if (rightPaneMode === 'default' && !autoSwitchTriggered) {
+        console.info('Planning pane auto-switch triggered', {
+          triggerToolName:
+            pendingTriggerToolNameByArtifactKeyRef.current[artifact.artifactKey] ?? 'unknown',
+          title: artifact.title,
+        })
+
+        setRightPaneMode('planning')
+        setAutoSwitchTriggered(true)
+      }
+
+      delete pendingTriggerToolNameByArtifactKeyRef.current[artifact.artifactKey]
+      setIsFetching(false)
       applyPlanningArtifact(artifact)
     })
 
     return () => {
-      unsubscribe()
+      unsubscribeFetchState()
+      unsubscribeArtifactUpdated()
     }
-  }, [applyPlanningArtifact, setActiveArtifactTitle, setArtifacts, setError, setLoading])
+  }, [
+    applyPlanningArtifact,
+    autoSwitchTriggered,
+    rightPaneMode,
+    setActiveArtifactTitle,
+    setArtifacts,
+    setAutoSwitchTriggered,
+    setError,
+    setIsFetching,
+    setLoading,
+    setRightPaneMode,
+  ])
 }

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -30,7 +30,8 @@ export const rightPaneModeAtom = atomWithStorage<'planning' | 'default'>(
 )
 export const autoSwitchTriggeredAtom = atom<boolean>(false)
 export const planningLoadingAtom = atom<boolean>(false)
-export const isFetchingAtom = atom<boolean>(false)
+export const artifactFetchInFlightCountAtom = atom<number>(0)
+export const isFetchingAtom = atom((get) => get(artifactFetchInFlightCountAtom) > 0)
 export const planningErrorAtom = atom<string | null>(null)
 export const lastViewedPlanningArtifactAtom = atom<Record<string, string>>({})
 
@@ -49,7 +50,7 @@ export const resetPlanningSessionStateAtom = atom(null, (_get, set) => {
   set(activePlanningArtifactAtom, null)
   set(autoSwitchTriggeredAtom, false)
   set(planningLoadingAtom, false)
-  set(isFetchingAtom, false)
+  set(artifactFetchInFlightCountAtom, 0)
   set(planningErrorAtom, null)
   set(lastViewedPlanningArtifactAtom, {})
 })
@@ -89,12 +90,17 @@ export function usePlanningArtifactBridge(): void {
   const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
   const setArtifacts = useSetAtom(planningArtifactsAtom)
   const pendingTriggerToolNameByArtifactKeyRef = useRef<Record<string, string>>({})
+  const rightPaneModeRef = useRef(rightPaneMode)
+  const autoSwitchTriggeredRef = useRef(autoSwitchTriggered)
   const setActiveArtifactTitle = useSetAtom(activePlanningArtifactAtom)
   const setRightPaneMode = useSetAtom(rightPaneModeAtom)
   const setAutoSwitchTriggered = useSetAtom(autoSwitchTriggeredAtom)
   const setLoading = useSetAtom(planningLoadingAtom)
-  const setIsFetching = useSetAtom(isFetchingAtom)
+  const setArtifactFetchInFlightCount = useSetAtom(artifactFetchInFlightCountAtom)
   const setError = useSetAtom(planningErrorAtom)
+
+  rightPaneModeRef.current = rightPaneMode
+  autoSwitchTriggeredRef.current = autoSwitchTriggered
 
   useEffect(() => {
     setLoading(true)
@@ -150,14 +156,14 @@ export function usePlanningArtifactBridge(): void {
 
     const unsubscribeFetchState = window.api.planning.onArtifactFetchState((event) => {
       if (event.state === 'start') {
-        setIsFetching(true)
+        setArtifactFetchInFlightCount((current) => current + 1)
         setError(null)
         pendingTriggerToolNameByArtifactKeyRef.current[event.artifactKey] =
           event.toolName ?? 'unknown'
         return
       }
 
-      setIsFetching(false)
+      setArtifactFetchInFlightCount((current) => Math.max(0, current - 1))
       delete pendingTriggerToolNameByArtifactKeyRef.current[event.artifactKey]
 
       if (event.error) {
@@ -166,19 +172,21 @@ export function usePlanningArtifactBridge(): void {
     })
 
     const unsubscribeArtifactUpdated = window.api.planning.onArtifactUpdated((artifact) => {
-      if (rightPaneMode === 'default' && !autoSwitchTriggered) {
+      if (rightPaneModeRef.current === 'default' && !autoSwitchTriggeredRef.current) {
         console.info('Planning pane auto-switch triggered', {
           triggerToolName:
             pendingTriggerToolNameByArtifactKeyRef.current[artifact.artifactKey] ?? 'unknown',
           title: artifact.title,
         })
 
+        rightPaneModeRef.current = 'planning'
+        autoSwitchTriggeredRef.current = true
+
         setRightPaneMode('planning')
         setAutoSwitchTriggered(true)
       }
 
       delete pendingTriggerToolNameByArtifactKeyRef.current[artifact.artifactKey]
-      setIsFetching(false)
       applyPlanningArtifact(artifact)
     })
 
@@ -188,13 +196,11 @@ export function usePlanningArtifactBridge(): void {
     }
   }, [
     applyPlanningArtifact,
-    autoSwitchTriggered,
-    rightPaneMode,
     setActiveArtifactTitle,
     setArtifacts,
+    setArtifactFetchInFlightCount,
     setAutoSwitchTriggered,
     setError,
-    setIsFetching,
     setLoading,
     setRightPaneMode,
   ])

--- a/apps/desktop/src/renderer/atoms/session.ts
+++ b/apps/desktop/src/renderer/atoms/session.ts
@@ -2,6 +2,7 @@ import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import type { SessionListResponse, SessionListItem } from '@shared/types'
 import { resetChatStateAtom } from './chat'
+import { resetPlanningSessionStateAtom } from './planning'
 
 const CURRENT_SESSION_STORAGE_KEY = 'kata-desktop:current-session-id'
 const WORKING_DIRECTORY_STORAGE_KEY = 'kata-desktop:working-directory'
@@ -97,6 +98,7 @@ export const createSessionAtom = atom(null, async (get, set) => {
     }
 
     set(resetChatStateAtom)
+    set(resetPlanningSessionStateAtom)
 
     await set(refreshSessionListAtom)
 
@@ -120,6 +122,7 @@ export const switchWorkspaceAtom = atom(null, async (_get, set, workspacePath: s
     set(workingDirectoryAtom, response.path)
     set(currentSessionIdAtom, null)
     set(resetChatStateAtom)
+    set(resetPlanningSessionStateAtom)
     await set(refreshSessionListAtom)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)

--- a/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
@@ -1,10 +1,13 @@
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { LayoutGrid } from 'lucide-react'
 import { rightPaneModeAtom } from '@/atoms/planning'
 import { PlanningPane } from '@/components/planning/PlanningPane'
+import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 
 export function RightPane() {
   const rightPaneMode = useAtomValue(rightPaneModeAtom)
+  const setRightPaneMode = useSetAtom(rightPaneModeAtom)
 
   if (rightPaneMode === 'planning') {
     return <PlanningPane />
@@ -12,10 +15,27 @@ export function RightPane() {
 
   return (
     <aside className="flex h-full flex-col bg-muted/40">
-      <div className="flex h-14 items-center px-4">
+      <div className="flex h-14 items-center justify-between px-4">
         <h2 className="text-sm font-semibold tracking-wide uppercase text-muted-foreground">
           Context Pane
         </h2>
+
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          aria-label="Open planning view"
+          onClick={() => {
+            console.info('Right pane mode toggled', {
+              trigger: 'manual',
+              from: 'default',
+              to: 'planning',
+            })
+            setRightPaneMode('planning')
+          }}
+        >
+          <LayoutGrid className="size-4" />
+        </Button>
       </div>
 
       <Separator />

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -139,14 +139,28 @@ export function PlanningPane() {
 
     setIsContentVisible(false)
 
-    let animationFrame = window.requestAnimationFrame(() => {
-      animationFrame = window.requestAnimationFrame(() => {
-        setIsContentVisible(true)
+    let cancelled = false
+    let outerFrame: number | null = null
+    let innerFrame: number | null = null
+
+    outerFrame = window.requestAnimationFrame(() => {
+      innerFrame = window.requestAnimationFrame(() => {
+        if (!cancelled) {
+          setIsContentVisible(true)
+        }
       })
     })
 
     return () => {
-      window.cancelAnimationFrame(animationFrame)
+      cancelled = true
+
+      if (outerFrame !== null) {
+        window.cancelAnimationFrame(outerFrame)
+      }
+
+      if (innerFrame !== null) {
+        window.cancelAnimationFrame(innerFrame)
+      }
     }
   }, [activeArtifactVersion])
 

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Loader2 } from 'lucide-react'
-import { useEffect, useMemo, useRef } from 'react'
+import { Loader2, X } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type {
   ParsedContext,
   ParsedDecisions,
@@ -11,17 +11,20 @@ import { Markdown } from '@kata-ui/components/markdown/Markdown'
 import {
   activePlanningArtifactAtom,
   applyPlanningArtifactAtom,
+  isFetchingAtom,
   lastViewedPlanningArtifactAtom,
   markPlanningArtifactViewedAtom,
   planningArtifactsAtom,
   planningErrorAtom,
   planningLoadingAtom,
+  rightPaneModeAtom,
 } from '@/atoms/planning'
 import { ArtifactTabs } from '@/components/planning/ArtifactTabs'
 import { ContextView } from '@/components/planning/ContextView'
 import { DecisionsView } from '@/components/planning/DecisionsView'
 import { RequirementsView } from '@/components/planning/RequirementsView'
 import { RoadmapView } from '@/components/planning/RoadmapView'
+import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import {
   detectArtifactType,
@@ -30,16 +33,19 @@ import {
   parseRequirements,
   parseRoadmap,
 } from '@/lib/artifact-parser'
+import { cn } from '@/lib/utils'
 
 export function PlanningPane() {
   const artifactsByKey = useAtomValue(planningArtifactsAtom)
   const activeArtifactRef = useAtomValue(activePlanningArtifactAtom)
   const loading = useAtomValue(planningLoadingAtom)
+  const isFetching = useAtomValue(isFetchingAtom)
   const error = useAtomValue(planningErrorAtom)
   const lastViewedByArtifactKey = useAtomValue(lastViewedPlanningArtifactAtom)
 
   const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
   const setActiveArtifact = useSetAtom(activePlanningArtifactAtom)
+  const setRightPaneMode = useSetAtom(rightPaneModeAtom)
   const markPlanningArtifactViewed = useSetAtom(markPlanningArtifactViewedAtom)
   const setPlanningLoading = useSetAtom(planningLoadingAtom)
   const setPlanningError = useSetAtom(planningErrorAtom)
@@ -50,6 +56,11 @@ export function PlanningPane() {
   const scrollPositionsByKeyRef = useRef<Record<string, number>>({})
 
   const activeArtifact = activeArtifactRef ? artifactsByKey[activeArtifactRef.artifactKey] : null
+  const activeArtifactVersion = activeArtifact
+    ? `${activeArtifact.artifactKey}:${activeArtifact.updatedAt}`
+    : null
+
+  const [isContentVisible, setIsContentVisible] = useState(true)
 
   useEffect(() => {
     if (!activeArtifactRef || activeArtifact) {
@@ -119,6 +130,25 @@ export function PlanningPane() {
       updatedAt: activeArtifact.updatedAt,
     })
   }, [activeArtifact, markPlanningArtifactViewed])
+
+  useEffect(() => {
+    if (!activeArtifactVersion) {
+      setIsContentVisible(true)
+      return
+    }
+
+    setIsContentVisible(false)
+
+    let animationFrame = window.requestAnimationFrame(() => {
+      animationFrame = window.requestAnimationFrame(() => {
+        setIsContentVisible(true)
+      })
+    })
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame)
+    }
+  }, [activeArtifactVersion])
 
   const parsedArtifact = useMemo(() => {
     if (!activeArtifact) {
@@ -216,7 +246,7 @@ export function PlanningPane() {
   return (
     <aside className="flex h-full flex-col bg-muted/20">
       <div className="flex flex-col py-2">
-        <div className="flex items-center justify-between px-4">
+        <div className="flex items-center justify-between gap-2 px-4">
           <div className="flex min-w-0 flex-col">
             <h2 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">
               Planning View
@@ -226,11 +256,30 @@ export function PlanningPane() {
             </p>
           </div>
 
-          {activeArtifact ? (
-            <span className="text-xs text-muted-foreground">
-              {new Date(activeArtifact.updatedAt).toLocaleTimeString()}
-            </span>
-          ) : null}
+          <div className="flex items-center gap-2">
+            {activeArtifact ? (
+              <span className="text-xs text-muted-foreground">
+                {new Date(activeArtifact.updatedAt).toLocaleTimeString()}
+              </span>
+            ) : null}
+
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              aria-label="Close planning view"
+              onClick={() => {
+                console.info('Right pane mode toggled', {
+                  trigger: 'manual',
+                  from: 'planning',
+                  to: 'default',
+                })
+                setRightPaneMode('default')
+              }}
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
         </div>
 
         {artifacts.length > 0 ? (
@@ -257,45 +306,60 @@ export function PlanningPane() {
         </div>
       ) : null}
 
-      <div
-        ref={scrollContainerRef}
-        onScroll={handleScroll}
-        className="flex-1 overflow-auto px-4 py-3"
-      >
-        {loading && !activeArtifact ? (
-          <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
-            <Loader2 className="size-5 animate-spin" />
-            <p>Loading planning artifact…</p>
-          </div>
-        ) : null}
+      <div className="relative flex-1 overflow-hidden">
+        <div
+          ref={scrollContainerRef}
+          onScroll={handleScroll}
+          className="h-full overflow-auto px-4 py-3"
+        >
+          {loading && !activeArtifact ? (
+            <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+              <Loader2 className="size-5 animate-spin" />
+              <p>Loading planning artifacts…</p>
+            </div>
+          ) : null}
 
-        {!loading && !activeArtifact ? (
-          <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
-            <p className="font-medium text-foreground">No artifacts yet</p>
-            <p>Start a planning session with `/kata plan` to populate this pane.</p>
-          </div>
-        ) : null}
+          {!loading && artifacts.length === 0 ? (
+            <div className="flex h-full flex-col items-center justify-center px-4 text-center text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">
+                No planning artifacts yet — start planning with /kata plan
+              </p>
+            </div>
+          ) : null}
 
-        {activeArtifact ? (
-          <div
-            role="tabpanel"
-            id={`panel-${activeArtifact.artifactKey}`}
-            aria-labelledby={`tab-${activeArtifact.artifactKey}`}
-            className="text-sm leading-relaxed"
-          >
-            {parsedArtifact?.type === 'roadmap' && parsedArtifact.parsed ? (
-              <RoadmapView roadmap={parsedArtifact.parsed as ParsedRoadmap} />
-            ) : parsedArtifact?.type === 'requirements' && parsedArtifact.parsed ? (
-              <RequirementsView requirements={parsedArtifact.parsed as ParsedRequirements} />
-            ) : parsedArtifact?.type === 'decisions' && parsedArtifact.parsed ? (
-              <DecisionsView decisions={parsedArtifact.parsed as ParsedDecisions} />
-            ) : parsedArtifact?.type === 'context' && parsedArtifact.parsed ? (
-              <ContextView context={parsedArtifact.parsed as ParsedContext} />
-            ) : (
-              <Markdown mode="full" className="text-sm leading-relaxed">
-                {activeArtifact.content}
-              </Markdown>
-            )}
+          {activeArtifact ? (
+            <div
+              role="tabpanel"
+              id={`panel-${activeArtifact.artifactKey}`}
+              aria-labelledby={`tab-${activeArtifact.artifactKey}`}
+              className={cn(
+                'text-sm leading-relaxed transition-[opacity,transform] duration-200 ease-out',
+                isContentVisible ? 'translate-y-0 opacity-100' : 'translate-y-1 opacity-0',
+              )}
+            >
+              {parsedArtifact?.type === 'roadmap' && parsedArtifact.parsed ? (
+                <RoadmapView roadmap={parsedArtifact.parsed as ParsedRoadmap} />
+              ) : parsedArtifact?.type === 'requirements' && parsedArtifact.parsed ? (
+                <RequirementsView requirements={parsedArtifact.parsed as ParsedRequirements} />
+              ) : parsedArtifact?.type === 'decisions' && parsedArtifact.parsed ? (
+                <DecisionsView decisions={parsedArtifact.parsed as ParsedDecisions} />
+              ) : parsedArtifact?.type === 'context' && parsedArtifact.parsed ? (
+                <ContextView context={parsedArtifact.parsed as ParsedContext} />
+              ) : (
+                <Markdown mode="full" className="text-sm leading-relaxed">
+                  {activeArtifact.content}
+                </Markdown>
+              )}
+            </div>
+          ) : null}
+        </div>
+
+        {isFetching ? (
+          <div className="pointer-events-none absolute inset-x-4 top-3 z-10 flex justify-end">
+            <div className="inline-flex items-center gap-2 rounded-md border border-border bg-background/95 px-2.5 py-1 text-xs text-muted-foreground shadow-sm backdrop-blur-sm">
+              <Loader2 className="size-3.5 animate-spin" />
+              <span>Fetching...</span>
+            </div>
           </div>
         ) : null}
       </div>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -22,6 +22,7 @@ export const IPC_CHANNELS = {
   authRemoveKey: 'auth:remove-key',
   authValidateKey: 'auth:validate-key',
   planningArtifactUpdated: 'planning:artifact-updated',
+  planningArtifactFetchState: 'planning:artifact-fetch-state',
   planningFetchArtifact: 'planning:fetch-artifact',
   planningListArtifacts: 'planning:list-artifacts',
 } as const
@@ -418,6 +419,14 @@ export interface PlanningArtifact {
   issueId?: string
 }
 
+export interface PlanningArtifactFetchStateEvent {
+  state: 'start' | 'end'
+  title: string
+  artifactKey: string
+  toolName?: string
+  error?: PlanningArtifactError
+}
+
 export function buildPlanningArtifactKey({
   title,
   scope,
@@ -551,6 +560,7 @@ export interface DesktopApi {
   }
   planning: {
     onArtifactUpdated: (listener: (artifact: PlanningArtifact) => void) => () => void
+    onArtifactFetchState: (listener: (event: PlanningArtifactFetchStateEvent) => void) => () => void
     fetchArtifact: (title: string, artifactKey?: string) => Promise<PlanningArtifactFetchResponse>
     listArtifacts: () => Promise<PlanningArtifactListResponse>
   }


### PR DESCRIPTION
## Summary
- add one-shot planning auto-switch logic with persisted right-pane mode and manual header toggles
- add planning fetch lifecycle signaling from main -> preload -> renderer for in-pane fetching overlays
- polish PlanningPane UX with smooth content fade transitions, empty-state messaging, and inline fetch error continuity
- reset planning session-local state (including auto-switch guard) on new session/workspace switches

## Validation
- bun run --filter @kata/desktop typecheck
- bun run --filter @kata/desktop test
- bun run --filter @kata/desktop build
- bun test apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts

Closes KAT-2148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual loading indicator when fetching planning artifacts
  * New header button provides quick access to the planning view
  * Improved placeholder messages during loading and empty states
  * Enhanced animations for smoother transitions between artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR polishes the planning pane UX by adding a one-shot auto-switch from the default context pane to the planning pane when the first artifact arrives, persisted pane-mode toggles in both directions, an in-pane fetch overlay driven by new `start`/`end` IPC lifecycle events from main → preload → renderer, smooth content fade transitions via a double-`requestAnimationFrame` pattern, improved empty-state messaging, and session/workspace-scoped reset of the auto-switch guard.

**Key changes:**
- `ipc.ts`: Wraps `fetchPlanningArtifact` in an async IIFE and emits `planningArtifactFetchState` events (`start`/`end`) to the renderer, with proper error forwarding.
- `preload/index.ts`: Exposes `onArtifactFetchState` via the context bridge.
- `planning.ts`: Adds `autoSwitchTriggeredAtom`, `isFetchingAtom`, `resetPlanningSessionStateAtom`, and the full auto-switch + fetch-overlay logic in `usePlanningArtifactBridge`.
- `PlanningPane.tsx`: Adds the inline fetching overlay, a close button, the content-fade effect, and an improved empty-state message.
- `RightPane.tsx`: Adds a button to manually open the planning view from the default context pane.
- `session.ts`: Calls `resetPlanningSessionStateAtom` on new session creation and workspace switches.

**Issue found:** In `usePlanningArtifactBridge`, `rightPaneMode` and `autoSwitchTriggered` are read via `useAtomValue` and included in the `useEffect` dependency array, but they are only needed inside the `onArtifactUpdated` callback for the one-shot guard check. As a result, every auto-switch (changing both atoms) or manual pane toggle (changing `rightPaneMode`) causes the effect to re-run — re-calling `listArtifacts()`, re-triggering a brief loading state, and tearing down and re-registering all IPC listeners unnecessarily. Moving these values behind refs and removing them from the dependency array would fix this.

<h3>Confidence Score: 3/5</h3>

Safe to merge with awareness of the re-subscription bug; no data loss or security risk, but redundant IPC calls and transient loading flashes occur on every pane toggle.

The IPC plumbing, preload bridge, type definitions, and UI components are all well-structured and follow existing patterns. The one actionable bug is in `usePlanningArtifactBridge`: including `rightPaneMode` and `autoSwitchTriggered` as `useEffect` dependencies causes `listArtifacts()` to be called again (and listeners to re-register) every time the auto-switch fires or the user toggles the pane manually. This degrades UX with spurious loading flashes and unnecessary IPC round-trips, but doesn't cause data corruption or crashes. The `isFetchingAtom` boolean race is a minor concern for concurrent fetches.

apps/desktop/src/renderer/atoms/planning.ts — the `usePlanningArtifactBridge` `useEffect` dependency array needs attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/atoms/planning.ts | Adds auto-switch guard, fetch-state tracking, and session-reset atom; `useEffect` in `usePlanningArtifactBridge` has a dependency issue that causes `listArtifacts()` to be re-called on every pane-mode or auto-switch-guard change. |
| apps/desktop/src/renderer/components/planning/PlanningPane.tsx | Adds inline fetch overlay, close button, fade transition via double-rAF, and improved empty-state messaging; logic is clean and the double-rAF pattern for CSS-transition triggering is correct. |
| apps/desktop/src/renderer/components/app-shell/RightPane.tsx | Adds a toggle button to open the planning view from the default context pane; straightforward UI change with no issues. |
| apps/desktop/src/main/ipc.ts | Wraps the planning fetch in an async IIFE to emit start/end state events to the renderer; correctly guards against destroyed renderer windows and logs errors on failure. |
| apps/desktop/src/preload/index.ts | Exposes the new `onArtifactFetchState` IPC listener via the preload bridge, following the same unsubscribe-on-return pattern used by `onArtifactUpdated`. |
| apps/desktop/src/renderer/atoms/session.ts | Calls `resetPlanningSessionStateAtom` on new-session creation and workspace switch, correctly scoping the auto-switch guard to the current session. |
| apps/desktop/src/shared/types.ts | Adds `PlanningArtifactFetchStateEvent` type and `planningArtifactFetchState` IPC channel constant; well-typed and consistent with existing patterns. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Planning Tool
    participant Main as main/ipc.ts
    participant Preload as preload/index.ts
    participant Renderer as usePlanningArtifactBridge
    participant UI as PlanningPane

    Agent->>Main: planningArtifactEvent (artifact detected)
    Main->>Preload: send planningArtifactFetchState {state:'start'}
    Preload->>Renderer: onArtifactFetchState({state:'start'})
    Renderer->>UI: setIsFetching(true) → shows overlay

    Main->>Main: fetchPlanningArtifact()

    alt Fetch succeeds
        Main->>Preload: send planningArtifactFetchState {state:'end'}
        Main->>Preload: send planningArtifactUpdated (artifact)
        Preload->>Renderer: onArtifactFetchState({state:'end'})
        Renderer->>UI: setIsFetching(false) → hides overlay
        Preload->>Renderer: onArtifactUpdated(artifact)
        Renderer->>Renderer: auto-switch guard check
        Renderer->>UI: setRightPaneMode('planning') [once only]
        Renderer->>UI: applyPlanningArtifact → content fade-in
    else Fetch fails
        Main->>Preload: send planningArtifactFetchState {state:'end', error}
        Preload->>Renderer: onArtifactFetchState({state:'end', error})
        Renderer->>UI: setIsFetching(false), setError(message)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/planning.ts
Line: 99-200

Comment:
**`listArtifacts()` re-called on every auto-switch / pane toggle**

`rightPaneMode` and `autoSwitchTriggered` are included in the `useEffect` dependency array. Because `usePlanningArtifactBridge` is called in `App.tsx`, any change to either atom causes the effect to fully re-execute — meaning `setLoading(true)` and `listArtifacts()` are called again, and the IPC listeners are torn down and re-registered.

Concretely, when the first artifact arrives and `setRightPaneMode('planning')` + `setAutoSwitchTriggered(true)` are called, both atoms change, immediately triggering another `listArtifacts()` call. The same happens every time the user manually toggles the pane (which changes `rightPaneMode`), and on every session reset (which sets `autoSwitchTriggered` back to `false`).

These values are only used **inside** the `onArtifactUpdated` callback for the one-shot guard check. The standard fix is to put them behind refs so the effect itself doesn't need to re-subscribe:

```ts
// outside the effect:
const rightPaneModeRef = useRef(rightPaneMode)
rightPaneModeRef.current = rightPaneMode

const autoSwitchTriggeredRef = useRef(autoSwitchTriggered)
autoSwitchTriggeredRef.current = autoSwitchTriggered

// inside onArtifactUpdated callback:
if (rightPaneModeRef.current === 'default' && !autoSwitchTriggeredRef.current) {
  ...
}
```

Remove `rightPaneMode` and `autoSwitchTriggered` from the dependency array after making this change.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/planning.ts
Line: 151-166

Comment:
**`isFetchingAtom` not concurrency-safe**

`isFetchingAtom` is a plain boolean. If two artifact fetches are triggered concurrently (e.g. two planning tool invocations in quick succession), the first `'end'` event will set `isFetching` to `false` while the second fetch is still in-flight, hiding the loading indicator prematurely.

Consider tracking a fetch counter instead of a boolean:

```ts
// set on 'start':
setIsFetching((n) => n + 1)
// set on 'end':
setIsFetching((n) => Math.max(0, n - 1))
// read as: isFetching > 0
```

Or, if concurrent fetches are guaranteed to be impossible by the tool detector, add a comment to that effect so future maintainers understand the assumption.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): implement KAT-2150 KAT-21..."](https://github.com/gannonh/kata/commit/95540604e0a5fe32d23e4b4a97c7f600902c79b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27207765)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->