### PR TITLE
feat(desktop): workflow context switching and failure visibility (KAT-2250)

### DIFF
--- a/apps/desktop/e2e/tests/workflow-context-switching.e2e.ts
+++ b/apps/desktop/e2e/tests/workflow-context-switching.e2e.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '../fixtures/electron.fixture'
+
+test.describe('Workflow context switching and failure visibility', () => {
+  test('auto-enters kanban in execution context and supports manual override', async ({ readyWindow }) => {
+    await expect(readyWindow.getByTestId('workflow-kanban-pane')).toBeVisible()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Context: execution')
+
+    await readyWindow.getByRole('button', { name: /Open planning view/i }).click()
+    await expect(readyWindow.getByText('Planning View')).toBeVisible()
+
+    await readyWindow.reload()
+    await expect(readyWindow.getByText('Planning View')).toBeVisible()
+
+    await readyWindow.getByRole('button', { name: /Close planning view/i }).click()
+    await expect(readyWindow.getByTestId('workflow-kanban-pane')).toBeVisible()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Manual override: kanban')
+
+    await readyWindow.getByRole('button', { name: /Return to auto mode/i }).click()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Auto mode:')
+  })
+
+  test('renders deterministic missing-config, auth-failure, empty, stale, and recovery states', async ({ readyWindow }) => {
+    const refreshButton = readyWindow.getByRole('button', { name: /Refresh workflow board/i })
+
+    const setScenario = async (scenario: string) => {
+      await readyWindow.evaluate(async (nextScenario) => {
+        await window.api.workflow.setScope(`scenario:${nextScenario}`)
+      }, scenario)
+      await refreshButton.click()
+    }
+
+    await setScenario('missing-config')
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Workflow board unavailable')
+    await expect(readyWindow.getByText(/not configured/i)).toBeVisible()
+
+    await setScenario('auth-failure')
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Workflow board unavailable')
+    await expect(readyWindow.getByText(/Invalid Linear API key/i)).toBeVisible()
+
+    await setScenario('empty')
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('No slices found in the active milestone')
+
+    await setScenario('stale')
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Showing stale board snapshot')
+
+    await setScenario('recovery')
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Live data · linear')
+  })
+})

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -376,4 +376,49 @@ describe('WorkflowBoardService', () => {
     const finalBoard = await service.getBoard()
     expect(finalBoard.snapshot.source.projectId).toBe('project-ref-second')
   })
+
+  test('refreshContext reports unknown mode when preferences lookup throws in non-test mode', async () => {
+    const workspacePath = path.join(tmpdir(), `workflow-board-refresh-context-error-${randomUUID()}`)
+    writeFileSync(workspacePath, 'not-a-directory', 'utf8')
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const context = await service.refreshContext()
+    expect(context.mode).toBe('unknown')
+    expect(context.trackerConfigured).toBe(false)
+  })
+
+  test('ignores invalid scenario markers in test mode and falls back to normal refresh path', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    service.setActive(true)
+    service.setScope('workspace:a::session:b::scenario:not-real')
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.status).toBe('fresh')
+    expect(response.snapshot.lastError).toBeUndefined()
+  })
+
+  test('supports scope keys without scenario markers while in test mode', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    service.setActive(true)
+    service.setScope('workspace:a::session:b')
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.status).toBe('fresh')
+  })
 })

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -347,9 +347,15 @@ describe('WorkflowBoardService', () => {
 
     service.setScope('workspace:a::session:first')
     const firstRefresh = service.refreshBoard()
+    await vi.waitFor(() => {
+      expect((service as any).linearClient.fetchActiveMilestoneSnapshot).toHaveBeenCalledTimes(1)
+    })
 
     service.setScope('workspace:a::session:second')
     const secondRefresh = service.refreshBoard()
+    await vi.waitFor(() => {
+      expect((service as any).linearClient.fetchActiveMilestoneSnapshot).toHaveBeenCalledTimes(2)
+    })
 
     resolveSecond({
       backend: 'linear',

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -272,4 +272,108 @@ describe('WorkflowBoardService', () => {
     expect((service as any).linearClient.fetchActiveMilestoneSnapshot).toHaveBeenCalledTimes(1)
     expect(first.snapshot).toEqual(second.snapshot)
   })
+
+  test('returns inactive snapshot when deactivated during an in-flight refresh', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-inactive-mid-refresh-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectSlug: project-ref', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    let resolveFetch!: (value: any) => void
+    const deferredFetch = new Promise<any>((resolve) => {
+      resolveFetch = resolve
+    })
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(() => deferredFetch)
+
+    service.setActive(true)
+    const refreshPromise = service.refreshBoard()
+
+    service.setActive(false)
+
+    resolveFetch({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'fresh',
+      source: { projectId: 'project-ref', activeMilestoneId: 'm1' },
+      activeMilestone: { id: 'm1', name: '[M001] Demo' },
+      columns: [],
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    })
+
+    const response = await refreshPromise
+    expect(response.snapshot.status).toBe('error')
+    expect(response.snapshot.lastError?.message).toContain('Workflow board inactive')
+  })
+
+  test('does not let stale in-flight refresh overwrite a newer scope snapshot', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-scope-race-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectSlug: project-ref', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    let resolveFirst!: (value: any) => void
+    let resolveSecond!: (value: any) => void
+
+    const firstFetch = new Promise<any>((resolve) => {
+      resolveFirst = resolve
+    })
+    const secondFetch = new Promise<any>((resolve) => {
+      resolveSecond = resolve
+    })
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi
+      .fn()
+      .mockImplementationOnce(() => firstFetch)
+      .mockImplementationOnce(() => secondFetch)
+
+    service.setActive(true)
+
+    service.setScope('workspace:a::session:first')
+    const firstRefresh = service.refreshBoard()
+
+    service.setScope('workspace:a::session:second')
+    const secondRefresh = service.refreshBoard()
+
+    resolveSecond({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:02.000Z',
+      status: 'fresh',
+      source: { projectId: 'project-ref-second', activeMilestoneId: 'm2' },
+      activeMilestone: { id: 'm2', name: '[M002] Second' },
+      columns: [],
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:02.000Z' },
+    })
+
+    resolveFirst({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:01.000Z',
+      status: 'fresh',
+      source: { projectId: 'project-ref-first', activeMilestoneId: 'm1' },
+      activeMilestone: { id: 'm1', name: '[M001] First' },
+      columns: [],
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:01.000Z' },
+    })
+
+    await Promise.all([firstRefresh, secondRefresh])
+
+    const finalBoard = await service.getBoard()
+    expect(finalBoard.snapshot.source.projectId).toBe('project-ref-second')
+  })
 })

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -41,6 +41,7 @@ describe('WorkflowBoardService', () => {
       getWorkspacePath: () => workspacePath,
     })
 
+    service.setActive(true)
     const response = await service.refreshBoard()
     expect(response.snapshot.status).toBe('error')
     expect(response.snapshot.lastError?.code).toBe('NOT_CONFIGURED')
@@ -75,6 +76,7 @@ describe('WorkflowBoardService', () => {
       getWorkspacePath: () => workspacePath,
     })
 
+    service.setActive(true)
     const client = (service as any).linearClient
     client.fetchActiveMilestoneSnapshot = vi
       .fn()
@@ -113,6 +115,7 @@ describe('WorkflowBoardService', () => {
       getWorkspacePath: () => workspacePath,
     })
 
