### PR TITLE
feat(desktop): linear workflow board in right pane (KAT-2247)

### DIFF
--- a/apps/desktop/e2e/tests/app-shell.e2e.ts
+++ b/apps/desktop/e2e/tests/app-shell.e2e.ts
@@ -19,8 +19,9 @@ test.describe('App shell', () => {
     await expect(mainWindow.getByLabel(/Auto/i)).toBeVisible()
   })
 
-  test('shows right-pane placeholder copy', async ({ mainWindow }) => {
-    await expect(mainWindow.getByText('Planning and kanban views are coming in M002/M003.')).toBeVisible()
+  test('shows workflow board pane in right pane', async ({ mainWindow }) => {
+    await expect(mainWindow.getByRole('heading', { name: /Workflow Board/i })).toBeVisible()
+    await expect(mainWindow.getByTestId('workflow-board-status')).toBeVisible()
   })
 
   test('opens settings panel from the settings button', async ({ readyWindow }) => {

--- a/apps/desktop/e2e/tests/workflow-kanban.e2e.ts
+++ b/apps/desktop/e2e/tests/workflow-kanban.e2e.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '../fixtures/electron.fixture'
+
+test.describe('Workflow kanban board', () => {
+  test('renders canonical columns and allows expanding tasks', async ({ readyWindow }) => {
+    // Test seam: in KATA_TEST_MODE, WorkflowBoardService serves a deterministic board fixture
+    await expect(readyWindow.getByRole('heading', { name: /Workflow Board/i })).toBeVisible()
+    await expect(readyWindow.getByRole('heading', { name: 'Backlog' })).toBeVisible()
+    await expect(readyWindow.getByRole('heading', { name: 'Todo' })).toBeVisible()
+    await expect(readyWindow.getByRole('heading', { name: 'In Progress' })).toBeVisible()
+    await expect(readyWindow.getByRole('heading', { name: 'Agent Review' })).toBeVisible()
+    await expect(readyWindow.getByRole('heading', { name: 'Human Review' })).toBeVisible()
+    await expect(readyWindow.getByRole('heading', { name: 'Merging' })).toBeVisible()
+    await expect(readyWindow.getByRole('heading', { name: 'Done' })).toBeVisible()
+
+    const sliceTitle = readyWindow.getByText(/KAT-2247 · \[S01\] Linear Workflow Board in the Right Pane/i)
+    await expect(sliceTitle).toBeVisible()
+
+    await readyWindow.getByRole('button', { name: /Show tasks/i }).click()
+
+    await expect(readyWindow.getByText(/KAT-2251 · \[T01\] Define canonical workflow snapshot contract/i)).toBeVisible()
+    await expect(readyWindow.getByText(/KAT-2252 · \[T02\] Wire workflow board service through IPC/i)).toBeVisible()
+  })
+
+  test('documents live Linear smoke path for manual integration proof', async ({ readyWindow }) => {
+    // Manual smoke path:
+    // 1. Run desktop dev app without KATA_TEST_MODE and with a Linear-backed workspace.
+    // 2. Confirm right pane header shows the active milestone name and "Live data · linear" status.
+    // 3. Expand at least one slice card and verify child tasks match live Linear statuses.
+    // 4. Move one task in Linear, click "Refresh workflow board", and verify UI status updates.
+    await expect(readyWindow.getByTestId('workflow-board-status')).toBeVisible()
+  })
+})

--- a/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
@@ -127,15 +127,30 @@ describe('LinearWorkflowClient', () => {
   test('returns NOT_FOUND when project cannot be resolved', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 
-    globalThis.fetch = (async () =>
-      new Response(
-        JSON.stringify({
-          data: {
-            project: null,
-          },
-        }),
-        { status: 200 },
-      )) as unknown as typeof fetch
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: null,
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              projects: {
+                nodes: [],
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
 
     const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
 
@@ -144,6 +159,186 @@ describe('LinearWorkflowClient', () => {
         code: 'NOT_FOUND',
       },
     )
+  })
+
+  test('resolves project by slug when id lookup misses', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: null,
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              projects: {
+                nodes: [{ id: 'project-from-slug' }],
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issues: {
+                nodes: [],
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null,
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    const snapshot = await client.fetchActiveMilestoneSnapshot({ projectRef: 'desktop-project' })
+    expect(snapshot.source.projectId).toBe('project-from-slug')
+  })
+
+  test('paginates issues and child tasks before normalization', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-1',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'slice-a',
+                    identifier: 'KAT-100',
+                    title: '[S01] Paged slice',
+                    parent: null,
+                    state: { name: 'In Progress', type: 'started' },
+                    projectMilestone: {
+                      id: 'milestone-active',
+                      name: '[M003] Workflow Kanban',
+                      sortOrder: 1,
+                    },
+                    children: {
+                      nodes: [
+                        {
+                          id: 'task-a1',
+                          identifier: 'KAT-101',
+                          title: 'Task page 1',
+                          state: { name: 'Todo', type: 'unstarted' },
+                        },
+                      ],
+                      pageInfo: {
+                        hasNextPage: true,
+                        endCursor: 'child-cursor-1',
+                      },
+                    },
+                  },
+                ],
+                pageInfo: {
+                  hasNextPage: true,
+                  endCursor: 'issues-cursor-1',
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'slice-b',
+                    identifier: 'KAT-102',
+                    title: '[S02] Paged slice 2',
+                    parent: null,
+                    state: { name: 'Todo', type: 'unstarted' },
+                    projectMilestone: {
+                      id: 'milestone-active',
+                      name: '[M003] Workflow Kanban',
+                      sortOrder: 1,
+                    },
+                    children: {
+                      nodes: [],
+                      pageInfo: {
+                        hasNextPage: false,
+                        endCursor: null,
+                      },
+                    },
+                  },
+                ],
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null,
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                children: {
+                  nodes: [
+                    {
+                      id: 'task-a2',
+                      identifier: 'KAT-103',
+                      title: 'Task page 2',
+                      state: { name: 'Done', type: 'completed' },
+                    },
+                  ],
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    const snapshot = await client.fetchActiveMilestoneSnapshot({ projectRef: 'project-1' })
+    const inProgressColumn = snapshot.columns.find((column) => column.id === 'in_progress')
+    expect(inProgressColumn?.cards[0]?.tasks).toHaveLength(2)
+    expect((globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(4)
   })
 
   test('maps unauthorized and rate-limited backend responses', async () => {

--- a/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
@@ -124,6 +124,92 @@ describe('LinearWorkflowClient', () => {
     )
   })
 
+  test('returns NOT_FOUND when project cannot be resolved', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            project: null,
+          },
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(client.fetchActiveMilestoneSnapshot({ projectRef: 'missing-project' })).rejects.toMatchObject(
+      {
+        code: 'NOT_FOUND',
+      },
+    )
+  })
+
+  test('maps unauthorized and rate-limited backend responses', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = (async () => new Response('{}', { status: 401 })) as unknown as typeof fetch
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(client.fetchActiveMilestoneSnapshot({ projectRef: 'project-ref' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    })
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-1',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response('{}', { status: 429 })) as unknown as typeof fetch
+
+    await expect(client.fetchActiveMilestoneSnapshot({ projectRef: 'project-ref' })).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+    })
+  })
+
+  test('maps GraphQL error payloads to structured codes', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-1',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            errors: [{ message: 'rate limit hit' }],
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(client.fetchActiveMilestoneSnapshot({ projectRef: 'project-ref' })).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+    })
+  })
+
   test('exposes structured workflow error codes', () => {
     const mapped = LinearWorkflowClient.toWorkflowError(
       new LinearWorkflowClientError('UNAUTHORIZED', 'bad key', 401),
@@ -133,14 +219,24 @@ describe('LinearWorkflowClient', () => {
       code: 'UNAUTHORIZED',
       message: 'bad key',
     })
+
+    const networkMapped = LinearWorkflowClient.toWorkflowError(new TypeError('fetch failed'))
+    expect(networkMapped).toEqual({
+      code: 'NETWORK',
+      message: 'fetch failed',
+    })
   })
 })
 
 describe('mapLinearStateToColumnId', () => {
   test('uses exact Kata state names before state type fallback', () => {
     expect(mapLinearStateToColumnId('Human Review', 'started')).toBe('human_review')
+    expect(mapLinearStateToColumnId('Merging', 'started')).toBe('merging')
     expect(mapLinearStateToColumnId('Unknown', 'backlog')).toBe('backlog')
+    expect(mapLinearStateToColumnId(undefined, 'unstarted')).toBe('todo')
+    expect(mapLinearStateToColumnId(undefined, 'started')).toBe('in_progress')
     expect(mapLinearStateToColumnId(undefined, 'completed')).toBe('done')
+    expect(mapLinearStateToColumnId(undefined, 'canceled')).toBe('done')
     expect(mapLinearStateToColumnId('Unexpected', 'unexpected')).toBe('todo')
   })
 })
@@ -156,5 +252,31 @@ describe('normalizeLinearBoard', () => {
 
     expect(snapshot.status).toBe('empty')
     expect(snapshot.emptyReason).toContain('No slices found')
+  })
+
+  test('normalizes task counts with mixed states', () => {
+    const snapshot = normalizeLinearBoard({
+      projectId: 'project-1',
+      milestoneId: 'milestone-1',
+      milestoneName: 'Milestone 1',
+      issues: [
+        {
+          id: 'slice-1',
+          identifier: 'KAT-1',
+          title: 'Slice',
+          state: { name: 'Todo', type: 'unstarted' },
+          projectMilestone: { id: 'milestone-1', name: 'Milestone 1' },
+          children: {
+            nodes: [
+              { id: 'task-1', title: 'Task 1', state: { name: 'Done', type: 'completed' } },
+              { id: 'task-2', title: 'Task 2', state: { name: 'Todo', type: 'unstarted' } },
+            ],
+          },
+        } as never,
+      ],
+    })
+
+    const todoColumn = snapshot.columns.find((column) => column.id === 'todo')
+    expect(todoColumn?.cards[0]?.taskCounts).toEqual({ total: 2, done: 1 })
   })
 })

