### PR TITLE
feat(desktop): implement S01 desktop-controlled symphony runtime lifecycle

### DIFF
--- a/apps/desktop/docs/uat/M004/S01-RUNTIME-SMOKE.md
+++ b/apps/desktop/docs/uat/M004/S01-RUNTIME-SMOKE.md
@@ -1,0 +1,44 @@
+# S01 Runtime Smoke — Dev + Packaged
+
+This checklist validates **S01 only** (runtime lifecycle controls + truthful status surfaces).
+
+## Preconditions
+
+- Symphony workflow file exists and is valid.
+- `symphony.url` and `symphony.workflow_path` are set in `.kata/preferences.md` for the workspace.
+- Desktop app can launch with renderer/main bundles built.
+
+## Dev-mode smoke
+
+1. Launch Desktop in dev mode.
+2. Open **Settings → Symphony**.
+3. Confirm lifecycle starts in one of: `Stopped`, `Disconnected`, or `Config Error` (truthful initial state).
+4. Click **Start**.
+5. Confirm state transitions through `Starting` → `Ready`.
+6. Confirm header badge shows **Symphony: Ready**.
+7. Click **Restart**.
+8. Confirm temporary `Restarting`/`Starting` then back to `Ready`.
+9. Click **Stop**.
+10. Confirm state transitions through `Stopping` → `Stopped` (or `Disconnected` if process exited externally).
+11. Validate no secrets are shown in status/error surfaces.
+
+## Packaged-mode smoke
+
+1. Build packaged (or packaged-like) Desktop artifact.
+2. Launch packaged app and open **Settings → Symphony**.
+3. Repeat Start / Restart / Stop flow from dev checklist.
+4. Confirm runtime uses packaged/bundled discovery path (not terminal-managed process).
+5. Confirm same lifecycle labels and error presentation as dev mode.
+
+## Failure-state smoke
+
+- Misconfigure `symphony.url` (invalid protocol): expect `Config Error` with actionable message.
+- Point `symphony.workflow_path` to missing file: expect `Config Error` with missing-path message.
+- Keep valid config but force unreachable API URL: expect `Failed` with readiness error.
+
+## Evidence capture
+
+- Screenshot of Symphony settings panel in `Ready` state.
+- Screenshot of panel in `Config Error` state.
+- Screenshot of app-shell badge while ready and while stopped.
+- Note exact Desktop build (dev or packaged) and commit SHA used for smoke.

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -71,9 +71,11 @@ type DesktopFixtures = {
   workspaceDir: string
   mainWindow: Page
   readyWindow: Page
+  symphonyMockMode: 'ready' | 'config_error' | 'readiness_error'
 }
 
 export const test = base.extend<DesktopFixtures>({
+  symphonyMockMode: ['ready', { option: true }],
   workspaceDir: async ({}, use) => {
     const dataDir = createIsolatedDataDir()
     const workspaceDir = path.join(dataDir, 'workspace')
@@ -83,7 +85,7 @@ export const test = base.extend<DesktopFixtures>({
       try { rmSync(dataDir, { recursive: true, force: true }) } catch { /* noop */ }
     }
   },
-  electronApp: async ({ workspaceDir }, use) => {
+  electronApp: async ({ workspaceDir, symphonyMockMode }, use) => {
     const dataDir = path.dirname(workspaceDir)
     const mainEntry = path.join(__dirname, '../../dist/main.cjs')
     const preloadEntry = path.join(__dirname, '../../dist/preload.cjs')
@@ -113,6 +115,8 @@ export const test = base.extend<DesktopFixtures>({
         NODE_ENV: 'test',
         KATA_TEST_MODE: '1',
         KATA_WORKSPACE_PATH: workspaceDir,
+        KATA_DESKTOP_SYMPHONY_MOCK: symphonyMockMode,
+        KATA_SYMPHONY_URL: 'http://127.0.0.1:8080',
         // Don't override HOME — that breaks CLI binary discovery and auth.json lookup.
         // The --user-data-dir flag isolates Electron's own data (localStorage, cookies).
       },

--- a/apps/desktop/e2e/tests/symphony-runtime.e2e.ts
+++ b/apps/desktop/e2e/tests/symphony-runtime.e2e.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '../fixtures/electron.fixture'
+
+test.describe('Symphony runtime lifecycle', () => {
+  test.use({ symphonyMockMode: 'ready' })
+
+  test('supports start, restart, and stop from settings panel', async ({ readyWindow }) => {
+    await readyWindow.getByRole('button', { name: /Settings/i }).click()
+    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+
+    await expect(readyWindow.getByTestId('symphony-phase-badge')).toContainText('Idle')
+
+    await readyWindow.getByTestId('symphony-start-button').click()
+    await expect(readyWindow.getByTestId('symphony-phase-badge')).toContainText('Ready')
+
+    await readyWindow.getByTestId('symphony-stop-button').click()
+    await expect(readyWindow.getByTestId('symphony-phase-badge')).toContainText('Stopped')
+
+    await readyWindow.getByTestId('symphony-start-button').click()
+    await expect(readyWindow.getByTestId('symphony-phase-badge')).toContainText('Ready')
+
+    await readyWindow.getByTestId('symphony-restart-button').click()
+    await expect(readyWindow.getByTestId('symphony-phase-badge')).toContainText('Ready')
+
+    await expect(readyWindow.getByTestId('symphony-status-badge')).toContainText('Symphony: Ready')
+  })
+})
+
+test.describe('Symphony config error state', () => {
+  test.use({ symphonyMockMode: 'config_error' })
+
+  test('renders config error guidance', async ({ readyWindow }) => {
+    await readyWindow.getByRole('button', { name: /Settings/i }).click()
+    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+
+    await readyWindow.getByTestId('symphony-start-button').click()
+    await expect(readyWindow.getByTestId('symphony-phase-badge')).toContainText('Config Error')
+    await expect(readyWindow.getByTestId('symphony-runtime-error')).toContainText('CONFIG_MISSING')
+    await expect(readyWindow.getByTestId('symphony-config-guidance')).toBeVisible()
+  })
+})
+
+test.describe('Symphony readiness failure state', () => {
+  test.use({ symphonyMockMode: 'readiness_error' })
+
+  test('renders readiness failure state', async ({ readyWindow }) => {
+    await readyWindow.getByRole('button', { name: /Settings/i }).click()
+    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+
+    await readyWindow.getByTestId('symphony-start-button').click()
+    await expect(readyWindow.getByTestId('symphony-phase-badge')).toContainText('Failed')
+    await expect(readyWindow.getByTestId('symphony-runtime-error')).toContainText('READINESS_FAILED')
+  })
+})

--- a/apps/desktop/src/main/__tests__/symphony-config.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-config.test.ts
@@ -1,0 +1,174 @@
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+import { resolveSymphonyLaunch } from '../symphony-config'
+
+function createWorkspace(): { workspacePath: string; cleanup: () => void } {
+  const workspacePath = mkdtempSync(path.join(tmpdir(), 'desktop-symphony-config-'))
+  mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+
+  return {
+    workspacePath,
+    cleanup: () => rmSync(workspacePath, { recursive: true, force: true }),
+  }
+}
+
+function createExecutable(workspacePath: string, name = 'symphony'): string {
+  const executablePath = path.join(workspacePath, name)
+  writeFileSync(executablePath, '#!/usr/bin/env bash\nexit 0\n', 'utf8')
+  chmodSync(executablePath, 0o755)
+  return executablePath
+}
+
+describe('resolveSymphonyLaunch', () => {
+  const cleanups: Array<() => void> = []
+
+  afterEach(() => {
+    for (const cleanup of cleanups.splice(0)) {
+      cleanup()
+    }
+  })
+
+  test('resolves launch descriptor from preferences', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const workflowPath = path.join(workspace.workspacePath, 'workflow-test.md')
+    writeFileSync(workflowPath, '# workflow\n', 'utf8')
+    const executablePath = createExecutable(workspace.workspacePath, 'symphony-bin')
+
+    writeFileSync(
+      path.join(workspace.workspacePath, '.kata', 'preferences.md'),
+      [
+        '---',
+        'symphony:',
+        '  url: http://127.0.0.1:8080',
+        `  workflow_path: ${workflowPath}`,
+        '---',
+      ].join('\n'),
+      'utf8',
+    )
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: executablePath,
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.launch.command).toBe(executablePath)
+    expect(result.launch.workflowPath).toBe(workflowPath)
+    expect(result.launch.resolvedUrl).toBe('http://127.0.0.1:8080')
+    expect(result.launch.args).toEqual([workflowPath, '--no-tui', '--port', '8080'])
+  })
+
+  test('returns config error when URL is malformed', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+
+    writeFileSync(
+      path.join(workspace.workspacePath, '.kata', 'preferences.md'),
+      ['---', 'symphony:', '  url: not-a-url', '---'].join('\n'),
+      'utf8',
+    )
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: process.env,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).toBe('CONFIG_INVALID')
+  })
+
+  test('returns workflow path missing when configured path does not exist', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(
+      path.join(workspace.workspacePath, '.kata', 'preferences.md'),
+      ['---', 'symphony:', '  url: http://localhost:8080', '  workflow_path: ./missing.md', '---'].join(
+        '\n',
+      ),
+      'utf8',
+    )
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: process.env,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).toBe('WORKFLOW_PATH_MISSING')
+  })
+
+  test('returns config invalid on unsupported protocol', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+    writeFileSync(
+      path.join(workspace.workspacePath, '.kata', 'preferences.md'),
+      ['---', 'symphony:', '  url: ws://localhost:8080', '---'].join('\n'),
+      'utf8',
+    )
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: process.env,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).toBe('CONFIG_INVALID')
+    expect(result.error.details).toBe('unsupported_protocol')
+  })
+
+  test('returns binary not found when command cannot be resolved', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: 'http://localhost:8080',
+        PATH: '/definitely/missing/path',
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).toBe('BINARY_NOT_FOUND')
+  })
+})

--- a/apps/desktop/src/main/__tests__/symphony-config.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-config.test.ts
@@ -54,6 +54,34 @@ describe('resolveSymphonyLaunch', () => {
     expect(await loadWorkspacePreferences(workspace.workspacePath)).toBeNull()
   })
 