+    service.setActive(true)
     ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(async () => ({
       backend: 'linear',
       fetchedAt: '2026-04-04T00:00:00.000Z',
@@ -137,6 +140,7 @@ describe('WorkflowBoardService', () => {
       getWorkspacePath: () => workspacePath,
     })
 
+    service.setActive(true)
     const response = await service.refreshBoard()
     expect(response.snapshot.status).toBe('error')
     expect(response.snapshot.lastError?.code).toBe('UNKNOWN')
@@ -174,6 +178,7 @@ describe('WorkflowBoardService', () => {
 
     ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(() => deferredFetch)
 
+    service.setActive(true)
     const firstPromise = service.refreshBoard()
     const secondPromise = service.refreshBoard()
 

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { WorkflowBoardService } from '../workflow-board-service'
 
 const originalFixtureFlag = process.env.KATA_TEST_WORKFLOW_FIXTURE
+const originalTestModeFlag = process.env.KATA_TEST_MODE
 
 describe('WorkflowBoardService', () => {
   beforeEach(() => {
@@ -17,6 +18,12 @@ describe('WorkflowBoardService', () => {
       process.env.KATA_TEST_WORKFLOW_FIXTURE = originalFixtureFlag
     } else {
       delete process.env.KATA_TEST_WORKFLOW_FIXTURE
+    }
+
+    if (originalTestModeFlag !== undefined) {
+      process.env.KATA_TEST_MODE = originalTestModeFlag
+    } else {
+      delete process.env.KATA_TEST_MODE
     }
   })
 
@@ -145,6 +152,83 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.status).toBe('error')
     expect(response.snapshot.lastError?.code).toBe('UNKNOWN')
     expect(response.snapshot.lastError?.message).toContain('Unable to read .kata/preferences.md')
+  })
+
+  test('returns inactive error snapshot when board is not active', async () => {
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.status).toBe('error')
+    expect(response.snapshot.lastError?.message).toContain('Workflow board inactive')
+  })
+
+  test('supports deterministic test scenarios via scope key in test mode', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    service.setActive(true)
+
+    service.setScope('workspace:a::session:b::scenario:missing-config')
+    expect((await service.refreshBoard()).snapshot.lastError?.code).toBe('NOT_CONFIGURED')
+
+    service.setScope('workspace:a::session:b::scenario:auth-failure')
+    expect((await service.refreshBoard()).snapshot.lastError?.code).toBe('UNAUTHORIZED')
+
+    service.setScope('workspace:a::session:b::scenario:empty')
+    expect((await service.refreshBoard()).snapshot.status).toBe('empty')
+
+    service.setScope('workspace:a::session:b::scenario:stale')
+    expect((await service.refreshBoard()).snapshot.status).toBe('stale')
+
+    service.setScope('workspace:a::session:b::scenario:recovery')
+    expect((await service.refreshBoard()).snapshot.status).toBe('fresh')
+
+    delete process.env.KATA_TEST_MODE
+  })
+
+  test('refreshContext reflects planning signals and tracker availability', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    service.setPlanningActive(true)
+    const planningContext = await service.refreshContext()
+    expect(planningContext.mode).toBe('planning')
+
+    service.setPlanningActive(false)
+    const executionContext = await service.refreshContext()
+    expect(executionContext.mode).toBe('execution')
+
+    delete process.env.KATA_TEST_MODE
+  })
+
+  test('setScope resets cached board snapshots on scope changes', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    service.setActive(true)
+    service.setScope('workspace:a::session:b::scenario:recovery')
+    const first = await service.getBoard()
+
+    service.setScope('workspace:a::session:c::scenario:empty')
+    const second = await service.getBoard()
+
+    expect(first.snapshot.status).toBe('fresh')
+    expect(second.snapshot.status).toBe('empty')
   })
 
   test('deduplicates concurrent refresh requests to a single Linear fetch', async () => {

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -397,6 +397,43 @@ describe('WorkflowBoardService', () => {
     expect(context.trackerConfigured).toBe(false)
   })
 
+  test('refreshContext marks tracker configured when preferences define a project reference', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-refresh-context-configured-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectSlug: demo-project', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const context = await service.refreshContext()
+    expect(context.trackerConfigured).toBe(true)
+  })
+
+  test('treats frontmatter without project reference as not configured', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-no-project-ref-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'foo: bar', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    service.setActive(true)
+    const response = await service.refreshBoard()
+    expect(response.snapshot.lastError?.code).toBe('NOT_CONFIGURED')
+  })
+
   test('ignores invalid scenario markers in test mode and falls back to normal refresh path', async () => {
     process.env.KATA_TEST_MODE = '1'
 

--- a/apps/desktop/src/main/__tests__/workflow-context-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-context-service.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest'
+import {
+  WorkflowContextService,
+  buildWorkflowContextSnapshot,
+} from '../workflow-context-service'
+import type { WorkflowBoardSnapshot } from '../../shared/types'
+
+const freshBoard: WorkflowBoardSnapshot = {
+  backend: 'linear',
+  fetchedAt: '2026-04-04T00:00:00.000Z',
+  status: 'fresh',
+  source: { projectId: 'p1' },
+  activeMilestone: null,
+  columns: [],
+  poll: {
+    status: 'success',
+    backend: 'linear',
+    lastAttemptAt: '2026-04-04T00:00:00.000Z',
+  },
+}
+
+describe('workflow-context-service', () => {
+  test('prefers planning context when planning activity is active', () => {
+    const snapshot = buildWorkflowContextSnapshot({
+      planningActive: true,
+      trackerConfigured: true,
+      boardSnapshot: freshBoard,
+    })
+
+    expect(snapshot.mode).toBe('planning')
+    expect(snapshot.reason).toBe('planning_activity_detected')
+  })
+
+  test('resolves execution context when tracker is configured and board is pending', () => {
+    const snapshot = buildWorkflowContextSnapshot({
+      planningActive: false,
+      trackerConfigured: true,
+      boardSnapshot: null,
+    })
+
+    expect(snapshot.mode).toBe('execution')
+    expect(snapshot.reason).toBe('tracker_configured_board_pending')
+  })
+
+  test('resolves unknown when neither planning nor execution signals exist', () => {
+    const snapshot = buildWorkflowContextSnapshot({
+      planningActive: false,
+      trackerConfigured: false,
+      boardSnapshot: null,
+    })
+
+    expect(snapshot.mode).toBe('unknown')
+    expect(snapshot.reason).toBe('unknown_context')
+  })
+
+  test('tracks transitions with previous and next snapshots', () => {
+    const service = new WorkflowContextService()
+
+    const first = service.resolve({
+      planningActive: false,
+      trackerConfigured: true,
+      boardSnapshot: null,
+    })
+
+    const second = service.resolve({
+      planningActive: true,
+      trackerConfigured: true,
+      boardSnapshot: freshBoard,
+    })
+
+    expect(first.previous).toBeNull()
+    expect(first.next.mode).toBe('execution')
+    expect(second.previous?.mode).toBe('execution')
+    expect(second.next.mode).toBe('planning')
+  })
+})

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -718,8 +718,6 @@ export function registerSessionIpc({
   ipcMain.handle(
     IPC_CHANNELS.sessionSwitch,
     async (_event, sessionId: string): Promise<SessionSwitchResponse> => {
-      workflowBoardService.setPlanningActive(false)
-
       const trimmedSessionId = sessionId?.trim()
       if (!trimmedSessionId) {
         return {
@@ -749,6 +747,8 @@ export function registerSessionIpc({
             error: `Session switch to ${trimmedSessionId} was cancelled`,
           }
         }
+
+        workflowBoardService.setPlanningActive(false)
 
         log.info('[desktop-ipc] session switched', {
           sessionId: trimmedSessionId,
@@ -848,8 +848,6 @@ export function registerSessionIpc({
   })
 
   ipcMain.handle(IPC_CHANNELS.workspaceSet, async (_event, workspacePath: string): Promise<WorkspaceInfo> => {
-    workflowBoardService.setPlanningActive(false)
-
     const trimmedWorkspacePath = workspacePath?.trim()
     if (!trimmedWorkspacePath) {
       throw new Error('Workspace path is required')
@@ -864,6 +862,7 @@ export function registerSessionIpc({
     const previousWorkspacePath = bridge.getWorkspacePath()
 
     await bridge.switchWorkspace(nextWorkspacePath)
+    workflowBoardService.setPlanningActive(false)
 
     if (onWorkspaceSelected) {
       try {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -41,6 +41,9 @@ import {
   type WorkspaceInfo,
   type ArtifactType,
   type WorkflowBoardSnapshotResponse,
+  type WorkflowBoardLifecycleResponse,
+  type WorkflowBoardScopeResponse,
+  type WorkflowContextResponse,
 } from '../shared/types'
 
 interface RegisterIpcOptions {
@@ -252,6 +255,7 @@ export function registerSessionIpc({
   }
 
   const onPlanningArtifactEvent = (planningEvent: PlanningArtifactEvent): void => {
+    workflowBoardService.setPlanningActive(true)
     planningMetadataByKey.set(planningEvent.artifactKey, planningEvent)
     planningLatestKeyByTitle.set(planningEvent.title, planningEvent.artifactKey)
 
@@ -491,6 +495,9 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.planningListArtifacts)
   ipcMain.removeHandler(IPC_CHANNELS.workflowGetBoard)
   ipcMain.removeHandler(IPC_CHANNELS.workflowRefreshBoard)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -711,6 +718,8 @@ export function registerSessionIpc({
   ipcMain.handle(
     IPC_CHANNELS.sessionSwitch,
     async (_event, sessionId: string): Promise<SessionSwitchResponse> => {
+      workflowBoardService.setPlanningActive(false)
+
       const trimmedSessionId = sessionId?.trim()
       if (!trimmedSessionId) {
         return {
@@ -839,6 +848,8 @@ export function registerSessionIpc({
   })
 
   ipcMain.handle(IPC_CHANNELS.workspaceSet, async (_event, workspacePath: string): Promise<WorkspaceInfo> => {
+    workflowBoardService.setPlanningActive(false)
+
     const trimmedWorkspacePath = workspacePath?.trim()
     if (!trimmedWorkspacePath) {
       throw new Error('Workspace path is required')
@@ -1077,6 +1088,27 @@ export function registerSessionIpc({
     return workflowBoardService.refreshBoard()
   })
 
+  ipcMain.handle(
+    IPC_CHANNELS.workflowSetBoardActive,
+    async (_event, active: boolean): Promise<WorkflowBoardLifecycleResponse> => {
+      return workflowBoardService.setActive(Boolean(active))
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.workflowSetScope,
+    async (_event, scopeKey: string): Promise<WorkflowBoardScopeResponse> => {
+      return workflowBoardService.setScope(scopeKey)
+    },
+  )
+
+  ipcMain.handle(IPC_CHANNELS.workflowGetContext, async (): Promise<WorkflowContextResponse> => {
+    return {
+      success: true,
+      context: await workflowBoardService.refreshContext(),
+    }
+  })
+
   return () => {
     bridge.off('rpc-event', onRpcEvent)
     bridge.off('extension-ui-request', onExtensionUiRequest)
@@ -1110,6 +1142,9 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.planningListArtifacts)
     ipcMain.removeHandler(IPC_CHANNELS.workflowGetBoard)
     ipcMain.removeHandler(IPC_CHANNELS.workflowRefreshBoard)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
   }
 }
 

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -97,7 +97,7 @@ export class WorkflowBoardService {
 
   setActive(active: boolean): { success: true; active: boolean } {
     this.active = active
-    this.emitContext()
+    this.syncContextSnapshot()
     return { success: true, active: this.active }
   }
 
@@ -112,13 +112,13 @@ export class WorkflowBoardService {
       this.lastSuccessSnapshot = null
     }
 
-    this.emitContext()
+    this.syncContextSnapshot()
     return { success: true, scopeKey: this.scopeKey }
   }
 
   setPlanningActive(active: boolean): void {
     this.planningActive = active
-    this.emitContext()
+    this.syncContextSnapshot()
   }
 
   getContext(): WorkflowContextSnapshot {
@@ -139,7 +139,7 @@ export class WorkflowBoardService {
 
   async getBoard(): Promise<WorkflowBoardSnapshotResponse> {
     if (this.lastSnapshot) {
-      this.emitContext()
+      this.syncContextSnapshot()
       return { success: true, snapshot: this.lastSnapshot }
     }
 
@@ -168,7 +168,7 @@ export class WorkflowBoardService {
         this.lastSuccessSnapshot = scenarioSnapshot
       }
       this.trackerConfigured = scenarioSnapshot.lastError?.code !== 'NOT_CONFIGURED'
-      this.emitContext()
+      this.syncContextSnapshot()
       return { success: true, snapshot: scenarioSnapshot }
     }
 
@@ -177,12 +177,12 @@ export class WorkflowBoardService {
       this.lastSnapshot = fixture
       this.lastSuccessSnapshot = fixture
       this.trackerConfigured = true
-      this.emitContext()
+      this.syncContextSnapshot()
       return { success: true, snapshot: fixture }
     }
 
     if (!this.active && this.lastSnapshot) {
-      this.emitContext()
+      this.syncContextSnapshot()
       return { success: true, snapshot: this.lastSnapshot }
     }
 
@@ -194,7 +194,7 @@ export class WorkflowBoardService {
         message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
       })
       this.lastSnapshot = inactive
-      this.emitContext()
+      this.syncContextSnapshot()
       return { success: true, snapshot: inactive }
     }
 
@@ -216,7 +216,7 @@ export class WorkflowBoardService {
       })
 
       this.lastSnapshot = snapshot
-      this.emitContext()
+      this.syncContextSnapshot()
       return { success: true, snapshot }
     }
 
@@ -228,7 +228,7 @@ export class WorkflowBoardService {
         message: 'Linear project is not configured in .kata/preferences.md (projectId or projectSlug).',
       })
       this.lastSnapshot = snapshot
-      this.emitContext()
+      this.syncContextSnapshot()
       return { success: true, snapshot }
     }
 
@@ -236,7 +236,7 @@ export class WorkflowBoardService {
       const snapshot = await this.linearClient.fetchActiveMilestoneSnapshot({ projectRef })
       this.lastSnapshot = snapshot
       this.lastSuccessSnapshot = snapshot
-      this.emitContext()
+      this.syncContextSnapshot()
       return { success: true, snapshot }
     } catch (error) {
       const workflowError = LinearWorkflowClient.toWorkflowError(error)
@@ -268,12 +268,12 @@ export class WorkflowBoardService {
         error: workflowError,
       })
 
-      this.emitContext()
+      this.syncContextSnapshot()
       return { success: true, snapshot: staleSnapshot }
     }
   }
 
-  private emitContext(): void {
+  private syncContextSnapshot(): void {
     this.contextService.resolve({
       planningActive: this.planningActive,
       trackerConfigured: this.trackerConfigured,

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -3,9 +3,11 @@ import path from 'node:path'
 import { AuthBridge } from './auth-bridge'
 import { LinearWorkflowClient } from './linear-workflow-client'
 import log from './logger'
-import {
-  type WorkflowBoardSnapshot,
-  type WorkflowBoardSnapshotResponse,
+import { WorkflowContextService } from './workflow-context-service'
+import type {
+  WorkflowBoardSnapshot,
+  WorkflowBoardSnapshotResponse,
+  WorkflowContextSnapshot,
 } from '../shared/types'
 
 const TEST_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
@@ -21,11 +23,7 @@ const TEST_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
     name: '[M003] Workflow Kanban',
   },
   columns: [
-    {
-      id: 'backlog',
-      title: 'Backlog',
-      cards: [],
-    },
+    { id: 'backlog', title: 'Backlog', cards: [] },
     {
       id: 'todo',
       title: 'Todo',
@@ -61,31 +59,11 @@ const TEST_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
         },
       ],
     },
-    {
-      id: 'in_progress',
-      title: 'In Progress',
-      cards: [],
-    },
-    {
-      id: 'agent_review',
-      title: 'Agent Review',
-      cards: [],
-    },
-    {
-      id: 'human_review',
-      title: 'Human Review',
-      cards: [],
-    },
-    {
-      id: 'merging',
-      title: 'Merging',
-      cards: [],
-    },
-    {
-      id: 'done',
-      title: 'Done',
-      cards: [],
-    },
+    { id: 'in_progress', title: 'In Progress', cards: [] },
+    { id: 'agent_review', title: 'Agent Review', cards: [] },
+    { id: 'human_review', title: 'Human Review', cards: [] },
+    { id: 'merging', title: 'Merging', cards: [] },
+    { id: 'done', title: 'Done', cards: [] },
   ],
   poll: {
     status: 'success',
@@ -101,19 +79,68 @@ interface WorkflowBoardServiceOptions {
 
 export class WorkflowBoardService {
   private readonly linearClient: LinearWorkflowClient
+  private readonly contextService = new WorkflowContextService()
+
   private lastSnapshot: WorkflowBoardSnapshot | null = null
+  private lastSuccessSnapshot: WorkflowBoardSnapshot | null = null
   private inFlightRefresh: Promise<WorkflowBoardSnapshotResponse> | null = null
+
+  private active = false
+  private planningActive = false
+  private scopeKey = 'workspace:none::session:none'
+  private trackerConfigured = false
+  private testScenario: WorkflowTestScenario | null = null
 
   constructor(private readonly options: WorkflowBoardServiceOptions) {
     this.linearClient = new LinearWorkflowClient(options.authBridge)
   }
 
+  setActive(active: boolean): { success: true; active: boolean } {
+    this.active = active
+    this.emitContext()
+    return { success: true, active: this.active }
+  }
+
+  setScope(scopeKey: string): { success: true; scopeKey: string } {
+    const normalized = scopeKey.trim() || 'workspace:none::session:none'
+    const nextScenario = parseWorkflowTestScenario(normalized)
+
+    if (this.scopeKey !== normalized || this.testScenario !== nextScenario) {
+      this.scopeKey = normalized
+      this.testScenario = nextScenario
+      this.lastSnapshot = null
+      this.lastSuccessSnapshot = null
+    }
+
+    this.emitContext()
+    return { success: true, scopeKey: this.scopeKey }
+  }
+
+  setPlanningActive(active: boolean): void {
+    this.planningActive = active
+    this.emitContext()
+  }
+
+  getContext(): WorkflowContextSnapshot {
+    const existing = this.contextService.getSnapshot()
+    if (existing) {
+      return existing
+    }
+
+    return {
+      mode: 'unknown',
+      reason: 'unknown_context',
+      planningActive: this.planningActive,
+      trackerConfigured: this.trackerConfigured,
+      boardAvailable: Boolean(this.lastSnapshot),
+      updatedAt: new Date().toISOString(),
+    }
+  }
+
   async getBoard(): Promise<WorkflowBoardSnapshotResponse> {
     if (this.lastSnapshot) {
-      return {
-        success: true,
-        snapshot: this.lastSnapshot,
-      }
+      this.emitContext()
+      return { success: true, snapshot: this.lastSnapshot }
     }
 
     return this.refreshBoard()
@@ -134,22 +161,49 @@ export class WorkflowBoardService {
   }
 
   private async performRefreshBoard(): Promise<WorkflowBoardSnapshotResponse> {
-    const nowIso = new Date().toISOString()
+    if (this.testScenario) {
+      const scenarioSnapshot = this.buildScenarioSnapshot(this.testScenario)
+      this.lastSnapshot = scenarioSnapshot
+      if (scenarioSnapshot.status === 'fresh' || scenarioSnapshot.status === 'empty') {
+        this.lastSuccessSnapshot = scenarioSnapshot
+      }
+      this.trackerConfigured = scenarioSnapshot.lastError?.code !== 'NOT_CONFIGURED'
+      this.emitContext()
+      return { success: true, snapshot: scenarioSnapshot }
+    }
 
     if (isWorkflowFixtureEnabled()) {
       const fixture = withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
       this.lastSnapshot = fixture
-      return {
-        success: true,
-        snapshot: fixture,
-      }
+      this.lastSuccessSnapshot = fixture
+      this.trackerConfigured = true
+      this.emitContext()
+      return { success: true, snapshot: fixture }
     }
 
+    if (!this.active && this.lastSnapshot) {
+      this.emitContext()
+      return { success: true, snapshot: this.lastSnapshot }
+    }
+
+    if (!this.active) {
+      const inactive = this.toErrorSnapshot({
+        nowIso: new Date().toISOString(),
+        projectId: 'unknown',
+        code: 'UNKNOWN',
+        message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
+      })
+      this.lastSnapshot = inactive
+      this.emitContext()
+      return { success: true, snapshot: inactive }
+    }
+
+    const nowIso = new Date().toISOString()
     const workspacePath = this.options.getWorkspacePath()
 
     let projectRef: string | null
     try {
-      projectRef = await readLinearProjectReference(workspacePath)
+      projectRef = await this.resolveProjectReference(workspacePath)
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Unable to read .kata/preferences.md due to an unknown error.'
@@ -162,11 +216,8 @@ export class WorkflowBoardService {
       })
 
       this.lastSnapshot = snapshot
-
-      return {
-        success: true,
-        snapshot,
-      }
+      this.emitContext()
+      return { success: true, snapshot }
     }
 
     if (!projectRef) {
@@ -177,28 +228,26 @@ export class WorkflowBoardService {
         message: 'Linear project is not configured in .kata/preferences.md (projectId or projectSlug).',
       })
       this.lastSnapshot = snapshot
-      return {
-        success: true,
-        snapshot,
-      }
+      this.emitContext()
+      return { success: true, snapshot }
     }
 
     try {
       const snapshot = await this.linearClient.fetchActiveMilestoneSnapshot({ projectRef })
       this.lastSnapshot = snapshot
-      return {
-        success: true,
-        snapshot,
-      }
+      this.lastSuccessSnapshot = snapshot
+      this.emitContext()
+      return { success: true, snapshot }
     } catch (error) {
       const workflowError = LinearWorkflowClient.toWorkflowError(error)
-      const staleSnapshot: WorkflowBoardSnapshot = this.lastSnapshot
+
+      const staleSnapshot: WorkflowBoardSnapshot = this.lastSuccessSnapshot
         ? {
-            ...this.lastSnapshot,
+            ...this.lastSuccessSnapshot,
             status: 'stale',
             lastError: workflowError,
             poll: {
-              ...this.lastSnapshot.poll,
+              ...this.lastSuccessSnapshot.poll,
               status: 'error',
               lastAttemptAt: nowIso,
             },
@@ -215,14 +264,98 @@ export class WorkflowBoardService {
       log.warn('[workflow-board-service] workflow refresh failed', {
         workspacePath,
         projectRef,
+        scopeKey: this.scopeKey,
         error: workflowError,
       })
 
+      this.emitContext()
+      return { success: true, snapshot: staleSnapshot }
+    }
+  }
+
+  private emitContext(): void {
+    this.contextService.resolve({
+      planningActive: this.planningActive,
+      trackerConfigured: this.trackerConfigured,
+      boardSnapshot: this.lastSnapshot,
+    })
+  }
+
+  private buildScenarioSnapshot(scenario: WorkflowTestScenario): WorkflowBoardSnapshot {
+    const nowIso = new Date().toISOString()
+
+    if (scenario === 'missing-config') {
+      return this.toErrorSnapshot({
+        nowIso,
+        projectId: 'unknown',
+        code: 'NOT_CONFIGURED',
+        message: 'Linear project is not configured in .kata/preferences.md (projectId or projectSlug).',
+      })
+    }
+
+    if (scenario === 'auth-failure') {
+      return this.toErrorSnapshot({
+        nowIso,
+        projectId: 'test-project',
+        code: 'UNAUTHORIZED',
+        message: 'Invalid Linear API key',
+      })
+    }
+
+    if (scenario === 'empty') {
+      const fixture = withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
       return {
-        success: true,
-        snapshot: staleSnapshot,
+        ...fixture,
+        status: 'empty',
+        columns: fixture.columns.map((column) => ({ ...column, cards: [] })),
+        activeMilestone: null,
+        emptyReason: 'No slices found in the active milestone.',
       }
     }
+
+    if (scenario === 'stale') {
+      const baseline = this.lastSuccessSnapshot ?? withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
+      return {
+        ...baseline,
+        status: 'stale',
+        lastError: {
+          code: 'NETWORK',
+          message: 'Network error while refreshing workflow board',
+        },
+        poll: {
+          ...baseline.poll,
+          status: 'error',
+          lastAttemptAt: nowIso,
+        },
+      }
+    }
+
+    return withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
+  }
+
+  async refreshContext(): Promise<WorkflowContextSnapshot> {
+    if (isWorkflowFixtureEnabled()) {
+      this.trackerConfigured = true
+    } else {
+      try {
+        const projectRef = await this.resolveProjectReference(this.options.getWorkspacePath())
+        this.trackerConfigured = Boolean(projectRef)
+      } catch {
+        this.trackerConfigured = false
+      }
+    }
+
+    return this.contextService.resolve({
+      planningActive: this.planningActive,
+      trackerConfigured: this.trackerConfigured,
+      boardSnapshot: this.lastSnapshot,
+    }).next
+  }
+
+  private async resolveProjectReference(workspacePath: string): Promise<string | null> {
+    const projectRef = await readLinearProjectReference(workspacePath)
+    this.trackerConfigured = Boolean(projectRef)
+    return projectRef
   }
 
   private toErrorSnapshot(input: {
@@ -235,9 +368,7 @@ export class WorkflowBoardService {
       backend: 'linear',
       fetchedAt: input.nowIso,
       status: 'error',
-      source: {
-        projectId: input.projectId,
-      },
+      source: { projectId: input.projectId },
       activeMilestone: null,
       columns: TEST_WORKFLOW_FIXTURE.columns.map((column) => ({
         id: column.id,
@@ -328,4 +459,36 @@ async function readLinearProjectReference(workspacePath: string): Promise<string
 
 function stripYamlWrapping(value: string): string {
   return value.replace(/^['"]/, '').replace(/['"]$/, '').trim()
+}
+
+type WorkflowTestScenario =
+  | 'missing-config'
+  | 'auth-failure'
+  | 'empty'
+  | 'stale'
+  | 'recovery'
+
+function parseWorkflowTestScenario(scopeKey: string): WorkflowTestScenario | null {
+  if (process.env.KATA_TEST_MODE !== '1') {
+    return null
+  }
+
+  const marker = 'scenario:'
+  const idx = scopeKey.indexOf(marker)
+  if (idx < 0) {
+    return null
+  }
+
+  const value = scopeKey.slice(idx + marker.length).trim().toLowerCase()
+  if (
+    value === 'missing-config' ||
+    value === 'auth-failure' ||
+    value === 'empty' ||
+    value === 'stale' ||
+    value === 'recovery'
+  ) {
+    return value
+  }
+
+  return null
 }

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -229,9 +229,9 @@ export class WorkflowBoardService {
         message,
       })
 
-      this.trackerConfigured = false
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = snapshot
+        this.trackerConfigured = false
         this.syncContextSnapshot()
       }
       return { success: true, snapshot }

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -84,6 +84,7 @@ export class WorkflowBoardService {
   private lastSnapshot: WorkflowBoardSnapshot | null = null
   private lastSuccessSnapshot: WorkflowBoardSnapshot | null = null
   private inFlightRefresh: Promise<WorkflowBoardSnapshotResponse> | null = null
+  private inFlightScopeKey: string | null = null
 
   private active = false
   private planningActive = false
@@ -147,37 +148,48 @@ export class WorkflowBoardService {
   }
 
   async refreshBoard(): Promise<WorkflowBoardSnapshotResponse> {
-    if (this.inFlightRefresh) {
+    const capturedScopeKey = this.scopeKey
+
+    if (this.inFlightRefresh && this.inFlightScopeKey === capturedScopeKey) {
       return this.inFlightRefresh
     }
 
-    this.inFlightRefresh = this.performRefreshBoard()
+    const refreshPromise = this.performRefreshBoard(capturedScopeKey)
+    this.inFlightRefresh = refreshPromise
+    this.inFlightScopeKey = capturedScopeKey
 
     try {
-      return await this.inFlightRefresh
+      return await refreshPromise
     } finally {
-      this.inFlightRefresh = null
+      if (this.inFlightRefresh === refreshPromise) {
+        this.inFlightRefresh = null
+        this.inFlightScopeKey = null
+      }
     }
   }
 
-  private async performRefreshBoard(): Promise<WorkflowBoardSnapshotResponse> {
+  private async performRefreshBoard(capturedScopeKey: string): Promise<WorkflowBoardSnapshotResponse> {
     if (this.testScenario) {
       const scenarioSnapshot = this.buildScenarioSnapshot(this.testScenario)
-      this.lastSnapshot = scenarioSnapshot
-      if (scenarioSnapshot.status === 'fresh' || scenarioSnapshot.status === 'empty') {
-        this.lastSuccessSnapshot = scenarioSnapshot
+      if (capturedScopeKey === this.scopeKey) {
+        this.lastSnapshot = scenarioSnapshot
+        if (scenarioSnapshot.status === 'fresh' || scenarioSnapshot.status === 'empty') {
+          this.lastSuccessSnapshot = scenarioSnapshot
+        }
+        this.trackerConfigured = scenarioSnapshot.lastError?.code !== 'NOT_CONFIGURED'
+        this.syncContextSnapshot()
       }
-      this.trackerConfigured = scenarioSnapshot.lastError?.code !== 'NOT_CONFIGURED'
-      this.syncContextSnapshot()
       return { success: true, snapshot: scenarioSnapshot }
     }
 
     if (isWorkflowFixtureEnabled()) {
       const fixture = withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
-      this.lastSnapshot = fixture
-      this.lastSuccessSnapshot = fixture
-      this.trackerConfigured = true
-      this.syncContextSnapshot()
+      if (capturedScopeKey === this.scopeKey) {
+        this.lastSnapshot = fixture
+        this.lastSuccessSnapshot = fixture
+        this.trackerConfigured = true
+        this.syncContextSnapshot()
+      }
       return { success: true, snapshot: fixture }
     }
 
@@ -193,8 +205,10 @@ export class WorkflowBoardService {
         code: 'UNKNOWN',
         message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
       })
-      this.lastSnapshot = inactive
-      this.syncContextSnapshot()
+      if (capturedScopeKey === this.scopeKey) {
+        this.lastSnapshot = inactive
+        this.syncContextSnapshot()
+      }
       return { success: true, snapshot: inactive }
     }
 
@@ -215,8 +229,11 @@ export class WorkflowBoardService {
         message,
       })
 
-      this.lastSnapshot = snapshot
-      this.syncContextSnapshot()
+      this.trackerConfigured = false
+      if (capturedScopeKey === this.scopeKey) {
+        this.lastSnapshot = snapshot
+        this.syncContextSnapshot()
+      }
       return { success: true, snapshot }
     }
 
@@ -227,18 +244,50 @@ export class WorkflowBoardService {
         code: 'NOT_CONFIGURED',
         message: 'Linear project is not configured in .kata/preferences.md (projectId or projectSlug).',
       })
-      this.lastSnapshot = snapshot
-      this.syncContextSnapshot()
+      if (capturedScopeKey === this.scopeKey) {
+        this.lastSnapshot = snapshot
+        this.syncContextSnapshot()
+      }
       return { success: true, snapshot }
     }
 
     try {
       const snapshot = await this.linearClient.fetchActiveMilestoneSnapshot({ projectRef })
-      this.lastSnapshot = snapshot
-      this.lastSuccessSnapshot = snapshot
-      this.syncContextSnapshot()
+      if (!this.active) {
+        const inactive = this.toErrorSnapshot({
+          nowIso,
+          projectId: projectRef,
+          code: 'UNKNOWN',
+          message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
+        })
+        if (capturedScopeKey === this.scopeKey) {
+          this.lastSnapshot = inactive
+          this.syncContextSnapshot()
+        }
+        return { success: true, snapshot: inactive }
+      }
+
+      if (capturedScopeKey === this.scopeKey) {
+        this.lastSnapshot = snapshot
+        this.lastSuccessSnapshot = snapshot
+        this.syncContextSnapshot()
+      }
       return { success: true, snapshot }
     } catch (error) {
+      if (!this.active) {
+        const inactive = this.toErrorSnapshot({
+          nowIso,
+          projectId: projectRef,
+          code: 'UNKNOWN',
+          message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
+        })
+        if (capturedScopeKey === this.scopeKey) {
+          this.lastSnapshot = inactive
+          this.syncContextSnapshot()
+        }
+        return { success: true, snapshot: inactive }
+      }
+
       const workflowError = LinearWorkflowClient.toWorkflowError(error)
 
       const staleSnapshot: WorkflowBoardSnapshot = this.lastSuccessSnapshot
@@ -259,7 +308,9 @@ export class WorkflowBoardService {
             message: workflowError.message,
           })
 
-      this.lastSnapshot = staleSnapshot
+      if (capturedScopeKey === this.scopeKey) {
+        this.lastSnapshot = staleSnapshot
+      }
 
       log.warn('[workflow-board-service] workflow refresh failed', {
         workspacePath,
@@ -268,7 +319,9 @@ export class WorkflowBoardService {
         error: workflowError,
       })
 
-      this.syncContextSnapshot()
+      if (capturedScopeKey === this.scopeKey) {
+        this.syncContextSnapshot()
+      }
       return { success: true, snapshot: staleSnapshot }
     }
   }

--- a/apps/desktop/src/main/workflow-context-service.ts
+++ b/apps/desktop/src/main/workflow-context-service.ts
@@ -1,0 +1,80 @@
+import type {
+  WorkflowBoardSnapshot,
+  WorkflowContextSnapshot,
+  WorkflowContextMode,
+  WorkflowContextReason,
+} from '../shared/types'
+
+export interface ResolveWorkflowContextInput {
+  planningActive: boolean
+  trackerConfigured: boolean
+  boardSnapshot: WorkflowBoardSnapshot | null
+}
+
+export interface WorkflowContextTransition {
+  previous: WorkflowContextSnapshot | null
+  next: WorkflowContextSnapshot
+}
+
+export class WorkflowContextService {
+  private snapshot: WorkflowContextSnapshot | null = null
+
+  resolve(input: ResolveWorkflowContextInput): WorkflowContextTransition {
+    const next = buildWorkflowContextSnapshot(input)
+    const previous = this.snapshot
+    this.snapshot = next
+    return { previous, next }
+  }
+
+  getSnapshot(): WorkflowContextSnapshot | null {
+    return this.snapshot
+  }
+
+  reset(): void {
+    this.snapshot = null
+  }
+}
+
+export function buildWorkflowContextSnapshot(
+  input: ResolveWorkflowContextInput,
+): WorkflowContextSnapshot {
+  const boardAvailable = isBoardAvailable(input.boardSnapshot)
+
+  let mode: WorkflowContextMode = 'unknown'
+  let reason: WorkflowContextReason = 'unknown_context'
+
+  if (input.planningActive) {
+    mode = 'planning'
+    reason = 'planning_activity_detected'
+  } else if (input.trackerConfigured && boardAvailable) {
+    mode = 'execution'
+    reason = 'tracker_and_board_available'
+  } else if (input.trackerConfigured) {
+    mode = 'execution'
+    reason = 'tracker_configured_board_pending'
+  } else if (boardAvailable) {
+    mode = 'execution'
+    reason = 'board_available_without_tracker'
+  }
+
+  return {
+    mode,
+    reason,
+    planningActive: input.planningActive,
+    trackerConfigured: input.trackerConfigured,
+    boardAvailable,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+function isBoardAvailable(boardSnapshot: WorkflowBoardSnapshot | null): boolean {
+  if (!boardSnapshot) {
+    return false
+  }
+
+  return (
+    boardSnapshot.status === 'fresh' ||
+    boardSnapshot.status === 'empty' ||
+    boardSnapshot.status === 'stale'
+  )
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -155,6 +155,15 @@ const api: DesktopApi = {
     refreshBoard: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowRefreshBoard)
     },
+    setBoardActive: async (active: boolean) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowSetBoardActive, active)
+    },
+    setScope: async (scopeKey: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowSetScope, scopeKey)
+    },
+    getContext: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowGetContext)
+    },
   },
 }
 

--- a/apps/desktop/src/renderer/atoms/__tests__/right-pane-mode.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/right-pane-mode.test.ts
@@ -51,5 +51,6 @@ describe('right-pane mode resolver', () => {
 
     expect(store.get(rightPaneOverrideAtom)).toBeNull()
     expect(store.get(rightPaneModeAtom)).toBe('planning')
+    expect(store.get(rightPaneResolutionAtom).source).toBe('automatic')
   })
 })

--- a/apps/desktop/src/renderer/atoms/__tests__/right-pane-mode.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/right-pane-mode.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest'
+import { createStore } from 'jotai'
+import {
+  clearRightPaneOverrideAtom,
+  rightPaneModeAtom,
+  rightPaneResolutionAtom,
+  rightPaneOverrideAtom,
+  setRightPaneOverrideAtom,
+  setWorkflowContextAtom,
+} from '../right-pane'
+import type { WorkflowContextSnapshot } from '@shared/types'
+
+function context(mode: WorkflowContextSnapshot['mode']): WorkflowContextSnapshot {
+  return {
+    mode,
+    reason: mode === 'planning' ? 'planning_activity_detected' : 'tracker_configured_board_pending',
+    planningActive: mode === 'planning',
+    trackerConfigured: true,
+    boardAvailable: mode === 'execution',
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+describe('right-pane mode resolver', () => {
+  test('uses automatic planning mode when planning context is active', () => {
+    const store = createStore()
+    store.set(setWorkflowContextAtom, context('planning'))
+
+    expect(store.get(rightPaneModeAtom)).toBe('planning')
+    expect(store.get(rightPaneResolutionAtom).source).toBe('automatic')
+  })
+
+  test('uses automatic kanban mode when execution context is active', () => {
+    const store = createStore()
+    store.set(setWorkflowContextAtom, context('execution'))
+
+    expect(store.get(rightPaneModeAtom)).toBe('kanban')
+    expect(store.get(rightPaneResolutionAtom).reason).toBe('tracker_configured_board_pending')
+  })
+
+  test('manual override persists until cleared', () => {
+    const store = createStore()
+    store.set(setWorkflowContextAtom, context('planning'))
+    store.set(setRightPaneOverrideAtom, 'kanban')
+
+    expect(store.get(rightPaneOverrideAtom)).toBe('kanban')
+    expect(store.get(rightPaneModeAtom)).toBe('kanban')
+    expect(store.get(rightPaneResolutionAtom).source).toBe('manual')
+
+    store.set(clearRightPaneOverrideAtom)
+
+    expect(store.get(rightPaneOverrideAtom)).toBeNull()
+    expect(store.get(rightPaneModeAtom)).toBe('planning')
+  })
+})

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -2,8 +2,8 @@ import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import { useEffect, useRef } from 'react'
 import type { PlanningArtifact, PlanningSliceData } from '@shared/types'
+import { setRightPaneOverrideAtom } from './right-pane'
 
-export const RIGHT_PANE_MODE_STORAGE_KEY = 'kata-desktop:right-pane-mode'
 const PLANNING_ARTIFACTS_STORAGE_KEY = 'kata-desktop:planning-artifacts'
 const PLANNING_ARTIFACT_KEYS_STORAGE_KEY = 'kata-desktop:planning-artifact-keys'
 const ACTIVE_PLANNING_ARTIFACT_STORAGE_KEY = 'kata-desktop:active-planning-artifact'
@@ -36,10 +36,6 @@ export const slicePlanningAtom = atom<Record<string, PlanningSliceData>>({})
 export const activePlanningArtifactAtom = atomWithStorage<ActivePlanningArtifactRef | null>(
   ACTIVE_PLANNING_ARTIFACT_STORAGE_KEY,
   null,
-)
-export const rightPaneModeAtom = atomWithStorage<'planning' | 'default'>(
-  RIGHT_PANE_MODE_STORAGE_KEY,
-  'default',
 )
 export const autoSwitchTriggeredAtom = atom<boolean>(false)
 export const planningLoadingAtom = atom<boolean>(false)
@@ -147,7 +143,6 @@ export const clearPlanningArtifactsAtom = atom(null, (_get, set) => {
 })
 
 export function usePlanningArtifactBridge(): void {
-  const rightPaneMode = useAtomValue(rightPaneModeAtom)
   const autoSwitchTriggered = useAtomValue(autoSwitchTriggeredAtom)
   const planningReloadNonce = useAtomValue(planningReloadNonceAtom)
 
@@ -155,11 +150,10 @@ export function usePlanningArtifactBridge(): void {
   const applyBulkPlanningArtifacts = useSetAtom(applyBulkPlanningArtifactsAtom)
   const clearPlanningArtifacts = useSetAtom(clearPlanningArtifactsAtom)
   const pendingTriggerToolNameByArtifactKeyRef = useRef<Record<string, string>>({})
-  const rightPaneModeRef = useRef(rightPaneMode)
   const autoSwitchTriggeredRef = useRef(autoSwitchTriggered)
   const setActiveArtifactTitle = useSetAtom(activePlanningArtifactAtom)
   const setSlices = useSetAtom(slicePlanningAtom)
-  const setRightPaneMode = useSetAtom(rightPaneModeAtom)
+  const setRightPaneOverride = useSetAtom(setRightPaneOverrideAtom)
   const setAutoSwitchTriggered = useSetAtom(autoSwitchTriggeredAtom)
   const setLoading = useSetAtom(planningLoadingAtom)
   const setArtifactFetchInFlightCount = useSetAtom(artifactFetchInFlightCountAtom)
@@ -167,7 +161,6 @@ export function usePlanningArtifactBridge(): void {
   const setStale = useSetAtom(planningArtifactsStaleAtom)
   const setStaleReason = useSetAtom(planningStaleReasonAtom)
 
-  rightPaneModeRef.current = rightPaneMode
   autoSwitchTriggeredRef.current = autoSwitchTriggered
 
   useEffect(() => {
@@ -326,17 +319,16 @@ export function usePlanningArtifactBridge(): void {
     })
 
     const unsubscribeArtifactUpdated = window.api.planning.onArtifactUpdated((artifact) => {
-      if (rightPaneModeRef.current === 'default' && !autoSwitchTriggeredRef.current) {
+      if (!autoSwitchTriggeredRef.current) {
         console.info('Planning pane auto-switch triggered', {
           triggerToolName:
             pendingTriggerToolNameByArtifactKeyRef.current[artifact.artifactKey] ?? 'unknown',
           title: artifact.title,
         })
 
-        rightPaneModeRef.current = 'planning'
         autoSwitchTriggeredRef.current = true
 
-        setRightPaneMode('planning')
+        setRightPaneOverride('planning')
         setAutoSwitchTriggered(true)
       }
 
@@ -353,7 +345,7 @@ export function usePlanningArtifactBridge(): void {
     setArtifactFetchInFlightCount,
     setAutoSwitchTriggered,
     setError,
-    setRightPaneMode,
+    setRightPaneOverride,
   ])
 }
 

--- a/apps/desktop/src/renderer/atoms/planning.ts
+++ b/apps/desktop/src/renderer/atoms/planning.ts
@@ -2,7 +2,7 @@ import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import { useEffect, useRef } from 'react'
 import type { PlanningArtifact, PlanningSliceData } from '@shared/types'
-import { setRightPaneOverrideAtom } from './right-pane'
+import { clearRightPaneOverrideAtom } from './right-pane'
 
 const PLANNING_ARTIFACTS_STORAGE_KEY = 'kata-desktop:planning-artifacts'
 const PLANNING_ARTIFACT_KEYS_STORAGE_KEY = 'kata-desktop:planning-artifact-keys'
@@ -153,7 +153,7 @@ export function usePlanningArtifactBridge(): void {
   const autoSwitchTriggeredRef = useRef(autoSwitchTriggered)
   const setActiveArtifactTitle = useSetAtom(activePlanningArtifactAtom)
   const setSlices = useSetAtom(slicePlanningAtom)
-  const setRightPaneOverride = useSetAtom(setRightPaneOverrideAtom)
+  const clearRightPaneOverride = useSetAtom(clearRightPaneOverrideAtom)
   const setAutoSwitchTriggered = useSetAtom(autoSwitchTriggeredAtom)
   const setLoading = useSetAtom(planningLoadingAtom)
   const setArtifactFetchInFlightCount = useSetAtom(artifactFetchInFlightCountAtom)
@@ -328,7 +328,7 @@ export function usePlanningArtifactBridge(): void {
 
         autoSwitchTriggeredRef.current = true
 
-        setRightPaneOverride('planning')
+        clearRightPaneOverride()
         setAutoSwitchTriggered(true)
       }
 
@@ -345,7 +345,7 @@ export function usePlanningArtifactBridge(): void {
     setArtifactFetchInFlightCount,
     setAutoSwitchTriggered,
     setError,
-    setRightPaneOverride,
+    clearRightPaneOverride,
   ])
 }
 

--- a/apps/desktop/src/renderer/atoms/right-pane.ts
+++ b/apps/desktop/src/renderer/atoms/right-pane.ts
@@ -1,0 +1,81 @@
+import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+import type {
+  RightPaneMode,
+  RightPaneOverride,
+  RightPaneResolution,
+  WorkflowContextSnapshot,
+} from '@shared/types'
+
+export const RIGHT_PANE_OVERRIDE_STORAGE_KEY = 'kata-desktop:right-pane-override'
+
+const defaultWorkflowContext: WorkflowContextSnapshot = {
+  mode: 'unknown',
+  reason: 'unknown_context',
+  planningActive: false,
+  trackerConfigured: false,
+  boardAvailable: false,
+  updatedAt: new Date(0).toISOString(),
+}
+
+export const rightPaneOverrideAtom = atomWithStorage<RightPaneOverride>(
+  RIGHT_PANE_OVERRIDE_STORAGE_KEY,
+  null,
+)
+
+export const workflowContextAtom = atom<WorkflowContextSnapshot>(defaultWorkflowContext)
+
+export const rightPaneResolutionAtom = atom<RightPaneResolution>((get) => {
+  const override = get(rightPaneOverrideAtom)
+  const context = get(workflowContextAtom)
+
+  if (override) {
+    return {
+      mode: override,
+      source: 'manual',
+      reason: 'manual_override',
+    }
+  }
+
+  if (context.mode === 'planning') {
+    return {
+      mode: 'planning',
+      source: 'automatic',
+      reason: context.reason,
+    }
+  }
+
+  if (context.mode === 'execution') {
+    return {
+      mode: 'kanban',
+      source: 'automatic',
+      reason: context.reason,
+    }
+  }
+
+  return {
+    mode: 'planning',
+    source: 'automatic',
+    reason: 'default_fallback',
+  }
+})
+
+export const rightPaneModeAtom = atom<RightPaneMode>((get) => get(rightPaneResolutionAtom).mode)
+
+export const setRightPaneOverrideAtom = atom(
+  null,
+  (_get, set, override: RightPaneOverride) => {
+    set(rightPaneOverrideAtom, override)
+  },
+)
+
+export const clearRightPaneOverrideAtom = atom(null, (_get, set) => {
+  set(rightPaneOverrideAtom, null)
+})
+
+export const setWorkflowContextAtom = atom(
+  null,
+  (_get, set, context: WorkflowContextSnapshot) => {
+    set(workflowContextAtom, context)
+  },
+)

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -1,130 +1,153 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { WorkflowBoardSnapshot } from '@shared/types'
+import { currentSessionIdAtom, workingDirectoryAtom } from './session'
+import { rightPaneModeAtom, setWorkflowContextAtom } from './right-pane'
 
 const REFRESH_INTERVAL_MS = 30_000
-
-let latestRefreshRequestId = 0
-
-function beginRefreshRequest(): number {
-  latestRefreshRequestId += 1
-  return latestRefreshRequestId
-}
-
-function isLatestRefreshRequest(requestId: number): boolean {
-  return requestId === latestRefreshRequestId
-}
 
 export const workflowBoardAtom = atom<WorkflowBoardSnapshot | null>(null)
 export const workflowBoardLoadingAtom = atom<boolean>(false)
 export const workflowBoardRefreshingAtom = atom<boolean>(false)
 export const workflowBoardErrorAtom = atom<string | null>(null)
+export const workflowBoardActiveAtom = atom<boolean>(false)
 
 export const workflowBoardHasCardsAtom = atom((get) => {
   const snapshot = get(workflowBoardAtom)
-  if (!snapshot) {
-    return false
-  }
-
-  return snapshot.columns.some((column) => column.cards.length > 0)
+  return snapshot ? snapshot.columns.some((column) => column.cards.length > 0) : false
 })
 
 export const refreshWorkflowBoardAtom = atom(null, async (_get, set) => {
-  const requestId = beginRefreshRequest()
   set(workflowBoardRefreshingAtom, true)
   set(workflowBoardErrorAtom, null)
 
   try {
     const response = await window.api.workflow.refreshBoard()
-    if (!isLatestRefreshRequest(requestId)) {
-      return
-    }
-
     set(workflowBoardAtom, response.snapshot)
     set(workflowBoardErrorAtom, response.snapshot.lastError?.message ?? null)
   } catch (error) {
-    if (!isLatestRefreshRequest(requestId)) {
-      return
-    }
-
     set(workflowBoardErrorAtom, error instanceof Error ? error.message : String(error))
   } finally {
-    if (isLatestRefreshRequest(requestId)) {
-      set(workflowBoardRefreshingAtom, false)
-    }
+    set(workflowBoardRefreshingAtom, false)
   }
 })
+
 export function useWorkflowBoardBridge(): void {
+  const rightPaneMode = useAtomValue(rightPaneModeAtom)
+  const workspacePath = useAtomValue(workingDirectoryAtom)
+  const sessionId = useAtomValue(currentSessionIdAtom)
+
   const setBoard = useSetAtom(workflowBoardAtom)
   const setLoading = useSetAtom(workflowBoardLoadingAtom)
   const setRefreshing = useSetAtom(workflowBoardRefreshingAtom)
   const setError = useSetAtom(workflowBoardErrorAtom)
+  const setActive = useSetAtom(workflowBoardActiveAtom)
+  const setWorkflowContext = useSetAtom(setWorkflowContextAtom)
+
+  const intervalIdRef = useRef<number | null>(null)
+  const activeRef = useRef(false)
 
   useEffect(() => {
-    let cancelled = false
-
-    const loadBoard = async (mode: 'initial' | 'refresh') => {
-      if (cancelled) {
-        return
-      }
-
-      const requestId = mode === 'refresh' ? beginRefreshRequest() : null
-      if (cancelled) {
-        return
-      }
-
-      if (mode === 'initial') {
-        setLoading(true)
-      } else {
-        setRefreshing(true)
-      }
-
+    const syncContext = async () => {
       try {
-        const response =
-          mode === 'initial' ? await window.api.workflow.getBoard() : await window.api.workflow.refreshBoard()
+        const response = await window.api.workflow.getContext()
+        setWorkflowContext(response.context)
+      } catch {
+        // best-effort context sync
+      }
+    }
 
-        if (cancelled) {
-          return
-        }
+    void syncContext()
+  }, [setWorkflowContext])
 
-        if (mode === 'refresh' && requestId !== null && !isLatestRefreshRequest(requestId)) {
-          return
-        }
+  useEffect(() => {
+    const scopeKey = `${workspacePath || 'workspace:none'}::${sessionId || 'session:none'}`
 
-        setBoard(response.snapshot)
-        setError(response.snapshot.lastError?.message ?? null)
+    const activatePolling = async () => {
+      setActive(true)
+      activeRef.current = true
+      await window.api.workflow.setScope(scopeKey)
+      await window.api.workflow.setBoardActive(true)
+
+      setLoading(true)
+      try {
+        const initial = await window.api.workflow.getBoard()
+        setBoard(initial.snapshot)
+        setError(initial.snapshot.lastError?.message ?? null)
       } catch (error) {
-        if (cancelled) {
-          return
-        }
-
-        if (mode === 'refresh' && requestId !== null && !isLatestRefreshRequest(requestId)) {
-          return
-        }
-
         setError(error instanceof Error ? error.message : String(error))
       } finally {
-        if (!cancelled) {
-          if (mode === 'initial') {
-            setLoading(false)
-          } else if (requestId !== null && isLatestRefreshRequest(requestId)) {
+        setLoading(false)
+      }
+
+      if (intervalIdRef.current !== null) {
+        window.clearInterval(intervalIdRef.current)
+      }
+
+      intervalIdRef.current = window.setInterval(() => {
+        void (async () => {
+          if (!activeRef.current) {
+            return
+          }
+
+          setRefreshing(true)
+          try {
+            const refreshed = await window.api.workflow.refreshBoard()
+            setBoard(refreshed.snapshot)
+            setError(refreshed.snapshot.lastError?.message ?? null)
+          } catch (error) {
+            setError(error instanceof Error ? error.message : String(error))
+          } finally {
             setRefreshing(false)
           }
-        }
-      }
+
+          try {
+            const contextResponse = await window.api.workflow.getContext()
+            setWorkflowContext(contextResponse.context)
+          } catch {
+            // ignore context sync failures during interval
+          }
+        })()
+      }, REFRESH_INTERVAL_MS)
     }
 
-    void loadBoard('initial')
+    const deactivatePolling = async () => {
+      activeRef.current = false
+      setActive(false)
+      if (intervalIdRef.current !== null) {
+        window.clearInterval(intervalIdRef.current)
+        intervalIdRef.current = null
+      }
 
-    const intervalId = window.setInterval(() => {
-      void loadBoard('refresh')
-    }, REFRESH_INTERVAL_MS)
+      await window.api.workflow.setBoardActive(false)
+    }
+
+    if (rightPaneMode === 'kanban') {
+      void activatePolling()
+    } else {
+      void deactivatePolling()
+    }
 
     return () => {
-      cancelled = true
-      window.clearInterval(intervalId)
+      activeRef.current = false
+      if (intervalIdRef.current !== null) {
+        window.clearInterval(intervalIdRef.current)
+        intervalIdRef.current = null
+      }
+      void window.api.workflow.setBoardActive(false)
+      setActive(false)
     }
-  }, [setBoard, setError, setLoading, setRefreshing])
+  }, [
+    rightPaneMode,
+    sessionId,
+    setActive,
+    setBoard,
+    setError,
+    setLoading,
+    setRefreshing,
+    setWorkflowContext,
+    workspacePath,
+  ])
 }
 
 export function useWorkflowBoardSnapshot(): WorkflowBoardSnapshot | null {

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -47,22 +47,29 @@ export function useWorkflowBoardBridge(): void {
   const intervalIdRef = useRef<number | null>(null)
   const activeRef = useRef(false)
   const activationVersionRef = useRef(0)
+  const scopeKey = `${workspacePath || 'workspace:none'}::${sessionId || 'session:none'}`
 
   useEffect(() => {
-    const syncContext = async () => {
+    let cancelled = false
+
+    void (async () => {
       try {
+        await window.api.workflow.setScope(scopeKey)
         const response = await window.api.workflow.getContext()
-        setWorkflowContext(response.context)
+        if (!cancelled) {
+          setWorkflowContext(response.context)
+        }
       } catch {
-        // best-effort context sync
+        // best-effort scope/context sync
       }
-    }
+    })()
 
-    void syncContext()
-  }, [setWorkflowContext])
+    return () => {
+      cancelled = true
+    }
+  }, [scopeKey, setWorkflowContext])
 
   useEffect(() => {
-    const scopeKey = `${workspacePath || 'workspace:none'}::${sessionId || 'session:none'}`
 
     const deactivateInterval = () => {
       if (intervalIdRef.current !== null) {
@@ -86,11 +93,6 @@ export function useWorkflowBoardBridge(): void {
 
       setActive(true)
       activeRef.current = true
-
-      await window.api.workflow.setScope(scopeKey)
-      if (!isCurrentActivation()) {
-        return
-      }
 
       await window.api.workflow.setBoardActive(true)
       if (!isCurrentActivation()) {
@@ -178,14 +180,12 @@ export function useWorkflowBoardBridge(): void {
     }
   }, [
     rightPaneMode,
-    sessionId,
     setActive,
     setBoard,
     setError,
     setLoading,
     setRefreshing,
     setWorkflowContext,
-    workspacePath,
   ])
 }
 

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -46,6 +46,7 @@ export function useWorkflowBoardBridge(): void {
 
   const intervalIdRef = useRef<number | null>(null)
   const activeRef = useRef(false)
+  const activationVersionRef = useRef(0)
 
   useEffect(() => {
     const syncContext = async () => {
@@ -63,63 +64,103 @@ export function useWorkflowBoardBridge(): void {
   useEffect(() => {
     const scopeKey = `${workspacePath || 'workspace:none'}::${sessionId || 'session:none'}`
 
+    const deactivateInterval = () => {
+      if (intervalIdRef.current !== null) {
+        window.clearInterval(intervalIdRef.current)
+        intervalIdRef.current = null
+      }
+    }
+
+    const deactivatePolling = async () => {
+      activeRef.current = false
+      activationVersionRef.current += 1
+      setActive(false)
+      deactivateInterval()
+      await window.api.workflow.setBoardActive(false)
+    }
+
     const activatePolling = async () => {
+      const activationVersion = ++activationVersionRef.current
+      const isCurrentActivation = () =>
+        activeRef.current && activationVersionRef.current === activationVersion
+
       setActive(true)
       activeRef.current = true
+
       await window.api.workflow.setScope(scopeKey)
+      if (!isCurrentActivation()) {
+        return
+      }
+
       await window.api.workflow.setBoardActive(true)
+      if (!isCurrentActivation()) {
+        return
+      }
 
       setLoading(true)
       try {
         const initial = await window.api.workflow.getBoard()
+        if (!isCurrentActivation()) {
+          return
+        }
+
         setBoard(initial.snapshot)
         setError(initial.snapshot.lastError?.message ?? null)
       } catch (error) {
+        if (!isCurrentActivation()) {
+          return
+        }
+
         setError(error instanceof Error ? error.message : String(error))
       } finally {
-        setLoading(false)
+        if (isCurrentActivation()) {
+          setLoading(false)
+        }
       }
 
-      if (intervalIdRef.current !== null) {
-        window.clearInterval(intervalIdRef.current)
+      if (!isCurrentActivation()) {
+        return
       }
+
+      deactivateInterval()
 
       intervalIdRef.current = window.setInterval(() => {
         void (async () => {
-          if (!activeRef.current) {
+          if (!isCurrentActivation()) {
             return
           }
 
           setRefreshing(true)
           try {
             const refreshed = await window.api.workflow.refreshBoard()
+            if (!isCurrentActivation()) {
+              return
+            }
+
             setBoard(refreshed.snapshot)
             setError(refreshed.snapshot.lastError?.message ?? null)
           } catch (error) {
+            if (!isCurrentActivation()) {
+              return
+            }
+
             setError(error instanceof Error ? error.message : String(error))
           } finally {
-            setRefreshing(false)
+            if (isCurrentActivation()) {
+              setRefreshing(false)
+            }
           }
 
           try {
             const contextResponse = await window.api.workflow.getContext()
-            setWorkflowContext(contextResponse.context)
+            if (isCurrentActivation()) {
+              setWorkflowContext(contextResponse.context)
+            }
           } catch {
             // ignore context sync failures during interval
           }
         })()
       }, REFRESH_INTERVAL_MS)
-    }
-
-    const deactivatePolling = async () => {
-      activeRef.current = false
-      setActive(false)
-      if (intervalIdRef.current !== null) {
-        window.clearInterval(intervalIdRef.current)
-        intervalIdRef.current = null
-      }
-
-      await window.api.workflow.setBoardActive(false)
     }
 
     if (rightPaneMode === 'kanban') {
@@ -130,10 +171,8 @@ export function useWorkflowBoardBridge(): void {
 
     return () => {
       activeRef.current = false
-      if (intervalIdRef.current !== null) {
-        window.clearInterval(intervalIdRef.current)
-        intervalIdRef.current = null
-      }
+      activationVersionRef.current += 1
+      deactivateInterval()
       void window.api.workflow.setBoardActive(false)
       setActive(false)
     }

--- a/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from 'jotai'
-import { rightPaneModeAtom } from '@/atoms/planning'
+import { rightPaneModeAtom } from '@/atoms/right-pane'
 import { KanbanPane } from '@/components/kanban/KanbanPane'
 import { PlanningPane } from '@/components/planning/PlanningPane'
 

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -7,18 +7,54 @@ import {
   workflowBoardLoadingAtom,
   workflowBoardRefreshingAtom,
 } from '@/atoms/workflow-board'
-import { rightPaneModeAtom } from '@/atoms/planning'
+import {
+  clearRightPaneOverrideAtom,
+  rightPaneOverrideAtom,
+  rightPaneResolutionAtom,
+  setRightPaneOverrideAtom,
+  workflowContextAtom,
+} from '@/atoms/right-pane'
 import { KanbanColumn } from '@/components/kanban/KanbanColumn'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { normalizeWorkflowColumns } from '@/lib/workflow-board'
+
+export function formatWorkflowBoardStatus(input: {
+  loading: boolean
+  boardStatus?: 'fresh' | 'stale' | 'empty' | 'error'
+  backend?: string
+  emptyReason?: string
+  refreshing: boolean
+}): string {
+  if (input.loading) {
+    return 'Loading workflow board…'
+  }
+
+  let status = 'Workflow board not loaded'
+
+  if (input.boardStatus === 'fresh') {
+    status = `Live data · ${input.backend ?? 'unknown'}`
+  } else if (input.boardStatus === 'empty') {
+    status = input.emptyReason ?? 'No work items found'
+  } else if (input.boardStatus === 'stale') {
+    status = 'Showing stale board snapshot'
+  } else if (input.boardStatus === 'error') {
+    status = 'Workflow board unavailable'
+  }
+
+  return input.refreshing ? `${status} · Refreshing…` : status
+}
 
 export function KanbanPane() {
   const board = useAtomValue(workflowBoardAtom)
   const loading = useAtomValue(workflowBoardLoadingAtom)
   const refreshing = useAtomValue(workflowBoardRefreshingAtom)
   const error = useAtomValue(workflowBoardErrorAtom)
-  const setRightPaneMode = useSetAtom(rightPaneModeAtom)
+  const setRightPaneOverride = useSetAtom(setRightPaneOverrideAtom)
+  const clearOverride = useSetAtom(clearRightPaneOverrideAtom)
+  const rightPaneOverride = useAtomValue(rightPaneOverrideAtom)
+  const paneResolution = useAtomValue(rightPaneResolutionAtom)
+  const workflowContext = useAtomValue(workflowContextAtom)
   const refreshBoard = useSetAtom(refreshWorkflowBoardAtom)
 
   const columns = board ? normalizeWorkflowColumns(board) : []
@@ -39,7 +75,7 @@ export function KanbanPane() {
             size="icon"
             variant="ghost"
             aria-label="Open planning view"
-            onClick={() => setRightPaneMode('planning')}
+            onClick={() => setRightPaneOverride('planning')}
           >
             <LayoutGrid className="size-4" />
           </Button>
@@ -61,14 +97,32 @@ export function KanbanPane() {
       <Separator />
 
       <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-status">
-        {loading ? 'Loading workflow board…' : null}
-        {!loading && !board ? 'Workflow board not loaded' : null}
-        {!loading && board?.status === 'fresh' ? `Live data · ${board.backend}` : null}
-        {!loading && board?.status === 'empty' ? board.emptyReason ?? 'No work items found' : null}
-        {!loading && board?.status === 'stale' ? 'Showing stale board snapshot' : null}
-        {!loading && board?.status === 'error' ? 'Workflow board unavailable' : null}
-        {refreshing ? ' · Refreshing…' : null}
+        {rightPaneOverride ? `Manual override: ${rightPaneOverride}` : `Auto mode: ${paneResolution.reason}`}
+        {' · '}
+        {`Context: ${workflowContext.mode}`}
+        {' · '}
+        {formatWorkflowBoardStatus({
+          loading,
+          boardStatus: board?.status,
+          backend: board?.backend,
+          emptyReason: board?.emptyReason,
+          refreshing,
+        })}
       </div>
+
+      {rightPaneOverride ? (
+        <div className="border-b border-border bg-muted/70 px-4 py-2 text-xs text-muted-foreground">
+          Manual pane override is active.
+          <Button
+            type="button"
+            variant="link"
+            className="ml-1 h-auto p-0 text-xs"
+            onClick={() => clearOverride()}
+          >
+            Return to auto mode
+          </Button>
+        </div>
+      ) : null}
 
       {error ? (
         <div className="border-b border-border bg-destructive/10 px-4 py-2 text-xs text-destructive">{error}</div>

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -19,6 +19,20 @@ import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { normalizeWorkflowColumns } from '@/lib/workflow-board'
 
+function formatPaneResolutionReason(reason: string): string {
+  const labels: Record<string, string> = {
+    manual_override: 'Manual override',
+    default_fallback: 'Default fallback',
+    planning_activity_detected: 'Planning activity detected',
+    tracker_and_board_available: 'Tracker configured and board available',
+    tracker_configured_board_pending: 'Tracker configured — board pending',
+    board_available_without_tracker: 'Board available without tracker config',
+    unknown_context: 'Context unavailable',
+  }
+
+  return labels[reason] ?? 'Automatic context resolution'
+}
+
 export function formatWorkflowBoardStatus(input: {
   loading: boolean
   boardStatus?: 'fresh' | 'stale' | 'empty' | 'error'
@@ -97,7 +111,9 @@ export function KanbanPane() {
       <Separator />
 
       <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-status">
-        {rightPaneOverride ? `Manual override: ${rightPaneOverride}` : `Auto mode: ${paneResolution.reason}`}
+        {rightPaneOverride
+          ? `Manual override: ${rightPaneOverride}`
+          : `Auto mode: ${formatPaneResolutionReason(paneResolution.reason)}`}
         {' · '}
         {`Context: ${workflowContext.mode}`}
         {' · '}

--- a/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest'
+import { formatWorkflowBoardStatus } from '../KanbanPane'
+
+describe('KanbanPane status formatting', () => {
+  test('renders loading state', () => {
+    expect(
+      formatWorkflowBoardStatus({
+        loading: true,
+        refreshing: false,
+      }),
+    ).toBe('Loading workflow board…')
+  })
+
+  test('renders stale state with refresh indicator', () => {
+    expect(
+      formatWorkflowBoardStatus({
+        loading: false,
+        boardStatus: 'stale',
+        refreshing: true,
+      }),
+    ).toBe('Showing stale board snapshot · Refreshing…')
+  })
+
+  test('renders empty reason when provided', () => {
+    expect(
+      formatWorkflowBoardStatus({
+        loading: false,
+        boardStatus: 'empty',
+        emptyReason: 'No slices in active milestone',
+        refreshing: false,
+      }),
+    ).toBe('No slices in active milestone')
+  })
+})

--- a/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningPane.tsx
@@ -19,7 +19,6 @@ import {
   planningErrorAtom,
   planningLoadingAtom,
   planningStaleReasonAtom,
-  rightPaneModeAtom,
   slicePlanningAtom,
 } from '@/atoms/planning'
 import { ArtifactTabs } from '@/components/planning/ArtifactTabs'
@@ -38,6 +37,7 @@ import {
   parseRoadmap,
 } from '@/lib/artifact-parser'
 import { cn } from '@/lib/utils'
+import { setRightPaneOverrideAtom } from '@/atoms/right-pane'
 
 export function PlanningPane() {
   const artifactsByKey = useAtomValue(planningArtifactsAtom)
@@ -52,7 +52,7 @@ export function PlanningPane() {
 
   const applyPlanningArtifact = useSetAtom(applyPlanningArtifactAtom)
   const setActiveArtifact = useSetAtom(activePlanningArtifactAtom)
-  const setRightPaneMode = useSetAtom(rightPaneModeAtom)
+  const setRightPaneOverride = useSetAtom(setRightPaneOverrideAtom)
   const markPlanningArtifactViewed = useSetAtom(markPlanningArtifactViewedAtom)
   const setPlanningLoading = useSetAtom(planningLoadingAtom)
   const setPlanningError = useSetAtom(planningErrorAtom)
@@ -305,9 +305,9 @@ export function PlanningPane() {
                 console.info('Right pane mode toggled', {
                   trigger: 'manual',
                   from: 'planning',
-                  to: 'default',
+                  to: 'kanban',
                 })
-                setRightPaneMode('default')
+                setRightPaneOverride('kanban')
               }}
             >
               <X className="size-4" />

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -29,6 +29,9 @@ export const IPC_CHANNELS = {
   planningListArtifacts: 'planning:list-artifacts',
   workflowGetBoard: 'workflow:get-board',
   workflowRefreshBoard: 'workflow:refresh-board',
+  workflowSetBoardActive: 'workflow:set-board-active',
+  workflowSetScope: 'workflow:set-scope',
+  workflowGetContext: 'workflow:get-context',
 } as const
 
 export type PermissionMode = 'explore' | 'ask' | 'auto'
@@ -533,6 +536,34 @@ export type WorkflowBoardBackend = 'linear' | 'github'
 
 export type WorkflowBoardStatus = 'fresh' | 'stale' | 'empty' | 'error'
 
+export type WorkflowContextMode = 'planning' | 'execution' | 'unknown'
+
+export type WorkflowContextReason =
+  | 'planning_activity_detected'
+  | 'tracker_and_board_available'
+  | 'tracker_configured_board_pending'
+  | 'board_available_without_tracker'
+  | 'unknown_context'
+
+export interface WorkflowContextSnapshot {
+  mode: WorkflowContextMode
+  reason: WorkflowContextReason
+  planningActive: boolean
+  trackerConfigured: boolean
+  boardAvailable: boolean
+  updatedAt: string
+}
+
+export type RightPaneMode = 'planning' | 'kanban'
+
+export type RightPaneOverride = RightPaneMode | null
+
+export interface RightPaneResolution {
+  mode: RightPaneMode
+  source: 'manual' | 'automatic'
+  reason: WorkflowContextReason | 'manual_override' | 'default_fallback'
+}
+
 export type WorkflowBoardErrorCode =
   | 'NOT_CONFIGURED'
   | 'MISSING_API_KEY'
@@ -612,6 +643,21 @@ export interface WorkflowBoardSnapshot {
 export interface WorkflowBoardSnapshotResponse {
   success: boolean
   snapshot: WorkflowBoardSnapshot
+}
+
+export interface WorkflowBoardLifecycleResponse {
+  success: boolean
+  active: boolean
+}
+
+export interface WorkflowBoardScopeResponse {
+  success: boolean
+  scopeKey: string
+}
+
+export interface WorkflowContextResponse {
+  success: boolean
+  context: WorkflowContextSnapshot
 }
 
 export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context' | 'slice'
@@ -724,6 +770,9 @@ export interface DesktopApi {
   workflow: {
     getBoard: () => Promise<WorkflowBoardSnapshotResponse>
     refreshBoard: () => Promise<WorkflowBoardSnapshotResponse>
+    setBoardActive: (active: boolean) => Promise<WorkflowBoardLifecycleResponse>
+    setScope: (scopeKey: string) => Promise<WorkflowBoardScopeResponse>
+    getContext: () => Promise<WorkflowContextResponse>
   }
 }
 

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -5,10 +5,11 @@ export default defineConfig({
   resolve: {
     alias: {
       '@shared': path.resolve(__dirname, 'src/shared'),
+      '@': path.resolve(__dirname, 'src/renderer'),
     },
   },
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     passWithNoTests: true,
     testTimeout: 15_000,
     coverage: {

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       include: ['src/**/*.ts', 'src/**/*.tsx'],
       exclude: [
         'src/**/*.test.ts',
+        'src/**/*.test.tsx',
         'src/**/*.d.ts',
         'dist/**',
         // Electron main process entrypoint — requires a running Electron app (app.whenReady, BrowserWindow)


### PR DESCRIPTION
## Summary
- separate workflow context resolution from manual right-pane override
- bind workflow board polling lifecycle to pane activation, workspace, and session scope
- render backend-neutral kanban loading/empty/stale/auth/error surfaces with recovery actions
- add Electron e2e coverage for planning→execution auto-entry, override persistence, and recovery flows

## Validation
- npx vitest run src/main/__tests__/workflow-context-service.test.ts src/main/__tests__/workflow-board-service.test.ts src/renderer/atoms/__tests__/right-pane-mode.test.ts src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
- bun run typecheck
- npx playwright test e2e/tests/workflow-context-switching.e2e.ts

Relates to KAT-2250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and switching between planning and execution contexts with visible mode indicators and preserved planning view after reload.
  * Manual override to force Kanban or Planning, persisted across sessions, plus a “Return to auto mode” action.
  * Consolidated workflow-board status banner with scenario-specific messages and new controls to set board active/scope and refresh the board.

* **Tests**
  * New E2E and unit tests covering context switching, persistence, scenario-driven refresh states, concurrency, and transition tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces workflow context switching by separating automatic context resolution (`WorkflowContextService`) from manual right-pane overrides (`rightPaneOverrideAtom`), binds board polling lifecycle to pane activation/workspace/session scope via `useWorkflowBoardBridge`, and adds kanban loading/error/stale/empty surface states with recovery actions. All four findings are P2.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/quality suggestions with no blocking correctness issues.

The architecture is sound: context resolution, override, and polling lifecycle are cleanly separated and well-tested. The leaked-interval race is functionally harmless (interval no-ops on every tick), the backend active-state race self-corrects via deactivatePolling, and all remaining findings are naming/duplication/UX polish. No data loss, broken paths, or security concerns.

apps/desktop/src/renderer/atoms/workflow-board.ts (leaked interval on rapid toggle) and apps/desktop/src/main/workflow-board-service.ts (readLinearProjectReference duplication)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/workflow-board-service.ts | New service managing board snapshot lifecycle, test scenarios, and context resolution; contains a duplicate of readLinearProjectReference that also appears in ipc.ts, and emitContext name is misleading |
| apps/desktop/src/renderer/atoms/workflow-board.ts | Polling bridge hook wires board lifecycle to pane mode; has a potential leaked-interval path on rapid kanban→planning toggle since activatePolling's async continuation can run after cleanup |
| apps/desktop/src/main/workflow-context-service.ts | Clean, simple state machine mapping planningActive/trackerConfigured/boardSnapshot to mode+reason; well-tested |
| apps/desktop/src/renderer/atoms/right-pane.ts | Override/context resolution logic is clean; manual override correctly takes precedence over automatic context-derived mode |
| apps/desktop/src/main/ipc.ts | New workflow IPC handlers wired correctly with proper cleanup; setPlanningActive(false) is correctly called on session/workspace switch; contains its own copy of readLinearProjectReference duplicated from workflow-board-service.ts |
| apps/desktop/src/renderer/components/kanban/KanbanPane.tsx | Renders board status bar with override/context debug info; empty body when board is null/error and loading is false may look blank without an explicit empty-state placeholder |
| apps/desktop/src/shared/types.ts | New WorkflowContext* and RightPane* types are well-structured with clear discriminated unions |
| apps/desktop/src/preload/index.ts | workflow API surface correctly exposed via contextBridge; all 5 new channels are registered and typed |
| apps/desktop/e2e/tests/workflow-context-switching.e2e.ts | E2E coverage for context auto-entry, manual override persistence across reload, and all scenario states; test flow is straightforward and well-scoped |
| apps/desktop/src/renderer/atoms/planning.ts | Minimal change — setRightPaneOverride('planning') auto-switch and setRightPaneOverride import moved here from old location; no behavioral regressions |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer (useWorkflowBoardBridge)
    participant IPC as IPC Layer
    participant WBS as WorkflowBoardService
    participant WCS as WorkflowContextService
    participant FS as Filesystem (.kata/preferences.md)

    R->>IPC: workflow:get-context (on mount)
    IPC->>WBS: refreshContext()
    WBS->>FS: readLinearProjectReference()
    FS-->>WBS: projectRef | null
    WBS->>WCS: resolve({ planningActive, trackerConfigured, boardSnapshot })
    WCS-->>WBS: WorkflowContextSnapshot
    WBS-->>IPC: WorkflowContextSnapshot
    IPC-->>R: WorkflowContextResponse
    R->>R: setWorkflowContextAtom → rightPaneResolutionAtom → rightPaneModeAtom

    Note over R: rightPaneMode = 'kanban'
    R->>IPC: workflow:set-scope(scopeKey)
    IPC->>WBS: setScope() → reset snapshots + emitContext()
    R->>IPC: workflow:set-board-active(true)
    IPC->>WBS: setActive(true) → emitContext()
    R->>IPC: workflow:get-board
    IPC->>WBS: getBoard() → performRefreshBoard()
    WBS->>FS: readLinearProjectReference()
    FS-->>WBS: projectRef
    WBS-->>IPC: WorkflowBoardSnapshotResponse
    IPC-->>R: snapshot → setBoard + setError

    loop Every 30s
        R->>IPC: workflow:refresh-board
        IPC->>WBS: refreshBoard()
        WBS-->>IPC: WorkflowBoardSnapshotResponse
        IPC-->>R: snapshot
        R->>IPC: workflow:get-context
        IPC->>WBS: refreshContext()
        WBS-->>IPC: WorkflowContextSnapshot
        IPC-->>R: context → setWorkflowContextAtom
    end

    Note over R: rightPaneMode → 'planning'
    R->>IPC: workflow:set-board-active(false)
    IPC->>WBS: setActive(false) → emitContext()
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/main/workflow-board-service.ts`, line 408-462 ([link](https://github.com/gannonh/kata/blob/3320d45374efa56b3c5d4072259c0c6c8493e5aa/apps/desktop/src/main/workflow-board-service.ts#L408-L462)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`readLinearProjectReference` is duplicated**

   This function is defined verbatim again starting at line ~1190 of `ipc.ts` where the `planningListArtifacts` handler uses its own copy. Both parse `.kata/preferences.md` with the same regex/YAML logic. Keeping two copies means a bug fix or format change in one will silently miss the other. Consider extracting this into a shared utility (e.g. `src/main/workspace-prefs.ts`).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/workflow-board-service.ts
   Line: 408-462

   Comment:
   **`readLinearProjectReference` is duplicated**

   This function is defined verbatim again starting at line ~1190 of `ipc.ts` where the `planningListArtifacts` handler uses its own copy. Both parse `.kata/preferences.md` with the same regex/YAML logic. Keeping two copies means a bug fix or format change in one will silently miss the other. Consider extracting this into a shared utility (e.g. `src/main/workspace-prefs.ts`).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/desktop/src/renderer/components/kanban/KanbanPane.tsx`, line 131-144 ([link](https://github.com/gannonh/kata/blob/3320d45374efa56b3c5d4072259c0c6c8493e5aa/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx#L131-L144)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Empty body in error/null board state**

   When `loading === false` and `board === null` (e.g. `NOT_CONFIGURED` or `UNAUTHORIZED` error), `columns` is `[]`, so the main area renders an empty `<div className="flex h-full min-w-max gap-3">` with no children. The error text is shown in a narrow bar above, but the body is a blank white space. Consider a centered empty-state element (icon + short message) in this branch, especially since `formatWorkflowBoardStatus` already returns `'Workflow board unavailable'` for this case.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
   Line: 131-144

   Comment:
   **Empty body in error/null board state**

   When `loading === false` and `board === null` (e.g. `NOT_CONFIGURED` or `UNAUTHORIZED` error), `columns` is `[]`, so the main area renders an empty `<div className="flex h-full min-w-max gap-3">` with no children. The error text is shown in a narrow bar above, but the body is a blank white space. Consider a centered empty-state element (icon + short message) in this branch, especially since `formatWorkflowBoardStatus` already returns `'Workflow board unavailable'` for this case.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/workflow-board.ts
Line: 114-139

Comment:
**Leaked interval on rapid mode toggle**

If `rightPaneMode` flips from `'kanban'` to `'planning'` while `activatePolling` is still awaiting IPC responses, the cleanup runs first (sets `activeRef.current = false`, clears any existing interval), but `activatePolling` continues and eventually executes `intervalIdRef.current = window.setInterval(...)`. That new interval ID is stored in the ref but was never cleared by the cleanup that already ran. The interval callback will always no-op (`!activeRef.current`), yet it keeps ticking every 30 s until a subsequent cleanup clears it. More critically, `activatePolling` also calls `setBoardActive(true)` after cleanup has already sent `setBoardActive(false)`, which can leave the backend service in `active=true` state.

Consider checking `activeRef.current` at each `await` boundary inside `activatePolling`, and guard the interval setup:

```ts
// After all awaits, before setInterval
if (!activeRef.current) return

intervalIdRef.current = window.setInterval(() => { … }, REFRESH_INTERVAL_MS)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/workflow-board-service.ts
Line: 276-282

Comment:
**Misleading method name `emitContext`**

`emitContext()` only resolves and stores the context snapshot inside the internal `WorkflowContextService` — it does not push anything to external consumers. The name implies a pub/sub push, which misleads readers into thinking context changes propagate automatically to the renderer. A name like `syncContext()` or `updateContext()` would better describe the behavior.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/workflow-board-service.ts
Line: 408-462

Comment:
**`readLinearProjectReference` is duplicated**

This function is defined verbatim again starting at line ~1190 of `ipc.ts` where the `planningListArtifacts` handler uses its own copy. Both parse `.kata/preferences.md` with the same regex/YAML logic. Keeping two copies means a bug fix or format change in one will silently miss the other. Consider extracting this into a shared utility (e.g. `src/main/workspace-prefs.ts`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
Line: 131-144

Comment:
**Empty body in error/null board state**

When `loading === false` and `board === null` (e.g. `NOT_CONFIGURED` or `UNAUTHORIZED` error), `columns` is `[]`, so the main area renders an empty `<div className="flex h-full min-w-max gap-3">` with no children. The error text is shown in a narrow bar above, but the body is a blank white space. Consider a centered empty-state element (icon + short message) in this branch, especially since `formatWorkflowBoardStatus` already returns `'Workflow board unavailable'` for this case.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(KAT-2268): extend workflow board li..."](https://github.com/gannonh/kata/commit/3320d45374efa56b3c5d4072259c0c6c8493e5aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27335002)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->