### PR TITLE
feat(desktop): load and switch persisted session history

### DIFF
--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -325,6 +325,33 @@ describe('PiAgentBridge additional coverage', () => {
     expect(bridge.getSelectedModel()).toBe('anthropic/claude-sonnet-4-5')
   })
 
+  test('switchSession sends switch_session command and maps cancelled payload', async () => {
+    const bridge = new PiAgentBridge(process.cwd())
+    const sendSpy = vi.spyOn(bridge, 'send')
+
+    await expect(bridge.switchSession('   ')).rejects.toThrow('Session path is required')
+
+    sendSpy.mockResolvedValueOnce({
+      command: 'switch_session',
+      success: true,
+      data: { cancelled: false },
+    } as CommandResult)
+
+    await expect(bridge.switchSession('/tmp/session-a.jsonl')).resolves.toBe(true)
+    expect(sendSpy).toHaveBeenCalledWith({
+      type: 'switch_session',
+      sessionPath: '/tmp/session-a.jsonl',
+    })
+
+    sendSpy.mockResolvedValueOnce({
+      command: 'switch_session',
+      success: true,
+      data: { cancelled: true },
+    } as CommandResult)
+
+    await expect(bridge.switchSession('/tmp/session-b.jsonl')).resolves.toBe(false)
+  })
+
   test('getSelectedModel and getWorkspacePath return constructor values', () => {
     const bridge = new PiAgentBridge('/tmp/my-workspace', 'kata', 30_000, '  provider/model  ')
 

--- a/apps/desktop/src/main/__tests__/session-history-loader.test.ts
+++ b/apps/desktop/src/main/__tests__/session-history-loader.test.ts
@@ -87,6 +87,18 @@ describe('SessionHistoryLoader', () => {
     expect(result.events.some((event) => event.type === 'thinking_delta')).toBe(true)
     expect(result.events.some((event) => event.type === 'tool_start')).toBe(true)
 
+    const toolStartIndex = result.events.findIndex(
+      (event) => event.type === 'tool_start' && event.toolCallId === 'tool-read-1',
+    )
+    const summaryTextIndex = result.events.findIndex(
+      (event) =>
+        event.type === 'text_delta' &&
+        event.delta.includes('summarized it below'),
+    )
+
+    expect(toolStartIndex).toBeGreaterThanOrEqual(0)
+    expect(summaryTextIndex).toBeGreaterThan(toolStartIndex)
+
     const toolEnd = result.events.find(
       (event) => event.type === 'tool_end' && event.toolCallId === 'tool-read-1',
     )
@@ -140,6 +152,26 @@ describe('SessionHistoryLoader', () => {
     expect(result.events).toEqual([])
     expect(result.warnings).toEqual(['Session file is empty'])
     expect(result.sessionId).toBe('2026-04-03_empty')
+  })
+
+  test('ignores non-session first-line ids when determining session id', async () => {
+    const loader = new SessionHistoryLoader()
+    const filePath = path.join(tempDir, '2026-04-03_fallback-from-filename.jsonl')
+
+    await writeJsonl(filePath, [
+      {
+        type: 'message',
+        id: 'not-a-session-header-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      },
+    ])
+
+    const result = await loader.load(filePath)
+
+    expect(result.sessionId).toBe('2026-04-03_fallback-from-filename')
   })
 
   test('maps toolResult without explicit toolCallId to most recent unresolved tool', async () => {

--- a/apps/desktop/src/main/__tests__/session-history-loader.test.ts
+++ b/apps/desktop/src/main/__tests__/session-history-loader.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { SessionHistoryLoader } from '../session-history-loader'
+
+async function writeJsonl(filePath: string, lines: Array<Record<string, unknown> | string>): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  const body = lines
+    .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
+    .join('\n')
+  await fs.writeFile(filePath, body.length > 0 ? `${body}\n` : '', 'utf8')
+}
+
+describe('SessionHistoryLoader', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'kata-desktop-session-history-'))
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test('loads user/assistant history with thinking and tool calls', async () => {
+    const loader = new SessionHistoryLoader()
+    const filePath = path.join(tempDir, '2026-04-03_abc123.jsonl')
+
+    await writeJsonl(filePath, [
+      {
+        type: 'session',
+        id: 'session-1',
+        cwd: '/repo/project',
+        timestamp: '2026-04-03T00:00:00.000Z',
+      },
+      {
+        type: 'message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Show me README' }],
+        },
+      },
+      {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', text: 'Need to inspect the file first.' },
+            {
+              type: 'tool_use',
+              id: 'tool-read-1',
+              name: 'read',
+              input: { path: '/repo/project/README.md', offset: 1, limit: 200 },
+            },
+            { type: 'text', text: 'I loaded README and summarized it below.' },
+          ],
+        },
+      },
+      {
+        type: 'message',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'tool-read-1',
+          toolName: 'read',
+          content: [{ type: 'text', text: '# README\nhello world' }],
+          isError: false,
+        },
+      },
+      {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Done.' }],
+        },
+      },
+    ])
+
+    const result = await loader.load(filePath)
+
+    expect(result.sessionId).toBe('session-1')
+    expect(result.warnings).toEqual([])
+
+    expect(result.events.some((event) => event.type === 'history_user_message')).toBe(true)
+    expect(result.events.some((event) => event.type === 'thinking_start')).toBe(true)
+    expect(result.events.some((event) => event.type === 'thinking_delta')).toBe(true)
+    expect(result.events.some((event) => event.type === 'tool_start')).toBe(true)
+
+    const toolEnd = result.events.find(
+      (event) => event.type === 'tool_end' && event.toolCallId === 'tool-read-1',
+    )
+
+    expect(toolEnd).toBeDefined()
+    if (toolEnd && toolEnd.type === 'tool_end' && toolEnd.result && 'path' in toolEnd.result) {
+      expect(toolEnd.result.path).toBe('/repo/project/README.md')
+    }
+  })
+
+  test('continues on corrupted lines and reports warnings', async () => {
+    const loader = new SessionHistoryLoader()
+    const filePath = path.join(tempDir, '2026-04-03_corrupt.jsonl')
+
+    await writeJsonl(filePath, [
+      {
+        type: 'session',
+        id: 'session-corrupt',
+        cwd: '/repo/project',
+      },
+      '{not valid json',
+      {
+        type: 'message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'still parse me' }],
+        },
+      },
+      {
+        type: 'message',
+      },
+    ])
+
+    const result = await loader.load(filePath)
+
+    expect(result.sessionId).toBe('session-corrupt')
+    expect(result.events.some((event) => event.type === 'history_user_message')).toBe(true)
+    expect(result.warnings.length).toBeGreaterThanOrEqual(2)
+    expect(result.warnings.join('\n')).toContain('invalid JSON')
+    expect(result.warnings.join('\n')).toContain("missing 'message' payload")
+  })
+
+  test('returns empty events with warning for empty sessions', async () => {
+    const loader = new SessionHistoryLoader()
+    const filePath = path.join(tempDir, '2026-04-03_empty.jsonl')
+
+    await writeJsonl(filePath, [])
+
+    const result = await loader.load(filePath)
+
+    expect(result.events).toEqual([])
+    expect(result.warnings).toEqual(['Session file is empty'])
+    expect(result.sessionId).toBe('2026-04-03_empty')
+  })
+
+  test('maps toolResult without explicit toolCallId to most recent unresolved tool', async () => {
+    const loader = new SessionHistoryLoader()
+    const filePath = path.join(tempDir, '2026-04-03_ordered.jsonl')
+
+    await writeJsonl(filePath, [
+      {
+        type: 'session',
+        id: 'session-order',
+        cwd: '/repo/project',
+      },
+      {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tool-bash-1',
+              name: 'bash',
+              input: { command: 'echo one' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'message',
+        message: {
+          role: 'toolResult',
+          toolName: 'bash',
+          toolResult: 'one\n',
+          isError: false,
+        },
+      },
+    ])
+
+    const result = await loader.load(filePath)
+    const toolEnd = result.events.find(
+      (event) => event.type === 'tool_end' && event.toolCallId === 'tool-bash-1',
+    )
+
+    expect(toolEnd).toBeDefined()
+  })
+})

--- a/apps/desktop/src/main/__tests__/session-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/session-manager.test.ts
@@ -228,6 +228,43 @@ describe('DesktopSessionManager', () => {
     expect(result.warnings.join('\n')).toContain('Invalid JSON at line 2')
   })
 
