### PR TITLE
feat(desktop): GitHub workflow board parity in kanban pane (KAT-2249)

### DIFF
--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -68,14 +68,23 @@ async function dismissOnboardingIfPresent(window: Page): Promise<void> {
 
 type DesktopFixtures = {
   electronApp: ElectronApplication
+  workspaceDir: string
   mainWindow: Page
   readyWindow: Page
 }
 
 export const test = base.extend<DesktopFixtures>({
-  electronApp: async ({}, use) => {
+  workspaceDir: async ({}, use) => {
     const dataDir = createIsolatedDataDir()
     const workspaceDir = path.join(dataDir, 'workspace')
+    try {
+      await use(workspaceDir)
+    } finally {
+      try { rmSync(dataDir, { recursive: true, force: true }) } catch { /* noop */ }
+    }
+  },
+  electronApp: async ({ workspaceDir }, use) => {
+    const dataDir = path.dirname(workspaceDir)
     const mainEntry = path.join(__dirname, '../../dist/main.cjs')
     const preloadEntry = path.join(__dirname, '../../dist/preload.cjs')
 

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -130,7 +130,6 @@ export const test = base.extend<DesktopFixtures>({
       if (pid) {
         try { process.kill(pid, 'SIGKILL') } catch { /* already dead */ }
       }
-      try { rmSync(dataDir, { recursive: true, force: true }) } catch { /* race with dying process */ }
     }
   },
 

--- a/apps/desktop/e2e/tests/workflow-kanban-github.e2e.ts
+++ b/apps/desktop/e2e/tests/workflow-kanban-github.e2e.ts
@@ -1,0 +1,64 @@
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from '../fixtures/electron.fixture'
+
+test.describe('Workflow kanban GitHub parity', () => {
+  test('renders github labels mode snapshot through the runtime board path', async ({ readyWindow, workspaceDir }) => {
+    writeFileSync(
+      path.join(workspaceDir, 'WORKFLOW.md'),
+      [
+        '---',
+        'tracker:',
+        '  kind: github',
+        '  repo_owner: kata-sh',
+        '  repo_name: kata-mono',
+        '  label_prefix: symphony',
+        '---',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+
+    await readyWindow.getByRole('button', { name: /Refresh workflow board/i }).click()
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText(
+      'Live data · github · labels · kata-sh/kata-mono',
+    )
+    await expect(readyWindow.getByText(/#2249 · \[S02\] GitHub Workflow Board Parity/i)).toBeVisible()
+    await expect(readyWindow.getByText(/#2250 · \[S03\] Workflow Context Switching and Failure Visibility/i)).toBeVisible()
+  })
+
+  test('renders github projects v2 mode snapshot through the runtime board path', async ({ readyWindow, workspaceDir }) => {
+    writeFileSync(
+      path.join(workspaceDir, 'WORKFLOW.md'),
+      [
+        '---',
+        'tracker:',
+        '  kind: github',
+        '  repo_owner: kata-sh',
+        '  repo_name: kata-mono',
+        '  github_project_number: 7',
+        '---',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+
+    await readyWindow.getByRole('button', { name: /Refresh workflow board/i }).click()
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText(
+      'Live data · github · projects_v2 · kata-sh/kata-mono',
+    )
+    await expect(readyWindow.getByText(/#2249 · \[S02\] GitHub Workflow Board Parity/i)).toBeVisible()
+    await expect(readyWindow.getByText(/#2251 · \[S04\] End-to-End Kanban Integration Proof/i)).toBeVisible()
+  })
+
+  test('documents live github smoke path for parity proof', async ({ readyWindow }) => {
+    // Manual smoke path:
+    // 1. Launch Desktop without KATA_TEST_MODE and open a GitHub-backed workspace (WORKFLOW.md tracker.kind=github).
+    // 2. Verify board header badge shows backend `github` and mode (`labels` or `projects_v2`).
+    // 3. Confirm cards link to GitHub issues and statuses match either project status field or state labels.
+    // 4. Change one issue state in GitHub, click "Refresh workflow board", and verify the card moves columns.
+    await expect(readyWindow.getByTestId('workflow-board-status')).toBeVisible()
+  })
+})

--- a/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { GithubWorkflowClient } from '../github-workflow-client'
+
+const originalFetch = globalThis.fetch
+const originalGhToken = process.env.GH_TOKEN
+const originalGithubToken = process.env.GITHUB_TOKEN
+
+describe('GithubWorkflowClient', () => {
+  beforeEach(() => {
+    delete process.env.GH_TOKEN
+    delete process.env.GITHUB_TOKEN
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+
+    if (originalGhToken) {
+      process.env.GH_TOKEN = originalGhToken
+    } else {
+      delete process.env.GH_TOKEN
+    }
+
+    if (originalGithubToken) {
+      process.env.GITHUB_TOKEN = originalGithubToken
+    } else {
+      delete process.env.GITHUB_TOKEN
+    }
+  })
+
+  test('normalizes label mode issues into canonical board columns', async () => {
+    process.env.GH_TOKEN = 'ghp_test'
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          {
+            id: 1001,
+            number: 2249,
+            title: '[S02] GitHub Workflow Board Parity',
+            html_url: 'https://github.com/kata-sh/kata/issues/2249',
+            labels: [{ name: 'symphony:in-progress' }],
+          },
+          {
+            id: 1002,
+            number: 2250,
+            title: '[S03] Workflow Context Switching',
+            labels: [{ name: 'bug' }],
+          },
+          {
+            id: 1003,
+            number: 2251,
+            title: 'PR item',
+            pull_request: { url: 'https://api.github.com/repos/kata-sh/kata/pulls/2251' },
+            labels: [{ name: 'symphony:todo' }],
+          },
+        ]),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch
+
+    const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    const snapshot = await client.fetchSnapshot({
+      config: {
+        kind: 'github',
+        repoOwner: 'kata-sh',
+        repoName: 'kata',
+        stateMode: 'labels',
+        labelPrefix: 'symphony',
+      },
+    })
+
+    expect(snapshot.backend).toBe('github')
+    expect(snapshot.source.githubStateMode).toBe('labels')
+    expect(snapshot.columns.find((column) => column.id === 'in_progress')?.cards[0]).toMatchObject({
+      identifier: '#2249',
+      stateName: 'In Progress',
+    })
+    expect(snapshot.columns.find((column) => column.id === 'todo')?.cards).toHaveLength(0)
+  })
+
+  test('normalizes projects v2 status into canonical board columns', async () => {
+    process.env.GH_TOKEN = 'ghp_test'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              user: {
+                projectV2: {
+                  id: 'PVT_kwDOG7',
+                  field: { id: 'PVTSSF_kwDOG7_status' },
+                },
+              },
+              organization: null,
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                items: {
+                  nodes: [
+                    {
+                      id: 'PVTI_1',
+                      content: {
+                        id: 'I_kwDOA',
+                        number: 2249,
+                        title: '[S02] GitHub Workflow Board Parity',
+                        url: 'https://github.com/kata-sh/kata/issues/2249',
+                      },
+                      fieldValueByName: {
+                        name: 'Agent Review',
+                        optionId: 'opt_1',
+                      },
+                    },
+                  ],
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    const snapshot = await client.fetchSnapshot({
+      config: {
+        kind: 'github',
+        repoOwner: 'kata-sh',
+        repoName: 'kata',
+        stateMode: 'projects_v2',
+        githubProjectNumber: 7,
+      },
+    })
+
+    expect(snapshot.backend).toBe('github')
+    expect(snapshot.source.githubStateMode).toBe('projects_v2')
+    expect(snapshot.activeMilestone?.name).toBe('GitHub Project #7')
+    expect(snapshot.columns.find((column) => column.id === 'agent_review')?.cards[0]).toMatchObject({
+      identifier: '#2249',
+      stateName: 'Agent Review',
+    })
+  })
+
+  test('maps missing token to MISSING_API_KEY', async () => {
+    const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(
+      client.fetchSnapshot({
+        config: {
+          kind: 'github',
+          repoOwner: 'kata-sh',
+          repoName: 'kata',
+          stateMode: 'labels',
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'MISSING_API_KEY' })
+  })
+})

--- a/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
@@ -189,6 +189,24 @@ describe('GithubWorkflowClient', () => {
     expect((globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2)
   })
 
+  test('treats empty REST response body as empty issue list', async () => {
+    process.env.GH_TOKEN = 'ghp_test'
+
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response('', { status: 200 })) as unknown as typeof fetch
+
+    const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+    const snapshot = await client.fetchSnapshot({
+      config: {
+        kind: 'github',
+        repoOwner: 'kata-sh',
+        repoName: 'kata',
+        stateMode: 'labels',
+      },
+    })
+
+    expect(snapshot.status).toBe('empty')
+  })
+
   test('uses authBridge token fallback when GH_TOKEN is absent', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify([]), { status: 200 })) as unknown as typeof fetch
 

--- a/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
@@ -154,6 +154,142 @@ describe('GithubWorkflowClient', () => {
     })
   })
 
+  test('paginates label mode issue requests and returns empty state when no mapped labels are present', async () => {
+    process.env.GH_TOKEN = 'ghp_test'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify(
+            Array.from({ length: 100 }, (_value, index) => ({
+              id: 2000 + index,
+              number: 3000 + index,
+              title: `Issue ${index}`,
+              labels: [{ name: 'bug' }],
+            })),
+          ),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 })) as unknown as typeof fetch
+
+    const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+    const snapshot = await client.fetchSnapshot({
+      config: {
+        kind: 'github',
+        repoOwner: 'kata-sh',
+        repoName: 'kata',
+        stateMode: 'labels',
+      },
+    })
+
+    expect(snapshot.status).toBe('empty')
+    expect(snapshot.emptyReason).toContain('symphony:')
+    expect((globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2)
+  })
+
+  test('uses authBridge token fallback when GH_TOKEN is absent', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify([]), { status: 200 })) as unknown as typeof fetch
+
+    const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => 'bridge_token') } as never)
+    await client.fetchSnapshot({
+      config: {
+        kind: 'github',
+        repoOwner: 'kata-sh',
+        repoName: 'kata',
+        stateMode: 'labels',
+      },
+    })
+
+    const request = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(request?.[1]?.headers?.authorization).toBe('Bearer bridge_token')
+  })
+
+  test('maps GitHub HTTP and GraphQL failures to structured errors', async () => {
+    process.env.GH_TOKEN = 'ghp_test'
+
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response('{}', { status: 401 })) as unknown as typeof fetch
+    const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+    await expect(
+      client.fetchSnapshot({
+        config: {
+          kind: 'github',
+          repoOwner: 'kata-sh',
+          repoName: 'kata',
+          stateMode: 'labels',
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response('{}', { status: 404 })) as unknown as typeof fetch
+    await expect(
+      client.fetchSnapshot({
+        config: {
+          kind: 'github',
+          repoOwner: 'kata-sh',
+          repoName: 'kata',
+          stateMode: 'labels',
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { user: { projectV2: { id: 'p1', field: { id: 'f1' } } }, organization: null } }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errors: [{ message: 'bad graphql' }] }), { status: 200 })) as unknown as typeof fetch
+
+    await expect(
+      client.fetchSnapshot({
+        config: {
+          kind: 'github',
+          repoOwner: 'kata-sh',
+          repoName: 'kata',
+          stateMode: 'projects_v2',
+          githubProjectNumber: 7,
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'GRAPHQL' })
+  })
+
+  test('maps invalid projects v2 config and missing project to explicit errors', async () => {
+    process.env.GH_TOKEN = 'ghp_test'
+
+    const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(
+      client.fetchSnapshot({
+        config: {
+          kind: 'github',
+          repoOwner: 'kata-sh',
+          repoName: 'kata',
+          stateMode: 'projects_v2',
+        } as any,
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_CONFIG' })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { user: { projectV2: null }, organization: null } }), { status: 200 }),
+    ) as unknown as typeof fetch
+
+    await expect(
+      client.fetchSnapshot({
+        config: {
+          kind: 'github',
+          repoOwner: 'kata-sh',
+          repoName: 'kata',
+          stateMode: 'projects_v2',
+          githubProjectNumber: 7,
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
   test('maps missing token to MISSING_API_KEY', async () => {
     const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
 
@@ -167,5 +303,17 @@ describe('GithubWorkflowClient', () => {
         },
       }),
     ).rejects.toMatchObject({ code: 'MISSING_API_KEY' })
+  })
+
+  test('maps unknown errors through toWorkflowError helper', () => {
+    expect(GithubWorkflowClient.toWorkflowError(new TypeError('network fail'))).toEqual({
+      code: 'NETWORK',
+      message: 'network fail',
+    })
+
+    expect(GithubWorkflowClient.toWorkflowError(new Error('boom'))).toEqual({
+      code: 'UNKNOWN',
+      message: 'boom',
+    })
   })
 })

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { WorkflowBoardService } from '../workflow-board-service'
 
 const originalFixtureFlag = process.env.KATA_TEST_WORKFLOW_FIXTURE
+const originalTestMode = process.env.KATA_TEST_MODE
 
 describe('WorkflowBoardService', () => {
   beforeEach(() => {
@@ -18,10 +19,16 @@ describe('WorkflowBoardService', () => {
     } else {
       delete process.env.KATA_TEST_WORKFLOW_FIXTURE
     }
+
+    if (originalTestMode !== undefined) {
+      process.env.KATA_TEST_MODE = originalTestMode
+    } else {
+      delete process.env.KATA_TEST_MODE
+    }
   })
 
   test('returns deterministic fixture snapshot when fixture mode is enabled', async () => {
-    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = 'linear'
 
     const service = new WorkflowBoardService({
       authBridge: { getApiKey: vi.fn(async () => null) } as never,
@@ -31,6 +38,7 @@ describe('WorkflowBoardService', () => {
     const response = await service.getBoard()
     expect(response.success).toBe(true)
     expect(response.snapshot.status).toBe('fresh')
+    expect(response.snapshot.backend).toBe('linear')
     expect(response.snapshot.columns.find((column) => column.id === 'todo')?.cards).toHaveLength(1)
   })
 
@@ -47,7 +55,7 @@ describe('WorkflowBoardService', () => {
   })
 
   test('getBoard reuses cached snapshot after first refresh', async () => {
-    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = 'linear'
 
     const service = new WorkflowBoardService({
       authBridge: { getApiKey: vi.fn(async () => null) } as never,
@@ -140,7 +148,31 @@ describe('WorkflowBoardService', () => {
     const response = await service.refreshBoard()
     expect(response.snapshot.status).toBe('error')
     expect(response.snapshot.lastError?.code).toBe('UNKNOWN')
-    expect(response.snapshot.lastError?.message).toContain('Unable to read .kata/preferences.md')
+    expect(response.snapshot.lastError?.message).toContain('Unable to read WORKFLOW.md')
+  })
+
+  test('refreshes GitHub fixture mode based on WORKFLOW tracker config in test mode', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-github-fixture-'))
+    writeFileSync(
+      path.join(workspacePath, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: github', '  repo_owner: kata-sh', '  repo_name: kata', '  github_project_number: 7', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const response = await service.refreshBoard()
+
+    expect(response.snapshot.backend).toBe('github')
+    expect(response.snapshot.source.githubStateMode).toBe('projects_v2')
+    expect(response.snapshot.columns.find((column) => column.id === 'agent_review')?.cards).toHaveLength(1)
+
+    delete process.env.KATA_TEST_MODE
   })
 
   test('deduplicates concurrent refresh requests to a single Linear fetch', async () => {

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -147,6 +147,7 @@ describe('WorkflowBoardService', () => {
 
     const response = await service.refreshBoard()
     expect(response.snapshot.status).toBe('error')
+    expect(response.snapshot.backend).toBe('linear')
     expect(response.snapshot.lastError?.code).toBe('UNKNOWN')
     expect(response.snapshot.lastError?.message).toContain('Unable to read WORKFLOW.md')
   })
@@ -171,8 +172,6 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.backend).toBe('github')
     expect(response.snapshot.source.githubStateMode).toBe('projects_v2')
     expect(response.snapshot.columns.find((column) => column.id === 'agent_review')?.cards).toHaveLength(1)
-
-    delete process.env.KATA_TEST_MODE
   })
 
   test('returns github error snapshot when github refresh fails without prior cache', async () => {

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -175,6 +175,126 @@ describe('WorkflowBoardService', () => {
     delete process.env.KATA_TEST_MODE
   })
 
+  test('returns github error snapshot when github refresh fails without prior cache', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-github-error-'))
+    writeFileSync(
+      path.join(workspacePath, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: github', '  repo_owner: kata-sh', '  repo_name: kata', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    ;(service as any).githubClient.fetchSnapshot = vi.fn(async () => {
+      throw new Error('github offline')
+    })
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.backend).toBe('github')
+    expect(response.snapshot.status).toBe('error')
+    expect(response.snapshot.lastError?.message).toContain('github offline')
+    expect(response.snapshot.source.repoOwner).toBe('kata-sh')
+  })
+
+  test('returns stale github snapshot when github refresh fails after a successful fetch', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-github-stale-'))
+    writeFileSync(
+      path.join(workspacePath, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: github', '  repo_owner: kata-sh', '  repo_name: kata', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    ;(service as any).githubClient.fetchSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({
+        backend: 'github',
+        fetchedAt: '2026-04-04T00:00:00.000Z',
+        status: 'fresh',
+        source: {
+          projectId: 'github:kata-sh/kata',
+          trackerKind: 'github',
+          githubStateMode: 'labels',
+          repoOwner: 'kata-sh',
+          repoName: 'kata',
+        },
+        activeMilestone: null,
+        columns: [],
+        poll: { status: 'success', backend: 'github', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+      })
+      .mockRejectedValueOnce(new Error('github down'))
+
+    const first = await service.refreshBoard()
+    expect(first.snapshot.status).toBe('fresh')
+
+    const second = await service.refreshBoard()
+    expect(second.snapshot.status).toBe('stale')
+    expect(second.snapshot.lastError?.message).toContain('github down')
+    expect(second.snapshot.poll.status).toBe('error')
+  })
+
+  test('uses explicit github_labels fixture mode override', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = 'github_labels'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.backend).toBe('github')
+    expect(response.snapshot.source.githubStateMode).toBe('labels')
+  })
+
+  test('treats preferences without frontmatter as not configured', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-no-frontmatter-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(path.join(workspacePath, '.kata', 'preferences.md'), 'projectId: demo\n', 'utf8')
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.lastError?.code).toBe('NOT_CONFIGURED')
+  })
+
+  test('falls back to projectSlug when projectId is empty in preferences', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-empty-projectid-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectId: ""', 'projectSlug: slug-ref', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(async ({ projectRef }: { projectRef: string }) => ({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'empty',
+      source: { projectId: projectRef },
+      activeMilestone: null,
+      columns: [],
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    }))
+
+    const response = await service.refreshBoard()
+    expect(response.snapshot.source.projectId).toBe('slug-ref')
+  })
+
   test('deduplicates concurrent refresh requests to a single Linear fetch', async () => {
     const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-concurrent-'))
     mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })

--- a/apps/desktop/src/main/__tests__/workflow-config-reader.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-config-reader.test.ts
@@ -53,6 +53,103 @@ describe('readWorkspaceWorkflowTrackerConfig', () => {
     })
   })
 
+  test('returns linear config when tracker is missing or non-github', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-linear-'))
+    writeFileSync(
+      path.join(workspace, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: linear', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspace)
+    expect(result).toEqual({ config: { kind: 'linear' } })
+  })
+
+  test('returns INVALID_CONFIG when github repo fields are missing', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-missing-repo-'))
+    writeFileSync(
+      path.join(workspace, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: github', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspace)
+    expect(result.config).toBeNull()
+    expect(result.error?.code).toBe('INVALID_CONFIG')
+  })
+
+  test('returns INVALID_CONFIG when github_project_number is invalid', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-invalid-project-'))
+    writeFileSync(
+      path.join(workspace, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: github', '  repo_owner: kata-sh', '  repo_name: kata-mono', '  github_project_number: nope', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspace)
+    expect(result.config).toBeNull()
+    expect(result.error?.code).toBe('INVALID_CONFIG')
+  })
+
+  test('preserves quoted values containing hash characters', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-hash-value-'))
+    writeFileSync(
+      path.join(workspace, 'WORKFLOW.md'),
+      [
+        '---',
+        'tracker:',
+        '  kind: github',
+        '  repo_owner: kata-sh',
+        '  repo_name: kata-mono',
+        "  label_prefix: 'sym#flow'",
+        '---',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspace)
+    expect(result.config).toMatchObject({
+      kind: 'github',
+      stateMode: 'labels',
+      labelPrefix: 'sym#flow',
+    })
+  })
+
+  test('strips inline comments from unquoted values but keeps hashes inside double quotes', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-inline-comment-'))
+    writeFileSync(
+      path.join(workspace, 'WORKFLOW.md'),
+      [
+        '---',
+        'tracker:',
+        '  kind: github',
+        '  repo_owner: kata-sh',
+        '  repo_name: kata-mono',
+        '  label_prefix: "sym#flow" # inline comment',
+        '---',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspace)
+    expect(result.config).toMatchObject({
+      kind: 'github',
+      stateMode: 'labels',
+      labelPrefix: 'sym#flow',
+    })
+  })
+
+  test('returns UNKNOWN when WORKFLOW path cannot be read due to invalid workspace', async () => {
+    const workspacePath = path.join(tmpdir(), 'workflow-config-not-a-dir')
+    writeFileSync(workspacePath, 'not-a-dir', 'utf8')
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspacePath)
+    expect(result.config).toBeNull()
+    expect(result.error?.code).toBe('UNKNOWN')
+  })
+
   test('parses github projects v2 mode tracker config', async () => {
     const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-github-projects-'))
     mkdirSync(workspace, { recursive: true })

--- a/apps/desktop/src/main/__tests__/workflow-config-reader.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-config-reader.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
@@ -152,7 +152,6 @@ describe('readWorkspaceWorkflowTrackerConfig', () => {
 
   test('parses github projects v2 mode tracker config', async () => {
     const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-github-projects-'))
-    mkdirSync(workspace, { recursive: true })
     writeFileSync(
       path.join(workspace, 'WORKFLOW.md'),
       [

--- a/apps/desktop/src/main/__tests__/workflow-config-reader.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-config-reader.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { readWorkspaceWorkflowTrackerConfig } from '../workflow-config-reader'
+
+describe('readWorkspaceWorkflowTrackerConfig', () => {
+  test('returns null config when WORKFLOW.md is missing', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-missing-'))
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspace)
+
+    expect(result.config).toBeNull()
+    expect(result.error).toBeUndefined()
+  })
+
+  test('returns INVALID_CONFIG when frontmatter is malformed', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-malformed-'))
+    writeFileSync(path.join(workspace, 'WORKFLOW.md'), '# no frontmatter\n', 'utf8')
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspace)
+
+    expect(result.config).toBeNull()
+    expect(result.error?.code).toBe('INVALID_CONFIG')
+  })
+
+  test('parses github label mode tracker config', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-github-labels-'))
+    writeFileSync(
+      path.join(workspace, 'WORKFLOW.md'),
+      [
+        '---',
+        'tracker:',
+        '  kind: github',
+        '  repo_owner: kata-sh',
+        '  repo_name: kata-mono',
+        '  label_prefix: symphony',
+        '---',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspace)
+
+    expect(result.error).toBeUndefined()
+    expect(result.config).toEqual({
+      kind: 'github',
+      repoOwner: 'kata-sh',
+      repoName: 'kata-mono',
+      stateMode: 'labels',
+      labelPrefix: 'symphony',
+    })
+  })
+
+  test('parses github projects v2 mode tracker config', async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-github-projects-'))
+    mkdirSync(workspace, { recursive: true })
+    writeFileSync(
+      path.join(workspace, 'WORKFLOW.md'),
+      [
+        '---',
+        'tracker:',
+        '  kind: github',
+        '  repo_owner: kata-sh',
+        '  repo_name: kata-mono',
+        '  github_project_number: 7',
+        '---',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+
+    const result = await readWorkspaceWorkflowTrackerConfig(workspace)
+
+    expect(result.error).toBeUndefined()
+    expect(result.config).toEqual({
+      kind: 'github',
+      repoOwner: 'kata-sh',
+      repoName: 'kata-mono',
+      stateMode: 'projects_v2',
+      githubProjectNumber: 7,
+      labelPrefix: undefined,
+    })
+  })
+})

--- a/apps/desktop/src/main/github-workflow-client.ts
+++ b/apps/desktop/src/main/github-workflow-client.ts
@@ -1,0 +1,593 @@
+import { AuthBridge } from './auth-bridge'
+import log from './logger'
+import {
+  type WorkflowBoardErrorCode,
+  type WorkflowBoardSliceCard,
+  type WorkflowBoardSnapshot,
+  type WorkflowTrackerConfig,
+} from '../shared/types'
+import { createEmptyWorkflowColumns, mapLinearStateToColumnId } from './linear-workflow-client'
+
+const GITHUB_API_URL = 'https://api.github.com'
+const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql'
+const REQUEST_TIMEOUT_MS = 12_000
+const PAGE_SIZE = 100
+
+interface GithubIssueLabel {
+  name?: string
+}
+
+interface GithubIssueResponse {
+  id?: number
+  number?: number
+  title?: string
+  html_url?: string
+  labels?: GithubIssueLabel[]
+  pull_request?: unknown
+}
+
+interface GithubProjectsGraphqlEnvelope<TData> {
+  data?: TData
+  errors?: Array<{ message?: string }>
+}
+
+interface GithubProjectsFieldResponse {
+  user?: GithubProjectsOwner | null
+  organization?: GithubProjectsOwner | null
+}
+
+interface GithubProjectsOwner {
+  projectV2?: GithubProjectsNode | null
+}
+
+interface GithubProjectsNode {
+  id?: string
+  field?: {
+    id?: string
+    options?: Array<{
+      id?: string
+      name?: string
+    }>
+  } | null
+}
+
+interface GithubProjectItemNode {
+  id?: string
+  content?: {
+    id?: string
+    number?: number
+    title?: string
+    url?: string
+    labels?: { nodes?: Array<{ name?: string }> }
+  } | null
+  fieldValueByName?: {
+    name?: string
+    optionId?: string
+  } | null
+}
+
+interface GithubProjectsItemsResponse {
+  node?: {
+    items?: {
+      nodes?: GithubProjectItemNode[]
+      pageInfo?: {
+        hasNextPage?: boolean
+        endCursor?: string | null
+      }
+    }
+  } | null
+}
+
+interface FetchGithubBoardOptions {
+  config: Extract<WorkflowTrackerConfig, { kind: 'github' }>
+}
+
+export class GithubWorkflowClientError extends Error {
+  constructor(
+    public readonly code: WorkflowBoardErrorCode,
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message)
+    this.name = 'GithubWorkflowClientError'
+  }
+}
+
+export class GithubWorkflowClient {
+  constructor(private readonly authBridge: AuthBridge) {}
+
+  async fetchSnapshot(options: FetchGithubBoardOptions): Promise<WorkflowBoardSnapshot> {
+    const { config } = options
+    const token = await this.requireApiToken()
+
+    const startedAt = Date.now()
+
+    const snapshot =
+      config.stateMode === 'projects_v2'
+        ? await this.fetchProjectsV2Snapshot(token, config)
+        : await this.fetchLabelModeSnapshot(token, config)
+
+    log.info('[github-workflow-client] workflow:fetch', {
+      repo: `${config.repoOwner}/${config.repoName}`,
+      mode: config.stateMode,
+      status: snapshot.status,
+      cardCount: snapshot.columns.reduce((count, column) => count + column.cards.length, 0),
+      latencyMs: Date.now() - startedAt,
+    })
+
+    return snapshot
+  }
+
+  static toWorkflowError(error: unknown): { code: WorkflowBoardErrorCode; message: string } {
+    const normalized = toGithubWorkflowClientError(error)
+    return {
+      code: normalized.code,
+      message: normalized.message,
+    }
+  }
+
+  private async fetchLabelModeSnapshot(
+    token: string,
+    config: Extract<WorkflowTrackerConfig, { kind: 'github' }>,
+  ): Promise<WorkflowBoardSnapshot> {
+    const prefix = config.labelPrefix?.trim() || 'symphony'
+
+    const issues = await this.fetchAllRepoIssues(token, config.repoOwner, config.repoName)
+    const cards: WorkflowBoardSliceCard[] = []
+    let unlabeledCount = 0
+
+    for (const issue of issues) {
+      if (issue.pull_request) {
+        continue
+      }
+
+      const issueNumber = issue.number
+      const issueTitle = issue.title?.trim()
+      if (!issueNumber || !issueTitle) {
+        continue
+      }
+
+      const parsedState = extractStateFromLabels(issue.labels ?? [], prefix)
+      if (!parsedState) {
+        unlabeledCount += 1
+        continue
+      }
+
+      cards.push({
+        id: String(issue.id ?? issueNumber),
+        identifier: `#${issueNumber}`,
+        title: issueTitle,
+        url: issue.html_url,
+        columnId: mapLinearStateToColumnId(parsedState.displayState, undefined),
+        stateName: parsedState.displayState,
+        stateType: 'label',
+        milestoneId: `github:${config.repoOwner}/${config.repoName}`,
+        milestoneName: `${config.repoOwner}/${config.repoName}`,
+        taskCounts: { total: 0, done: 0 },
+        tasks: [],
+      })
+    }
+
+    const hasCards = cards.length > 0
+    const nowIso = new Date().toISOString()
+    const columns = createEmptyWorkflowColumns()
+
+    for (const card of cards) {
+      const column = columns.find((entry) => entry.id === card.columnId)
+      column?.cards.push(card)
+    }
+
+    for (const column of columns) {
+      column.cards.sort((left, right) => left.identifier.localeCompare(right.identifier))
+    }
+
+    return {
+      backend: 'github',
+      fetchedAt: nowIso,
+      status: hasCards ? 'fresh' : 'empty',
+      source: {
+        projectId: `github:${config.repoOwner}/${config.repoName}`,
+        trackerKind: 'github',
+        githubStateMode: 'labels',
+        repoOwner: config.repoOwner,
+        repoName: config.repoName,
+      },
+      activeMilestone: null,
+      columns,
+      emptyReason: hasCards
+        ? undefined
+        : unlabeledCount > 0
+          ? `No open issues have workflow labels with prefix "${prefix}:".`
+          : 'No open GitHub issues found for workflow board.',
+      poll: {
+        status: 'success',
+        backend: 'github',
+        lastAttemptAt: nowIso,
+      },
+    }
+  }
+
+  private async fetchProjectsV2Snapshot(
+    token: string,
+    config: Extract<WorkflowTrackerConfig, { kind: 'github' }>,
+  ): Promise<WorkflowBoardSnapshot> {
+    const projectNumber = config.githubProjectNumber
+    if (!projectNumber) {
+      throw new GithubWorkflowClientError(
+        'INVALID_CONFIG',
+        'GitHub Projects v2 mode requires tracker.github_project_number.',
+      )
+    }
+
+    const projectField = await this.resolveProjectsV2Field(token, config.repoOwner, projectNumber)
+
+    if (!projectField.projectId || !projectField.statusFieldId) {
+      throw new GithubWorkflowClientError(
+        'NOT_FOUND',
+        `GitHub project #${projectNumber} not found for owner ${config.repoOwner}.`,
+      )
+    }
+
+    const items = await this.fetchProjectsV2Items(token, projectField.projectId)
+
+    const cards: WorkflowBoardSliceCard[] = []
+    for (const item of items) {
+      const issueNumber = item.content?.number
+      const issueTitle = item.content?.title?.trim()
+      if (!issueNumber || !issueTitle) {
+        continue
+      }
+
+      const stateName = item.fieldValueByName?.name?.trim() || 'Unknown'
+
+      cards.push({
+        id: item.content?.id || String(issueNumber),
+        identifier: `#${issueNumber}`,
+        title: issueTitle,
+        url: item.content?.url,
+        columnId: mapLinearStateToColumnId(stateName, undefined),
+        stateName,
+        stateType: 'projects_v2',
+        milestoneId: `github-project:${projectNumber}`,
+        milestoneName: `GitHub Project #${projectNumber}`,
+        taskCounts: { total: 0, done: 0 },
+        tasks: [],
+      })
+    }
+
+    const hasCards = cards.length > 0
+    const nowIso = new Date().toISOString()
+    const columns = createEmptyWorkflowColumns()
+
+    for (const card of cards) {
+      const column = columns.find((entry) => entry.id === card.columnId)
+      column?.cards.push(card)
+    }
+
+    for (const column of columns) {
+      column.cards.sort((left, right) => left.identifier.localeCompare(right.identifier))
+    }
+
+    return {
+      backend: 'github',
+      fetchedAt: nowIso,
+      status: hasCards ? 'fresh' : 'empty',
+      source: {
+        projectId: `github:${config.repoOwner}/${config.repoName}`,
+        trackerKind: 'github',
+        githubStateMode: 'projects_v2',
+        repoOwner: config.repoOwner,
+        repoName: config.repoName,
+      },
+      activeMilestone: {
+        id: `github-project:${projectNumber}`,
+        name: `GitHub Project #${projectNumber}`,
+      },
+      columns,
+      emptyReason: hasCards ? undefined : 'No GitHub project issues matched workflow board.',
+      poll: {
+        status: 'success',
+        backend: 'github',
+        lastAttemptAt: nowIso,
+      },
+    }
+  }
+
+  private async resolveProjectsV2Field(token: string, owner: string, projectNumber: number): Promise<{
+    projectId: string | null
+    statusFieldId: string | null
+  }> {
+    const query = `
+      query($projectNumber: Int!, $owner: String!) {
+        user(login: $owner) {
+          projectV2(number: $projectNumber) {
+            id
+            field(name: "Status") {
+              ... on ProjectV2SingleSelectField {
+                id
+              }
+            }
+          }
+        }
+        organization(login: $owner) {
+          projectV2(number: $projectNumber) {
+            id
+            field(name: "Status") {
+              ... on ProjectV2SingleSelectField {
+                id
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await this.graphqlRequest<GithubProjectsFieldResponse>(token, query, {
+      owner,
+      projectNumber,
+    })
+
+    const project = data.user?.projectV2 ?? data.organization?.projectV2
+
+    return {
+      projectId: project?.id?.trim() || null,
+      statusFieldId: project?.field?.id?.trim() || null,
+    }
+  }
+
+  private async fetchProjectsV2Items(
+    token: string,
+    projectId: string,
+  ): Promise<GithubProjectItemNode[]> {
+    const query = `
+      query($projectId: ID!, $first: Int!, $after: String) {
+        node(id: $projectId) {
+          ... on ProjectV2 {
+            items(first: $first, after: $after) {
+              nodes {
+                id
+                content {
+                  ... on Issue {
+                    id
+                    number
+                    title
+                    url
+                    labels(first: 20) {
+                      nodes {
+                        name
+                      }
+                    }
+                  }
+                }
+                fieldValueByName(name: "Status") {
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    optionId
+                  }
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const items: GithubProjectItemNode[] = []
+    let after: string | null = null
+
+    do {
+      const data: GithubProjectsItemsResponse = await this.graphqlRequest<GithubProjectsItemsResponse>(
+        token,
+        query,
+        {
+          projectId,
+          first: PAGE_SIZE,
+          after,
+        },
+      )
+
+      const pageNodes: GithubProjectItemNode[] = data.node?.items?.nodes ?? []
+      items.push(...pageNodes)
+
+      const pageInfo = data.node?.items?.pageInfo
+      after = pageInfo?.hasNextPage ? pageInfo.endCursor ?? null : null
+    } while (after)
+
+    return items
+  }
+
+  private async fetchAllRepoIssues(
+    token: string,
+    repoOwner: string,
+    repoName: string,
+  ): Promise<GithubIssueResponse[]> {
+    const issues: GithubIssueResponse[] = []
+
+    for (let page = 1; page <= 10; page += 1) {
+      const pageItems = await this.restRequest<GithubIssueResponse[]>(
+        token,
+        `/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/issues?state=open&per_page=${PAGE_SIZE}&page=${page}`,
+      )
+
+      issues.push(...pageItems)
+      if (pageItems.length < PAGE_SIZE) {
+        break
+      }
+    }
+
+    return issues
+  }
+
+  private async restRequest<T>(token: string, endpoint: string): Promise<T> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+    let response: Response
+    try {
+      response = await fetch(`${GITHUB_API_URL}${endpoint}`, {
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+        },
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timeout)
+    }
+
+    return this.readJsonOrThrow<T>(response)
+  }
+
+  private async graphqlRequest<TData>(
+    token: string,
+    query: string,
+    variables: Record<string, unknown>,
+  ): Promise<TData> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+    let response: Response
+    try {
+      response = await fetch(GITHUB_GRAPHQL_URL, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+        },
+        body: JSON.stringify({ query, variables }),
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timeout)
+    }
+
+    const payload = await this.readJsonOrThrow<GithubProjectsGraphqlEnvelope<TData>>(response)
+
+    if (payload.errors?.length) {
+      throw new GithubWorkflowClientError('GRAPHQL', payload.errors[0]?.message || 'GitHub GraphQL error')
+    }
+
+    return (payload.data ?? {}) as TData
+  }
+
+  private async readJsonOrThrow<T>(response: Response): Promise<T> {
+    if (response.status === 401 || response.status === 403) {
+      throw new GithubWorkflowClientError('UNAUTHORIZED', 'Invalid GitHub token', response.status)
+    }
+
+    if (response.status === 404) {
+      throw new GithubWorkflowClientError('NOT_FOUND', 'GitHub repository or project not found', response.status)
+    }
+
+    if (response.status === 429) {
+      throw new GithubWorkflowClientError('RATE_LIMITED', 'GitHub API rate limit exceeded', response.status)
+    }
+
+    const text = await response.text().catch(() => '')
+
+    if (!response.ok) {
+      throw new GithubWorkflowClientError(
+        'NETWORK',
+        `GitHub API request failed with status ${response.status}`,
+        response.status,
+      )
+    }
+
+    return (text ? JSON.parse(text) : {}) as T
+  }
+
+  private async requireApiToken(): Promise<string> {
+    const envToken = process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim()
+    if (envToken) {
+      return envToken
+    }
+
+    const authToken = (await this.authBridge.getApiKey('github'))?.trim()
+    if (authToken) {
+      return authToken
+    }
+
+    throw new GithubWorkflowClientError(
+      'MISSING_API_KEY',
+      'GitHub token required. Set GH_TOKEN/GITHUB_TOKEN or configure provider "github" in auth.json.',
+    )
+  }
+}
+
+function extractStateFromLabels(
+  labels: GithubIssueLabel[],
+  prefix: string,
+): { normalizedState: string; displayState: string } | null {
+  const marker = `${prefix.toLowerCase()}:`
+
+  for (const label of labels) {
+    const labelName = label.name?.trim()
+    if (!labelName) {
+      continue
+    }
+
+    const lower = labelName.toLowerCase()
+    if (!lower.startsWith(marker)) {
+      continue
+    }
+
+    const suffix = labelName.split(':').slice(1).join(':').trim()
+    if (!suffix) {
+      continue
+    }
+
+    const normalizedState = suffix
+      .toLowerCase()
+      .replace(/_/g, '-')
+      .split(/\s+/)
+      .filter(Boolean)
+      .join('-')
+
+    return {
+      normalizedState,
+      displayState: denormalizeLabelState(normalizedState),
+    }
+  }
+
+  return null
+}
+
+function denormalizeLabelState(value: string): string {
+  return value
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function toGithubWorkflowClientError(error: unknown): GithubWorkflowClientError {
+  if (error instanceof GithubWorkflowClientError) {
+    return error
+  }
+
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return new GithubWorkflowClientError('NETWORK', 'GitHub API request timed out')
+  }
+
+  if (error instanceof TypeError) {
+    return new GithubWorkflowClientError('NETWORK', error.message)
+  }
+
+  if (error instanceof SyntaxError) {
+    return new GithubWorkflowClientError('GRAPHQL', `Invalid GitHub API response: ${error.message}`)
+  }
+
+  if (error instanceof Error) {
+    return new GithubWorkflowClientError('UNKNOWN', error.message)
+  }
+
+  return new GithubWorkflowClientError('UNKNOWN', String(error))
+}

--- a/apps/desktop/src/main/github-workflow-client.ts
+++ b/apps/desktop/src/main/github-workflow-client.ts
@@ -12,6 +12,7 @@ const GITHUB_API_URL = 'https://api.github.com'
 const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql'
 const REQUEST_TIMEOUT_MS = 12_000
 const PAGE_SIZE = 100
+const MAX_REST_PAGES = 10
 
 interface GithubIssueLabel {
   name?: string
@@ -400,29 +401,44 @@ export class GithubWorkflowClient {
     return items
   }
 
+  // We intentionally cap REST pagination to MAX_REST_PAGES * PAGE_SIZE (1000 issues)
+  // to avoid excessive API calls for very large repositories.
   private async fetchAllRepoIssues(
     token: string,
     repoOwner: string,
     repoName: string,
   ): Promise<GithubIssueResponse[]> {
     const issues: GithubIssueResponse[] = []
+    let reachedPaginationCap = false
 
-    for (let page = 1; page <= 10; page += 1) {
+    for (let page = 1; page <= MAX_REST_PAGES; page += 1) {
       const pageItems = await this.restRequest<GithubIssueResponse[]>(
         token,
         `/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/issues?state=open&per_page=${PAGE_SIZE}&page=${page}`,
+        [],
       )
 
       issues.push(...pageItems)
       if (pageItems.length < PAGE_SIZE) {
+        reachedPaginationCap = false
         break
       }
+
+      reachedPaginationCap = page === MAX_REST_PAGES
+    }
+
+    if (reachedPaginationCap) {
+      log.warn('[github-workflow-client] issue pagination cap reached; snapshot may be truncated', {
+        repo: `${repoOwner}/${repoName}`,
+        maxPages: MAX_REST_PAGES,
+        pageSize: PAGE_SIZE,
+      })
     }
 
     return issues
   }
 
-  private async restRequest<T>(token: string, endpoint: string): Promise<T> {
+  private async restRequest<T>(token: string, endpoint: string, defaultEmptyResponse?: T): Promise<T> {
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
 
@@ -441,7 +457,7 @@ export class GithubWorkflowClient {
       clearTimeout(timeout)
     }
 
-    return this.readJsonOrThrow<T>(response)
+    return this.readJsonOrThrow<T>(response, defaultEmptyResponse)
   }
 
   private async graphqlRequest<TData>(
@@ -478,7 +494,7 @@ export class GithubWorkflowClient {
     return (payload.data ?? {}) as TData
   }
 
-  private async readJsonOrThrow<T>(response: Response): Promise<T> {
+  private async readJsonOrThrow<T>(response: Response, defaultEmptyResponse?: T): Promise<T> {
     if (response.status === 401 || response.status === 403) {
       throw new GithubWorkflowClientError('UNAUTHORIZED', 'Invalid GitHub token', response.status)
     }
@@ -501,7 +517,14 @@ export class GithubWorkflowClient {
       )
     }
 
-    return (text ? JSON.parse(text) : {}) as T
+    if (!text.trim()) {
+      if (defaultEmptyResponse !== undefined) {
+        return defaultEmptyResponse
+      }
+      throw new GithubWorkflowClientError('GRAPHQL', 'GitHub API returned an empty response body')
+    }
+
+    return JSON.parse(text) as T
   }
 
   private async requireApiToken(): Promise<string> {
@@ -525,7 +548,7 @@ export class GithubWorkflowClient {
 function extractStateFromLabels(
   labels: GithubIssueLabel[],
   prefix: string,
-): { normalizedState: string; displayState: string } | null {
+): { displayState: string } | null {
   const marker = `${prefix.toLowerCase()}:`
 
   for (const label of labels) {
@@ -544,7 +567,7 @@ function extractStateFromLabels(
       continue
     }
 
-    const normalizedState = suffix
+    const normalized = suffix
       .toLowerCase()
       .replace(/_/g, '-')
       .split(/\s+/)
@@ -552,8 +575,7 @@ function extractStateFromLabels(
       .join('-')
 
     return {
-      normalizedState,
-      displayState: denormalizeLabelState(normalizedState),
+      displayState: denormalizeLabelState(normalized),
     }
   }
 

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -254,10 +254,11 @@ export class WorkflowBoardService {
     const trackerResult = await readWorkspaceWorkflowTrackerConfig(workspacePath)
 
     if (trackerResult.error) {
+      const backend: WorkflowBoardBackend = this.lastSnapshot?.backend === 'github' ? 'github' : 'linear'
       const snapshot = this.toErrorSnapshot({
         nowIso,
-        backend: 'github',
-        projectId: 'github:unknown/unknown',
+        backend,
+        projectId: backend === 'github' ? 'github:unknown/unknown' : 'unknown',
         message: trackerResult.error.message,
         code: trackerResult.error.code,
       })

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -1,19 +1,24 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { AuthBridge } from './auth-bridge'
-import { LinearWorkflowClient } from './linear-workflow-client'
+import { GithubWorkflowClient } from './github-workflow-client'
+import { LinearWorkflowClient, createEmptyWorkflowColumns } from './linear-workflow-client'
 import log from './logger'
+import { readWorkspaceWorkflowTrackerConfig } from './workflow-config-reader'
 import {
+  type WorkflowBoardBackend,
   type WorkflowBoardSnapshot,
   type WorkflowBoardSnapshotResponse,
+  type WorkflowTrackerConfig,
 } from '../shared/types'
 
-const TEST_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
+const TEST_WORKFLOW_FIXTURE_LINEAR: WorkflowBoardSnapshot = {
   backend: 'linear',
   fetchedAt: '2026-04-04T00:00:00.000Z',
   status: 'fresh',
   source: {
     projectId: 'test-project',
+    trackerKind: 'linear',
     activeMilestoneId: 'm003',
   },
   activeMilestone: {
@@ -21,11 +26,7 @@ const TEST_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
     name: '[M003] Workflow Kanban',
   },
   columns: [
-    {
-      id: 'backlog',
-      title: 'Backlog',
-      cards: [],
-    },
+    { id: 'backlog', title: 'Backlog', cards: [] },
     {
       id: 'todo',
       title: 'Todo',
@@ -61,35 +62,146 @@ const TEST_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
         },
       ],
     },
-    {
-      id: 'in_progress',
-      title: 'In Progress',
-      cards: [],
-    },
-    {
-      id: 'agent_review',
-      title: 'Agent Review',
-      cards: [],
-    },
-    {
-      id: 'human_review',
-      title: 'Human Review',
-      cards: [],
-    },
-    {
-      id: 'merging',
-      title: 'Merging',
-      cards: [],
-    },
-    {
-      id: 'done',
-      title: 'Done',
-      cards: [],
-    },
+    { id: 'in_progress', title: 'In Progress', cards: [] },
+    { id: 'agent_review', title: 'Agent Review', cards: [] },
+    { id: 'human_review', title: 'Human Review', cards: [] },
+    { id: 'merging', title: 'Merging', cards: [] },
+    { id: 'done', title: 'Done', cards: [] },
   ],
   poll: {
     status: 'success',
     backend: 'linear',
+    lastAttemptAt: '2026-04-04T00:00:00.000Z',
+  },
+}
+
+const TEST_WORKFLOW_FIXTURE_GITHUB_LABELS: WorkflowBoardSnapshot = {
+  backend: 'github',
+  fetchedAt: '2026-04-04T00:00:00.000Z',
+  status: 'fresh',
+  source: {
+    projectId: 'github:kata-sh/kata-mono',
+    trackerKind: 'github',
+    githubStateMode: 'labels',
+    repoOwner: 'kata-sh',
+    repoName: 'kata-mono',
+  },
+  activeMilestone: null,
+  columns: [
+    { id: 'backlog', title: 'Backlog', cards: [] },
+    {
+      id: 'todo',
+      title: 'Todo',
+      cards: [
+        {
+          id: 'gh-2249',
+          identifier: '#2249',
+          title: '[S02] GitHub Workflow Board Parity',
+          url: 'https://github.com/kata-sh/kata/issues/2249',
+          columnId: 'todo',
+          stateName: 'Todo',
+          stateType: 'label',
+          milestoneId: 'github:kata-sh/kata-mono',
+          milestoneName: 'kata-sh/kata-mono',
+          taskCounts: { total: 0, done: 0 },
+          tasks: [],
+        },
+      ],
+    },
+    {
+      id: 'in_progress',
+      title: 'In Progress',
+      cards: [
+        {
+          id: 'gh-2250',
+          identifier: '#2250',
+          title: '[S03] Workflow Context Switching and Failure Visibility',
+          url: 'https://github.com/kata-sh/kata/issues/2250',
+          columnId: 'in_progress',
+          stateName: 'In Progress',
+          stateType: 'label',
+          milestoneId: 'github:kata-sh/kata-mono',
+          milestoneName: 'kata-sh/kata-mono',
+          taskCounts: { total: 0, done: 0 },
+          tasks: [],
+        },
+      ],
+    },
+    { id: 'agent_review', title: 'Agent Review', cards: [] },
+    { id: 'human_review', title: 'Human Review', cards: [] },
+    { id: 'merging', title: 'Merging', cards: [] },
+    { id: 'done', title: 'Done', cards: [] },
+  ],
+  poll: {
+    status: 'success',
+    backend: 'github',
+    lastAttemptAt: '2026-04-04T00:00:00.000Z',
+  },
+}
+
+const TEST_WORKFLOW_FIXTURE_GITHUB_PROJECTS: WorkflowBoardSnapshot = {
+  backend: 'github',
+  fetchedAt: '2026-04-04T00:00:00.000Z',
+  status: 'fresh',
+  source: {
+    projectId: 'github:kata-sh/kata-mono',
+    trackerKind: 'github',
+    githubStateMode: 'projects_v2',
+    repoOwner: 'kata-sh',
+    repoName: 'kata-mono',
+  },
+  activeMilestone: {
+    id: 'github-project:7',
+    name: 'GitHub Project #7',
+  },
+  columns: [
+    { id: 'backlog', title: 'Backlog', cards: [] },
+    { id: 'todo', title: 'Todo', cards: [] },
+    {
+      id: 'in_progress',
+      title: 'In Progress',
+      cards: [
+        {
+          id: 'ghp-2249',
+          identifier: '#2249',
+          title: '[S02] GitHub Workflow Board Parity',
+          url: 'https://github.com/kata-sh/kata/issues/2249',
+          columnId: 'in_progress',
+          stateName: 'In Progress',
+          stateType: 'projects_v2',
+          milestoneId: 'github-project:7',
+          milestoneName: 'GitHub Project #7',
+          taskCounts: { total: 0, done: 0 },
+          tasks: [],
+        },
+      ],
+    },
+    {
+      id: 'agent_review',
+      title: 'Agent Review',
+      cards: [
+        {
+          id: 'ghp-2251',
+          identifier: '#2251',
+          title: '[S04] End-to-End Kanban Integration Proof',
+          url: 'https://github.com/kata-sh/kata/issues/2251',
+          columnId: 'agent_review',
+          stateName: 'Agent Review',
+          stateType: 'projects_v2',
+          milestoneId: 'github-project:7',
+          milestoneName: 'GitHub Project #7',
+          taskCounts: { total: 0, done: 0 },
+          tasks: [],
+        },
+      ],
+    },
+    { id: 'human_review', title: 'Human Review', cards: [] },
+    { id: 'merging', title: 'Merging', cards: [] },
+    { id: 'done', title: 'Done', cards: [] },
+  ],
+  poll: {
+    status: 'success',
+    backend: 'github',
     lastAttemptAt: '2026-04-04T00:00:00.000Z',
   },
 }
@@ -101,11 +213,13 @@ interface WorkflowBoardServiceOptions {
 
 export class WorkflowBoardService {
   private readonly linearClient: LinearWorkflowClient
+  private readonly githubClient: GithubWorkflowClient
   private lastSnapshot: WorkflowBoardSnapshot | null = null
   private inFlightRefresh: Promise<WorkflowBoardSnapshotResponse> | null = null
 
   constructor(private readonly options: WorkflowBoardServiceOptions) {
     this.linearClient = new LinearWorkflowClient(options.authBridge)
+    this.githubClient = new GithubWorkflowClient(options.authBridge)
   }
 
   async getBoard(): Promise<WorkflowBoardSnapshotResponse> {
@@ -135,9 +249,26 @@ export class WorkflowBoardService {
 
   private async performRefreshBoard(): Promise<WorkflowBoardSnapshotResponse> {
     const nowIso = new Date().toISOString()
+    const workspacePath = this.options.getWorkspacePath()
+
+    const trackerResult = await readWorkspaceWorkflowTrackerConfig(workspacePath)
+
+    if (trackerResult.error) {
+      const snapshot = this.toErrorSnapshot({
+        nowIso,
+        backend: 'github',
+        projectId: 'github:unknown/unknown',
+        message: trackerResult.error.message,
+        code: trackerResult.error.code,
+      })
+      this.lastSnapshot = snapshot
+      return { success: true, snapshot }
+    }
+
+    const trackerConfig = trackerResult.config
 
     if (isWorkflowFixtureEnabled()) {
-      const fixture = withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
+      const fixture = withFreshTimestamps(selectFixtureForMode(resolveFixtureMode(trackerConfig)))
       this.lastSnapshot = fixture
       return {
         success: true,
@@ -145,8 +276,72 @@ export class WorkflowBoardService {
       }
     }
 
-    const workspacePath = this.options.getWorkspacePath()
+    if (trackerConfig?.kind === 'github') {
+      return this.refreshGithubBoard(nowIso, trackerConfig)
+    }
 
+    return this.refreshLinearBoard(nowIso, workspacePath)
+  }
+
+  private async refreshGithubBoard(
+    nowIso: string,
+    config: Extract<WorkflowTrackerConfig, { kind: 'github' }>,
+  ): Promise<WorkflowBoardSnapshotResponse> {
+    try {
+      const snapshot = await this.githubClient.fetchSnapshot({ config })
+      this.lastSnapshot = snapshot
+      return {
+        success: true,
+        snapshot,
+      }
+    } catch (error) {
+      const workflowError = GithubWorkflowClient.toWorkflowError(error)
+
+      const staleSnapshot =
+        this.lastSnapshot && this.lastSnapshot.backend === 'github'
+          ? {
+              ...this.lastSnapshot,
+              status: 'stale' as const,
+              lastError: workflowError,
+              poll: {
+                ...this.lastSnapshot.poll,
+                status: 'error' as const,
+                lastAttemptAt: nowIso,
+              },
+            }
+          : this.toErrorSnapshot({
+              nowIso,
+              backend: 'github',
+              projectId: `github:${config.repoOwner}/${config.repoName}`,
+              message: workflowError.message,
+              code: workflowError.code,
+              source: {
+                trackerKind: 'github',
+                githubStateMode: config.stateMode,
+                repoOwner: config.repoOwner,
+                repoName: config.repoName,
+              },
+            })
+
+      this.lastSnapshot = staleSnapshot
+
+      log.warn('[workflow-board-service] github workflow refresh failed', {
+        repo: `${config.repoOwner}/${config.repoName}`,
+        mode: config.stateMode,
+        error: workflowError,
+      })
+
+      return {
+        success: true,
+        snapshot: staleSnapshot,
+      }
+    }
+  }
+
+  private async refreshLinearBoard(
+    nowIso: string,
+    workspacePath: string,
+  ): Promise<WorkflowBoardSnapshotResponse> {
     let projectRef: string | null
     try {
       projectRef = await readLinearProjectReference(workspacePath)
@@ -156,6 +351,7 @@ export class WorkflowBoardService {
 
       const snapshot = this.toErrorSnapshot({
         nowIso,
+        backend: 'linear',
         projectId: 'unknown',
         code: 'UNKNOWN',
         message,
@@ -172,6 +368,7 @@ export class WorkflowBoardService {
     if (!projectRef) {
       const snapshot = this.toErrorSnapshot({
         nowIso,
+        backend: 'linear',
         projectId: 'unknown',
         code: 'NOT_CONFIGURED',
         message: 'Linear project is not configured in .kata/preferences.md (projectId or projectSlug).',
@@ -192,27 +389,32 @@ export class WorkflowBoardService {
       }
     } catch (error) {
       const workflowError = LinearWorkflowClient.toWorkflowError(error)
-      const staleSnapshot: WorkflowBoardSnapshot = this.lastSnapshot
-        ? {
-            ...this.lastSnapshot,
-            status: 'stale',
-            lastError: workflowError,
-            poll: {
-              ...this.lastSnapshot.poll,
-              status: 'error',
-              lastAttemptAt: nowIso,
-            },
-          }
-        : this.toErrorSnapshot({
-            nowIso,
-            projectId: projectRef,
-            code: workflowError.code,
-            message: workflowError.message,
-          })
+      const staleSnapshot: WorkflowBoardSnapshot =
+        this.lastSnapshot && this.lastSnapshot.backend === 'linear'
+          ? {
+              ...this.lastSnapshot,
+              status: 'stale',
+              lastError: workflowError,
+              poll: {
+                ...this.lastSnapshot.poll,
+                status: 'error',
+                lastAttemptAt: nowIso,
+              },
+            }
+          : this.toErrorSnapshot({
+              nowIso,
+              backend: 'linear',
+              projectId: projectRef,
+              code: workflowError.code,
+              message: workflowError.message,
+              source: {
+                trackerKind: 'linear',
+              },
+            })
 
       this.lastSnapshot = staleSnapshot
 
-      log.warn('[workflow-board-service] workflow refresh failed', {
+      log.warn('[workflow-board-service] linear workflow refresh failed', {
         workspacePath,
         projectRef,
         error: workflowError,
@@ -227,23 +429,22 @@ export class WorkflowBoardService {
 
   private toErrorSnapshot(input: {
     nowIso: string
+    backend: WorkflowBoardBackend
     projectId: string
     code: NonNullable<WorkflowBoardSnapshot['lastError']>['code']
     message: string
+    source?: Partial<WorkflowBoardSnapshot['source']>
   }): WorkflowBoardSnapshot {
     return {
-      backend: 'linear',
+      backend: input.backend,
       fetchedAt: input.nowIso,
       status: 'error',
       source: {
         projectId: input.projectId,
+        ...input.source,
       },
       activeMilestone: null,
-      columns: TEST_WORKFLOW_FIXTURE.columns.map((column) => ({
-        id: column.id,
-        title: column.title,
-        cards: [],
-      })),
+      columns: createEmptyWorkflowColumns(),
       emptyReason: 'Workflow board unavailable',
       lastError: {
         code: input.code,
@@ -251,15 +452,42 @@ export class WorkflowBoardService {
       },
       poll: {
         status: 'error',
-        backend: 'linear',
+        backend: input.backend,
         lastAttemptAt: input.nowIso,
       },
     }
   }
 }
 
+type FixtureMode = 'linear' | 'github_labels' | 'github_projects_v2'
+
 function isWorkflowFixtureEnabled(): boolean {
-  return process.env.KATA_TEST_MODE === '1' || process.env.KATA_TEST_WORKFLOW_FIXTURE === '1'
+  return process.env.KATA_TEST_MODE === '1' || Boolean(process.env.KATA_TEST_WORKFLOW_FIXTURE)
+}
+
+function resolveFixtureMode(config: WorkflowTrackerConfig | null): FixtureMode {
+  const explicit = process.env.KATA_TEST_WORKFLOW_FIXTURE?.trim()
+  if (explicit === 'github_labels' || explicit === 'github_projects_v2' || explicit === 'linear') {
+    return explicit
+  }
+
+  if (config?.kind === 'github') {
+    return config.stateMode === 'projects_v2' ? 'github_projects_v2' : 'github_labels'
+  }
+
+  return 'linear'
+}
+
+function selectFixtureForMode(mode: FixtureMode): WorkflowBoardSnapshot {
+  if (mode === 'github_labels') {
+    return TEST_WORKFLOW_FIXTURE_GITHUB_LABELS
+  }
+
+  if (mode === 'github_projects_v2') {
+    return TEST_WORKFLOW_FIXTURE_GITHUB_PROJECTS
+  }
+
+  return TEST_WORKFLOW_FIXTURE_LINEAR
 }
 
 function withFreshTimestamps(snapshot: WorkflowBoardSnapshot): WorkflowBoardSnapshot {

--- a/apps/desktop/src/main/workflow-config-reader.ts
+++ b/apps/desktop/src/main/workflow-config-reader.ts
@@ -1,0 +1,196 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import type { WorkflowBoardError, WorkflowTrackerConfig } from '../shared/types'
+
+export interface WorkflowConfigReadResult {
+  config: WorkflowTrackerConfig | null
+  error?: WorkflowBoardError
+}
+
+export async function readWorkspaceWorkflowTrackerConfig(
+  workspacePath: string,
+): Promise<WorkflowConfigReadResult> {
+  const workflowPath = path.join(workspacePath, 'WORKFLOW.md')
+
+  let content: string
+  try {
+    content = await fs.readFile(workflowPath, 'utf8')
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : undefined
+
+    if (code === 'ENOENT') {
+      return { config: null }
+    }
+
+    return {
+      config: null,
+      error: {
+        code: 'UNKNOWN',
+        message: `Unable to read WORKFLOW.md: ${error instanceof Error ? error.message : String(error)}`,
+      },
+    }
+  }
+
+  const frontmatterMatch = content.match(/^\uFEFF?\s*---\s*\r?\n([\s\S]*?)\r?\n---/)
+  if (!frontmatterMatch?.[1]) {
+    return {
+      config: null,
+      error: {
+        code: 'INVALID_CONFIG',
+        message: 'WORKFLOW.md is missing YAML frontmatter.',
+      },
+    }
+  }
+
+  const frontmatter = frontmatterMatch[1]
+  const trackerBlock = extractNestedBlock(frontmatter, 'tracker')
+
+  if (!trackerBlock) {
+    return { config: { kind: 'linear' } }
+  }
+
+  const trackerFields = parseSimpleObject(trackerBlock)
+  const kind = (trackerFields.kind ?? 'linear').toLowerCase()
+
+  if (kind !== 'github') {
+    return { config: { kind: 'linear' } }
+  }
+
+  const repoOwner = stripYamlWrapping(trackerFields.repo_owner ?? '')
+  const repoName = stripYamlWrapping(trackerFields.repo_name ?? '')
+  const labelPrefix = stripYamlWrapping(trackerFields.label_prefix ?? '') || undefined
+
+  if (!repoOwner || !repoName) {
+    return {
+      config: null,
+      error: {
+        code: 'INVALID_CONFIG',
+        message: 'GitHub tracker requires tracker.repo_owner and tracker.repo_name in WORKFLOW.md.',
+      },
+    }
+  }
+
+  const projectNumberRaw = stripYamlWrapping(trackerFields.github_project_number ?? '')
+
+  let githubProjectNumber: number | undefined
+  if (projectNumberRaw) {
+    const parsedProjectNumber = Number(projectNumberRaw)
+    if (!Number.isFinite(parsedProjectNumber) || parsedProjectNumber <= 0) {
+      return {
+        config: null,
+        error: {
+          code: 'INVALID_CONFIG',
+          message: 'tracker.github_project_number must be a positive number in WORKFLOW.md.',
+        },
+      }
+    }
+
+    githubProjectNumber = parsedProjectNumber
+  }
+
+  return {
+    config: {
+      kind: 'github',
+      repoOwner,
+      repoName,
+      stateMode: githubProjectNumber ? 'projects_v2' : 'labels',
+      githubProjectNumber,
+      labelPrefix,
+    },
+  }
+}
+
+function extractNestedBlock(frontmatter: string, key: string): string | null {
+  const lines = frontmatter.split(/\r?\n/)
+  const anchorIndex = lines.findIndex((line) => new RegExp(`^\\s*${escapeRegex(key)}:\\s*$`).test(line))
+
+  if (anchorIndex === -1) {
+    return null
+  }
+
+  const anchorIndent = indentationOf(lines[anchorIndex] ?? '')
+  const nested: string[] = []
+
+  for (let index = anchorIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? ''
+    if (!line.trim()) {
+      nested.push(line)
+      continue
+    }
+
+    const indent = indentationOf(line)
+    if (indent <= anchorIndent) {
+      break
+    }
+
+    nested.push(line.slice(anchorIndent + 2))
+  }
+
+  return nested.join('\n')
+}
+
+function parseSimpleObject(block: string): Record<string, string> {
+  const result: Record<string, string> = {}
+
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+
+    const match = line.match(/^([a-zA-Z0-9_]+)\s*:\s*(.*)$/)
+    if (!match) {
+      continue
+    }
+
+    const key = match[1]
+    if (!key) {
+      continue
+    }
+
+    const rawValue = match[2] ?? ''
+    result[key] = stripInlineComment(rawValue).trim()
+  }
+
+  return result
+}
+
+function stripInlineComment(value: string): string {
+  let inSingle = false
+  let inDouble = false
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+    if (char === "'" && !inDouble) {
+      inSingle = !inSingle
+      continue
+    }
+
+    if (char === '"' && !inSingle) {
+      inDouble = !inDouble
+      continue
+    }
+
+    if (char === '#' && !inSingle && !inDouble) {
+      return value.slice(0, index)
+    }
+  }
+
+  return value
+}
+
+function stripYamlWrapping(value: string): string {
+  return value.replace(/^['"]/, '').replace(/['"]$/, '').trim()
+}
+
+function indentationOf(line: string): number {
+  const match = line.match(/^\s*/)
+  return match?.[0].length ?? 0
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/apps/desktop/src/main/workflow-config-reader.ts
+++ b/apps/desktop/src/main/workflow-config-reader.ts
@@ -146,11 +146,7 @@ function parseSimpleObject(block: string): Record<string, string> {
       continue
     }
 
-    const key = match[1]
-    if (!key) {
-      continue
-    }
-
+    const key = match[1] ?? ''
     const rawValue = match[2] ?? ''
     result[key] = stripInlineComment(rawValue).trim()
   }

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -63,7 +63,9 @@ export function KanbanPane() {
       <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-status">
         {loading ? 'Loading workflow board…' : null}
         {!loading && !board ? 'Workflow board not loaded' : null}
-        {!loading && board?.status === 'fresh' ? `Live data · ${board.backend}` : null}
+        {!loading && board?.status === 'fresh'
+          ? `Live data · ${board.backend}${board.source.githubStateMode ? ` · ${board.source.githubStateMode}` : ''}${board.source.repoOwner && board.source.repoName ? ` · ${board.source.repoOwner}/${board.source.repoName}` : ''}`
+          : null}
         {!loading && board?.status === 'empty' ? board.emptyReason ?? 'No work items found' : null}
         {!loading && board?.status === 'stale' ? 'Showing stale board snapshot' : null}
         {!loading && board?.status === 'error' ? 'Workflow board unavailable' : null}

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -17,7 +17,13 @@ export function SliceCard({ card }: SliceCardProps) {
     <Card size="sm" className="gap-3 rounded-xl border border-border/70 py-3 shadow-none">
       <CardHeader className="px-3 pb-0">
         <CardTitle className="text-sm leading-tight">
-          {card.identifier} · {card.title}
+          {card.url ? (
+            <a href={card.url} target="_blank" rel="noreferrer" className="hover:underline">
+              {card.identifier} · {card.title}
+            </a>
+          ) : (
+            <>{card.identifier} · {card.title}</>
+          )}
         </CardTitle>
       </CardHeader>
 

--- a/apps/desktop/src/renderer/lib/__tests__/workflow-board.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/workflow-board.test.ts
@@ -63,6 +63,48 @@ const snapshotFixture: WorkflowBoardSnapshot = {
   },
 }
 
+const githubSnapshotFixture: WorkflowBoardSnapshot = {
+  backend: 'github',
+  fetchedAt: '2026-04-04T00:00:00.000Z',
+  status: 'fresh',
+  source: {
+    projectId: 'github:kata-sh/kata',
+    trackerKind: 'github',
+    githubStateMode: 'projects_v2',
+    repoOwner: 'kata-sh',
+    repoName: 'kata',
+  },
+  activeMilestone: {
+    id: 'github-project:7',
+    name: 'GitHub Project #7',
+  },
+  columns: [
+    {
+      id: 'agent_review',
+      title: 'Agent Review',
+      cards: [
+        {
+          id: 'github-2249',
+          identifier: '#2249',
+          title: '[S02] GitHub Workflow Board Parity',
+          columnId: 'agent_review',
+          stateName: 'Agent Review',
+          stateType: 'projects_v2',
+          milestoneId: 'github-project:7',
+          milestoneName: 'GitHub Project #7',
+          taskCounts: { total: 0, done: 0 },
+          tasks: [],
+        },
+      ],
+    },
+  ],
+  poll: {
+    status: 'success',
+    backend: 'github',
+    lastAttemptAt: '2026-04-04T00:00:00.000Z',
+  },
+}
+
 describe('workflow-board renderer helpers', () => {
   test('normalizes columns into canonical workflow order', () => {
     const columns = normalizeWorkflowColumns(snapshotFixture)
@@ -79,5 +121,19 @@ describe('workflow-board renderer helpers', () => {
   test('flattens task rows across all slice cards', () => {
     const tasks = flattenWorkflowTasks(snapshotFixture)
     expect(tasks.map((task) => task.id)).toEqual(['task-1', 'task-2'])
+  })
+
+  test('keeps renderer parity for github snapshots', () => {
+    const columns = normalizeWorkflowColumns(githubSnapshotFixture)
+    expect(columns.map((column) => column.id)).toEqual(WORKFLOW_COLUMN_ORDER)
+
+    const agentReviewColumn = columns.find((column) => column.id === 'agent_review')
+    expect(agentReviewColumn?.cards[0]).toMatchObject({
+      identifier: '#2249',
+      stateType: 'projects_v2',
+    })
+
+    expect(countWorkflowCards(githubSnapshotFixture)).toBe(1)
+    expect(flattenWorkflowTasks(githubSnapshotFixture)).toEqual([])
   })
 })

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -531,10 +531,26 @@ export const WORKFLOW_COLUMNS: ReadonlyArray<{ id: WorkflowColumnId; title: stri
 
 export type WorkflowBoardBackend = 'linear' | 'github'
 
+export type GithubWorkflowStateMode = 'labels' | 'projects_v2'
+
+export type WorkflowTrackerConfig =
+  | {
+      kind: 'linear'
+    }
+  | {
+      kind: 'github'
+      repoOwner: string
+      repoName: string
+      stateMode: GithubWorkflowStateMode
+      githubProjectNumber?: number
+      labelPrefix?: string
+    }
+
 export type WorkflowBoardStatus = 'fresh' | 'stale' | 'empty' | 'error'
 
 export type WorkflowBoardErrorCode =
   | 'NOT_CONFIGURED'
+  | 'INVALID_CONFIG'
   | 'MISSING_API_KEY'
   | 'UNAUTHORIZED'
   | 'NOT_FOUND'
@@ -555,6 +571,7 @@ export interface WorkflowBoardTask {
   columnId: WorkflowColumnId
   stateName: string
   stateType: string
+  url?: string
 }
 
 export interface WorkflowBoardSliceCard {
@@ -564,6 +581,7 @@ export interface WorkflowBoardSliceCard {
   columnId: WorkflowColumnId
   stateName: string
   stateType: string
+  url?: string
   milestoneId: string
   milestoneName: string
   taskCounts: {
@@ -592,6 +610,10 @@ export interface WorkflowBoardSnapshot {
   source: {
     projectId: string
     activeMilestoneId?: string
+    trackerKind?: 'linear' | 'github'
+    githubStateMode?: GithubWorkflowStateMode
+    repoOwner?: string
+    repoName?: string
   }
   activeMilestone:
     | {


### PR DESCRIPTION
## Summary
- read GitHub tracker configuration from workspace `WORKFLOW.md` frontmatter in the main process and keep renderer-facing metadata typed and backend-neutral
- normalize GitHub workflow state for both label mode and Projects v2 mode into the existing `WorkflowBoardSnapshot` contract
- keep the same kanban renderer path for Linear and GitHub snapshots while exposing source/mode badges and metadata only at presentation level
- add deterministic Electron parity coverage for GitHub labels mode + projects_v2 mode and include explicit smoke-path proof expectations
- harden edge-case tests for config parsing, pagination, auth fallback, stale/error fallback behavior, and HTTP/GraphQL error mapping

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/workflow-config-reader.test.ts src/main/__tests__/github-workflow-client.test.ts src/main/__tests__/workflow-board-service.test.ts src/renderer/lib/__tests__/workflow-board.test.ts`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/workflow-kanban-github.e2e.ts`
- `cd apps/desktop && bun run test`

Closes KAT-2249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced GitHub workflow board support alongside Linear, with GitHub labels and projects v2 modes
  * Workflow card titles now function as clickable hyperlinks to external resources when URLs are available
  * Expanded board status display to include GitHub configuration details such as state mode and repository information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up a full GitHub workflow board backend for Kata Desktop, enabling the existing kanban pane to display issues from GitHub label-based workflows and GitHub Projects v2. It introduces three main additions: a custom `WORKFLOW.md` frontmatter reader (`workflow-config-reader.ts`), a `GithubWorkflowClient` that normalizes REST (label mode) and GraphQL (projects_v2 mode) responses into the existing `WorkflowBoardSnapshot` contract, and test-mode fixture snapshots for both GitHub modes. The renderer (`KanbanPane`, `SliceCard`) is extended with minimal changes — a source/mode status badge and conditional URL linking — keeping the shared kanban path intact.

Key highlights:
- The `WorkflowBoardSnapshot` contract is correctly reused for GitHub, with `source.githubStateMode`, `source.repoOwner`, and `source.repoName` added as optional presentation-layer metadata.
- Stale-snapshot and error-fallback logic mirrors the Linear path and is well-tested.
- The `workspaceDir` fixture refactor in `electron.fixture.ts` correctly exposes the workspace path for test-time file writes, though it leaves behind a redundant double-`rmSync` across both fixtures.
- **Primary concern**: `SliceCard.tsx` always renders the \"Show tasks\" collapsible regardless of whether `card.tasks` is non-empty. GitHub cards always have `tasks: []`, so every GitHub card will show a non-functional \"Show tasks\" toggle.
- The REST pagination in `fetchAllRepoIssues` uses a hard 10-page ceiling (1,000 issues) rather than the `Link` header; this is a silent cap that could affect large repos.

<h3>Confidence Score: 3/5</h3>

Safe to merge with the SliceCard task-collapsible fix applied; the empty "Show tasks" toggle on every GitHub card is a visible UX regression.

The core backend logic (config parsing, REST/GraphQL client, snapshot normalization, stale/error fallback) is well-structured and thoroughly tested. The main blocker is the SliceCard UX regression that renders a non-functional "Show tasks" toggle on all GitHub cards due to a missing guard on card.tasks.length. The double-cleanup and REST pagination ceiling are style/design issues that don't break functionality.

apps/desktop/src/renderer/components/kanban/SliceCard.tsx (missing task-count guard), apps/desktop/e2e/fixtures/electron.fixture.ts (redundant cleanup), apps/desktop/src/main/github-workflow-client.ts (pagination ceiling)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/kanban/SliceCard.tsx | Adds conditional URL link rendering for GitHub cards; however the "Show tasks" collapsible is always rendered even for GitHub cards that always have zero tasks. |
| apps/desktop/src/main/github-workflow-client.ts | New GitHub workflow client that fetches issues via REST (label mode) or GraphQL (projects_v2 mode), normalizing both into the shared WorkflowBoardSnapshot contract; REST pagination is hard-capped at 10 pages (1000 issues). |
| apps/desktop/src/main/workflow-board-service.ts | Significantly updated to route between GitHub and Linear backends based on WORKFLOW.md config; adds test fixtures for both GitHub modes; stale/error fallback is well-handled. |
| apps/desktop/src/main/workflow-config-reader.ts | New minimal custom YAML frontmatter parser for WORKFLOW.md; handles inline comments, quoted values, and basic indentation correctly for the expected input format. |
| apps/desktop/e2e/fixtures/electron.fixture.ts | Extracts workspaceDir as a separate fixture to allow test-time file writes; introduces a redundant double-cleanup where both workspaceDir and electronApp teardowns attempt to delete the same dataDir. |
| apps/desktop/e2e/tests/workflow-kanban-github.e2e.ts | New e2e tests covering GitHub labels mode and projects_v2 mode; the smoke-path test is effectively a documentation placeholder. |
| apps/desktop/src/main/__tests__/github-workflow-client.test.ts | Comprehensive unit tests covering label mode, projects_v2 mode, auth fallback, error codes, and pagination edge cases. |
| apps/desktop/src/main/__tests__/workflow-board-service.test.ts | Well-hardened tests covering stale/error fallback, concurrent dedup, fixture mode selection, and both Linear and GitHub error paths. |
| apps/desktop/src/shared/types.ts | Adds WorkflowTrackerConfig union, GithubWorkflowStateMode, and extends WorkflowBoardSnapshot.source with GitHub-specific metadata fields; type additions are well-structured. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WS as Workspace WORKFLOW.md
    participant CR as WorkflowConfigReader
    participant SVC as WorkflowBoardService
    participant GH as GithubWorkflowClient
    participant LIN as LinearWorkflowClient
    participant R as KanbanPane (Renderer)

    R->>SVC: refreshBoard()
    SVC->>CR: readWorkspaceWorkflowTrackerConfig(workspacePath)
    CR->>WS: read WORKFLOW.md (frontmatter)
    WS-->>CR: YAML content
    CR-->>SVC: WorkflowTrackerConfig {kind: github|linear}

    alt KATA_TEST_MODE enabled
        SVC-->>R: selectFixtureForMode() snapshot
    else kind === github
        SVC->>GH: fetchSnapshot({config})
        alt stateMode === labels
            GH->>GH: fetchAllRepoIssues (REST, paginated 1-10 pages)
            GH->>GH: extractStateFromLabels + mapLinearStateToColumnId
        else stateMode === projects_v2
            GH->>GH: resolveProjectsV2Field (GraphQL)
            GH->>GH: fetchProjectsV2Items (GraphQL, cursor paginated)
        end
        GH-->>SVC: WorkflowBoardSnapshot {backend: github}
        SVC-->>R: WorkflowBoardSnapshotResponse
    else kind === linear (default)
        SVC->>LIN: fetchActiveMilestoneSnapshot({projectRef})
        LIN-->>SVC: WorkflowBoardSnapshot {backend: linear}
        SVC-->>R: WorkflowBoardSnapshotResponse
    end

    R->>R: normalizeWorkflowColumns(board)
    R->>R: render KanbanColumn → SliceCard per card
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/renderer/components/kanban/SliceCard.tsx`, line 38-46 ([link](https://github.com/gannonh/kata/blob/3d5329b9226a0145d8569bbea09128b438330b2f/apps/desktop/src/renderer/components/kanban/SliceCard.tsx#L38-L46)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **"Show tasks" collapsible always renders for taskless GitHub cards**

   GitHub cards are always created with `tasks: []` and `taskCounts: { total: 0, done: 0 }` (see `github-workflow-client.ts` lines 166–168 and 253–255). Because the `<Collapsible>` block has no guard, every GitHub card renders a "Show tasks" toggle that opens to an empty `<TaskList />`. This is a UX regression introduced by routing GitHub cards through this shared component.

   The collapsible section should be conditionally rendered when tasks are actually present:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/kanban/SliceCard.tsx
   Line: 38-46

   Comment:
   **"Show tasks" collapsible always renders for taskless GitHub cards**

   GitHub cards are always created with `tasks: []` and `taskCounts: { total: 0, done: 0 }` (see `github-workflow-client.ts` lines 166–168 and 253–255). Because the `<Collapsible>` block has no guard, every GitHub card renders a "Show tasks" toggle that opens to an empty `<TaskList />`. This is a UX regression introduced by routing GitHub cards through this shared component.

   The collapsible section should be conditionally rendered when tasks are actually present:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/desktop/e2e/fixtures/electron.fixture.ts`, line 86-134 ([link](https://github.com/gannonh/kata/blob/3d5329b9226a0145d8569bbea09128b438330b2f/apps/desktop/e2e/fixtures/electron.fixture.ts#L86-L134)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant double `rmSync(dataDir)` across two fixtures**

   After this refactor, `dataDir` is deleted twice for every test that uses `electronApp` (directly or via `readyWindow`/`mainWindow`):

   1. `electronApp` teardown (~line 133): `rmSync(dataDir, { recursive: true, force: true })`
   2. `workspaceDir` teardown (~line 83): `rmSync(dataDir, { recursive: true, force: true })`

   Playwright tears down fixtures in reverse dependency order, so `electronApp` runs first. By the time `workspaceDir` cleanup fires, the directory is already gone. The `force: true` flag suppresses the resulting error, so it's safe — but the second call is a no-op and its original intent (workspace file cleanup) is already covered by the first.

   Consider removing the `rmSync` from `electronApp`'s `finally` block since `workspaceDir` now owns the lifecycle of `dataDir`. The comment "race with dying process" was valid when `electronApp` owned `dataDir`, but that ownership has moved.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/e2e/fixtures/electron.fixture.ts
   Line: 86-134

   Comment:
   **Redundant double `rmSync(dataDir)` across two fixtures**

   After this refactor, `dataDir` is deleted twice for every test that uses `electronApp` (directly or via `readyWindow`/`mainWindow`):

   1. `electronApp` teardown (~line 133): `rmSync(dataDir, { recursive: true, force: true })`
   2. `workspaceDir` teardown (~line 83): `rmSync(dataDir, { recursive: true, force: true })`

   Playwright tears down fixtures in reverse dependency order, so `electronApp` runs first. By the time `workspaceDir` cleanup fires, the directory is already gone. The `force: true` flag suppresses the resulting error, so it's safe — but the second call is a no-op and its original intent (workspace file cleanup) is already covered by the first.

   Consider removing the `rmSync` from `electronApp`'s `finally` block since `workspaceDir` now owns the lifecycle of `dataDir`. The comment "race with dying process" was valid when `electronApp` owned `dataDir`, but that ownership has moved.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/kanban/SliceCard.tsx
Line: 38-46

Comment:
**"Show tasks" collapsible always renders for taskless GitHub cards**

GitHub cards are always created with `tasks: []` and `taskCounts: { total: 0, done: 0 }` (see `github-workflow-client.ts` lines 166–168 and 253–255). Because the `<Collapsible>` block has no guard, every GitHub card renders a "Show tasks" toggle that opens to an empty `<TaskList />`. This is a UX regression introduced by routing GitHub cards through this shared component.

The collapsible section should be conditionally rendered when tasks are actually present:

```suggestion
        {card.tasks.length > 0 && (
          <Collapsible open={isOpen} onOpenChange={setIsOpen}>
            <CollapsibleTrigger className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
              <ChevronDown className={`size-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
              {isOpen ? 'Hide tasks' : 'Show tasks'}
            </CollapsibleTrigger>
            <CollapsibleContent className="pt-2">
              <TaskList tasks={card.tasks} />
            </CollapsibleContent>
          </Collapsible>
        )}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/e2e/fixtures/electron.fixture.ts
Line: 86-134

Comment:
**Redundant double `rmSync(dataDir)` across two fixtures**

After this refactor, `dataDir` is deleted twice for every test that uses `electronApp` (directly or via `readyWindow`/`mainWindow`):

1. `electronApp` teardown (~line 133): `rmSync(dataDir, { recursive: true, force: true })`
2. `workspaceDir` teardown (~line 83): `rmSync(dataDir, { recursive: true, force: true })`

Playwright tears down fixtures in reverse dependency order, so `electronApp` runs first. By the time `workspaceDir` cleanup fires, the directory is already gone. The `force: true` flag suppresses the resulting error, so it's safe — but the second call is a no-op and its original intent (workspace file cleanup) is already covered by the first.

Consider removing the `rmSync` from `electronApp`'s `finally` block since `workspaceDir` now owns the lifecycle of `dataDir`. The comment "race with dying process" was valid when `electronApp` owned `dataDir`, but that ownership has moved.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/github-workflow-client.ts
Line: 410-422

Comment:
**REST pagination uses a hard page-number ceiling instead of the Link header**

`fetchAllRepoIssues` iterates pages 1–10, breaking early when a page returns fewer than `PAGE_SIZE` items. This is correct for the common case, but it silently caps at 1,000 issues and will miss items in repos with more than that. The GitHub REST API advertises the next page via a `Link: <url>; rel="next"` response header, which is the idiomatic and reliable stop condition.

The existing GraphQL path in `fetchProjectsV2Items` already follows proper cursor-based pagination. Consider applying the same pattern (or at minimum, documenting the 1,000-issue ceiling with a log warning) so operators with large repos aren't silently surprised.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/__tests__/workflow-config-reader.test.ts
Line: 153-156

Comment:
**Redundant `mkdirSync` call after `mkdtempSync`**

`mkdtempSync` already creates the directory; calling `mkdirSync(workspace, { recursive: true })` on the same path immediately after is a no-op.

```suggestion
    const workspace = mkdtempSync(path.join(tmpdir(), 'workflow-config-github-projects-'))
    writeFileSync(
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): harden github workflow bo..."](https://github.com/gannonh/kata/commit/3d5329b9226a0145d8569bbea09128b438330b2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27335023)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->