### PR TITLE
feat(desktop): add slice/task planning detection and slice view

### DIFF
--- a/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
+++ b/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
@@ -205,7 +205,34 @@ describe('PlanningToolDetector', () => {
       },
     })
 
-    expect(events).toHaveLength(2)
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-task-status-result-overrides-args',
+      toolName: 'kata_create_task',
+      args: {
+        raw: {
+          kataId: 'T04',
+          title: '[T04] Result precedence task',
+          description: 'task body',
+          sliceIssueId: 'slice-issue-1',
+          initialPhase: 'executing',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-task-status-result-overrides-args',
+      toolName: 'kata_create_task',
+      isError: false,
+      result: {
+        raw: {
+          status: 'completed',
+        },
+      },
+    })
+
+    expect(events).toHaveLength(3)
     expect(events[0]).toMatchObject({
       eventType: 'task_created',
       task: {
@@ -217,6 +244,13 @@ describe('PlanningToolDetector', () => {
       eventType: 'task_created',
       task: {
         id: 'T03',
+        status: 'done',
+      },
+    })
+    expect(events[2]).toMatchObject({
+      eventType: 'task_created',
+      task: {
+        id: 'T04',
         status: 'done',
       },
     })

--- a/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
+++ b/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
@@ -3,7 +3,7 @@ import { PlanningToolDetector } from '../planning-tool-detector'
 import type { PlanningArtifactEvent } from '../../shared/types'
 
 describe('PlanningToolDetector', () => {
-  test('emits planning artifact event for kata_write_document on tool_end', () => {
+  test('emits document planning artifact event for kata_write_document on tool_end', () => {
     const detector = new PlanningToolDetector()
     const events: PlanningArtifactEvent[] = []
 
@@ -32,6 +32,7 @@ describe('PlanningToolDetector', () => {
 
     expect(events).toHaveLength(1)
     expect(events[0]).toEqual({
+      eventType: 'document',
       toolCallId: 'tool-1',
       toolName: 'kata_write_document',
       title: 'M001-ROADMAP',
@@ -43,7 +44,402 @@ describe('PlanningToolDetector', () => {
     })
   })
 
-  test('emits for kata_read_document and ignores failed, unrelated, or non-document planning tools', () => {
+  test('emits slice_created event with normalized slice data for kata_create_slice', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-slice-1',
+      toolName: 'kata_create_slice',
+      args: {
+        raw: {
+          kataId: 'S01',
+          title: '[S01] Build planning pane slice view',
+          description: 'Render slice description and task checklist.',
+          projectId: 'project-123',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-slice-1',
+      toolName: 'kata_create_slice',
+      isError: false,
+      result: {
+        raw: {
+          id: 'slice-issue-1',
+        },
+      },
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({
+      eventType: 'slice_created',
+      toolCallId: 'tool-slice-1',
+      toolName: 'kata_create_slice',
+      title: '[S01] Build planning pane slice view',
+      artifactKey: 'issue:slice-issue-1:[S01] Build planning pane slice view',
+      scope: 'issue',
+      action: 'created',
+      projectId: 'project-123',
+      issueId: 'slice-issue-1',
+      slice: {
+        id: 'S01',
+        title: 'Build planning pane slice view',
+        description: 'Render slice description and task checklist.',
+        issueId: 'slice-issue-1',
+      },
+    })
+  })
+
+  test('emits task_created event for kata_create_task using parent slice issue id', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-task-1',
+      toolName: 'kata_create_task',
+      args: {
+        raw: {
+          kataId: 'T01',
+          title: '[T01] Render task checklist item',
+          description: 'Include task id, title, status, and expandable details.',
+          sliceIssueId: 'slice-issue-1',
+          projectId: 'project-123',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-task-1',
+      toolName: 'kata_create_task',
+      isError: false,
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({
+      eventType: 'task_created',
+      toolCallId: 'tool-task-1',
+      toolName: 'kata_create_task',
+      title: 'slice:slice-issue-1',
+      artifactKey: 'issue:slice-issue-1:slice:slice-issue-1',
+      scope: 'issue',
+      action: 'updated',
+      projectId: 'project-123',
+      issueId: 'slice-issue-1',
+      targetSliceIssueId: 'slice-issue-1',
+      task: {
+        id: 'T01',
+        title: 'Render task checklist item',
+        description: 'Include task id, title, status, and expandable details.',
+        status: 'todo',
+      },
+    })
+  })
+
+  test('emits milestone_created roadmap refresh event for kata_create_milestone', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-milestone-1',
+      toolName: 'kata_create_milestone',
+      args: {
+        raw: {
+          kataId: 'M002',
+          title: '[M002] Planning View',
+          projectId: 'project-123',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-milestone-1',
+      toolName: 'kata_create_milestone',
+      isError: false,
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({
+      eventType: 'milestone_created',
+      toolCallId: 'tool-milestone-1',
+      toolName: 'kata_create_milestone',
+      title: 'M002-ROADMAP',
+      artifactKey: 'project:project-123:M002-ROADMAP',
+      scope: 'project',
+      action: 'updated',
+      projectId: 'project-123',
+    })
+  })
+
+  test('uses positional args fallback for document title extraction', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-read-args-array',
+      toolName: 'kata_read_document',
+      args: {
+        raw: {
+          args: ['REQUIREMENTS'],
+          issueId: 'issue-321',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-read-args-array',
+      toolName: 'kata_read_document',
+      isError: false,
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventType: 'document',
+      title: 'REQUIREMENTS',
+      artifactKey: 'issue:issue-321:REQUIREMENTS',
+    })
+  })
+
+  test('extracts slice issue id from nested result.issue payload', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-slice-nested',
+      toolName: 'kata_create_slice',
+      args: {
+        raw: {
+          title: 'S02: Build nested issue extraction',
+          description: 'Slice description from args.',
+          projectId: 'project-777',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-slice-nested',
+      toolName: 'kata_create_slice',
+      isError: false,
+      result: {
+        raw: {
+          issue: {
+            id: 'slice-issue-nested',
+          },
+        },
+      },
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventType: 'slice_created',
+      scope: 'issue',
+      issueId: 'slice-issue-nested',
+      artifactKey: 'issue:slice-issue-nested:[S02] Build nested issue extraction',
+    })
+  })
+
+  test('extracts issue id from data.issue and supports task id/title fallback parsing', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-slice-data',
+      toolName: 'kata_create_slice',
+      args: {
+        raw: {
+          title: 'S03 - Data issue extraction',
+          description: 'Slice desc',
+          projectId: 'project-888',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-slice-data',
+      toolName: 'kata_create_slice',
+      isError: false,
+      result: {
+        raw: {
+          data: {
+            issue: {
+              id: 'slice-issue-data',
+            },
+          },
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-task-parent',
+      toolName: 'kata_create_task',
+      args: {
+        raw: {
+          title: 'T09 - ParentId fallback task',
+          description: 'Task description',
+          parentId: 'slice-issue-data',
+          projectId: 'project-888',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-task-parent',
+      toolName: 'kata_create_task',
+      isError: false,
+    })
+
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      eventType: 'slice_created',
+      issueId: 'slice-issue-data',
+    })
+    expect(events[1]).toMatchObject({
+      eventType: 'task_created',
+      issueId: 'slice-issue-data',
+      targetSliceIssueId: 'slice-issue-data',
+      task: {
+        id: 'T09',
+        title: 'ParentId fallback task',
+        status: 'todo',
+      },
+    })
+  })
+
+  test('falls back to project scope when create_slice result has no issue id', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-slice-project-scope',
+      toolName: 'kata_create_slice',
+      args: {
+        raw: {
+          title: '[S12] Project scope slice',
+          description: 'No issue id in args/result.',
+          projectId: 'project-xyz',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-slice-project-scope',
+      toolName: 'kata_create_slice',
+      isError: false,
+      result: {
+        raw: {
+          created: true,
+        },
+      },
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventType: 'slice_created',
+      scope: 'project',
+      issueId: undefined,
+      artifactKey: 'project:project-xyz:[S12] Project scope slice',
+    })
+  })
+
+  test('ignores malformed planning payloads and non-tool events', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'turn_start',
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'bad-task',
+      toolName: 'kata_create_task',
+      args: {
+        raw: {
+          title: 'Task without id token',
+          sliceIssueId: 'slice-issue-1',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'bad-task',
+      toolName: 'kata_create_task',
+      isError: false,
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'bad-milestone',
+      toolName: 'kata_create_milestone',
+      args: {
+        raw: {
+          title: 'Milestone without id',
+          projectId: 'project-1',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'bad-milestone',
+      toolName: 'kata_create_milestone',
+      isError: false,
+    })
+
+    expect(events).toHaveLength(0)
+  })
+
+  test('emits for kata_read_document and ignores failed or unrelated tools', () => {
     const detector = new PlanningToolDetector()
     const events: PlanningArtifactEvent[] = []
 
@@ -92,27 +488,9 @@ describe('PlanningToolDetector', () => {
       isError: false,
     })
 
-    detector.handleChatEvent({
-      type: 'tool_start',
-      toolCallId: 'tool-6',
-      toolName: 'kata_create_task',
-      args: {
-        raw: {
-          title: 'Should not emit as document artifact',
-          sliceIssueId: 'issue-should-not-fetch',
-        },
-      },
-    })
-
-    detector.handleChatEvent({
-      type: 'tool_end',
-      toolCallId: 'tool-6',
-      toolName: 'kata_create_task',
-      isError: false,
-    })
-
     expect(events).toHaveLength(1)
     expect(events[0]).toMatchObject({
+      eventType: 'document',
       toolName: 'kata_read_document',
       title: 'DECISIONS',
       artifactKey: 'issue:issue-789:DECISIONS',

--- a/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
+++ b/apps/desktop/src/main/__tests__/planning-tool-detector.test.ts
@@ -149,6 +149,79 @@ describe('PlanningToolDetector', () => {
     })
   })
 
+  test('maps task status from create_task phase payloads', () => {
+    const detector = new PlanningToolDetector()
+    const events: PlanningArtifactEvent[] = []
+
+    detector.on('artifact', (event) => {
+      events.push(event)
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-task-status-progress',
+      toolName: 'kata_create_task',
+      args: {
+        raw: {
+          kataId: 'T02',
+          title: '[T02] In-progress task',
+          description: 'task body',
+          sliceIssueId: 'slice-issue-1',
+          initialPhase: 'executing',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-task-status-progress',
+      toolName: 'kata_create_task',
+      isError: false,
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-task-status-done',
+      toolName: 'kata_create_task',
+      args: {
+        raw: {
+          kataId: 'T03',
+          title: '[T03] Completed task',
+          description: 'task body',
+          sliceIssueId: 'slice-issue-1',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-task-status-done',
+      toolName: 'kata_create_task',
+      isError: false,
+      result: {
+        raw: {
+          status: 'done',
+        },
+      },
+    })
+
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      eventType: 'task_created',
+      task: {
+        id: 'T02',
+        status: 'in_progress',
+      },
+    })
+    expect(events[1]).toMatchObject({
+      eventType: 'task_created',
+      task: {
+        id: 'T03',
+        status: 'done',
+      },
+    })
+  })
+
   test('emits milestone_created roadmap refresh event for kata_create_milestone', () => {
     const detector = new PlanningToolDetector()
     const events: PlanningArtifactEvent[] = []
@@ -411,8 +484,27 @@ describe('PlanningToolDetector', () => {
     })
 
     detector.handleChatEvent({
+      type: 'tool_start',
+      toolCallId: 'bad-task-mid-string-id',
+      toolName: 'kata_create_task',
+      args: {
+        raw: {
+          title: 'Retry T2 implementation details',
+          sliceIssueId: 'slice-issue-1',
+        },
+      },
+    })
+
+    detector.handleChatEvent({
       type: 'tool_end',
       toolCallId: 'bad-task',
+      toolName: 'kata_create_task',
+      isError: false,
+    })
+
+    detector.handleChatEvent({
+      type: 'tool_end',
+      toolCallId: 'bad-task-mid-string-id',
       toolName: 'kata_create_task',
       isError: false,
     })

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -62,6 +62,7 @@ export function registerSessionIpc({
   const planningArtifactsByKey = new Map<string, PlanningArtifact>()
   const planningMetadataByKey = new Map<string, PlanningArtifactEvent>()
   const planningLatestKeyByTitle = new Map<string, string>()
+  const pendingTasksBySliceIssueId = new Map<string, PlanningSliceData['tasks']>()
 
   const canSendToRenderer = (): boolean => !window.isDestroyed() && !window.webContents.isDestroyed()
 
@@ -206,9 +207,38 @@ export function registerSessionIpc({
   }
 
   const upsertPlanningArtifact = (artifact: PlanningArtifact): void => {
-    planningArtifactsByKey.set(artifact.artifactKey, artifact)
-    planningLatestKeyByTitle.set(artifact.title, artifact.artifactKey)
-    sendPlanningArtifactToRenderer(artifact)
+    let artifactToStore = artifact
+
+    if (artifact.artifactType === 'slice') {
+      const sliceIssueId = artifact.sliceData?.issueId ?? artifact.issueId
+      const pendingTasks = sliceIssueId ? pendingTasksBySliceIssueId.get(sliceIssueId) ?? [] : []
+
+      if (sliceIssueId && pendingTasks.length > 0) {
+        pendingTasksBySliceIssueId.delete(sliceIssueId)
+
+        const baseSliceData: PlanningSliceData =
+          artifact.sliceData ??
+          ({
+            id: extractSliceIdFromTitle(artifact.title) ?? 'S00',
+            title: artifact.title,
+            description: artifact.content,
+            issueId: sliceIssueId,
+            tasks: [],
+          } satisfies PlanningSliceData)
+
+        artifactToStore = {
+          ...artifact,
+          sliceData: {
+            ...baseSliceData,
+            tasks: mergeSliceTasks(baseSliceData.tasks, pendingTasks),
+          },
+        }
+      }
+    }
+
+    planningArtifactsByKey.set(artifactToStore.artifactKey, artifactToStore)
+    planningLatestKeyByTitle.set(artifactToStore.title, artifactToStore.artifactKey)
+    sendPlanningArtifactToRenderer(artifactToStore)
   }
 
   const onPlanningArtifactEvent = (planningEvent: PlanningArtifactEvent): void => {
@@ -256,11 +286,30 @@ export function registerSessionIpc({
       })
 
       if (!targetSliceArtifact) {
-        log.warn('[desktop-ipc] unable to append task: slice artifact not found', {
-          taskId: planningEvent.task.id,
-          targetSliceIssueId,
-          artifactKey: planningEvent.artifactKey,
-        })
+        if (targetSliceIssueId) {
+          const existingPendingTasks = pendingTasksBySliceIssueId.get(targetSliceIssueId) ?? []
+          const hasTask = existingPendingTasks.some((task) => task.id === planningEvent.task?.id)
+
+          if (!hasTask) {
+            pendingTasksBySliceIssueId.set(targetSliceIssueId, [
+              ...existingPendingTasks,
+              planningEvent.task,
+            ])
+          }
+
+          log.warn('[desktop-ipc] queued task for unresolved slice artifact', {
+            taskId: planningEvent.task.id,
+            targetSliceIssueId,
+            queuedTasks: hasTask ? existingPendingTasks.length : existingPendingTasks.length + 1,
+            artifactKey: planningEvent.artifactKey,
+          })
+        } else {
+          log.warn('[desktop-ipc] unable to append task: missing target slice issue id', {
+            taskId: planningEvent.task.id,
+            artifactKey: planningEvent.artifactKey,
+          })
+        }
+
         return
       }
 
@@ -275,8 +324,7 @@ export function registerSessionIpc({
         } satisfies PlanningSliceData)
 
       const existingTasks = currentSliceData.tasks
-      const hasTask = existingTasks.some((task) => task.id === planningEvent.task?.id)
-      const nextTasks = hasTask ? existingTasks : [...existingTasks, planningEvent.task]
+      const nextTasks = mergeSliceTasks(existingTasks, [planningEvent.task])
 
       upsertPlanningArtifact({
         ...targetSliceArtifact,
@@ -782,7 +830,11 @@ function detectArtifactTypeFromTitle(title: string): ArtifactType | undefined {
     return 'context'
   }
 
-  if (/^\[S\d+\]\s+/.test(title.trim()) || /^S\d+[:\-\s]/.test(title.trim())) {
+  if (
+    /^\[S\d+\]\s+/.test(title.trim()) ||
+    /^S\d+[:\-\s]/.test(title.trim()) ||
+    /^SLICE:/.test(normalized)
+  ) {
     return 'slice'
   }
 
@@ -792,4 +844,19 @@ function detectArtifactTypeFromTitle(title: string): ArtifactType | undefined {
 function extractSliceIdFromTitle(title: string): string | undefined {
   const match = title.match(/S\d+/i)
   return match?.[0]?.toUpperCase()
+}
+
+function mergeSliceTasks(
+  existingTasks: PlanningSliceData['tasks'],
+  newTasks: PlanningSliceData['tasks'],
+): PlanningSliceData['tasks'] {
+  const mergedTasks = [...existingTasks]
+
+  for (const task of newTasks) {
+    if (!mergedTasks.some((existingTask) => existingTask.id === task.id)) {
+      mergedTasks.push(task)
+    }
+  }
+
+  return mergedTasks
 }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -26,6 +26,7 @@ import {
   buildPlanningArtifactKey,
   type PlanningArtifact,
   type PlanningArtifactEvent,
+  type PlanningSliceData,
   type PlanningArtifactFetchResponse,
   type PlanningArtifactFetchStateEvent,
   type PlanningArtifactListResponse,
@@ -34,6 +35,7 @@ import {
   type SetThinkingLevelResponse,
   type ThinkingLevel,
   type WorkspaceInfo,
+  type ArtifactType,
 } from '../shared/types'
 
 interface RegisterIpcOptions {
@@ -181,6 +183,7 @@ export function registerSessionIpc({
         ...fetchedArtifact,
         scope,
         artifactKey,
+        artifactType: detectArtifactTypeFromTitle(fetchedArtifact.title),
       }
 
       planningArtifactsByKey.set(artifactKey, artifact)
@@ -202,9 +205,91 @@ export function registerSessionIpc({
     }
   }
 
+  const upsertPlanningArtifact = (artifact: PlanningArtifact): void => {
+    planningArtifactsByKey.set(artifact.artifactKey, artifact)
+    planningLatestKeyByTitle.set(artifact.title, artifact.artifactKey)
+    sendPlanningArtifactToRenderer(artifact)
+  }
+
   const onPlanningArtifactEvent = (planningEvent: PlanningArtifactEvent): void => {
     planningMetadataByKey.set(planningEvent.artifactKey, planningEvent)
     planningLatestKeyByTitle.set(planningEvent.title, planningEvent.artifactKey)
+
+    if (planningEvent.eventType === 'slice_created' && planningEvent.slice) {
+      const existingArtifact = planningArtifactsByKey.get(planningEvent.artifactKey)
+      const existingSliceData = existingArtifact?.sliceData
+      const tasks = existingSliceData?.tasks ?? []
+
+      const sliceData: PlanningSliceData = {
+        id: planningEvent.slice.id,
+        title: planningEvent.slice.title,
+        description: planningEvent.slice.description,
+        issueId: planningEvent.slice.issueId ?? planningEvent.issueId,
+        tasks,
+      }
+
+      upsertPlanningArtifact({
+        title: planningEvent.title,
+        artifactKey: planningEvent.artifactKey,
+        content: sliceData.description,
+        updatedAt: new Date().toISOString(),
+        scope: planningEvent.scope,
+        projectId: planningEvent.projectId,
+        issueId: planningEvent.issueId,
+        artifactType: 'slice',
+        sliceData,
+      })
+
+      return
+    }
+
+    if (planningEvent.eventType === 'task_created' && planningEvent.task) {
+      const targetSliceIssueId = planningEvent.targetSliceIssueId ?? planningEvent.issueId
+      const targetSliceArtifact = Array.from(planningArtifactsByKey.values()).find((artifact) => {
+        if (artifact.artifactType !== 'slice') {
+          return false
+        }
+
+        return (
+          artifact.issueId === targetSliceIssueId || artifact.sliceData?.issueId === targetSliceIssueId
+        )
+      })
+
+      if (!targetSliceArtifact) {
+        log.warn('[desktop-ipc] unable to append task: slice artifact not found', {
+          taskId: planningEvent.task.id,
+          targetSliceIssueId,
+          artifactKey: planningEvent.artifactKey,
+        })
+        return
+      }
+
+      const currentSliceData =
+        targetSliceArtifact.sliceData ??
+        ({
+          id: extractSliceIdFromTitle(targetSliceArtifact.title) ?? 'S00',
+          title: targetSliceArtifact.title,
+          description: targetSliceArtifact.content,
+          issueId: targetSliceIssueId,
+          tasks: [],
+        } satisfies PlanningSliceData)
+
+      const existingTasks = currentSliceData.tasks
+      const hasTask = existingTasks.some((task) => task.id === planningEvent.task?.id)
+      const nextTasks = hasTask ? existingTasks : [...existingTasks, planningEvent.task]
+
+      upsertPlanningArtifact({
+        ...targetSliceArtifact,
+        updatedAt: new Date().toISOString(),
+        artifactType: 'slice',
+        sliceData: {
+          ...currentSliceData,
+          tasks: nextTasks,
+        },
+      })
+
+      return
+    }
 
     sendPlanningFetchStateToRenderer({
       state: 'start',
@@ -676,4 +761,35 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.planningFetchArtifact)
     ipcMain.removeHandler(IPC_CHANNELS.planningListArtifacts)
   }
+}
+
+function detectArtifactTypeFromTitle(title: string): ArtifactType | undefined {
+  const normalized = title.trim().toUpperCase()
+
+  if (/-ROADMAP(?:\b|$)/.test(normalized) || normalized === 'ROADMAP') {
+    return 'roadmap'
+  }
+
+  if (normalized === 'REQUIREMENTS' || /-REQUIREMENTS(?:\b|$)/.test(normalized)) {
+    return 'requirements'
+  }
+
+  if (normalized === 'DECISIONS' || /-DECISIONS(?:\b|$)/.test(normalized)) {
+    return 'decisions'
+  }
+
+  if (/-CONTEXT(?:\b|$)/.test(normalized) || normalized === 'CONTEXT') {
+    return 'context'
+  }
+
+  if (/^\[S\d+\]\s+/.test(title.trim()) || /^S\d+[:\-\s]/.test(title.trim())) {
+    return 'slice'
+  }
+
+  return undefined
+}
+
+function extractSliceIdFromTitle(title: string): string | undefined {
+  const match = title.match(/S\d+/i)
+  return match?.[0]?.toUpperCase()
 }

--- a/apps/desktop/src/main/planning-tool-detector.ts
+++ b/apps/desktop/src/main/planning-tool-detector.ts
@@ -369,9 +369,6 @@ function resolveTaskStatus(
   result: Record<string, unknown>,
 ): 'todo' | 'in_progress' | 'done' {
   const candidates: Array<string | undefined> = [
-    asString(args.initialPhase),
-    asString(args.phase),
-    asString(args.status),
     asString(result.initialPhase),
     asString(result.phase),
     asString(result.status),
@@ -389,6 +386,9 @@ function resolveTaskStatus(
     asString(statePayload?.type),
     asString(taskPayload?.status),
     asString(taskPayload?.phase),
+    asString(args.initialPhase),
+    asString(args.phase),
+    asString(args.status),
   )
 
   for (const candidate of candidates) {

--- a/apps/desktop/src/main/planning-tool-detector.ts
+++ b/apps/desktop/src/main/planning-tool-detector.ts
@@ -193,6 +193,7 @@ export class PlanningToolDetector extends EventEmitter {
 
       const taskTitle = stripKataIdPrefix(rawTitle, taskId) || rawTitle
       const description = asString(args.description) ?? ''
+      const taskStatus = resolveTaskStatus(args, result)
 
       return {
         eventType: 'task_created',
@@ -214,7 +215,7 @@ export class PlanningToolDetector extends EventEmitter {
           id: taskId,
           title: taskTitle,
           description,
-          status: 'todo',
+          status: taskStatus,
         },
       }
     }
@@ -346,13 +347,13 @@ function extractKataId(rawValue: string | undefined, prefix: 'M' | 'S' | 'T'): s
   }
 
   const trimmed = rawValue.trim()
-  const pattern = new RegExp(`${prefix}\\d+`, 'i')
-  const match = trimmed.match(pattern)
-  if (!match) {
+  const leadingPattern = new RegExp(`^\\[?(${prefix}\\d+)\\]?(?=\\b|[:\\-\\s])`, 'i')
+  const leadingMatch = trimmed.match(leadingPattern)
+  if (!leadingMatch?.[1]) {
     return undefined
   }
 
-  return match[0].toUpperCase()
+  return leadingMatch[1].toUpperCase()
 }
 
 function stripKataIdPrefix(rawTitle: string, kataId: string): string {
@@ -361,4 +362,76 @@ function stripKataIdPrefix(rawTitle: string, kataId: string): string {
     .replace(new RegExp(`^\\[${escapedKataId}\\]\\s*`, 'i'), '')
     .replace(new RegExp(`^${escapedKataId}[:\\-\\s]+`, 'i'), '')
     .trim()
+}
+
+function resolveTaskStatus(
+  args: Record<string, unknown>,
+  result: Record<string, unknown>,
+): 'todo' | 'in_progress' | 'done' {
+  const candidates: Array<string | undefined> = [
+    asString(args.initialPhase),
+    asString(args.phase),
+    asString(args.status),
+    asString(result.initialPhase),
+    asString(result.phase),
+    asString(result.status),
+  ]
+
+  const issuePayload = isRecord(result.issue) ? result.issue : undefined
+  const taskPayload = isRecord(result.task) ? result.task : undefined
+  const statePayload = isRecord(issuePayload?.state) ? issuePayload.state : undefined
+
+  candidates.push(
+    asString(issuePayload?.status),
+    asString(issuePayload?.phase),
+    asString(issuePayload?.state),
+    asString(statePayload?.name),
+    asString(statePayload?.type),
+    asString(taskPayload?.status),
+    asString(taskPayload?.phase),
+  )
+
+  for (const candidate of candidates) {
+    const normalized = normalizePhase(candidate)
+    if (!normalized) {
+      continue
+    }
+
+    if (
+      normalized === 'done' ||
+      normalized === 'completed' ||
+      normalized === 'complete' ||
+      normalized === 'closed'
+    ) {
+      return 'done'
+    }
+
+    if (
+      normalized === 'in_progress' ||
+      normalized === 'progress' ||
+      normalized === 'started' ||
+      normalized === 'starting' ||
+      normalized === 'executing' ||
+      normalized === 'doing' ||
+      normalized === 'active' ||
+      normalized === 'in_review' ||
+      normalized === 'review'
+    ) {
+      return 'in_progress'
+    }
+  }
+
+  return 'todo'
+}
+
+function normalizePhase(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
 }

--- a/apps/desktop/src/main/planning-tool-detector.ts
+++ b/apps/desktop/src/main/planning-tool-detector.ts
@@ -6,6 +6,7 @@ import {
   type PlanningArtifactEvent,
   type PlanningArtifactScope,
   type ToolArgs,
+  type ToolResult,
 } from '../shared/types'
 
 interface PendingToolCall {
@@ -20,6 +21,9 @@ interface PlanningToolDetectorEvents {
 const PLANNING_TOOL_NAMES = new Set([
   'kata_write_document',
   'kata_read_document',
+  'kata_create_slice',
+  'kata_create_task',
+  'kata_create_milestone',
 ])
 
 export class PlanningToolDetector extends EventEmitter {
@@ -59,11 +63,12 @@ export class PlanningToolDetector extends EventEmitter {
       return
     }
 
-    const artifactEvent = this.toPlanningArtifactEvent(
-      event.toolCallId,
-      event.toolName,
-      pending?.args,
-    )
+    const artifactEvent = this.toPlanningArtifactEvent({
+      toolCallId: event.toolCallId,
+      toolName: event.toolName,
+      toolArgs: pending?.args,
+      toolResult: event.result,
+    })
 
     if (!artifactEvent) {
       return
@@ -71,47 +76,174 @@ export class PlanningToolDetector extends EventEmitter {
 
     log.info('[planning-tool-detector] planning:tool-detected', {
       toolName: artifactEvent.toolName,
+      eventType: artifactEvent.eventType,
       documentTitle: artifactEvent.title,
       scope: artifactEvent.scope,
       action: artifactEvent.action,
       projectId: artifactEvent.projectId,
       issueId: artifactEvent.issueId,
+      targetSliceIssueId: artifactEvent.targetSliceIssueId,
     })
 
     this.emit('artifact', artifactEvent)
   }
 
-  private toPlanningArtifactEvent(
-    toolCallId: string,
-    toolName: string,
-    toolArgs: ToolArgs | undefined,
-  ): PlanningArtifactEvent | null {
+  private toPlanningArtifactEvent({
+    toolCallId,
+    toolName,
+    toolArgs,
+    toolResult,
+  }: {
+    toolCallId: string
+    toolName: string
+    toolArgs: ToolArgs | undefined
+    toolResult: ToolResult | undefined
+  }): PlanningArtifactEvent | null {
     const args = this.extractRawArgs(toolArgs)
-    const title = this.extractTitle(toolName, args)
+    const result = this.extractRawResult(toolResult)
 
-    if (!title) {
-      return null
-    }
-
-    const issueId = this.extractIssueId(args)
     const projectId = asString(args.projectId)
-    const scope = this.extractScope(args)
 
-    return {
-      toolCallId,
-      toolName,
-      title,
-      artifactKey: buildPlanningArtifactKey({
+    if (toolName === 'kata_write_document' || toolName === 'kata_read_document') {
+      const title = this.extractDocumentTitle(args)
+      if (!title) {
+        return null
+      }
+
+      const issueId = this.extractIssueId(args)
+      const scope = issueId ? 'issue' : 'project'
+
+      return {
+        eventType: 'document',
+        toolCallId,
+        toolName,
         title,
+        artifactKey: buildPlanningArtifactKey({
+          title,
+          scope,
+          projectId,
+          issueId,
+        }),
         scope,
+        action: 'updated',
         projectId,
         issueId,
-      }),
-      scope,
-      action: 'updated',
-      projectId,
-      issueId,
+      }
     }
+
+    if (toolName === 'kata_create_slice') {
+      const rawTitle = asString(args.title)
+      if (!rawTitle) {
+        return null
+      }
+
+      const sliceId = asString(args.kataId) ?? extractKataId(rawTitle, 'S')
+      if (!sliceId) {
+        return null
+      }
+
+      const normalizedSliceTitle = stripKataIdPrefix(rawTitle, sliceId)
+      const displayTitle = `[${sliceId}] ${normalizedSliceTitle || rawTitle}`
+      const description = asString(args.description) ?? ''
+
+      const sliceIssueId =
+        this.extractIssueId(result) ?? this.extractIssueId(args) ?? this.extractIssueFromCreateResult(result)
+
+      const scope: PlanningArtifactScope = sliceIssueId ? 'issue' : 'project'
+
+      return {
+        eventType: 'slice_created',
+        toolCallId,
+        toolName,
+        title: displayTitle,
+        artifactKey: buildPlanningArtifactKey({
+          title: displayTitle,
+          scope,
+          projectId,
+          issueId: sliceIssueId,
+        }),
+        scope,
+        action: 'created',
+        projectId,
+        issueId: sliceIssueId,
+        slice: {
+          id: sliceId,
+          title: normalizedSliceTitle || rawTitle,
+          description,
+          issueId: sliceIssueId,
+        },
+      }
+    }
+
+    if (toolName === 'kata_create_task') {
+      const rawTitle = asString(args.title)
+      if (!rawTitle) {
+        return null
+      }
+
+      const taskId = asString(args.kataId) ?? extractKataId(rawTitle, 'T')
+      if (!taskId) {
+        return null
+      }
+
+      const sliceIssueId = this.extractIssueId(args)
+      if (!sliceIssueId) {
+        return null
+      }
+
+      const taskTitle = stripKataIdPrefix(rawTitle, taskId) || rawTitle
+      const description = asString(args.description) ?? ''
+
+      return {
+        eventType: 'task_created',
+        toolCallId,
+        toolName,
+        title: `slice:${sliceIssueId}`,
+        artifactKey: buildPlanningArtifactKey({
+          title: `slice:${sliceIssueId}`,
+          scope: 'issue',
+          issueId: sliceIssueId,
+          projectId,
+        }),
+        scope: 'issue',
+        action: 'updated',
+        projectId,
+        issueId: sliceIssueId,
+        targetSliceIssueId: sliceIssueId,
+        task: {
+          id: taskId,
+          title: taskTitle,
+          description,
+          status: 'todo',
+        },
+      }
+    }
+
+    if (toolName === 'kata_create_milestone') {
+      const milestoneId = asString(args.kataId) ?? extractKataId(asString(args.title), 'M')
+      if (!milestoneId) {
+        return null
+      }
+
+      const roadmapTitle = `${milestoneId}-ROADMAP`
+
+      return {
+        eventType: 'milestone_created',
+        toolCallId,
+        toolName,
+        title: roadmapTitle,
+        artifactKey: buildPlanningArtifactKey({
+          title: roadmapTitle,
+          scope: 'project',
+          projectId,
+        }),
+        scope: 'project',
+        action: 'updated',
+        projectId,
+      }
+    }
+
+    return null
   }
 
   private extractRawArgs(toolArgs: ToolArgs | undefined): Record<string, unknown> {
@@ -130,7 +262,23 @@ export class PlanningToolDetector extends EventEmitter {
     return {}
   }
 
-  private extractTitle(_toolName: string, args: Record<string, unknown>): string | null {
+  private extractRawResult(toolResult: ToolResult | undefined): Record<string, unknown> {
+    if (!toolResult) {
+      return {}
+    }
+
+    if ('raw' in toolResult && isRecord(toolResult.raw)) {
+      return toolResult.raw
+    }
+
+    if (isRecord(toolResult)) {
+      return toolResult
+    }
+
+    return {}
+  }
+
+  private extractDocumentTitle(args: Record<string, unknown>): string | null {
     const directTitle = asString(args.title)
     if (directTitle) {
       return directTitle
@@ -141,10 +289,6 @@ export class PlanningToolDetector extends EventEmitter {
     }
 
     return null
-  }
-
-  private extractScope(args: Record<string, unknown>): PlanningArtifactScope {
-    return this.extractIssueId(args) ? 'issue' : 'project'
   }
 
   private extractIssueId(args: Record<string, unknown>): string | undefined {
@@ -166,6 +310,26 @@ export class PlanningToolDetector extends EventEmitter {
     return undefined
   }
 
+  private extractIssueFromCreateResult(result: Record<string, unknown>): string | undefined {
+    const directIssueId = asString(result.id) ?? asString(result.issueId)
+    if (directIssueId) {
+      return directIssueId
+    }
+
+    if (isRecord(result.issue)) {
+      return asString(result.issue.id)
+    }
+
+    if (isRecord(result.sliceIssue)) {
+      return asString(result.sliceIssue.id)
+    }
+
+    if (isRecord(result.data) && isRecord(result.data.issue)) {
+      return asString(result.data.issue.id)
+    }
+
+    return undefined
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -174,4 +338,27 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function extractKataId(rawValue: string | undefined, prefix: 'M' | 'S' | 'T'): string | undefined {
+  if (!rawValue) {
+    return undefined
+  }
+
+  const trimmed = rawValue.trim()
+  const pattern = new RegExp(`${prefix}\\d+`, 'i')
+  const match = trimmed.match(pattern)
+  if (!match) {
+    return undefined
+  }
+
+  return match[0].toUpperCase()
+}
+
+function stripKataIdPrefix(rawTitle: string, kataId: string): string {
+  const escapedKataId = kataId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return rawTitle
+    .replace(new RegExp(`^\\[${escapedKataId}\\]\\s*`, 'i'), '')
+    .replace(new RegExp(`^${escapedKataId}[:\\-\\s]+`, 'i'), '')
+    .trim()
 }

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -1,7 +1,7 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import { useEffect, useRef } from 'react'
-import type { PlanningArtifact } from '@shared/types'
+import type { PlanningArtifact, PlanningSliceData } from '@shared/types'
 
 export const RIGHT_PANE_MODE_STORAGE_KEY = 'kata-desktop:right-pane-mode'
 
@@ -13,6 +13,8 @@ export interface PlanningArtifactState {
   scope: PlanningArtifact['scope']
   projectId?: string
   issueId?: string
+  artifactType?: PlanningArtifact['artifactType']
+  sliceData?: PlanningSliceData
 }
 
 export type PlanningArtifactsMap = Record<string, PlanningArtifactState>
@@ -23,6 +25,7 @@ export interface ActivePlanningArtifactRef {
 }
 
 export const planningArtifactsAtom = atom<PlanningArtifactsMap>({})
+export const slicePlanningAtom = atom<Record<string, PlanningSliceData>>({})
 export const activePlanningArtifactAtom = atom<ActivePlanningArtifactRef | null>(null)
 export const rightPaneModeAtom = atomWithStorage<'planning' | 'default'>(
   RIGHT_PANE_MODE_STORAGE_KEY,
@@ -48,6 +51,7 @@ export const markPlanningArtifactViewedAtom = atom(
 export const resetPlanningSessionStateAtom = atom(null, (_get, set) => {
   set(planningArtifactsAtom, {})
   set(activePlanningArtifactAtom, null)
+  set(slicePlanningAtom, {})
   set(autoSwitchTriggeredAtom, false)
   set(planningLoadingAtom, false)
   set(artifactFetchInFlightCountAtom, 0)
@@ -66,10 +70,19 @@ export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: Plannin
       scope: artifact.scope,
       projectId: artifact.projectId,
       issueId: artifact.issueId,
+      artifactType: artifact.artifactType,
+      sliceData: artifact.sliceData,
     },
   }
 
   set(planningArtifactsAtom, nextArtifacts)
+
+  if (artifact.artifactType === 'slice' && artifact.sliceData) {
+    set(slicePlanningAtom, {
+      ...get(slicePlanningAtom),
+      [artifact.artifactKey]: artifact.sliceData,
+    })
+  }
 
   const currentActiveArtifact = get(activePlanningArtifactAtom)
   if (!currentActiveArtifact || !nextArtifacts[currentActiveArtifact.artifactKey]) {
@@ -93,6 +106,7 @@ export function usePlanningArtifactBridge(): void {
   const rightPaneModeRef = useRef(rightPaneMode)
   const autoSwitchTriggeredRef = useRef(autoSwitchTriggered)
   const setActiveArtifactTitle = useSetAtom(activePlanningArtifactAtom)
+  const setSlices = useSetAtom(slicePlanningAtom)
   const setRightPaneMode = useSetAtom(rightPaneModeAtom)
   const setAutoSwitchTriggered = useSetAtom(autoSwitchTriggeredAtom)
   const setLoading = useSetAtom(planningLoadingAtom)
@@ -127,12 +141,29 @@ export function usePlanningArtifactBridge(): void {
             scope: artifact.scope,
             projectId: artifact.projectId,
             issueId: artifact.issueId,
+            artifactType: artifact.artifactType,
+            sliceData: artifact.sliceData,
           }
         }
 
         setArtifacts((currentArtifacts) => ({
           ...nextArtifacts,
           ...currentArtifacts,
+        }))
+
+        const nextSlices = response.artifacts.reduce<Record<string, PlanningSliceData>>(
+          (result, artifact) => {
+            if (artifact.artifactType === 'slice' && artifact.sliceData) {
+              result[artifact.artifactKey] = artifact.sliceData
+            }
+            return result
+          },
+          {},
+        )
+
+        setSlices((currentSlices) => ({
+          ...nextSlices,
+          ...currentSlices,
         }))
 
         const mostRecentArtifact = response.artifacts[0]
@@ -203,5 +234,6 @@ export function usePlanningArtifactBridge(): void {
     setError,
     setLoading,
     setRightPaneMode,
+    setSlices,
   ])
 }

--- a/apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx
+++ b/apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx
@@ -11,9 +11,10 @@ export interface ArtifactTabsProps {
 
 const TYPE_SORT_ORDER: Record<string, number> = {
   roadmap: 0,
-  requirements: 1,
-  decisions: 2,
-  context: 3,
+  slice: 1,
+  requirements: 2,
+  decisions: 3,
+  context: 4,
 }
 
 const TYPE_LABEL: Record<string, string> = {
@@ -86,6 +87,10 @@ export function ArtifactTabs({
 function formatArtifactTitle(title: string, typeCounts: Record<string, number>): string {
   const detectedType = detectArtifactType(title)
   if (!detectedType) {
+    return title
+  }
+
+  if (detectedType === 'slice') {
     return title
   }
 

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -18,12 +18,14 @@ import {
   planningErrorAtom,
   planningLoadingAtom,
   rightPaneModeAtom,
+  slicePlanningAtom,
 } from '@/atoms/planning'
 import { ArtifactTabs } from '@/components/planning/ArtifactTabs'
 import { ContextView } from '@/components/planning/ContextView'
 import { DecisionsView } from '@/components/planning/DecisionsView'
 import { RequirementsView } from '@/components/planning/RequirementsView'
 import { RoadmapView } from '@/components/planning/RoadmapView'
+import { SliceView } from '@/components/planning/SliceView'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import {
@@ -42,6 +44,7 @@ export function PlanningPane() {
   const isFetching = useAtomValue(isFetchingAtom)
   const error = useAtomValue(planningErrorAtom)
   const lastViewedByArtifactKey = useAtomValue(lastViewedPlanningArtifactAtom)
+  const slicesByArtifactKey = useAtomValue(slicePlanningAtom)
 
   const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
   const setActiveArtifact = useSetAtom(activePlanningArtifactAtom)
@@ -169,7 +172,7 @@ export function PlanningPane() {
       return null
     }
 
-    const type = detectArtifactType(activeArtifact.title)
+    const type = activeArtifact.artifactType ?? detectArtifactType(activeArtifact.title)
 
     if (type === 'roadmap') {
       return {
@@ -199,13 +202,25 @@ export function PlanningPane() {
       }
     }
 
+    if (type === 'slice') {
+      return {
+        type,
+        parsed: null,
+      }
+    }
+
     return {
       type: null,
       parsed: null,
     }
   }, [activeArtifact])
 
-  const parseFailed = Boolean(activeArtifact && parsedArtifact?.type && !parsedArtifact.parsed)
+  const parseFailed = Boolean(
+    activeArtifact &&
+      parsedArtifact?.type &&
+      parsedArtifact.type !== 'slice' &&
+      !parsedArtifact.parsed,
+  )
 
   useEffect(() => {
     if (!activeArtifact || !parseFailed || !parsedArtifact?.type) {
@@ -359,6 +374,10 @@ export function PlanningPane() {
                 <DecisionsView decisions={parsedArtifact.parsed as ParsedDecisions} />
               ) : parsedArtifact?.type === 'context' && parsedArtifact.parsed ? (
                 <ContextView context={parsedArtifact.parsed as ParsedContext} />
+              ) : parsedArtifact?.type === 'slice' ? (
+                <SliceView
+                  slice={activeArtifact.sliceData ?? slicesByArtifactKey[activeArtifact.artifactKey]}
+                />
               ) : (
                 <Markdown mode="full" className="text-sm leading-relaxed">
                   {activeArtifact.content}

--- a/apps/desktop/src/renderer/components/planning/SliceView.tsx
+++ b/apps/desktop/src/renderer/components/planning/SliceView.tsx
@@ -63,6 +63,12 @@ export function SliceView({ slice }: SliceViewProps) {
                         readOnly
                         aria-label={`${task.id} completion state`}
                         className="size-4 rounded border-border"
+                        onClick={(event) => {
+                          event.stopPropagation()
+                        }}
+                        onMouseDown={(event) => {
+                          event.stopPropagation()
+                        }}
                       />
 
                       <Badge variant="outline">{task.id}</Badge>

--- a/apps/desktop/src/renderer/components/planning/SliceView.tsx
+++ b/apps/desktop/src/renderer/components/planning/SliceView.tsx
@@ -1,0 +1,106 @@
+import { ChevronDown } from 'lucide-react'
+import type { PlanningSliceData } from '@shared/types'
+import { Badge } from '@/components/ui/badge'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { cn } from '@/lib/utils'
+
+export interface SliceViewProps {
+  slice?: PlanningSliceData
+}
+
+export function SliceView({ slice }: SliceViewProps) {
+  if (!slice) {
+    return (
+      <div className="rounded-lg border border-border bg-background px-3 py-4 text-sm text-muted-foreground">
+        Slice details are not available yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <section className="rounded-lg border border-border bg-background px-3 py-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="secondary">{slice.id}</Badge>
+          <h3 className="text-sm font-semibold text-foreground">{slice.title}</h3>
+        </div>
+
+        <div className="mt-3">
+          <p className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">Description</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+            {slice.description || 'No description provided.'}
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">Task Checklist</p>
+          <span className="text-xs text-muted-foreground">{slice.tasks.length} tasks</span>
+        </div>
+
+        {slice.tasks.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-background px-3 py-4 text-sm text-muted-foreground">
+            No tasks created yet.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {slice.tasks.map((task) => {
+              const isDone = task.status === 'done'
+              const isInProgress = task.status === 'in_progress'
+
+              return (
+                <Collapsible
+                  key={`${slice.id}-${task.id}-${task.title}`}
+                  defaultOpen={false}
+                  className="group/task overflow-hidden rounded-lg border border-border bg-background"
+                >
+                  <CollapsibleTrigger asChild>
+                    <button type="button" className="flex w-full items-center gap-2 px-3 py-2 text-left">
+                      <input
+                        type="checkbox"
+                        checked={isDone}
+                        readOnly
+                        aria-label={`${task.id} completion state`}
+                        className="size-4 rounded border-border"
+                      />
+
+                      <Badge variant="outline">{task.id}</Badge>
+
+                      <div className="min-w-0 flex-1">
+                        <p className={cn('truncate text-sm font-medium', isDone && 'line-through text-muted-foreground')}>
+                          {task.title}
+                        </p>
+                      </div>
+
+                      <Badge
+                        className={cn(
+                          'capitalize',
+                          isDone && 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300',
+                          isInProgress &&
+                            'bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300',
+                          !isDone && !isInProgress &&
+                            'bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300',
+                        )}
+                      >
+                        {task.status.replace('_', ' ')}
+                      </Badge>
+
+                      <ChevronDown className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]/task:rotate-180" />
+                    </button>
+                  </CollapsibleTrigger>
+
+                  <CollapsibleContent className="border-t border-border px-3 py-2">
+                    <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+                      {task.description || 'No description provided.'}
+                    </p>
+                  </CollapsibleContent>
+                </Collapsible>
+              )
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts
@@ -126,6 +126,7 @@ describe('artifact-parser', () => {
     expect(detectArtifactType('DECISIONS')).toBe('decisions')
     expect(detectArtifactType('M002-CONTEXT')).toBe('context')
     expect(detectArtifactType('[S01] Slice and Task Detection')).toBe('slice')
+    expect(detectArtifactType('SLICE: Legacy slice artifact')).toBe('slice')
     expect(detectArtifactType('PROJECT')).toBeNull()
   })
 

--- a/apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/artifact-parser.test.ts
@@ -125,6 +125,7 @@ describe('artifact-parser', () => {
     expect(detectArtifactType('REQUIREMENTS')).toBe('requirements')
     expect(detectArtifactType('DECISIONS')).toBe('decisions')
     expect(detectArtifactType('M002-CONTEXT')).toBe('context')
+    expect(detectArtifactType('[S01] Slice and Task Detection')).toBe('slice')
     expect(detectArtifactType('PROJECT')).toBeNull()
   })
 

--- a/apps/desktop/src/renderer/lib/artifact-parser.ts
+++ b/apps/desktop/src/renderer/lib/artifact-parser.ts
@@ -35,6 +35,10 @@ export function detectArtifactType(title: string): ArtifactType | null {
     return 'context'
   }
 
+  if (/^\[S\d+\]\s+/.test(title.trim()) || /^S\d+[:\-\s]/.test(title.trim()) || /^SLICE:/.test(normalized)) {
+    return 'slice'
+  }
+
   return null
 }
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -398,7 +398,29 @@ export interface PlanningArtifactError {
   message: string
 }
 
+export interface PlanningSliceTask {
+  id: string
+  title: string
+  description: string
+  status: 'todo' | 'in_progress' | 'done'
+}
+
+export interface PlanningSliceData {
+  id: string
+  title: string
+  description: string
+  issueId?: string
+  tasks: PlanningSliceTask[]
+}
+
+export type PlanningArtifactEventType =
+  | 'document'
+  | 'slice_created'
+  | 'task_created'
+  | 'milestone_created'
+
 export interface PlanningArtifactEvent {
+  eventType: PlanningArtifactEventType
   toolName: string
   toolCallId: string
   title: string
@@ -407,6 +429,9 @@ export interface PlanningArtifactEvent {
   action: PlanningArtifactAction
   projectId?: string
   issueId?: string
+  slice?: Omit<PlanningSliceData, 'tasks'>
+  task?: PlanningSliceTask
+  targetSliceIssueId?: string
 }
 
 export interface PlanningArtifact {
@@ -417,6 +442,8 @@ export interface PlanningArtifact {
   scope: PlanningArtifactScope
   projectId?: string
   issueId?: string
+  artifactType?: ArtifactType
+  sliceData?: PlanningSliceData
 }
 
 export interface PlanningArtifactFetchStateEvent {
@@ -459,7 +486,7 @@ export interface PlanningArtifactListResponse {
   error?: PlanningArtifactError
 }
 
-export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context'
+export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context' | 'slice'
 
 export type RoadmapRisk = 'high' | 'medium' | 'low'
 


### PR DESCRIPTION
## Summary
- extend planning tool detection to include `kata_create_slice`, `kata_create_task`, and `kata_create_milestone`
- construct slice/task planning artifacts directly from tool args/results and route them through IPC without Linear document fetches
- add `SliceView` and slice planning atom support so slice tabs render description + task checklist with expandable task details
- keep milestone-created ROADMAP refresh on the existing document fetch pipeline
- expand detector and artifact parser test coverage for slice/task/milestone behavior

## Validation
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx vitest run src/main/__tests__/planning-tool-detector.test.ts src/renderer/lib/__tests__/artifact-parser.test.ts`
- `cd apps/desktop && bun run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added planning slices, task creation/aggregation, and milestone creation with normalized fields and status mapping.

* **UI**
  * Slice view added to planning pane and artifact tabs; slices ordered and show tasks, statuses, IDs and descriptions.

* **Detection**
  * Artifact detection now recognizes slice title patterns and prefers explicit artifact types.

* **Tests**
  * Expanded tests for document/slice/task/milestone events, payload normalization, edge cases and negative scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the planning tool detector to handle `kata_create_slice`, `kata_create_task`, and `kata_create_milestone`, routing slice/task artifacts directly through IPC (bypassing Linear document fetches) while keeping milestone creation on the existing document-fetch pipeline. The new `SliceView` component and `slicePlanningAtom` complete the renderer-side rendering of slice tabs with description and expandable task checklist.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/robustness suggestions with no current runtime breakage.

The core logic is correct and well-tested. The three findings are all non-blocking: orphaned task handling is a future-proofing concern, the detectArtifactTypeFromTitle divergence has no current impact since slices bypass Linear fetching, and the unanchored regex is a fallback path that is rarely exercised in practice.

ipc.ts (task-dropped edge case and detectArtifactTypeFromTitle divergence); planning-tool-detector.ts (unanchored extractKataId regex)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/planning-tool-detector.ts | Adds detection for kata_create_slice/task/milestone tools with multi-path issue ID extraction and KataId regex fallback parsing; logic is correct and well-covered by tests. |
| apps/desktop/src/main/ipc.ts | Routes slice_created and task_created events directly through IPC without Linear fetches; task_created silently drops if the parent slice artifact is not yet in memory. |
| apps/desktop/src/renderer/atoms/planning.ts | Adds slicePlanningAtom and wires it into applyPlanningArtifactAtom and resetPlanningSessionStateAtom; slice data is kept in sync with planningArtifactsAtom. |
| apps/desktop/src/renderer/components/planning/SliceView.tsx | New read-only slice view with collapsible task checklist; clean implementation with correct readOnly checkbox semantics. |
| apps/desktop/src/renderer/components/planning/ArtifactTabs.tsx | Adds slice to TYPE_SORT_ORDER (position 1) and intentionally omits it from TYPE_LABEL so raw slice titles are displayed; no issues. |
| apps/desktop/src/renderer/lib/artifact-parser.ts | Extends detectArtifactType with three slice-title patterns ([S\d+], S\d+:-, SLICE:) for the renderer; consistent with how the detector emits slice titles. |
| apps/desktop/src/shared/types.ts | Adds PlanningSliceTask, PlanningSliceData, new eventType discriminant, and slice to ArtifactType; types are well-structured and backward-compatible. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Kata Agent
    participant PTD as PlanningToolDetector
    participant IPC as ipc.ts (main)
    participant Renderer as Renderer (atoms)

    Note over Agent,Renderer: Slice creation flow
    Agent->>PTD: tool_start (kata_create_slice, args)
    Agent->>PTD: tool_end (kata_create_slice, result { id })
    PTD->>PTD: toPlanningArtifactEvent → slice_created
    PTD->>IPC: emit('artifact', slice_created)
    IPC->>IPC: build PlanningArtifact { artifactType:'slice', sliceData }
    IPC->>Renderer: planningArtifactUpdated (no Linear fetch)

    Note over Agent,Renderer: Task creation flow
    Agent->>PTD: tool_start (kata_create_task, args { sliceIssueId })
    Agent->>PTD: tool_end (kata_create_task)
    PTD->>PTD: toPlanningArtifactEvent → task_created
    PTD->>IPC: emit('artifact', task_created)
    IPC->>IPC: find slice artifact by targetSliceIssueId
    IPC->>IPC: append task to sliceData.tasks
    IPC->>Renderer: planningArtifactUpdated (updated slice)

    Note over Agent,Renderer: Milestone creation flow
    Agent->>PTD: tool_start (kata_create_milestone, args)
    Agent->>PTD: tool_end (kata_create_milestone)
    PTD->>PTD: toPlanningArtifactEvent → milestone_created
    PTD->>IPC: emit('artifact', milestone_created)
    IPC->>IPC: sendPlanningFetchStateToRenderer (start)
    IPC->>IPC: fetchPlanningArtifact (Linear doc fetch for ROADMAP)
    IPC->>Renderer: planningArtifactUpdated (fetched roadmap)
    IPC->>IPC: sendPlanningFetchStateToRenderer (end)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/ipc.ts
Line: 258-265

Comment:
**Task silently dropped if parent slice not yet in memory**

If `task_created` arrives before the corresponding `slice_created` artifact has been stored in `planningArtifactsByKey` (e.g. app reconnect mid-session, or unexpected tool-call ordering), `targetSliceArtifact` will be `undefined` and the task is silently discarded with only a log warning. The task is never retried.

Consider queuing orphaned tasks keyed by `targetSliceIssueId` and flushing them when the matching slice artifact later arrives in `upsertPlanningArtifact`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/ipc.ts
Line: 766-790

Comment:
**`detectArtifactTypeFromTitle` has diverged from `detectArtifactType` in the renderer**

The private helper in `ipc.ts` does not include the `SLICE:` prefix check (`/^SLICE:/`) or the `[S\d+]` / `S\d+:-` patterns that `artifact-parser.ts` now handles. They share the same conceptual purpose but can silently diverge. Since slices bypass Linear fetching this causes no current bug, but a future document fetch that produces a slice-shaped title would be typed as `undefined` instead of `'slice'` in the main process.

Consider re-exporting `detectArtifactType` from `artifact-parser.ts` and using it here, or at minimum adding the slice patterns to the local copy.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/planning-tool-detector.ts
Line: 343-356

Comment:
**`extractKataId` regex is unanchored and may match mid-string**

`new RegExp(\`${prefix}\\d+\`, 'i')` matches the *first* occurrence of e.g. `T\d+` anywhere in the title string. A task title like `"Retry T2 implementation"` would extract `T2` rather than failing gracefully. Since `kataId` is passed explicitly by the model in normal usage this is only a fallback concern, but anchoring the search to word boundaries (`\b${prefix}\\d+\b`) would prevent unintended matches.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): render slice/task plannin..."](https://github.com/gannonh/kata/commit/950645fc46cfbc19f4b3601166bced39d1f44d8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27232624)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->