+  test('resolveSessionPathById returns matching session path for workspace-scoped ID', async () => {
+    const manager = new DesktopSessionManager(sessionsDir)
+    const workspaceA = path.join(tempDir, 'workspace-a')
+    const workspaceB = path.join(tempDir, 'workspace-b')
+
+    await fs.mkdir(workspaceA, { recursive: true })
+    await fs.mkdir(workspaceB, { recursive: true })
+
+    const targetPath = path.join(sessionsDir, 'target-session.jsonl')
+    const otherPath = path.join(sessionsDir, 'other-session.jsonl')
+
+    await writeJsonl(targetPath, [
+      {
+        id: 'target-session',
+        cwd: workspaceA,
+      },
+    ])
+
+    await writeJsonl(otherPath, [
+      {
+        id: 'target-session',
+        cwd: workspaceB,
+      },
+    ])
+
+    await expect(manager.resolveSessionPathById('target-session', workspaceA)).resolves.toBe(
+      targetPath,
+    )
+    await expect(manager.resolveSessionPathById('target-session', workspaceB)).resolves.toBe(
+      otherPath,
+    )
+    await expect(manager.resolveSessionPathById('missing', workspaceA)).resolves.toBeNull()
+    await expect(manager.resolveSessionPathById('   ', workspaceA)).rejects.toThrow(
+      'Session ID is required',
+    )
+  })
+
   test('getSessionInfo resolves relative paths and extracts model/provider/token usage from message payload', async () => {
     const manager = new DesktopSessionManager(sessionsDir)
     const filePath = path.join(sessionsDir, 'nested', 'rich-session.jsonl')

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -8,6 +8,7 @@ import { PiAgentBridge } from './pi-agent-bridge'
 import { PlanningToolDetector } from './planning-tool-detector'
 import { RpcEventAdapter } from './rpc-event-adapter'
 import { DesktopSessionManager } from './session-manager'
+import { SessionHistoryLoader } from './session-history-loader'
 import {
   IPC_CHANNELS,
   type AuthProvider,
@@ -20,6 +21,8 @@ import {
   type AuthRemoveKeyResponse,
   type AuthValidationResult,
   type CreateSessionResponse,
+  type SessionHistoryResponse,
+  type SessionSwitchResponse,
   type ExtensionUIRequest,
   type ExtensionUIResponse,
   type PermissionMode,
@@ -56,6 +59,7 @@ export function registerSessionIpc({
   const adapter = new RpcEventAdapter()
   const planningToolDetector = new PlanningToolDetector()
   const linearDocumentClient = new LinearDocumentClient(authBridge)
+  const sessionHistoryLoader = new SessionHistoryLoader()
 
   const planningArtifactsByKey = new Map<string, PlanningArtifact>()
   const planningMetadataByKey = new Map<string, PlanningArtifactEvent>()
@@ -308,6 +312,8 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.sessionList)
   ipcMain.removeHandler(IPC_CHANNELS.sessionNew)
   ipcMain.removeHandler(IPC_CHANNELS.sessionGetInfo)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionSwitch)
+  ipcMain.removeHandler(IPC_CHANNELS.sessionGetHistory)
   ipcMain.removeHandler(IPC_CHANNELS.workspaceGet)
   ipcMain.removeHandler(IPC_CHANNELS.workspaceSet)
   ipcMain.removeHandler(IPC_CHANNELS.workspacePick)
@@ -506,6 +512,121 @@ export function registerSessionIpc({
     },
   )
 
+  ipcMain.handle(
+    IPC_CHANNELS.sessionSwitch,
+    async (_event, sessionId: string): Promise<SessionSwitchResponse> => {
+      const trimmedSessionId = sessionId?.trim()
+      if (!trimmedSessionId) {
+        return {
+          success: false,
+          sessionId: null,
+          error: 'Session ID is required',
+        }
+      }
+
+      const workspacePath = bridge.getWorkspacePath()
+
+      try {
+        const sessionPath = await sessionManager.resolveSessionPathById(trimmedSessionId, workspacePath)
+        if (!sessionPath) {
+          return {
+            success: false,
+            sessionId: null,
+            error: `Session ${trimmedSessionId} was not found in the current workspace`,
+          }
+        }
+
+        const switched = await bridge.switchSession(sessionPath)
+        if (!switched) {
+          return {
+            success: false,
+            sessionId: null,
+            error: `Session switch to ${trimmedSessionId} was cancelled`,
+          }
+        }
+
+        log.info('[desktop-ipc] session switched', {
+          sessionId: trimmedSessionId,
+          workspacePath,
+          sessionPath,
+        })
+
+        return {
+          success: true,
+          sessionId: trimmedSessionId,
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.error('[desktop-ipc] session switch failed', {
+          sessionId: trimmedSessionId,
+          workspacePath,
+          error: message,
+        })
+
+        return {
+          success: false,
+          sessionId: null,
+          error: message,
+        }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.sessionGetHistory,
+    async (_event, sessionId: string): Promise<SessionHistoryResponse> => {
+      const trimmedSessionId = sessionId?.trim()
+      if (!trimmedSessionId) {
+        return {
+          success: false,
+          sessionId: null,
+          events: [],
+          warnings: [],
+          error: 'Session ID is required',
+        }
+      }
+
+      const workspacePath = bridge.getWorkspacePath()
+
+      try {
+        const sessionPath = await sessionManager.resolveSessionPathById(trimmedSessionId, workspacePath)
+        if (!sessionPath) {
+          return {
+            success: false,
+            sessionId: null,
+            events: [],
+            warnings: [],
+            error: `Session ${trimmedSessionId} was not found in the current workspace`,
+          }
+        }
+
+        const loaded = await sessionHistoryLoader.load(sessionPath)
+
+        return {
+          success: true,
+          sessionId: loaded.sessionId ?? trimmedSessionId,
+          events: loaded.events,
+          warnings: loaded.warnings,
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.error('[desktop-ipc] session history load failed', {
+          sessionId: trimmedSessionId,
+          workspacePath,
+          error: message,
+        })
+
+        return {
+          success: false,
+          sessionId: trimmedSessionId,
+          events: [],
+          warnings: [],
+          error: message,
+        }
+      }
+    },
+  )
+
   ipcMain.handle(IPC_CHANNELS.workspaceGet, async (): Promise<WorkspaceInfo> => {
     return {
       path: bridge.getWorkspacePath(),
@@ -666,6 +787,8 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.sessionList)
     ipcMain.removeHandler(IPC_CHANNELS.sessionNew)
     ipcMain.removeHandler(IPC_CHANNELS.sessionGetInfo)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionSwitch)
+    ipcMain.removeHandler(IPC_CHANNELS.sessionGetHistory)
     ipcMain.removeHandler(IPC_CHANNELS.workspaceGet)
     ipcMain.removeHandler(IPC_CHANNELS.workspaceSet)
     ipcMain.removeHandler(IPC_CHANNELS.workspacePick)

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -554,6 +554,7 @@ export function registerSessionIpc({
         return {
           success: true,
           sessionId: trimmedSessionId,
+          sessionPath,
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
@@ -574,12 +575,13 @@ export function registerSessionIpc({
 
   ipcMain.handle(
     IPC_CHANNELS.sessionGetHistory,
-    async (_event, sessionId: string): Promise<SessionHistoryResponse> => {
+    async (_event, sessionId: string, sessionPath?: string): Promise<SessionHistoryResponse> => {
       const trimmedSessionId = sessionId?.trim()
       if (!trimmedSessionId) {
         return {
           success: false,
           sessionId: null,
+          sessionPath: null,
           events: [],
           warnings: [],
           error: 'Session ID is required',
@@ -589,22 +591,28 @@ export function registerSessionIpc({
       const workspacePath = bridge.getWorkspacePath()
 
       try {
-        const sessionPath = await sessionManager.resolveSessionPathById(trimmedSessionId, workspacePath)
-        if (!sessionPath) {
+        const explicitSessionPath = sessionPath?.trim() || null
+        const resolvedSessionPath =
+          explicitSessionPath ??
+          await sessionManager.resolveSessionPathById(trimmedSessionId, workspacePath)
+
+        if (!resolvedSessionPath) {
           return {
             success: false,
             sessionId: null,
+            sessionPath: null,
             events: [],
             warnings: [],
             error: `Session ${trimmedSessionId} was not found in the current workspace`,
           }
         }
 
-        const loaded = await sessionHistoryLoader.load(sessionPath)
+        const loaded = await sessionHistoryLoader.load(resolvedSessionPath)
 
         return {
           success: true,
           sessionId: loaded.sessionId ?? trimmedSessionId,
+          sessionPath: resolvedSessionPath,
           events: loaded.events,
           warnings: loaded.warnings,
         }
@@ -619,6 +627,7 @@ export function registerSessionIpc({
         return {
           success: false,
           sessionId: trimmedSessionId,
+          sessionPath: sessionPath?.trim() || null,
           events: [],
           warnings: [],
           error: message,

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -422,6 +422,25 @@ export class PiAgentBridge extends EventEmitter {
     await this.send({ type: 'set_thinking_level', level: trimmed as import('../shared/types').ThinkingLevel })
   }
 
+  public async switchSession(sessionPath: string): Promise<boolean> {
+    const trimmed = sessionPath.trim()
+    if (!trimmed) {
+      throw new Error('Session path is required')
+    }
+
+    const result = await this.send({ type: 'switch_session', sessionPath: trimmed })
+    const payload = result.data
+    const cancelled =
+      payload &&
+      typeof payload === 'object' &&
+      'cancelled' in payload &&
+      typeof (payload as { cancelled?: unknown }).cancelled === 'boolean'
+        ? (payload as { cancelled: boolean }).cancelled
+        : false
+
+    return !cancelled
+  }
+
   public getSelectedModel(): string | null {
     return this.selectedModel
   }

--- a/apps/desktop/src/main/session-history-loader.ts
+++ b/apps/desktop/src/main/session-history-loader.ts
@@ -126,36 +126,40 @@ function extractToolResultFromMessage(message: Record<string, unknown>, toolName
   return normalizeToolResultPayload(toolName, '')
 }
 
+type AssistantContentBlock =
+  | {
+      type: 'text'
+      text: string
+    }
+  | {
+      type: 'thinking'
+      text: string
+    }
+  | {
+      type: 'tool_use'
+      toolCallId: string
+      toolName: string
+      args: Record<string, unknown>
+    }
+
 interface AssistantContentParseResult {
-  textBlocks: string[]
-  thinkingBlocks: string[]
-  toolUses: Array<{
-    toolCallId: string
-    toolName: string
-    args: Record<string, unknown>
-  }>
+  blocks: AssistantContentBlock[]
 }
 
 function parseAssistantContent(content: unknown, fallbackLine: number): AssistantContentParseResult {
   if (typeof content === 'string') {
     return {
-      textBlocks: [content],
-      thinkingBlocks: [],
-      toolUses: [],
+      blocks: [{ type: 'text', text: content }],
     }
   }
 
   if (!Array.isArray(content)) {
     return {
-      textBlocks: [],
-      thinkingBlocks: [],
-      toolUses: [],
+      blocks: [],
     }
   }
 
-  const textBlocks: string[] = []
-  const thinkingBlocks: string[] = []
-  const toolUses: AssistantContentParseResult['toolUses'] = []
+  const blocks: AssistantContentBlock[] = []
 
   for (let index = 0; index < content.length; index += 1) {
     const block = asRecord(content[index])
@@ -177,7 +181,8 @@ function parseAssistantContent(content: unknown, fallbackLine: number): Assistan
         asRecord(block.args) ??
         {}
 
-      toolUses.push({
+      blocks.push({
+        type: 'tool_use',
         toolCallId,
         toolName,
         args,
@@ -188,23 +193,21 @@ function parseAssistantContent(content: unknown, fallbackLine: number): Assistan
     const text = asString(block.text)
     if (text) {
       if (blockType === 'thinking' || blockType === 'reasoning') {
-        thinkingBlocks.push(text)
+        blocks.push({ type: 'thinking', text })
       } else {
-        textBlocks.push(text)
+        blocks.push({ type: 'text', text })
       }
       continue
     }
 
     const thinking = asString(block.thinking)
     if (thinking) {
-      thinkingBlocks.push(thinking)
+      blocks.push({ type: 'thinking', text: thinking })
     }
   }
 
   return {
-    textBlocks,
-    thinkingBlocks,
-    toolUses,
+    blocks,
   }
 }
 
@@ -251,7 +254,7 @@ export class SessionHistoryLoader {
         continue
       }
 
-      if (index === 0) {
+      if (index === 0 && asString(entry.type) === 'session') {
         sessionId = asString(entry.id)
       }
 
@@ -293,51 +296,53 @@ export class SessionHistoryLoader {
 
         const parsedContent = parseAssistantContent(message.content, index + 1)
 
-        for (const thinking of parsedContent.thinkingBlocks) {
-          events.push(...adapter.adapt({
-            type: 'message_update',
-            assistantMessageEvent: {
-              type: 'thinking_start',
-            },
-          }))
-          events.push(...adapter.adapt({
-            type: 'message_update',
-            assistantMessageEvent: {
-              type: 'thinking_delta',
-              delta: thinking,
-            },
-          }))
-          events.push(...adapter.adapt({
-            type: 'message_update',
-            assistantMessageEvent: {
-              type: 'thinking_end',
-              content: thinking,
-            },
-          }))
-        }
+        for (const block of parsedContent.blocks) {
+          if (block.type === 'thinking') {
+            events.push(...adapter.adapt({
+              type: 'message_update',
+              assistantMessageEvent: {
+                type: 'thinking_start',
+              },
+            }))
+            events.push(...adapter.adapt({
+              type: 'message_update',
+              assistantMessageEvent: {
+                type: 'thinking_delta',
+                delta: block.text,
+              },
+            }))
+            events.push(...adapter.adapt({
+              type: 'message_update',
+              assistantMessageEvent: {
+                type: 'thinking_end',
+                content: block.text,
+              },
+            }))
+            continue
+          }
 
-        for (const text of parsedContent.textBlocks) {
-          events.push(...adapter.adapt({
-            type: 'message_update',
-            assistantMessageEvent: {
-              type: 'text_delta',
-              delta: text,
-            },
-          }))
-        }
+          if (block.type === 'text') {
+            events.push(...adapter.adapt({
+              type: 'message_update',
+              assistantMessageEvent: {
+                type: 'text_delta',
+                delta: block.text,
+              },
+            }))
+            continue
+          }
 
-        for (const toolUse of parsedContent.toolUses) {
-          toolMetaByCallId.set(toolUse.toolCallId, {
-            name: toolUse.toolName,
-            args: toolUse.args,
+          toolMetaByCallId.set(block.toolCallId, {
+            name: block.toolName,
+            args: block.args,
           })
-          unresolvedToolOrder.push(toolUse.toolCallId)
+          unresolvedToolOrder.push(block.toolCallId)
 
           events.push(...adapter.adapt({
             type: 'tool_execution_start',
-            toolCallId: toolUse.toolCallId,
-            toolName: toolUse.toolName,
-            args: toolUse.args,
+            toolCallId: block.toolCallId,
+            toolName: block.toolName,
+            args: block.args,
           }))
         }
 

--- a/apps/desktop/src/main/session-history-loader.ts
+++ b/apps/desktop/src/main/session-history-loader.ts
@@ -1,0 +1,388 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import type { ChatEvent } from '../shared/types'
+import { RpcEventAdapter } from './rpc-event-adapter'
+
+export interface SessionHistoryLoadResult {
+  sessionId: string | null
+  events: ChatEvent[]
+  warnings: string[]
+}
+
+interface ToolMeta {
+  name: string
+  args?: unknown
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function extractSessionIdFromFilename(filePath: string): string | null {
+  const base = path.basename(filePath, '.jsonl')
+  if (!base) {
+    return null
+  }
+
+  const match = base.match(/_([0-9a-fA-F-]{32,36})$/)
+  return match?.[1] ?? base
+}
+
+function extractTextFromContent(content: unknown): string | null {
+  if (typeof content === 'string' && content.length > 0) {
+    return content
+  }
+
+  if (!Array.isArray(content)) {
+    return null
+  }
+
+  const parts: string[] = []
+  for (const item of content) {
+    const block = asRecord(item)
+    if (!block) {
+      continue
+    }
+
+    const text = asString(block.text)
+    if (text) {
+      parts.push(text)
+      continue
+    }
+
+    const thinking = asString(block.thinking)
+    if (thinking) {
+      parts.push(thinking)
+    }
+  }
+
+  if (parts.length === 0) {
+    return null
+  }
+
+  return parts.join('')
+}
+
+function normalizeToolResultPayload(toolName: string, raw: unknown): unknown {
+  if (raw && typeof raw === 'object') {
+    return raw
+  }
+
+  const rawText = typeof raw === 'string' ? raw : String(raw ?? '')
+
+  try {
+    return JSON.parse(rawText)
+  } catch {
+    // keep plain text fallbacks below
+  }
+
+  switch (toolName) {
+    case 'bash':
+      return {
+        stdout: rawText,
+        stderr: '',
+      }
+    case 'read':
+      return {
+        content: [{ type: 'text', text: rawText }],
+      }
+    case 'edit':
+      return {
+        diff: rawText,
+      }
+    case 'write':
+      return {
+        content: rawText,
+      }
+    default:
+      return {
+        raw: rawText,
+      }
+  }
+}
+
+function extractToolResultFromMessage(message: Record<string, unknown>, toolName: string): unknown {
+  if (message.result !== undefined) {
+    return normalizeToolResultPayload(toolName, message.result)
+  }
+
+  if (message.toolResult !== undefined) {
+    return normalizeToolResultPayload(toolName, message.toolResult)
+  }
+
+  const content = extractTextFromContent(message.content)
+  if (content !== null) {
+    return normalizeToolResultPayload(toolName, content)
+  }
+
+  return normalizeToolResultPayload(toolName, '')
+}
+
+interface AssistantContentParseResult {
+  textBlocks: string[]
+  thinkingBlocks: string[]
+  toolUses: Array<{
+    toolCallId: string
+    toolName: string
+    args: Record<string, unknown>
+  }>
+}
+
+function parseAssistantContent(content: unknown, fallbackLine: number): AssistantContentParseResult {
+  if (typeof content === 'string') {
+    return {
+      textBlocks: [content],
+      thinkingBlocks: [],
+      toolUses: [],
+    }
+  }
+
+  if (!Array.isArray(content)) {
+    return {
+      textBlocks: [],
+      thinkingBlocks: [],
+      toolUses: [],
+    }
+  }
+
+  const textBlocks: string[] = []
+  const thinkingBlocks: string[] = []
+  const toolUses: AssistantContentParseResult['toolUses'] = []
+
+  for (let index = 0; index < content.length; index += 1) {
+    const block = asRecord(content[index])
+    if (!block) {
+      continue
+    }
+
+    const blockType = asString(block.type)
+
+    if (blockType === 'tool_use') {
+      const toolCallId =
+        asString(block.id) ??
+        asString(block.toolCallId) ??
+        asString(block.toolUseId) ??
+        `tool:${fallbackLine}:${index}`
+      const toolName = asString(block.name) ?? asString(block.toolName) ?? 'unknown_tool'
+      const args =
+        asRecord(block.input) ??
+        asRecord(block.args) ??
+        {}
+
+      toolUses.push({
+        toolCallId,
+        toolName,
+        args,
+      })
+      continue
+    }
+
+    const text = asString(block.text)
+    if (text) {
+      if (blockType === 'thinking' || blockType === 'reasoning') {
+        thinkingBlocks.push(text)
+      } else {
+        textBlocks.push(text)
+      }
+      continue
+    }
+
+    const thinking = asString(block.thinking)
+    if (thinking) {
+      thinkingBlocks.push(thinking)
+    }
+  }
+
+  return {
+    textBlocks,
+    thinkingBlocks,
+    toolUses,
+  }
+}
+
+export class SessionHistoryLoader {
+  public async load(sessionFilePath: string): Promise<SessionHistoryLoadResult> {
+    const raw = await fs.readFile(sessionFilePath, 'utf8')
+    const lines = raw.split(/\r?\n/)
+
+    const warnings: string[] = []
+    if (lines.every((line) => line.trim().length === 0)) {
+      warnings.push('Session file is empty')
+      return {
+        sessionId: extractSessionIdFromFilename(sessionFilePath),
+        events: [],
+        warnings,
+      }
+    }
+
+    const adapter = new RpcEventAdapter()
+    const events: ChatEvent[] = []
+    const toolMetaByCallId = new Map<string, ToolMeta>()
+    const unresolvedToolOrder: string[] = []
+
+    let sessionId: string | null = null
+    let userMessageCounter = 0
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index]?.trim()
+      if (!line) {
+        continue
+      }
+
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(line)
+      } catch (error) {
+        warnings.push(`Line ${index + 1}: invalid JSON (${error instanceof Error ? error.message : String(error)})`)
+        continue
+      }
+
+      const entry = asRecord(parsed)
+      if (!entry) {
+        warnings.push(`Line ${index + 1}: expected object entry`)
+        continue
+      }
+
+      if (index === 0) {
+        sessionId = asString(entry.id)
+      }
+
+      if (asString(entry.type) !== 'message') {
+        continue
+      }
+
+      const message = asRecord(entry.message)
+      if (!message) {
+        warnings.push(`Line ${index + 1}: message entry missing 'message' payload`)
+        continue
+      }
+
+      const role = asString(message.role)
+      if (!role) {
+        continue
+      }
+
+      if (role === 'user') {
+        const text = extractTextFromContent(message.content)
+        if (!text) {
+          continue
+        }
+
+        userMessageCounter += 1
+        events.push({
+          type: 'history_user_message',
+          messageId: `history:user:${userMessageCounter}`,
+          text,
+        })
+        continue
+      }
+
+      if (role === 'assistant') {
+        events.push(...adapter.adapt({
+          type: 'message_start',
+          message: { role: 'assistant' },
+        }))
+
+        const parsedContent = parseAssistantContent(message.content, index + 1)
+
+        for (const thinking of parsedContent.thinkingBlocks) {
+          events.push(...adapter.adapt({
+            type: 'message_update',
+            assistantMessageEvent: {
+              type: 'thinking_start',
+            },
+          }))
+          events.push(...adapter.adapt({
+            type: 'message_update',
+            assistantMessageEvent: {
+              type: 'thinking_delta',
+              delta: thinking,
+            },
+          }))
+          events.push(...adapter.adapt({
+            type: 'message_update',
+            assistantMessageEvent: {
+              type: 'thinking_end',
+              content: thinking,
+            },
+          }))
+        }
+
+        for (const text of parsedContent.textBlocks) {
+          events.push(...adapter.adapt({
+            type: 'message_update',
+            assistantMessageEvent: {
+              type: 'text_delta',
+              delta: text,
+            },
+          }))
+        }
+
+        for (const toolUse of parsedContent.toolUses) {
+          toolMetaByCallId.set(toolUse.toolCallId, {
+            name: toolUse.toolName,
+            args: toolUse.args,
+          })
+          unresolvedToolOrder.push(toolUse.toolCallId)
+
+          events.push(...adapter.adapt({
+            type: 'tool_execution_start',
+            toolCallId: toolUse.toolCallId,
+            toolName: toolUse.toolName,
+            args: toolUse.args,
+          }))
+        }
+
+        events.push(...adapter.adapt({
+          type: 'message_end',
+          message,
+        }))
+        continue
+      }
+
+      if (role === 'toolResult') {
+        const explicitToolCallId =
+          asString(message.toolCallId) ??
+          asString(message.toolUseId)
+
+        const toolCallId = explicitToolCallId ?? unresolvedToolOrder.shift() ?? `tool:result:${index + 1}`
+
+        if (explicitToolCallId) {
+          const pendingIndex = unresolvedToolOrder.indexOf(explicitToolCallId)
+          if (pendingIndex >= 0) {
+            unresolvedToolOrder.splice(pendingIndex, 1)
+          }
+        }
+
+        const knownMeta = toolMetaByCallId.get(toolCallId)
+        const toolName = asString(message.toolName) ?? knownMeta?.name ?? 'unknown_tool'
+        const resultPayload = extractToolResultFromMessage(message, toolName)
+        const error = asString(message.error)
+
+        events.push(...adapter.adapt({
+          type: 'tool_execution_end',
+          toolCallId,
+          toolName,
+          args: knownMeta?.args,
+          result: resultPayload,
+          isError: Boolean(message.isError || error),
+          error: error ?? undefined,
+        }))
+      }
+    }
+
+    return {
+      sessionId: sessionId ?? extractSessionIdFromFilename(sessionFilePath),
+      events,
+      warnings,
+    }
+  }
+}

--- a/apps/desktop/src/main/session-manager.ts
+++ b/apps/desktop/src/main/session-manager.ts
@@ -253,6 +253,17 @@ export class DesktopSessionManager {
     }
   }
 
+  public async resolveSessionPathById(sessionId: string, cwd: string): Promise<string | null> {
+    const trimmedSessionId = sessionId.trim()
+    if (!trimmedSessionId) {
+      throw new Error('Session ID is required')
+    }
+
+    const response = await this.listSessions(cwd)
+    const match = response.sessions.find((session) => session.id === trimmedSessionId)
+    return match?.path ?? null
+  }
+
   private resolveSessionPath(sessionPath: string): string {
     const trimmed = sessionPath.trim()
     if (!trimmed) {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -89,8 +89,8 @@ const api: DesktopApi = {
     switch: async (sessionId: string) => {
       return ipcRenderer.invoke(IPC_CHANNELS.sessionSwitch, sessionId)
     },
-    getHistory: async (sessionId: string) => {
-      return ipcRenderer.invoke(IPC_CHANNELS.sessionGetHistory, sessionId)
+    getHistory: async (sessionId: string, sessionPath?: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.sessionGetHistory, sessionId, sessionPath)
     },
   },
   workspace: {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -86,6 +86,12 @@ const api: DesktopApi = {
     getInfo: async (sessionPath: string) => {
       return ipcRenderer.invoke(IPC_CHANNELS.sessionGetInfo, sessionPath)
     },
+    switch: async (sessionId: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.sessionSwitch, sessionId)
+    },
+    getHistory: async (sessionId: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.sessionGetHistory, sessionId)
+    },
   },
   workspace: {
     get: async () => {

--- a/apps/desktop/src/renderer/atoms/chat.ts
+++ b/apps/desktop/src/renderer/atoms/chat.ts
@@ -92,6 +92,20 @@ export const applyChatEventAtom = atom(null, (get, set, event: ChatEvent) => {
       return
     }
 
+    case 'history_user_message': {
+      set(messagesAtom, [
+        ...get(messagesAtom),
+        {
+          id: event.messageId,
+          role: 'user',
+          content: event.text,
+          streaming: false,
+          isThinking: false,
+        },
+      ])
+      return
+    }
+
     case 'message_start': {
       if (event.role !== 'assistant') {
         return

--- a/apps/desktop/src/renderer/atoms/session.ts
+++ b/apps/desktop/src/renderer/atoms/session.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import type { SessionListResponse, SessionListItem } from '@shared/types'
-import { resetChatStateAtom } from './chat'
+import { applyChatEventAtom, resetChatStateAtom } from './chat'
 import { resetPlanningSessionStateAtom } from './planning'
 
 const CURRENT_SESSION_STORAGE_KEY = 'kata-desktop:current-session-id'
@@ -14,6 +14,8 @@ export const sessionDirectoryAtom = atom<string>('')
 export const sessionListLoadingAtom = atom<boolean>(false)
 export const sessionListErrorAtom = atom<string | null>(null)
 export const sessionCreatingAtom = atom<boolean>(false)
+export const sessionSwitchingAtom = atom<boolean>(false)
+export const sessionHistoryLoadingAtom = atom<boolean>(false)
 
 export const currentSessionIdAtom = atomWithStorage<string | null>(
   CURRENT_SESSION_STORAGE_KEY,
@@ -49,6 +51,46 @@ const applySessionListResponseAtom = atom(
   },
 )
 
+const hydrateSessionHistoryAtom = atom(null, async (_get, set, sessionId: string) => {
+  const trimmedSessionId = sessionId.trim()
+  if (!trimmedSessionId) {
+    return
+  }
+
+  set(sessionHistoryLoadingAtom, true)
+  set(sessionListErrorAtom, null)
+  set(resetChatStateAtom)
+  set(resetPlanningSessionStateAtom)
+
+  try {
+    const historyResponse = await window.api.sessions.getHistory(trimmedSessionId)
+
+    if (!historyResponse.success) {
+      set(sessionListErrorAtom, historyResponse.error ?? 'Unable to load session history')
+      return
+    }
+
+    for (const event of historyResponse.events) {
+      set(applyChatEventAtom, event)
+    }
+
+    if (historyResponse.warnings.length > 0) {
+      set(sessionWarningsAtom, (currentWarnings) => {
+        const merged = [
+          ...currentWarnings,
+          ...historyResponse.warnings.map((warning) => `[history] ${warning}`),
+        ]
+        return Array.from(new Set(merged))
+      })
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    set(sessionListErrorAtom, `Unable to load history for ${trimmedSessionId}: ${message}`)
+  } finally {
+    set(sessionHistoryLoadingAtom, false)
+  }
+})
+
 export const refreshSessionListAtom = atom(null, async (_get, set) => {
   set(sessionListLoadingAtom, true)
   set(sessionListErrorAtom, null)
@@ -64,7 +106,7 @@ export const refreshSessionListAtom = atom(null, async (_get, set) => {
   }
 })
 
-export const initializeSessionsAtom = atom(null, async (_get, set) => {
+export const initializeSessionsAtom = atom(null, async (get, set) => {
   set(sessionListLoadingAtom, true)
   set(sessionListErrorAtom, null)
 
@@ -74,6 +116,14 @@ export const initializeSessionsAtom = atom(null, async (_get, set) => {
 
     const response = await window.api.sessions.list()
     set(applySessionListResponseAtom, response)
+
+    const currentSessionId = get(currentSessionIdAtom)
+    if (currentSessionId) {
+      await set(hydrateSessionHistoryAtom, currentSessionId)
+    } else {
+      set(resetChatStateAtom)
+      set(resetPlanningSessionStateAtom)
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     set(sessionListErrorAtom, message)
@@ -110,11 +160,48 @@ export const createSessionAtom = atom(null, async (get, set) => {
   }
 })
 
+export const switchSessionAtom = atom(null, async (get, set, sessionId: string) => {
+  const trimmedSessionId = sessionId.trim()
+  if (!trimmedSessionId) {
+    return
+  }
+
+  if (get(sessionSwitchingAtom) || get(sessionCreatingAtom)) {
+    return
+  }
+
+  if (get(currentSessionIdAtom) === trimmedSessionId) {
+    return
+  }
+
+  set(sessionSwitchingAtom, true)
+  set(sessionListErrorAtom, null)
+
+  try {
+    const switchResponse = await window.api.sessions.switch(trimmedSessionId)
+    if (!switchResponse.success) {
+      set(sessionListErrorAtom, switchResponse.error ?? `Unable to switch to ${trimmedSessionId}`)
+      return
+    }
+
+    const nextSessionId = switchResponse.sessionId ?? trimmedSessionId
+    set(currentSessionIdAtom, nextSessionId)
+
+    await set(hydrateSessionHistoryAtom, nextSessionId)
+    await set(refreshSessionListAtom)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    set(sessionListErrorAtom, `Unable to switch session to ${trimmedSessionId}: ${message}`)
+  } finally {
+    set(sessionSwitchingAtom, false)
+  }
+})
+
 export const pickWorkspaceAtom = atom(null, async () => {
   return window.api.workspace.pick()
 })
 
-export const switchWorkspaceAtom = atom(null, async (_get, set, workspacePath: string) => {
+export const switchWorkspaceAtom = atom(null, async (get, set, workspacePath: string) => {
   set(sessionListErrorAtom, null)
 
   try {
@@ -123,7 +210,13 @@ export const switchWorkspaceAtom = atom(null, async (_get, set, workspacePath: s
     set(currentSessionIdAtom, null)
     set(resetChatStateAtom)
     set(resetPlanningSessionStateAtom)
+
     await set(refreshSessionListAtom)
+
+    const currentSessionId = get(currentSessionIdAtom)
+    if (currentSessionId) {
+      await set(hydrateSessionHistoryAtom, currentSessionId)
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     set(sessionListErrorAtom, `Unable to switch workspace to ${workspacePath}: ${message}`)

--- a/apps/desktop/src/renderer/atoms/session.ts
+++ b/apps/desktop/src/renderer/atoms/session.ts
@@ -13,6 +13,7 @@ export const sessionWarningsAtom = atom<string[]>([])
 export const sessionDirectoryAtom = atom<string>('')
 export const sessionListLoadingAtom = atom<boolean>(false)
 export const sessionListErrorAtom = atom<string | null>(null)
+export const sessionHistoryErrorAtom = atom<string | null>(null)
 export const sessionCreatingAtom = atom<boolean>(false)
 export const sessionSwitchingAtom = atom<boolean>(false)
 export const sessionHistoryLoadingAtom = atom<boolean>(false)
@@ -51,45 +52,58 @@ const applySessionListResponseAtom = atom(
   },
 )
 
-const hydrateSessionHistoryAtom = atom(null, async (_get, set, sessionId: string) => {
-  const trimmedSessionId = sessionId.trim()
-  if (!trimmedSessionId) {
-    return
-  }
-
-  set(sessionHistoryLoadingAtom, true)
-  set(sessionListErrorAtom, null)
-  set(resetChatStateAtom)
-  set(resetPlanningSessionStateAtom)
-
-  try {
-    const historyResponse = await window.api.sessions.getHistory(trimmedSessionId)
-
-    if (!historyResponse.success) {
-      set(sessionListErrorAtom, historyResponse.error ?? 'Unable to load session history')
+const hydrateSessionHistoryAtom = atom(
+  null,
+  async (
+    get,
+    set,
+    { sessionId, sessionPath }: { sessionId: string; sessionPath?: string | null },
+  ) => {
+    const trimmedSessionId = sessionId.trim()
+    if (!trimmedSessionId) {
       return
     }
 
-    for (const event of historyResponse.events) {
-      set(applyChatEventAtom, event)
-    }
+    set(sessionHistoryLoadingAtom, true)
+    set(sessionHistoryErrorAtom, null)
+    set(resetChatStateAtom)
+    set(resetPlanningSessionStateAtom)
 
-    if (historyResponse.warnings.length > 0) {
-      set(sessionWarningsAtom, (currentWarnings) => {
-        const merged = [
-          ...currentWarnings,
-          ...historyResponse.warnings.map((warning) => `[history] ${warning}`),
-        ]
-        return Array.from(new Set(merged))
-      })
+    try {
+      const resolvedSessionPath =
+        sessionPath ?? get(sessionListAtom).find((session) => session.id === trimmedSessionId)?.path
+
+      const historyResponse = await window.api.sessions.getHistory(
+        trimmedSessionId,
+        resolvedSessionPath,
+      )
+
+      if (!historyResponse.success) {
+        set(sessionHistoryErrorAtom, historyResponse.error ?? 'Unable to load session history')
+        return
+      }
+
+      for (const event of historyResponse.events) {
+        set(applyChatEventAtom, event)
+      }
+
+      if (historyResponse.warnings.length > 0) {
+        set(sessionWarningsAtom, (currentWarnings) => {
+          const merged = [
+            ...currentWarnings,
+            ...historyResponse.warnings.map((warning) => `[history] ${warning}`),
+          ]
+          return Array.from(new Set(merged))
+        })
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      set(sessionHistoryErrorAtom, `Unable to load history for ${trimmedSessionId}: ${message}`)
+    } finally {
+      set(sessionHistoryLoadingAtom, false)
     }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    set(sessionListErrorAtom, `Unable to load history for ${trimmedSessionId}: ${message}`)
-  } finally {
-    set(sessionHistoryLoadingAtom, false)
-  }
-})
+  },
+)
 
 export const refreshSessionListAtom = atom(null, async (_get, set) => {
   set(sessionListLoadingAtom, true)
@@ -109,6 +123,7 @@ export const refreshSessionListAtom = atom(null, async (_get, set) => {
 export const initializeSessionsAtom = atom(null, async (get, set) => {
   set(sessionListLoadingAtom, true)
   set(sessionListErrorAtom, null)
+  set(sessionHistoryErrorAtom, null)
 
   try {
     const workspace = await window.api.workspace.get()
@@ -119,7 +134,7 @@ export const initializeSessionsAtom = atom(null, async (get, set) => {
 
     const currentSessionId = get(currentSessionIdAtom)
     if (currentSessionId) {
-      await set(hydrateSessionHistoryAtom, currentSessionId)
+      await set(hydrateSessionHistoryAtom, { sessionId: currentSessionId })
     } else {
       set(resetChatStateAtom)
       set(resetPlanningSessionStateAtom)
@@ -139,6 +154,7 @@ export const createSessionAtom = atom(null, async (get, set) => {
 
   set(sessionCreatingAtom, true)
   set(sessionListErrorAtom, null)
+  set(sessionHistoryErrorAtom, null)
 
   try {
     const response = await window.api.sessions.create()
@@ -176,6 +192,7 @@ export const switchSessionAtom = atom(null, async (get, set, sessionId: string) 
 
   set(sessionSwitchingAtom, true)
   set(sessionListErrorAtom, null)
+  set(sessionHistoryErrorAtom, null)
 
   try {
     const switchResponse = await window.api.sessions.switch(trimmedSessionId)
@@ -187,7 +204,10 @@ export const switchSessionAtom = atom(null, async (get, set, sessionId: string) 
     const nextSessionId = switchResponse.sessionId ?? trimmedSessionId
     set(currentSessionIdAtom, nextSessionId)
 
-    await set(hydrateSessionHistoryAtom, nextSessionId)
+    await set(hydrateSessionHistoryAtom, {
+      sessionId: nextSessionId,
+      sessionPath: switchResponse.sessionPath ?? null,
+    })
     await set(refreshSessionListAtom)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -203,6 +223,7 @@ export const pickWorkspaceAtom = atom(null, async () => {
 
 export const switchWorkspaceAtom = atom(null, async (get, set, workspacePath: string) => {
   set(sessionListErrorAtom, null)
+  set(sessionHistoryErrorAtom, null)
 
   try {
     const response = await window.api.workspace.set(workspacePath)
@@ -215,7 +236,7 @@ export const switchWorkspaceAtom = atom(null, async (get, set, workspacePath: st
 
     const currentSessionId = get(currentSessionIdAtom)
     if (currentSessionId) {
-      await set(hydrateSessionHistoryAtom, currentSessionId)
+      await set(hydrateSessionHistoryAtom, { sessionId: currentSessionId })
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)

--- a/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils'
 interface SessionListItemProps {
   session: SessionListItemType
   isCurrent: boolean
+  disabled?: boolean
+  onSelect: (sessionId: string) => void
 }
 
 function formatRelativeTime(value: string): string {
@@ -53,15 +55,26 @@ function sessionModelLabel(session: SessionListItemType): string {
   return 'Unknown model'
 }
 
-export function SessionListItem({ session, isCurrent }: SessionListItemProps) {
+export function SessionListItem({
+  session,
+  isCurrent,
+  disabled = false,
+  onSelect,
+}: SessionListItemProps) {
   const model = sessionModelLabel(session)
 
   return (
-    <div
+    <button
+      type="button"
       title={session.title}
+      disabled={disabled}
+      onClick={() => onSelect(session.id)}
       className={cn(
-        'w-full rounded-md border bg-card/70 px-2 py-2 text-left',
-        isCurrent ? 'border-primary/60 bg-accent/40' : 'border-border',
+        'w-full rounded-md border bg-card/70 px-2 py-2 text-left transition-colors',
+        isCurrent
+          ? 'border-primary/60 bg-accent/40'
+          : 'border-border hover:border-primary/40 hover:bg-accent/20',
+        disabled && 'cursor-not-allowed opacity-60',
       )}
     >
       <div className="flex flex-col gap-1.5">
@@ -106,6 +119,6 @@ export function SessionListItem({ session, isCurrent }: SessionListItemProps) {
           </Badge>
         </div>
       </div>
-    </div>
+    </button>
   )
 }

--- a/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
@@ -8,7 +8,9 @@ import {
   sessionListAtom,
   sessionListErrorAtom,
   sessionListLoadingAtom,
+  sessionSwitchingAtom,
   sessionWarningsAtom,
+  switchSessionAtom,
 } from '@/atoms/session'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -25,10 +27,12 @@ export function SessionSidebar({ open }: SessionSidebarProps) {
   const currentSessionId = useAtomValue(currentSessionIdAtom)
   const loading = useAtomValue(sessionListLoadingAtom)
   const creatingSession = useAtomValue(sessionCreatingAtom)
+  const switchingSession = useAtomValue(sessionSwitchingAtom)
   const error = useAtomValue(sessionListErrorAtom)
   const warnings = useAtomValue(sessionWarningsAtom)
 
   const createSession = useSetAtom(createSessionAtom)
+  const switchSession = useSetAtom(switchSessionAtom)
   const refreshSessions = useSetAtom(refreshSessionListAtom)
 
   if (!open) {
@@ -43,7 +47,7 @@ export function SessionSidebar({ open }: SessionSidebarProps) {
           onClick={() => {
             void createSession()
           }}
-          disabled={creatingSession}
+          disabled={creatingSession || switchingSession}
           className="w-full"
         >
           <Plus data-icon="inline-start" />
@@ -61,15 +65,16 @@ export function SessionSidebar({ open }: SessionSidebarProps) {
             onClick={() => {
               void refreshSessions()
             }}
+            disabled={switchingSession}
           >
             <RefreshCw data-icon="inline-start" />
             Refresh
           </Button>
         </div>
 
-        <p className="text-[10px] text-muted-foreground">
-          Session switching is not available yet in Desktop.
-        </p>
+        {switchingSession && (
+          <p className="text-[10px] text-muted-foreground">Switching session…</p>
+        )}
 
         {warnings.length > 0 && (
           <p className="rounded border border-amber-500/50 bg-amber-500/10 px-2 py-1 text-[10px] text-amber-200">
@@ -99,6 +104,10 @@ export function SessionSidebar({ open }: SessionSidebarProps) {
               key={session.id}
               session={session}
               isCurrent={session.id === currentSessionId}
+              disabled={switchingSession || creatingSession}
+              onSelect={(sessionId) => {
+                void switchSession(sessionId)
+              }}
             />
           ))}
         </div>

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -10,7 +10,7 @@ import {
   messagesAtom,
   toolCallsAtom,
 } from '@/atoms/chat'
-import { refreshSessionListAtom } from '@/atoms/session'
+import { refreshSessionListAtom, sessionHistoryErrorAtom } from '@/atoms/session'
 import { ErrorBanner } from './ErrorBanner'
 import { ExtensionUIHandler } from './ExtensionUIHandler'
 import { MessageInput } from './MessageInput'
@@ -24,6 +24,7 @@ export function ChatPanel() {
   const error = useAtomValue(errorAtom)
   const isStreaming = useAtomValue(isStreamingAtom)
   const bridgeStatus = useAtomValue(bridgeStatusAtom)
+  const sessionHistoryError = useAtomValue(sessionHistoryErrorAtom)
 
   const appendUserMessage = useSetAtom(appendUserMessageAtom)
   const applyChatEvent = useSetAtom(applyChatEventAtom)
@@ -90,6 +91,11 @@ export function ChatPanel() {
       </div>
 
       <div ref={scrollRef} className="flex-1 overflow-auto">
+        {sessionHistoryError && (
+          <div className="border-b border-rose-500/30 bg-rose-500/10 px-4 py-2 text-xs text-rose-200">
+            Unable to load session history: {sessionHistoryError}
+          </div>
+        )}
         <MessageList messages={messages} tools={tools} />
       </div>
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -14,6 +14,8 @@ export const IPC_CHANNELS = {
   sessionList: 'session:list',
   sessionNew: 'session:new',
   sessionGetInfo: 'session:get-info',
+  sessionSwitch: 'session:switch',
+  sessionGetHistory: 'session:get-history',
   workspaceGet: 'workspace:get',
   workspaceSet: 'workspace:set',
   workspacePick: 'workspace:pick',
@@ -159,6 +161,12 @@ export interface CreateSessionResponse {
   error?: string
 }
 
+export interface SessionSwitchResponse {
+  success: boolean
+  sessionId: string | null
+  error?: string
+}
+
 export interface WorkspaceInfo {
   path: string
 }
@@ -174,6 +182,7 @@ export type RpcCommandType =
   | 'get_available_models'
   | 'set_model'
   | 'set_thinking_level'
+  | 'switch_session'
 
 export interface RpcCommand {
   type: RpcCommandType
@@ -183,6 +192,7 @@ export interface RpcCommand {
   provider?: string
   modelId?: string
   level?: ThinkingLevel
+  sessionPath?: string
 }
 
 export interface CommandResult {
@@ -370,6 +380,7 @@ export type ChatEvent =
   | { type: 'thinking_start'; messageId: string }
   | { type: 'thinking_delta'; messageId: string; delta: string }
   | { type: 'thinking_end'; messageId: string; content: string }
+  | { type: 'history_user_message'; messageId: string; text: string }
 
 export interface BridgeState {
   running: boolean
@@ -378,6 +389,14 @@ export interface BridgeState {
   status: BridgeLifecycleState
   permissionMode: PermissionMode
   selectedModel: string | null
+}
+
+export interface SessionHistoryResponse {
+  success: boolean
+  sessionId: string | null
+  events: ChatEvent[]
+  warnings: string[]
+  error?: string
 }
 
 export type PlanningArtifactScope = 'project' | 'issue'
@@ -546,6 +565,8 @@ export interface DesktopApi {
     list: () => Promise<SessionListResponse>
     create: () => Promise<CreateSessionResponse>
     getInfo: (sessionPath: string) => Promise<SessionInfo>
+    switch: (sessionId: string) => Promise<SessionSwitchResponse>
+    getHistory: (sessionId: string) => Promise<SessionHistoryResponse>
   }
   workspace: {
     get: () => Promise<WorkspaceInfo>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -164,6 +164,7 @@ export interface CreateSessionResponse {
 export interface SessionSwitchResponse {
   success: boolean
   sessionId: string | null
+  sessionPath?: string | null
   error?: string
 }
 
@@ -394,6 +395,7 @@ export interface BridgeState {
 export interface SessionHistoryResponse {
   success: boolean
   sessionId: string | null
+  sessionPath?: string | null
   events: ChatEvent[]
   warnings: string[]
   error?: string
@@ -566,7 +568,7 @@ export interface DesktopApi {
     create: () => Promise<CreateSessionResponse>
     getInfo: (sessionPath: string) => Promise<SessionInfo>
     switch: (sessionId: string) => Promise<SessionSwitchResponse>
-    getHistory: (sessionId: string) => Promise<SessionHistoryResponse>
+    getHistory: (sessionId: string, sessionPath?: string) => Promise<SessionHistoryResponse>
   }
   workspace: {
     get: () => Promise<WorkspaceInfo>


### PR DESCRIPTION
## Summary
- add `SessionHistoryLoader` to parse session JSONL files into `ChatEvent[]`, including thinking/tool execution replay and resilient corrupted-line warnings
- add IPC + preload APIs for `session:switch` and `session:get-history`, and wire bridge/session-manager support for session-path resolution and RPC `switch_session`
- update session atoms/sidebar UX to support click-to-switch, startup history hydration of the most recent session, and reset+rehydrate orchestration
- add tests for session history loading and session manager/bridge session-switch helpers

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/session-history-loader.test.ts src/main/__tests__/session-manager.test.ts src/main/__tests__/pi-agent-bridge.test.ts`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && bun run test`
- pre-push hook: `turbo run lint typecheck test --affected`

Closes KAT-2224

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements session history persistence and switching for Kata Desktop: a new `SessionHistoryLoader` parses JSONL session files back into `ChatEvent` streams, two new IPC channels (`session:switch`, `session:get-history`) wire the main process to the renderer via the preload bridge, and the Jotai session atoms gain `switchSessionAtom`, `hydrateSessionHistoryAtom`, and startup history hydration. The `SessionListItem` component is introduced for the sidebar and `SessionSidebar` is updated to call `switchSessionAtom` on click.

The overall architecture is sound and the tests provide good coverage. A few issues worth addressing before merge:

- **Content-block ordering not preserved in replay** (`session-history-loader.ts`): `parseAssistantContent` separates thinking/text/tool blocks into separate arrays and always emits them in fixed order (all thinking → all text → all tools), discarding the original interleaved order from the JSONL content array. This can render the assistant's textual summary before the tool card that produced it.
- **History errors leaked into the session-list error slot** (`session.ts` / `SessionSidebar.tsx`): `hydrateSessionHistoryAtom` writes failures to `sessionListErrorAtom`, causing the sidebar to display *"Unable to load sessions"* when only history hydration failed — the session list itself is fine and the sessions remain visible but the error banner is misleading.
- **Implicit cross-atom state dependency in `switchWorkspaceAtom`** (`session.ts`): after nulling `currentSessionIdAtom` and awaiting `refreshSessionListAtom`, the atom re-reads `currentSessionIdAtom` expecting `applySessionListResponseAtom` to have updated it. This works today but is a fragile hidden contract.
- **Double directory scan per session switch**: `resolveSessionPathById` calls `listSessions` on every invocation. A switch triggers it twice in quick succession (once for `sessionSwitch`, once for `sessionGetHistory`).

<h3>Confidence Score: 3/5</h3>

Functional but has a P1 display-ordering bug in history replay and a misleading error message on history-load failure before merge.

Two P1 logic issues: content-block ordering in the history loader can render assistant messages with text before the tool that produced it, and history-load failures surface as a session-list error with misleading text. The cross-atom dependency in switchWorkspaceAtom is subtle but currently correct. The double directory scan is a performance concern. No crashes or data-loss risks.

apps/desktop/src/main/session-history-loader.ts (block ordering), apps/desktop/src/renderer/atoms/session.ts (error atom misuse, workspace-switch dependency)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/session-history-loader.ts | New file: parses JSONL session files into ChatEvent arrays; content-block ordering (text vs tool_use) within an assistant message is not preserved during replay, and the session-ID extraction only fires on the very first line regardless of entry type. |
| apps/desktop/src/renderer/atoms/session.ts | History/session-switch atoms added; hydrateSessionHistoryAtom stores its errors in sessionListErrorAtom, causing the sidebar to display a misleading "Unable to load sessions" message when only history hydration failed; switchWorkspaceAtom has a read-after-set ordering dependency that is subtle but currently correct. |
| apps/desktop/src/main/session-manager.ts | New methods resolveSessionPathById and getSessionInfo added; path-traversal guard in resolveSessionPath is correct; resolveSessionPathById lists all sessions from disk on every call, meaning two full directory scans happen per session switch (once for switch, once for getHistory). |
| apps/desktop/src/main/ipc.ts | Two new IPC handlers (sessionSwitch, sessionGetHistory) added with correct error handling and logging; handler registration/cleanup list is kept in sync. |
| apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx | SessionListItem integration and session switching wired; error rendering uses sessionListErrorAtom which can be set by history-loading failures, potentially showing misleading "Unable to load sessions" text. |
| apps/desktop/src/main/pi-agent-bridge.ts | switchSession method added; validates input, sends switch_session RPC, and correctly maps the cancelled payload to a boolean return value. |
| apps/desktop/src/preload/index.ts | sessions.switch and sessions.getHistory preload bridge methods added; mirrors the IPC channel correctly. |
| apps/desktop/src/renderer/atoms/chat.ts | history_user_message event handler added to applyChatEventAtom; straightforward and correct. |
| apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx | New component renders session metadata in the sidebar; onSelect wired to session.id; relative time formatting and model label helpers look correct. |
| apps/desktop/src/shared/types.ts | sessionSwitch, sessionGetHistory IPC channels, SessionSwitchResponse, and SessionHistoryResponse types added correctly. |
| apps/desktop/src/main/__tests__/session-history-loader.test.ts | Good coverage of happy path, corrupted lines, empty sessions, and unordered tool results; tests are well-structured. |
| apps/desktop/src/main/__tests__/session-manager.test.ts | Tests cover ENOENT, cwd filtering, sorting, path resolution, and path-traversal rejection; comprehensive. |
| apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts | Tests for switchSession validate empty-path rejection, success=true/cancelled=false, and success=true/cancelled=true cases. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Renderer as Renderer (Jotai)
    participant Preload as Preload Bridge
    participant IPC as IPC Main
    participant SM as SessionManager
    participant Bridge as PiAgentBridge
    participant Loader as SessionHistoryLoader

    Renderer->>Preload: sessions.switch(sessionId)
    Preload->>IPC: invoke session:switch
    IPC->>SM: resolveSessionPathById(sessionId, cwd)
    SM-->>IPC: sessionPath
    IPC->>Bridge: switchSession(sessionPath)
    Bridge-->>IPC: switched (bool)
    IPC-->>Renderer: SessionSwitchResponse

    Renderer->>Renderer: set currentSessionIdAtom
    Renderer->>Preload: sessions.getHistory(sessionId)
    Preload->>IPC: invoke session:get-history
    IPC->>SM: resolveSessionPathById(sessionId, cwd)
    Note over SM: Second full directory scan
    SM-->>IPC: sessionPath
    IPC->>Loader: load(sessionPath)
    Loader-->>IPC: { sessionId, events[], warnings[] }
    IPC-->>Renderer: SessionHistoryResponse
    Renderer->>Renderer: applyChatEventAtom x N (replay history)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/atoms/session.ts`, line 204-223 ([link](https://github.com/gannonh/kata/blob/378193160ba81b2ae83b580a30547150dbce9808/apps/desktop/src/renderer/atoms/session.ts#L204-L223)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`switchWorkspaceAtom` hydrates history using a stale `currentSessionIdAtom` read**

   The atom sets `currentSessionIdAtom` to `null` on line 210, then awaits `refreshSessionListAtom`. Inside `refreshSessionListAtom`, `applySessionListResponseAtom` runs and sets `currentSessionIdAtom` to `response.sessions[0]?.id ?? null`. After that await, `switchWorkspaceAtom` reads `get(currentSessionIdAtom)` expecting the new value.

   This depends on Jotai propagating the write from `applySessionListResponseAtom` through the `set` call chain such that the outer `get` sees the updated value synchronously after `await set(refreshSessionListAtom)` resolves. In the current Jotai v2 write model this does work, but it is a non-obvious dependency: the outer atom's `get` reads state that was mutated by a nested atom's `set` mid-execution. A future refactor of `applySessionListResponseAtom` (e.g. stopping the auto-select behavior) would silently break workspace-switching history hydration with no type error.

   Consider making the dependency explicit — return the new `currentSessionId` from `refreshSessionListAtom` (or pass it as a return value of `applySessionListResponseAtom`) and use that directly rather than reading the atom again after the fact.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/atoms/session.ts
   Line: 204-223

   Comment:
   **`switchWorkspaceAtom` hydrates history using a stale `currentSessionIdAtom` read**

   The atom sets `currentSessionIdAtom` to `null` on line 210, then awaits `refreshSessionListAtom`. Inside `refreshSessionListAtom`, `applySessionListResponseAtom` runs and sets `currentSessionIdAtom` to `response.sessions[0]?.id ?? null`. After that await, `switchWorkspaceAtom` reads `get(currentSessionIdAtom)` expecting the new value.

   This depends on Jotai propagating the write from `applySessionListResponseAtom` through the `set` call chain such that the outer `get` sees the updated value synchronously after `await set(refreshSessionListAtom)` resolves. In the current Jotai v2 write model this does work, but it is a non-obvious dependency: the outer atom's `get` reads state that was mutated by a nested atom's `set` mid-execution. A future refactor of `applySessionListResponseAtom` (e.g. stopping the auto-select behavior) would silently break workspace-switching history hydration with no type error.

   Consider making the dependency explicit — return the new `currentSessionId` from `refreshSessionListAtom` (or pass it as a return value of `applySessionListResponseAtom`) and use that directly rather than reading the atom again after the fact.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/session-history-loader.ts
Line: 319-342

Comment:
**Content-block ordering within an assistant message is not preserved**

`parseAssistantContent` correctly separates blocks into `thinkingBlocks`, `textBlocks`, and `toolUses`, but the replay loop always emits them in fixed order: **all thinking → all text → all tool uses**. The original interleaved order in the JSONL content array is discarded.

For the common case `[thinking, tool_use]` the result is fine, but for content like:
```json
[
  { "type": "thinking", "text": "…" },
  { "type": "tool_use", … },
  { "type": "text", "text": "Here is what I found" }
]
```
the replay emits thinking → "Here is what I found" → tool_use, inverting the text/tool relationship. A user switching to this session would see the assistant's summary rendered before the tool card that produced it.

To preserve ordering, `parseAssistantContent` should return the blocks in original sequence (e.g. as a tagged union array `Array<ThinkingBlock | TextBlock | ToolUseBlock>`) and the emission loop should iterate that array in order.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/session.ts
Line: 68-70

Comment:
**History-load errors stored in `sessionListErrorAtom` produce misleading UI**

When history hydration fails, the error is written to `sessionListErrorAtom`. In `SessionSidebar.tsx` that atom is rendered as:

```tsx
{!loading && error && (
  <p className="... text-rose-200">
    Unable to load sessions: {error}
  </p>
)}
```

So a transient history-load failure (e.g. a single corrupted JSONL) tells the user *"Unable to load sessions"* even though the session list itself loaded fine. This also hides the session list items behind the error banner in practice, making it look like the workspace has no sessions.

Consider introducing a dedicated `sessionHistoryErrorAtom` (distinct from `sessionListErrorAtom`) and surfacing the history error inline in the chat pane or as a dismissible toast rather than in the session-list error slot.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/session.ts
Line: 204-223

Comment:
**`switchWorkspaceAtom` hydrates history using a stale `currentSessionIdAtom` read**

The atom sets `currentSessionIdAtom` to `null` on line 210, then awaits `refreshSessionListAtom`. Inside `refreshSessionListAtom`, `applySessionListResponseAtom` runs and sets `currentSessionIdAtom` to `response.sessions[0]?.id ?? null`. After that await, `switchWorkspaceAtom` reads `get(currentSessionIdAtom)` expecting the new value.

This depends on Jotai propagating the write from `applySessionListResponseAtom` through the `set` call chain such that the outer `get` sees the updated value synchronously after `await set(refreshSessionListAtom)` resolves. In the current Jotai v2 write model this does work, but it is a non-obvious dependency: the outer atom's `get` reads state that was mutated by a nested atom's `set` mid-execution. A future refactor of `applySessionListResponseAtom` (e.g. stopping the auto-select behavior) would silently break workspace-switching history hydration with no type error.

Consider making the dependency explicit — return the new `currentSessionId` from `refreshSessionListAtom` (or pass it as a return value of `applySessionListResponseAtom`) and use that directly rather than reading the atom again after the fact.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/session-manager.ts
Line: 256-265

Comment:
**`resolveSessionPathById` performs a full directory scan on every call**

`resolveSessionPathById` calls `listSessions(cwd)`, which opens every `.jsonl` file in the sessions directory to read its header and parse metadata. When a user switches sessions, this full scan is triggered twice in close succession:

1. `sessionSwitch` IPC handler → `resolveSessionPathById`
2. `sessionGetHistory` IPC handler (called immediately after by `hydrateSessionHistoryAtom`) → `resolveSessionPathById` again

For workspaces with many sessions this is a noticeable disk hit. Consider passing the resolved `sessionPath` directly from the switch response through to `getHistory` (so the renderer doesn't need to re-resolve it), or maintaining a lightweight in-memory `id → path` cache that is invalidated on session-list refresh.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/session-history-loader.ts
Line: 254-256

Comment:
**Session ID is extracted from line 0 regardless of entry type**

```typescript
if (index === 0) {
  sessionId = asString(entry.id)
}
```

The session header is expected to be the first line, so this is correct for well-formed files. However, if the first line *does* have an `id` field for a different reason (e.g. a malformed envelope), it would be used as the session ID incorrectly. A defensive guard like `asString(entry.type) === 'session'` would make the intent explicit and prevent accidental ID assignment from non-header lines.

```suggestion
      if (index === 0 && asString(entry.type) === 'session') {
        sessionId = asString(entry.id)
      }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): restore and switch sessio..."](https://github.com/gannonh/kata/commit/378193160ba81b2ae83b580a30547150dbce9808) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27233634)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->