--- a/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  LinearWorkflowClient,
+  LinearWorkflowClientError,
+  mapLinearStateToColumnId,
+  normalizeLinearBoard,
+} from '../linear-workflow-client'
+
+const originalFetch = globalThis.fetch
+const originalLinearApiKey = process.env.LINEAR_API_KEY
+
+describe('LinearWorkflowClient', () => {
+  beforeEach(() => {
+    delete process.env.LINEAR_API_KEY
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalLinearApiKey) {
+      process.env.LINEAR_API_KEY = originalLinearApiKey
+    } else {
+      delete process.env.LINEAR_API_KEY
+    }
+  })
+
+  test('normalizes active milestone slices and tasks into canonical columns', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-1',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'slice-a',
+                    identifier: 'KAT-100',
+                    title: '[S01] Active milestone slice',
+                    parent: null,
+                    state: { name: 'In Progress', type: 'started' },
+                    projectMilestone: {
+                      id: 'milestone-active',
+                      name: '[M003] Workflow Kanban',
+                      sortOrder: 1,
+                    },
+                    children: {
+                      nodes: [
+                        {
+                          id: 'task-a1',
+                          identifier: 'KAT-101',
+                          title: 'Task in review',
+                          state: { name: 'Agent Review', type: 'started' },
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    id: 'slice-b',
+                    identifier: 'KAT-200',
+                    title: '[S02] Older milestone slice',
+                    parent: null,
+                    state: { name: 'Todo', type: 'unstarted' },
+                    projectMilestone: {
+                      id: 'milestone-old',
+                      name: '[M002] Planning View',
+                      sortOrder: 0,
+                    },
+                    children: {
+                      nodes: [],
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    const snapshot = await client.fetchActiveMilestoneSnapshot({ projectRef: 'desktop-project' })
+
+    expect(snapshot.activeMilestone).toEqual({
+      id: 'milestone-active',
+      name: '[M003] Workflow Kanban',
+    })
+
+    const inProgressColumn = snapshot.columns.find((column) => column.id === 'in_progress')
+    expect(inProgressColumn?.cards).toHaveLength(1)
+    expect(inProgressColumn?.cards[0]?.identifier).toBe('KAT-100')
+
+    const todoCards = snapshot.columns.find((column) => column.id === 'todo')?.cards ?? []
+    expect(todoCards).toHaveLength(0)
+
+    expect(inProgressColumn?.cards[0]?.tasks[0]).toMatchObject({
+      id: 'task-a1',
+      identifier: 'KAT-101',
+      columnId: 'agent_review',
+    })
+  })
+
+  test('maps missing key to MISSING_API_KEY', async () => {
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(client.fetchActiveMilestoneSnapshot({ projectRef: 'desktop-project' })).rejects.toMatchObject(
+      {
+        code: 'MISSING_API_KEY',
+      },
+    )
+  })
+
+  test('exposes structured workflow error codes', () => {
+    const mapped = LinearWorkflowClient.toWorkflowError(
+      new LinearWorkflowClientError('UNAUTHORIZED', 'bad key', 401),
+    )
+
+    expect(mapped).toEqual({
+      code: 'UNAUTHORIZED',
+      message: 'bad key',
+    })
+  })
+})
+
+describe('mapLinearStateToColumnId', () => {
+  test('uses exact Kata state names before state type fallback', () => {
+    expect(mapLinearStateToColumnId('Human Review', 'started')).toBe('human_review')
+    expect(mapLinearStateToColumnId('Unknown', 'backlog')).toBe('backlog')
+    expect(mapLinearStateToColumnId(undefined, 'completed')).toBe('done')
+    expect(mapLinearStateToColumnId('Unexpected', 'unexpected')).toBe('todo')
+  })
+})
+
+describe('normalizeLinearBoard', () => {
+  test('returns empty snapshot when no active milestone slices exist', () => {
+    const snapshot = normalizeLinearBoard({
+      projectId: 'project-1',
+      issues: [],
+      milestoneId: undefined,
+      milestoneName: undefined,
+    })
+
+    expect(snapshot.status).toBe('empty')
+    expect(snapshot.emptyReason).toContain('No slices found')
+  })
+})

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
@@ -45,6 +46,21 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.lastError?.code).toBe('NOT_CONFIGURED')
   })
 
+  test('getBoard reuses cached snapshot after first refresh', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const first = await service.getBoard()
+    const second = await service.getBoard()
+
+    expect(first.snapshot.fetchedAt).toBe(second.snapshot.fetchedAt)
+    expect(second.snapshot.status).toBe('fresh')
+  })
+
   test('returns stale snapshot with error metadata when refresh fails after a successful fetch', async () => {
     const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-stale-'))
     mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
@@ -81,5 +97,48 @@ describe('WorkflowBoardService', () => {
     expect(second.snapshot.lastError?.code).toBe('UNKNOWN')
     expect(second.snapshot.lastError?.message).toContain('network down')
     expect(second.snapshot.poll.status).toBe('error')
+  })
+
+  test('uses projectId from preferences frontmatter when available', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-project-id-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectId: "project-id-123"', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(async () => ({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'empty',
+      source: { projectId: 'project-id-123' },
+      activeMilestone: null,
+      columns: [],
+      emptyReason: 'No slices found in the active milestone.',
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    }))
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.source.projectId).toBe('project-id-123')
+  })
+
+  test('handles malformed preferences path errors as NOT_CONFIGURED fallback', async () => {
+    const workspacePath = path.join(tmpdir(), `workflow-board-invalid-${randomUUID()}`)
+    writeFileSync(workspacePath, 'not-a-directory', 'utf8')
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.status).toBe('error')
+    expect(response.snapshot.lastError?.code).toBe('NOT_CONFIGURED')
   })
 })

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { WorkflowBoardService } from '../workflow-board-service'
+
+const originalFixtureFlag = process.env.KATA_TEST_WORKFLOW_FIXTURE
+
+describe('WorkflowBoardService', () => {
+  beforeEach(() => {
+    delete process.env.KATA_TEST_WORKFLOW_FIXTURE
+  })
+
+  afterEach(() => {
+    if (originalFixtureFlag) {
+      process.env.KATA_TEST_WORKFLOW_FIXTURE = originalFixtureFlag
+    } else {
+      delete process.env.KATA_TEST_WORKFLOW_FIXTURE
+    }
+  })
+
+  test('returns deterministic fixture snapshot when fixture mode is enabled', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const response = await service.getBoard()
+    expect(response.success).toBe(true)
+    expect(response.snapshot.status).toBe('fresh')
+    expect(response.snapshot.columns.find((column) => column.id === 'todo')?.cards).toHaveLength(1)
+  })
+
+  test('returns NOT_CONFIGURED when preferences are missing', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-missing-'))
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.status).toBe('error')
+    expect(response.snapshot.lastError?.code).toBe('NOT_CONFIGURED')
+  })
+
+  test('returns stale snapshot with error metadata when refresh fails after a successful fetch', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-stale-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectSlug: project-ref', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const client = (service as any).linearClient
+    client.fetchActiveMilestoneSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({
+        backend: 'linear',
+        fetchedAt: '2026-04-04T00:00:00.000Z',
+        status: 'fresh',
+        source: { projectId: 'project-ref', activeMilestoneId: 'm1' },
+        activeMilestone: { id: 'm1', name: '[M001] Demo' },
+        columns: [],
+        poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+      })
+      .mockRejectedValueOnce(new Error('network down'))
+
+    const first = await service.refreshBoard()
+    expect(first.snapshot.status).toBe('fresh')
+
+    const second = await service.refreshBoard()
+    expect(second.snapshot.status).toBe('stale')
+    expect(second.snapshot.lastError?.code).toBe('UNKNOWN')
+    expect(second.snapshot.lastError?.message).toContain('network down')
+    expect(second.snapshot.poll.status).toBe('error')
+  })
+})

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -13,7 +13,7 @@ describe('WorkflowBoardService', () => {
   })
 
   afterEach(() => {
-    if (originalFixtureFlag) {
+    if (originalFixtureFlag !== undefined) {
       process.env.KATA_TEST_WORKFLOW_FIXTURE = originalFixtureFlag
     } else {
       delete process.env.KATA_TEST_WORKFLOW_FIXTURE
@@ -167,11 +167,18 @@ describe('WorkflowBoardService', () => {
       poll: { status: 'success' as const, backend: 'linear' as const, lastAttemptAt: '2026-04-04T00:00:00.000Z' },
     }
 
-    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(
-      async () => await new Promise((resolve) => setTimeout(() => resolve(snapshot), 25)),
-    )
+    let resolveFetch!: (value: typeof snapshot) => void
+    const deferredFetch = new Promise<typeof snapshot>((resolve) => {
+      resolveFetch = resolve
+    })
 
-    const [first, second] = await Promise.all([service.refreshBoard(), service.refreshBoard()])
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(() => deferredFetch)
+
+    const firstPromise = service.refreshBoard()
+    const secondPromise = service.refreshBoard()
+
+    resolveFetch(snapshot)
+    const [first, second] = await Promise.all([firstPromise, secondPromise])
 
     expect((service as any).linearClient.fetchActiveMilestoneSnapshot).toHaveBeenCalledTimes(1)
     expect(first.snapshot).toEqual(second.snapshot)

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -128,7 +128,7 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.source.projectId).toBe('project-id-123')
   })
 
-  test('handles malformed preferences path errors as NOT_CONFIGURED fallback', async () => {
+  test('surfaces malformed preferences path errors without misreporting NOT_CONFIGURED', async () => {
     const workspacePath = path.join(tmpdir(), `workflow-board-invalid-${randomUUID()}`)
     writeFileSync(workspacePath, 'not-a-directory', 'utf8')
 
@@ -139,6 +139,41 @@ describe('WorkflowBoardService', () => {
 
     const response = await service.refreshBoard()
     expect(response.snapshot.status).toBe('error')
-    expect(response.snapshot.lastError?.code).toBe('NOT_CONFIGURED')
+    expect(response.snapshot.lastError?.code).toBe('UNKNOWN')
+    expect(response.snapshot.lastError?.message).toContain('Unable to read .kata/preferences.md')
+  })
+
+  test('deduplicates concurrent refresh requests to a single Linear fetch', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-concurrent-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectSlug: project-ref', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const snapshot = {
+      backend: 'linear' as const,
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'fresh' as const,
+      source: { projectId: 'project-ref', activeMilestoneId: 'm1' },
+      activeMilestone: { id: 'm1', name: '[M001] Demo' },
+      columns: [],
+      poll: { status: 'success' as const, backend: 'linear' as const, lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    }
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(
+      async () => await new Promise((resolve) => setTimeout(() => resolve(snapshot), 25)),
+    )
+
+    const [first, second] = await Promise.all([service.refreshBoard(), service.refreshBoard()])
+
+    expect((service as any).linearClient.fetchActiveMilestoneSnapshot).toHaveBeenCalledTimes(1)
+    expect(first.snapshot).toEqual(second.snapshot)
   })
 })

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -9,6 +9,7 @@ import { PlanningToolDetector } from './planning-tool-detector'
 import { RpcEventAdapter } from './rpc-event-adapter'
 import { DesktopSessionManager } from './session-manager'
 import { SessionHistoryLoader } from './session-history-loader'
+import { WorkflowBoardService } from './workflow-board-service'
 import {
   IPC_CHANNELS,
   type AuthProvider,
@@ -39,6 +40,7 @@ import {
   type ThinkingLevel,
   type WorkspaceInfo,
   type ArtifactType,
+  type WorkflowBoardSnapshotResponse,
 } from '../shared/types'
 
 interface RegisterIpcOptions {
@@ -62,6 +64,10 @@ export function registerSessionIpc({
   const planningToolDetector = new PlanningToolDetector()
   const linearDocumentClient = new LinearDocumentClient(authBridge)
   const sessionHistoryLoader = new SessionHistoryLoader()
+  const workflowBoardService = new WorkflowBoardService({
+    authBridge,
+    getWorkspacePath: () => bridge.getWorkspacePath(),
+  })
 
   const planningArtifactsByKey = new Map<string, PlanningArtifact>()
   const planningMetadataByKey = new Map<string, PlanningArtifactEvent>()
@@ -483,6 +489,8 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.authValidateKey)
   ipcMain.removeHandler(IPC_CHANNELS.planningFetchArtifact)
   ipcMain.removeHandler(IPC_CHANNELS.planningListArtifacts)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowGetBoard)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowRefreshBoard)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -1061,6 +1069,14 @@ export function registerSessionIpc({
     }
   })
 
+  ipcMain.handle(IPC_CHANNELS.workflowGetBoard, async (): Promise<WorkflowBoardSnapshotResponse> => {
+    return workflowBoardService.getBoard()
+  })
+
+  ipcMain.handle(IPC_CHANNELS.workflowRefreshBoard, async (): Promise<WorkflowBoardSnapshotResponse> => {
+    return workflowBoardService.refreshBoard()
+  })
+
   return () => {
     bridge.off('rpc-event', onRpcEvent)
     bridge.off('extension-ui-request', onExtensionUiRequest)
@@ -1092,6 +1108,8 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.authValidateKey)
     ipcMain.removeHandler(IPC_CHANNELS.planningFetchArtifact)
     ipcMain.removeHandler(IPC_CHANNELS.planningListArtifacts)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowGetBoard)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowRefreshBoard)
   }
 }
 

