### PR TITLE
KAT-2226: proactive artifact loading and planning persistence

### DIFF
--- a/apps/desktop/src/main/__tests__/linear-document-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-document-client.test.ts
@@ -185,6 +185,99 @@ describe('LinearDocumentClient', () => {
     expect(firstRequestBody.query).toContain('query ResolveProjectId($projectRef: ID!)')
   })
 
+  test('paginates project documents and requests updatedAt-desc ordering', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-uuid-123',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              documents: {
+                nodes: [
+                  {
+                    title: 'ROADMAP',
+                    content: '# First page',
+                    updatedAt: '2026-04-03T00:00:00.000Z',
+                    project: { id: 'project-uuid-123' },
+                    issue: null,
+                  },
+                ],
+                pageInfo: {
+                  hasNextPage: true,
+                  endCursor: 'cursor-page-1',
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              documents: {
+                nodes: [
+                  {
+                    title: 'DECISIONS',
+                    content: '# Second page',
+                    updatedAt: '2026-04-03T01:00:00.000Z',
+                    project: { id: 'project-uuid-123' },
+                    issue: null,
+                  },
+                ],
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null,
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    const client = new LinearDocumentClient({ getApiKey: vi.fn(async () => null) } as never)
+    const artifacts = await client.listByProject('project-ref')
+
+    expect(artifacts.map((artifact) => artifact.title)).toEqual(['DECISIONS', 'ROADMAP'])
+
+    const firstDocumentsBody = JSON.parse(
+      String((fetchSpy.mock.calls[1]?.[1] as RequestInit | undefined)?.body),
+    ) as {
+      query: string
+      variables: Record<string, string>
+    }
+    expect(firstDocumentsBody.query).toContain('orderBy: { updatedAt: DESC }')
+    expect(firstDocumentsBody.variables).toEqual({ projectId: 'project-uuid-123' })
+
+    const secondDocumentsBody = JSON.parse(
+      String((fetchSpy.mock.calls[2]?.[1] as RequestInit | undefined)?.body),
+    ) as {
+      variables: Record<string, string>
+    }
+    expect(secondDocumentsBody.variables).toEqual({
+      projectId: 'project-uuid-123',
+      after: 'cursor-page-1',
+    })
+  })
+
   test('returns NOT_FOUND when project reference cannot be resolved', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 

--- a/apps/desktop/src/main/__tests__/linear-document-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-document-client.test.ts
@@ -75,6 +75,96 @@ describe('LinearDocumentClient', () => {
     })
   })
 
+  test('lists project-scoped planning artifacts with project slug resolution', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-uuid-123',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              documents: {
+                nodes: [
+                  {
+                    title: 'DECISIONS',
+                    content: '# Decisions',
+                    updatedAt: '2026-04-03T00:00:00.000Z',
+                    project: { id: 'project-uuid-123' },
+                    issue: null,
+                  },
+                  {
+                    title: 'M002B-ROADMAP',
+                    content: '# Roadmap',
+                    updatedAt: '2026-04-03T01:00:00.000Z',
+                    project: { id: 'project-uuid-123' },
+                    issue: null,
+                  },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearDocumentClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(client.listByProject('b0f5a7be6537')).resolves.toEqual([
+      {
+        title: 'M002B-ROADMAP',
+        artifactKey: 'project:project-uuid-123:M002B-ROADMAP',
+        content: '# Roadmap',
+        updatedAt: '2026-04-03T01:00:00.000Z',
+        scope: 'project',
+        projectId: 'project-uuid-123',
+        issueId: undefined,
+      },
+      {
+        title: 'DECISIONS',
+        artifactKey: 'project:project-uuid-123:DECISIONS',
+        content: '# Decisions',
+        updatedAt: '2026-04-03T00:00:00.000Z',
+        scope: 'project',
+        projectId: 'project-uuid-123',
+        issueId: undefined,
+      },
+    ])
+  })
+
+  test('returns NOT_FOUND when project reference cannot be resolved', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            project: null,
+          },
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch
+
+    const client = new LinearDocumentClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(client.listByProject('missing-project')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: expect.stringContaining('missing-project'),
+    })
+  })
+
   test('returns null when Linear responds with no matching documents', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 

--- a/apps/desktop/src/main/__tests__/linear-document-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-document-client.test.ts
@@ -144,6 +144,47 @@ describe('LinearDocumentClient', () => {
     ])
   })
 
