### PR TITLE
KAT-2248: End-to-End Kanban integration proof

### DIFF
--- a/apps/desktop/docs/uat/M003/M003-UAT.md
+++ b/apps/desktop/docs/uat/M003/M003-UAT.md
@@ -1,0 +1,46 @@
+# M003: Workflow Kanban — UAT Report
+
+**Date:** 2026-04-04
+**Milestone:** M003 Workflow Kanban
+**Slice:** S04 End-to-End Kanban Integration Proof
+**Method:** Deterministic Electron Playwright matrix + live workspace smoke checklist
+
+---
+
+## Acceptance Matrix
+
+| # | Acceptance criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | Planning → execution handoff uses real main→preload→renderer path and pane reasoning is visible | ✅ PASS (deterministic) | `e2e/tests/workflow-context-switching.e2e.ts`, `e2e/tests/workflow-kanban-integration.e2e.ts` |
+| 2 | Manual override persists across reload and can return to auto mode | ✅ PASS (deterministic) | `e2e/tests/workflow-context-switching.e2e.ts`, `e2e/tests/workflow-kanban-integration.e2e.ts` |
+| 3 | Linear board renders with backend/freshness provenance and refresh support | ✅ PASS (deterministic seam) | `e2e/tests/workflow-kanban.e2e.ts` |
+| 4 | GitHub label mode renders on the same renderer path | ✅ PASS (deterministic seam) | `e2e/tests/workflow-kanban-github.e2e.ts`, `e2e/tests/workflow-kanban-integration.e2e.ts` |
+| 5 | GitHub Projects v2 mode renders on the same renderer path | ✅ PASS (deterministic seam) | `e2e/tests/workflow-kanban-github.e2e.ts`, `e2e/tests/workflow-kanban-integration.e2e.ts` |
+| 6 | Stale/error state remains truthful and refresh recovery is visible | ✅ PASS (deterministic seam) | `e2e/tests/workflow-context-switching.e2e.ts`, `e2e/tests/workflow-kanban-integration.e2e.ts` |
+| 7 | Live Linear smoke captured with screenshot evidence | ⚠️ BLOCKED | `02-linear-runtime-board.png` (pending live run) |
+| 8 | Live GitHub smoke captured for labels + projects_v2 with screenshot evidence | ⚠️ BLOCKED | `03-github-labels-runtime-board.png`, `04-github-projects-runtime-board.png` (pending live run) |
+
+---
+
+## Deterministic Runtime Proof (completed)
+
+The S04 deterministic matrix now exercises the assembled runtime path through Electron main process, preload IPC bridge, and renderer:
+
+- `workflow-kanban.e2e.ts` — canonical board rendering + task expansion
+- `workflow-kanban-github.e2e.ts` — GitHub labels/projects_v2 parity via WORKFLOW.md-backed runtime config
+- `workflow-context-switching.e2e.ts` — planning/execution context resolution, override persistence, stale/error surfaces
+- `workflow-kanban-integration.e2e.ts` — assembled cross-boundary proof (handoff + stale recovery + backend mode switching)
+
+These tests validate that a single renderer path presents Linear and GitHub boards with truthful provenance (`backend`, `mode`, `repo`, freshness status).
+
+## Live Proof Status (truthful)
+
+Live screenshots are **not recorded in this unattended session**. Final milestone sign-off still requires running the checklist in `README.md` against configured real Linear and GitHub workspaces and attaching:
+
+- `01-planning-to-kanban-handoff.png`
+- `02-linear-runtime-board.png`
+- `03-github-labels-runtime-board.png`
+- `04-github-projects-runtime-board.png`
+- `05-refresh-retry-stale.png`
+
+Until those images exist, live acceptance is intentionally marked **BLOCKED** instead of pass.

--- a/apps/desktop/docs/uat/M003/README.md
+++ b/apps/desktop/docs/uat/M003/README.md
@@ -1,0 +1,23 @@
+# M003 UAT Evidence Pack
+
+This folder contains acceptance evidence for **M003: Workflow Kanban** final-assembly proof (S04).
+
+## Artifacts
+
+- `M003-UAT.md` — acceptance matrix with deterministic + live checks
+- `01-planning-to-kanban-handoff.png` — planning→execution handoff view
+- `02-linear-runtime-board.png` — live Linear board proof (backend/mode/freshness visible)
+- `03-github-labels-runtime-board.png` — live GitHub label-mode proof
+- `04-github-projects-runtime-board.png` — live GitHub Projects v2 proof
+- `05-refresh-retry-stale.png` — stale/error + refresh recovery proof
+
+> Screenshot filenames are fixed so future runs can overwrite evidence deterministically.
+
+## Runbook (live)
+
+1. Launch Desktop against a real Linear workspace (no `KATA_TEST_MODE`).
+2. Verify planning→execution handoff and capture `01-planning-to-kanban-handoff.png`.
+3. Capture live Linear board with provenance badges as `02-linear-runtime-board.png`.
+4. Switch workspace config to GitHub labels mode and capture `03-github-labels-runtime-board.png`.
+5. Switch to GitHub Projects v2 mode and capture `04-github-projects-runtime-board.png`.
+6. Trigger a stale/error state and capture post-refresh recovery as `05-refresh-retry-stale.png`.