+  test('loadWorkspacePreferences ignores comments, malformed lines, and dedented keys', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(
+      path.join(workspace.workspacePath, '.kata', 'preferences.md'),
+      [
+        '---',
+        'symphony:',
+        '  # comment line',
+        '  url: http://localhost:8080',
+        '',
+        '  malformed line',
+        '  workflow_path: WORKFLOW.md',
+        'theme: dark',
+        '---',
+      ].join('\n'),
+      'utf8',
+    )
+
+    await expect(loadWorkspacePreferences(workspace.workspacePath)).resolves.toEqual({
+      symphony: {
+        url: 'http://localhost:8080',
+        workflow_path: 'WORKFLOW.md',
+      },
+    })
+  })
+
   test('resolves launch descriptor from preferences', async () => {
     const workspace = createWorkspace()
     cleanups.push(workspace.cleanup)

--- a/apps/desktop/src/main/__tests__/symphony-config.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-config.test.ts
@@ -38,6 +38,32 @@ describe('resolveSymphonyLaunch', () => {
     expect(loaded).toBeNull()
   })
 
+  test('resolveSymphonyLaunch surfaces preferences read errors beyond ENOENT', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const preferencesPath = path.join(workspace.workspacePath, '.kata', 'preferences.md')
+    mkdirSync(preferencesPath, { recursive: true })
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: 'http://localhost:8080',
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).toBe('CONFIG_INVALID')
+    expect(result.error.details).toBe('preferences_read_failed')
+  })
+
   test('loadWorkspacePreferences returns null without frontmatter/symphony block', async () => {
     const workspace = createWorkspace()
     cleanups.push(workspace.cleanup)
@@ -120,6 +146,42 @@ describe('resolveSymphonyLaunch', () => {
     expect(result.launch.workflowPath).toBe(workflowPath)
     expect(result.launch.resolvedUrl).toBe('http://127.0.0.1:8080')
     expect(result.launch.args).toEqual([workflowPath, '--no-tui', '--port', '8080'])
+  })
+
+  test('normalizes backslash workflow paths when resolving preferences', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const workflowDir = path.join(workspace.workspacePath, 'nested')
+    mkdirSync(workflowDir, { recursive: true })
+    const workflowPath = path.join(workflowDir, 'WORKFLOW.md')
+    writeFileSync(workflowPath, '# workflow\n', 'utf8')
+
+    const executablePath = createExecutable(workspace.workspacePath, 'symphony-bin')
+
+    writeFileSync(
+      path.join(workspace.workspacePath, '.kata', 'preferences.md'),
+      ['---', 'symphony:', '  url: http://127.0.0.1:8080', '  workflow_path: nested\\WORKFLOW.md', '---'].join(
+        '\n',
+      ),
+      'utf8',
+    )
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: executablePath,
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.launch.workflowPath).toBe(workflowPath)
   })
 
   test('returns config error when URL is malformed', async () => {

--- a/apps/desktop/src/main/__tests__/symphony-config.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-config.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:f
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, test } from 'vitest'
-import { resolveSymphonyLaunch } from '../symphony-config'
+import { loadWorkspacePreferences, resolveSymphonyLaunch } from '../symphony-config'
 
 function createWorkspace(): { workspacePath: string; cleanup: () => void } {
   const workspacePath = mkdtempSync(path.join(tmpdir(), 'desktop-symphony-config-'))
@@ -28,6 +28,30 @@ describe('resolveSymphonyLaunch', () => {
     for (const cleanup of cleanups.splice(0)) {
       cleanup()
     }
+  })
+
+  test('loadWorkspacePreferences returns null when preferences file is missing', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const loaded = await loadWorkspacePreferences(workspace.workspacePath)
+    expect(loaded).toBeNull()
+  })
+
+  test('loadWorkspacePreferences returns null without frontmatter/symphony block', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, '.kata', 'preferences.md'), 'plain text', 'utf8')
+    expect(await loadWorkspacePreferences(workspace.workspacePath)).toBeNull()
+
+    writeFileSync(
+      path.join(workspace.workspacePath, '.kata', 'preferences.md'),
+      ['---', 'theme: dark', '---'].join('\n'),
+      'utf8',
+    )
+
+    expect(await loadWorkspacePreferences(workspace.workspacePath)).toBeNull()
   })
 
   test('resolves launch descriptor from preferences', async () => {
@@ -146,6 +170,208 @@ describe('resolveSymphonyLaunch', () => {
 
     expect(result.error.code).toBe('CONFIG_INVALID')
     expect(result.error.details).toBe('unsupported_protocol')
+  })
+
+  test('uses env URL and default WORKFLOW path when preferences are missing', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const executablePath = createExecutable(workspace.workspacePath, 'symphony-from-env')
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: 'http://localhost:9090/',
+        KATA_SYMPHONY_BIN_PATH: executablePath,
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.launch.urlSource).toBe('env')
+    expect(result.launch.workflowPathSource).toBe('default')
+    expect(result.launch.args).toEqual([
+      path.join(workspace.workspacePath, 'WORKFLOW.md'),
+      '--no-tui',
+      '--port',
+      '9090',
+    ])
+  })
+
+  test('returns config missing when no URL is configured', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: '',
+        SYMPHONY_URL: '',
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).toBe('CONFIG_MISSING')
+  })
+
+  test('returns binary not found when env binary path is invalid', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: 'http://localhost:8080',
+        KATA_SYMPHONY_BIN_PATH: './missing-binary',
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).toBe('BINARY_NOT_FOUND')
+  })
+
+  test('resolves packaged binary path when running in packaged mode', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const resourcesPath = mkdtempSync(path.join(tmpdir(), 'desktop-symphony-resources-'))
+    cleanups.push(() => rmSync(resourcesPath, { recursive: true, force: true }))
+
+    const packagedBinary = createExecutable(resourcesPath, 'symphony')
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: true,
+      resourcesPath,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: 'http://localhost:8080',
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.launch.command).toBe(packagedBinary)
+    expect(result.launch.source).toBe('bundled')
+  })
+
+  test('parses quoted preference values and strips inline comments', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+    const executablePath = createExecutable(workspace.workspacePath, 'quoted-symphony-bin')
+
+    writeFileSync(
+      path.join(workspace.workspacePath, '.kata', 'preferences.md'),
+      [
+        '---',
+        'symphony:',
+        '  url: "http://localhost:8082" # inline comment',
+        "  workflow_path: 'WORKFLOW.md'",
+        '---',
+      ].join('\n'),
+      'utf8',
+    )
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: executablePath,
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.launch.resolvedUrl).toBe('http://localhost:8082')
+  })
+
+  test('falls back to SYMPHONY_URL when KATA_SYMPHONY_URL is missing', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+    const executablePath = createExecutable(workspace.workspacePath, 'fallback-env-bin')
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: '',
+        SYMPHONY_URL: 'http://localhost:8123',
+        KATA_SYMPHONY_BIN_PATH: executablePath,
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.launch.resolvedUrl).toBe('http://localhost:8123')
+  })
+
+  test('resolves binary from PATH discovery when env override is absent', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+
+    const binDir = mkdtempSync(path.join(tmpdir(), 'desktop-symphony-path-bin-'))
+    cleanups.push(() => rmSync(binDir, { recursive: true, force: true }))
+    const pathBinary = createExecutable(binDir, 'symphony')
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: 'http://localhost:8080',
+        KATA_SYMPHONY_BIN_PATH: '',
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.launch.command).toBe(pathBinary)
+    expect(result.launch.source).toBe('path')
   })
 
   test('returns binary not found when command cannot be resolved', async () => {

--- a/apps/desktop/src/main/__tests__/symphony-config.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-config.test.ts
@@ -236,6 +236,33 @@ describe('resolveSymphonyLaunch', () => {
     expect(result.error.code).toBe('WORKFLOW_PATH_MISSING')
   })
 
+  test('returns workflow path missing when configured workflow_path points to a directory', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const workflowDir = path.join(workspace.workspacePath, 'workflow-dir')
+    mkdirSync(workflowDir, { recursive: true })
+
+    writeFileSync(
+      path.join(workspace.workspacePath, '.kata', 'preferences.md'),
+      ['---', 'symphony:', '  url: http://localhost:8080', '  workflow_path: ./workflow-dir', '---'].join('\n'),
+      'utf8',
+    )
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: process.env,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).toBe('WORKFLOW_PATH_MISSING')
+  })
+
   test('returns config invalid on unsupported protocol', async () => {
     const workspace = createWorkspace()
     cleanups.push(workspace.cleanup)
@@ -292,6 +319,29 @@ describe('resolveSymphonyLaunch', () => {
       '--port',
       '9090',
     ])
+  })
+
+  test('returns workflow path missing when default WORKFLOW.md is a directory', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    mkdirSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), { recursive: true })
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: 'http://localhost:8080',
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).toBe('WORKFLOW_PATH_MISSING')
   })
 
   test('returns config missing when no URL is configured', async () => {

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -1,0 +1,116 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { IPC_CHANNELS } from '@shared/types'
+
+const handlers = new Map<string, (...args: any[]) => any>()
+
+vi.mock('electron', () => {
+  return {
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+        handlers.set(channel, handler)
+      }),
+      removeHandler: vi.fn((channel: string) => {
+        handlers.delete(channel)
+      }),
+    },
+    dialog: {
+      showOpenDialog: vi.fn(async () => ({ canceled: true, filePaths: [] })),
+    },
+  }
+})
+
+import { registerSessionIpc } from '../ipc'
+
+function createBridgeStub() {
+  const emitter = new EventEmitter()
+
+  return Object.assign(emitter, {
+    getState: vi.fn(() => ({ status: 'running', pid: 1, running: true })),
+    getWorkspacePath: vi.fn(() => process.cwd()),
+    prompt: vi.fn(),
+    abort: vi.fn(),
+    restart: vi.fn(),
+    sendExtensionUIResponse: vi.fn(),
+    setPermissionMode: vi.fn(),
+    getAvailableModels: vi.fn(async () => []),
+    setModel: vi.fn(),
+    setThinkingLevel: vi.fn(),
+    send: vi.fn(async () => ({ data: {} })),
+    switchSession: vi.fn(async () => true),
+    switchWorkspace: vi.fn(async () => undefined),
+  }) as any
+}
+
+function createWindowStub() {
+  return {
+    isDestroyed: () => false,
+    webContents: {
+      isDestroyed: () => false,
+      send: vi.fn(),
+    },
+  } as any
+}
+
+describe('symphony ipc handlers', () => {
+  beforeEach(() => {
+    handlers.clear()
+  })
+
+  test('routes symphony start/stop/restart through supervisor', async () => {
+    const bridge = createBridgeStub()
+
+    const supervisor = {
+      on: vi.fn(),
+      off: vi.fn(),
+      getStatus: vi.fn(() => ({
+        phase: 'idle',
+        managedProcessRunning: false,
+        pid: null,
+        url: null,
+        diagnostics: { stdout: [], stderr: [] },
+        updatedAt: new Date().toISOString(),
+        restartCount: 0,
+      })),
+      start: vi.fn(async () => ({ success: true, status: { phase: 'starting' } })),
+      stop: vi.fn(async () => ({ success: true, status: { phase: 'stopped' } })),
+      restart: vi.fn(async () => ({ success: true, status: { phase: 'restarting' } })),
+      setWorkspacePath: vi.fn(async () => undefined),
+    } as any
+
+    const unregister = registerSessionIpc({
+      bridge,
+      authBridge: {
+        getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+        setProviderKey: vi.fn(),
+        removeProviderKey: vi.fn(),
+        validateKey: vi.fn(),
+      } as any,
+      sessionManager: {
+        listSessions: vi.fn(async () => ({ sessions: [], warnings: [], directory: process.cwd() })),
+        getSessionInfo: vi.fn(),
+        resolveSessionPathById: vi.fn(async () => null),
+      } as any,
+      window: createWindowStub(),
+      symphonySupervisor: supervisor,
+    })
+
+    const startHandler = handlers.get(IPC_CHANNELS.symphonyStart)
+    const stopHandler = handlers.get(IPC_CHANNELS.symphonyStop)
+    const restartHandler = handlers.get(IPC_CHANNELS.symphonyRestart)
+
+    expect(startHandler).toBeTypeOf('function')
+    expect(stopHandler).toBeTypeOf('function')
+    expect(restartHandler).toBeTypeOf('function')
+
+    await startHandler?.({})
+    await stopHandler?.({})
+    await restartHandler?.({})
+
+    expect(supervisor.start).toHaveBeenCalledTimes(1)
+    expect(supervisor.stop).toHaveBeenCalledTimes(1)
+    expect(supervisor.restart).toHaveBeenCalledTimes(1)
+
+    unregister()
+  })
+})

--- a/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
@@ -122,6 +122,8 @@ describe('SymphonySupervisor', () => {
     expect(result.success).toBe(false)
     expect(result.error?.code).toBe('READINESS_FAILED')
     expect(supervisor.getStatus().phase).toBe('failed')
+    expect(supervisor.getStatus().managedProcessRunning).toBe(false)
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
   })
 
   test('supports stop and restart with lifecycle updates', async () => {
@@ -237,6 +239,37 @@ describe('SymphonySupervisor', () => {
 
     expect(supervisor.getStatus().phase).toBe('failed')
     expect(supervisor.getStatus().lastError?.code).toBe('PROCESS_EXITED')
+  })
+
+  test('returns process exit error when child exits before readiness succeeds', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const child = createMockChild()
+    const fetchImpl = vi.fn(async () => {
+      child.emit('exit', 2, null)
+      child.exitCode = 2
+      return { ok: false } as Response
+    })
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: vi.fn(() => child as any) as any,
+      fetchImpl: fetchImpl as any,
+      readinessTimeoutMs: 1_000,
+      readinessIntervalMs: 200,
+    })
+
+    const result = await supervisor.start()
+
+    expect(result.success).toBe(false)
+    expect(result.error?.code).toBe('PROCESS_EXITED')
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
   test('resets runtime state when workspace path changes', async () => {

--- a/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
@@ -373,6 +373,41 @@ describe('SymphonySupervisor', () => {
     expect(supervisor.getStatus().phase).toBe('failed')
   })
 
+  test('treats SIGKILL exit as successful stop after graceful timeout', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const child = createMockChild()
+    child.kill = vi.fn((signal?: string) => {
+      if (signal === 'SIGKILL') {
+        child.exitCode = 0
+        child.emit('exit', 0, 'SIGKILL')
+        child.emit('close', 0, 'SIGKILL')
+      }
+      return true
+    })
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: vi.fn(() => child as any) as any,
+      fetchImpl: vi.fn(async () => ({ ok: true } as Response)) as any,
+      stopTimeoutMs: 20,
+    })
+
+    await supervisor.start()
+    const stopped = await supervisor.stop('force_kill')
+
+    expect(stopped.success).toBe(true)
+    expect(supervisor.getStatus().phase).toBe('stopped')
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+
   test('returns immediately when start is called while already ready', async () => {
     const workspace = createWorkspace()
     cleanups.push(workspace.cleanup)

--- a/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
@@ -158,4 +158,246 @@ describe('SymphonySupervisor', () => {
     expect(supervisor.getStatus().phase).toBe('stopped')
     expect(supervisor.getStatus().managedProcessRunning).toBe(false)
   })
+
+  test('supports mocked ready mode for deterministic e2e seams', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_DESKTOP_SYMPHONY_MOCK: 'ready',
+        KATA_SYMPHONY_URL: 'http://127.0.0.1:7000',
+      },
+    })
+
+    const started = await supervisor.start()
+    expect(started.success).toBe(true)
+    expect(supervisor.getStatus().phase).toBe('ready')
+    expect(supervisor.getStatus().pid).toBe(4242)
+
+    const stopped = await supervisor.stop('mock_stop')
+    expect(stopped.success).toBe(true)
+    expect(supervisor.getStatus().phase).toBe('stopped')
+  })
+
+  test('supports mocked config and readiness failure modes', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const configErrorSupervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_DESKTOP_SYMPHONY_MOCK: 'config_error',
+      },
+    })
+
+    const configResult = await configErrorSupervisor.start()
+    expect(configResult.success).toBe(false)
+    expect(configResult.error?.code).toBe('CONFIG_MISSING')
+    expect(configErrorSupervisor.getStatus().phase).toBe('config_error')
+
+    const readinessErrorSupervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_DESKTOP_SYMPHONY_MOCK: 'readiness_error',
+      },
+    })
+
+    const readinessResult = await readinessErrorSupervisor.start()
+    expect(readinessResult.success).toBe(false)
+    expect(readinessResult.error?.code).toBe('READINESS_FAILED')
+    expect(readinessErrorSupervisor.getStatus().phase).toBe('failed')
+  })
+
+  test('captures unexpected process exits as failures', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const child = createMockChild()
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: vi.fn(() => child as any) as any,
+      fetchImpl: vi.fn(async () => ({ ok: true } as Response)) as any,
+    })
+
+    await supervisor.start()
+    child.emit('exit', 9, null)
+
+    expect(supervisor.getStatus().phase).toBe('failed')
+    expect(supervisor.getStatus().lastError?.code).toBe('PROCESS_EXITED')
+  })
+
+  test('resets runtime state when workspace path changes', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_DESKTOP_SYMPHONY_MOCK: 'ready',
+      },
+    })
+
+    await supervisor.start()
+
+    const nextWorkspace = mkdtempSync(path.join(tmpdir(), 'desktop-symphony-next-workspace-'))
+    cleanups.push(() => rmSync(nextWorkspace, { recursive: true, force: true }))
+
+    await supervisor.setWorkspacePath(nextWorkspace)
+
+    expect(supervisor.getStatus().phase).toBe('stopped')
+    expect(supervisor.getStatus().url).toBeNull()
+    expect(supervisor.getStatus().managedProcessRunning).toBe(false)
+  })
+
+  test('captures diagnostics from stdout and stderr streams', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const child = createMockChild()
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: vi.fn(() => child as any) as any,
+      fetchImpl: vi.fn(async () => ({ ok: true } as Response)) as any,
+    })
+
+    await supervisor.start()
+    child.stdout.emit('data', 'line one\nline two\n')
+    child.stderr.emit('data', 'warn one\n')
+
+    expect(supervisor.getStatus().diagnostics.stdout).toContain('line one')
+    expect(supervisor.getStatus().diagnostics.stdout).toContain('line two')
+    expect(supervisor.getStatus().diagnostics.stderr).toContain('warn one')
+  })
+
+  test('handles spawn implementation failures', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: vi.fn(() => {
+        throw new Error('spawn exploded')
+      }) as any,
+      fetchImpl: vi.fn(async () => ({ ok: true } as Response)) as any,
+    })
+
+    const result = await supervisor.start()
+    expect(result.success).toBe(false)
+    expect(result.error?.code).toBe('SPAWN_FAILED')
+    expect(supervisor.getStatus().phase).toBe('failed')
+  })
+
+  test('returns stop timeout when process ignores signals', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const child = createMockChild()
+    child.kill = vi.fn(() => true)
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: vi.fn(() => child as any) as any,
+      fetchImpl: vi.fn(async () => ({ ok: true } as Response)) as any,
+      stopTimeoutMs: 20,
+    })
+
+    await supervisor.start()
+    const stopped = await supervisor.stop('timeout_case')
+
+    expect(stopped.success).toBe(false)
+    expect(stopped.error?.code).toBe('STOP_TIMEOUT')
+    expect(supervisor.getStatus().phase).toBe('failed')
+  })
+
+  test('returns immediately when start is called while already ready', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const spawnImpl = vi.fn(() => createMockChild() as any)
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: spawnImpl as any,
+      fetchImpl: vi.fn(async () => ({ ok: true } as Response)) as any,
+    })
+
+    await supervisor.start()
+    const secondStart = await supervisor.start()
+
+    expect(secondStart.success).toBe(true)
+    expect(spawnImpl).toHaveBeenCalledTimes(1)
+  })
+
+  test('stop succeeds when no child process is running', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: process.env,
+    })
+
+    const result = await supervisor.stop('idle_stop')
+    expect(result.success).toBe(true)
+    expect(supervisor.getStatus().phase).toBe('stopped')
+  })
+
+  test('marks runtime failed when child emits process error', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const child = createMockChild()
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: vi.fn(() => child as any) as any,
+      fetchImpl: vi.fn(async () => ({ ok: true } as Response)) as any,
+    })
+
+    await supervisor.start()
+    child.emit('error', new Error('child failure'))
+
+    expect(supervisor.getStatus().phase).toBe('failed')
+    expect(supervisor.getStatus().lastError?.code).toBe('SPAWN_FAILED')
+  })
 })