--- a/apps/desktop/src/main/linear-workflow-client.ts
+++ b/apps/desktop/src/main/linear-workflow-client.ts
@@ -1,0 +1,477 @@
+import { AuthBridge } from './auth-bridge'
+import log from './logger'
+import {
+  type WorkflowBoardColumn,
+  type WorkflowBoardErrorCode,
+  type WorkflowBoardSliceCard,
+  type WorkflowBoardSnapshot,
+  type WorkflowBoardTask,
+  type WorkflowColumnId,
+} from '../shared/types'
+
+const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql'
+const LINEAR_REQUEST_TIMEOUT_MS = 10_000
+
+const WORKFLOW_COLUMNS: Array<{ id: WorkflowColumnId; title: string }> = [
+  { id: 'backlog', title: 'Backlog' },
+  { id: 'todo', title: 'Todo' },
+  { id: 'in_progress', title: 'In Progress' },
+  { id: 'agent_review', title: 'Agent Review' },
+  { id: 'human_review', title: 'Human Review' },
+  { id: 'merging', title: 'Merging' },
+  { id: 'done', title: 'Done' },
+]
+
+const EXACT_NAME_TO_COLUMN_ID: Record<string, WorkflowColumnId> = {
+  backlog: 'backlog',
+  todo: 'todo',
+  'in progress': 'in_progress',
+  'agent review': 'agent_review',
+  'human review': 'human_review',
+  merging: 'merging',
+  done: 'done',
+}
+
+interface GraphQLResponse<TData> {
+  data?: TData
+  errors?: Array<{ message?: string }>
+}
+
+interface LinearWorkflowState {
+  name?: string
+  type?: string
+}
+
+interface LinearWorkflowMilestone {
+  id?: string
+  name?: string
+  sortOrder?: number
+}
+
+interface LinearWorkflowIssue {
+  id?: string
+  identifier?: string
+  title?: string
+  parent?: { id?: string } | null
+  state?: LinearWorkflowState | null
+  projectMilestone?: LinearWorkflowMilestone | null
+  children?: {
+    nodes?: LinearWorkflowIssue[]
+  } | null
+}
+
+interface ResolveProjectQueryData {
+  project?: {
+    id?: string
+  } | null
+}
+
+interface WorkflowIssuesQueryData {
+  issues?: {
+    nodes?: LinearWorkflowIssue[]
+  }
+}
+
+export interface FetchLinearBoardOptions {
+  projectRef: string
+}
+
+export class LinearWorkflowClientError extends Error {
+  constructor(
+    public readonly code: WorkflowBoardErrorCode,
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message)
+    this.name = 'LinearWorkflowClientError'
+  }
+}
+
+export class LinearWorkflowClient {
+  constructor(
+    private readonly authBridge: AuthBridge,
+    private readonly apiUrl = LINEAR_GRAPHQL_URL,
+    private readonly requestTimeoutMs = LINEAR_REQUEST_TIMEOUT_MS,
+  ) {}
+
+  async fetchActiveMilestoneSnapshot(options: FetchLinearBoardOptions): Promise<WorkflowBoardSnapshot> {
+    const projectRef = options.projectRef.trim()
+    if (!projectRef) {
+      throw new LinearWorkflowClientError('NOT_CONFIGURED', 'Linear project reference is required')
+    }
+
+    const startedAt = Date.now()
+    const apiKey = await this.requireApiKey()
+    const projectId = await this.resolveProjectId(apiKey, projectRef)
+
+    if (!projectId) {
+      throw new LinearWorkflowClientError('NOT_FOUND', `Linear project "${projectRef}" was not found`)
+    }
+
+    const issuesData = await this.request<WorkflowIssuesQueryData>(
+      apiKey,
+      `
+        query WorkflowIssuesByProject($projectId: ID!) {
+          issues(
+            first: 250
+            filter: {
+              project: { id: { eq: $projectId } }
+            }
+          ) {
+            nodes {
+              id
+              identifier
+              title
+              parent {
+                id
+              }
+              state {
+                name
+                type
+              }
+              projectMilestone {
+                id
+                name
+                sortOrder
+              }
+              children(first: 100) {
+                nodes {
+                  id
+                  identifier
+                  title
+                  state {
+                    name
+                    type
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      { projectId },
+    )
+
+    const allIssues = issuesData.issues?.nodes ?? []
+    const sliceIssues = allIssues.filter((issue) => !issue.parent?.id)
+
+    const activeMilestone = chooseActiveMilestone(sliceIssues)
+    const snapshot = normalizeLinearBoard({
+      projectId,
+      milestoneId: activeMilestone?.id,
+      milestoneName: activeMilestone?.name,
+      issues: sliceIssues,
+    })
+
+    log.info('[linear-workflow-client] workflow:fetch', {
+      projectRef,
+      projectId,
+      milestoneId: snapshot.activeMilestone?.id,
+      status: snapshot.status,
+      cardCount: snapshot.columns.reduce((count, column) => count + column.cards.length, 0),
+      latencyMs: Date.now() - startedAt,
+    })
+
+    return snapshot
+  }
+
+  static toWorkflowError(error: unknown): { code: WorkflowBoardErrorCode; message: string } {
+    const mapped = toLinearWorkflowClientError(error)
+    return {
+      code: mapped.code,
+      message: mapped.message,
+    }
+  }
+
+  private async requireApiKey(): Promise<string> {
+    const envKey = process.env.LINEAR_API_KEY?.trim()
+    if (envKey) {
+      return envKey
+    }
+
+    const authKey = await this.authBridge.getApiKey('linear')
+    if (authKey?.trim()) {
+      return authKey.trim()
+    }
+
+    throw new LinearWorkflowClientError(
+      'MISSING_API_KEY',
+      'Linear API key required. Configure provider "linear" in auth.json or set LINEAR_API_KEY.',
+    )
+  }
+
+  private async resolveProjectId(apiKey: string, projectRef: string): Promise<string | null> {
+    const data = await this.request<ResolveProjectQueryData>(
+      apiKey,
+      `
+        query ResolveProjectId($projectRef: String!) {
+          project(id: $projectRef) {
+            id
+          }
+        }
+      `,
+      { projectRef },
+    )
+
+    return data.project?.id?.trim() || null
+  }
+
+  private async request<TData>(
+    apiKey: string,
+    query: string,
+    variables: Record<string, string>,
+  ): Promise<TData> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => {
+      controller.abort()
+    }, this.requestTimeoutMs)
+
+    let response: Response
+    try {
+      response = await fetch(this.apiUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: apiKey,
+        },
+        signal: controller.signal,
+        body: JSON.stringify({ query, variables }),
+      })
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new LinearWorkflowClientError('UNAUTHORIZED', 'Invalid Linear API key', response.status)
+    }
+
+    if (response.status === 404) {
+      throw new LinearWorkflowClientError(
+        'NETWORK',
+        'Linear API endpoint not found (HTTP 404). Verify endpoint configuration.',
+        response.status,
+      )
+    }
+
+    if (response.status === 429) {
+      throw new LinearWorkflowClientError('RATE_LIMITED', 'Linear API rate limit exceeded', response.status)
+    }
+
+    const payload = (await response.json().catch(() => ({}))) as GraphQLResponse<TData>
+
+    if (!response.ok) {
+      const firstError = payload.errors?.[0]?.message
+      if (firstError) {
+        throw toGraphqlError(firstError, response.status)
+      }
+
+      throw new LinearWorkflowClientError(
+        'NETWORK',
+        `Linear API request failed with status ${response.status}`,
+        response.status,
+      )
+    }
+
+    if (payload.errors?.length) {
+      throw toGraphqlError(payload.errors[0]?.message ?? 'Unknown GraphQL error', response.status)
+    }
+
+    return (payload.data ?? {}) as TData
+  }
+}
+
+function chooseActiveMilestone(
+  issues: LinearWorkflowIssue[],
+): { id: string; name: string } | null {
+  const milestones = new Map<string, { id: string; name: string; sortOrder: number; hasActive: boolean }>()
+
+  for (const issue of issues) {
+    const milestoneId = issue.projectMilestone?.id?.trim()
+    const milestoneName = issue.projectMilestone?.name?.trim()
+    if (!milestoneId || !milestoneName) {
+      continue
+    }
+
+    const sortOrder = Number(issue.projectMilestone?.sortOrder ?? Number.MAX_SAFE_INTEGER)
+    const columnId = mapLinearStateToColumnId(issue.state?.name, issue.state?.type)
+    const hasActive = columnId !== 'done'
+
+    const existing = milestones.get(milestoneId)
+    if (!existing) {
+      milestones.set(milestoneId, {
+        id: milestoneId,
+        name: milestoneName,
+        sortOrder,
+        hasActive,
+      })
+      continue
+    }
+
+    existing.hasActive = existing.hasActive || hasActive
+    existing.sortOrder = Math.min(existing.sortOrder, sortOrder)
+  }
+
+  if (milestones.size === 0) {
+    return null
+  }
+
+  const sorted = Array.from(milestones.values()).sort((left, right) => right.sortOrder - left.sortOrder)
+  return sorted.find((milestone) => milestone.hasActive) ?? sorted[0] ?? null
+}
+
+export function mapLinearStateToColumnId(
+  stateName: string | undefined,
+  stateType: string | undefined,
+): WorkflowColumnId {
+  const normalizedName = stateName?.trim().toLowerCase()
+  if (normalizedName && normalizedName in EXACT_NAME_TO_COLUMN_ID) {
+    const exactMatch = EXACT_NAME_TO_COLUMN_ID[normalizedName as keyof typeof EXACT_NAME_TO_COLUMN_ID]
+    if (exactMatch) {
+      return exactMatch
+    }
+  }
+
+  const normalizedType = stateType?.trim().toLowerCase()
+  if (normalizedType === 'backlog') {
+    return 'backlog'
+  }
+
+  if (normalizedType === 'unstarted') {
+    return 'todo'
+  }
+
+  if (normalizedType === 'started') {
+    return 'in_progress'
+  }
+
+  if (normalizedType === 'completed' || normalizedType === 'canceled') {
+    return 'done'
+  }
+
+  return 'todo'
+}
+
+export function createEmptyWorkflowColumns(): WorkflowBoardColumn[] {
+  return WORKFLOW_COLUMNS.map((column) => ({
+    id: column.id,
+    title: column.title,
+    cards: [],
+  }))
+}
+
+export function normalizeLinearBoard(input: {
+  projectId: string
+  milestoneId?: string
+  milestoneName?: string
+  issues: LinearWorkflowIssue[]
+}): WorkflowBoardSnapshot {
+  const columns = createEmptyWorkflowColumns()
+
+  const scopedIssues = input.milestoneId
+    ? input.issues.filter((issue) => issue.projectMilestone?.id === input.milestoneId)
+    : []
+
+  const sliceCards = scopedIssues
+    .filter((issue) => issue.id && issue.identifier && issue.title)
+    .map((issue) => {
+      const tasks = (issue.children?.nodes ?? [])
+        .filter((task) => task.id && task.title)
+        .map((task) => {
+          const taskColumnId = mapLinearStateToColumnId(task.state?.name, task.state?.type)
+          return {
+            id: task.id as string,
+            identifier: task.identifier,
+            title: task.title as string,
+            columnId: taskColumnId,
+            stateName: task.state?.name?.trim() || 'Unknown',
+            stateType: task.state?.type?.trim() || 'unknown',
+          } satisfies WorkflowBoardTask
+        })
+
+      const columnId = mapLinearStateToColumnId(issue.state?.name, issue.state?.type)
+      const doneTasks = tasks.filter((task) => task.columnId === 'done').length
+
+      return {
+        id: issue.id as string,
+        identifier: issue.identifier as string,
+        title: issue.title as string,
+        columnId,
+        stateName: issue.state?.name?.trim() || 'Unknown',
+        stateType: issue.state?.type?.trim() || 'unknown',
+        milestoneId: input.milestoneId ?? 'none',
+        milestoneName: input.milestoneName ?? 'No active milestone',
+        taskCounts: {
+          total: tasks.length,
+          done: doneTasks,
+        },
+        tasks,
+      } satisfies WorkflowBoardSliceCard
+    })
+
+  for (const card of sliceCards) {
+    const column = columns.find((entry) => entry.id === card.columnId)
+    column?.cards.push(card)
+  }
+
+  for (const column of columns) {
+    column.cards.sort((left, right) => left.identifier.localeCompare(right.identifier))
+  }
+
+  const hasCards = columns.some((column) => column.cards.length > 0)
+
+  return {
+    backend: 'linear',
+    fetchedAt: new Date().toISOString(),
+    status: hasCards ? 'fresh' : 'empty',
+    source: {
+      projectId: input.projectId,
+      activeMilestoneId: input.milestoneId,
+    },
+    activeMilestone:
+      input.milestoneId && input.milestoneName
+        ? {
+            id: input.milestoneId,
+            name: input.milestoneName,
+          }
+        : null,
+    columns,
+    emptyReason: hasCards ? undefined : 'No slices found in the active milestone.',
+    poll: {
+      status: 'success',
+      backend: 'linear',
+      lastAttemptAt: new Date().toISOString(),
+    },
+  }
+}
+
+function toGraphqlError(message: string, status?: number): LinearWorkflowClientError {
+  if (/rate\s*limit/i.test(message)) {
+    return new LinearWorkflowClientError('RATE_LIMITED', message, status)
+  }
+
+  if (/not\s*found/i.test(message)) {
+    return new LinearWorkflowClientError('NOT_FOUND', message, status)
+  }
+
+  return new LinearWorkflowClientError('GRAPHQL', message, status)
+}
+
+function toLinearWorkflowClientError(error: unknown): LinearWorkflowClientError {
+  if (error instanceof LinearWorkflowClientError) {
+    return error
+  }
+
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return new LinearWorkflowClientError('NETWORK', 'Linear API request timed out')
+  }
+
+  if (error instanceof TypeError) {
+    return new LinearWorkflowClientError('NETWORK', error.message)
+  }
+
+  if (error instanceof Error) {
+    return new LinearWorkflowClientError('UNKNOWN', error.message)
+  }
+
+  return new LinearWorkflowClientError('UNKNOWN', String(error))
+}

--- a/apps/desktop/src/main/linear-workflow-client.ts
+++ b/apps/desktop/src/main/linear-workflow-client.ts
@@ -1,6 +1,7 @@
 import { AuthBridge } from './auth-bridge'
 import log from './logger'
 import {
+  WORKFLOW_COLUMNS,
   type WorkflowBoardColumn,
   type WorkflowBoardErrorCode,
   type WorkflowBoardSliceCard,
@@ -11,16 +12,6 @@ import {
 
 const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql'
 const LINEAR_REQUEST_TIMEOUT_MS = 10_000
-
-const WORKFLOW_COLUMNS: Array<{ id: WorkflowColumnId; title: string }> = [
-  { id: 'backlog', title: 'Backlog' },
-  { id: 'todo', title: 'Todo' },
-  { id: 'in_progress', title: 'In Progress' },
-  { id: 'agent_review', title: 'Agent Review' },
-  { id: 'human_review', title: 'Human Review' },
-  { id: 'merging', title: 'Merging' },
-  { id: 'done', title: 'Done' },
-]
 
 const EXACT_NAME_TO_COLUMN_ID: Record<string, WorkflowColumnId> = {
   backlog: 'backlog',
@@ -48,6 +39,11 @@ interface LinearWorkflowMilestone {
   sortOrder?: number
 }
 
+interface LinearWorkflowPageInfo {
+  hasNextPage?: boolean
+  endCursor?: string | null
+}
+
 interface LinearWorkflowIssue {
   id?: string
   identifier?: string
@@ -57,6 +53,7 @@ interface LinearWorkflowIssue {
   projectMilestone?: LinearWorkflowMilestone | null
   children?: {
     nodes?: LinearWorkflowIssue[]
+    pageInfo?: LinearWorkflowPageInfo
   } | null
 }
 
@@ -66,10 +63,28 @@ interface ResolveProjectQueryData {
   } | null
 }
 
+interface ResolveProjectBySlugQueryData {
+  projects?: {
+    nodes?: Array<{
+      id?: string
+    }>
+  } | null
+}
+
 interface WorkflowIssuesQueryData {
   issues?: {
     nodes?: LinearWorkflowIssue[]
+    pageInfo?: LinearWorkflowPageInfo
   }
+}
+
+interface WorkflowIssueChildrenQueryData {
+  issue?: {
+    children?: {
+      nodes?: LinearWorkflowIssue[]
+      pageInfo?: LinearWorkflowPageInfo
+    } | null
+  } | null
 }
 
 export interface FetchLinearBoardOptions {
@@ -108,51 +123,7 @@ export class LinearWorkflowClient {
       throw new LinearWorkflowClientError('NOT_FOUND', `Linear project "${projectRef}" was not found`)
     }
 
-    const issuesData = await this.request<WorkflowIssuesQueryData>(
-      apiKey,
-      `
-        query WorkflowIssuesByProject($projectId: ID!) {
-          issues(
-            first: 250
-            filter: {
-              project: { id: { eq: $projectId } }
-            }
-          ) {
-            nodes {
-              id
-              identifier
-              title
-              parent {
-                id
-              }
-              state {
-                name
-                type
-              }
-              projectMilestone {
-                id
-                name
-                sortOrder
-              }
-              children(first: 100) {
-                nodes {
-                  id
-                  identifier
-                  title
-                  state {
-                    name
-                    type
-                  }
-                }
-              }
-            }
-          }
-        }
-      `,
-      { projectId },
-    )
-
-    const allIssues = issuesData.issues?.nodes ?? []
+    const allIssues = await this.fetchAllIssuesForProject(apiKey, projectId)
     const sliceIssues = allIssues.filter((issue) => !issue.parent?.id)
 
     const activeMilestone = chooseActiveMilestone(sliceIssues)
@@ -201,7 +172,7 @@ export class LinearWorkflowClient {
   }
 
   private async resolveProjectId(apiKey: string, projectRef: string): Promise<string | null> {
-    const data = await this.request<ResolveProjectQueryData>(
+    const byId = await this.request<ResolveProjectQueryData>(
       apiKey,
       `
         query ResolveProjectId($projectRef: String!) {
@@ -213,13 +184,160 @@ export class LinearWorkflowClient {
       { projectRef },
     )
 
-    return data.project?.id?.trim() || null
+    const idMatch = byId.project?.id?.trim()
+    if (idMatch) {
+      return idMatch
+    }
+
+    const bySlug = await this.request<ResolveProjectBySlugQueryData>(
+      apiKey,
+      `
+        query ResolveProjectBySlug($projectRef: String!) {
+          projects(first: 1, filter: { slug: { eq: $projectRef } }) {
+            nodes {
+              id
+            }
+          }
+        }
+      `,
+      { projectRef },
+    )
+
+    return bySlug.projects?.nodes?.[0]?.id?.trim() || null
+  }
+
+  private async fetchAllIssuesForProject(apiKey: string, projectId: string): Promise<LinearWorkflowIssue[]> {
+    const issues: LinearWorkflowIssue[] = []
+    let after: string | null = null
+
+    do {
+      const page: WorkflowIssuesQueryData = await this.request<WorkflowIssuesQueryData>(
+        apiKey,
+        `
+          query WorkflowIssuesByProject($projectId: ID!, $after: String) {
+            issues(
+              first: 100
+              after: $after
+              filter: {
+                project: { id: { eq: $projectId } }
+              }
+            ) {
+              nodes {
+                id
+                identifier
+                title
+                parent {
+                  id
+                }
+                state {
+                  name
+                  type
+                }
+                projectMilestone {
+                  id
+                  name
+                  sortOrder
+                }
+                children(first: 100) {
+                  nodes {
+                    id
+                    identifier
+                    title
+                    state {
+                      name
+                      type
+                    }
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        `,
+        { projectId, after },
+      )
+
+      const pageNodes = page.issues?.nodes ?? []
+      issues.push(...pageNodes)
+
+      after = page.issues?.pageInfo?.hasNextPage ? (page.issues.pageInfo.endCursor ?? null) : null
+    } while (after)
+
+    for (const issue of issues) {
+      const issueId = issue.id?.trim()
+      if (!issueId || !issue.children?.pageInfo?.hasNextPage) {
+        continue
+      }
+
+      const existingChildren = issue.children.nodes ?? []
+      const extraChildren = await this.fetchAllChildrenForIssue(apiKey, issueId, issue.children.pageInfo.endCursor)
+      issue.children = {
+        nodes: [...existingChildren, ...extraChildren],
+        pageInfo: {
+          hasNextPage: false,
+          endCursor: null,
+        },
+      }
+    }
+
+    return issues
+  }
+
+  private async fetchAllChildrenForIssue(
+    apiKey: string,
+    issueId: string,
+    initialCursor?: string | null,
+  ): Promise<LinearWorkflowIssue[]> {
+    const children: LinearWorkflowIssue[] = []
+    let after = initialCursor ?? null
+
+    while (after) {
+      const page: WorkflowIssueChildrenQueryData = await this.request<WorkflowIssueChildrenQueryData>(
+        apiKey,
+        `
+          query WorkflowIssueChildrenPage($issueId: String!, $after: String) {
+            issue(id: $issueId) {
+              children(first: 100, after: $after) {
+                nodes {
+                  id
+                  identifier
+                  title
+                  state {
+                    name
+                    type
+                  }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        `,
+        { issueId, after },
+      )
+
+      children.push(...(page.issue?.children?.nodes ?? []))
+      after = page.issue?.children?.pageInfo?.hasNextPage
+        ? (page.issue.children.pageInfo.endCursor ?? null)
+        : null
+    }
+
+    return children
   }
 
   private async request<TData>(
     apiKey: string,
     query: string,
-    variables: Record<string, string>,
+    variables: Record<string, string | null>,
   ): Promise<TData> {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -102,6 +102,7 @@ interface WorkflowBoardServiceOptions {
 export class WorkflowBoardService {
   private readonly linearClient: LinearWorkflowClient
   private lastSnapshot: WorkflowBoardSnapshot | null = null
+  private inFlightRefresh: Promise<WorkflowBoardSnapshotResponse> | null = null
 
   constructor(private readonly options: WorkflowBoardServiceOptions) {
     this.linearClient = new LinearWorkflowClient(options.authBridge)
@@ -119,6 +120,20 @@ export class WorkflowBoardService {
   }
 
   async refreshBoard(): Promise<WorkflowBoardSnapshotResponse> {
+    if (this.inFlightRefresh) {
+      return this.inFlightRefresh
+    }
+
+    this.inFlightRefresh = this.performRefreshBoard()
+
+    try {
+      return await this.inFlightRefresh
+    } finally {
+      this.inFlightRefresh = null
+    }
+  }
+
+  private async performRefreshBoard(): Promise<WorkflowBoardSnapshotResponse> {
     const nowIso = new Date().toISOString()
 
     if (isWorkflowFixtureEnabled()) {
@@ -131,7 +146,28 @@ export class WorkflowBoardService {
     }
 
     const workspacePath = this.options.getWorkspacePath()
-    const projectRef = await readLinearProjectReference(workspacePath)
+
+    let projectRef: string | null
+    try {
+      projectRef = await readLinearProjectReference(workspacePath)
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unable to read .kata/preferences.md due to an unknown error.'
+
+      const snapshot = this.toErrorSnapshot({
+        nowIso,
+        projectId: 'unknown',
+        code: 'UNKNOWN',
+        message,
+      })
+
+      this.lastSnapshot = snapshot
+
+      return {
+        success: true,
+        snapshot,
+      }
+    }
 
     if (!projectRef) {
       const snapshot = this.toErrorSnapshot({
@@ -254,12 +290,15 @@ async function readLinearProjectReference(workspacePath: string): Promise<string
       return null
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error)
+
     log.warn('[workflow-board-service] unable to read preferences', {
       workspacePath,
       preferencesPath,
-      error: error instanceof Error ? error.message : String(error),
+      error: errorMessage,
     })
-    return null
+
+    throw new Error(`Unable to read .kata/preferences.md: ${errorMessage}`)
   }
 
   const frontmatterMatch = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/)

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -301,7 +301,7 @@ async function readLinearProjectReference(workspacePath: string): Promise<string
     throw new Error(`Unable to read .kata/preferences.md: ${errorMessage}`)
   }
 
-  const frontmatterMatch = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/)
+  const frontmatterMatch = content.match(/^\uFEFF?\s*---\s*\r?\n([\s\S]*?)\r?\n---/)
   if (!frontmatterMatch?.[1]) {
     return null
   }

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -1,0 +1,292 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { AuthBridge } from './auth-bridge'
+import { LinearWorkflowClient } from './linear-workflow-client'
+import log from './logger'
+import {
+  type WorkflowBoardSnapshot,
+  type WorkflowBoardSnapshotResponse,
+} from '../shared/types'
+
+const TEST_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
+  backend: 'linear',
+  fetchedAt: '2026-04-04T00:00:00.000Z',
+  status: 'fresh',
+  source: {
+    projectId: 'test-project',
+    activeMilestoneId: 'm003',
+  },
+  activeMilestone: {
+    id: 'm003',
+    name: '[M003] Workflow Kanban',
+  },
+  columns: [
+    {
+      id: 'backlog',
+      title: 'Backlog',
+      cards: [],
+    },
+    {
+      id: 'todo',
+      title: 'Todo',
+      cards: [
+        {
+          id: 'slice-1',
+          identifier: 'KAT-2247',
+          title: '[S01] Linear Workflow Board in the Right Pane',
+          columnId: 'todo',
+          stateName: 'Todo',
+          stateType: 'unstarted',
+          milestoneId: 'm003',
+          milestoneName: '[M003] Workflow Kanban',
+          taskCounts: { total: 2, done: 1 },
+          tasks: [
+            {
+              id: 'task-1',
+              identifier: 'KAT-2251',
+              title: '[T01] Define canonical workflow snapshot contract',
+              columnId: 'done',
+              stateName: 'Done',
+              stateType: 'completed',
+            },
+            {
+              id: 'task-2',
+              identifier: 'KAT-2252',
+              title: '[T02] Wire workflow board service through IPC',
+              columnId: 'in_progress',
+              stateName: 'In Progress',
+              stateType: 'started',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'in_progress',
+      title: 'In Progress',
+      cards: [],
+    },
+    {
+      id: 'agent_review',
+      title: 'Agent Review',
+      cards: [],
+    },
+    {
+      id: 'human_review',
+      title: 'Human Review',
+      cards: [],
+    },
+    {
+      id: 'merging',
+      title: 'Merging',
+      cards: [],
+    },
+    {
+      id: 'done',
+      title: 'Done',
+      cards: [],
+    },
+  ],
+  poll: {
+    status: 'success',
+    backend: 'linear',
+    lastAttemptAt: '2026-04-04T00:00:00.000Z',
+  },
+}
+
+interface WorkflowBoardServiceOptions {
+  authBridge: AuthBridge
+  getWorkspacePath: () => string
+}
+
+export class WorkflowBoardService {
+  private readonly linearClient: LinearWorkflowClient
+  private lastSnapshot: WorkflowBoardSnapshot | null = null
+
+  constructor(private readonly options: WorkflowBoardServiceOptions) {
+    this.linearClient = new LinearWorkflowClient(options.authBridge)
+  }
+
+  async getBoard(): Promise<WorkflowBoardSnapshotResponse> {
+    if (this.lastSnapshot) {
+      return {
+        success: true,
+        snapshot: this.lastSnapshot,
+      }
+    }
+
+    return this.refreshBoard()
+  }
+
+  async refreshBoard(): Promise<WorkflowBoardSnapshotResponse> {
+    const nowIso = new Date().toISOString()
+
+    if (isWorkflowFixtureEnabled()) {
+      const fixture = withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
+      this.lastSnapshot = fixture
+      return {
+        success: true,
+        snapshot: fixture,
+      }
+    }
+
+    const workspacePath = this.options.getWorkspacePath()
+    const projectRef = await readLinearProjectReference(workspacePath)
+
+    if (!projectRef) {
+      const snapshot = this.toErrorSnapshot({
+        nowIso,
+        projectId: 'unknown',
+        code: 'NOT_CONFIGURED',
+        message: 'Linear project is not configured in .kata/preferences.md (projectId or projectSlug).',
+      })
+      this.lastSnapshot = snapshot
+      return {
+        success: true,
+        snapshot,
+      }
+    }
+
+    try {
+      const snapshot = await this.linearClient.fetchActiveMilestoneSnapshot({ projectRef })
+      this.lastSnapshot = snapshot
+      return {
+        success: true,
+        snapshot,
+      }
+    } catch (error) {
+      const workflowError = LinearWorkflowClient.toWorkflowError(error)
+      const staleSnapshot: WorkflowBoardSnapshot = this.lastSnapshot
+        ? {
+            ...this.lastSnapshot,
+            status: 'stale',
+            lastError: workflowError,
+            poll: {
+              ...this.lastSnapshot.poll,
+              status: 'error',
+              lastAttemptAt: nowIso,
+            },
+          }
+        : this.toErrorSnapshot({
+            nowIso,
+            projectId: projectRef,
+            code: workflowError.code,
+            message: workflowError.message,
+          })
+
+      this.lastSnapshot = staleSnapshot
+
+      log.warn('[workflow-board-service] workflow refresh failed', {
+        workspacePath,
+        projectRef,
+        error: workflowError,
+      })
+
+      return {
+        success: true,
+        snapshot: staleSnapshot,
+      }
+    }
+  }
+
+  private toErrorSnapshot(input: {
+    nowIso: string
+    projectId: string
+    code: NonNullable<WorkflowBoardSnapshot['lastError']>['code']
+    message: string
+  }): WorkflowBoardSnapshot {
+    return {
+      backend: 'linear',
+      fetchedAt: input.nowIso,
+      status: 'error',
+      source: {
+        projectId: input.projectId,
+      },
+      activeMilestone: null,
+      columns: TEST_WORKFLOW_FIXTURE.columns.map((column) => ({
+        id: column.id,
+        title: column.title,
+        cards: [],
+      })),
+      emptyReason: 'Workflow board unavailable',
+      lastError: {
+        code: input.code,
+        message: input.message,
+      },
+      poll: {
+        status: 'error',
+        backend: 'linear',
+        lastAttemptAt: input.nowIso,
+      },
+    }
+  }
+}
+
+function isWorkflowFixtureEnabled(): boolean {
+  return process.env.KATA_TEST_MODE === '1' || process.env.KATA_TEST_WORKFLOW_FIXTURE === '1'
+}
+
+function withFreshTimestamps(snapshot: WorkflowBoardSnapshot): WorkflowBoardSnapshot {
+  const nowIso = new Date().toISOString()
+  return {
+    ...snapshot,
+    fetchedAt: nowIso,
+    poll: {
+      ...snapshot.poll,
+      lastAttemptAt: nowIso,
+    },
+  }
+}
+
+async function readLinearProjectReference(workspacePath: string): Promise<string | null> {
+  const preferencesPath = path.join(workspacePath, '.kata', 'preferences.md')
+
+  let content: string
+  try {
+    content = await fs.readFile(preferencesPath, 'utf8')
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : undefined
+
+    if (code === 'ENOENT') {
+      return null
+    }
+
+    log.warn('[workflow-board-service] unable to read preferences', {
+      workspacePath,
+      preferencesPath,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+
+  const frontmatterMatch = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/)
+  if (!frontmatterMatch?.[1]) {
+    return null
+  }
+
+  const frontmatter = frontmatterMatch[1]
+  const projectIdMatch = frontmatter.match(/^\s*projectId:\s*([^\n#]+)$/m)
+  if (projectIdMatch?.[1]) {
+    const projectId = stripYamlWrapping(projectIdMatch[1].trim())
+    if (projectId) {
+      return projectId
+    }
+  }
+
+  const projectSlugMatch = frontmatter.match(/^\s*projectSlug:\s*([^\n#]+)$/m)
+  if (projectSlugMatch?.[1]) {
+    const projectSlug = stripYamlWrapping(projectSlugMatch[1].trim())
+    if (projectSlug) {
+      return projectSlug
+    }
+  }
+
+  return null
+}
+
+function stripYamlWrapping(value: string): string {
+  return value.replace(/^['"]/, '').replace(/['"]$/, '').trim()
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -148,6 +148,14 @@ const api: DesktopApi = {
       return ipcRenderer.invoke(IPC_CHANNELS.planningListArtifacts)
     },
   },
+  workflow: {
+    getBoard: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowGetBoard)
+    },
+    refreshBoard: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowRefreshBoard)
+    },
+  },
 }
 
 contextBridge.exposeInMainWorld('api', api)

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -3,12 +3,14 @@ import { onboardingCompleteAtom } from './atoms/onboarding'
 import { AppShell } from './components/app-shell/AppShell'
 import { OnboardingWizard } from './components/onboarding/OnboardingWizard'
 import { usePlanningArtifactBridge } from '@/atoms/planning'
+import { useWorkflowBoardBridge } from '@/atoms/workflow-board'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
 export default function App() {
   const onboardingComplete = useAtomValue(onboardingCompleteAtom)
 
   usePlanningArtifactBridge()
+  useWorkflowBoardBridge()
 
   return (
     <TooltipProvider>

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -1,0 +1,99 @@
+import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { useEffect } from 'react'
+import type { WorkflowBoardSnapshot } from '@shared/types'
+
+const REFRESH_INTERVAL_MS = 30_000
+
+export const workflowBoardAtom = atom<WorkflowBoardSnapshot | null>(null)
+export const workflowBoardLoadingAtom = atom<boolean>(false)
+export const workflowBoardRefreshingAtom = atom<boolean>(false)
+export const workflowBoardErrorAtom = atom<string | null>(null)
+
+export const workflowBoardHasCardsAtom = atom((get) => {
+  const snapshot = get(workflowBoardAtom)
+  if (!snapshot) {
+    return false
+  }
+
+  return snapshot.columns.some((column) => column.cards.length > 0)
+})
+
+export const refreshWorkflowBoardAtom = atom(null, async (_get, set) => {
+  set(workflowBoardRefreshingAtom, true)
+  set(workflowBoardErrorAtom, null)
+
+  try {
+    const response = await window.api.workflow.refreshBoard()
+    set(workflowBoardAtom, response.snapshot)
+    set(workflowBoardErrorAtom, response.snapshot.lastError?.message ?? null)
+  } catch (error) {
+    set(workflowBoardErrorAtom, error instanceof Error ? error.message : String(error))
+  } finally {
+    set(workflowBoardRefreshingAtom, false)
+  }
+})
+export function useWorkflowBoardBridge(): void {
+  const setBoard = useSetAtom(workflowBoardAtom)
+  const setLoading = useSetAtom(workflowBoardLoadingAtom)
+  const setRefreshing = useSetAtom(workflowBoardRefreshingAtom)
+  const setError = useSetAtom(workflowBoardErrorAtom)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const loadBoard = async (mode: 'initial' | 'refresh') => {
+      if (cancelled) {
+        return
+      }
+
+      if (mode === 'initial') {
+        setLoading(true)
+      } else {
+        setRefreshing(true)
+      }
+
+      try {
+        const response =
+          mode === 'initial' ? await window.api.workflow.getBoard() : await window.api.workflow.refreshBoard()
+
+        if (cancelled) {
+          return
+        }
+
+        setBoard(response.snapshot)
+        setError(response.snapshot.lastError?.message ?? null)
+      } catch (error) {
+        if (cancelled) {
+          return
+        }
+
+        setError(error instanceof Error ? error.message : String(error))
+      } finally {
+        if (cancelled) {
+          return
+        }
+
+        if (mode === 'initial') {
+          setLoading(false)
+        } else {
+          setRefreshing(false)
+        }
+      }
+    }
+
+    void loadBoard('initial')
+
+    const intervalId = window.setInterval(() => {
+      void loadBoard('refresh')
+    }, REFRESH_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(intervalId)
+    }
+  }, [setBoard, setError, setLoading, setRefreshing])
+}
+
+export function useWorkflowBoardSnapshot(): WorkflowBoardSnapshot | null {
+  return useAtomValue(workflowBoardAtom)
+}

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -4,6 +4,17 @@ import type { WorkflowBoardSnapshot } from '@shared/types'
 
 const REFRESH_INTERVAL_MS = 30_000
 
+let latestRefreshRequestId = 0
+
+function beginRefreshRequest(): number {
+  latestRefreshRequestId += 1
+  return latestRefreshRequestId
+}
+
+function isLatestRefreshRequest(requestId: number): boolean {
+  return requestId === latestRefreshRequestId
+}
+
 export const workflowBoardAtom = atom<WorkflowBoardSnapshot | null>(null)
 export const workflowBoardLoadingAtom = atom<boolean>(false)
 export const workflowBoardRefreshingAtom = atom<boolean>(false)
@@ -19,17 +30,28 @@ export const workflowBoardHasCardsAtom = atom((get) => {
 })
 
 export const refreshWorkflowBoardAtom = atom(null, async (_get, set) => {
+  const requestId = beginRefreshRequest()
   set(workflowBoardRefreshingAtom, true)
   set(workflowBoardErrorAtom, null)
 
   try {
     const response = await window.api.workflow.refreshBoard()
+    if (!isLatestRefreshRequest(requestId)) {
+      return
+    }
+
     set(workflowBoardAtom, response.snapshot)
     set(workflowBoardErrorAtom, response.snapshot.lastError?.message ?? null)
   } catch (error) {
+    if (!isLatestRefreshRequest(requestId)) {
+      return
+    }
+
     set(workflowBoardErrorAtom, error instanceof Error ? error.message : String(error))
   } finally {
-    set(workflowBoardRefreshingAtom, false)
+    if (isLatestRefreshRequest(requestId)) {
+      set(workflowBoardRefreshingAtom, false)
+    }
   }
 })
 export function useWorkflowBoardBridge(): void {
@@ -42,6 +64,11 @@ export function useWorkflowBoardBridge(): void {
     let cancelled = false
 
     const loadBoard = async (mode: 'initial' | 'refresh') => {
+      if (cancelled) {
+        return
+      }
+
+      const requestId = mode === 'refresh' ? beginRefreshRequest() : null
       if (cancelled) {
         return
       }
@@ -60,6 +87,10 @@ export function useWorkflowBoardBridge(): void {
           return
         }
 
+        if (mode === 'refresh' && requestId !== null && !isLatestRefreshRequest(requestId)) {
+          return
+        }
+
         setBoard(response.snapshot)
         setError(response.snapshot.lastError?.message ?? null)
       } catch (error) {
@@ -67,16 +98,18 @@ export function useWorkflowBoardBridge(): void {
           return
         }
 
-        setError(error instanceof Error ? error.message : String(error))
-      } finally {
-        if (cancelled) {
+        if (mode === 'refresh' && requestId !== null && !isLatestRefreshRequest(requestId)) {
           return
         }
 
-        if (mode === 'initial') {
-          setLoading(false)
-        } else {
-          setRefreshing(false)
+        setError(error instanceof Error ? error.message : String(error))
+      } finally {
+        if (!cancelled) {
+          if (mode === 'initial') {
+            setLoading(false)
+          } else if (requestId !== null && isLatestRefreshRequest(requestId)) {
+            setRefreshing(false)
+          }
         }
       }
     }

--- a/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
@@ -1,51 +1,14 @@
-import { useAtomValue, useSetAtom } from 'jotai'
-import { LayoutGrid } from 'lucide-react'
+import { useAtomValue } from 'jotai'
 import { rightPaneModeAtom } from '@/atoms/planning'
+import { KanbanPane } from '@/components/kanban/KanbanPane'
 import { PlanningPane } from '@/components/planning/PlanningPane'
-import { Button } from '@/components/ui/button'
-import { Separator } from '@/components/ui/separator'
 
 export function RightPane() {
   const rightPaneMode = useAtomValue(rightPaneModeAtom)
-  const setRightPaneMode = useSetAtom(rightPaneModeAtom)
 
   if (rightPaneMode === 'planning') {
     return <PlanningPane />
   }
 
-  return (
-    <aside className="flex h-full flex-col bg-muted/40">
-      <div className="flex h-14 items-center justify-between px-4">
-        <h2 className="text-sm font-semibold tracking-wide uppercase text-muted-foreground">
-          Context Pane
-        </h2>
-
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          aria-label="Open planning view"
-          onClick={() => {
-            console.info('Right pane mode toggled', {
-              trigger: 'manual',
-              from: 'default',
-              to: 'planning',
-            })
-            setRightPaneMode('planning')
-          }}
-        >
-          <LayoutGrid className="size-4" />
-        </Button>
-      </div>
-
-      <Separator />
-
-      <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
-        <div className="flex flex-col gap-2">
-          <p className="font-medium text-foreground">Kata Desktop</p>
-          <p>Planning artifacts appear here during /kata plan. Kanban view is coming in M003.</p>
-        </div>
-      </div>
-    </aside>
-  )
+  return <KanbanPane />
 }

--- a/apps/desktop/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanColumn.tsx
@@ -1,0 +1,25 @@
+import type { WorkflowBoardColumn } from '@shared/types'
+import { SliceCard } from '@/components/kanban/SliceCard'
+
+interface KanbanColumnProps {
+  column: WorkflowBoardColumn
+}
+
+export function KanbanColumn({ column }: KanbanColumnProps) {
+  return (
+    <section className="flex min-h-0 min-w-[260px] max-w-[320px] flex-1 flex-col rounded-xl border border-border/70 bg-muted/20">
+      <header className="flex items-center justify-between border-b border-border/70 px-3 py-2">
+        <h3 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">{column.title}</h3>
+        <span className="text-xs text-muted-foreground">{column.cards.length}</span>
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">
+        {column.cards.length === 0 ? (
+          <p className="px-1 py-2 text-xs text-muted-foreground">No slices</p>
+        ) : (
+          column.cards.map((card) => <SliceCard key={card.id} card={card} />)
+        )}
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -1,0 +1,92 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import { LayoutGrid, Loader2, RefreshCcw } from 'lucide-react'
+import {
+  refreshWorkflowBoardAtom,
+  workflowBoardAtom,
+  workflowBoardErrorAtom,
+  workflowBoardLoadingAtom,
+  workflowBoardRefreshingAtom,
+} from '@/atoms/workflow-board'
+import { rightPaneModeAtom } from '@/atoms/planning'
+import { KanbanColumn } from '@/components/kanban/KanbanColumn'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { normalizeWorkflowColumns } from '@/lib/workflow-board'
+
+export function KanbanPane() {
+  const board = useAtomValue(workflowBoardAtom)
+  const loading = useAtomValue(workflowBoardLoadingAtom)
+  const refreshing = useAtomValue(workflowBoardRefreshingAtom)
+  const error = useAtomValue(workflowBoardErrorAtom)
+  const setRightPaneMode = useSetAtom(rightPaneModeAtom)
+  const refreshBoard = useSetAtom(refreshWorkflowBoardAtom)
+
+  const columns = board ? normalizeWorkflowColumns(board) : []
+
+  return (
+    <aside className="flex h-full flex-col bg-muted/40" data-testid="workflow-kanban-pane">
+      <div className="flex h-14 items-center justify-between px-4">
+        <div className="min-w-0">
+          <h2 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">Workflow Board</h2>
+          <p className="truncate text-sm font-medium text-foreground">
+            {board?.activeMilestone?.name ?? 'No active milestone'}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Open planning view"
+            onClick={() => setRightPaneMode('planning')}
+          >
+            <LayoutGrid className="size-4" />
+          </Button>
+
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Refresh workflow board"
+            onClick={() => {
+              void refreshBoard()
+            }}
+          >
+            <RefreshCcw className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-status">
+        {loading ? 'Loading workflow board…' : null}
+        {!loading && board?.status === 'fresh' ? `Live data · ${board.backend}` : null}
+        {!loading && board?.status === 'empty' ? board.emptyReason ?? 'No work items found' : null}
+        {!loading && board?.status === 'stale' ? 'Showing stale board snapshot' : null}
+        {!loading && board?.status === 'error' ? 'Workflow board unavailable' : null}
+        {refreshing ? ' · Refreshing…' : null}
+      </div>
+
+      {error ? (
+        <div className="border-b border-border bg-destructive/10 px-4 py-2 text-xs text-destructive">{error}</div>
+      ) : null}
+
+      <div className="min-h-0 flex-1 overflow-x-auto px-3 py-3">
+        {loading ? (
+          <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            <span>Loading workflow board…</span>
+          </div>
+        ) : (
+          <div className="flex h-full min-w-max gap-3">
+            {columns.map((column) => (
+              <KanbanColumn key={column.id} column={column} />
+            ))}
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -62,6 +62,7 @@ export function KanbanPane() {
 
       <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-status">
         {loading ? 'Loading workflow board…' : null}
+        {!loading && !board ? 'Workflow board not loaded' : null}
         {!loading && board?.status === 'fresh' ? `Live data · ${board.backend}` : null}
         {!loading && board?.status === 'empty' ? board.emptyReason ?? 'No work items found' : null}
         {!loading && board?.status === 'stale' ? 'Showing stale board snapshot' : null}

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -1,0 +1,41 @@
+import { ChevronDown } from 'lucide-react'
+import type { WorkflowBoardSliceCard } from '@shared/types'
+import { TaskList } from '@/components/kanban/TaskList'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+
+interface SliceCardProps {
+  card: WorkflowBoardSliceCard
+}
+
+export function SliceCard({ card }: SliceCardProps) {
+  return (
+    <Card size="sm" className="gap-3 rounded-xl border border-border/70 py-3 shadow-none">
+      <CardHeader className="px-3 pb-0">
+        <CardTitle className="text-sm leading-tight">
+          {card.identifier} · {card.title}
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent className="space-y-2 px-3">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>{card.stateName}</span>
+          <Badge variant="outline" className="text-[10px]">
+            {card.taskCounts.done}/{card.taskCounts.total} tasks done
+          </Badge>
+        </div>
+
+        <Collapsible>
+          <CollapsibleTrigger className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
+            <ChevronDown className="size-3" />
+            Show tasks
+          </CollapsibleTrigger>
+          <CollapsibleContent className="pt-2">
+            <TaskList tasks={card.tasks} />
+          </CollapsibleContent>
+        </Collapsible>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown } from 'lucide-react'
+import { useState } from 'react'
 import type { WorkflowBoardSliceCard } from '@shared/types'
 import { TaskList } from '@/components/kanban/TaskList'
 import { Badge } from '@/components/ui/badge'
@@ -10,6 +11,8 @@ interface SliceCardProps {
 }
 
 export function SliceCard({ card }: SliceCardProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
   return (
     <Card size="sm" className="gap-3 rounded-xl border border-border/70 py-3 shadow-none">
       <CardHeader className="px-3 pb-0">
@@ -26,10 +29,10 @@ export function SliceCard({ card }: SliceCardProps) {
           </Badge>
         </div>
 
-        <Collapsible>
+        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
           <CollapsibleTrigger className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
-            <ChevronDown className="size-3" />
-            Show tasks
+            <ChevronDown className={`size-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+            {isOpen ? 'Hide tasks' : 'Show tasks'}
           </CollapsibleTrigger>
           <CollapsibleContent className="pt-2">
             <TaskList tasks={card.tasks} />

--- a/apps/desktop/src/renderer/components/kanban/TaskList.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskList.tsx
@@ -6,6 +6,8 @@ interface TaskListProps {
   tasks: WorkflowBoardTask[]
 }
 
+const DEFAULT_TASK_TONE = 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200'
+
 const TASK_STATE_TONE: Record<WorkflowBoardTask['columnId'], string> = {
   backlog: 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200',
   todo: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200',
@@ -30,7 +32,10 @@ export function TaskList({ tasks }: TaskListProps) {
               {task.identifier ? `${task.identifier} · ` : ''}
               {task.title}
             </p>
-            <Badge variant="outline" className={cn('border-transparent text-[10px]', TASK_STATE_TONE[task.columnId])}>
+            <Badge
+              variant="outline"
+              className={cn('border-transparent text-[10px]', TASK_STATE_TONE[task.columnId] ?? DEFAULT_TASK_TONE)}
+            >
               {task.stateName}
             </Badge>
           </div>

--- a/apps/desktop/src/renderer/components/kanban/TaskList.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskList.tsx
@@ -1,0 +1,41 @@
+import type { WorkflowBoardTask } from '@shared/types'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+interface TaskListProps {
+  tasks: WorkflowBoardTask[]
+}
+
+const TASK_STATE_TONE: Record<WorkflowBoardTask['columnId'], string> = {
+  backlog: 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200',
+  todo: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200',
+  in_progress: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  agent_review: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+  human_review: 'bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900/40 dark:text-fuchsia-300',
+  merging: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  done: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+}
+
+export function TaskList({ tasks }: TaskListProps) {
+  if (tasks.length === 0) {
+    return <p className="text-xs text-muted-foreground">No child tasks</p>
+  }
+
+  return (
+    <ul className="space-y-2">
+      {tasks.map((task) => (
+        <li key={task.id} className="rounded-md border border-border/60 bg-background/50 px-2 py-1.5">
+          <div className="flex items-center justify-between gap-2">
+            <p className="truncate text-xs font-medium text-foreground">
+              {task.identifier ? `${task.identifier} · ` : ''}
+              {task.title}
+            </p>
+            <Badge variant="outline" className={cn('border-transparent text-[10px]', TASK_STATE_TONE[task.columnId])}>
+              {task.stateName}
+            </Badge>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/desktop/src/renderer/lib/__tests__/workflow-board.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/workflow-board.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'vitest'
+import type { WorkflowBoardSnapshot } from '@shared/types'
+import {
+  WORKFLOW_COLUMN_ORDER,
+  countWorkflowCards,
+  flattenWorkflowTasks,
+  normalizeWorkflowColumns,
+} from '../workflow-board'
+
+const snapshotFixture: WorkflowBoardSnapshot = {
+  backend: 'linear',
+  fetchedAt: '2026-04-04T00:00:00.000Z',
+  status: 'fresh',
+  source: {
+    projectId: 'project-1',
+    activeMilestoneId: 'milestone-1',
+  },
+  activeMilestone: {
+    id: 'milestone-1',
+    name: '[M003] Workflow Kanban',
+  },
+  columns: [
+    {
+      id: 'todo',
+      title: 'Todo',
+      cards: [
+        {
+          id: 'slice-1',
+          identifier: 'KAT-1',
+          title: 'First slice',
+          columnId: 'todo',
+          stateName: 'Todo',
+          stateType: 'unstarted',
+          milestoneId: 'milestone-1',
+          milestoneName: '[M003] Workflow Kanban',
+          taskCounts: { total: 2, done: 1 },
+          tasks: [
+            {
+              id: 'task-1',
+              title: 'First task',
+              identifier: 'KAT-2',
+              columnId: 'in_progress',
+              stateName: 'In Progress',
+              stateType: 'started',
+            },
+            {
+              id: 'task-2',
+              title: 'Second task',
+              identifier: 'KAT-3',
+              columnId: 'done',
+              stateName: 'Done',
+              stateType: 'completed',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  poll: {
+    status: 'success',
+    backend: 'linear',
+    lastAttemptAt: '2026-04-04T00:00:00.000Z',
+  },
+}
+
+describe('workflow-board renderer helpers', () => {
+  test('normalizes columns into canonical workflow order', () => {
+    const columns = normalizeWorkflowColumns(snapshotFixture)
+
+    expect(columns.map((column) => column.id)).toEqual(WORKFLOW_COLUMN_ORDER)
+    expect(columns.find((column) => column.id === 'todo')?.cards).toHaveLength(1)
+    expect(columns.find((column) => column.id === 'backlog')?.cards).toHaveLength(0)
+  })
+
+  test('counts cards across all columns', () => {
+    expect(countWorkflowCards(snapshotFixture)).toBe(1)
+  })
+
+  test('flattens task rows across all slice cards', () => {
+    const tasks = flattenWorkflowTasks(snapshotFixture)
+    expect(tasks.map((task) => task.id)).toEqual(['task-1', 'task-2'])
+  })
+})

--- a/apps/desktop/src/renderer/lib/workflow-board.ts
+++ b/apps/desktop/src/renderer/lib/workflow-board.ts
@@ -1,0 +1,62 @@
+import type {
+  WorkflowBoardColumn,
+  WorkflowBoardSliceCard,
+  WorkflowBoardSnapshot,
+  WorkflowColumnId,
+} from '@shared/types'
+
+export const WORKFLOW_COLUMN_ORDER: WorkflowColumnId[] = [
+  'backlog',
+  'todo',
+  'in_progress',
+  'agent_review',
+  'human_review',
+  'merging',
+  'done',
+]
+
+export function normalizeWorkflowColumns(snapshot: WorkflowBoardSnapshot): WorkflowBoardColumn[] {
+  const sourceById = new Map(snapshot.columns.map((column) => [column.id, column]))
+
+  return WORKFLOW_COLUMN_ORDER.map((columnId) => {
+    const existing = sourceById.get(columnId)
+    if (existing) {
+      return existing
+    }
+
+    return {
+      id: columnId,
+      title: toColumnTitle(columnId),
+      cards: [],
+    }
+  })
+}
+
+export function countWorkflowCards(snapshot: WorkflowBoardSnapshot): number {
+  return snapshot.columns.reduce((count, column) => count + column.cards.length, 0)
+}
+
+export function flattenWorkflowTasks(snapshot: WorkflowBoardSnapshot): WorkflowBoardSliceCard['tasks'] {
+  return normalizeWorkflowColumns(snapshot).flatMap((column) =>
+    column.cards.flatMap((card) => card.tasks),
+  )
+}
+
+export function toColumnTitle(columnId: WorkflowColumnId): string {
+  if (columnId === 'in_progress') {
+    return 'In Progress'
+  }
+
+  if (columnId === 'agent_review') {
+    return 'Agent Review'
+  }
+
+  if (columnId === 'human_review') {
+    return 'Human Review'
+  }
+
+  return columnId
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}

--- a/apps/desktop/src/renderer/lib/workflow-board.ts
+++ b/apps/desktop/src/renderer/lib/workflow-board.ts
@@ -1,19 +1,12 @@
-import type {
-  WorkflowBoardColumn,
-  WorkflowBoardSliceCard,
-  WorkflowBoardSnapshot,
-  WorkflowColumnId,
+import {
+  WORKFLOW_COLUMNS,
+  type WorkflowBoardColumn,
+  type WorkflowBoardSliceCard,
+  type WorkflowBoardSnapshot,
+  type WorkflowColumnId,
 } from '@shared/types'
 
-export const WORKFLOW_COLUMN_ORDER: WorkflowColumnId[] = [
-  'backlog',
-  'todo',
-  'in_progress',
-  'agent_review',
-  'human_review',
-  'merging',
-  'done',
-]
+export const WORKFLOW_COLUMN_ORDER: WorkflowColumnId[] = WORKFLOW_COLUMNS.map((column) => column.id)
 
 export function normalizeWorkflowColumns(snapshot: WorkflowBoardSnapshot): WorkflowBoardColumn[] {
   const sourceById = new Map(snapshot.columns.map((column) => [column.id, column]))
@@ -26,7 +19,7 @@ export function normalizeWorkflowColumns(snapshot: WorkflowBoardSnapshot): Workf
 
     return {
       id: columnId,
-      title: toColumnTitle(columnId),
+      title: WORKFLOW_COLUMNS.find((column) => column.id === columnId)?.title ?? toColumnTitle(columnId),
       cards: [],
     }
   })

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -519,6 +519,16 @@ export type WorkflowColumnId =
   | 'merging'
   | 'done'
 
+export const WORKFLOW_COLUMNS: ReadonlyArray<{ id: WorkflowColumnId; title: string }> = [
+  { id: 'backlog', title: 'Backlog' },
+  { id: 'todo', title: 'Todo' },
+  { id: 'in_progress', title: 'In Progress' },
+  { id: 'agent_review', title: 'Agent Review' },
+  { id: 'human_review', title: 'Human Review' },
+  { id: 'merging', title: 'Merging' },
+  { id: 'done', title: 'Done' },
+]
+
 export type WorkflowBoardBackend = 'linear' | 'github'
 
 export type WorkflowBoardStatus = 'fresh' | 'stale' | 'empty' | 'error'
@@ -595,6 +605,10 @@ export interface WorkflowBoardSnapshot {
   poll: WorkflowBoardPollMetadata
 }
 
+/**
+ * Workflow responses always include a snapshot, even on failed fetches.
+ * Callers should check `success` and inspect `snapshot.lastError` for failure details.
+ */
 export interface WorkflowBoardSnapshotResponse {
   success: boolean
   snapshot: WorkflowBoardSnapshot

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -27,6 +27,8 @@ export const IPC_CHANNELS = {
   planningArtifactFetchState: 'planning:artifact-fetch-state',
   planningFetchArtifact: 'planning:fetch-artifact',
   planningListArtifacts: 'planning:list-artifacts',
+  workflowGetBoard: 'workflow:get-board',
+  workflowRefreshBoard: 'workflow:refresh-board',
 } as const
 
 export type PermissionMode = 'explore' | 'ask' | 'auto'
@@ -508,6 +510,96 @@ export interface PlanningArtifactListResponse {
   error?: PlanningArtifactError
 }
 
+export type WorkflowColumnId =
+  | 'backlog'
+  | 'todo'
+  | 'in_progress'
+  | 'agent_review'
+  | 'human_review'
+  | 'merging'
+  | 'done'
+
+export type WorkflowBoardBackend = 'linear' | 'github'
+
+export type WorkflowBoardStatus = 'fresh' | 'stale' | 'empty' | 'error'
+
+export type WorkflowBoardErrorCode =
+  | 'NOT_CONFIGURED'
+  | 'MISSING_API_KEY'
+  | 'UNAUTHORIZED'
+  | 'NOT_FOUND'
+  | 'RATE_LIMITED'
+  | 'NETWORK'
+  | 'GRAPHQL'
+  | 'UNKNOWN'
+
+export interface WorkflowBoardError {
+  code: WorkflowBoardErrorCode
+  message: string
+}
+
+export interface WorkflowBoardTask {
+  id: string
+  identifier?: string
+  title: string
+  columnId: WorkflowColumnId
+  stateName: string
+  stateType: string
+}
+
+export interface WorkflowBoardSliceCard {
+  id: string
+  identifier: string
+  title: string
+  columnId: WorkflowColumnId
+  stateName: string
+  stateType: string
+  milestoneId: string
+  milestoneName: string
+  taskCounts: {
+    total: number
+    done: number
+  }
+  tasks: WorkflowBoardTask[]
+}
+
+export interface WorkflowBoardColumn {
+  id: WorkflowColumnId
+  title: string
+  cards: WorkflowBoardSliceCard[]
+}
+
+export interface WorkflowBoardPollMetadata {
+  status: 'idle' | 'success' | 'error'
+  backend: WorkflowBoardBackend
+  lastAttemptAt: string
+}
+
+export interface WorkflowBoardSnapshot {
+  backend: WorkflowBoardBackend
+  fetchedAt: string
+  status: WorkflowBoardStatus
+  source: {
+    projectId: string
+    activeMilestoneId?: string
+  }
+  activeMilestone:
+    | {
+        id: string
+        name: string
+      }
+    | null
+  columns: WorkflowBoardColumn[]
+  emptyReason?: string
+  lastError?: WorkflowBoardError
+  poll: WorkflowBoardPollMetadata
+}
+
+export interface WorkflowBoardSnapshotResponse {
+  success: boolean
+  snapshot: WorkflowBoardSnapshot
+}
+
 export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context' | 'slice'
 
 export type RoadmapRisk = 'high' | 'medium' | 'low'
@@ -614,6 +706,10 @@ export interface DesktopApi {
     onArtifactFetchState: (listener: (event: PlanningArtifactFetchStateEvent) => void) => () => void
     fetchArtifact: (title: string, artifactKey?: string) => Promise<PlanningArtifactFetchResponse>
     listArtifacts: () => Promise<PlanningArtifactListResponse>
+  }
+  workflow: {
+    getBoard: () => Promise<WorkflowBoardSnapshotResponse>
+    refreshBoard: () => Promise<WorkflowBoardSnapshotResponse>
   }
 }
 


### PR DESCRIPTION
## Summary
- implement canonical `WorkflowBoardSnapshot` contract and Linear normalization for active milestone slices/tasks
- wire workflow board service through Electron main-process IPC + preload `window.api.workflow` API
- render live kanban board in right pane with canonical columns, expandable task rows, and truthful loading/empty/stale states
- add Playwright workflow-kanban e2e coverage and document manual live-Linear smoke path
- raise workflow board client/service coverage

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/linear-workflow-client.test.ts src/main/__tests__/workflow-board-service.test.ts src/renderer/lib/__tests__/workflow-board.test.ts`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/workflow-kanban.e2e.ts e2e/tests/app-shell.e2e.ts`

Closes KAT-2247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Workflow Kanban board with canonical columns and per-slice cards; cards can expand to show child tasks.
  * Right pane now shows the Kanban view and includes status/refresh controls; board auto-refreshes every 30s and supports manual refresh.
  * Desktop app exposes workflow API methods for getting/refreshing board data and integrates with Linear for live data.

* **Tests**
  * Added unit and end-to-end tests covering client, service, renderer helpers, and UI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a live Linear workflow kanban board in the Electron right pane — wiring a new `LinearWorkflowClient` → `WorkflowBoardService` → IPC → preload → Jotai atoms → React component chain for the `WorkflowBoardSnapshot` contract. The implementation is solid: structured error codes, stale-snapshot fallback, a KATA_TEST_MODE fixture seam for Playwright, and thorough unit + e2e coverage. All remaining findings are P2 style suggestions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues; all findings are minor style suggestions.

The feature is well-tested (unit, service, e2e), error paths are fully handled with stale-snapshot fallback, IPC registration follows the existing pattern, and TypeScript types are complete end-to-end. The three inline comments are all P2 quality-of-life suggestions that do not affect correctness.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/linear-workflow-client.ts | New file: GraphQL client for Linear API with milestone normalization, timeout handling, structured error codes, and state-to-column mapping. |
| apps/desktop/src/main/workflow-board-service.ts | New file: orchestration service with snapshot caching, test fixture injection, preferences parsing, and stale-snapshot fallback; non-ENOENT file errors silently resolve to NOT_CONFIGURED (P2). |
| apps/desktop/src/renderer/atoms/workflow-board.ts | New file: Jotai atoms for board state with 30-second polling bridge; manual refresh and auto-poll can trigger simultaneous IPC calls (P2). |
| apps/desktop/src/renderer/components/kanban/SliceCard.tsx | New file: slice card with collapsible task list; trigger label and chevron never update to reflect expanded state (P2). |
| apps/desktop/src/shared/types.ts | Adds WorkflowBoardSnapshot contract and IPC channel constants; WorkflowBoardSnapshotResponse added to DesktopApi correctly. |
| apps/desktop/src/main/ipc.ts | Wires WorkflowBoardService into IPC with workflowGetBoard/workflowRefreshBoard handlers; follows existing pre-registration removeHandler pattern correctly. |
| apps/desktop/src/renderer/components/kanban/KanbanPane.tsx | New file: kanban board pane with loading/empty/stale/error states, column rendering, and manual refresh button. |
| apps/desktop/src/renderer/lib/workflow-board.ts | New file: pure utilities for column normalization and title generation; correct and side-effect free. |
| apps/desktop/e2e/tests/workflow-kanban.e2e.ts | New Playwright e2e covering column rendering and task expansion against the deterministic test fixture; second test is a documented manual smoke-path placeholder. |
| apps/desktop/src/main/__tests__/linear-workflow-client.test.ts | New test: comprehensive coverage of state mapping, error codes, milestone normalization, and network/auth failure paths. |
| apps/desktop/src/main/__tests__/workflow-board-service.test.ts | New test: fixture mode, cache reuse, stale-on-failure, missing preferences, and malformed path scenarios all covered. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer (React)
    participant A as Jotai Atoms
    participant P as Preload
    participant I as IPC Main
    participant S as WorkflowBoardService
    participant C as LinearWorkflowClient
    participant L as Linear GraphQL API

    R->>A: useWorkflowBoardBridge() mount
    A->>P: workflow.getBoard()
    P->>I: IPC workflowGetBoard
    I->>S: getBoard()
    alt no cached snapshot
        S->>C: fetchActiveMilestoneSnapshot()
        C->>L: resolveProjectId (GraphQL)
        L-->>C: projectId
        C->>L: WorkflowIssuesByProject (GraphQL)
        L-->>C: issues[]
        C->>C: chooseActiveMilestone() + normalizeLinearBoard()
        C-->>S: WorkflowBoardSnapshot
        S->>S: cache lastSnapshot
    else cached snapshot
        S-->>I: lastSnapshot
    end
    S-->>I: WorkflowBoardSnapshotResponse
    I-->>P: response
    P-->>A: response
    A->>R: update atoms (board, loading, error)

    Note over A,R: Every 30s auto-poll via setInterval
    A->>P: workflow.refreshBoard()
    P->>I: IPC workflowRefreshBoard
    I->>S: refreshBoard()
    S->>C: fetchActiveMilestoneSnapshot()
    C->>L: GraphQL queries
    L-->>C: updated snapshot
    S-->>A: updated board
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/kanban/SliceCard.tsx
Line: 29-37

Comment:
**Collapsible trigger has no open/closed visual indicator**

The trigger text is always "Show tasks" and the `ChevronDown` icon never rotates, so users have no visual feedback indicating whether tasks are already expanded. The Radix `Collapsible` manages its own open state internally, but nothing in the trigger reflects that state. A `useState` open tracker on the `Collapsible` component itself (`open` / `onOpenChange`) would give the same effect.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/workflow-board-service.ts
Line: 246-263

Comment:
**Non-ENOENT read errors silently collapse to NOT_CONFIGURED**

Any `fs.readFile` failure that is not `ENOENT` (e.g., `EACCES`, `EISDIR`) falls through to `return null`, which causes the service to emit a `NOT_CONFIGURED` snapshot with the message "Linear project is not configured in .kata/preferences.md". On a system where the file exists but is unreadable (CI, restrictive container mounts, etc.) this misleads the operator into believing configuration is missing when the real problem is a permission/I/O error.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/workflow-board.ts
Line: 21-34

Comment:
**Manual refresh and auto-poll can fire Linear API calls concurrently**

`refreshWorkflowBoardAtom` (triggered by the Refresh button in `KanbanPane`) calls `window.api.workflow.refreshBoard()` while `useWorkflowBoardBridge`'s 30-second interval also calls `window.api.workflow.refreshBoard()`. Both land on `WorkflowBoardService.refreshBoard()` simultaneously with no in-flight guard, firing two `linearClient.fetchActiveMilestoneSnapshot()` calls back-to-back. Adding an in-flight promise cache or a simple `isRefreshing` flag on the service would prevent the duplicate request.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): raise coverage for workfl..."](https://github.com/gannonh/kata/commit/8cf79fb4480bdb67c08c069f7911e7c552caaddf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27332098)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->