--- a/apps/desktop/e2e/tests/workflow-kanban-integration.e2e.ts
+++ b/apps/desktop/e2e/tests/workflow-kanban-integration.e2e.ts
@@ -1,0 +1,86 @@
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from '../fixtures/electron.fixture'
+
+function writeGithubWorkflowConfig(
+  workspaceDir: string,
+  mode: 'labels' | 'projects_v2',
+): void {
+  const lines =
+    mode === 'projects_v2'
+      ? [
+          '---',
+          'tracker:',
+          '  kind: github',
+          '  repo_owner: kata-sh',
+          '  repo_name: kata-mono',
+          '  github_project_number: 7',
+          '---',
+          '',
+        ]
+      : [
+          '---',
+          'tracker:',
+          '  kind: github',
+          '  repo_owner: kata-sh',
+          '  repo_name: kata-mono',
+          '  label_prefix: symphony',
+          '---',
+          '',
+        ]
+
+  writeFileSync(path.join(workspaceDir, 'WORKFLOW.md'), lines.join('\n'), 'utf8')
+}
+
+test.describe('Workflow kanban integration proof', () => {
+  test('preserves manual override and recovers stale/error states through refresh path', async ({ readyWindow }) => {
+    const refreshButton = readyWindow.getByRole('button', { name: /Refresh workflow board/i })
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Context: execution')
+
+    await readyWindow.getByRole('button', { name: /Open planning view/i }).click()
+    await expect(readyWindow.getByText('Planning View')).toBeVisible()
+
+    await readyWindow.reload()
+    await expect(readyWindow.getByText('Planning View')).toBeVisible()
+
+    await readyWindow.getByRole('button', { name: /Close planning view/i }).click()
+    await readyWindow.getByRole('button', { name: /Return to auto mode/i }).click()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Auto mode:')
+
+    await readyWindow.evaluate(async () => {
+      await window.api.workflow.setScope('scenario:stale')
+    })
+    await refreshButton.click()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Showing stale board snapshot')
+
+    await readyWindow.evaluate(async () => {
+      await window.api.workflow.setScope('scenario:recovery')
+    })
+    await refreshButton.click()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Live data · linear')
+  })
+
+  test('switches between github labels and projects_v2 without changing renderer path', async ({
+    readyWindow,
+    workspaceDir,
+  }) => {
+    const refreshButton = readyWindow.getByRole('button', { name: /Refresh workflow board/i })
+
+    writeGithubWorkflowConfig(workspaceDir, 'labels')
+    await refreshButton.click()
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText(
+      'Live data · github · labels · kata-sh/kata-mono',
+    )
+    await expect(readyWindow.getByText(/#2249 · \[S02\] GitHub Workflow Board Parity/i)).toBeVisible()
+
+    writeGithubWorkflowConfig(workspaceDir, 'projects_v2')
+    await refreshButton.click()
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText(
+      'Live data · github · projects_v2 · kata-sh/kata-mono',
+    )
+    await expect(readyWindow.getByText(/#2251 · \[S04\] End-to-End Kanban Integration Proof/i)).toBeVisible()
+  })
+})

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -464,4 +464,119 @@ describe('WorkflowBoardService', () => {
     const response = await service.refreshBoard()
     expect(response.snapshot.status).toBe('fresh')
   })
+
+  test('uses github labels fixture in test mode when WORKFLOW tracker.kind=github labels', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-github-labels-'))
+    writeFileSync(
+      path.join(workspacePath, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: github', '  repo_owner: kata-sh', '  repo_name: kata-mono', '  label_prefix: symphony', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    service.setActive(true)
+    const response = await service.refreshBoard()
+
+    expect(response.snapshot.backend).toBe('github')
+    expect(response.snapshot.source.githubStateMode).toBe('labels')
+    expect(response.snapshot.status).toBe('fresh')
+  })
+
+  test('uses github projects_v2 fixture in test mode when WORKFLOW project number is set', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-github-projects-'))
+    writeFileSync(
+      path.join(workspacePath, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: github', '  repo_owner: kata-sh', '  repo_name: kata-mono', '  github_project_number: 7', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    service.setActive(true)
+    const response = await service.refreshBoard()
+
+    expect(response.snapshot.backend).toBe('github')
+    expect(response.snapshot.source.githubStateMode).toBe('projects_v2')
+    expect(response.snapshot.activeMilestone?.name).toContain('GitHub Project')
+  })
+
+  test('returns INVALID_CONFIG when WORKFLOW frontmatter is malformed', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-invalid-config-'))
+    writeFileSync(path.join(workspacePath, 'WORKFLOW.md'), '# no frontmatter\n', 'utf8')
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    service.setActive(true)
+    const response = await service.refreshBoard()
+
+    expect(response.snapshot.status).toBe('error')
+    expect(response.snapshot.lastError?.code).toBe('INVALID_CONFIG')
+  })
+
+  test('refreshContext marks tracker configured for github tracker config', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-refresh-context-github-'))
+    writeFileSync(
+      path.join(workspacePath, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: github', '  repo_owner: kata-sh', '  repo_name: kata-mono', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const context = await service.refreshContext()
+    expect(context.trackerConfigured).toBe(true)
+    expect(context.mode).toBe('execution')
+  })
+
+  test('returns UNKNOWN when WORKFLOW exists but preferences path is unreadable', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-preferences-unreadable-'))
+    writeFileSync(path.join(workspacePath, 'WORKFLOW.md'), ['---', 'project: demo', '---', ''].join('\n'), 'utf8')
+    writeFileSync(path.join(workspacePath, '.kata'), 'not-a-directory', 'utf8')
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    service.setActive(true)
+    const response = await service.refreshBoard()
+    expect(response.snapshot.status).toBe('error')
+    expect(response.snapshot.lastError?.code).toBe('UNKNOWN')
+    expect(response.snapshot.lastError?.message).toContain('Unable to read .kata/preferences.md')
+  })
+
+  test('treats preferences without frontmatter as not configured', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-no-frontmatter-'))
+    writeFileSync(path.join(workspacePath, 'WORKFLOW.md'), ['---', 'project: demo', '---', ''].join('\n'), 'utf8')
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(path.join(workspacePath, '.kata', 'preferences.md'), 'projectId: demo\n', 'utf8')
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    service.setActive(true)
+    const response = await service.refreshBoard()
+    expect(response.snapshot.lastError?.code).toBe('NOT_CONFIGURED')
+  })
 })

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -2,15 +2,18 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { AuthBridge } from './auth-bridge'
 import { LinearWorkflowClient } from './linear-workflow-client'
+import { GithubWorkflowClient } from './github-workflow-client'
 import log from './logger'
 import { WorkflowContextService } from './workflow-context-service'
+import { readWorkspaceWorkflowTrackerConfig } from './workflow-config-reader'
 import type {
   WorkflowBoardSnapshot,
   WorkflowBoardSnapshotResponse,
   WorkflowContextSnapshot,
+  WorkflowTrackerConfig,
 } from '../shared/types'
 
-const TEST_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
+const TEST_LINEAR_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
   backend: 'linear',
   fetchedAt: '2026-04-04T00:00:00.000Z',
   status: 'fresh',
@@ -72,6 +75,137 @@ const TEST_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
   },
 }
 