--- a/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
@@ -1,0 +1,161 @@
+import { EventEmitter } from 'node:events'
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { SymphonySupervisor } from '../symphony-supervisor'
+
+function createWorkspace(): { workspacePath: string; executablePath: string; cleanup: () => void } {
+  const workspacePath = mkdtempSync(path.join(tmpdir(), 'desktop-symphony-supervisor-'))
+  mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+
+  const workflowPath = path.join(workspacePath, 'WORKFLOW.md')
+  writeFileSync(workflowPath, '# workflow\n', 'utf8')
+
+  const executablePath = path.join(workspacePath, 'symphony-bin')
+  writeFileSync(executablePath, '#!/usr/bin/env bash\nexit 0\n', 'utf8')
+  chmodSync(executablePath, 0o755)
+
+  writeFileSync(
+    path.join(workspacePath, '.kata', 'preferences.md'),
+    ['---', 'symphony:', '  url: http://127.0.0.1:8080', '  workflow_path: ./WORKFLOW.md', '---'].join(
+      '\n',
+    ),
+    'utf8',
+  )
+
+  return {
+    workspacePath,
+    executablePath,
+    cleanup: () => rmSync(workspacePath, { recursive: true, force: true }),
+  }
+}
+
+function createMockChild(pid = 4321) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    pid: number
+    exitCode: number | null
+    kill: ReturnType<typeof vi.fn>
+  }
+
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.pid = pid
+  child.exitCode = null
+  child.kill = vi.fn((signal?: string) => {
+    if (signal === 'SIGTERM' || signal === 'SIGKILL') {
+      child.exitCode = 0
+      child.emit('exit', 0, signal ?? null)
+      child.emit('close', 0, signal ?? null)
+    }
+    return true
+  })
+
+  return child
+}
+
+describe('SymphonySupervisor', () => {
+  const cleanups: Array<() => void> = []
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    for (const cleanup of cleanups.splice(0)) {
+      cleanup()
+    }
+  })
+
+  test('moves to ready state when process starts and readiness probe succeeds', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const child = createMockChild()
+    const spawnImpl = vi.fn(() => child as any)
+    const fetchImpl = vi.fn(async () => ({ ok: true } as Response))
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: spawnImpl as any,
+      fetchImpl: fetchImpl as any,
+      readinessTimeoutMs: 1_000,
+      readinessIntervalMs: 10,
+    })
+
+    const result = await supervisor.start()
+
+    expect(result.success).toBe(true)
+    expect(supervisor.getStatus().phase).toBe('ready')
+    expect(supervisor.getStatus().managedProcessRunning).toBe(true)
+    expect(spawnImpl).toHaveBeenCalledTimes(1)
+    expect(fetchImpl).toHaveBeenCalled()
+  })
+
+  test('returns readiness failure when API never becomes healthy', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const child = createMockChild()
+    const spawnImpl = vi.fn(() => child as any)
+    const fetchImpl = vi.fn(async () => ({ ok: false } as Response))
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: spawnImpl as any,
+      fetchImpl: fetchImpl as any,
+      readinessTimeoutMs: 40,
+      readinessIntervalMs: 10,
+    })
+
+    const result = await supervisor.start()
+
+    expect(result.success).toBe(false)
+    expect(result.error?.code).toBe('READINESS_FAILED')
+    expect(supervisor.getStatus().phase).toBe('failed')
+  })
+
+  test('supports stop and restart with lifecycle updates', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const childFactory = vi
+      .fn()
+      .mockImplementationOnce(() => createMockChild(1001) as any)
+      .mockImplementationOnce(() => createMockChild(1002) as any)
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_BIN_PATH: workspace.executablePath,
+      },
+      spawnImpl: childFactory as any,
+      fetchImpl: vi.fn(async () => ({ ok: true } as Response)) as any,
+      readinessTimeoutMs: 200,
+      readinessIntervalMs: 5,
+    })
+
+    await supervisor.start()
+
+    const restartResult = await supervisor.restart('test_restart')
+    expect(restartResult.success).toBe(true)
+    expect(supervisor.getStatus().phase).toBe('ready')
+    expect(supervisor.getStatus().restartCount).toBe(1)
+
+    const stopResult = await supervisor.stop('test_stop')
+    expect(stopResult.success).toBe(true)
+    expect(supervisor.getStatus().phase).toBe('stopped')
+    expect(supervisor.getStatus().managedProcessRunning).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -30,11 +30,13 @@ import log from './logger'
 import { PiAgentBridge } from './pi-agent-bridge'
 import { registerSessionIpc } from './ipc'
 import { DesktopSessionManager } from './session-manager'
+import { SymphonySupervisor } from './symphony-supervisor'
 
 const SETTINGS_PATH = path.join(homedir(), '.kata-cli', 'agent', 'settings.json')
 
 let mainWindow: BrowserWindow | null = null
 let bridge: PiAgentBridge | null = null