+  test('uses ID variable typing when resolving project references', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-uuid-123',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              documents: {
+                nodes: [],
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    const client = new LinearDocumentClient({ getApiKey: vi.fn(async () => null) } as never)
+    await client.listByProject('project-ref')
+
+    const firstRequestInit = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined
+    const firstRequestBody = JSON.parse(String(firstRequestInit?.body)) as { query: string }
+
+    expect(firstRequestBody.query).toContain('query ResolveProjectId($projectRef: ID!)')
+  })
+
   test('returns NOT_FOUND when project reference cannot be resolved', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -899,6 +899,55 @@ export function registerSessionIpc({
   )
 
   ipcMain.handle(IPC_CHANNELS.planningListArtifacts, async (): Promise<PlanningArtifactListResponse> => {
+    let stale = false
+    let staleError: PlanningArtifactListResponse['error']
+
+    const workspacePath = bridge.getWorkspacePath()
+    const projectRef = await readLinearProjectReference(workspacePath)
+
+    if (projectRef) {
+      try {
+        const projectArtifacts = await linearDocumentClient.listByProject(projectRef)
+
+        for (const projectArtifact of projectArtifacts) {
+          const artifactType = detectArtifactTypeFromTitle(projectArtifact.title)
+          if (!isStartupProactiveArtifactType(artifactType)) {
+            continue
+          }
+
+          const existingArtifact = planningArtifactsByKey.get(projectArtifact.artifactKey)
+          const artifact: PlanningArtifact = {
+            ...projectArtifact,
+            artifactType,
+            sliceData: projectArtifact.sliceData ?? existingArtifact?.sliceData,
+          }
+
+          planningArtifactsByKey.set(artifact.artifactKey, artifact)
+          planningLatestKeyByTitle.set(artifact.title, artifact.artifactKey)
+          planningMetadataByKey.set(artifact.artifactKey, {
+            eventType: 'document',
+            toolName: 'startup_proactive_load',
+            toolCallId: `startup:${artifact.artifactKey}`,
+            title: artifact.title,
+            artifactKey: artifact.artifactKey,
+            scope: artifact.scope,
+            action: 'updated',
+            projectId: artifact.projectId,
+            issueId: artifact.issueId,
+          })
+        }
+      } catch (error) {
+        stale = true
+        staleError = LinearDocumentClient.toPlanningArtifactError(error)
+
+        log.warn('[desktop-ipc] planning proactive artifact load failed', {
+          workspacePath,
+          projectRef,
+          error: staleError,
+        })
+      }
+    }
+
     const artifacts = Array.from(planningArtifactsByKey.values()).sort((left, right) => {
       return Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
     })
@@ -906,6 +955,8 @@ export function registerSessionIpc({
     return {
       success: true,
       artifacts,
+      stale,
+      error: staleError,
     }
   })
 
@@ -971,6 +1022,72 @@ function detectArtifactTypeFromTitle(title: string): ArtifactType | undefined {
   }
 
   return undefined
+}
+
+function isStartupProactiveArtifactType(artifactType: ArtifactType | undefined): boolean {
+  return (
+    artifactType === 'roadmap' ||
+    artifactType === 'requirements' ||
+    artifactType === 'decisions' ||
+    artifactType === 'context'
+  )
+}
+
+async function readLinearProjectReference(workspacePath: string): Promise<string | null> {
+  const preferencesPath = path.join(workspacePath, '.kata', 'preferences.md')
+
+  let content: string
+  try {
+    content = await fs.readFile(preferencesPath, 'utf8')
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : undefined
+
+    if (code === 'ENOENT') {
+      return null
+    }
+
+    log.warn('[desktop-ipc] unable to read .kata/preferences.md for proactive planning load', {
+      workspacePath,
+      preferencesPath,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+
+  const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/)
+  if (!frontmatterMatch) {
+    return null
+  }
+
+  const frontmatter = frontmatterMatch[1]
+  if (!frontmatter) {
+    return null
+  }
+
+  const projectIdMatch = frontmatter.match(/^\s*projectId:\s*([^\n#]+)$/m)
+  if (projectIdMatch?.[1]) {
+    const projectId = stripYamlWrapping(projectIdMatch[1].trim())
+    if (projectId) {
+      return projectId
+    }
+  }
+
+  const projectSlugMatch = frontmatter.match(/^\s*projectSlug:\s*([^\n#]+)$/m)
+  if (projectSlugMatch?.[1]) {
+    const projectSlug = stripYamlWrapping(projectSlugMatch[1].trim())
+    if (projectSlug) {
+      return projectSlug
+    }
+  }
+
+  return null
+}
+
+function stripYamlWrapping(value: string): string {
+  return value.replace(/^['"]/, '').replace(/['"]$/, '').trim()
 }
 
 function extractSliceIdFromTitle(title: string): string | undefined {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -899,15 +899,32 @@ export function registerSessionIpc({
   )
 
   ipcMain.handle(IPC_CHANNELS.planningListArtifacts, async (): Promise<PlanningArtifactListResponse> => {
-    let stale = false
     let staleError: PlanningArtifactListResponse['error']
 
     const workspacePath = bridge.getWorkspacePath()
     const projectRef = await readLinearProjectReference(workspacePath)
+    const startupScopePrefix = projectRef ? `startup:${workspacePath}:${projectRef}:` : null
+
+    const clearStartupProactiveArtifacts = (): void => {
+      for (const [artifactKey, metadata] of planningMetadataByKey.entries()) {
+        if (metadata.toolName !== 'startup_proactive_load') {
+          continue
+        }
+
+        planningMetadataByKey.delete(artifactKey)
+        planningArtifactsByKey.delete(artifactKey)
+
+        if (planningLatestKeyByTitle.get(metadata.title) === artifactKey) {
+          planningLatestKeyByTitle.delete(metadata.title)
+        }
+      }
+    }
 
     if (projectRef) {
       try {
         const projectArtifacts = await linearDocumentClient.listByProject(projectRef)
+
+        clearStartupProactiveArtifacts()
 
         for (const projectArtifact of projectArtifacts) {
           const artifactType = detectArtifactTypeFromTitle(projectArtifact.title)
@@ -927,7 +944,7 @@ export function registerSessionIpc({
           planningMetadataByKey.set(artifact.artifactKey, {
             eventType: 'document',
             toolName: 'startup_proactive_load',
-            toolCallId: `startup:${artifact.artifactKey}`,
+            toolCallId: `${startupScopePrefix ?? 'startup:'}${artifact.artifactKey}`,
             title: artifact.title,
             artifactKey: artifact.artifactKey,
             scope: artifact.scope,
@@ -937,7 +954,6 @@ export function registerSessionIpc({
           })
         }
       } catch (error) {
-        stale = true
         staleError = LinearDocumentClient.toPlanningArtifactError(error)
 
         log.warn('[desktop-ipc] planning proactive artifact load failed', {
@@ -948,15 +964,45 @@ export function registerSessionIpc({
       }
     }
 
-    const artifacts = Array.from(planningArtifactsByKey.values()).sort((left, right) => {
-      return Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
-    })
+    const artifacts = Array.from(planningArtifactsByKey.values())
+      .filter((artifact) => {
+        if (!startupScopePrefix) {
+          return true
+        }
+
+        const metadata = planningMetadataByKey.get(artifact.artifactKey)
+        if (metadata?.toolName !== 'startup_proactive_load') {
+          return true
+        }
+
+        return metadata.toolCallId.startsWith(startupScopePrefix)
+      })
+      .sort((left, right) => {
+        return Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+      })
+
+    if (staleError) {
+      if (artifacts.length === 0) {
+        return {
+          success: false,
+          artifacts: [],
+          stale: false,
+          error: staleError,
+        }
+      }
+
+      return {
+        success: true,
+        artifacts,
+        stale: true,
+        error: staleError,
+      }
+    }
 
     return {
       success: true,
       artifacts,
-      stale,
-      error: staleError,
+      stale: false,
     }
   })
 
@@ -1057,7 +1103,7 @@ async function readLinearProjectReference(workspacePath: string): Promise<string
     return null
   }
 
-  const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/)
+  const frontmatterMatch = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/)
   if (!frontmatterMatch) {
     return null
   }

--- a/apps/desktop/src/main/linear-document-client.ts
+++ b/apps/desktop/src/main/linear-document-client.ts
@@ -39,6 +39,10 @@ interface GraphQLResponse<TData> {
 interface DocumentsQueryData {
   documents?: {
     nodes?: LinearDocumentNode[]
+    pageInfo?: {
+      hasNextPage?: boolean
+      endCursor?: string | null
+    }
   }
 }
 
@@ -214,31 +218,57 @@ export class LinearDocumentClient {
         )
       }
 
-      const data = await this.request<DocumentsQueryData>(
-        apiKey,
-        `
-          query PlanningDocumentsByProject($projectId: ID!) {
-            documents(first: 100, filter: { project: { id: { eq: $projectId } } }) {
-              nodes {
-                title
-                content
-                updatedAt
-                project {
-                  id
+      const nodes: LinearDocumentNode[] = []
+      let afterCursor: string | null = null
+
+      while (true) {
+        const data: DocumentsQueryData = await this.request<DocumentsQueryData>(
+          apiKey,
+          `
+            query PlanningDocumentsByProject($projectId: ID!, $after: String) {
+              documents(
+                first: 100
+                after: $after
+                orderBy: { updatedAt: DESC }
+                filter: { project: { id: { eq: $projectId } } }
+              ) {
+                nodes {
+                  title
+                  content
+                  updatedAt
+                  project {
+                    id
+                  }
+                  issue {
+                    id
+                  }
                 }
-                issue {
-                  id
+                pageInfo {
+                  hasNextPage
+                  endCursor
                 }
               }
             }
-          }
-        `,
-        {
-          projectId,
-        },
-      )
+          `,
+          {
+            projectId,
+            ...(afterCursor ? { after: afterCursor } : {}),
+          },
+        )
 
-      const artifacts = (data.documents?.nodes ?? [])
+        nodes.push(...(data.documents?.nodes ?? []))
+
+        const hasNextPage = data.documents?.pageInfo?.hasNextPage === true
+        const nextCursor: string | null = data.documents?.pageInfo?.endCursor?.trim() || null
+
+        if (!hasNextPage || !nextCursor) {
+          break
+        }
+
+        afterCursor = nextCursor
+      }
+
+      const artifacts = nodes
         .filter((node): node is LinearDocumentNode & { title: string } => Boolean(node.title?.trim()))
         .map((node) => {
           const scope: PlanningArtifactScope = node.issue?.id ? 'issue' : 'project'

--- a/apps/desktop/src/main/linear-document-client.ts
+++ b/apps/desktop/src/main/linear-document-client.ts
@@ -42,6 +42,12 @@ interface DocumentsQueryData {
   }
 }
 
+interface ResolveProjectQueryData {
+  project?: {
+    id?: string
+  } | null
+}
+
 export class LinearDocumentClientError extends Error {
   constructor(
     public readonly code: PlanningArtifactErrorCode,
@@ -69,13 +75,7 @@ export class LinearDocumentClient {
     const startedAt = Date.now()
 
     try {
-      const apiKey = await this.resolveApiKey()
-      if (!apiKey) {
-        throw new LinearDocumentClientError(
-          'MISSING_API_KEY',
-          'Linear API key required. Configure provider "linear" in auth.json or set LINEAR_API_KEY.',
-        )
-      }
+      const apiKey = await this.requireApiKey()
 
       const variables: Record<string, string> = {
         title,
@@ -101,90 +101,29 @@ export class LinearDocumentClient {
         .filter((value): value is string => Boolean(value))
         .join(', ')
 
-      const query = `
-        query PlanningDocumentByTitle(${variableDefinitions}) {
-          documents(first: 20, filter: { ${filterConditions.join(', ')} }) {
-            nodes {
-              title
-              content
-              updatedAt
-              project {
-                id
-              }
-              issue {
-                id
+      const data = await this.request<DocumentsQueryData>(
+        apiKey,
+        `
+          query PlanningDocumentByTitle(${variableDefinitions}) {
+            documents(first: 20, filter: { ${filterConditions.join(', ')} }) {
+              nodes {
+                title
+                content
+                updatedAt
+                project {
+                  id
+                }
+                issue {
+                  id
+                }
               }
             }
           }
-        }
-      `
+        `,
+        variables,
+      )
 
-      const controller = new AbortController()
-      const timeoutId = setTimeout(() => {
-        controller.abort()
-      }, this.requestTimeoutMs)
-
-      let response: Response
-      try {
-        response = await fetch(this.apiUrl, {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            authorization: apiKey,
-          },
-          signal: controller.signal,
-          body: JSON.stringify({
-            query,
-            variables,
-          }),
-        })
-      } finally {
-        clearTimeout(timeoutId)
-      }
-
-      if (response.status === 401 || response.status === 403) {
-        throw new LinearDocumentClientError('UNAUTHORIZED', 'Invalid Linear API key', response.status)
-      }
-
-      if (response.status === 404) {
-        throw new LinearDocumentClientError(
-          'NETWORK',
-          'Linear API endpoint not found (HTTP 404). Verify endpoint configuration.',
-          response.status,
-        )
-      }
-
-      if (response.status === 429) {
-        throw new LinearDocumentClientError('RATE_LIMITED', 'Linear API rate limit exceeded', response.status)
-      }
-
-      const payload = (await response
-        .json()
-        .catch(() => ({}))) as GraphQLResponse<DocumentsQueryData>
-
-      if (!response.ok) {
-        const firstErrorMessage = payload.errors?.[0]?.message
-        if (firstErrorMessage) {
-          throw new LinearDocumentClientError('GRAPHQL', firstErrorMessage, response.status)
-        }
-
-        throw new LinearDocumentClientError(
-          'NETWORK',
-          `Linear API request failed with status ${response.status}`,
-          response.status,
-        )
-      }
-
-      if (Array.isArray(payload.errors) && payload.errors.length > 0) {
-        const firstErrorMessage = payload.errors[0]?.message ?? 'Unknown GraphQL error'
-        if (/rate\s*limit/i.test(firstErrorMessage)) {
-          throw new LinearDocumentClientError('RATE_LIMITED', firstErrorMessage, response.status)
-        }
-
-        throw new LinearDocumentClientError('GRAPHQL', firstErrorMessage, response.status)
-      }
-
-      const nodes = payload.data?.documents?.nodes ?? []
+      const nodes = data.documents?.nodes ?? []
       if (nodes.length === 0) {
         log.info('[linear-document-client] planning:fetch', {
           title,
@@ -256,12 +195,113 @@ export class LinearDocumentClient {
     }
   }
 
+  public async listByProject(projectRef: string): Promise<PlanningArtifact[]> {
+    const normalizedProjectRef = projectRef.trim()
+    if (!normalizedProjectRef) {
+      throw new LinearDocumentClientError('UNKNOWN', 'Project reference is required')
+    }
+
+    const startedAt = Date.now()
+
+    try {
+      const apiKey = await this.requireApiKey()
+      const projectId = await this.resolveProjectId(apiKey, normalizedProjectRef)
+
+      if (!projectId) {
+        throw new LinearDocumentClientError(
+          'NOT_FOUND',
+          `Linear project "${normalizedProjectRef}" was not found`,
+        )
+      }
+
+      const data = await this.request<DocumentsQueryData>(
+        apiKey,
+        `
+          query PlanningDocumentsByProject($projectId: ID!) {
+            documents(first: 100, filter: { project: { id: { eq: $projectId } } }) {
+              nodes {
+                title
+                content
+                updatedAt
+                project {
+                  id
+                }
+                issue {
+                  id
+                }
+              }
+            }
+          }
+        `,
+        {
+          projectId,
+        },
+      )
+
+      const artifacts = (data.documents?.nodes ?? [])
+        .filter((node): node is LinearDocumentNode & { title: string } => Boolean(node.title?.trim()))
+        .map((node) => {
+          const scope: PlanningArtifactScope = node.issue?.id ? 'issue' : 'project'
+          const resolvedProjectId = node.project?.id ?? projectId
+          const resolvedIssueId = node.issue?.id
+
+          return {
+            title: node.title,
+            artifactKey: buildPlanningArtifactKey({
+              title: node.title,
+              scope,
+              projectId: resolvedProjectId,
+              issueId: resolvedIssueId,
+            }),
+            content: node.content ?? '',
+            updatedAt: node.updatedAt ?? new Date().toISOString(),
+            scope,
+            projectId: resolvedProjectId,
+            issueId: resolvedIssueId,
+          } satisfies PlanningArtifact
+        })
+        .sort((left, right) => toTimestamp(right.updatedAt) - toTimestamp(left.updatedAt))
+
+      log.info('[linear-document-client] planning:list-by-project', {
+        projectRef: normalizedProjectRef,
+        projectId,
+        artifactCount: artifacts.length,
+        latencyMs: Date.now() - startedAt,
+      })
+
+      return artifacts
+    } catch (error) {
+      const clientError = toLinearDocumentClientError(error)
+
+      log.warn('[linear-document-client] planning:list-by-project', {
+        projectRef: normalizedProjectRef,
+        status: clientError.code.toLowerCase(),
+        error: clientError.message,
+        latencyMs: Date.now() - startedAt,
+      })
+
+      throw clientError
+    }
+  }
+
   public static toPlanningArtifactError(error: unknown): PlanningArtifactError {
     const clientError = toLinearDocumentClientError(error)
     return {
       code: clientError.code,
       message: clientError.message,
     }
+  }
+
+  private async requireApiKey(): Promise<string> {
+    const apiKey = await this.resolveApiKey()
+    if (!apiKey) {
+      throw new LinearDocumentClientError(
+        'MISSING_API_KEY',
+        'Linear API key required. Configure provider "linear" in auth.json or set LINEAR_API_KEY.',
+      )
+    }
+
+    return apiKey
   }
 
   private async resolveApiKey(): Promise<string | null> {
@@ -273,12 +313,99 @@ export class LinearDocumentClient {
     return this.authBridge.getApiKey('linear')
   }
 
+  private async resolveProjectId(apiKey: string, projectRef: string): Promise<string | null> {
+    const data = await this.request<ResolveProjectQueryData>(
+      apiKey,
+      `
+        query ResolveProjectId($projectRef: String!) {
+          project(id: $projectRef) {
+            id
+          }
+        }
+      `,
+      {
+        projectRef,
+      },
+    )
+
+    return data.project?.id?.trim() || null
+  }
+
   private resolveScope(options: FetchByTitleOptions, node: LinearDocumentNode): PlanningArtifactScope {
     if (options.issueId || node.issue?.id) {
       return 'issue'
     }
 
     return 'project'
+  }
+
+  private async request<TData>(
+    apiKey: string,
+    query: string,
+    variables: Record<string, string>,
+  ): Promise<TData> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => {
+      controller.abort()
+    }, this.requestTimeoutMs)
+
+    let response: Response
+    try {
+      response = await fetch(this.apiUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: apiKey,
+        },
+        signal: controller.signal,
+        body: JSON.stringify({
+          query,
+          variables,
+        }),
+      })
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new LinearDocumentClientError('UNAUTHORIZED', 'Invalid Linear API key', response.status)
+    }
+
+    if (response.status === 404) {
+      throw new LinearDocumentClientError(
+        'NETWORK',
+        'Linear API endpoint not found (HTTP 404). Verify endpoint configuration.',
+        response.status,
+      )
+    }
+
+    if (response.status === 429) {
+      throw new LinearDocumentClientError('RATE_LIMITED', 'Linear API rate limit exceeded', response.status)
+    }
+
+    const payload = (await response
+      .json()
+      .catch(() => ({}))) as GraphQLResponse<TData>
+
+    if (!response.ok) {
+      const firstErrorMessage = payload.errors?.[0]?.message
+      if (firstErrorMessage) {
+        throw toGraphqlError(firstErrorMessage, response.status)
+      }
+
+      throw new LinearDocumentClientError(
+        'NETWORK',
+        `Linear API request failed with status ${response.status}`,
+        response.status,
+      )
+    }
+
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+      const firstErrorMessage = payload.errors[0]?.message ?? 'Unknown GraphQL error'
+      throw toGraphqlError(firstErrorMessage, response.status)
+    }
+
+    return (payload.data ?? {}) as TData
   }
 }
 
@@ -289,6 +416,18 @@ function toTimestamp(value: string | undefined): number {
 
   const timestamp = Date.parse(value)
   return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+function toGraphqlError(message: string, status?: number): LinearDocumentClientError {
+  if (/rate\s*limit/i.test(message)) {
+    return new LinearDocumentClientError('RATE_LIMITED', message, status)
+  }
+
+  if (/not\s*found/i.test(message)) {
+    return new LinearDocumentClientError('NOT_FOUND', message, status)
+  }
+
+  return new LinearDocumentClientError('GRAPHQL', message, status)
 }
 
 function toLinearDocumentClientError(error: unknown): LinearDocumentClientError {

--- a/apps/desktop/src/main/linear-document-client.ts
+++ b/apps/desktop/src/main/linear-document-client.ts
@@ -317,7 +317,7 @@ export class LinearDocumentClient {
     const data = await this.request<ResolveProjectQueryData>(
       apiKey,
       `
-        query ResolveProjectId($projectRef: String!) {
+        query ResolveProjectId($projectRef: ID!) {
           project(id: $projectRef) {
             id
           }

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -4,6 +4,9 @@ import { useEffect, useRef } from 'react'
 import type { PlanningArtifact, PlanningSliceData } from '@shared/types'
 
 export const RIGHT_PANE_MODE_STORAGE_KEY = 'kata-desktop:right-pane-mode'
+const PLANNING_ARTIFACTS_STORAGE_KEY = 'kata-desktop:planning-artifacts'
+const PLANNING_ARTIFACT_KEYS_STORAGE_KEY = 'kata-desktop:planning-artifact-keys'
+const ACTIVE_PLANNING_ARTIFACT_STORAGE_KEY = 'kata-desktop:active-planning-artifact'
 
 export interface PlanningArtifactState {
   artifactKey: string
@@ -24,9 +27,16 @@ export interface ActivePlanningArtifactRef {
   title: string
 }
 
-export const planningArtifactsAtom = atom<PlanningArtifactsMap>({})
+export const planningArtifactsAtom = atomWithStorage<PlanningArtifactsMap>(
+  PLANNING_ARTIFACTS_STORAGE_KEY,
+  {},
+)
+export const planningArtifactKeysAtom = atomWithStorage<string[]>(PLANNING_ARTIFACT_KEYS_STORAGE_KEY, [])
 export const slicePlanningAtom = atom<Record<string, PlanningSliceData>>({})
-export const activePlanningArtifactAtom = atom<ActivePlanningArtifactRef | null>(null)
+export const activePlanningArtifactAtom = atomWithStorage<ActivePlanningArtifactRef | null>(
+  ACTIVE_PLANNING_ARTIFACT_STORAGE_KEY,
+  null,
+)
 export const rightPaneModeAtom = atomWithStorage<'planning' | 'default'>(
   RIGHT_PANE_MODE_STORAGE_KEY,
   'default',
@@ -36,7 +46,14 @@ export const planningLoadingAtom = atom<boolean>(false)
 export const artifactFetchInFlightCountAtom = atom<number>(0)
 export const isFetchingAtom = atom((get) => get(artifactFetchInFlightCountAtom) > 0)
 export const planningErrorAtom = atom<string | null>(null)
+export const planningArtifactsStaleAtom = atom<boolean>(false)
+export const planningStaleReasonAtom = atom<string | null>(null)
+export const planningReloadNonceAtom = atom<number>(0)
 export const lastViewedPlanningArtifactAtom = atom<Record<string, string>>({})
+
+export const requestPlanningReloadAtom = atom(null, (get, set) => {
+  set(planningReloadNonceAtom, get(planningReloadNonceAtom) + 1)
+})
 
 export const markPlanningArtifactViewedAtom = atom(
   null,
@@ -50,12 +67,15 @@ export const markPlanningArtifactViewedAtom = atom(
 
 export const resetPlanningSessionStateAtom = atom(null, (_get, set) => {
   set(planningArtifactsAtom, {})
+  set(planningArtifactKeysAtom, [])
   set(activePlanningArtifactAtom, null)
   set(slicePlanningAtom, {})
   set(autoSwitchTriggeredAtom, false)
   set(planningLoadingAtom, false)
   set(artifactFetchInFlightCountAtom, 0)
   set(planningErrorAtom, null)
+  set(planningArtifactsStaleAtom, false)
+  set(planningStaleReasonAtom, null)
   set(lastViewedPlanningArtifactAtom, {})
 })
 
@@ -76,6 +96,7 @@ export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: Plannin
   }
 
   set(planningArtifactsAtom, nextArtifacts)
+  set(planningArtifactKeysAtom, deriveArtifactKeys(nextArtifacts))
 
   if (artifact.artifactType === 'slice' && artifact.sliceData) {
     set(slicePlanningAtom, {
@@ -94,14 +115,19 @@ export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: Plannin
 
   set(planningLoadingAtom, false)
   set(planningErrorAtom, null)
+  set(planningArtifactsStaleAtom, false)
+  set(planningStaleReasonAtom, null)
 })
 
 export function usePlanningArtifactBridge(): void {
   const rightPaneMode = useAtomValue(rightPaneModeAtom)
   const autoSwitchTriggered = useAtomValue(autoSwitchTriggeredAtom)
+  const planningReloadNonce = useAtomValue(planningReloadNonceAtom)
 
+  const currentArtifacts = useAtomValue(planningArtifactsAtom)
   const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
   const setArtifacts = useSetAtom(planningArtifactsAtom)
+  const setArtifactKeys = useSetAtom(planningArtifactKeysAtom)
   const pendingTriggerToolNameByArtifactKeyRef = useRef<Record<string, string>>({})
   const rightPaneModeRef = useRef(rightPaneMode)
   const autoSwitchTriggeredRef = useRef(autoSwitchTriggered)
@@ -112,19 +138,38 @@ export function usePlanningArtifactBridge(): void {
   const setLoading = useSetAtom(planningLoadingAtom)
   const setArtifactFetchInFlightCount = useSetAtom(artifactFetchInFlightCountAtom)
   const setError = useSetAtom(planningErrorAtom)
+  const setStale = useSetAtom(planningArtifactsStaleAtom)
+  const setStaleReason = useSetAtom(planningStaleReasonAtom)
 
   rightPaneModeRef.current = rightPaneMode
   autoSwitchTriggeredRef.current = autoSwitchTriggered
 
   useEffect(() => {
+    if (planningReloadNonce === 0) {
+      return
+    }
+
+    let cancelled = false
+
     setLoading(true)
 
     void window.api.planning
       .listArtifacts()
       .then((response) => {
+        if (cancelled) {
+          return
+        }
+
         if (!response.success) {
           setError(response.error?.message ?? 'Unable to list planning artifacts')
           return
+        }
+
+        setStale(response.stale === true)
+        setStaleReason(response.stale ? response.error?.message ?? 'Using cached planning artifacts' : null)
+
+        if (response.stale && response.artifacts.length > 0) {
+          setError(null)
         }
 
         if (response.artifacts.length === 0) {
@@ -146,10 +191,13 @@ export function usePlanningArtifactBridge(): void {
           }
         }
 
-        setArtifacts((currentArtifacts) => ({
-          ...nextArtifacts,
+        const mergedArtifacts: PlanningArtifactsMap = {
           ...currentArtifacts,
-        }))
+          ...nextArtifacts,
+        }
+
+        setArtifacts(mergedArtifacts)
+        setArtifactKeys(deriveArtifactKeys(mergedArtifacts))
 
         const nextSlices = response.artifacts.reduce<Record<string, PlanningSliceData>>(
           (result, artifact) => {
@@ -168,23 +216,47 @@ export function usePlanningArtifactBridge(): void {
 
         const mostRecentArtifact = response.artifacts[0]
         if (mostRecentArtifact) {
-          setActiveArtifactTitle(
-            (currentActiveArtifact) =>
-              currentActiveArtifact ?? {
-                artifactKey: mostRecentArtifact.artifactKey,
-                title: mostRecentArtifact.title,
-              },
+          setActiveArtifactTitle((currentActiveArtifact) =>
+            currentActiveArtifact ?? {
+              artifactKey: mostRecentArtifact.artifactKey,
+              title: mostRecentArtifact.title,
+            },
           )
         }
       })
       .catch((error: unknown) => {
+        if (cancelled) {
+          return
+        }
+
         const message = error instanceof Error ? error.message : String(error)
         setError(message)
       })
       .finally(() => {
+        if (cancelled) {
+          return
+        }
+
         setLoading(false)
       })
 
+    return () => {
+      cancelled = true
+    }
+  }, [
+    currentArtifacts,
+    planningReloadNonce,
+    setActiveArtifactTitle,
+    setArtifactKeys,
+    setArtifacts,
+    setError,
+    setLoading,
+    setSlices,
+    setStale,
+    setStaleReason,
+  ])
+
+  useEffect(() => {
     const unsubscribeFetchState = window.api.planning.onArtifactFetchState((event) => {
       if (event.state === 'start') {
         setArtifactFetchInFlightCount((current) => current + 1)
@@ -227,13 +299,15 @@ export function usePlanningArtifactBridge(): void {
     }
   }, [
     applyPlanningArtifact,
-    setActiveArtifactTitle,
-    setArtifacts,
     setArtifactFetchInFlightCount,
     setAutoSwitchTriggered,
     setError,
-    setLoading,
     setRightPaneMode,
-    setSlices,
   ])
+}
+
+function deriveArtifactKeys(artifactsByKey: PlanningArtifactsMap): string[] {
+  return Object.values(artifactsByKey)
+    .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
+    .map((artifact) => artifact.artifactKey)
 }

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -119,15 +119,43 @@ export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: Plannin
   set(planningStaleReasonAtom, null)
 })
 
+export const applyBulkPlanningArtifactsAtom = atom(
+  null,
+  (
+    get,
+    set,
+    options: {
+      nextArtifacts: PlanningArtifactsMap
+      mergeWithExisting: boolean
+    },
+  ) => {
+    const resolvedArtifacts = options.mergeWithExisting
+      ? {
+          ...get(planningArtifactsAtom),
+          ...options.nextArtifacts,
+        }
+      : options.nextArtifacts
+
+    set(planningArtifactsAtom, resolvedArtifacts)
+    set(planningArtifactKeysAtom, deriveArtifactKeys(resolvedArtifacts))
+  },
+)
+
+export const clearPlanningArtifactsAtom = atom(null, (_get, set) => {
+  set(planningArtifactsAtom, {})
+  set(planningArtifactKeysAtom, [])
+  set(slicePlanningAtom, {})
+  set(activePlanningArtifactAtom, null)
+})
+
 export function usePlanningArtifactBridge(): void {
   const rightPaneMode = useAtomValue(rightPaneModeAtom)
   const autoSwitchTriggered = useAtomValue(autoSwitchTriggeredAtom)
   const planningReloadNonce = useAtomValue(planningReloadNonceAtom)
 
-  const currentArtifacts = useAtomValue(planningArtifactsAtom)
   const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
-  const setArtifacts = useSetAtom(planningArtifactsAtom)
-  const setArtifactKeys = useSetAtom(planningArtifactKeysAtom)
+  const applyBulkPlanningArtifacts = useSetAtom(applyBulkPlanningArtifactsAtom)
+  const clearPlanningArtifacts = useSetAtom(clearPlanningArtifactsAtom)
   const pendingTriggerToolNameByArtifactKeyRef = useRef<Record<string, string>>({})
   const rightPaneModeRef = useRef(rightPaneMode)
   const autoSwitchTriggeredRef = useRef(autoSwitchTriggered)
@@ -168,11 +196,14 @@ export function usePlanningArtifactBridge(): void {
         setStale(response.stale === true)
         setStaleReason(response.stale ? response.error?.message ?? 'Using cached planning artifacts' : null)
 
-        if (response.stale && response.artifacts.length > 0) {
+        if (response.stale) {
           setError(null)
         }
 
         if (response.artifacts.length === 0) {
+          if (!response.stale) {
+            clearPlanningArtifacts()
+          }
           return
         }
 
@@ -191,13 +222,10 @@ export function usePlanningArtifactBridge(): void {
           }
         }
 
-        const mergedArtifacts: PlanningArtifactsMap = {
-          ...currentArtifacts,
-          ...nextArtifacts,
-        }
-
-        setArtifacts(mergedArtifacts)
-        setArtifactKeys(deriveArtifactKeys(mergedArtifacts))
+        applyBulkPlanningArtifacts({
+          nextArtifacts,
+          mergeWithExisting: response.stale === true,
+        })
 
         const nextSlices = response.artifacts.reduce<Record<string, PlanningSliceData>>(
           (result, artifact) => {
@@ -209,20 +237,41 @@ export function usePlanningArtifactBridge(): void {
           {},
         )
 
-        setSlices((currentSlices) => ({
-          ...nextSlices,
-          ...currentSlices,
-        }))
+        if (response.stale) {
+          setSlices((currentSlices) => ({
+            ...nextSlices,
+            ...currentSlices,
+          }))
+        } else {
+          setSlices(nextSlices)
+        }
 
         const mostRecentArtifact = response.artifacts[0]
-        if (mostRecentArtifact) {
-          setActiveArtifactTitle((currentActiveArtifact) =>
-            currentActiveArtifact ?? {
-              artifactKey: mostRecentArtifact.artifactKey,
-              title: mostRecentArtifact.title,
-            },
-          )
-        }
+        setActiveArtifactTitle((currentActiveArtifact) => {
+          if (!currentActiveArtifact) {
+            return mostRecentArtifact
+              ? {
+                  artifactKey: mostRecentArtifact.artifactKey,
+                  title: mostRecentArtifact.title,
+                }
+              : null
+          }
+
+          if (response.stale) {
+            return currentActiveArtifact
+          }
+
+          if (nextArtifacts[currentActiveArtifact.artifactKey]) {
+            return currentActiveArtifact
+          }
+
+          return mostRecentArtifact
+            ? {
+                artifactKey: mostRecentArtifact.artifactKey,
+                title: mostRecentArtifact.title,
+              }
+            : null
+        })
       })
       .catch((error: unknown) => {
         if (cancelled) {
@@ -244,11 +293,10 @@ export function usePlanningArtifactBridge(): void {
       cancelled = true
     }
   }, [
-    currentArtifacts,
+    applyBulkPlanningArtifacts,
+    clearPlanningArtifacts,
     planningReloadNonce,
     setActiveArtifactTitle,
-    setArtifactKeys,
-    setArtifacts,
     setError,
     setLoading,
     setSlices,

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -115,8 +115,6 @@ export const applyPlanningArtifactAtom = atom(null, (get, set, artifact: Plannin
 
   set(planningLoadingAtom, false)
   set(planningErrorAtom, null)
-  set(planningArtifactsStaleAtom, false)
-  set(planningStaleReasonAtom, null)
 })
 
 export const applyBulkPlanningArtifactsAtom = atom(
@@ -195,10 +193,7 @@ export function usePlanningArtifactBridge(): void {
 
         setStale(response.stale === true)
         setStaleReason(response.stale ? response.error?.message ?? 'Using cached planning artifacts' : null)
-
-        if (response.stale) {
-          setError(null)
-        }
+        setError(null)
 
         if (response.artifacts.length === 0) {
           if (!response.stale) {
@@ -261,8 +256,16 @@ export function usePlanningArtifactBridge(): void {
             return currentActiveArtifact
           }
 
-          if (nextArtifacts[currentActiveArtifact.artifactKey]) {
-            return currentActiveArtifact
+          const updatedArtifact = nextArtifacts[currentActiveArtifact.artifactKey]
+          if (updatedArtifact) {
+            if (updatedArtifact.title === currentActiveArtifact.title) {
+              return currentActiveArtifact
+            }
+
+            return {
+              artifactKey: updatedArtifact.artifactKey,
+              title: updatedArtifact.title,
+            }
           }
 
           return mostRecentArtifact

--- a/apps/desktop/src/renderer/atoms/session.ts
+++ b/apps/desktop/src/renderer/atoms/session.ts
@@ -2,7 +2,7 @@ import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import type { SessionListResponse, SessionListItem } from '@shared/types'
 import { applyChatEventAtom, resetChatStateAtom } from './chat'
-import { resetPlanningSessionStateAtom } from './planning'
+import { requestPlanningReloadAtom, resetPlanningSessionStateAtom } from './planning'
 
 const CURRENT_SESSION_STORAGE_KEY = 'kata-desktop:current-session-id'
 const WORKING_DIRECTORY_STORAGE_KEY = 'kata-desktop:working-directory'
@@ -57,7 +57,11 @@ const hydrateSessionHistoryAtom = atom(
   async (
     get,
     set,
-    { sessionId, sessionPath }: { sessionId: string; sessionPath?: string | null },
+    {
+      sessionId,
+      sessionPath,
+      resetPlanning = true,
+    }: { sessionId: string; sessionPath?: string | null; resetPlanning?: boolean },
   ) => {
     const trimmedSessionId = sessionId.trim()
     if (!trimmedSessionId) {
@@ -67,7 +71,9 @@ const hydrateSessionHistoryAtom = atom(
     set(sessionHistoryLoadingAtom, true)
     set(sessionHistoryErrorAtom, null)
     set(resetChatStateAtom)
-    set(resetPlanningSessionStateAtom)
+    if (resetPlanning) {
+      set(resetPlanningSessionStateAtom)
+    }
 
     try {
       const resolvedSessionPath =
@@ -134,11 +140,16 @@ export const initializeSessionsAtom = atom(null, async (get, set) => {
 
     const currentSessionId = get(currentSessionIdAtom)
     if (currentSessionId) {
-      await set(hydrateSessionHistoryAtom, { sessionId: currentSessionId })
+      await set(hydrateSessionHistoryAtom, {
+        sessionId: currentSessionId,
+        resetPlanning: false,
+      })
     } else {
       set(resetChatStateAtom)
       set(resetPlanningSessionStateAtom)
     }
+
+    set(requestPlanningReloadAtom)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     set(sessionListErrorAtom, message)
@@ -171,6 +182,8 @@ export const createSessionAtom = atom(null, async (get, set) => {
     if (response.sessionId) {
       set(currentSessionIdAtom, response.sessionId)
     }
+
+    set(requestPlanningReloadAtom)
   } finally {
     set(sessionCreatingAtom, false)
   }
@@ -209,6 +222,7 @@ export const switchSessionAtom = atom(null, async (get, set, sessionId: string) 
       sessionPath: switchResponse.sessionPath ?? null,
     })
     await set(refreshSessionListAtom)
+    set(requestPlanningReloadAtom)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     set(sessionListErrorAtom, `Unable to switch session to ${trimmedSessionId}: ${message}`)
@@ -238,6 +252,8 @@ export const switchWorkspaceAtom = atom(null, async (get, set, workspacePath: st
     if (currentSessionId) {
       await set(hydrateSessionHistoryAtom, { sessionId: currentSessionId })
     }
+
+    set(requestPlanningReloadAtom)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     set(sessionListErrorAtom, `Unable to switch workspace to ${workspacePath}: ${message}`)

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -1,10 +1,12 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+import { useSetAtom } from 'jotai'
 import {
   Group,
   Panel,
   Separator as PanelSeparator,
   type Layout,
 } from 'react-resizable-panels'
+import { initializeSessionsAtom } from '@/atoms/session'
 import { LeftPane } from './LeftPane'
 import { RightPane } from './RightPane'
 
@@ -53,6 +55,11 @@ function readInitialLayout(): Layout {
 
 export function AppShell() {
   const defaultLayout = useMemo(readInitialLayout, [])
+  const initializeSessions = useSetAtom(initializeSessionsAtom)
+
+  useEffect(() => {
+    void initializeSessions()
+  }, [initializeSessions])
 
   return (
     <main className="size-full bg-background text-foreground">

--- a/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Menu, Settings } from 'lucide-react'
-import { useAtom, useSetAtom } from 'jotai'
-import { initializeSessionsAtom, sessionSidebarOpenAtom } from '@/atoms/session'
+import { useAtom } from 'jotai'
+import { sessionSidebarOpenAtom } from '@/atoms/session'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { SettingsPanel } from '../settings/SettingsPanel'
@@ -13,11 +13,6 @@ import { WorkspaceIndicator } from './WorkspaceIndicator'
 export function LeftPane() {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [sessionSidebarOpen, setSessionSidebarOpen] = useAtom(sessionSidebarOpenAtom)
-  const initializeSessions = useSetAtom(initializeSessionsAtom)
-
-  useEffect(() => {
-    void initializeSessions()
-  }, [initializeSessions])
 
   return (
     <section className="flex h-full flex-col border-r border-border bg-background">

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -15,8 +15,10 @@ import {
   lastViewedPlanningArtifactAtom,
   markPlanningArtifactViewedAtom,
   planningArtifactsAtom,
+  planningArtifactsStaleAtom,
   planningErrorAtom,
   planningLoadingAtom,
+  planningStaleReasonAtom,
   rightPaneModeAtom,
   slicePlanningAtom,
 } from '@/atoms/planning'
@@ -43,6 +45,8 @@ export function PlanningPane() {
   const loading = useAtomValue(planningLoadingAtom)
   const isFetching = useAtomValue(isFetchingAtom)
   const error = useAtomValue(planningErrorAtom)
+  const stale = useAtomValue(planningArtifactsStaleAtom)
+  const staleReason = useAtomValue(planningStaleReasonAtom)
   const lastViewedByArtifactKey = useAtomValue(lastViewedPlanningArtifactAtom)
   const slicesByArtifactKey = useAtomValue(slicePlanningAtom)
 
@@ -326,6 +330,12 @@ export function PlanningPane() {
       {error ? (
         <div className="border-b border-border bg-destructive/10 px-4 py-3 text-xs text-destructive">
           Unable to fetch artifact: {error}
+        </div>
+      ) : null}
+
+      {stale ? (
+        <div className="border-b border-border bg-amber-100/60 px-4 py-3 text-xs text-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+          Showing cached planning artifacts{staleReason ? ` (${staleReason})` : ''}.
         </div>
       ) : null}
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -504,6 +504,7 @@ export interface PlanningArtifactFetchResponse {
 export interface PlanningArtifactListResponse {
   success: boolean
   artifacts: PlanningArtifact[]
+  stale?: boolean
   error?: PlanningArtifactError
 }
 


### PR DESCRIPTION
## Summary
- add proactive Linear project artifact loading via `planningListArtifacts` and new `LinearDocumentClient.listByProject()`
- persist planning artifacts and active tab with `atomWithStorage` so planning tabs survive app restarts
- trigger background planning reload after session initialization/switch and show stale-cache indicator when Linear is unavailable
- add tests for project-scoped Linear artifact loading and project-not-found handling

## Validation
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx vitest run src/main/__tests__/linear-document-client.test.ts src/renderer/lib/__tests__/artifact-parser.test.ts`
- `cd apps/desktop && bun run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist planning artifacts to local storage and proactively load artifacts from linked Linear projects at startup.
  * Public method to list project-scoped planning artifacts.

* **Improvements**
  * Added stale flag and optional reason; UI shows “Showing cached planning artifacts” when stale.
  * Smarter merge/replace behavior on load and triggered planning reloads during session/workspace changes.
  * Proactive startup load filters planning artifact types and preserves existing slice data when present.

* **Tests**
  * Added tests for project resolution, pagination, listing behavior, and error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds proactive Linear project artifact loading on session init/switch by reading a `projectRef` from `.kata/preferences.md`, fetching all matching documents via a new `LinearDocumentClient.listByProject()`, and surfacing a stale-cache banner when Linear is unavailable. Planning artifacts and the active tab are now persisted with `atomWithStorage` so they survive app restarts.

- **P1 — infinite fetch loop**: `currentArtifacts` (derived from `planningArtifactsAtom`) is a dependency of the reload effect in `usePlanningArtifactBridge`. Every successful `listArtifacts()` call updates the atom, which re-triggers the effect, creating an unbounded loop of IPC calls after each planning reload.

<h3>Confidence Score: 4/5</h3>

Hold for the infinite-fetch loop in the reload effect before merging.

One confirmed P1 bug: including currentArtifacts in the useEffect dependency array causes listArtifacts() to be called in an infinite loop after each planning reload. All other findings are P2. The rest of the feature — Linear client refactor, IPC stale-cache propagation, and storage persistence — is well-structured.

apps/desktop/src/renderer/atoms/planning.ts — the reload useEffect dependency array.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/atoms/planning.ts | Adds atomWithStorage persistence for planning artifacts and active tab, plus a reload effect triggered by planningReloadNonce — but currentArtifacts in the effect's dep array causes an infinite listArtifacts() loop after every reload. |
| apps/desktop/src/main/linear-document-client.ts | Adds listByProject() that resolves a project reference via a GraphQL lookup and fetches all project documents; refactors shared HTTP logic into a private request() method. Minor: $projectRef variable type should be ID! not String!. |
| apps/desktop/src/main/ipc.ts | Extends planningListArtifacts handler to proactively load Linear project artifacts from preferences.md on each call, with stale-cache signalling when Linear is unavailable; adds readLinearProjectReference and stripYamlWrapping helpers. |
| apps/desktop/src/renderer/atoms/session.ts | Triggers background planning reload (requestPlanningReloadAtom) after session init, creation, switch, and workspace switch; keeps resetPlanning=false on initial hydration to preserve persisted artifacts. |
| apps/desktop/src/renderer/components/planning/PlanningPane.tsx | Adds stale-cache amber banner powered by planningArtifactsStaleAtom/planningStaleReasonAtom; on-demand artifact fetch when activeArtifactRef has no loaded content (useful after cold restart with persisted key). |
| apps/desktop/src/shared/types.ts | Adds optional stale and error fields to PlanningArtifactListResponse to carry stale-cache metadata from the main process to the renderer. |
| apps/desktop/src/main/__tests__/linear-document-client.test.ts | Adds two new tests: project-scoped artifact listing with slug resolution and NOT_FOUND handling when project doesn't exist. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as AppShell
    participant SA as session.ts (atom)
    participant PA as planning.ts (atom)
    participant IPC as ipc.ts (main)
    participant LDC as LinearDocumentClient
    participant Linear as Linear GraphQL API

    App->>SA: initializeSessions()
    SA->>SA: hydrateSessionHistory(resetPlanning=false)
    SA->>SA: requestPlanningReloadAtom (nonce++)
    SA-->>PA: planningReloadNonce changes
    PA->>IPC: window.api.planning.listArtifacts()
    IPC->>IPC: readLinearProjectReference(.kata/preferences.md)
    alt projectRef found
        IPC->>LDC: listByProject(projectRef)
        LDC->>Linear: ResolveProjectId query
        Linear-->>LDC: project.id
        LDC->>Linear: PlanningDocumentsByProject query
        Linear-->>LDC: documents[]
        LDC-->>IPC: PlanningArtifact[]
        IPC-->>PA: { success, artifacts, stale: false }
    else Linear unavailable
        IPC-->>PA: { success, artifacts: cached, stale: true, error }
    end
    PA->>PA: merge & persist to atomWithStorage
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/planning.ts
Line: 147-257

Comment:
**`currentArtifacts` in the reload effect causes an infinite fetch loop**

`currentArtifacts` is derived from `planningArtifactsAtom` and listed as a dependency of this effect. After each successful `listArtifacts()` call, `setArtifacts(mergedArtifacts)` updates the atom, which changes `currentArtifacts`, which re-triggers the effect — calling `listArtifacts()` again in a loop. The `planningReloadNonce === 0` guard doesn't help because the nonce is never reset between calls.

The merge should be done inside a Jotai write-atom that reads `planningArtifactsAtom` at write-time, so `currentArtifacts` doesn't need to be a reactive dependency here:

```ts
// Remove currentArtifacts from the useAtomValue call and the dep array.
// Move the merge into applyBulkPlanningArtifactsAtom:
export const applyBulkPlanningArtifactsAtom = atom(null, (get, set, nextArtifacts: PlanningArtifactsMap) => {
  const merged = { ...get(planningArtifactsAtom), ...nextArtifacts }
  set(planningArtifactsAtom, merged)
  set(planningArtifactKeysAtom, deriveArtifactKeys(merged))
})
```

Then in the effect, call `applyBulkPlanningArtifacts(nextArtifacts)` and remove `currentArtifacts` from the dep array entirely.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/linear-document-client.ts
Line: 316-332

Comment:
**GraphQL variable type mismatch in `ResolveProjectId`**

The variable `$projectRef` is declared as `String!`, but Linear's `project(id: ...)` argument is typed `ID!` in the schema. Many servers coerce these types, but a strict validator will reject the query. The variable should be typed `ID!` to match the schema argument.

```suggestion
  private async resolveProjectId(apiKey: string, projectRef: string): Promise<string | null> {
    const data = await this.request<ResolveProjectQueryData>(
      apiKey,
      `
        query ResolveProjectId($projectRef: ID!) {
          project(id: $projectRef) {
            id
          }
        }
      `,
      {
        projectRef,
      },
    )

    return data.project?.id?.trim() || null
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/planning.ts
Line: 162-176

Comment:
**Previous error not cleared on a stale-but-empty reload**

When `response.stale === true` and `response.artifacts.length === 0` (Linear is unreachable and the cache is empty), `setError(null)` is never called. Any error left over in `planningErrorAtom` from a prior operation will continue to render alongside the stale banner, showing two overlapping warning messages to the user.

Consider calling `setError(null)` unconditionally when `response.success` is true and `response.stale` is set, regardless of artifact count:

```ts
if (response.stale) {
  setError(null)   // clear prior error; the stale banner is the only warning needed
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): proactively load and pers..."](https://github.com/gannonh/kata/commit/b84fb615cf858c8cf261b038a96dbf011b8f7ddb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27242093)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->