+const TEST_GITHUB_LABELS_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
+  backend: 'github',
+  fetchedAt: '2026-04-04T00:00:00.000Z',
+  status: 'fresh',
+  source: {
+    projectId: 'github:kata-sh/kata-mono',
+    trackerKind: 'github',
+    githubStateMode: 'labels',
+    repoOwner: 'kata-sh',
+    repoName: 'kata-mono',
+  },
+  activeMilestone: null,
+  columns: [
+    { id: 'backlog', title: 'Backlog', cards: [] },
+    {
+      id: 'todo',
+      title: 'Todo',
+      cards: [
+        {
+          id: 'gh-2249',
+          identifier: '#2249',
+          title: '[S02] GitHub Workflow Board Parity',
+          columnId: 'todo',
+          stateName: 'Todo',
+          stateType: 'label',
+          milestoneId: 'github:kata-sh/kata-mono',
+          milestoneName: 'kata-sh/kata-mono',
+          taskCounts: { total: 0, done: 0 },
+          tasks: [],
+          url: 'https://github.com/kata-sh/kata-mono/issues/2249',
+        },
+      ],
+    },
+    {
+      id: 'in_progress',
+      title: 'In Progress',
+      cards: [
+        {
+          id: 'gh-2250',
+          identifier: '#2250',
+          title: '[S03] Workflow Context Switching and Failure Visibility',
+          columnId: 'in_progress',
+          stateName: 'In Progress',
+          stateType: 'label',
+          milestoneId: 'github:kata-sh/kata-mono',
+          milestoneName: 'kata-sh/kata-mono',
+          taskCounts: { total: 0, done: 0 },
+          tasks: [],
+          url: 'https://github.com/kata-sh/kata-mono/issues/2250',
+        },
+      ],
+    },
+    { id: 'agent_review', title: 'Agent Review', cards: [] },
+    { id: 'human_review', title: 'Human Review', cards: [] },
+    { id: 'merging', title: 'Merging', cards: [] },
+    { id: 'done', title: 'Done', cards: [] },
+  ],
+  poll: {
+    status: 'success',
+    backend: 'github',
+    lastAttemptAt: '2026-04-04T00:00:00.000Z',
+  },
+}
+
+const TEST_GITHUB_PROJECTS_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
+  backend: 'github',
+  fetchedAt: '2026-04-04T00:00:00.000Z',
+  status: 'fresh',
+  source: {
+    projectId: 'github:kata-sh/kata-mono:project:7',
+    trackerKind: 'github',
+    githubStateMode: 'projects_v2',
+    repoOwner: 'kata-sh',
+    repoName: 'kata-mono',
+  },
+  activeMilestone: {
+    id: 'github-project-7',
+    name: 'GitHub Project #7',
+  },
+  columns: [
+    { id: 'backlog', title: 'Backlog', cards: [] },
+    {
+      id: 'todo',
+      title: 'Todo',
+      cards: [
+        {
+          id: 'gh-2249',
+          identifier: '#2249',
+          title: '[S02] GitHub Workflow Board Parity',
+          columnId: 'todo',
+          stateName: 'Todo',
+          stateType: 'projects_v2',
+          milestoneId: 'github-project:7',
+          milestoneName: 'GitHub Project #7',
+          taskCounts: { total: 0, done: 0 },
+          tasks: [],
+          url: 'https://github.com/kata-sh/kata-mono/issues/2249',
+        },
+      ],
+    },
+    {
+      id: 'in_progress',
+      title: 'In Progress',
+      cards: [
+        {
+          id: 'gh-2251',
+          identifier: '#2251',
+          title: '[S04] End-to-End Kanban Integration Proof',
+          columnId: 'in_progress',
+          stateName: 'In Progress',
+          stateType: 'projects_v2',
+          milestoneId: 'github-project:7',
+          milestoneName: 'GitHub Project #7',
+          taskCounts: { total: 0, done: 0 },
+          tasks: [],
+          url: 'https://github.com/kata-sh/kata-mono/issues/2251',
+        },
+      ],
+    },
+    { id: 'agent_review', title: 'Agent Review', cards: [] },
+    { id: 'human_review', title: 'Human Review', cards: [] },
+    { id: 'merging', title: 'Merging', cards: [] },
+    { id: 'done', title: 'Done', cards: [] },
+  ],
+  poll: {
+    status: 'success',
+    backend: 'github',
+    lastAttemptAt: '2026-04-04T00:00:00.000Z',
+  },
+}
+
 interface WorkflowBoardServiceOptions {
   authBridge: AuthBridge
   getWorkspacePath: () => string
@@ -79,6 +213,7 @@ interface WorkflowBoardServiceOptions {
 
 export class WorkflowBoardService {
   private readonly linearClient: LinearWorkflowClient
+  private readonly githubClient: GithubWorkflowClient
   private readonly contextService = new WorkflowContextService()
 
   private lastSnapshot: WorkflowBoardSnapshot | null = null
@@ -94,6 +229,7 @@ export class WorkflowBoardService {
 
   constructor(private readonly options: WorkflowBoardServiceOptions) {
     this.linearClient = new LinearWorkflowClient(options.authBridge)
+    this.githubClient = new GithubWorkflowClient(options.authBridge)
   }
 
   setActive(active: boolean): { success: true; active: boolean } {
@@ -182,8 +318,8 @@ export class WorkflowBoardService {
       return { success: true, snapshot: scenarioSnapshot }
     }
 
-    if (isWorkflowFixtureEnabled()) {
-      const fixture = withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
+    if (process.env.KATA_TEST_WORKFLOW_FIXTURE === '1') {
+      const fixture = withFreshTimestamps(TEST_LINEAR_WORKFLOW_FIXTURE)
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = fixture
         this.lastSuccessSnapshot = fixture
@@ -202,6 +338,7 @@ export class WorkflowBoardService {
       const inactive = this.toErrorSnapshot({
         nowIso: new Date().toISOString(),
         projectId: 'unknown',
+        backend: 'linear',
         code: 'UNKNOWN',
         message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
       })
@@ -215,18 +352,14 @@ export class WorkflowBoardService {
     const nowIso = new Date().toISOString()
     const workspacePath = this.options.getWorkspacePath()
 
-    let projectRef: string | null
-    try {
-      projectRef = await this.resolveProjectReference(workspacePath)
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Unable to read .kata/preferences.md due to an unknown error.'
-
+    const trackerResolution = await this.resolveTrackerConfig(workspacePath)
+    if (trackerResolution.error) {
       const snapshot = this.toErrorSnapshot({
         nowIso,
         projectId: 'unknown',
-        code: 'UNKNOWN',
-        message,
+        backend: 'linear',
+        code: trackerResolution.error.code,
+        message: trackerResolution.error.message,
       })
 
       if (capturedScopeKey === this.scopeKey) {
@@ -237,26 +370,58 @@ export class WorkflowBoardService {
       return { success: true, snapshot }
     }
 
-    if (!projectRef) {
+    const tracker = trackerResolution.config
+
+    if (!tracker) {
       const snapshot = this.toErrorSnapshot({
         nowIso,
         projectId: 'unknown',
+        backend: 'linear',
         code: 'NOT_CONFIGURED',
-        message: 'Linear project is not configured in .kata/preferences.md (projectId or projectSlug).',
+        message: 'Workflow board tracker is not configured in WORKFLOW.md or .kata/preferences.md.',
       })
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = snapshot
+        this.trackerConfigured = false
         this.syncContextSnapshot()
       }
       return { success: true, snapshot }
     }
 
+    if (isWorkflowFixtureEnabled()) {
+      const fixture = withFreshTimestamps(this.fixtureForTracker(tracker))
+      if (capturedScopeKey === this.scopeKey) {
+        this.lastSnapshot = fixture
+        this.lastSuccessSnapshot = fixture
+        this.trackerConfigured = true
+        this.syncContextSnapshot()
+      }
+      return { success: true, snapshot: fixture }
+    }
+
+    const boardProjectId = tracker.kind === 'github'
+      ? `github:${tracker.repoOwner}/${tracker.repoName}`
+      : tracker.projectRef
+
     try {
-      const snapshot = await this.linearClient.fetchActiveMilestoneSnapshot({ projectRef })
+      const fetchedSnapshot =
+        tracker.kind === 'github'
+          ? await this.githubClient.fetchSnapshot({ config: tracker })
+          : await this.linearClient.fetchActiveMilestoneSnapshot({ projectRef: tracker.projectRef })
+
+      const snapshot: WorkflowBoardSnapshot = {
+        ...fetchedSnapshot,
+        poll: {
+          ...fetchedSnapshot.poll,
+          lastSuccessAt: fetchedSnapshot.fetchedAt,
+        },
+      }
+
       if (!this.active) {
         const inactive = this.toErrorSnapshot({
           nowIso,
-          projectId: projectRef,
+          projectId: boardProjectId,
+          backend: snapshot.backend,
           code: 'UNKNOWN',
           message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
         })
@@ -270,6 +435,7 @@ export class WorkflowBoardService {
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = snapshot
         this.lastSuccessSnapshot = snapshot
+        this.trackerConfigured = true
         this.syncContextSnapshot()
       }
       return { success: true, snapshot }
@@ -277,7 +443,8 @@ export class WorkflowBoardService {
       if (!this.active) {
         const inactive = this.toErrorSnapshot({
           nowIso,
-          projectId: projectRef,
+          projectId: boardProjectId,
+          backend: tracker.kind === 'github' ? 'github' : 'linear',
           code: 'UNKNOWN',
           message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
         })
@@ -288,7 +455,10 @@ export class WorkflowBoardService {
         return { success: true, snapshot: inactive }
       }
 
-      const workflowError = LinearWorkflowClient.toWorkflowError(error)
+      const workflowError =
+        tracker.kind === 'github'
+          ? GithubWorkflowClient.toWorkflowError(error)
+          : LinearWorkflowClient.toWorkflowError(error)
 
       const staleSnapshot: WorkflowBoardSnapshot = this.lastSuccessSnapshot
         ? {
@@ -303,7 +473,8 @@ export class WorkflowBoardService {
           }
         : this.toErrorSnapshot({
             nowIso,
-            projectId: projectRef,
+            projectId: boardProjectId,
+            backend: tracker.kind === 'github' ? 'github' : 'linear',
             code: workflowError.code,
             message: workflowError.message,
           })
@@ -314,7 +485,7 @@ export class WorkflowBoardService {
 
       log.warn('[workflow-board-service] workflow refresh failed', {
         workspacePath,
-        projectRef,
+        tracker,
         scopeKey: this.scopeKey,
         error: workflowError,
       })
@@ -341,6 +512,7 @@ export class WorkflowBoardService {
       return this.toErrorSnapshot({
         nowIso,
         projectId: 'unknown',
+        backend: 'linear',
         code: 'NOT_CONFIGURED',
         message: 'Linear project is not configured in .kata/preferences.md (projectId or projectSlug).',
       })
@@ -350,13 +522,14 @@ export class WorkflowBoardService {
       return this.toErrorSnapshot({
         nowIso,
         projectId: 'test-project',
+        backend: 'linear',
         code: 'UNAUTHORIZED',
         message: 'Invalid Linear API key',
       })
     }
 
     if (scenario === 'empty') {
-      const fixture = withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
+      const fixture = withFreshTimestamps(TEST_LINEAR_WORKFLOW_FIXTURE)
       return {
         ...fixture,
         status: 'empty',
@@ -367,7 +540,7 @@ export class WorkflowBoardService {
     }
 
     if (scenario === 'stale') {
-      const baseline = this.lastSuccessSnapshot ?? withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
+      const baseline = this.lastSuccessSnapshot ?? withFreshTimestamps(TEST_LINEAR_WORKFLOW_FIXTURE)
       return {
         ...baseline,
         status: 'stale',
@@ -383,19 +556,15 @@ export class WorkflowBoardService {
       }
     }
 
-    return withFreshTimestamps(TEST_WORKFLOW_FIXTURE)
+    return withFreshTimestamps(TEST_LINEAR_WORKFLOW_FIXTURE)
   }
 
   async refreshContext(): Promise<WorkflowContextSnapshot> {
-    if (isWorkflowFixtureEnabled()) {
-      this.trackerConfigured = true
-    } else {
-      try {
-        const projectRef = await this.resolveProjectReference(this.options.getWorkspacePath())
-        this.trackerConfigured = Boolean(projectRef)
-      } catch {
-        this.trackerConfigured = false
-      }
+    try {
+      const tracker = await this.resolveTrackerConfig(this.options.getWorkspacePath())
+      this.trackerConfigured = Boolean(tracker.config)
+    } catch {
+      this.trackerConfigured = false
     }
 
     return this.contextService.resolve({
@@ -405,25 +574,110 @@ export class WorkflowBoardService {
     }).next
   }
 
-  private async resolveProjectReference(workspacePath: string): Promise<string | null> {
-    const projectRef = await readLinearProjectReference(workspacePath)
-    this.trackerConfigured = Boolean(projectRef)
-    return projectRef
+  private async resolveTrackerConfig(workspacePath: string): Promise<{
+    config:
+      | ({ kind: 'github' } & Extract<WorkflowTrackerConfig, { kind: 'github' }>)
+      | ({ kind: 'linear'; projectRef: string })
+      | null
+    error?: NonNullable<WorkflowBoardSnapshot['lastError']>
+  }> {
+    if (process.env.KATA_TEST_WORKFLOW_FIXTURE === '1') {
+      return {
+        config: {
+          kind: 'linear',
+          projectRef: 'test-project',
+        },
+      }
+    }
+
+    const trackerResult = await readWorkspaceWorkflowTrackerConfig(workspacePath)
+    if (trackerResult.error) {
+      if (trackerResult.error.code === 'UNKNOWN') {
+        try {
+          await readLinearProjectReference(workspacePath)
+        } catch (error) {
+          return {
+            config: null,
+            error: {
+              code: 'UNKNOWN',
+              message: error instanceof Error ? error.message : String(error),
+            },
+          }
+        }
+      }
+
+      return { config: null, error: trackerResult.error }
+    }
+
+    const trackerConfig = trackerResult.config
+    if (trackerConfig?.kind === 'github') {
+      return {
+        config: trackerConfig,
+      }
+    }
+
+    let projectRef: string | null
+    try {
+      projectRef = await readLinearProjectReference(workspacePath)
+    } catch (error) {
+      return {
+        config: null,
+        error: {
+          code: 'UNKNOWN',
+          message: error instanceof Error ? error.message : String(error),
+        },
+      }
+    }
+
+    if (projectRef) {
+      return {
+        config: {
+          kind: 'linear',
+          projectRef,
+        },
+      }
+    }
+
+    if (process.env.KATA_TEST_MODE === '1') {
+      return {
+        config: {
+          kind: 'linear',
+          projectRef: 'test-project',
+        },
+      }
+    }
+
+    return { config: null }
+  }
+
+  private fixtureForTracker(
+    tracker:
+      | ({ kind: 'github' } & Extract<WorkflowTrackerConfig, { kind: 'github' }>)
+      | { kind: 'linear'; projectRef: string },
+  ): WorkflowBoardSnapshot {
+    if (tracker.kind === 'github') {
+      return tracker.stateMode === 'projects_v2'
+        ? TEST_GITHUB_PROJECTS_WORKFLOW_FIXTURE
+        : TEST_GITHUB_LABELS_WORKFLOW_FIXTURE
+    }
+
+    return TEST_LINEAR_WORKFLOW_FIXTURE
   }
 
   private toErrorSnapshot(input: {
     nowIso: string
     projectId: string
+    backend: WorkflowBoardSnapshot['backend']
     code: NonNullable<WorkflowBoardSnapshot['lastError']>['code']
     message: string
   }): WorkflowBoardSnapshot {
     return {
-      backend: 'linear',
+      backend: input.backend,
       fetchedAt: input.nowIso,
       status: 'error',
       source: { projectId: input.projectId },
       activeMilestone: null,
-      columns: TEST_WORKFLOW_FIXTURE.columns.map((column) => ({
+      columns: TEST_LINEAR_WORKFLOW_FIXTURE.columns.map((column) => ({
         id: column.id,
         title: column.title,
         cards: [],
@@ -435,7 +689,7 @@ export class WorkflowBoardService {
       },
       poll: {
         status: 'error',
-        backend: 'linear',
+        backend: input.backend,
         lastAttemptAt: input.nowIso,
       },
     }
@@ -454,6 +708,7 @@ function withFreshTimestamps(snapshot: WorkflowBoardSnapshot): WorkflowBoardSnap
     poll: {
       ...snapshot.poll,
       lastAttemptAt: nowIso,
+      lastSuccessAt: snapshot.poll.status === 'success' ? nowIso : snapshot.poll.lastSuccessAt,
     },
   }
 }

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -581,15 +581,6 @@ export class WorkflowBoardService {
       | null
     error?: NonNullable<WorkflowBoardSnapshot['lastError']>
   }> {
-    if (process.env.KATA_TEST_WORKFLOW_FIXTURE === '1') {
-      return {
-        config: {
-          kind: 'linear',
-          projectRef: 'test-project',
-        },
-      }
-    }
-
     const trackerResult = await readWorkspaceWorkflowTrackerConfig(workspacePath)
     if (trackerResult.error) {
       if (trackerResult.error.code === 'UNKNOWN') {

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -25,6 +25,9 @@ export const refreshWorkflowBoardAtom = atom(null, async (_get, set) => {
     const response = await window.api.workflow.refreshBoard()
     set(workflowBoardAtom, response.snapshot)
     set(workflowBoardErrorAtom, response.snapshot.lastError?.message ?? null)
+
+    const contextResponse = await window.api.workflow.getContext()
+    set(setWorkflowContextAtom, contextResponse.context)
   } catch (error) {
     set(workflowBoardErrorAtom, error instanceof Error ? error.message : String(error))
   } finally {

--- a/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
@@ -1,0 +1,138 @@
+import { LayoutGrid, RefreshCcw } from 'lucide-react'
+import type { RightPaneResolution, RightPaneOverride, WorkflowBoardSnapshot, WorkflowContextSnapshot } from '@shared/types'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+
+function formatPaneResolutionReason(reason: string): string {
+  const labels: Record<string, string> = {
+    manual_override: 'Manual override',
+    default_fallback: 'Default fallback',
+    planning_activity_detected: 'Planning activity detected',
+    tracker_and_board_available: 'Tracker configured and board available',
+    tracker_configured_board_pending: 'Tracker configured — board pending',
+    board_available_without_tracker: 'Board available without tracker config',
+    unknown_context: 'Context unavailable',
+  }
+
+  return labels[reason] ?? 'Automatic context resolution'
+}
+
+function formatBoardSource(snapshot: WorkflowBoardSnapshot | null): string {
+  if (!snapshot) {
+    return 'unknown source'
+  }
+
+  if (snapshot.backend === 'github') {
+    const mode = snapshot.source.githubStateMode ?? 'labels'
+    const repo =
+      snapshot.source.repoOwner && snapshot.source.repoName
+        ? `${snapshot.source.repoOwner}/${snapshot.source.repoName}`
+        : 'unknown-repo'
+    return `${snapshot.backend} · ${mode} · ${repo}`
+  }
+
+  return snapshot.backend
+}
+
+export function formatWorkflowBoardStatus(input: {
+  loading: boolean
+  boardStatus?: 'fresh' | 'stale' | 'empty' | 'error'
+  board?: WorkflowBoardSnapshot | null
+  emptyReason?: string
+  refreshing: boolean
+}): string {
+  if (input.loading) {
+    return 'Loading workflow board…'
+  }
+
+  let status = 'Workflow board not loaded'
+
+  if (input.boardStatus === 'fresh') {
+    status = `Live data · ${formatBoardSource(input.board ?? null)}`
+  } else if (input.boardStatus === 'empty') {
+    status = input.emptyReason ?? 'No work items found'
+  } else if (input.boardStatus === 'stale') {
+    const lastSuccess = input.board?.poll.lastSuccessAt
+      ? ` · Last success ${new Date(input.board.poll.lastSuccessAt).toLocaleTimeString()}`
+      : ''
+    status = `Showing stale board snapshot · ${formatBoardSource(input.board ?? null)}${lastSuccess}`
+  } else if (input.boardStatus === 'error') {
+    status = `Workflow board unavailable · ${formatBoardSource(input.board ?? null)}`
+  }
+
+  return input.refreshing ? `${status} · Refreshing…` : status
+}
+
+interface KanbanHeaderProps {
+  board: WorkflowBoardSnapshot | null
+  loading: boolean
+  refreshing: boolean
+  rightPaneOverride: RightPaneOverride
+  paneResolution: RightPaneResolution
+  workflowContext: WorkflowContextSnapshot
+  onOpenPlanningView: () => void
+  onRefresh: () => void
+  onClearOverride: () => void
+}
+
+export function KanbanHeader({
+  board,
+  loading,
+  refreshing,
+  rightPaneOverride,
+  paneResolution,
+  workflowContext,
+  onOpenPlanningView,
+  onRefresh,
+  onClearOverride,
+}: KanbanHeaderProps) {
+  return (
+    <>
+      <div className="flex h-14 items-center justify-between px-4">
+        <div className="min-w-0">
+          <h2 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">Workflow Board</h2>
+          <p className="truncate text-sm font-medium text-foreground">
+            {board?.activeMilestone?.name ?? 'No active milestone'}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button type="button" size="icon" variant="ghost" aria-label="Open planning view" onClick={onOpenPlanningView}>
+            <LayoutGrid className="size-4" />
+          </Button>
+
+          <Button type="button" size="icon" variant="ghost" aria-label="Refresh workflow board" onClick={onRefresh}>
+            <RefreshCcw className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-status">
+        {rightPaneOverride
+          ? `Manual override: ${rightPaneOverride}`
+          : `Auto mode: ${formatPaneResolutionReason(paneResolution.reason)}`}
+        {' · '}
+        {`Context: ${workflowContext.mode}`}
+        {' · '}
+        {formatWorkflowBoardStatus({
+          loading,
+          boardStatus: board?.status,
+          board,
+          emptyReason: board?.emptyReason,
+          refreshing,
+        })}
+      </div>
+
+      {rightPaneOverride ? (
+        <div className="border-b border-border bg-muted/70 px-4 py-2 text-xs text-muted-foreground">
+          Manual pane override is active.
+          <Button type="button" variant="link" className="ml-1 h-auto p-0 text-xs" onClick={onClearOverride}>
+            Return to auto mode
+          </Button>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from 'jotai'
-import { LayoutGrid, Loader2, RefreshCcw } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import {
   refreshWorkflowBoardAtom,
   workflowBoardAtom,
@@ -15,49 +15,8 @@ import {
   workflowContextAtom,
 } from '@/atoms/right-pane'
 import { KanbanColumn } from '@/components/kanban/KanbanColumn'
-import { Button } from '@/components/ui/button'
-import { Separator } from '@/components/ui/separator'
+import { KanbanHeader } from '@/components/kanban/KanbanHeader'
 import { normalizeWorkflowColumns } from '@/lib/workflow-board'
-
-function formatPaneResolutionReason(reason: string): string {
-  const labels: Record<string, string> = {
-    manual_override: 'Manual override',
-    default_fallback: 'Default fallback',
-    planning_activity_detected: 'Planning activity detected',
-    tracker_and_board_available: 'Tracker configured and board available',
-    tracker_configured_board_pending: 'Tracker configured — board pending',
-    board_available_without_tracker: 'Board available without tracker config',
-    unknown_context: 'Context unavailable',
-  }
-
-  return labels[reason] ?? 'Automatic context resolution'
-}
-
-export function formatWorkflowBoardStatus(input: {
-  loading: boolean
-  boardStatus?: 'fresh' | 'stale' | 'empty' | 'error'
-  backend?: string
-  emptyReason?: string
-  refreshing: boolean
-}): string {
-  if (input.loading) {
-    return 'Loading workflow board…'
-  }
-
-  let status = 'Workflow board not loaded'
-
-  if (input.boardStatus === 'fresh') {
-    status = `Live data · ${input.backend ?? 'unknown'}`
-  } else if (input.boardStatus === 'empty') {
-    status = input.emptyReason ?? 'No work items found'
-  } else if (input.boardStatus === 'stale') {
-    status = 'Showing stale board snapshot'
-  } else if (input.boardStatus === 'error') {
-    status = 'Workflow board unavailable'
-  }
-
-  return input.refreshing ? `${status} · Refreshing…` : status
-}
 
 export function KanbanPane() {
   const board = useAtomValue(workflowBoardAtom)
@@ -75,70 +34,19 @@ export function KanbanPane() {
 
   return (
     <aside className="flex h-full flex-col bg-muted/40" data-testid="workflow-kanban-pane">
-      <div className="flex h-14 items-center justify-between px-4">
-        <div className="min-w-0">
-          <h2 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">Workflow Board</h2>
-          <p className="truncate text-sm font-medium text-foreground">
-            {board?.activeMilestone?.name ?? 'No active milestone'}
-          </p>
-        </div>
-
-        <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            size="icon"
-            variant="ghost"
-            aria-label="Open planning view"
-            onClick={() => setRightPaneOverride('planning')}
-          >
-            <LayoutGrid className="size-4" />
-          </Button>
-
-          <Button
-            type="button"
-            size="icon"
-            variant="ghost"
-            aria-label="Refresh workflow board"
-            onClick={() => {
-              void refreshBoard()
-            }}
-          >
-            <RefreshCcw className="size-4" />
-          </Button>
-        </div>
-      </div>
-
-      <Separator />
-
-      <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-status">
-        {rightPaneOverride
-          ? `Manual override: ${rightPaneOverride}`
-          : `Auto mode: ${formatPaneResolutionReason(paneResolution.reason)}`}
-        {' · '}
-        {`Context: ${workflowContext.mode}`}
-        {' · '}
-        {formatWorkflowBoardStatus({
-          loading,
-          boardStatus: board?.status,
-          backend: board?.backend,
-          emptyReason: board?.emptyReason,
-          refreshing,
-        })}
-      </div>
-
-      {rightPaneOverride ? (
-        <div className="border-b border-border bg-muted/70 px-4 py-2 text-xs text-muted-foreground">
-          Manual pane override is active.
-          <Button
-            type="button"
-            variant="link"
-            className="ml-1 h-auto p-0 text-xs"
-            onClick={() => clearOverride()}
-          >
-            Return to auto mode
-          </Button>
-        </div>
-      ) : null}
+      <KanbanHeader
+        board={board}
+        loading={loading}
+        refreshing={refreshing}
+        rightPaneOverride={rightPaneOverride}
+        paneResolution={paneResolution}
+        workflowContext={workflowContext}
+        onOpenPlanningView={() => setRightPaneOverride('planning')}
+        onRefresh={() => {
+          void refreshBoard()
+        }}
+        onClearOverride={() => clearOverride()}
+      />
 
       {error ? (
         <div className="border-b border-border bg-destructive/10 px-4 py-2 text-xs text-destructive">{error}</div>

--- a/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { formatWorkflowBoardStatus } from '../KanbanPane'
+import { formatWorkflowBoardStatus } from '../KanbanHeader'
 
 describe('KanbanPane status formatting', () => {
   test('renders loading state', () => {
@@ -16,9 +16,24 @@ describe('KanbanPane status formatting', () => {
       formatWorkflowBoardStatus({
         loading: false,
         boardStatus: 'stale',
+        board: {
+          backend: 'linear',
+          fetchedAt: '2026-04-04T00:00:00.000Z',
+          status: 'stale',
+          source: { projectId: 'test-project' },
+          activeMilestone: null,
+          columns: [],
+          poll: {
+            status: 'error',
+            backend: 'linear',
+            lastAttemptAt: '2026-04-04T00:01:00.000Z',
+            lastSuccessAt: '2026-04-04T00:00:30.000Z',
+          },
+          lastError: { code: 'NETWORK', message: 'offline' },
+        },
         refreshing: true,
       }),
-    ).toBe('Showing stale board snapshot · Refreshing…')
+    ).toContain('Showing stale board snapshot · linear')
   })
 
   test('renders empty reason when provided', () => {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -632,6 +632,7 @@ export interface WorkflowBoardPollMetadata {
   status: 'idle' | 'success' | 'error'
   backend: WorkflowBoardBackend
   lastAttemptAt: string
+  lastSuccessAt?: string
 }
 
 export interface WorkflowBoardSnapshot {


### PR DESCRIPTION
## Summary
- complete assembled workflow runtime wiring so kanban provenance is explicit (backend, mode, repo, freshness, stale/error status)
- add a reusable `KanbanHeader` and richer status formatting for planning/execution resolution + board source visibility
- extend `WorkflowBoardService` deterministic test seams to cover linear + github (labels/projects_v2) runtime paths
- add a cross-boundary Electron integration spec for planning→execution handoff, override persistence, stale recovery, and backend parity
- add M003 UAT scaffold/docs with explicit evidence filenames and truthful live-proof status tracking

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/workflow-context-service.test.ts src/main/__tests__/workflow-board-service.test.ts src/renderer/atoms/__tests__/right-pane-mode.test.ts src/renderer/components/kanban/__tests__/KanbanPane.test.tsx`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/workflow-kanban.e2e.ts e2e/tests/workflow-kanban-github.e2e.ts e2e/tests/workflow-context-switching.e2e.ts e2e/tests/workflow-kanban-integration.e2e.ts`
- `cd apps/desktop && bun run test` (pre-push coverage gate)

## Linear
- KAT-2248
- child tasks moved to Done: KAT-2293, KAT-2292, KAT-2291

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the end-to-end Kanban integration proof by wiring backend/mode/repo provenance through the full main→preload→renderer path, extracting a reusable `KanbanHeader` with richer status formatting, adding deterministic test seams for Linear and GitHub (labels + projects_v2), and covering the planning→execution handoff with both unit and Playwright integration tests. All remaining findings are P2 style/observability suggestions.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/clarity suggestions with no correctness or data-integrity impact.

The three P2 comments cover a stale-context window of up to 30 seconds on initial kanban activation (not a data-loss issue, auto-corrected by the interval), an opaque probe pattern that works correctly as written, and hardcoded 'linear' backend in pre-resolution error snapshots (display-only). The unit test suite is thorough, the deduplication and scope-race guard are well-tested, and the KanbanHeader extraction is clean. No P0 or P1 issues found.

apps/desktop/src/renderer/atoms/workflow-board.ts (missing context refresh after initial board fetch) and apps/desktop/src/main/workflow-board-service.ts (probe pattern + hardcoded backend in error snapshots)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/workflow-board-service.ts | Adds GitHub Labels/Projects v2 fixtures, deterministic test-scenario seam via scope-key parsing, and `fixtureForTracker` routing; contains an opaque probe pattern in `resolveTrackerConfig` where the `readLinearProjectReference` return value is silently discarded in the UNKNOWN error path. |
| apps/desktop/src/renderer/atoms/workflow-board.ts | Adds scope management, versioned activation guard, and 30s polling loop; `activatePolling` sets the board but never calls `getContext()` after the initial `getBoard()`, leaving context stale until the first interval fires. |
| apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx | New reusable component extracting header, board-status formatting, and override banner from KanbanPane; clean, well-typed, and all label keys in `formatPaneResolutionReason` match the full union type. |
| apps/desktop/src/renderer/components/kanban/KanbanPane.tsx | Simplified to delegate all header concerns to KanbanHeader; clean refactor with no functional regressions. |
| apps/desktop/src/main/__tests__/workflow-board-service.test.ts | Comprehensive unit tests covering linear/github fixtures, scenario seam, stale/recovery, concurrent deduplication, scope-race guard, and context refresh paths; well-structured and complete. |
| apps/desktop/e2e/tests/workflow-kanban-integration.e2e.ts | New integration e2e covering planning→execution handoff, override persistence, stale recovery, and labels/projects_v2 backend switching; uses the mocked fixture correctly and Playwright's built-in retry handles timing. |
| apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx | Targeted unit tests for `formatWorkflowBoardStatus` covering loading, stale+refresh, and empty-reason paths; appropriately lightweight. |
| apps/desktop/src/shared/types.ts | Minor type additions/exports; `WorkflowContextReason`, `RightPaneResolution`, and related types look consistent with usage in KanbanHeader and the service. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as KanbanPane (Renderer)
    participant Atom as workflow-board atoms
    participant IPC as window.api.workflow
    participant Svc as WorkflowBoardService (Main)
    participant Tracker as Linear/GitHub Client

    Note over UI,Atom: rightPaneMode → 'kanban'
    UI->>Atom: activatePolling()
    Atom->>IPC: setBoardActive(true)
    Atom->>IPC: getBoard()
    IPC->>Svc: getBoard() / refreshBoard()
    alt testScenario set (KATA_TEST_MODE=1)
        Svc-->>IPC: buildScenarioSnapshot(scenario)
    else fixtureEnabled
        Svc->>Svc: fixtureForTracker(tracker)
        Svc-->>IPC: withFreshTimestamps(fixture)
    else live
        Svc->>Tracker: fetchSnapshot()
        Tracker-->>Svc: WorkflowBoardSnapshot
    end
    Svc->>Svc: syncContextSnapshot()
    IPC-->>Atom: WorkflowBoardSnapshotResponse
    Atom->>UI: setBoard / setError

    Note over UI,Atom: Every 30s (interval)
    Atom->>IPC: refreshBoard()
    IPC-->>Atom: updated snapshot
    Atom->>IPC: getContext()
    IPC-->>Atom: WorkflowContextSnapshot
    Atom->>UI: setWorkflowContext

    Note over UI,Atom: Manual refresh button
    UI->>Atom: refreshWorkflowBoardAtom
    Atom->>IPC: refreshBoard()
    IPC-->>Atom: updated snapshot
    Atom->>IPC: getContext()
    IPC-->>Atom: WorkflowContextSnapshot
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/atoms/workflow-board.ts`, line 107-124 ([link](https://github.com/gannonh/kata/blob/81ded54664169b6ee7e931211b76c1f333579804/apps/desktop/src/renderer/atoms/workflow-board.ts#L107-L124)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Context not refreshed after initial board fetch**

   After `getBoard()` resolves and `setBoard` is called, `window.api.workflow.getContext()` is never called. The scope effect already fetched context _before_ `setBoardActive(true)` ran, so between the initial board load and the first 30-second interval tick the `Context: …` / reason text in `KanbanHeader` can be stale (e.g. "Tracker configured — board pending" while the board column data is already visible on screen).

   The interval at line 159 does fix this, but only after up to 30 seconds. Adding a `getContext()` call after `setBoard` in the `try` block mirrors what the interval already does:

   ```typescript
           setBoard(initial.snapshot)
           setError(initial.snapshot.lastError?.message ?? null)

           try {
             const ctxResponse = await window.api.workflow.getContext()
             if (isCurrentActivation()) {
               setWorkflowContext(ctxResponse.context)
             }
           } catch {
             // best-effort context sync on initial load
           }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/atoms/workflow-board.ts
   Line: 107-124

   Comment:
   **Context not refreshed after initial board fetch**

   After `getBoard()` resolves and `setBoard` is called, `window.api.workflow.getContext()` is never called. The scope effect already fetched context _before_ `setBoardActive(true)` ran, so between the initial board load and the first 30-second interval tick the `Context: …` / reason text in `KanbanHeader` can be stale (e.g. "Tracker configured — board pending" while the board column data is already visible on screen).

   The interval at line 159 does fix this, but only after up to 30 seconds. Adding a `getContext()` call after `setBoard` in the `try` block mirrors what the interval already does:

   ```typescript
           setBoard(initial.snapshot)
           setError(initial.snapshot.lastError?.message ?? null)

           try {
             const ctxResponse = await window.api.workflow.getContext()
             if (isCurrentActivation()) {
               setWorkflowContext(ctxResponse.context)
             }
           } catch {
             // best-effort context sync on initial load
           }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/workflow-board.ts
Line: 107-124

Comment:
**Context not refreshed after initial board fetch**

After `getBoard()` resolves and `setBoard` is called, `window.api.workflow.getContext()` is never called. The scope effect already fetched context _before_ `setBoardActive(true)` ran, so between the initial board load and the first 30-second interval tick the `Context: …` / reason text in `KanbanHeader` can be stale (e.g. "Tracker configured — board pending" while the board column data is already visible on screen).

The interval at line 159 does fix this, but only after up to 30 seconds. Adding a `getContext()` call after `setBoard` in the `try` block mirrors what the interval already does:

```typescript
        setBoard(initial.snapshot)
        setError(initial.snapshot.lastError?.message ?? null)

        try {
          const ctxResponse = await window.api.workflow.getContext()
          if (isCurrentActivation()) {
            setWorkflowContext(ctxResponse.context)
          }
        } catch {
          // best-effort context sync on initial load
        }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/workflow-board-service.ts
Line: 586-600

Comment:
**`readLinearProjectReference` return value silently discarded**

When `trackerResult.error.code === 'UNKNOWN'`, the code calls `readLinearProjectReference(workspacePath)` but never uses the returned `projectRef` — only the exception path matters. As a result, the intent of this `try` block is unclear: it looks like a fallback that was never wired up.

If this is intentionally a "probe" (validate that preferences.md is readable before surfacing the WORKFLOW.md error), a comment would make that explicit:

```typescript
if (trackerResult.error.code === 'UNKNOWN') {
  try {
    // Probe only: surface a more precise error if preferences.md is itself unreadable.
    await readLinearProjectReference(workspacePath)
  } catch (error) {
    return { config: null, error: { code: 'UNKNOWN', message: error instanceof Error ? error.message : String(error) } }
  }
}
```

If the intent was to fall back to preferences when WORKFLOW.md has an UNKNOWN error, the returned value needs to be wired into a return statement before the fall-through.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/workflow-board-service.ts
Line: 355-371

Comment:
**Hardcoded `backend: 'linear'` in pre-tracker-resolution error snapshots**

`toErrorSnapshot` is called with `backend: 'linear'` in both the `trackerResolution.error` path (line 360) and the `!tracker` / NOT_CONFIGURED path (line 380). For workspaces that ultimately resolve to GitHub, this causes the error banner in `KanbanHeader` to report `formatBoardSource` as `"linear"` rather than the actual backend — misleading provenance in the status bar.

Since the tracker isn't resolved yet in these paths, `'unknown'` would be more accurate, or the same pattern used elsewhere (`tracker.kind === 'github' ? 'github' : 'linear'` at line 447) could be applied if a partial hint is available.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): harden workflow board ser..."](https://github.com/gannonh/kata/commit/81ded54664169b6ee7e931211b76c1f333579804) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27352111)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->