+let symphonySupervisor: SymphonySupervisor | null = null
 let unregisterSessionIpc: (() => void) | null = null
 
 function createWindow(): BrowserWindow {
@@ -187,6 +189,12 @@ app.whenReady().then(async () => {
   const persistedModel = await loadPersistedModel()
 
   bridge = new PiAgentBridge(workspacePath, 'kata', 30_000, persistedModel)
+  symphonySupervisor = new SymphonySupervisor({
+    workspacePath,
+    appIsPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+  })
+
   const authBridge = new AuthBridge()
   const sessionManager = new DesktopSessionManager()
   mainWindow = createWindow()
@@ -198,6 +206,7 @@ app.whenReady().then(async () => {
     window: mainWindow,
     onModelSelected: persistSelectedModel,
     onWorkspaceSelected: persistWorkspacePath,
+    symphonySupervisor,
   })
 
   mainWindow.on('closed', () => {
@@ -221,6 +230,12 @@ app.on('before-quit', async (event) => {
   }
 
   event.preventDefault()
+  try {
+    await symphonySupervisor?.stop('app_quit')
+  } catch (error) {
+    log.error('[desktop-main] symphony supervisor shutdown failed', error)
+  }
+
   try {
     await bridge.shutdown()
   } catch (error) {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -10,6 +10,7 @@ import { RpcEventAdapter } from './rpc-event-adapter'
 import { DesktopSessionManager } from './session-manager'
 import { SessionHistoryLoader } from './session-history-loader'
 import { WorkflowBoardService } from './workflow-board-service'
+import type { SymphonySupervisor } from './symphony-supervisor'
 import {
   IPC_CHANNELS,
   type AuthProvider,
@@ -44,6 +45,9 @@ import {
   type WorkflowBoardLifecycleResponse,
   type WorkflowBoardScopeResponse,
   type WorkflowContextResponse,
+  type SymphonyRuntimeStatus,
+  type SymphonyRuntimeCommandResult,
+  type SymphonyRuntimeStatusResponse,
 } from '../shared/types'
 
 interface RegisterIpcOptions {
@@ -53,6 +57,7 @@ interface RegisterIpcOptions {
   window: BrowserWindow
   onModelSelected?: (model: string) => Promise<void> | void
   onWorkspaceSelected?: (workspacePath: string) => Promise<void> | void
+  symphonySupervisor?: SymphonySupervisor
 }
 
 export function registerSessionIpc({
@@ -62,6 +67,7 @@ export function registerSessionIpc({
   window,
   onModelSelected,
   onWorkspaceSelected,
+  symphonySupervisor,
 }: RegisterIpcOptions): () => void {
   const adapter = new RpcEventAdapter()
   const planningToolDetector = new PlanningToolDetector()
@@ -113,6 +119,20 @@ export function registerSessionIpc({
       scope: artifact.scope,
       projectId: artifact.projectId,
       issueId: artifact.issueId,
+    })
+  }
+
+  const sendSymphonyStatusToRenderer = (status: SymphonyRuntimeStatus): void => {
+    if (!canSendToRenderer()) {
+      log.warn('[desktop-ipc] skipping symphony status dispatch: renderer window is destroyed')
+      return
+    }
+
+    window.webContents.send(IPC_CHANNELS.symphonyStatus, status)
+    log.debug('[desktop-ipc] symphony status', {
+      phase: status.phase,
+      pid: status.pid,
+      managedProcessRunning: status.managedProcessRunning,
     })
   }
 
@@ -463,12 +483,22 @@ export function registerSessionIpc({
   bridge.on('debug', onDebug)
   bridge.on('crash', onCrash)
 
+  const onSymphonyStatus = (status: SymphonyRuntimeStatus): void => {
+    sendSymphonyStatusToRenderer(status)
+  }
+
+  symphonySupervisor?.on('status', onSymphonyStatus)
+
   const initialState = bridge.getState()
   sendBridgeStatus({
     state: initialState.status,
     pid: initialState.pid,
     updatedAt: Date.now(),
   })
+
+  if (symphonySupervisor) {
+    sendSymphonyStatusToRenderer(symphonySupervisor.getStatus())
+  }
 
   ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
   ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
@@ -498,6 +528,10 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
   ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
   ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
+  ipcMain.removeHandler(IPC_CHANNELS.symphonyGetStatus)
+  ipcMain.removeHandler(IPC_CHANNELS.symphonyStart)
+  ipcMain.removeHandler(IPC_CHANNELS.symphonyStop)
+  ipcMain.removeHandler(IPC_CHANNELS.symphonyRestart)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -862,6 +896,7 @@ export function registerSessionIpc({
     const previousWorkspacePath = bridge.getWorkspacePath()
 
     await bridge.switchWorkspace(nextWorkspacePath)
+    await symphonySupervisor?.setWorkspacePath(nextWorkspacePath)
     workflowBoardService.setPlanningActive(false)
 
     if (onWorkspaceSelected) {
@@ -1108,12 +1143,83 @@ export function registerSessionIpc({
     }
   })
 
+  ipcMain.handle(IPC_CHANNELS.symphonyGetStatus, async (): Promise<SymphonyRuntimeStatusResponse> => {
+    if (!symphonySupervisor) {
+      return {
+        success: true,
+        status: {
+          phase: 'disconnected',
+          managedProcessRunning: false,
+          pid: null,
+          url: null,
+          diagnostics: { stdout: [], stderr: [] },
+          updatedAt: new Date().toISOString(),
+          restartCount: 0,
+          lastError: {
+            code: 'UNKNOWN',
+            phase: 'unknown',
+            message: 'Symphony supervisor is unavailable.',
+          },
+        },
+      }
+    }
+
+    return {
+      success: true,
+      status: symphonySupervisor.getStatus(),
+    }
+  })
+
+  const runSymphonyCommand = async (
+    command: () => Promise<SymphonyRuntimeCommandResult>,
+  ): Promise<SymphonyRuntimeCommandResult> => {
+    if (!symphonySupervisor) {
+      return {
+        success: false,
+        status: {
+          phase: 'disconnected',
+          managedProcessRunning: false,
+          pid: null,
+          url: null,
+          diagnostics: { stdout: [], stderr: [] },
+          updatedAt: new Date().toISOString(),
+          restartCount: 0,
+          lastError: {
+            code: 'UNKNOWN',
+            phase: 'unknown',
+            message: 'Symphony supervisor is unavailable.',
+          },
+        },
+        error: {
+          code: 'UNKNOWN',
+          phase: 'unknown',
+          message: 'Symphony supervisor is unavailable.',
+        },
+      }
+    }
+
+    return command()
+  }
+
+  ipcMain.handle(IPC_CHANNELS.symphonyStart, async (): Promise<SymphonyRuntimeCommandResult> => {
+    return runSymphonyCommand(() => symphonySupervisor!.start())
+  })
+
+  ipcMain.handle(IPC_CHANNELS.symphonyStop, async (): Promise<SymphonyRuntimeCommandResult> => {
+    return runSymphonyCommand(() => symphonySupervisor!.stop())
+  })
+
+  ipcMain.handle(IPC_CHANNELS.symphonyRestart, async (): Promise<SymphonyRuntimeCommandResult> => {
+    return runSymphonyCommand(() => symphonySupervisor!.restart())
+  })
+
   return () => {
     bridge.off('rpc-event', onRpcEvent)
     bridge.off('extension-ui-request', onExtensionUiRequest)
     bridge.off('status', onStatus)
     bridge.off('debug', onDebug)
     bridge.off('crash', onCrash)
+    symphonySupervisor?.off('status', onSymphonyStatus)
     planningToolDetector.off('artifact', onPlanningArtifactEvent)
 
     ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
@@ -1144,6 +1250,10 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
     ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
     ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
+    ipcMain.removeHandler(IPC_CHANNELS.symphonyGetStatus)
+    ipcMain.removeHandler(IPC_CHANNELS.symphonyStart)
+    ipcMain.removeHandler(IPC_CHANNELS.symphonyStop)
+    ipcMain.removeHandler(IPC_CHANNELS.symphonyRestart)
   }
 }
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1143,24 +1143,39 @@ export function registerSessionIpc({
     }
   })
 
+  const createSymphonyDisconnectedResult = (): SymphonyRuntimeCommandResult => {
+    const status: SymphonyRuntimeStatus = {
+      phase: 'disconnected',
+      managedProcessRunning: false,
+      pid: null,
+      url: null,
+      diagnostics: { stdout: [], stderr: [] },
+      updatedAt: new Date().toISOString(),
+      restartCount: 0,
+      lastError: {
+        code: 'UNKNOWN',
+        phase: 'unknown',
+        message: 'Symphony supervisor is unavailable.',
+      },
+    }
+
+    return {
+      success: false,
+      status,
+      error: {
+        code: 'UNKNOWN',
+        phase: 'unknown',
+        message: 'Symphony supervisor is unavailable.',
+      },
+    }
+  }
+
   ipcMain.handle(IPC_CHANNELS.symphonyGetStatus, async (): Promise<SymphonyRuntimeStatusResponse> => {
     if (!symphonySupervisor) {
+      const fallback = createSymphonyDisconnectedResult()
       return {
         success: true,
-        status: {
-          phase: 'disconnected',
-          managedProcessRunning: false,
-          pid: null,
-          url: null,
-          diagnostics: { stdout: [], stderr: [] },
-          updatedAt: new Date().toISOString(),
-          restartCount: 0,
-          lastError: {
-            code: 'UNKNOWN',
-            phase: 'unknown',
-            message: 'Symphony supervisor is unavailable.',
-          },
-        },
+        status: fallback.status,
       }
     }
 
@@ -1174,28 +1189,7 @@ export function registerSessionIpc({
     command: () => Promise<SymphonyRuntimeCommandResult>,
   ): Promise<SymphonyRuntimeCommandResult> => {
     if (!symphonySupervisor) {
-      return {
-        success: false,
-        status: {
-          phase: 'disconnected',
-          managedProcessRunning: false,
-          pid: null,
-          url: null,
-          diagnostics: { stdout: [], stderr: [] },
-          updatedAt: new Date().toISOString(),
-          restartCount: 0,
-          lastError: {
-            code: 'UNKNOWN',
-            phase: 'unknown',
-            message: 'Symphony supervisor is unavailable.',
-          },
-        },
-        error: {
-          code: 'UNKNOWN',
-          phase: 'unknown',
-          message: 'Symphony supervisor is unavailable.',
-        },
-      }
+      return createSymphonyDisconnectedResult()
     }
 
     return command()

--- a/apps/desktop/src/main/symphony-config.ts
+++ b/apps/desktop/src/main/symphony-config.ts
@@ -10,8 +10,8 @@ import type {
   SymphonyRuntimeError,
 } from '../shared/types'
 
-const DEFAULT_URL_ENV_KEY = 'SYMPHONY_URL'
-const FALLBACK_URL_ENV_KEY = 'KATA_SYMPHONY_URL'
+const PRIMARY_URL_ENV_KEY = 'KATA_SYMPHONY_URL'
+const LEGACY_URL_ENV_KEY = 'SYMPHONY_URL'
 const SYMPHONY_BIN_ENV_KEY = 'KATA_SYMPHONY_BIN_PATH'
 
 interface SymphonyPreferences {
@@ -133,7 +133,7 @@ function resolveConfiguredUrl(
     return normalizeAndValidateUrl(prefCandidate, 'preferences')
   }
 
-  const envCandidate = normalizeCandidate(env[FALLBACK_URL_ENV_KEY]) ?? normalizeCandidate(env[DEFAULT_URL_ENV_KEY])
+  const envCandidate = normalizeCandidate(env[PRIMARY_URL_ENV_KEY]) ?? normalizeCandidate(env[LEGACY_URL_ENV_KEY])
 
   if (envCandidate) {
     return normalizeAndValidateUrl(envCandidate, 'env')
@@ -144,7 +144,7 @@ function resolveConfiguredUrl(
     error: {
       code: 'CONFIG_MISSING',
       phase: 'config',
-      message: `Symphony URL is not configured. Set symphony.url in .kata/preferences.md or set ${FALLBACK_URL_ENV_KEY}/${DEFAULT_URL_ENV_KEY}.`,
+      message: `Symphony URL is not configured. Set symphony.url in .kata/preferences.md or set ${PRIMARY_URL_ENV_KEY}/${LEGACY_URL_ENV_KEY}.`,
     },
   }
 }

--- a/apps/desktop/src/main/symphony-config.ts
+++ b/apps/desktop/src/main/symphony-config.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants, existsSync } from 'node:fs'
+import { accessSync, constants, existsSync, statSync } from 'node:fs'
 import { promises as fs } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
@@ -217,7 +217,7 @@ function resolveWorkflowPath(
   const configuredPath = normalizeCandidate(preferences?.symphony?.workflow_path)
   if (configuredPath) {
     const resolved = toAbsolutePath(configuredPath, workspacePath)
-    if (existsSync(resolved)) {
+    if (existsSync(resolved) && isExistingFile(resolved)) {
       return {
         ok: true,
         workflowPath: resolved,
@@ -236,7 +236,7 @@ function resolveWorkflowPath(
   }
 
   const workspaceWorkflow = path.join(workspacePath, 'WORKFLOW.md')
-  if (existsSync(workspaceWorkflow)) {
+  if (existsSync(workspaceWorkflow) && isExistingFile(workspaceWorkflow)) {
     return {
       ok: true,
       workflowPath: workspaceWorkflow,
@@ -337,6 +337,14 @@ function toAbsolutePath(target: string, cwd: string): string {
       : normalized
 
   return path.isAbsolute(expanded) ? expanded : path.resolve(cwd, expanded)
+}
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile()
+  } catch {
+    return false
+  }
 }
 
 function isExecutableFile(filePath: string): boolean {

--- a/apps/desktop/src/main/symphony-config.ts
+++ b/apps/desktop/src/main/symphony-config.ts
@@ -43,7 +43,21 @@ export async function resolveSymphonyLaunch(
   options: ResolveSymphonyLaunchOptions,
 ): Promise<SymphonyLaunchResolution> {
   const env = options.env ?? process.env
-  const preferences = options.preferences ?? (await loadWorkspacePreferences(options.workspacePath))
+
+  let preferences: SymphonyPreferences | null
+  try {
+    preferences = options.preferences ?? (await loadWorkspacePreferences(options.workspacePath))
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: 'CONFIG_INVALID',
+        phase: 'config',
+        message: `Unable to read workspace preferences: ${error instanceof Error ? error.message : String(error)}`,
+        details: 'preferences_read_failed',
+      },
+    }
+  }
 
   const resolvedUrl = resolveConfiguredUrl(preferences, env)
   if (!resolvedUrl.ok) {
@@ -99,7 +113,7 @@ export async function loadWorkspacePreferences(workspacePath: string): Promise<S
       return null
     }
 
-    return null
+    throw error
   }
 
   const frontmatterMatch = content.match(/^\uFEFF?\s*---\s*\r?\n([\s\S]*?)\r?\n---/)
@@ -267,9 +281,16 @@ function resolveBinaryPath(options: {
   }
 
   if (options.appIsPackaged) {
-    const packagedPath = path.join(options.resourcesPath ?? process.resourcesPath, 'symphony')
-    if (isExecutableFile(packagedPath)) {
-      return { ok: true, command: packagedPath, source: 'bundled' }
+    const resourcesPath = options.resourcesPath ?? process.resourcesPath
+    const bundledCandidates =
+      process.platform === 'win32'
+        ? [path.join(resourcesPath, 'symphony.exe'), path.join(resourcesPath, 'symphony')]
+        : [path.join(resourcesPath, 'symphony')]
+
+    for (const bundledPath of bundledCandidates) {
+      if (isExecutableFile(bundledPath)) {
+        return { ok: true, command: bundledPath, source: 'bundled' }
+      }
     }
   }
 
@@ -309,21 +330,31 @@ function normalizeCandidate(value: unknown): string | null {
 }
 
 function toAbsolutePath(target: string, cwd: string): string {
+  const normalized = target.replace(/\\/g, path.sep)
   const expanded =
-    target === '~' || target.startsWith('~/')
-      ? path.join(homedir(), target === '~' ? '' : target.slice(2))
-      : target
+    normalized === '~' || normalized.startsWith(`~${path.sep}`)
+      ? path.join(homedir(), normalized === '~' ? '' : normalized.slice(2))
+      : normalized
 
   return path.isAbsolute(expanded) ? expanded : path.resolve(cwd, expanded)
 }
 
 function isExecutableFile(filePath: string): boolean {
-  try {
-    accessSync(filePath, constants.X_OK)
-    return true
-  } catch {
-    return false
+  const candidates =
+    process.platform === 'win32' && !filePath.toLowerCase().endsWith('.exe')
+      ? [filePath, `${filePath}.exe`]
+      : [filePath]
+
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate, constants.X_OK)
+      return true
+    } catch {
+      // keep checking candidate variants
+    }
   }
+
+  return false
 }
 
 function extractNestedBlock(frontmatter: string, key: string): string | null {

--- a/apps/desktop/src/main/symphony-config.ts
+++ b/apps/desktop/src/main/symphony-config.ts
@@ -277,6 +277,7 @@ function resolveBinaryPath(options: {
   const whichResult = spawnSync(lookupCommand, ['symphony'], {
     stdio: 'pipe',
     encoding: 'utf8',
+    env: options.env,
   })
 
   if (whichResult.status === 0) {

--- a/apps/desktop/src/main/symphony-config.ts
+++ b/apps/desktop/src/main/symphony-config.ts
@@ -1,0 +1,414 @@
+import { accessSync, constants, existsSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import type {
+  SymphonyConfigSource,
+  SymphonyLaunchDescriptor,
+  SymphonyLaunchSource,
+  SymphonyRuntimeError,
+} from '../shared/types'
+
+const DEFAULT_URL_ENV_KEY = 'SYMPHONY_URL'
+const FALLBACK_URL_ENV_KEY = 'KATA_SYMPHONY_URL'
+const SYMPHONY_BIN_ENV_KEY = 'KATA_SYMPHONY_BIN_PATH'
+
+interface SymphonyPreferences {
+  symphony?: {
+    url?: string
+    workflow_path?: string
+  }
+}
+
+export interface ResolveSymphonyLaunchOptions {
+  workspacePath: string
+  appIsPackaged: boolean
+  resourcesPath?: string
+  env?: NodeJS.ProcessEnv
+  preferences?: SymphonyPreferences | null
+}
+
+export type SymphonyLaunchResolution =
+  | {
+      ok: true
+      launch: SymphonyLaunchDescriptor
+    }
+  | {
+      ok: false
+      error: SymphonyRuntimeError
+    }
+
+export async function resolveSymphonyLaunch(
+  options: ResolveSymphonyLaunchOptions,
+): Promise<SymphonyLaunchResolution> {
+  const env = options.env ?? process.env
+  const preferences = options.preferences ?? (await loadWorkspacePreferences(options.workspacePath))
+
+  const resolvedUrl = resolveConfiguredUrl(preferences, env)
+  if (!resolvedUrl.ok) {
+    return resolvedUrl
+  }
+
+  const resolvedWorkflowPath = resolveWorkflowPath(preferences, options.workspacePath)
+  if (!resolvedWorkflowPath.ok) {
+    return resolvedWorkflowPath
+  }
+
+  const resolvedBinary = resolveBinaryPath({
+    appIsPackaged: options.appIsPackaged,
+    resourcesPath: options.resourcesPath,
+    env,
+    workspacePath: options.workspacePath,
+  })
+  if (!resolvedBinary.ok) {
+    return resolvedBinary
+  }
+
+  const parsedUrl = new URL(resolvedUrl.url)
+  const port = parsedUrl.port ? Number(parsedUrl.port) : parsedUrl.protocol === 'https:' ? 443 : 80
+
+  return {
+    ok: true,
+    launch: {
+      command: resolvedBinary.command,
+      args: [resolvedWorkflowPath.workflowPath, '--no-tui', '--port', String(port)],
+      cwd: options.workspacePath,
+      source: resolvedBinary.source,
+      resolvedUrl: resolvedUrl.url,
+      workflowPath: resolvedWorkflowPath.workflowPath,
+      urlSource: resolvedUrl.source,
+      workflowPathSource: resolvedWorkflowPath.source,
+    },
+  }
+}
+
+export async function loadWorkspacePreferences(workspacePath: string): Promise<SymphonyPreferences | null> {
+  const preferencesPath = path.join(workspacePath, '.kata', 'preferences.md')
+
+  let content: string
+  try {
+    content = await fs.readFile(preferencesPath, 'utf8')
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : undefined
+
+    if (code === 'ENOENT') {
+      return null
+    }
+
+    return null
+  }
+
+  const frontmatterMatch = content.match(/^\uFEFF?\s*---\s*\r?\n([\s\S]*?)\r?\n---/)
+  if (!frontmatterMatch?.[1]) {
+    return null
+  }
+
+  const symphonyBlock = extractNestedBlock(frontmatterMatch[1], 'symphony')
+  if (!symphonyBlock) {
+    return null
+  }
+
+  const fields = parseSimpleObject(symphonyBlock)
+
+  return {
+    symphony: {
+      url: stripYamlWrapping(fields.url ?? ''),
+      workflow_path: stripYamlWrapping(fields.workflow_path ?? ''),
+    },
+  }
+}
+
+function resolveConfiguredUrl(
+  preferences: SymphonyPreferences | null,
+  env: NodeJS.ProcessEnv,
+):
+  | { ok: true; url: string; source: SymphonyConfigSource }
+  | { ok: false; error: SymphonyRuntimeError } {
+  const prefCandidate = normalizeCandidate(preferences?.symphony?.url)
+  if (prefCandidate) {
+    return normalizeAndValidateUrl(prefCandidate, 'preferences')
+  }
+
+  const envCandidate = normalizeCandidate(env[FALLBACK_URL_ENV_KEY]) ?? normalizeCandidate(env[DEFAULT_URL_ENV_KEY])
+
+  if (envCandidate) {
+    return normalizeAndValidateUrl(envCandidate, 'env')
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: 'CONFIG_MISSING',
+      phase: 'config',
+      message: `Symphony URL is not configured. Set symphony.url in .kata/preferences.md or set ${FALLBACK_URL_ENV_KEY}/${DEFAULT_URL_ENV_KEY}.`,
+    },
+  }
+}
+
+function normalizeAndValidateUrl(
+  rawUrl: string,
+  source: SymphonyConfigSource,
+):
+  | { ok: true; url: string; source: SymphonyConfigSource }
+  | { ok: false; error: SymphonyRuntimeError } {
+  let parsed: URL
+
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: 'CONFIG_INVALID',
+        phase: 'config',
+        message: `Invalid Symphony URL from ${source}.`,
+        details: 'malformed_url',
+      },
+    }
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return {
+      ok: false,
+      error: {
+        code: 'CONFIG_INVALID',
+        phase: 'config',
+        message: `Invalid Symphony URL protocol from ${source}: ${parsed.protocol}`,
+        details: 'unsupported_protocol',
+      },
+    }
+  }
+
+  if (parsed.pathname.endsWith('/') && parsed.pathname !== '/') {
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '')
+  }
+
+  return {
+    ok: true,
+    url: parsed.toString().replace(/\/$/, ''),
+    source,
+  }
+}
+
+function resolveWorkflowPath(
+  preferences: SymphonyPreferences | null,
+  workspacePath: string,
+):
+  | { ok: true; workflowPath: string; source: SymphonyConfigSource }
+  | { ok: false; error: SymphonyRuntimeError } {
+  const configuredPath = normalizeCandidate(preferences?.symphony?.workflow_path)
+  if (configuredPath) {
+    const resolved = toAbsolutePath(configuredPath, workspacePath)
+    if (existsSync(resolved)) {
+      return {
+        ok: true,
+        workflowPath: resolved,
+        source: 'preferences',
+      }
+    }
+
+    return {
+      ok: false,
+      error: {
+        code: 'WORKFLOW_PATH_MISSING',
+        phase: 'config',
+        message: `Configured symphony.workflow_path does not exist: ${resolved}`,
+      },
+    }
+  }
+
+  const workspaceWorkflow = path.join(workspacePath, 'WORKFLOW.md')
+  if (existsSync(workspaceWorkflow)) {
+    return {
+      ok: true,
+      workflowPath: workspaceWorkflow,
+      source: 'default',
+    }
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: 'WORKFLOW_PATH_MISSING',
+      phase: 'config',
+      message:
+        'No workflow file is configured. Add symphony.workflow_path in .kata/preferences.md or create WORKFLOW.md in the workspace.',
+    },
+  }
+}
+
+function resolveBinaryPath(options: {
+  appIsPackaged: boolean
+  resourcesPath?: string
+  env: NodeJS.ProcessEnv
+  workspacePath: string
+}):
+  | { ok: true; command: string; source: SymphonyLaunchSource }
+  | { ok: false; error: SymphonyRuntimeError } {
+  const fromEnv = normalizeCandidate(options.env[SYMPHONY_BIN_ENV_KEY])
+  if (fromEnv) {
+    const envPath = toAbsolutePath(fromEnv, options.workspacePath)
+    if (isExecutableFile(envPath)) {
+      return { ok: true, command: envPath, source: 'env' }
+    }
+
+    return {
+      ok: false,
+      error: {
+        code: 'BINARY_NOT_FOUND',
+        phase: 'config',
+        message: `${SYMPHONY_BIN_ENV_KEY} is set but not executable: ${envPath}`,
+      },
+    }
+  }
+
+  if (options.appIsPackaged) {
+    const packagedPath = path.join(options.resourcesPath ?? process.resourcesPath, 'symphony')
+    if (isExecutableFile(packagedPath)) {
+      return { ok: true, command: packagedPath, source: 'bundled' }
+    }
+  }
+
+  const lookupCommand = process.platform === 'win32' ? 'where' : 'which'
+  const whichResult = spawnSync(lookupCommand, ['symphony'], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+  })
+
+  if (whichResult.status === 0) {
+    const discovered = whichResult.stdout.trim().split(/\r?\n/)[0]?.trim()
+    if (discovered && isExecutableFile(discovered)) {
+      return {
+        ok: true,
+        command: discovered,
+        source: 'path',
+      }
+    }
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: 'BINARY_NOT_FOUND',
+      phase: 'config',
+      message:
+        'Symphony binary not found. Install `symphony` on PATH, set KATA_SYMPHONY_BIN_PATH, or bundle the binary for packaged app execution.',
+    },
+  }
+}
+
+function normalizeCandidate(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function toAbsolutePath(target: string, cwd: string): string {
+  const expanded =
+    target === '~' || target.startsWith('~/')
+      ? path.join(homedir(), target === '~' ? '' : target.slice(2))
+      : target
+
+  return path.isAbsolute(expanded) ? expanded : path.resolve(cwd, expanded)
+}
+
+function isExecutableFile(filePath: string): boolean {
+  try {
+    accessSync(filePath, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function extractNestedBlock(frontmatter: string, key: string): string | null {
+  const lines = frontmatter.split(/\r?\n/)
+  const anchorIndex = lines.findIndex((line) => new RegExp(`^\\s*${escapeRegex(key)}:\\s*$`).test(line))
+
+  if (anchorIndex === -1) {
+    return null
+  }
+
+  const anchorIndent = indentationOf(lines[anchorIndex] ?? '')
+  const nested: string[] = []
+
+  for (let index = anchorIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? ''
+    if (!line.trim()) {
+      nested.push(line)
+      continue
+    }
+
+    const indent = indentationOf(line)
+    if (indent <= anchorIndent) {
+      break
+    }
+
+    nested.push(line.slice(anchorIndent + 2))
+  }
+
+  return nested.join('\n')
+}
+
+function parseSimpleObject(block: string): Record<string, string> {
+  const result: Record<string, string> = {}
+
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+
+    const match = line.match(/^([a-zA-Z0-9_]+)\s*:\s*(.*)$/)
+    if (!match) {
+      continue
+    }
+
+    const key = match[1] ?? ''
+    const rawValue = match[2] ?? ''
+    result[key] = stripInlineComment(rawValue).trim()
+  }
+
+  return result
+}
+
+function stripInlineComment(value: string): string {
+  let inSingle = false
+  let inDouble = false
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+    if (char === "'" && !inDouble) {
+      inSingle = !inSingle
+      continue
+    }
+
+    if (char === '"' && !inSingle) {
+      inDouble = !inDouble
+      continue
+    }
+
+    if (char === '#' && !inSingle && !inDouble) {
+      return value.slice(0, index)
+    }
+  }
+
+  return value
+}
+
+function stripYamlWrapping(value: string): string {
+  return value.replace(/^['"]/, '').replace(/['"]$/, '').trim()
+}
+
+function indentationOf(line: string): number {
+  const match = line.match(/^\s*/)
+  return match?.[0].length ?? 0
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/apps/desktop/src/main/symphony-supervisor.ts
+++ b/apps/desktop/src/main/symphony-supervisor.ts
@@ -226,9 +226,14 @@ export class SymphonySupervisor extends EventEmitter {
 
       const readiness = await this.waitForReadiness(launch.resolvedUrl)
       if (!readiness.ok) {
+        if (readiness.error.code === 'READINESS_FAILED') {
+          await this.terminateChildAfterReadinessFailure()
+        }
+
         this.updateStatus({
           phase: 'failed',
           managedProcessRunning: Boolean(this.child),
+          pid: this.child?.pid ?? null,
           lastError: readiness.error,
           lastReadinessCheckAt: new Date().toISOString(),
         })
@@ -411,6 +416,18 @@ export class SymphonySupervisor extends EventEmitter {
     const startedAt = Date.now()
 
     while (Date.now() - startedAt < this.readinessTimeoutMs) {
+      if (!this.child || this.child.exitCode !== null) {
+        return {
+          ok: false,
+          error:
+            this.status.lastError ?? {
+              code: 'PROCESS_EXITED',
+              phase: 'process',
+              message: 'Symphony exited before becoming ready.',
+            },
+        }
+      }
+
       const endpoint = buildEndpoint(url, '/api/v1/state')
       this.updateStatus({ lastReadinessCheckAt: new Date().toISOString() })
 
@@ -440,6 +457,23 @@ export class SymphonySupervisor extends EventEmitter {
         message: `Symphony readiness check failed after ${this.readinessTimeoutMs}ms.`,
       },
     }
+  }
+
+  private async terminateChildAfterReadinessFailure(): Promise<void> {
+    const child = this.child
+    if (!child) {
+      return
+    }
+
+    child.kill('SIGTERM')
+    const exited = await this.waitForExit(child, this.stopTimeoutMs)
+
+    if (!exited) {
+      child.kill('SIGKILL')
+      await this.waitForExit(child, 1_000)
+    }
+
+    this.child = null
   }
 
   private updateStatus(patch: Partial<SymphonyRuntimeStatus>): void {

--- a/apps/desktop/src/main/symphony-supervisor.ts
+++ b/apps/desktop/src/main/symphony-supervisor.ts
@@ -303,7 +303,20 @@ export class SymphonySupervisor extends EventEmitter {
 
     if (!exited) {
       child.kill('SIGKILL')
-      await this.waitForExit(child, 1_000)
+      const killed = await this.waitForExit(child, 1_000)
+
+      if (killed) {
+        this.child = null
+        this.updateStatus({
+          phase: 'stopped',
+          managedProcessRunning: false,
+          pid: null,
+          restartReason: reason,
+          lastError: undefined,
+        })
+
+        return { success: true, status: this.status }
+      }
 
       const error: SymphonyRuntimeError = {
         code: 'STOP_TIMEOUT',

--- a/apps/desktop/src/main/symphony-supervisor.ts
+++ b/apps/desktop/src/main/symphony-supervisor.ts
@@ -1,0 +1,534 @@
+import { EventEmitter } from 'node:events'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import log from './logger'
+import { resolveSymphonyLaunch, type ResolveSymphonyLaunchOptions } from './symphony-config'
+import type {
+  SymphonyRuntimeCommandResult,
+  SymphonyRuntimeError,
+  SymphonyRuntimeStatus,
+} from '../shared/types'
+
+const DEFAULT_READINESS_TIMEOUT_MS = 20_000
+const DEFAULT_READINESS_INTERVAL_MS = 750
+const DEFAULT_STOP_TIMEOUT_MS = 5_000
+const MAX_DIAGNOSTIC_LINES = 100
+
+interface SupervisorEvents {
+  status: (status: SymphonyRuntimeStatus) => void
+}
+
+export interface SymphonySupervisorOptions {
+  workspacePath: string
+  appIsPackaged: boolean
+  resourcesPath?: string
+  env?: NodeJS.ProcessEnv
+  fetchImpl?: typeof fetch
+  spawnImpl?: typeof spawn
+  readinessTimeoutMs?: number
+  readinessIntervalMs?: number
+  stopTimeoutMs?: number
+}
+
+export class SymphonySupervisor extends EventEmitter {
+  private child: ChildProcessWithoutNullStreams | null = null
+  private status: SymphonyRuntimeStatus = createInitialStatus()
+  private workspacePath: string
+  private readonly fetchImpl: typeof fetch
+  private readonly spawnImpl: typeof spawn
+  private readonly readinessTimeoutMs: number
+  private readonly readinessIntervalMs: number
+  private readonly stopTimeoutMs: number
+  private startInFlight: Promise<SymphonyRuntimeCommandResult> | null = null
+  private stopInFlight: Promise<SymphonyRuntimeCommandResult> | null = null
+  private restartInFlight: Promise<SymphonyRuntimeCommandResult> | null = null
+  private readonly mockMode: string | null
+
+  constructor(private readonly options: SymphonySupervisorOptions) {
+    super()
+    this.workspacePath = options.workspacePath
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis)
+    this.mockMode = (options.env ?? process.env).KATA_DESKTOP_SYMPHONY_MOCK?.trim() ?? null
+    this.spawnImpl = options.spawnImpl ?? spawn
+    this.readinessTimeoutMs = options.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS
+    this.readinessIntervalMs = options.readinessIntervalMs ?? DEFAULT_READINESS_INTERVAL_MS
+    this.stopTimeoutMs = options.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS
+  }
+
+  override on<K extends keyof SupervisorEvents>(event: K, listener: SupervisorEvents[K]): this {
+    return super.on(event, listener)
+  }
+
+  override emit<K extends keyof SupervisorEvents>(event: K, ...args: Parameters<SupervisorEvents[K]>): boolean {
+    return super.emit(event, ...args)
+  }
+
+  public getStatus(): SymphonyRuntimeStatus {
+    return this.status
+  }
+
+  public async setWorkspacePath(workspacePath: string): Promise<void> {
+    const resolved = workspacePath.trim()
+    if (!resolved || resolved === this.workspacePath) {
+      return
+    }
+
+    await this.stop('workspace_changed')
+    this.workspacePath = resolved
+    this.updateStatus({
+      phase: 'stopped',
+      managedProcessRunning: false,
+      pid: null,
+      url: null,
+      launch: undefined,
+      diagnostics: { stdout: [], stderr: [] },
+      lastError: undefined,
+      restartReason: 'workspace_changed',
+    })
+  }
+
+  public async start(): Promise<SymphonyRuntimeCommandResult> {
+    if (this.restartInFlight) {
+      return this.restartInFlight
+    }
+
+    if (this.startInFlight) {
+      return this.startInFlight
+    }
+
+    if (this.child && this.status.phase === 'ready') {
+      return { success: true, status: this.status }
+    }
+
+    this.startInFlight = this.startInternal()
+    try {
+      return await this.startInFlight
+    } finally {
+      this.startInFlight = null
+    }
+  }
+
+  public async stop(reason = 'user_requested'): Promise<SymphonyRuntimeCommandResult> {
+    if (this.stopInFlight) {
+      return this.stopInFlight
+    }
+
+    this.stopInFlight = this.stopInternal(reason)
+    try {
+      return await this.stopInFlight
+    } finally {
+      this.stopInFlight = null
+    }
+  }
+
+  public async restart(reason = 'user_requested'): Promise<SymphonyRuntimeCommandResult> {
+    if (this.restartInFlight) {
+      return this.restartInFlight
+    }
+
+    this.restartInFlight = this.restartInternal(reason)
+    try {
+      return await this.restartInFlight
+    } finally {
+      this.restartInFlight = null
+    }
+  }
+
+  private async startInternal(): Promise<SymphonyRuntimeCommandResult> {
+    if (this.mockMode) {
+      return this.startMockedRuntime(this.mockMode)
+    }
+
+    const resolved = await resolveSymphonyLaunch(this.resolveLaunchOptions())
+    if (!resolved.ok) {
+      this.updateStatus({
+        phase: 'config_error',
+        managedProcessRunning: false,
+        pid: null,
+        url: null,
+        lastError: resolved.error,
+      })
+      return {
+        success: false,
+        status: this.status,
+        error: resolved.error,
+      }
+    }
+
+    const launch = resolved.launch
+
+    this.updateStatus({
+      phase: 'starting',
+      managedProcessRunning: false,
+      pid: null,
+      url: launch.resolvedUrl,
+      launch: {
+        command: launch.command,
+        args: launch.args,
+        source: launch.source,
+      },
+      diagnostics: { stdout: [], stderr: [] },
+      lastError: undefined,
+    })
+
+    try {
+      const child = this.spawnImpl(launch.command, launch.args, {
+        cwd: launch.cwd,
+        env: this.options.env ?? process.env,
+        stdio: 'pipe',
+      })
+
+      this.child = child
+
+      child.stdout.on('data', (chunk: Buffer | string) => {
+        this.pushDiagnostics('stdout', chunk.toString())
+      })
+
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        this.pushDiagnostics('stderr', chunk.toString())
+      })
+
+      child.on('exit', (exitCode, signal) => {
+        const wasStopping = this.status.phase === 'stopping'
+        this.child = null
+
+        this.updateStatus({
+          managedProcessRunning: false,
+          pid: null,
+          phase: wasStopping ? 'stopped' : 'failed',
+          lastError: wasStopping
+            ? this.status.lastError
+            : {
+                code: 'PROCESS_EXITED',
+                phase: 'process',
+                message: `Symphony exited unexpectedly (${exitCode ?? 'null'}${signal ? `/${signal}` : ''}).`,
+              },
+        })
+      })
+
+      child.on('error', (error) => {
+        this.child = null
+        this.updateStatus({
+          phase: 'failed',
+          managedProcessRunning: false,
+          pid: null,
+          lastError: {
+            code: 'SPAWN_FAILED',
+            phase: 'spawn',
+            message: `Failed to launch Symphony: ${error.message}`,
+          },
+        })
+      })
+
+      this.updateStatus({
+        managedProcessRunning: true,
+        pid: child.pid ?? null,
+      })
+
+      const readiness = await this.waitForReadiness(launch.resolvedUrl)
+      if (!readiness.ok) {
+        this.updateStatus({
+          phase: 'failed',
+          managedProcessRunning: Boolean(this.child),
+          lastError: readiness.error,
+          lastReadinessCheckAt: new Date().toISOString(),
+        })
+
+        return {
+          success: false,
+          status: this.status,
+          error: readiness.error,
+        }
+      }
+
+      const nowIso = new Date().toISOString()
+      this.updateStatus({
+        phase: 'ready',
+        managedProcessRunning: true,
+        lastReadyAt: nowIso,
+        lastReadinessCheckAt: nowIso,
+      })
+
+      return {
+        success: true,
+        status: this.status,
+      }
+    } catch (error) {
+      const err: SymphonyRuntimeError = {
+        code: 'SPAWN_FAILED',
+        phase: 'spawn',
+        message: error instanceof Error ? error.message : String(error),
+      }
+
+      this.updateStatus({
+        phase: 'failed',
+        managedProcessRunning: false,
+        pid: null,
+        lastError: err,
+      })
+
+      return {
+        success: false,
+        status: this.status,
+        error: err,
+      }
+    }
+  }
+
+  private async stopInternal(reason: string): Promise<SymphonyRuntimeCommandResult> {
+    const child = this.child
+    if (!child) {
+      this.updateStatus({
+        phase: 'stopped',
+        managedProcessRunning: false,
+        pid: null,
+        restartReason: reason,
+      })
+      return { success: true, status: this.status }
+    }
+
+    this.updateStatus({
+      phase: 'stopping',
+      managedProcessRunning: true,
+      restartReason: reason,
+      lastError: undefined,
+    })
+
+    child.kill('SIGTERM')
+    const exited = await this.waitForExit(child, this.stopTimeoutMs)
+
+    if (!exited) {
+      child.kill('SIGKILL')
+      await this.waitForExit(child, 1_000)
+
+      const error: SymphonyRuntimeError = {
+        code: 'STOP_TIMEOUT',
+        phase: 'shutdown',
+        message: 'Timed out waiting for Symphony to stop gracefully.',
+      }
+
+      this.updateStatus({
+        phase: 'failed',
+        managedProcessRunning: false,
+        pid: null,
+        lastError: error,
+      })
+
+      return { success: false, status: this.status, error }
+    }
+
+    this.child = null
+    this.updateStatus({
+      phase: 'stopped',
+      managedProcessRunning: false,
+      pid: null,
+      restartReason: reason,
+    })
+
+    return { success: true, status: this.status }
+  }
+
+  private async restartInternal(reason: string): Promise<SymphonyRuntimeCommandResult> {
+    this.updateStatus({
+      phase: 'restarting',
+      restartCount: this.status.restartCount + 1,
+      restartReason: reason,
+    })
+
+    const stopResult = await this.stop('restart')
+    if (!stopResult.success) {
+      return stopResult
+    }
+
+    return this.startInternal()
+  }
+
+  private async startMockedRuntime(mockMode: string): Promise<SymphonyRuntimeCommandResult> {
+    const mockUrl = (this.options.env ?? process.env).KATA_SYMPHONY_URL ?? 'http://127.0.0.1:8080'
+
+    this.updateStatus({
+      phase: 'starting',
+      managedProcessRunning: false,
+      pid: null,
+      url: mockUrl,
+      lastError: undefined,
+      diagnostics: { stdout: [], stderr: [] },
+    })
+
+    await delay(25)
+
+    if (mockMode === 'config_error') {
+      const error: SymphonyRuntimeError = {
+        code: 'CONFIG_MISSING',
+        phase: 'config',
+        message: 'Mocked config error for e2e validation.',
+      }
+
+      this.updateStatus({
+        phase: 'config_error',
+        managedProcessRunning: false,
+        pid: null,
+        lastError: error,
+      })
+
+      return { success: false, status: this.status, error }
+    }
+
+    if (mockMode === 'readiness_error') {
+      const error: SymphonyRuntimeError = {
+        code: 'READINESS_FAILED',
+        phase: 'readiness',
+        message: 'Mocked readiness failure for e2e validation.',
+      }
+
+      this.updateStatus({
+        phase: 'failed',
+        managedProcessRunning: false,
+        pid: null,
+        lastError: error,
+      })
+
+      return { success: false, status: this.status, error }
+    }
+
+    const nowIso = new Date().toISOString()
+    this.updateStatus({
+      phase: 'ready',
+      managedProcessRunning: true,
+      pid: 4242,
+      lastReadyAt: nowIso,
+      lastReadinessCheckAt: nowIso,
+      launch: {
+        command: 'mock-symphony',
+        args: ['WORKFLOW.md', '--no-tui', '--port', '8080'],
+        source: 'env',
+      },
+    })
+
+    return { success: true, status: this.status }
+  }
+
+  private async waitForReadiness(url: string): Promise<{ ok: true } | { ok: false; error: SymphonyRuntimeError }> {
+    const startedAt = Date.now()
+
+    while (Date.now() - startedAt < this.readinessTimeoutMs) {
+      const endpoint = buildEndpoint(url, '/api/v1/state')
+      this.updateStatus({ lastReadinessCheckAt: new Date().toISOString() })
+
+      try {
+        const response = await this.fetchImpl(endpoint, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+          },
+        })
+
+        if (response.ok) {
+          return { ok: true }
+        }
+      } catch {
+        // keep polling until timeout
+      }
+
+      await delay(this.readinessIntervalMs)
+    }
+
+    return {
+      ok: false,
+      error: {
+        code: 'READINESS_FAILED',
+        phase: 'readiness',
+        message: `Symphony readiness check failed after ${this.readinessTimeoutMs}ms.`,
+      },
+    }
+  }
+
+  private updateStatus(patch: Partial<SymphonyRuntimeStatus>): void {
+    this.status = {
+      ...this.status,
+      ...patch,
+      diagnostics: patch.diagnostics ?? this.status.diagnostics,
+      updatedAt: new Date().toISOString(),
+    }
+
+    this.emit('status', this.status)
+  }
+
+  private pushDiagnostics(stream: 'stdout' | 'stderr', chunk: string): void {
+    const lines = chunk
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+
+    if (lines.length === 0) {
+      return
+    }
+
+    const next = {
+      ...this.status.diagnostics,
+      [stream]: [...this.status.diagnostics[stream], ...lines].slice(-MAX_DIAGNOSTIC_LINES),
+    }
+
+    this.updateStatus({ diagnostics: next })
+  }
+
+  private waitForExit(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      if (child.exitCode !== null) {
+        resolve(true)
+        return
+      }
+
+      const timeoutId = setTimeout(() => {
+        cleanup()
+        resolve(false)
+      }, timeoutMs)
+
+      const onExit = () => {
+        cleanup()
+        resolve(true)
+      }
+
+      const cleanup = () => {
+        clearTimeout(timeoutId)
+        child.removeListener('exit', onExit)
+        child.removeListener('close', onExit)
+      }
+
+      child.once('exit', onExit)
+      child.once('close', onExit)
+    })
+  }
+
+  private resolveLaunchOptions(): ResolveSymphonyLaunchOptions {
+    return {
+      workspacePath: this.workspacePath,
+      appIsPackaged: this.options.appIsPackaged,
+      resourcesPath: this.options.resourcesPath,
+      env: this.options.env,
+    }
+  }
+}
+
+function createInitialStatus(): SymphonyRuntimeStatus {
+  return {
+    phase: 'idle',
+    managedProcessRunning: false,
+    pid: null,
+    url: null,
+    diagnostics: {
+      stdout: [],
+      stderr: [],
+    },
+    updatedAt: new Date().toISOString(),
+    restartCount: 0,
+  }
+}
+
+function buildEndpoint(baseUrl: string, endpointPath: string): string {
+  const normalized = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+  return new URL(endpointPath.replace(/^\//, ''), normalized).toString()
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/apps/desktop/src/main/symphony-supervisor.ts
+++ b/apps/desktop/src/main/symphony-supervisor.ts
@@ -41,6 +41,7 @@ export class SymphonySupervisor extends EventEmitter {
   private startInFlight: Promise<SymphonyRuntimeCommandResult> | null = null
   private stopInFlight: Promise<SymphonyRuntimeCommandResult> | null = null
   private restartInFlight: Promise<SymphonyRuntimeCommandResult> | null = null
+  private lifecycleQueue: Promise<void> = Promise.resolve()
   private readonly mockMode: string | null
 
   constructor(private readonly options: SymphonySupervisorOptions) {
@@ -67,70 +68,78 @@ export class SymphonySupervisor extends EventEmitter {
   }
 
   public async setWorkspacePath(workspacePath: string): Promise<void> {
-    const resolved = workspacePath.trim()
-    if (!resolved || resolved === this.workspacePath) {
-      return
-    }
+    await this.withLifecycleGate(async () => {
+      const resolved = workspacePath.trim()
+      if (!resolved || resolved === this.workspacePath) {
+        return
+      }
 
-    await this.stop('workspace_changed')
-    this.workspacePath = resolved
-    this.updateStatus({
-      phase: 'stopped',
-      managedProcessRunning: false,
-      pid: null,
-      url: null,
-      launch: undefined,
-      diagnostics: { stdout: [], stderr: [] },
-      lastError: undefined,
-      restartReason: 'workspace_changed',
+      await this.stopInternal('workspace_changed')
+      this.workspacePath = resolved
+      this.updateStatus({
+        phase: 'stopped',
+        managedProcessRunning: false,
+        pid: null,
+        url: null,
+        launch: undefined,
+        diagnostics: { stdout: [], stderr: [] },
+        lastError: undefined,
+        restartReason: 'workspace_changed',
+      })
     })
   }
 
   public async start(): Promise<SymphonyRuntimeCommandResult> {
-    if (this.restartInFlight) {
-      return this.restartInFlight
-    }
+    return this.withLifecycleGate(async () => {
+      if (this.restartInFlight) {
+        return this.restartInFlight
+      }
 
-    if (this.startInFlight) {
-      return this.startInFlight
-    }
+      if (this.startInFlight) {
+        return this.startInFlight
+      }
 
-    if (this.child && this.status.phase === 'ready') {
-      return { success: true, status: this.status }
-    }
+      if (this.child && this.status.phase === 'ready') {
+        return { success: true, status: this.status }
+      }
 
-    this.startInFlight = this.startInternal()
-    try {
-      return await this.startInFlight
-    } finally {
-      this.startInFlight = null
-    }
+      this.startInFlight = this.startInternal()
+      try {
+        return await this.startInFlight
+      } finally {
+        this.startInFlight = null
+      }
+    })
   }
 
   public async stop(reason = 'user_requested'): Promise<SymphonyRuntimeCommandResult> {
-    if (this.stopInFlight) {
-      return this.stopInFlight
-    }
+    return this.withLifecycleGate(async () => {
+      if (this.stopInFlight) {
+        return this.stopInFlight
+      }
 
-    this.stopInFlight = this.stopInternal(reason)
-    try {
-      return await this.stopInFlight
-    } finally {
-      this.stopInFlight = null
-    }
+      this.stopInFlight = this.stopInternal(reason)
+      try {
+        return await this.stopInFlight
+      } finally {
+        this.stopInFlight = null
+      }
+    })
   }
 
   public async restart(reason = 'user_requested'): Promise<SymphonyRuntimeCommandResult> {
-    if (this.restartInFlight) {
-      return this.restartInFlight
-    }
+    return this.withLifecycleGate(async () => {
+      if (this.restartInFlight) {
+        return this.restartInFlight
+      }
 
-    this.restartInFlight = this.restartInternal(reason)
-    try {
-      return await this.restartInFlight
-    } finally {
-      this.restartInFlight = null
-    }
+      this.restartInFlight = this.restartInternal(reason)
+      try {
+        return await this.restartInFlight
+      } finally {
+        this.restartInFlight = null
+      }
+    })
   }
 
   private async startInternal(): Promise<SymphonyRuntimeCommandResult> {
@@ -352,7 +361,7 @@ export class SymphonySupervisor extends EventEmitter {
       restartReason: reason,
     })
 
-    const stopResult = await this.stop('restart')
+    const stopResult = await this.stopInternal('restart')
     if (!stopResult.success) {
       return stopResult
     }
@@ -469,6 +478,23 @@ export class SymphonySupervisor extends EventEmitter {
         phase: 'readiness',
         message: `Symphony readiness check failed after ${this.readinessTimeoutMs}ms.`,
       },
+    }
+  }
+
+  private async withLifecycleGate<T>(operation: () => Promise<T>): Promise<T> {
+    const waitForTurn = this.lifecycleQueue
+
+    let releaseTurn!: () => void
+    this.lifecycleQueue = new Promise<void>((resolve) => {
+      releaseTurn = resolve
+    })
+
+    await waitForTurn
+
+    try {
+      return await operation()
+    } finally {
+      releaseTurn()
     }
   }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -10,6 +10,7 @@ import {
   type PlanningArtifact,
   type PlanningArtifactFetchStateEvent,
   type ThinkingLevel,
+  type SymphonyRuntimeStatus,
 } from '../shared/types'
 
 const api: DesktopApi = {
@@ -163,6 +164,31 @@ const api: DesktopApi = {
     },
     getContext: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowGetContext)
+    },
+  },
+  symphony: {
+    getStatus: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.symphonyGetStatus)
+    },
+    start: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.symphonyStart)
+    },
+    stop: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.symphonyStop)
+    },
+    restart: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.symphonyRestart)
+    },
+    onStatus: (listener: (status: SymphonyRuntimeStatus) => void) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, status: SymphonyRuntimeStatus) => {
+        listener(status)
+      }
+
+      ipcRenderer.on(IPC_CHANNELS.symphonyStatus, wrapped)
+
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.symphonyStatus, wrapped)
+      }
     },
   },
 }

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import { AppShell } from './components/app-shell/AppShell'
 import { OnboardingWizard } from './components/onboarding/OnboardingWizard'
 import { usePlanningArtifactBridge } from '@/atoms/planning'
 import { useWorkflowBoardBridge } from '@/atoms/workflow-board'
+import { useSymphonyBridge } from '@/atoms/symphony'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
 export default function App() {
@@ -11,6 +12,7 @@ export default function App() {
 
   usePlanningArtifactBridge()
   useWorkflowBoardBridge()
+  useSymphonyBridge()
 
   return (
     <TooltipProvider>

--- a/apps/desktop/src/renderer/atoms/symphony.ts
+++ b/apps/desktop/src/renderer/atoms/symphony.ts
@@ -1,0 +1,79 @@
+import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { useEffect } from 'react'
+import type {
+  SymphonyRuntimeCommandResult,
+  SymphonyRuntimeStatus,
+} from '@shared/types'
+
+const FALLBACK_STATUS: SymphonyRuntimeStatus = {
+  phase: 'disconnected',
+  managedProcessRunning: false,
+  pid: null,
+  url: null,
+  diagnostics: {
+    stdout: [],
+    stderr: [],
+  },
+  updatedAt: new Date(0).toISOString(),
+  restartCount: 0,
+}
+
+export const symphonyStatusAtom = atom<SymphonyRuntimeStatus>(FALLBACK_STATUS)
+export const symphonyCommandPendingAtom = atom<boolean>(false)
+
+export const symphonyErrorMessageAtom = atom((get) => {
+  return get(symphonyStatusAtom).lastError?.message ?? null
+})
+
+export const runSymphonyCommandAtom = atom(
+  null,
+  async (
+    _get,
+    set,
+    command: 'start' | 'stop' | 'restart',
+  ): Promise<SymphonyRuntimeCommandResult> => {
+    set(symphonyCommandPendingAtom, true)
+
+    try {
+      let result: SymphonyRuntimeCommandResult
+      if (command === 'start') {
+        result = await window.api.symphony.start()
+      } else if (command === 'stop') {
+        result = await window.api.symphony.stop()
+      } else {
+        result = await window.api.symphony.restart()
+      }
+
+      set(symphonyStatusAtom, result.status)
+      return result
+    } finally {
+      set(symphonyCommandPendingAtom, false)
+    }
+  },
+)
+
+export const refreshSymphonyStatusAtom = atom(null, async (_get, set) => {
+  const response = await window.api.symphony.getStatus()
+  set(symphonyStatusAtom, response.status)
+})
+
+export function useSymphonyBridge(): void {
+  const setStatus = useSetAtom(symphonyStatusAtom)
+  const refresh = useSetAtom(refreshSymphonyStatusAtom)
+
+  useEffect(() => {
+    void refresh()
+
+    const unsubscribe = window.api.symphony.onStatus((status) => {
+      setStatus(status)
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [refresh, setStatus])
+}
+
+export function useSymphonyStatus(): SymphonyRuntimeStatus {
+  return useAtomValue(symphonyStatusAtom)
+}

--- a/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
@@ -9,6 +9,7 @@ import { ChatPanel } from '../chat/ChatPanel'
 import { ModelSelector } from './ModelSelector'
 import { SessionSidebar } from './SessionSidebar'
 import { WorkspaceIndicator } from './WorkspaceIndicator'
+import { SymphonyStatusBadge } from './SymphonyStatusBadge'
 
 export function LeftPane() {
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -31,6 +32,7 @@ export function LeftPane() {
 
           <h1 className="text-sm font-semibold tracking-wide uppercase text-foreground">Kata Desktop</h1>
           <WorkspaceIndicator />
+          <SymphonyStatusBadge />
         </div>
 
         <div className="flex flex-1 items-center justify-end gap-2">

--- a/apps/desktop/src/renderer/components/app-shell/SymphonyStatusBadge.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SymphonyStatusBadge.tsx
@@ -1,0 +1,14 @@
+import { useAtomValue } from 'jotai'
+import { Badge } from '@/components/ui/badge'
+import { symphonyStatusAtom } from '@/atoms/symphony'
+import { formatSymphonyPhaseLabel, phaseBadgeVariant } from '../settings/SymphonyRuntimePanel'
+
+export function SymphonyStatusBadge() {
+  const status = useAtomValue(symphonyStatusAtom)
+
+  return (
+    <Badge variant={phaseBadgeVariant(status.phase)} data-testid="symphony-status-badge">
+      Symphony: {formatSymphonyPhaseLabel(status.phase)}
+    </Badge>
+  )
+}

--- a/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
@@ -12,8 +12,9 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ProviderAuthPanel } from './ProviderAuthPanel'
+import { SymphonyRuntimePanel } from './SymphonyRuntimePanel'
 
-type SettingsTab = 'providers' | 'general' | 'appearance'
+type SettingsTab = 'providers' | 'general' | 'appearance' | 'symphony'
 
 interface SettingsPanelProps {
   open: boolean
@@ -22,6 +23,7 @@ interface SettingsPanelProps {
 
 const SETTINGS_TABS: Array<{ id: SettingsTab; label: string }> = [
   { id: 'providers', label: 'Providers' },
+  { id: 'symphony', label: 'Symphony' },
   { id: 'general', label: 'General' },
   { id: 'appearance', label: 'Appearance' },
 ]
@@ -75,6 +77,10 @@ export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
           <div className="flex-1 overflow-hidden">
             <TabsContent value="providers" className="mt-0 h-full overflow-auto p-4">
               <ProviderAuthPanel />
+            </TabsContent>
+
+            <TabsContent value="symphony" className="mt-0 h-full overflow-auto p-4">
+              <SymphonyRuntimePanel />
             </TabsContent>
 
             <TabsContent value="general" className="mt-0 h-full overflow-auto p-4">

--- a/apps/desktop/src/renderer/components/settings/SymphonyRuntimePanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/SymphonyRuntimePanel.tsx
@@ -1,0 +1,149 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import { AlertCircle, Loader2, RotateCcw, Square, Play } from 'lucide-react'
+import { symphonyCommandPendingAtom, symphonyStatusAtom, runSymphonyCommandAtom } from '@/atoms/symphony'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+const PHASE_LABELS: Record<string, string> = {
+  idle: 'Idle',
+  starting: 'Starting',
+  ready: 'Ready',
+  disconnected: 'Disconnected',
+  restarting: 'Restarting',
+  stopping: 'Stopping',
+  stopped: 'Stopped',
+  failed: 'Failed',
+  config_error: 'Config Error',
+}
+
+export function formatSymphonyPhaseLabel(phase: string): string {
+  return PHASE_LABELS[phase] ?? phase
+}
+
+export function phaseBadgeVariant(phase: string): 'default' | 'secondary' | 'outline' | 'destructive' {
+  if (phase === 'ready') return 'default'
+  if (phase === 'failed' || phase === 'config_error') return 'destructive'
+  if (phase === 'starting' || phase === 'restarting' || phase === 'stopping') return 'secondary'
+  return 'outline'
+}
+
+export function deriveSymphonyControlState(options: {
+  phase: string
+  managedProcessRunning: boolean
+  pending: boolean
+}): { canStart: boolean; canStop: boolean; canRestart: boolean } {
+  const canStart =
+    !options.pending && !options.managedProcessRunning && options.phase !== 'starting'
+  const canStop = !options.pending && options.managedProcessRunning
+  const canRestart =
+    !options.pending && (options.managedProcessRunning || options.phase === 'ready')
+
+  return {
+    canStart,
+    canStop,
+    canRestart,
+  }
+}
+
+export function SymphonyRuntimePanel() {
+  const status = useAtomValue(symphonyStatusAtom)
+  const pending = useAtomValue(symphonyCommandPendingAtom)
+  const runCommand = useSetAtom(runSymphonyCommandAtom)
+
+  const controls = deriveSymphonyControlState({
+    phase: status.phase,
+    managedProcessRunning: status.managedProcessRunning,
+    pending,
+  })
+
+  return (
+    <Card className="border border-border bg-card/60 py-0" data-testid="symphony-runtime-panel">
+      <CardHeader className="px-4 pt-4 pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-sm text-foreground">Symphony Runtime</CardTitle>
+          <Badge variant={phaseBadgeVariant(status.phase)} data-testid="symphony-phase-badge">
+            {formatSymphonyPhaseLabel(status.phase)}
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3 p-4 pt-2 text-xs">
+        <div className="grid gap-1 text-muted-foreground">
+          <span>
+            URL: <span className="font-mono text-foreground">{status.url ?? 'Not configured'}</span>
+          </span>
+          <span>
+            Process: <span className="font-mono text-foreground">{status.pid ?? 'Not running'}</span>
+          </span>
+          {status.launch?.command ? (
+            <span>
+              Command: <span className="font-mono text-foreground">{status.launch.command}</span>
+            </span>
+          ) : null}
+        </div>
+
+        {status.lastError ? (
+          <Alert variant="destructive" data-testid="symphony-runtime-error">
+            <AlertCircle />
+            <AlertTitle>{status.lastError.code}</AlertTitle>
+            <AlertDescription>{status.lastError.message}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void runCommand('start')}
+            disabled={!controls.canStart}
+            data-testid="symphony-start-button"
+          >
+            <Play className="size-3.5" />
+            Start
+          </Button>
+
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => void runCommand('restart')}
+            disabled={!controls.canRestart}
+            data-testid="symphony-restart-button"
+          >
+            <RotateCcw className="size-3.5" />
+            Restart
+          </Button>
+
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => void runCommand('stop')}
+            disabled={!controls.canStop}
+            data-testid="symphony-stop-button"
+          >
+            <Square className="size-3.5" />
+            Stop
+          </Button>
+
+          {pending ? (
+            <span className={cn('inline-flex items-center gap-1 text-muted-foreground')}>
+              <Loader2 className="size-3 animate-spin" />
+              Applying runtime command…
+            </span>
+          ) : null}
+        </div>
+
+        {status.phase === 'config_error' ? (
+          <p className="text-muted-foreground" data-testid="symphony-config-guidance">
+            Configure <code>symphony.url</code> and <code>symphony.workflow_path</code> in
+            <code> .kata/preferences.md</code> or ensure <code>WORKFLOW.md</code> exists.
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/desktop/src/renderer/components/settings/__tests__/SymphonyRuntimePanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SymphonyRuntimePanel.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest'
+import {
+  deriveSymphonyControlState,
+  formatSymphonyPhaseLabel,
+  phaseBadgeVariant,
+} from '../SymphonyRuntimePanel'
+
+describe('SymphonyRuntimePanel helpers', () => {
+  test('maps lifecycle phase labels for user-facing copy', () => {
+    expect(formatSymphonyPhaseLabel('ready')).toBe('Ready')
+    expect(formatSymphonyPhaseLabel('config_error')).toBe('Config Error')
+    expect(formatSymphonyPhaseLabel('disconnected')).toBe('Disconnected')
+  })
+
+  test('selects destructive badge for failing phases', () => {
+    expect(phaseBadgeVariant('failed')).toBe('destructive')
+    expect(phaseBadgeVariant('config_error')).toBe('destructive')
+    expect(phaseBadgeVariant('ready')).toBe('default')
+  })
+
+  test('enables start/stop/restart controls based on runtime status', () => {
+    const stopped = deriveSymphonyControlState({
+      phase: 'stopped',
+      managedProcessRunning: false,
+      pending: false,
+    })
+
+    expect(stopped).toEqual({
+      canStart: true,
+      canStop: false,
+      canRestart: false,
+    })
+
+    const ready = deriveSymphonyControlState({
+      phase: 'ready',
+      managedProcessRunning: true,
+      pending: false,
+    })
+
+    expect(ready).toEqual({
+      canStart: false,
+      canStop: true,
+      canRestart: true,
+    })
+
+    const pending = deriveSymphonyControlState({
+      phase: 'ready',
+      managedProcessRunning: true,
+      pending: true,
+    })
+
+    expect(pending).toEqual({
+      canStart: false,
+      canStop: false,
+      canRestart: false,
+    })
+  })
+})

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -32,6 +32,11 @@ export const IPC_CHANNELS = {
   workflowSetBoardActive: 'workflow:set-board-active',
   workflowSetScope: 'workflow:set-scope',
   workflowGetContext: 'workflow:get-context',
+  symphonyGetStatus: 'symphony:get-status',
+  symphonyStart: 'symphony:start',
+  symphonyStop: 'symphony:stop',
+  symphonyRestart: 'symphony:restart',
+  symphonyStatus: 'symphony:status',
 } as const
 
 export type PermissionMode = 'explore' | 'ask' | 'auto'
@@ -683,6 +688,81 @@ export interface WorkflowContextResponse {
   context: WorkflowContextSnapshot
 }
 
+export type SymphonyConfigSource = 'preferences' | 'env' | 'default'
+
+export type SymphonyLaunchSource = 'bundled' | 'path' | 'env'
+
+export type SymphonyRuntimePhase =
+  | 'idle'
+  | 'starting'
+  | 'ready'
+  | 'disconnected'
+  | 'restarting'
+  | 'stopping'
+  | 'stopped'
+  | 'failed'
+  | 'config_error'
+
+export type SymphonyRuntimeErrorCode =
+  | 'CONFIG_MISSING'
+  | 'CONFIG_INVALID'
+  | 'WORKFLOW_PATH_MISSING'
+  | 'BINARY_NOT_FOUND'
+  | 'SPAWN_FAILED'
+  | 'PROCESS_EXITED'
+  | 'READINESS_FAILED'
+  | 'STOP_TIMEOUT'
+  | 'UNKNOWN'
+
+export interface SymphonyRuntimeError {
+  code: SymphonyRuntimeErrorCode
+  message: string
+  phase: 'config' | 'spawn' | 'process' | 'readiness' | 'shutdown' | 'unknown'
+  details?: string
+}
+
+export interface SymphonyLaunchDescriptor {
+  command: string
+  args: string[]
+  cwd: string
+  source: SymphonyLaunchSource
+  resolvedUrl: string
+  workflowPath: string
+  urlSource: SymphonyConfigSource
+  workflowPathSource: SymphonyConfigSource
+}
+
+export interface SymphonyRuntimeDiagnostics {
+  stdout: string[]
+  stderr: string[]
+}
+
+export interface SymphonyRuntimeStatus {
+  phase: SymphonyRuntimePhase
+  managedProcessRunning: boolean
+  pid: number | null
+  url: string | null
+  launch?: Pick<SymphonyLaunchDescriptor, 'command' | 'args' | 'source'>
+  diagnostics: SymphonyRuntimeDiagnostics
+  updatedAt: string
+  lastReadyAt?: string
+  lastReadinessCheckAt?: string
+  restartCount: number
+  restartReason?: string
+  lastError?: SymphonyRuntimeError
+}
+
+export interface SymphonyRuntimeCommandResult {
+  success: boolean
+  status: SymphonyRuntimeStatus
+  error?: SymphonyRuntimeError
+}
+
+export interface SymphonyRuntimeStatusResponse {
+  success: boolean
+  status: SymphonyRuntimeStatus
+}
+
 export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context' | 'slice'
 
 export type RoadmapRisk = 'high' | 'medium' | 'low'
@@ -796,6 +876,13 @@ export interface DesktopApi {
     setBoardActive: (active: boolean) => Promise<WorkflowBoardLifecycleResponse>
     setScope: (scopeKey: string) => Promise<WorkflowBoardScopeResponse>
     getContext: () => Promise<WorkflowContextResponse>
+  }
+  symphony: {
+    getStatus: () => Promise<SymphonyRuntimeStatusResponse>
+    start: () => Promise<SymphonyRuntimeCommandResult>
+    stop: () => Promise<SymphonyRuntimeCommandResult>
+    restart: () => Promise<SymphonyRuntimeCommandResult>
+    onStatus: (listener: (status: SymphonyRuntimeStatus) => void) => () => void
   }
 }
 


### PR DESCRIPTION
## Summary
- deliver S01 runtime lifecycle plumbing across Desktop main/preload/renderer for Symphony start/stop/restart management
- add deterministic runtime config resolution and launch descriptor handling (URL/workflow path/binary discovery)
- add supervisor + IPC + renderer runtime controls and status surfaces with lifecycle/error visibility
- add e2e runtime lifecycle coverage and smoke checklist documentation
- harden branch/coverage with additional symphony config and supervisor test cases

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/symphony-config.test.ts src/main/__tests__/symphony-supervisor.test.ts src/main/__tests__/symphony-ipc.test.ts`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/symphony-runtime.e2e.ts`
- `cd apps/desktop && bun run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Symphony runtime status indicator added to app header.
  * New "Symphony" settings panel to view runtime details and Start/Stop/Restart the runtime.
  * Real-time status display showing phase, PID, URL, diagnostics and actionable error guidance for configuration issues.

* **Tests**
  * Added end-to-end and unit tests covering lifecycle, config error, readiness failure, and control behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the S01 Symphony runtime lifecycle plumbing for Kata Desktop, wiring together a `SymphonySupervisor` (child-process management with SIGTERM/SIGKILL stop, readiness polling, and diagnostic capture), deterministic config resolution (`symphony-config.ts`), IPC handlers for start/stop/restart/status, a preload bridge, Jotai state atoms, and a `SymphonyRuntimePanel` UI with lifecycle controls and error surfaces. It also adds a full E2E test suite with a `symphonyMockMode` fixture and extensive unit tests for config and supervisor logic.

**Key changes:**
- `SymphonySupervisor` manages the Symphony child process end-to-end, including readiness polling against `/api/v1/state`, graceful stop with SIGTERM/SIGKILL fallback, and a `mockMode` path for E2E testing.
- `symphony-config.ts` resolves binary path (env override → bundled → PATH), URL (preferences → `KATA_SYMPHONY_URL` → `SYMPHONY_URL`), and workflow path (preferences → default `WORKFLOW.md`) with deterministic error codes per failure mode.
- IPC handlers in `ipc.ts` gate all symphony commands through `runSymphonyCommand` and push status events to the renderer via `webContents.send`.
- `before-quit` in `index.ts` properly stops the supervisor before bridge shutdown.
- Two issues found: env-var constant names in `symphony-config.ts` are inverted (minor naming confusion), and in `stopInternal` the SIGKILL outcome is never checked — the supervisor unconditionally returns `success: false` even when SIGKILL successfully terminates the process, leaving the UI in a `Failed` state after a clean forceful kill.

<h3>Confidence Score: 3/5</h3>

Safe to merge with the SIGKILL outcome bug acknowledged — it produces a misleading failure state but does not corrupt data or leave zombie processes.

The PR is well-structured with comprehensive test coverage (unit + E2E + mock modes). The SIGKILL outcome not being checked is a real logic gap: after a graceful-stop timeout, SIGKILL typically succeeds, but the supervisor always transitions to phase 'failed' regardless, giving the user a false error state. The env-var naming inversion is a minor maintenance hazard. No data-loss, security, or correctness-critical issues found elsewhere.

apps/desktop/src/main/symphony-supervisor.ts — stopInternal SIGKILL path; apps/desktop/src/main/symphony-config.ts — constant naming

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/symphony-supervisor.ts | New supervisor class managing Symphony child-process lifecycle; SIGKILL outcome is not checked in stopInternal, causing a spurious 'failed' state after successful forceful termination. |
| apps/desktop/src/main/symphony-config.ts | Config resolution for Symphony launch; inverted constant names (FALLBACK/DEFAULT) are misleading about priority ordering, but logic is functionally correct. |
| apps/desktop/src/main/ipc.ts | Symphony IPC handlers for start/stop/restart/getStatus added correctly; supervisor events forwarded to renderer via sendSymphonyStatusToRenderer with proper cleanup in return function. |
| apps/desktop/src/main/index.ts | SymphonySupervisor instantiated on app ready and properly stopped on before-quit; clean wiring with registerSessionIpc. |
| apps/desktop/src/preload/index.ts | Symphony API surface (getStatus, start, stop, restart, onStatus) correctly exposed via contextBridge with proper IPC channel mappings. |
| apps/desktop/src/renderer/atoms/symphony.ts | Jotai atoms for symphony status, pending state, and command dispatch; useSymphonyBridge hook fetches initial status and subscribes to live updates correctly. |
| apps/desktop/src/renderer/components/settings/SymphonyRuntimePanel.tsx | Clean UI panel with start/stop/restart controls, phase badge, error display, and config guidance; control-state derivation logic is sound. |
| apps/desktop/src/shared/types.ts | New Symphony types (SymphonyRuntimePhase, SymphonyRuntimeStatus, SymphonyRuntimeError, SymphonyLaunchDescriptor, DesktopApi.symphony) are well-typed and complete. |
| apps/desktop/e2e/tests/symphony-runtime.e2e.ts | E2E tests cover start/stop/restart lifecycle, config error, and readiness failure states via the mock mode fixture; good coverage of the three modes. |
| apps/desktop/src/main/__tests__/symphony-supervisor.test.ts | Comprehensive unit tests for supervisor lifecycle including process starts, diagnostics, spawn errors, stop timeout, and workspace changes. |
| apps/desktop/src/main/__tests__/symphony-config.test.ts | Thorough tests for all resolveSymphonyLaunch paths: preferences, env fallbacks, binary discovery, and edge cases like quoted values and inline comments. |
| apps/desktop/e2e/fixtures/electron.fixture.ts | symphonyMockMode fixture option added with default 'ready'; KATA_DESKTOP_SYMPHONY_MOCK and KATA_SYMPHONY_URL env vars correctly injected into Electron process. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer
    participant P as Preload (contextBridge)
    participant I as IPC Main
    participant S as SymphonySupervisor
    participant C as Child Process (symphony)

    Note over R,C: Initial Load
    R->>P: window.api.symphony.getStatus()
    P->>I: ipcMain symphony:get-status
    I->>S: getStatus()
    S-->>I: SymphonyRuntimeStatus {phase:'idle'}
    I-->>P: SymphonyRuntimeStatusResponse
    P-->>R: status atom updated

    Note over R,C: User clicks Start
    R->>P: window.api.symphony.start()
    P->>I: ipcMain symphony:start
    I->>S: start()
    S->>S: resolveSymphonyLaunch()
    S->>C: spawn(command, args)
    S-->>I: status push {phase:'starting'}
    I->>P: webContents.send symphony:status
    P->>R: onStatus callback -> atom update
    S->>C: GET /api/v1/state (readiness poll)
    C-->>S: 200 OK
    S-->>I: CommandResult {success:true, phase:'ready'}
    S->>I: emit status {phase:'ready'}
    I->>P: webContents.send symphony:status
    P->>R: atom update -> badge shows Ready
    I-->>P: IPC reply
    P-->>R: runSymphonyCommandAtom resolves

    Note over R,C: User clicks Stop
    R->>P: window.api.symphony.stop()
    P->>I: ipcMain symphony:stop
    I->>S: stop()
    S->>C: kill(SIGTERM)
    C-->>S: exit event
    S-->>I: CommandResult {success:true, phase:'stopped'}
    I-->>P: IPC reply

    Note over R,C: App quit
    P->>I: app before-quit
    I->>S: stop('app_quit')
    S->>C: kill(SIGTERM)
    C-->>S: exit
    I->>I: bridge.shutdown()
    I->>I: app.exit(0)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/symphony-supervisor.ts
Line: 298-316

Comment:
**SIGKILL outcome ignored — supervisor always enters `failed` state even after a successful forceful kill**

After SIGKILL is sent, the result of the second `waitForExit(child, 1_000)` is discarded. The function unconditionally returns `{ success: false }` with a `STOP_TIMEOUT` error and sets `phase: 'failed'`, regardless of whether SIGKILL actually terminated the process.

In practice, SIGKILL succeeds in the vast majority of cases. This means:
- The process is dead, the child reference is nulled, `pid` is cleared — the runtime is in a **clean state**.
- But the UI shows `Failed` with a "Timed out" error, and `success: false` is returned to the caller.
- A subsequent `start()` call from a confused user would then try to spawn a fresh process, which is correct — but they first have to dismiss a spurious error.

The fix is to check whether the SIGKILL wait succeeded and, if so, transition to `'stopped'` rather than `'failed'`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/symphony-config.ts
Line: 13-15

Comment:
**Inverted env-var constant naming**

The variable names are backwards relative to their actual roles and priority in the lookup chain:

- `FALLBACK_URL_ENV_KEY` holds `'KATA_SYMPHONY_URL'` — this is checked **first** (the preferred/newer key), but the name says "FALLBACK".
- `DEFAULT_URL_ENV_KEY` holds `'SYMPHONY_URL'` — this is the legacy value tried only when `KATA_SYMPHONY_URL` is absent, but the name says "DEFAULT".

The test at line 498 confirms the intent: _"falls back to SYMPHONY_URL when KATA_SYMPHONY_URL is missing"_ — `SYMPHONY_URL` is the fallback, not `KATA_SYMPHONY_URL`. Consider renaming the constants to `PRIMARY_URL_ENV_KEY` / `LEGACY_URL_ENV_KEY` (or similar) to match the actual lookup order and prevent future misreads.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): KAT-2340 cover symphony c..."](https://github.com/gannonh/kata/commit/c770eede9405ffd3ca94472a897a28eac38d59ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27361561)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->