### PR TITLE
feat(desktop): live symphony dashboard and escalation handling (KAT-2338)

### DIFF
--- a/apps/desktop/docs/uat/M004/S02-DASHBOARD-SMOKE.md
+++ b/apps/desktop/docs/uat/M004/S02-DASHBOARD-SMOKE.md
@@ -1,0 +1,46 @@
+# S02 Dashboard + Escalation Live Smoke
+
+## Scope
+
+Validate S02 only:
+- live worker dashboard snapshot in Desktop settings
+- pending escalation visibility
+- inline escalation response submission
+- reconnect/disconnected/stale/failure feedback
+
+This checklist intentionally does **not** claim S03 kanban convergence.
+
+## Preconditions
+
+- Symphony runtime available and configured in `.kata/preferences.md` (`symphony.url`, `symphony.workflow_path`)
+- Desktop app built from current branch
+- A managed workflow that can produce at least one pending escalation
+
+## Smoke Steps
+
+1. Launch Desktop and open **Settings → Symphony**.
+2. Click **Start** in Symphony Runtime panel.
+3. Confirm runtime phase changes to **Ready**.
+4. Confirm dashboard connection badge is **connected** and worker/queue/completed counts render.
+5. Trigger or wait for a real pending escalation from Symphony.
+6. Confirm escalation card appears with identifier + question preview.
+7. Enter response text and click **Submit response**.
+8. Confirm success banner appears and escalation list updates (removed or state refreshed).
+9. Simulate/observe reconnect condition (restart Symphony or drop connection).
+10. Confirm dashboard shows reconnecting/disconnected feedback and stale/error visibility.
+11. Restore connection and confirm baseline refresh repopulates workers/escalations.
+
+## Expected Evidence
+
+- Screenshot: Symphony Runtime phase = Ready
+- Screenshot: Dashboard worker/escalation summary populated
+- Screenshot: Pending escalation card before submit
+- Screenshot: Post-submit success state and refreshed list
+- Screenshot: Reconnect/disconnected visible feedback
+
+## Pass Criteria
+
+- Dashboard updates from real Symphony runtime without renderer-side transport logic
+- Escalations are actionable inline and submission reaches Symphony
+- Reconnect/disconnect/failure states are visible and truthful
+- Post-response and post-reconnect baseline refreshes are observable in UI

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -71,7 +71,7 @@ type DesktopFixtures = {
   workspaceDir: string
   mainWindow: Page
   readyWindow: Page
-  symphonyMockMode: 'ready' | 'config_error' | 'readiness_error'
+  symphonyMockMode: 'ready' | 'config_error' | 'readiness_error' | 'response_failure' | 'reconnecting'
 }
 
 export const test = base.extend<DesktopFixtures>({
@@ -116,6 +116,7 @@ export const test = base.extend<DesktopFixtures>({
         KATA_TEST_MODE: '1',
         KATA_WORKSPACE_PATH: workspaceDir,
         KATA_DESKTOP_SYMPHONY_MOCK: symphonyMockMode,
+        KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: symphonyMockMode,
         KATA_SYMPHONY_URL: 'http://127.0.0.1:8080',
         // Don't override HOME — that breaks CLI binary discovery and auth.json lookup.
         // The --user-data-dir flag isolates Electron's own data (localStorage, cookies).

--- a/apps/desktop/e2e/tests/symphony-dashboard.e2e.ts
+++ b/apps/desktop/e2e/tests/symphony-dashboard.e2e.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '../fixtures/electron.fixture'
+
+test.describe('Symphony dashboard live surface', () => {
+  test.use({ symphonyMockMode: 'ready' })
+
+  test('renders worker summary and supports inline escalation response', async ({ readyWindow }) => {
+    await readyWindow.getByRole('button', { name: /Settings/i }).click()
+    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+
+    await readyWindow.getByTestId('symphony-start-button').click()
+    await expect(readyWindow.getByTestId('symphony-phase-badge')).toContainText('Ready')
+
+    await expect(readyWindow.getByTestId('symphony-dashboard-panel')).toBeVisible()
+    await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('connected')
+    await expect(readyWindow.getByTestId('symphony-summary-workers')).toContainText('1')
+    await expect(readyWindow.getByTestId('symphony-summary-escalations')).toContainText('1')
+
+    await readyWindow.getByTestId('symphony-escalation-input-req-123').fill('Use the stale-state wording from D023.')
+    await readyWindow.getByTestId('symphony-escalation-submit-req-123').click()
+
+    await expect(readyWindow.getByTestId('symphony-escalation-result')).toContainText('Escalation response sent')
+    await expect(readyWindow.getByTestId('symphony-escalation-empty')).toBeVisible()
+  })
+})
+
+test.describe('Symphony dashboard reconnect state', () => {
+  test.use({ symphonyMockMode: 'reconnecting' })
+
+  test('surfaces reconnecting connection feedback', async ({ readyWindow }) => {
+    await readyWindow.getByRole('button', { name: /Settings/i }).click()
+    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+
+    await readyWindow.getByTestId('symphony-start-button').click()
+
+    await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('reconnecting')
+    await expect(readyWindow.getByTestId('symphony-dashboard-error')).toContainText('Mocked reconnect in progress.')
+  })
+})
+
+test.describe('Symphony dashboard escalation failure state', () => {
+  test.use({ symphonyMockMode: 'response_failure' })
+
+  test('shows failed escalation response state', async ({ readyWindow }) => {
+    await readyWindow.getByRole('button', { name: /Settings/i }).click()
+    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+
+    await readyWindow.getByTestId('symphony-start-button').click()
+
+    await readyWindow.getByTestId('symphony-escalation-input-req-123').fill('Please continue with best effort.')
+    await readyWindow.getByTestId('symphony-escalation-submit-req-123').click()
+
+    await expect(readyWindow.getByTestId('symphony-escalation-result')).toContainText('Escalation response failed')
+    await expect(readyWindow.getByTestId('symphony-summary-escalations')).toContainText('1')
+  })
+})

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -57,8 +57,18 @@ describe('symphony ipc handlers', () => {
     handlers.clear()
   })
 
-  test('routes symphony start/stop/restart through supervisor', async () => {
+  test('routes runtime commands and dashboard methods through symphony services', async () => {
     const bridge = createBridgeStub()
+    const dashboardSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 1,
+      completedCount: 2,
+      workers: [],
+      escalations: [],
+      connection: { state: 'connected', updatedAt: new Date().toISOString() },
+      freshness: { status: 'fresh' },
+      response: {},
+    }
 
     const supervisor = {
       on: vi.fn(),
@@ -78,6 +88,15 @@ describe('symphony ipc handlers', () => {
       setWorkspacePath: vi.fn(async () => undefined),
     } as any
 
+    const operatorService = {
+      on: vi.fn(),
+      off: vi.fn(),
+      syncRuntimeStatus: vi.fn(async () => undefined),
+      getSnapshot: vi.fn(() => dashboardSnapshot),
+      refreshBaseline: vi.fn(async () => dashboardSnapshot),
+      respondToEscalation: vi.fn(async () => ({ success: true, snapshot: dashboardSnapshot })),
+    } as any
+
     const unregister = registerSessionIpc({
       bridge,
       authBridge: {
@@ -93,23 +112,30 @@ describe('symphony ipc handlers', () => {
       } as any,
       window: createWindowStub(),
       symphonySupervisor: supervisor,
+      symphonyOperatorService: operatorService,
     })
 
-    const startHandler = handlers.get(IPC_CHANNELS.symphonyStart)
-    const stopHandler = handlers.get(IPC_CHANNELS.symphonyStop)
-    const restartHandler = handlers.get(IPC_CHANNELS.symphonyRestart)
+    await handlers.get(IPC_CHANNELS.symphonyStart)?.({})
+    await handlers.get(IPC_CHANNELS.symphonyStop)?.({})
+    await handlers.get(IPC_CHANNELS.symphonyRestart)?.({})
 
-    expect(startHandler).toBeTypeOf('function')
-    expect(stopHandler).toBeTypeOf('function')
-    expect(restartHandler).toBeTypeOf('function')
-
-    await startHandler?.({})
-    await stopHandler?.({})
-    await restartHandler?.({})
+    const getDashboardResponse = await handlers.get(IPC_CHANNELS.symphonyGetDashboard)?.({})
+    const refreshDashboardResponse = await handlers.get(IPC_CHANNELS.symphonyRefreshDashboard)?.({})
+    const respondResult = await handlers.get(IPC_CHANNELS.symphonyRespondEscalation)?.(
+      {},
+      'req-1',
+      'Proceed',
+    )
 
     expect(supervisor.start).toHaveBeenCalledTimes(1)
     expect(supervisor.stop).toHaveBeenCalledTimes(1)
     expect(supervisor.restart).toHaveBeenCalledTimes(1)
+
+    expect(getDashboardResponse.snapshot).toEqual(dashboardSnapshot)
+    expect(refreshDashboardResponse.snapshot).toEqual(dashboardSnapshot)
+    expect(operatorService.refreshBaseline).toHaveBeenCalledTimes(1)
+    expect(operatorService.respondToEscalation).toHaveBeenCalledWith('req-1', 'Proceed')
+    expect(respondResult.success).toBe(true)
 
     unregister()
   })

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -488,6 +488,139 @@ describe('SymphonyOperatorService', () => {
     expect(openedUrls[1]).toBe('ws://example.test:9000/api/v1/events')
   })
 
+  test('sorts worker identifiers and escalation timestamps from baseline payloads', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({
+            running: {
+              '2': {
+                issue_id: '2',
+                issue_identifier: 'KAT-2',
+                issue_title: 'Second worker',
+                status: 'started',
+              },
+              '1': {
+                issue_id: '1',
+                issue_identifier: 'KAT-1',
+                issue_title: 'First worker',
+                status: 'started',
+              },
+            },
+            retry_queue: [],
+            completed: [],
+            pending_escalations: [],
+            running_session_info: {},
+          }),
+        } as Response
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          pending: [
+            {
+              request_id: 'req-new',
+              issue_id: '1',
+              issue_identifier: 'KAT-1',
+              preview: 'newer escalation',
+              created_at: '2026-01-02T00:00:00.000Z',
+              timeout_ms: 300000,
+            },
+            {
+              request_id: 'req-old',
+              issue_id: '2',
+              issue_identifier: 'KAT-2',
+              preview: 'older escalation',
+              created_at: '2026-01-01T00:00:00.000Z',
+              timeout_ms: 300000,
+            },
+          ],
+        }),
+      } as Response
+    })
+
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: () => fakeSocket })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    expect(service.getSnapshot().workers.map((worker) => worker.identifier)).toEqual(['KAT-1', 'KAT-2'])
+    expect(service.getSnapshot().escalations.map((escalation) => escalation.requestId)).toEqual(['req-old', 'req-new'])
+  })
+
+  test('sorts escalation_created stream events by createdAt', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          pending: [
+            {
+              request_id: 'req-late',
+              issue_id: '1',
+              issue_identifier: 'KAT-1',
+              preview: 'later',
+              created_at: '2026-01-02T00:00:00.000Z',
+              timeout_ms: 300000,
+            },
+          ],
+        }),
+      } as Response
+    })
+
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: () => fakeSocket })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    fakeSocket.emitMessage({
+      event: 'escalation_created',
+      payload: {
+        request_id: 'req-early',
+        issue_id: '2',
+        issue_identifier: 'KAT-2',
+        preview: 'earlier',
+        created_at: '2026-01-01T00:00:00.000Z',
+        timeout_ms: 300000,
+      },
+    })
+
+    expect(service.getSnapshot().escalations.map((escalation) => escalation.requestId)).toEqual(['req-early', 'req-late'])
+  })
+
+  test('clears pending reconnect timer when runtime stops', async () => {
+    vi.useFakeTimers()
+
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const socketFactory = vi.fn(() => fakeSocket)
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: socketFactory })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    fakeSocket.emitClose()
+    await service.syncRuntimeStatus({ ...READY_STATUS, phase: 'idle' })
+    await vi.advanceTimersByTimeAsync(1_200)
+
+    expect(socketFactory).toHaveBeenCalledTimes(1)
+    expect(service.getSnapshot().connection.state).toBe('disconnected')
+  })
+
   test('disconnects when state endpoint fails and does not open duplicate sockets', async () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { SymphonyRuntimeStatus } from '@shared/types'
 import { SymphonyOperatorService } from '../symphony-operator-service'
 
@@ -16,6 +16,14 @@ class FakeWebSocket {
     this.onopen?.({})
   }
 
+  emitError() {
+    this.onerror?.({})
+  }
+
+  emitClose() {
+    this.onclose?.({ code: 1006, reason: 'network' })
+  }
+
   emitMessage(payload: unknown) {
     this.onmessage?.({ data: JSON.stringify(payload) })
   }
@@ -31,11 +39,27 @@ const READY_STATUS: SymphonyRuntimeStatus = {
   restartCount: 0,
 }
 
+const DISCONNECTED_STATUS: SymphonyRuntimeStatus = {
+  ...READY_STATUS,
+  phase: 'failed',
+  managedProcessRunning: false,
+  url: null,
+  lastError: {
+    code: 'PROCESS_EXITED',
+    phase: 'process',
+    message: 'Runtime exited.',
+  },
+}
+
 describe('SymphonyOperatorService', () => {
   let fakeSocket: FakeWebSocket
 
   beforeEach(() => {
     fakeSocket = new FakeWebSocket()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   test('normalizes baseline snapshot from state and escalation endpoints', async () => {
@@ -101,7 +125,7 @@ describe('SymphonyOperatorService', () => {
     expect(snapshot.connection.lastBaselineRefreshAt).toBeTruthy()
   })
 
-  test('applies escalation stream events incrementally', async () => {
+  test('applies escalation stream events incrementally and removes responded entries', async () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url.endsWith('/api/v1/state')) {
@@ -147,14 +171,7 @@ describe('SymphonyOperatorService', () => {
     expect(service.getSnapshot().escalations).toHaveLength(1)
     expect(service.getSnapshot().connection.lastEventSequence).toBe(4)
 
-    fakeSocket.emitMessage({
-      sequence: 5,
-      event: 'escalation_responded',
-      payload: {
-        request_id: 'req-5',
-      },
-    })
-
+    fakeSocket.emitMessage({ sequence: 5, event: 'escalation_responded', payload: { request_id: 'req-5' } })
     expect(service.getSnapshot().escalations).toHaveLength(0)
   })
 
@@ -188,10 +205,7 @@ describe('SymphonyOperatorService', () => {
       } as Response
     })
 
-    const service = new SymphonyOperatorService({
-      fetchImpl,
-      createWebSocket: () => fakeSocket,
-    })
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: () => fakeSocket })
 
     await service.syncRuntimeStatus(READY_STATUS)
 
@@ -201,5 +215,126 @@ describe('SymphonyOperatorService', () => {
 
     const stateFetchCount = fetchImpl.mock.calls.filter((call) => String(call[0]).endsWith('/api/v1/state')).length
     expect(stateFetchCount).toBeGreaterThanOrEqual(2)
+  })
+
+  test('marks disconnected when no URL is available for refresh/respond', async () => {
+    const service = new SymphonyOperatorService({
+      fetchImpl: vi.fn(async () => ({ ok: true, json: async () => ({}) }) as Response),
+      createWebSocket: () => fakeSocket,
+    })
+
+    const snapshot = await service.refreshBaseline()
+    expect(snapshot.connection.state).toBe('disconnected')
+
+    const response = await service.respondToEscalation('req-missing', 'Ack')
+    expect(response.success).toBe(false)
+    expect(response.result?.message).toContain('URL is unavailable')
+  })
+
+  test('supports mocked dashboard baselines and mocked response failure/success branches', async () => {
+    const reconnectingService = new SymphonyOperatorService({
+      env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'reconnecting' },
+      createWebSocket: () => fakeSocket,
+    })
+
+    await reconnectingService.syncRuntimeStatus(READY_STATUS)
+    expect(reconnectingService.getSnapshot().connection.state).toBe('reconnecting')
+    expect(reconnectingService.getSnapshot().queueCount).toBe(2)
+
+    const failingService = new SymphonyOperatorService({
+      env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'response_failure' },
+      createWebSocket: () => fakeSocket,
+    })
+
+    await failingService.syncRuntimeStatus(READY_STATUS)
+    const failed = await failingService.respondToEscalation('req-123', 'Nope')
+    expect(failed.success).toBe(false)
+    expect(failed.result?.status).toBe(422)
+
+    const mockedSuccessService = new SymphonyOperatorService({
+      env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'ready' },
+      createWebSocket: () => fakeSocket,
+    })
+
+    await mockedSuccessService.syncRuntimeStatus(READY_STATUS)
+    const success = await mockedSuccessService.respondToEscalation('req-123', 'Approved')
+    expect(success.success).toBe(true)
+    expect(success.snapshot.escalations).toHaveLength(0)
+  })
+
+  test('handles runtime phase transitions and stream reconnect path', async () => {
+    vi.useFakeTimers()
+
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ pending: [] }),
+      } as Response
+    })
+
+    const socketFactory = vi.fn(() => fakeSocket)
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: socketFactory })
+
+    await service.syncRuntimeStatus({ ...READY_STATUS, phase: 'starting' })
+    expect(service.getSnapshot().connection.state).toBe('reconnecting')
+
+    await service.syncRuntimeStatus(READY_STATUS)
+    expect(socketFactory).toHaveBeenCalledTimes(1)
+
+    fakeSocket.emitError()
+    expect(service.getSnapshot().connection.state).toBe('reconnecting')
+
+    fakeSocket.emitClose()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(fetchImpl.mock.calls.filter((call) => String(call[0]).endsWith('/api/v1/state')).length).toBeGreaterThanOrEqual(2)
+  })
+
+  test('handles failed state refresh and supervisor disconnect status', async () => {
+    const failingFetch = vi.fn(async () => {
+      throw new Error('network down')
+    })
+
+    const service = new SymphonyOperatorService({ fetchImpl: failingFetch, createWebSocket: () => fakeSocket })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    expect(service.getSnapshot().connection.lastError).toContain('network down')
+
+    await service.syncRuntimeStatus(DISCONNECTED_STATUS)
+    expect(service.getSnapshot().connection.state).toBe('disconnected')
+    expect(service.getSnapshot().connection.lastError).toContain('Runtime exited')
+  })
+
+  test('returns failed response result when escalation POST returns non-OK', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/respond')) {
+        return { ok: false, status: 500 } as Response
+      }
+
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: () => fakeSocket })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    const result = await service.respondToEscalation('req-9', 'Retry later')
+    expect(result.success).toBe(false)
+    expect(result.result?.message).toContain('failed (500)')
   })
 })

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -298,6 +298,58 @@ describe('SymphonyOperatorService', () => {
     expect(fetchImpl.mock.calls.filter((call) => String(call[0]).endsWith('/api/v1/state')).length).toBeGreaterThanOrEqual(2)
   })
 
+  test('ignores stale ready transition when newer runtime status disconnects', async () => {
+    let releaseStateFetch = () => {}
+    const delayedStateResponse = new Promise<Response>((resolve) => {
+      releaseStateFetch = () =>
+        resolve({
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response)
+    })
+
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return delayedStateResponse
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({ pending: [] }) } as Response)
+    })
+
+    const socketFactory = vi.fn(() => fakeSocket)
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: socketFactory })
+
+    const inFlightReadySync = service.syncRuntimeStatus(READY_STATUS)
+    await service.syncRuntimeStatus(DISCONNECTED_STATUS)
+
+    releaseStateFetch()
+    await inFlightReadySync
+
+    expect(socketFactory).not.toHaveBeenCalled()
+    expect(service.getSnapshot().connection.state).toBe('disconnected')
+  })
+
+  test('handles explicit disconnected phase from runtime status', async () => {
+    const service = new SymphonyOperatorService({
+      fetchImpl: vi.fn(async () => ({ ok: true, json: async () => ({}) }) as Response),
+      createWebSocket: () => fakeSocket,
+    })
+
+    await service.syncRuntimeStatus({
+      ...READY_STATUS,
+      phase: 'disconnected',
+      lastError: {
+        code: 'UNKNOWN',
+        phase: 'unknown',
+        message: 'Lost heartbeat to runtime.',
+      },
+    })
+
+    expect(service.getSnapshot().connection.state).toBe('disconnected')
+    expect(service.getSnapshot().connection.lastError).toContain('Lost heartbeat')
+  })
+
   test('handles failed state refresh and supervisor disconnect status', async () => {
     const failingFetch = vi.fn(async () => {
       throw new Error('network down')

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -313,6 +313,31 @@ describe('SymphonyOperatorService', () => {
     expect(service.getSnapshot().connection.lastError).toContain('Runtime exited')
   })
 
+  test('returns failed response result when escalation POST throws transport error', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/respond')) {
+        throw new Error('transport down')
+      }
+
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: () => fakeSocket })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    const result = await service.respondToEscalation('req-throw', 'Retry later')
+    expect(result.success).toBe(false)
+    expect(result.result?.message).toContain('transport down')
+  })
+
   test('returns failed response result when escalation POST returns non-OK', async () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
@@ -336,5 +361,167 @@ describe('SymphonyOperatorService', () => {
     const result = await service.respondToEscalation('req-9', 'Retry later')
     expect(result.success).toBe(false)
     expect(result.result?.message).toContain('failed (500)')
+  })
+
+  test('handles snapshot stream payload and duplicate escalation creation safely', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: () => fakeSocket })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    fakeSocket.emitMessage({
+      sequence: 8,
+      kind: 'snapshot',
+      payload: {
+        running: {
+          '1': {
+            issue_id: '1',
+            issue_identifier: 'KAT-2338',
+            issue_title: 'Snapshot from stream',
+            status: 'started',
+            model: 'gpt-5',
+          },
+        },
+        retry_queue: [{ id: 'a' }, { id: 'b' }],
+        completed: [{ id: 'done' }],
+        pending_escalations: [
+          {
+            request_id: 'req-stream',
+            issue_id: '1',
+            issue_identifier: 'KAT-2338',
+            preview: 'Need stream answer',
+            created_at: new Date().toISOString(),
+            timeout_ms: 300000,
+          },
+        ],
+      },
+    })
+
+    expect(service.getSnapshot().workers).toHaveLength(1)
+    expect(service.getSnapshot().queueCount).toBe(2)
+
+    fakeSocket.emitMessage({
+      event: 'escalation_created',
+      payload: {
+        request_id: 'req-stream',
+        issue_id: '1',
+        issue_identifier: 'KAT-2338',
+        preview: 'duplicate',
+        created_at: new Date().toISOString(),
+        timeout_ms: 300000,
+      },
+    })
+
+    expect(service.getSnapshot().escalations).toHaveLength(1)
+  })
+
+  test('drops invalid worker/escalation entries from baseline payload', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({
+            running: {
+              invalid: { issue_identifier: 'MISSING_ID' },
+            },
+            retry_queue: [],
+            completed: [],
+            pending_escalations: [],
+            running_session_info: {},
+          }),
+        } as Response
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          pending: [{ issue_id: '1', issue_identifier: 'KAT-1' }],
+        }),
+      } as Response
+    })
+
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: () => fakeSocket })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    expect(service.getSnapshot().workers).toHaveLength(0)
+    expect(service.getSnapshot().escalations).toHaveLength(0)
+  })
+
+  test('uses websocket URL conversion for https and ws URLs', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const openedUrls: string[] = []
+
+    const createWebSocket = (url: string) => {
+      openedUrls.push(url)
+      return new FakeWebSocket()
+    }
+
+    const httpsService = new SymphonyOperatorService({ fetchImpl, createWebSocket })
+    await httpsService.syncRuntimeStatus({ ...READY_STATUS, url: 'https://example.test:8443' })
+
+    const wsService = new SymphonyOperatorService({ fetchImpl, createWebSocket })
+    await wsService.syncRuntimeStatus({ ...READY_STATUS, url: 'ws://example.test:9000' })
+
+    expect(openedUrls[0]).toBe('wss://example.test:8443/api/v1/events')
+    expect(openedUrls[1]).toBe('ws://example.test:9000/api/v1/events')
+  })
+
+  test('disconnects when state endpoint fails and does not open duplicate sockets', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return { ok: false, status: 503, json: async () => ({}) } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const socketFactory = vi.fn(() => fakeSocket)
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: socketFactory })
+
+    await service.syncRuntimeStatus(READY_STATUS)
+    expect(service.getSnapshot().connection.state).toBe('disconnected')
+
+    // ready again should still connect once when runtime remains ready
+    const healthyFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const healthyService = new SymphonyOperatorService({ fetchImpl: healthyFetch, createWebSocket: socketFactory })
+    await healthyService.syncRuntimeStatus(READY_STATUS)
+    await healthyService.syncRuntimeStatus(READY_STATUS)
+    expect(socketFactory).toHaveBeenCalledTimes(2)
+
+    await healthyService.syncRuntimeStatus({ ...READY_STATUS, phase: 'idle' })
+    expect(healthyService.getSnapshot().connection.state).toBe('disconnected')
   })
 })

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -621,6 +621,80 @@ describe('SymphonyOperatorService', () => {
     expect(service.getSnapshot().connection.state).toBe('disconnected')
   })
 
+  test('ignores blank stream messages and tolerates malformed payloads', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: () => fakeSocket })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    fakeSocket.onmessage?.({ data: '   ' })
+    fakeSocket.onmessage?.({ data: '{not-json' })
+
+    expect(service.getSnapshot().connection.state).toBe('connected')
+  })
+
+  test('marks reconnecting when websocket creation throws', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const service = new SymphonyOperatorService({
+      fetchImpl,
+      createWebSocket: () => {
+        throw new Error('socket constructor failed')
+      },
+    })
+
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    expect(service.getSnapshot().connection.state).toBe('reconnecting')
+    expect(service.getSnapshot().connection.lastError).toContain('socket constructor failed')
+  })
+
+  test('dispose clears scheduled reconnect timer', async () => {
+    vi.useFakeTimers()
+
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const socketFactory = vi.fn(() => fakeSocket)
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: socketFactory })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    fakeSocket.emitClose()
+    service.dispose()
+    await vi.advanceTimersByTimeAsync(1_200)
+
+    expect(socketFactory).toHaveBeenCalledTimes(1)
+  })
+
   test('disconnects when state endpoint fails and does not open duplicate sockets', async () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -9,7 +9,9 @@ class FakeWebSocket {
   public onclose: ((event: { code?: number; reason?: string }) => void) | null = null
 
   close = vi.fn(() => {
-    this.onclose?.({ code: 1000, reason: 'closed' })
+    queueMicrotask(() => {
+      this.onclose?.({ code: 1000, reason: 'closed' })
+    })
   })
 
   emitOpen() {
@@ -123,6 +125,46 @@ describe('SymphonyOperatorService', () => {
     expect(snapshot.escalations).toHaveLength(1)
     expect(snapshot.connection.state).toBe('connected')
     expect(snapshot.connection.lastBaselineRefreshAt).toBeTruthy()
+  })
+
+  test('falls back to state pending escalations when escalation endpoint fails', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({
+            running: {},
+            retry_queue: [],
+            completed: [],
+            pending_escalations: [
+              {
+                request_id: 'req-state',
+                issue_id: '1',
+                issue_identifier: 'KAT-2338',
+                preview: 'State fallback escalation',
+                created_at: new Date().toISOString(),
+                timeout_ms: 300000,
+              },
+            ],
+            running_session_info: {},
+          }),
+        } as Response
+      }
+
+      return {
+        ok: false,
+        status: 503,
+        json: async () => ({ pending: [] }),
+      } as Response
+    })
+
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: () => fakeSocket })
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    const snapshot = service.getSnapshot()
+    expect(snapshot.escalations.map((escalation) => escalation.requestId)).toContain('req-state')
+    expect(snapshot.connection.lastError).toContain('Escalation request failed (503)')
   })
 
   test('applies escalation stream events incrementally and removes responded entries', async () => {
@@ -262,6 +304,34 @@ describe('SymphonyOperatorService', () => {
     expect(success.snapshot.escalations).toHaveLength(0)
   })
 
+  test('reconnects websocket when runtime ready URL changes', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({ running: {}, retry_queue: [], completed: [], pending_escalations: [], running_session_info: {} }),
+        } as Response
+      }
+
+      return { ok: true, json: async () => ({ pending: [] }) } as Response
+    })
+
+    const firstSocket = new FakeWebSocket()
+    const secondSocket = new FakeWebSocket()
+    const socketFactory = vi.fn()
+      .mockReturnValueOnce(firstSocket)
+      .mockReturnValueOnce(secondSocket)
+
+    const service = new SymphonyOperatorService({ fetchImpl, createWebSocket: socketFactory })
+
+    await service.syncRuntimeStatus({ ...READY_STATUS, url: 'http://127.0.0.1:8080' })
+    await service.syncRuntimeStatus({ ...READY_STATUS, url: 'http://127.0.0.1:9090' })
+
+    expect(firstSocket.close).toHaveBeenCalledTimes(1)
+    expect(socketFactory).toHaveBeenCalledTimes(2)
+  })
+
   test('handles runtime phase transitions and stream reconnect path', async () => {
     vi.useFakeTimers()
 
@@ -292,6 +362,7 @@ describe('SymphonyOperatorService', () => {
     fakeSocket.emitError()
     expect(service.getSnapshot().connection.state).toBe('reconnecting')
 
+    fakeSocket.emitClose()
     fakeSocket.emitClose()
     await vi.advanceTimersByTimeAsync(1_000)
 
@@ -667,6 +738,7 @@ describe('SymphonyOperatorService', () => {
 
     fakeSocket.emitClose()
     await service.syncRuntimeStatus({ ...READY_STATUS, phase: 'idle' })
+    await Promise.resolve()
     await vi.advanceTimersByTimeAsync(1_200)
 
     expect(socketFactory).toHaveBeenCalledTimes(1)

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { SymphonyRuntimeStatus } from '@shared/types'
+import { SymphonyOperatorService } from '../symphony-operator-service'
+
+class FakeWebSocket {
+  public onopen: ((event: unknown) => void) | null = null
+  public onmessage: ((event: { data?: unknown }) => void) | null = null
+  public onerror: ((event: unknown) => void) | null = null
+  public onclose: ((event: { code?: number; reason?: string }) => void) | null = null
+
+  close = vi.fn(() => {
+    this.onclose?.({ code: 1000, reason: 'closed' })
+  })
+
+  emitOpen() {
+    this.onopen?.({})
+  }
+
+  emitMessage(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) })
+  }
+}
+
+const READY_STATUS: SymphonyRuntimeStatus = {
+  phase: 'ready',
+  managedProcessRunning: true,
+  pid: 1,
+  url: 'http://127.0.0.1:8080',
+  diagnostics: { stdout: [], stderr: [] },
+  updatedAt: new Date().toISOString(),
+  restartCount: 0,
+}
+
+describe('SymphonyOperatorService', () => {
+  let fakeSocket: FakeWebSocket
+
+  beforeEach(() => {
+    fakeSocket = new FakeWebSocket()
+  })
+
+  test('normalizes baseline snapshot from state and escalation endpoints', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({
+            running: {
+              '1': {
+                issue_id: '1',
+                issue_identifier: 'KAT-2338',
+                issue_title: 'Dashboard work',
+                status: 'in_progress',
+                model: 'claude-sonnet-4-6',
+              },
+            },
+            retry_queue: [{ id: 'r1' }],
+            completed: [{ id: 'c1' }, { id: 'c2' }],
+            pending_escalations: [],
+            running_session_info: {
+              '1': {
+                current_tool_name: 'edit',
+                last_activity_ms: Date.now(),
+              },
+            },
+          }),
+        } as Response
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          pending: [
+            {
+              request_id: 'req-1',
+              issue_id: '1',
+              issue_identifier: 'KAT-2338',
+              preview: 'Need operator input',
+              created_at: new Date().toISOString(),
+              timeout_ms: 300000,
+            },
+          ],
+        }),
+      } as Response
+    })
+
+    const service = new SymphonyOperatorService({
+      fetchImpl,
+      createWebSocket: () => fakeSocket,
+    })
+
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    const snapshot = service.getSnapshot()
+    expect(snapshot.queueCount).toBe(1)
+    expect(snapshot.completedCount).toBe(2)
+    expect(snapshot.workers).toHaveLength(1)
+    expect(snapshot.workers[0]?.toolName).toBe('edit')
+    expect(snapshot.escalations).toHaveLength(1)
+    expect(snapshot.connection.state).toBe('connected')
+    expect(snapshot.connection.lastBaselineRefreshAt).toBeTruthy()
+  })
+
+  test('applies escalation stream events incrementally', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({
+            running: {},
+            retry_queue: [],
+            completed: [],
+            pending_escalations: [],
+            running_session_info: {},
+          }),
+        } as Response
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ pending: [] }),
+      } as Response
+    })
+
+    const service = new SymphonyOperatorService({
+      fetchImpl,
+      createWebSocket: () => fakeSocket,
+    })
+
+    await service.syncRuntimeStatus(READY_STATUS)
+    fakeSocket.emitOpen()
+
+    fakeSocket.emitMessage({
+      sequence: 4,
+      event: 'escalation_created',
+      payload: {
+        request_id: 'req-5',
+        issue_id: '1',
+        issue_identifier: 'KAT-2338',
+        preview: 'Please decide on retry policy',
+        created_at: new Date().toISOString(),
+        timeout_ms: 300000,
+      },
+    })
+
+    expect(service.getSnapshot().escalations).toHaveLength(1)
+    expect(service.getSnapshot().connection.lastEventSequence).toBe(4)
+
+    fakeSocket.emitMessage({
+      sequence: 5,
+      event: 'escalation_responded',
+      payload: {
+        request_id: 'req-5',
+      },
+    })
+
+    expect(service.getSnapshot().escalations).toHaveLength(0)
+  })
+
+  test('forces baseline refresh after successful escalation response', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.includes('/respond')) {
+        return {
+          ok: true,
+          status: 200,
+        } as Response
+      }
+
+      if (url.endsWith('/api/v1/state')) {
+        return {
+          ok: true,
+          json: async () => ({
+            running: {},
+            retry_queue: [],
+            completed: [{ id: 'done' }],
+            pending_escalations: [],
+            running_session_info: {},
+          }),
+        } as Response
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ pending: [] }),
+      } as Response
+    })
+
+    const service = new SymphonyOperatorService({
+      fetchImpl,
+      createWebSocket: () => fakeSocket,
+    })
+
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    const result = await service.respondToEscalation('req-1', 'Proceed with retry')
+    expect(result.success).toBe(true)
+    expect(result.result?.ok).toBe(true)
+
+    const stateFetchCount = fetchImpl.mock.calls.filter((call) => String(call[0]).endsWith('/api/v1/state')).length
+    expect(stateFetchCount).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,12 +31,14 @@ import { PiAgentBridge } from './pi-agent-bridge'
 import { registerSessionIpc } from './ipc'
 import { DesktopSessionManager } from './session-manager'
 import { SymphonySupervisor } from './symphony-supervisor'
+import { SymphonyOperatorService } from './symphony-operator-service'
 
 const SETTINGS_PATH = path.join(homedir(), '.kata-cli', 'agent', 'settings.json')
 
 let mainWindow: BrowserWindow | null = null
 let bridge: PiAgentBridge | null = null
 let symphonySupervisor: SymphonySupervisor | null = null
+let symphonyOperatorService: SymphonyOperatorService | null = null
 let unregisterSessionIpc: (() => void) | null = null
 
 function createWindow(): BrowserWindow {
@@ -194,6 +196,7 @@ app.whenReady().then(async () => {
     appIsPackaged: app.isPackaged,
     resourcesPath: process.resourcesPath,
   })
+  symphonyOperatorService = new SymphonyOperatorService({ env: process.env })
 
   const authBridge = new AuthBridge()
   const sessionManager = new DesktopSessionManager()
@@ -207,6 +210,7 @@ app.whenReady().then(async () => {
     onModelSelected: persistSelectedModel,
     onWorkspaceSelected: persistWorkspacePath,
     symphonySupervisor,
+    symphonyOperatorService,
   })
 
   mainWindow.on('closed', () => {
@@ -232,6 +236,7 @@ app.on('before-quit', async (event) => {
   event.preventDefault()
   try {
     await symphonySupervisor?.stop('app_quit')
+    symphonyOperatorService?.dispose()
   } catch (error) {
     log.error('[desktop-main] symphony supervisor shutdown failed', error)
   }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -11,6 +11,7 @@ import { DesktopSessionManager } from './session-manager'
 import { SessionHistoryLoader } from './session-history-loader'
 import { WorkflowBoardService } from './workflow-board-service'
 import type { SymphonySupervisor } from './symphony-supervisor'
+import type { SymphonyOperatorService } from './symphony-operator-service'
 import {
   IPC_CHANNELS,
   type AuthProvider,
@@ -48,6 +49,9 @@ import {
   type SymphonyRuntimeStatus,
   type SymphonyRuntimeCommandResult,
   type SymphonyRuntimeStatusResponse,
+  type SymphonyOperatorSnapshot,
+  type SymphonyOperatorSnapshotResponse,
+  type SymphonyEscalationResponseCommandResult,
 } from '../shared/types'
 
 interface RegisterIpcOptions {
@@ -58,6 +62,7 @@ interface RegisterIpcOptions {
   onModelSelected?: (model: string) => Promise<void> | void
   onWorkspaceSelected?: (workspacePath: string) => Promise<void> | void
   symphonySupervisor?: SymphonySupervisor
+  symphonyOperatorService?: SymphonyOperatorService
 }
 
 export function registerSessionIpc({
@@ -68,6 +73,7 @@ export function registerSessionIpc({
   onModelSelected,
   onWorkspaceSelected,
   symphonySupervisor,
+  symphonyOperatorService,
 }: RegisterIpcOptions): () => void {
   const adapter = new RpcEventAdapter()
   const planningToolDetector = new PlanningToolDetector()
@@ -144,6 +150,22 @@ export function registerSessionIpc({
 
     window.webContents.send(IPC_CHANNELS.planningArtifactFetchState, event)
     log.debug('[desktop-ipc] planning fetch state', event)
+  }
+
+  const sendSymphonyDashboardSnapshot = (snapshot: SymphonyOperatorSnapshot): void => {
+    if (!canSendToRenderer()) {
+      log.warn('[desktop-ipc] skipping symphony dashboard snapshot dispatch: renderer window is destroyed')
+      return
+    }
+
+    window.webContents.send(IPC_CHANNELS.symphonyDashboardSnapshot, snapshot)
+    log.debug('[desktop-ipc] symphony dashboard snapshot', {
+      connectionState: snapshot.connection.state,
+      workers: snapshot.workers.length,
+      escalations: snapshot.escalations.length,
+      queueCount: snapshot.queueCount,
+      completedCount: snapshot.completedCount,
+    })
   }
 
   const getPlanningFetchContext = (
@@ -485,9 +507,15 @@ export function registerSessionIpc({
 
   const onSymphonyStatus = (status: SymphonyRuntimeStatus): void => {
     sendSymphonyStatusToRenderer(status)
+    void symphonyOperatorService?.syncRuntimeStatus(status)
+  }
+
+  const onSymphonyDashboardSnapshot = (snapshot: SymphonyOperatorSnapshot): void => {
+    sendSymphonyDashboardSnapshot(snapshot)
   }
 
   symphonySupervisor?.on('status', onSymphonyStatus)
+  symphonyOperatorService?.on('snapshot', onSymphonyDashboardSnapshot)
 
   const initialState = bridge.getState()
   sendBridgeStatus({
@@ -497,7 +525,13 @@ export function registerSessionIpc({
   })
 
   if (symphonySupervisor) {
-    sendSymphonyStatusToRenderer(symphonySupervisor.getStatus())
+    const initialSymphonyStatus = symphonySupervisor.getStatus()
+    sendSymphonyStatusToRenderer(initialSymphonyStatus)
+    void symphonyOperatorService?.syncRuntimeStatus(initialSymphonyStatus)
+  }
+
+  if (symphonyOperatorService) {
+    sendSymphonyDashboardSnapshot(symphonyOperatorService.getSnapshot())
   }
 
   ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
@@ -532,6 +566,9 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.symphonyStart)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyStop)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyRestart)
+  ipcMain.removeHandler(IPC_CHANNELS.symphonyGetDashboard)
+  ipcMain.removeHandler(IPC_CHANNELS.symphonyRefreshDashboard)
+  ipcMain.removeHandler(IPC_CHANNELS.symphonyRespondEscalation)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -1170,6 +1207,24 @@ export function registerSessionIpc({
     }
   }
 
+  const createUnavailableDashboardSnapshot = (): SymphonyOperatorSnapshot => ({
+    fetchedAt: new Date(0).toISOString(),
+    queueCount: 0,
+    completedCount: 0,
+    workers: [],
+    escalations: [],
+    connection: {
+      state: 'disconnected',
+      updatedAt: new Date().toISOString(),
+      lastError: 'Symphony dashboard service is unavailable.',
+    },
+    freshness: {
+      status: 'stale',
+      staleReason: 'Symphony dashboard service is unavailable.',
+    },
+    response: {},
+  })
+
   ipcMain.handle(IPC_CHANNELS.symphonyGetStatus, async (): Promise<SymphonyRuntimeStatusResponse> => {
     if (!symphonySupervisor) {
       const fallback = createSymphonyDisconnectedResult()
@@ -1207,6 +1262,42 @@ export function registerSessionIpc({
     return runSymphonyCommand(() => symphonySupervisor!.restart())
   })
 
+  ipcMain.handle(IPC_CHANNELS.symphonyGetDashboard, async (): Promise<SymphonyOperatorSnapshotResponse> => {
+    return {
+      success: true,
+      snapshot: symphonyOperatorService?.getSnapshot() ?? createUnavailableDashboardSnapshot(),
+    }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.symphonyRefreshDashboard, async (): Promise<SymphonyOperatorSnapshotResponse> => {
+    if (!symphonyOperatorService) {
+      return {
+        success: false,
+        snapshot: createUnavailableDashboardSnapshot(),
+      }
+    }
+
+    const snapshot = await symphonyOperatorService.refreshBaseline()
+    return {
+      success: true,
+      snapshot,
+    }
+  })
+
+  ipcMain.handle(
+    IPC_CHANNELS.symphonyRespondEscalation,
+    async (_event, requestId: string, responseText: string): Promise<SymphonyEscalationResponseCommandResult> => {
+      if (!symphonyOperatorService) {
+        return {
+          success: false,
+          snapshot: createUnavailableDashboardSnapshot(),
+        }
+      }
+
+      return symphonyOperatorService.respondToEscalation(requestId, responseText)
+    },
+  )
+
   return () => {
     bridge.off('rpc-event', onRpcEvent)
     bridge.off('extension-ui-request', onExtensionUiRequest)
@@ -1214,6 +1305,7 @@ export function registerSessionIpc({
     bridge.off('debug', onDebug)
     bridge.off('crash', onCrash)
     symphonySupervisor?.off('status', onSymphonyStatus)
+    symphonyOperatorService?.off('snapshot', onSymphonyDashboardSnapshot)
     planningToolDetector.off('artifact', onPlanningArtifactEvent)
 
     ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
@@ -1248,6 +1340,9 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.symphonyStart)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyStop)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyRestart)
+    ipcMain.removeHandler(IPC_CHANNELS.symphonyGetDashboard)
+    ipcMain.removeHandler(IPC_CHANNELS.symphonyRefreshDashboard)
+    ipcMain.removeHandler(IPC_CHANNELS.symphonyRespondEscalation)
   }
 }
 

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -1,0 +1,563 @@
+import { EventEmitter } from 'node:events'
+import type { SymphonyRuntimeStatus } from '../shared/types'
+import type {
+  SymphonyEscalationResponseCommandResult,
+  SymphonyEscalationResponseResult,
+  SymphonyOperatorEscalationItem,
+  SymphonyOperatorSnapshot,
+  SymphonyOperatorWorkerRow,
+} from '../shared/types'
+
+const STALE_AFTER_MS = 30_000
+
+type FetchLike = typeof fetch
+
+type WebSocketLike = {
+  onopen: ((event: unknown) => void) | null
+  onmessage: ((event: { data?: unknown }) => void) | null
+  onerror: ((event: unknown) => void) | null
+  onclose: ((event: { code?: number; reason?: string }) => void) | null
+  close: () => void
+}
+
+interface SymphonyStatePayload {
+  running?: Record<string, Record<string, unknown>>
+  retry_queue?: unknown[]
+  completed?: unknown[]
+  pending_escalations?: Array<Record<string, unknown>>
+  running_session_info?: Record<string, Record<string, unknown>>
+}
+
+interface SymphonyEventEnvelope {
+  sequence?: number
+  kind?: string
+  event?: string
+  payload?: Record<string, unknown>
+}
+
+export interface SymphonyOperatorServiceOptions {
+  fetchImpl?: FetchLike
+  createWebSocket?: (url: string) => WebSocketLike
+  env?: NodeJS.ProcessEnv
+}
+
+interface OperatorEvents {
+  snapshot: (snapshot: SymphonyOperatorSnapshot) => void
+}
+
+export class SymphonyOperatorService extends EventEmitter {
+  private readonly fetchImpl: FetchLike
+  private readonly createWebSocket: (url: string) => WebSocketLike
+  private readonly mockMode: string | null
+  private runtimeStatus: SymphonyRuntimeStatus | null = null
+  private activeUrl: string | null = null
+  private socket: WebSocketLike | null = null
+  private reconnectTimer: NodeJS.Timeout | null = null
+  private readonly snapshot: SymphonyOperatorSnapshot = createEmptySnapshot()
+
+  constructor(options: SymphonyOperatorServiceOptions = {}) {
+    super()
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis)
+    this.createWebSocket =
+      options.createWebSocket ??
+      ((url: string) => {
+        const WebSocketCtor = (globalThis as { WebSocket?: new (url: string) => WebSocketLike }).WebSocket
+        if (!WebSocketCtor) {
+          throw new Error('WebSocket is unavailable in the current runtime.')
+        }
+
+        return new WebSocketCtor(url)
+      })
+    this.mockMode = options.env?.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK?.trim() ?? null
+  }
+
+  override on<K extends keyof OperatorEvents>(event: K, listener: OperatorEvents[K]): this {
+    return super.on(event, listener)
+  }
+
+  override emit<K extends keyof OperatorEvents>(event: K, ...args: Parameters<OperatorEvents[K]>): boolean {
+    return super.emit(event, ...args)
+  }
+
+  public getSnapshot(): SymphonyOperatorSnapshot {
+    this.refreshFreshness()
+    return this.snapshot
+  }
+
+  public async refreshBaseline(): Promise<SymphonyOperatorSnapshot> {
+    const url = this.activeUrl ?? this.runtimeStatus?.url
+    if (!url) {
+      this.markDisconnected('Symphony URL is unavailable.')
+      return this.snapshot
+    }
+
+    if (this.mockMode) {
+      this.applyMockBaseline(this.mockMode)
+      return this.snapshot
+    }
+
+    try {
+      const [stateResponse, escalationResponse] = await Promise.all([
+        this.fetchImpl(buildEndpoint(url, '/api/v1/state'), {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+        }),
+        this.fetchImpl(buildEndpoint(url, '/api/v1/escalations'), {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+        }),
+      ])
+
+      if (!stateResponse.ok) {
+        this.markDisconnected(`State request failed (${stateResponse.status}).`)
+        return this.snapshot
+      }
+
+      const statePayload = (await stateResponse.json()) as SymphonyStatePayload
+      const escalationsPayload = escalationResponse.ok
+        ? ((await escalationResponse.json()) as { pending?: Array<Record<string, unknown>> })
+        : { pending: [] }
+
+      this.applyStatePayload(statePayload, escalationsPayload.pending ?? [])
+      this.snapshot.connection.lastBaselineRefreshAt = new Date().toISOString()
+      this.snapshot.connection.lastError = undefined
+      this.snapshot.connection.state = 'connected'
+      this.snapshot.connection.updatedAt = new Date().toISOString()
+      this.refreshFreshness()
+      this.emitSnapshot()
+      return this.snapshot
+    } catch (error) {
+      this.markDisconnected(error instanceof Error ? error.message : String(error))
+      return this.snapshot
+    }
+  }
+
+  public async respondToEscalation(
+    requestId: string,
+    responseText: string,
+  ): Promise<SymphonyEscalationResponseCommandResult> {
+    const trimmedRequestId = requestId.trim()
+    const submittedAt = new Date().toISOString()
+    this.snapshot.response.submittingRequestId = trimmedRequestId
+    this.emitSnapshot()
+
+    const url = this.activeUrl ?? this.runtimeStatus?.url
+    if (!url) {
+      const result = buildResponseResult(trimmedRequestId, false, 0, 'Symphony URL is unavailable.', submittedAt)
+      this.snapshot.response.submittingRequestId = undefined
+      this.snapshot.response.lastResult = result
+      this.refreshFreshness()
+      this.emitSnapshot()
+      return { success: false, snapshot: this.snapshot, result }
+    }
+
+    if (this.mockMode === 'response_failure') {
+      const result = buildResponseResult(trimmedRequestId, false, 422, 'Mocked response failure.', submittedAt)
+      this.snapshot.response.submittingRequestId = undefined
+      this.snapshot.response.lastResult = result
+      this.refreshFreshness()
+      this.emitSnapshot()
+      return { success: false, snapshot: this.snapshot, result }
+    }
+
+    if (this.mockMode) {
+      const result = buildResponseResult(trimmedRequestId, true, 200, 'Escalation response accepted.', submittedAt)
+      this.snapshot.escalations = this.snapshot.escalations.filter(
+        (escalation) => escalation.requestId !== trimmedRequestId,
+      )
+      this.snapshot.response.submittingRequestId = undefined
+      this.snapshot.response.lastResult = result
+      this.snapshot.connection.lastBaselineRefreshAt = new Date().toISOString()
+      this.refreshFreshness()
+      this.emitSnapshot()
+      return { success: true, snapshot: this.snapshot, result }
+    }
+
+    try {
+      const response = await this.fetchImpl(
+        buildEndpoint(url, `/api/v1/escalations/${encodeURIComponent(trimmedRequestId)}/respond`),
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify({
+            response: {
+              text: responseText,
+            },
+          }),
+        },
+      )
+
+      const result = buildResponseResult(
+        trimmedRequestId,
+        response.ok,
+        response.status,
+        response.ok ? 'Escalation response accepted.' : `Escalation response failed (${response.status}).`,
+        submittedAt,
+      )
+
+      this.snapshot.response.submittingRequestId = undefined
+      this.snapshot.response.lastResult = result
+
+      if (response.ok) {
+        await this.refreshBaseline()
+      } else {
+        this.refreshFreshness()
+        this.emitSnapshot()
+      }
+
+      return {
+        success: response.ok,
+        snapshot: this.snapshot,
+        result,
+      }
+    } catch (error) {
+      const result = buildResponseResult(
+        trimmedRequestId,
+        false,
+        0,
+        error instanceof Error ? error.message : String(error),
+        submittedAt,
+      )
+
+      this.snapshot.response.submittingRequestId = undefined
+      this.snapshot.response.lastResult = result
+      this.refreshFreshness()
+      this.emitSnapshot()
+      return { success: false, snapshot: this.snapshot, result }
+    }
+  }
+
+  public async syncRuntimeStatus(status: SymphonyRuntimeStatus): Promise<void> {
+    this.runtimeStatus = status
+    this.activeUrl = status.url
+
+    if (!status.url || status.phase === 'config_error' || status.phase === 'failed') {
+      this.stopStream()
+      this.markDisconnected(status.lastError?.message ?? 'Symphony runtime unavailable.')
+      return
+    }
+
+    if (status.phase === 'ready') {
+      await this.refreshBaseline()
+      this.connectStream(status.url)
+      return
+    }
+
+    if (status.phase === 'restarting' || status.phase === 'starting') {
+      this.snapshot.connection.state = 'reconnecting'
+      this.snapshot.connection.updatedAt = new Date().toISOString()
+      this.snapshot.connection.lastError = status.lastError?.message
+      this.refreshFreshness()
+      this.emitSnapshot()
+      return
+    }
+
+    if (status.phase === 'stopping' || status.phase === 'stopped' || status.phase === 'idle') {
+      this.stopStream()
+      this.markDisconnected('Symphony runtime is not running.')
+    }
+  }
+
+  public dispose(): void {
+    this.stopStream()
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+
+  private connectStream(url: string): void {
+    if (this.mockMode) {
+      return
+    }
+
+    const eventUrl = toWebSocketUrl(buildEndpoint(url, '/api/v1/events'))
+
+    if (this.socket) {
+      return
+    }
+
+    try {
+      const socket = this.createWebSocket(eventUrl)
+      this.socket = socket
+
+      socket.onopen = () => {
+        this.snapshot.connection.state = 'connected'
+        this.snapshot.connection.updatedAt = new Date().toISOString()
+        this.snapshot.connection.lastError = undefined
+        this.refreshFreshness()
+        this.emitSnapshot()
+      }
+
+      socket.onmessage = (message) => {
+        const raw = typeof message.data === 'string' ? message.data : ''
+        if (!raw.trim()) {
+          return
+        }
+
+        try {
+          const event = JSON.parse(raw) as SymphonyEventEnvelope
+          this.applyStreamEvent(event)
+        } catch {
+          // ignore malformed messages
+        }
+      }
+
+      socket.onerror = () => {
+        this.snapshot.connection.state = 'reconnecting'
+        this.snapshot.connection.updatedAt = new Date().toISOString()
+        this.snapshot.connection.lastError = 'Event stream error.'
+        this.refreshFreshness()
+        this.emitSnapshot()
+      }
+
+      socket.onclose = () => {
+        this.socket = null
+        this.snapshot.connection.state = 'reconnecting'
+        this.snapshot.connection.updatedAt = new Date().toISOString()
+        this.refreshFreshness()
+        this.emitSnapshot()
+
+        if (this.runtimeStatus?.phase === 'ready' && this.activeUrl) {
+          this.reconnectTimer = setTimeout(async () => {
+            this.reconnectTimer = null
+            await this.refreshBaseline()
+            this.connectStream(this.activeUrl!)
+          }, 1_000)
+        }
+      }
+    } catch (error) {
+      this.snapshot.connection.state = 'reconnecting'
+      this.snapshot.connection.updatedAt = new Date().toISOString()
+      this.snapshot.connection.lastError = error instanceof Error ? error.message : String(error)
+      this.refreshFreshness()
+      this.emitSnapshot()
+    }
+  }
+
+  private stopStream(): void {
+    if (this.socket) {
+      this.socket.close()
+      this.socket = null
+    }
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+
+  private markDisconnected(reason: string): void {
+    this.snapshot.connection.state = 'disconnected'
+    this.snapshot.connection.updatedAt = new Date().toISOString()
+    this.snapshot.connection.lastError = reason
+    this.refreshFreshness(reason)
+    this.emitSnapshot()
+  }
+
+  private applyStatePayload(
+    payload: SymphonyStatePayload,
+    escalationPayload: Array<Record<string, unknown>>,
+  ): void {
+    const nowIso = new Date().toISOString()
+    const running = payload.running ?? {}
+    const sessionInfo = payload.running_session_info ?? {}
+
+    this.snapshot.workers = Object.values(running)
+      .map((run) => this.mapWorker(run, sessionInfo[String(run.issue_id ?? '')]))
+      .filter((worker): worker is SymphonyOperatorWorkerRow => Boolean(worker))
+      .sort((left, right) => left.identifier.localeCompare(right.identifier))
+
+    this.snapshot.escalations = escalationPayload
+      .map((escalation) => this.mapEscalation(escalation))
+      .filter((item): item is SymphonyOperatorEscalationItem => Boolean(item))
+      .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt))
+
+    this.snapshot.queueCount = Array.isArray(payload.retry_queue) ? payload.retry_queue.length : 0
+    this.snapshot.completedCount = Array.isArray(payload.completed) ? payload.completed.length : 0
+    this.snapshot.fetchedAt = nowIso
+  }
+
+  private applyStreamEvent(event: SymphonyEventEnvelope): void {
+    if (typeof event.sequence === 'number') {
+      this.snapshot.connection.lastEventSequence = event.sequence
+    }
+
+    this.snapshot.fetchedAt = new Date().toISOString()
+
+    if (event.kind === 'snapshot' && event.payload) {
+      this.applyStatePayload(event.payload as SymphonyStatePayload, ((event.payload as SymphonyStatePayload).pending_escalations ?? []) as Array<Record<string, unknown>>)
+    } else if (event.event === 'escalation_created' && event.payload) {
+      const nextEscalation = this.mapEscalation(event.payload)
+      if (nextEscalation && !this.snapshot.escalations.some((item) => item.requestId === nextEscalation.requestId)) {
+        this.snapshot.escalations = [...this.snapshot.escalations, nextEscalation].sort(
+          (left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt),
+        )
+      }
+    } else if (
+      (event.event === 'escalation_responded' ||
+        event.event === 'escalation_timed_out' ||
+        event.event === 'escalation_cancelled') &&
+      event.payload
+    ) {
+      const requestId = String(event.payload.request_id ?? '').trim()
+      if (requestId) {
+        this.snapshot.escalations = this.snapshot.escalations.filter((item) => item.requestId !== requestId)
+      }
+    }
+
+    this.refreshFreshness()
+    this.emitSnapshot()
+  }
+
+  private applyMockBaseline(mockMode: string): void {
+    const nowIso = new Date().toISOString()
+
+    this.snapshot.fetchedAt = nowIso
+    this.snapshot.queueCount = mockMode === 'reconnecting' ? 2 : 1
+    this.snapshot.completedCount = 3
+    this.snapshot.workers = [
+      {
+        issueId: '1',
+        identifier: 'KAT-2338',
+        issueTitle: 'Live Worker Dashboard and Escalation Handling',
+        state: mockMode === 'reconnecting' ? 'reconnecting' : 'in_progress',
+        toolName: 'edit',
+        model: 'claude-sonnet-4-6',
+        lastActivityAt: nowIso,
+      },
+    ]
+
+    this.snapshot.escalations = [
+      {
+        requestId: 'req-123',
+        issueId: '1',
+        issueIdentifier: 'KAT-2338',
+        issueTitle: 'Live Worker Dashboard and Escalation Handling',
+        questionPreview: 'Need clarification on dashboard failure state copy.',
+        createdAt: new Date(Date.now() - 15_000).toISOString(),
+        timeoutMs: 300_000,
+      },
+    ]
+
+    this.snapshot.connection.state = mockMode === 'reconnecting' ? 'reconnecting' : 'connected'
+    this.snapshot.connection.updatedAt = nowIso
+    this.snapshot.connection.lastBaselineRefreshAt = nowIso
+    this.snapshot.connection.lastError =
+      mockMode === 'reconnecting' ? 'Mocked reconnect in progress.' : undefined
+    this.refreshFreshness()
+    this.emitSnapshot()
+  }
+
+  private mapWorker(
+    run: Record<string, unknown>,
+    info: Record<string, unknown> | undefined,
+  ): SymphonyOperatorWorkerRow | null {
+    const issueId = String(run.issue_id ?? '').trim()
+    const identifier = String(run.issue_identifier ?? '').trim()
+    if (!issueId || !identifier) {
+      return null
+    }
+
+    const startedAt = typeof run.started_at === 'string' ? run.started_at : undefined
+    const activityMs = typeof info?.last_activity_ms === 'number' ? info.last_activity_ms : undefined
+
+    return {
+      issueId,
+      identifier,
+      issueTitle: String(run.issue_title ?? identifier).trim() || identifier,
+      state: String(run.linear_state ?? run.status ?? 'unknown').trim(),
+      toolName: String(info?.current_tool_name ?? 'idle').trim() || 'idle',
+      model: String(run.model ?? 'default').trim() || 'default',
+      ...(activityMs ? { lastActivityAt: new Date(activityMs).toISOString() } : startedAt ? { lastActivityAt: startedAt } : {}),
+      ...(typeof run.error === 'string' && run.error.trim() ? { lastError: run.error.trim() } : {}),
+    }
+  }
+
+  private mapEscalation(raw: Record<string, unknown>): SymphonyOperatorEscalationItem | null {
+    const requestId = String(raw.request_id ?? '').trim()
+    const issueId = String(raw.issue_id ?? '').trim()
+    const issueIdentifier = String(raw.issue_identifier ?? '').trim()
+    if (!requestId || !issueId || !issueIdentifier) {
+      return null
+    }
+
+    return {
+      requestId,
+      issueId,
+      issueIdentifier,
+      issueTitle: issueIdentifier,
+      questionPreview: String(raw.preview ?? '').trim() || 'Escalation pending response.',
+      createdAt: String(raw.created_at ?? new Date().toISOString()),
+      timeoutMs: Number(raw.timeout_ms ?? 0) || 0,
+    }
+  }
+
+  private refreshFreshness(reason?: string): void {
+    const ageMs = Date.now() - Date.parse(this.snapshot.fetchedAt)
+    const isStale = Number.isFinite(ageMs) ? ageMs > STALE_AFTER_MS : true
+    this.snapshot.freshness.status = isStale ? 'stale' : 'fresh'
+    this.snapshot.freshness.staleReason = isStale ? reason ?? this.snapshot.connection.lastError ?? 'No recent updates.' : undefined
+  }
+
+  private emitSnapshot(): void {
+    this.emit('snapshot', this.snapshot)
+  }
+}
+
+function createEmptySnapshot(): SymphonyOperatorSnapshot {
+  const nowIso = new Date(0).toISOString()
+  return {
+    fetchedAt: nowIso,
+    queueCount: 0,
+    completedCount: 0,
+    workers: [],
+    escalations: [],
+    connection: {
+      state: 'disconnected',
+      updatedAt: nowIso,
+    },
+    freshness: {
+      status: 'stale',
+      staleReason: 'No baseline has been loaded yet.',
+    },
+    response: {},
+  }
+}
+
+function toWebSocketUrl(httpUrl: string): string {
+  if (httpUrl.startsWith('https://')) {
+    return `wss://${httpUrl.slice('https://'.length)}`
+  }
+
+  if (httpUrl.startsWith('http://')) {
+    return `ws://${httpUrl.slice('http://'.length)}`
+  }
+
+  return httpUrl
+}
+
+function buildEndpoint(baseUrl: string, endpointPath: string): string {
+  const normalized = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+  return new URL(endpointPath.replace(/^\//, ''), normalized).toString()
+}
+
+function buildResponseResult(
+  requestId: string,
+  ok: boolean,
+  status: number,
+  message: string,
+  submittedAt: string,
+): SymphonyEscalationResponseResult {
+  return {
+    requestId,
+    ok,
+    status,
+    message,
+    submittedAt,
+    completedAt: new Date().toISOString(),
+  }
+}

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -53,6 +53,7 @@ export class SymphonyOperatorService extends EventEmitter {
   private activeUrl: string | null = null
   private socket: WebSocketLike | null = null
   private reconnectTimer: NodeJS.Timeout | null = null
+  private runtimeSyncRevision = 0
   private readonly snapshot: SymphonyOperatorSnapshot = createEmptySnapshot()
 
   constructor(options: SymphonyOperatorServiceOptions = {}) {
@@ -77,6 +78,10 @@ export class SymphonyOperatorService extends EventEmitter {
 
   override emit<K extends keyof OperatorEvents>(event: K, ...args: Parameters<OperatorEvents[K]>): boolean {
     return super.emit(event, ...args)
+  }
+
+  override off<K extends keyof OperatorEvents>(event: K, listener: OperatorEvents[K]): this {
+    return super.off(event, listener)
   }
 
   public getSnapshot(): SymphonyOperatorSnapshot {
@@ -233,6 +238,7 @@ export class SymphonyOperatorService extends EventEmitter {
   public async syncRuntimeStatus(status: SymphonyRuntimeStatus): Promise<void> {
     this.runtimeStatus = status
     this.activeUrl = status.url
+    const syncRevision = ++this.runtimeSyncRevision
 
     if (!status.url || status.phase === 'config_error' || status.phase === 'failed') {
       this.stopStream()
@@ -242,6 +248,25 @@ export class SymphonyOperatorService extends EventEmitter {
 
     if (status.phase === 'ready') {
       await this.refreshBaseline()
+      const latestStatus = this.runtimeStatus
+      if (
+        syncRevision !== this.runtimeSyncRevision ||
+        latestStatus?.phase !== 'ready' ||
+        latestStatus.url !== status.url
+      ) {
+        if (latestStatus?.phase === 'starting' || latestStatus?.phase === 'restarting') {
+          this.snapshot.connection.state = 'reconnecting'
+          this.snapshot.connection.updatedAt = new Date().toISOString()
+          this.snapshot.connection.lastError = latestStatus.lastError?.message
+          this.refreshFreshness()
+          this.emitSnapshot()
+        } else if (latestStatus && latestStatus.phase !== 'ready') {
+          this.stopStream()
+          this.markDisconnected(latestStatus.lastError?.message ?? 'Symphony runtime unavailable.')
+        }
+        return
+      }
+
       this.connectStream(status.url)
       return
     }
@@ -252,6 +277,12 @@ export class SymphonyOperatorService extends EventEmitter {
       this.snapshot.connection.lastError = status.lastError?.message
       this.refreshFreshness()
       this.emitSnapshot()
+      return
+    }
+
+    if (status.phase === 'disconnected') {
+      this.stopStream()
+      this.markDisconnected(status.lastError?.message ?? 'Symphony runtime disconnected.')
       return
     }
 
@@ -322,10 +353,13 @@ export class SymphonyOperatorService extends EventEmitter {
         this.emitSnapshot()
 
         if (this.runtimeStatus?.phase === 'ready' && this.activeUrl) {
+          const reconnectUrl = this.activeUrl
           this.reconnectTimer = setTimeout(async () => {
             this.reconnectTimer = null
             await this.refreshBaseline()
-            this.connectStream(this.activeUrl!)
+            if (this.runtimeStatus?.phase === 'ready' && this.activeUrl === reconnectUrl) {
+              this.connectStream(reconnectUrl)
+            }
           }, 1_000)
         }
       }

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -52,6 +52,7 @@ export class SymphonyOperatorService extends EventEmitter {
   private runtimeStatus: SymphonyRuntimeStatus | null = null
   private activeUrl: string | null = null
   private socket: WebSocketLike | null = null
+  private socketUrl: string | null = null
   private reconnectTimer: NodeJS.Timeout | null = null
   private runtimeSyncRevision = 0
   private readonly snapshot: SymphonyOperatorSnapshot = createEmptySnapshot()
@@ -121,11 +122,17 @@ export class SymphonyOperatorService extends EventEmitter {
       const statePayload = (await stateResponse.json()) as SymphonyStatePayload
       const escalationsPayload = escalationResponse.ok
         ? ((await escalationResponse.json()) as { pending?: Array<Record<string, unknown>> })
-        : { pending: [] }
+        : { pending: statePayload.pending_escalations ?? [] }
+
+      if (!escalationResponse.ok) {
+        this.snapshot.connection.lastError = `Escalation request failed (${escalationResponse.status}).`
+      }
 
       this.applyStatePayload(statePayload, escalationsPayload.pending ?? [])
       this.snapshot.connection.lastBaselineRefreshAt = new Date().toISOString()
-      this.snapshot.connection.lastError = undefined
+      if (escalationResponse.ok) {
+        this.snapshot.connection.lastError = undefined
+      }
       this.snapshot.connection.state = 'connected'
       this.snapshot.connection.updatedAt = new Date().toISOString()
       this.refreshFreshness()
@@ -272,6 +279,7 @@ export class SymphonyOperatorService extends EventEmitter {
     }
 
     if (status.phase === 'restarting' || status.phase === 'starting') {
+      this.stopStream()
       this.snapshot.connection.state = 'reconnecting'
       this.snapshot.connection.updatedAt = new Date().toISOString()
       this.snapshot.connection.lastError = status.lastError?.message
@@ -294,10 +302,6 @@ export class SymphonyOperatorService extends EventEmitter {
 
   public dispose(): void {
     this.stopStream()
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer)
-      this.reconnectTimer = null
-    }
   }
 
   private connectStream(url: string): void {
@@ -308,12 +312,16 @@ export class SymphonyOperatorService extends EventEmitter {
     const eventUrl = toWebSocketUrl(buildEndpoint(url, '/api/v1/events'))
 
     if (this.socket) {
-      return
+      if (this.socketUrl === eventUrl) {
+        return
+      }
+      this.stopStream()
     }
 
     try {
       const socket = this.createWebSocket(eventUrl)
       this.socket = socket
+      this.socketUrl = eventUrl
 
       socket.onopen = () => {
         this.snapshot.connection.state = 'connected'
@@ -347,10 +355,16 @@ export class SymphonyOperatorService extends EventEmitter {
 
       socket.onclose = () => {
         this.socket = null
+        this.socketUrl = null
         this.snapshot.connection.state = 'reconnecting'
         this.snapshot.connection.updatedAt = new Date().toISOString()
         this.refreshFreshness()
         this.emitSnapshot()
+
+        if (this.reconnectTimer) {
+          clearTimeout(this.reconnectTimer)
+          this.reconnectTimer = null
+        }
 
         if (this.runtimeStatus?.phase === 'ready' && this.activeUrl) {
           const reconnectUrl = this.activeUrl
@@ -374,8 +388,13 @@ export class SymphonyOperatorService extends EventEmitter {
 
   private stopStream(): void {
     if (this.socket) {
+      this.socket.onopen = null
+      this.socket.onmessage = null
+      this.socket.onerror = null
+      this.socket.onclose = null
       this.socket.close()
       this.socket = null
+      this.socketUrl = null
     }
 
     if (this.reconnectTimer) {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -11,6 +11,7 @@ import {
   type PlanningArtifactFetchStateEvent,
   type ThinkingLevel,
   type SymphonyRuntimeStatus,
+  type SymphonyOperatorSnapshot,
 } from '../shared/types'
 
 const api: DesktopApi = {
@@ -188,6 +189,26 @@ const api: DesktopApi = {
 
       return () => {
         ipcRenderer.removeListener(IPC_CHANNELS.symphonyStatus, wrapped)
+      }
+    },
+    getDashboardSnapshot: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.symphonyGetDashboard)
+    },
+    refreshDashboardSnapshot: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.symphonyRefreshDashboard)
+    },
+    respondToEscalation: async (requestId: string, responseText: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.symphonyRespondEscalation, requestId, responseText)
+    },
+    onDashboardSnapshot: (listener: (snapshot: SymphonyOperatorSnapshot) => void) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, snapshot: SymphonyOperatorSnapshot) => {
+        listener(snapshot)
+      }
+
+      ipcRenderer.on(IPC_CHANNELS.symphonyDashboardSnapshot, wrapped)
+
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.symphonyDashboardSnapshot, wrapped)
       }
     },
   },

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -5,6 +5,7 @@ import { OnboardingWizard } from './components/onboarding/OnboardingWizard'
 import { usePlanningArtifactBridge } from '@/atoms/planning'
 import { useWorkflowBoardBridge } from '@/atoms/workflow-board'
 import { useSymphonyBridge } from '@/atoms/symphony'
+import { useSymphonyDashboardBridge } from '@/atoms/symphony-dashboard'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
 export default function App() {
@@ -13,6 +14,7 @@ export default function App() {
   usePlanningArtifactBridge()
   useWorkflowBoardBridge()
   useSymphonyBridge()
+  useSymphonyDashboardBridge()
 
   return (
     <TooltipProvider>

--- a/apps/desktop/src/renderer/atoms/symphony-dashboard.ts
+++ b/apps/desktop/src/renderer/atoms/symphony-dashboard.ts
@@ -58,15 +58,41 @@ export const respondToEscalationAtom = atom(
     const drafts = get(symphonyEscalationDraftsAtom)
     const responseText = drafts[input.requestId]?.trim() ?? ''
 
-    const result = await window.api.symphony.respondToEscalation(input.requestId, responseText)
-    set(symphonyDashboardSnapshotAtom, result.snapshot)
+    try {
+      const result = await window.api.symphony.respondToEscalation(input.requestId, responseText)
+      set(symphonyDashboardSnapshotAtom, result.snapshot)
 
-    if (result.success) {
-      const { [input.requestId]: _discarded, ...remaining } = drafts
-      set(symphonyEscalationDraftsAtom, remaining)
+      if (result.success) {
+        set(symphonyEscalationDraftsAtom, (currentDrafts) => {
+          const { [input.requestId]: _discarded, ...remaining } = currentDrafts
+          return remaining
+        })
+      }
+
+      return result
+    } catch (error) {
+      const currentSnapshot = get(symphonyDashboardSnapshotAtom)
+      const failureResult = {
+        requestId: input.requestId,
+        ok: false,
+        status: 0,
+        message: error instanceof Error ? error.message : String(error),
+        submittedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      }
+
+      const snapshot = {
+        ...currentSnapshot,
+        response: {
+          ...currentSnapshot.response,
+          submittingRequestId: undefined,
+          lastResult: failureResult,
+        },
+      }
+
+      set(symphonyDashboardSnapshotAtom, snapshot)
+      return { success: false, snapshot, result: failureResult }
     }
-
-    return result
   },
 )
 

--- a/apps/desktop/src/renderer/atoms/symphony-dashboard.ts
+++ b/apps/desktop/src/renderer/atoms/symphony-dashboard.ts
@@ -102,26 +102,26 @@ export function useSymphonyDashboardBridge(): void {
 
   useEffect(() => {
     let cancelled = false
+    let receivedPush = false
+
+    const unsubscribe = window.api.symphony.onDashboardSnapshot((snapshot) => {
+      receivedPush = true
+      setSnapshot(snapshot)
+    })
 
     const loadInitialSnapshot = async () => {
       setLoading(true)
       try {
         const response = await window.api.symphony.getDashboardSnapshot()
-        if (!cancelled) {
+        if (!cancelled && !receivedPush) {
           setSnapshot(response.snapshot)
         }
       } finally {
-        if (!cancelled) {
-          setLoading(false)
-        }
+        setLoading(false)
       }
     }
 
     void loadInitialSnapshot()
-
-    const unsubscribe = window.api.symphony.onDashboardSnapshot((snapshot) => {
-      setSnapshot(snapshot)
-    })
 
     return () => {
       cancelled = true

--- a/apps/desktop/src/renderer/atoms/symphony-dashboard.ts
+++ b/apps/desktop/src/renderer/atoms/symphony-dashboard.ts
@@ -1,0 +1,109 @@
+import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { useEffect } from 'react'
+import type {
+  SymphonyEscalationResponseCommandResult,
+  SymphonyOperatorSnapshot,
+} from '@shared/types'
+
+const EMPTY_SNAPSHOT: SymphonyOperatorSnapshot = {
+  fetchedAt: new Date(0).toISOString(),
+  queueCount: 0,
+  completedCount: 0,
+  workers: [],
+  escalations: [],
+  connection: {
+    state: 'disconnected',
+    updatedAt: new Date(0).toISOString(),
+  },
+  freshness: {
+    status: 'stale',
+    staleReason: 'Dashboard snapshot has not loaded yet.',
+  },
+  response: {},
+}
+
+export const symphonyDashboardSnapshotAtom = atom<SymphonyOperatorSnapshot>(EMPTY_SNAPSHOT)
+export const symphonyDashboardLoadingAtom = atom<boolean>(false)
+export const symphonyEscalationDraftsAtom = atom<Record<string, string>>({})
+
+export const setSymphonyEscalationDraftAtom = atom(
+  null,
+  (get, set, update: { requestId: string; value: string }) => {
+    const current = get(symphonyEscalationDraftsAtom)
+    set(symphonyEscalationDraftsAtom, {
+      ...current,
+      [update.requestId]: update.value,
+    })
+  },
+)
+
+export const refreshSymphonyDashboardAtom = atom(null, async (_get, set) => {
+  set(symphonyDashboardLoadingAtom, true)
+
+  try {
+    const response = await window.api.symphony.refreshDashboardSnapshot()
+    set(symphonyDashboardSnapshotAtom, response.snapshot)
+  } finally {
+    set(symphonyDashboardLoadingAtom, false)
+  }
+})
+
+export const respondToEscalationAtom = atom(
+  null,
+  async (
+    get,
+    set,
+    input: { requestId: string },
+  ): Promise<SymphonyEscalationResponseCommandResult> => {
+    const drafts = get(symphonyEscalationDraftsAtom)
+    const responseText = drafts[input.requestId]?.trim() ?? ''
+
+    const result = await window.api.symphony.respondToEscalation(input.requestId, responseText)
+    set(symphonyDashboardSnapshotAtom, result.snapshot)
+
+    if (result.success) {
+      const { [input.requestId]: _discarded, ...remaining } = drafts
+      set(symphonyEscalationDraftsAtom, remaining)
+    }
+
+    return result
+  },
+)
+
+export function useSymphonyDashboardBridge(): void {
+  const setSnapshot = useSetAtom(symphonyDashboardSnapshotAtom)
+  const setLoading = useSetAtom(symphonyDashboardLoadingAtom)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const loadInitialSnapshot = async () => {
+      setLoading(true)
+      try {
+        const response = await window.api.symphony.getDashboardSnapshot()
+        if (!cancelled) {
+          setSnapshot(response.snapshot)
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void loadInitialSnapshot()
+
+    const unsubscribe = window.api.symphony.onDashboardSnapshot((snapshot) => {
+      setSnapshot(snapshot)
+    })
+
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [setLoading, setSnapshot])
+}
+
+export function useSymphonyDashboardSnapshot(): SymphonyOperatorSnapshot {
+  return useAtomValue(symphonyDashboardSnapshotAtom)
+}

--- a/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
@@ -13,6 +13,7 @@ import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ProviderAuthPanel } from './ProviderAuthPanel'
 import { SymphonyRuntimePanel } from './SymphonyRuntimePanel'
+import { SymphonyDashboard } from '../symphony/SymphonyDashboard'
 
 type SettingsTab = 'providers' | 'general' | 'appearance' | 'symphony'
 
@@ -80,7 +81,10 @@ export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
             </TabsContent>
 
             <TabsContent value="symphony" className="mt-0 h-full overflow-auto p-4">
-              <SymphonyRuntimePanel />
+              <div className="space-y-4">
+                <SymphonyRuntimePanel />
+                <SymphonyDashboard />
+              </div>
             </TabsContent>
 
             <TabsContent value="general" className="mt-0 h-full overflow-auto p-4">

--- a/apps/desktop/src/renderer/components/symphony/EscalationList.tsx
+++ b/apps/desktop/src/renderer/components/symphony/EscalationList.tsx
@@ -1,0 +1,84 @@
+import type {
+  SymphonyEscalationResponseResult,
+  SymphonyOperatorEscalationItem,
+} from '@shared/types'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+interface EscalationListProps {
+  escalations: SymphonyOperatorEscalationItem[]
+  drafts: Record<string, string>
+  submittingRequestId?: string
+  lastResult?: SymphonyEscalationResponseResult
+  onDraftChange: (requestId: string, value: string) => void
+  onSubmit: (requestId: string) => void
+}
+
+export function EscalationList({
+  escalations,
+  drafts,
+  submittingRequestId,
+  lastResult,
+  onDraftChange,
+  onSubmit,
+}: EscalationListProps) {
+  return (
+    <section className="space-y-2" data-testid="symphony-escalation-list">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pending escalations</h3>
+
+      {lastResult ? (
+        <Alert variant={lastResult.ok ? 'default' : 'destructive'} data-testid="symphony-escalation-result">
+          <AlertTitle>{lastResult.ok ? 'Escalation response sent' : 'Escalation response failed'}</AlertTitle>
+          <AlertDescription>{lastResult.message}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {escalations.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground" data-testid="symphony-escalation-empty">
+          No pending escalations.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {escalations.map((escalation) => {
+            const draft = drafts[escalation.requestId] ?? ''
+            const submitting = submittingRequestId === escalation.requestId
+
+            return (
+              <article
+                key={escalation.requestId}
+                className="space-y-2 rounded-md border border-border bg-background/50 p-3"
+                data-testid={`symphony-escalation-${escalation.requestId}`}
+              >
+                <header>
+                  <p className="text-xs font-semibold text-foreground">{escalation.issueIdentifier}</p>
+                  <p className="text-xs text-muted-foreground">{escalation.questionPreview}</p>
+                </header>
+
+                <Textarea
+                  value={draft}
+                  placeholder="Type your response for Symphony…"
+                  onChange={(event) => onDraftChange(escalation.requestId, event.target.value)}
+                  data-testid={`symphony-escalation-input-${escalation.requestId}`}
+                  rows={3}
+                />
+
+                <div className="flex items-center justify-end gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => onSubmit(escalation.requestId)}
+                    disabled={submitting || draft.trim().length === 0}
+                    data-testid={`symphony-escalation-submit-${escalation.requestId}`}
+                  >
+                    {submitting ? 'Submitting…' : 'Submit response'}
+                  </Button>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
+++ b/apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
@@ -63,7 +63,7 @@ export function SymphonyDashboard() {
           <SummaryStat label="Escalations" value={snapshot.escalations.length} />
         </div>
 
-        {snapshot.freshness.status === 'stale' ? (
+        {snapshot.freshness.status === 'stale' && !snapshot.connection.lastError ? (
           <Alert variant="destructive" data-testid="symphony-dashboard-stale">
             <AlertTitle>Dashboard is stale</AlertTitle>
             <AlertDescription>{snapshot.freshness.staleReason ?? 'No recent updates from Symphony.'}</AlertDescription>
@@ -85,7 +85,11 @@ export function SymphonyDashboard() {
           submittingRequestId={snapshot.response.submittingRequestId}
           lastResult={snapshot.response.lastResult}
           onDraftChange={(requestId, value) => setDraft({ requestId, value })}
-          onSubmit={(requestId) => void respond({ requestId })}
+          onSubmit={(requestId) => {
+            void respond({ requestId }).catch((error) => {
+              console.error('[SymphonyDashboard] escalation submit failed', error)
+            })
+          }}
         />
       </CardContent>
     </Card>

--- a/apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
+++ b/apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
@@ -1,0 +1,102 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import { Loader2, RefreshCcw } from 'lucide-react'
+import {
+  refreshSymphonyDashboardAtom,
+  respondToEscalationAtom,
+  setSymphonyEscalationDraftAtom,
+  symphonyDashboardLoadingAtom,
+  symphonyEscalationDraftsAtom,
+  useSymphonyDashboardSnapshot,
+} from '@/atoms/symphony-dashboard'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { EscalationList } from './EscalationList'
+import { WorkerTable } from './WorkerTable'
+
+export function connectionBadgeVariant(
+  state: 'connected' | 'reconnecting' | 'disconnected',
+): 'default' | 'secondary' | 'destructive' {
+  if (state === 'connected') return 'default'
+  if (state === 'reconnecting') return 'secondary'
+  return 'destructive'
+}
+
+export function SymphonyDashboard() {
+  const snapshot = useSymphonyDashboardSnapshot()
+  const loading = useAtomValue(symphonyDashboardLoadingAtom)
+  const drafts = useAtomValue(symphonyEscalationDraftsAtom)
+  const refresh = useSetAtom(refreshSymphonyDashboardAtom)
+  const setDraft = useSetAtom(setSymphonyEscalationDraftAtom)
+  const respond = useSetAtom(respondToEscalationAtom)
+
+  return (
+    <Card className="border border-border bg-card/60 py-0" data-testid="symphony-dashboard-panel">
+      <CardHeader className="px-4 pt-4 pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-sm text-foreground">Live Symphony Dashboard</CardTitle>
+          <div className="flex items-center gap-2">
+            <Badge variant={connectionBadgeVariant(snapshot.connection.state)} data-testid="symphony-dashboard-connection">
+              {snapshot.connection.state}
+            </Badge>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => void refresh()}
+              disabled={loading}
+              data-testid="symphony-dashboard-refresh"
+            >
+              {loading ? <Loader2 className="size-3.5 animate-spin" /> : <RefreshCcw className="size-3.5" />}
+              Refresh
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4 p-4 pt-2 text-xs">
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-4" data-testid="symphony-dashboard-summary">
+          <SummaryStat label="Workers" value={snapshot.workers.length} />
+          <SummaryStat label="Queue" value={snapshot.queueCount} />
+          <SummaryStat label="Completed" value={snapshot.completedCount} />
+          <SummaryStat label="Escalations" value={snapshot.escalations.length} />
+        </div>
+
+        {snapshot.freshness.status === 'stale' ? (
+          <Alert variant="destructive" data-testid="symphony-dashboard-stale">
+            <AlertTitle>Dashboard is stale</AlertTitle>
+            <AlertDescription>{snapshot.freshness.staleReason ?? 'No recent updates from Symphony.'}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {snapshot.connection.lastError ? (
+          <Alert variant="destructive" data-testid="symphony-dashboard-error">
+            <AlertTitle>Connection issue</AlertTitle>
+            <AlertDescription>{snapshot.connection.lastError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <WorkerTable workers={snapshot.workers} />
+
+        <EscalationList
+          escalations={snapshot.escalations}
+          drafts={drafts}
+          submittingRequestId={snapshot.response.submittingRequestId}
+          lastResult={snapshot.response.lastResult}
+          onDraftChange={(requestId, value) => setDraft({ requestId, value })}
+          onSubmit={(requestId) => void respond({ requestId })}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+function SummaryStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border border-border bg-background/50 px-2 py-2" data-testid={`symphony-summary-${label.toLowerCase()}`}>
+      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="text-sm font-semibold text-foreground">{value}</p>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/symphony/WorkerTable.tsx
+++ b/apps/desktop/src/renderer/components/symphony/WorkerTable.tsx
@@ -4,6 +4,15 @@ interface WorkerTableProps {
   workers: SymphonyOperatorWorkerRow[]
 }
 
+export function formatLastActivity(lastActivityAt?: string): string {
+  if (!lastActivityAt) {
+    return '—'
+  }
+
+  const parsed = new Date(lastActivityAt)
+  return Number.isNaN(parsed.getTime()) ? '—' : parsed.toLocaleTimeString()
+}
+
 export function WorkerTable({ workers }: WorkerTableProps) {
   return (
     <section data-testid="symphony-worker-table" className="space-y-2">
@@ -34,9 +43,7 @@ export function WorkerTable({ workers }: WorkerTableProps) {
                   <td className="px-2 py-2 align-top text-foreground">{worker.state}</td>
                   <td className="px-2 py-2 align-top text-foreground">{worker.toolName}</td>
                   <td className="px-2 py-2 align-top text-foreground">{worker.model}</td>
-                  <td className="px-2 py-2 align-top text-foreground">
-                    {worker.lastActivityAt ? new Date(worker.lastActivityAt).toLocaleTimeString() : '—'}
-                  </td>
+                  <td className="px-2 py-2 align-top text-foreground">{formatLastActivity(worker.lastActivityAt)}</td>
                 </tr>
               ))}
             </tbody>

--- a/apps/desktop/src/renderer/components/symphony/WorkerTable.tsx
+++ b/apps/desktop/src/renderer/components/symphony/WorkerTable.tsx
@@ -1,0 +1,48 @@
+import type { SymphonyOperatorWorkerRow } from '@shared/types'
+
+interface WorkerTableProps {
+  workers: SymphonyOperatorWorkerRow[]
+}
+
+export function WorkerTable({ workers }: WorkerTableProps) {
+  return (
+    <section data-testid="symphony-worker-table" className="space-y-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Workers</h3>
+      {workers.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground" data-testid="symphony-worker-empty">
+          No active workers.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-border">
+          <table className="w-full text-left text-xs">
+            <thead className="bg-muted/40 text-muted-foreground">
+              <tr>
+                <th className="px-2 py-2 font-medium">Issue</th>
+                <th className="px-2 py-2 font-medium">State</th>
+                <th className="px-2 py-2 font-medium">Tool</th>
+                <th className="px-2 py-2 font-medium">Model</th>
+                <th className="px-2 py-2 font-medium">Last Activity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {workers.map((worker) => (
+                <tr key={worker.issueId} className="border-t border-border/80">
+                  <td className="px-2 py-2 align-top">
+                    <p className="font-medium text-foreground">{worker.identifier}</p>
+                    <p className="text-muted-foreground">{worker.issueTitle}</p>
+                  </td>
+                  <td className="px-2 py-2 align-top text-foreground">{worker.state}</td>
+                  <td className="px-2 py-2 align-top text-foreground">{worker.toolName}</td>
+                  <td className="px-2 py-2 align-top text-foreground">{worker.model}</td>
+                  <td className="px-2 py-2 align-top text-foreground">
+                    {worker.lastActivityAt ? new Date(worker.lastActivityAt).toLocaleTimeString() : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx
+++ b/apps/desktop/src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'vitest'
+import { connectionBadgeVariant } from '../SymphonyDashboard'
+
+describe('SymphonyDashboard helpers', () => {
+  test('maps connection states to expected badge variants', () => {
+    expect(connectionBadgeVariant('connected')).toBe('default')
+    expect(connectionBadgeVariant('reconnecting')).toBe('secondary')
+    expect(connectionBadgeVariant('disconnected')).toBe('destructive')
+  })
+})

--- a/apps/desktop/src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx
+++ b/apps/desktop/src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx
@@ -1,10 +1,17 @@
 import { describe, expect, test } from 'vitest'
 import { connectionBadgeVariant } from '../SymphonyDashboard'
+import { formatLastActivity } from '../WorkerTable'
 
 describe('SymphonyDashboard helpers', () => {
   test('maps connection states to expected badge variants', () => {
     expect(connectionBadgeVariant('connected')).toBe('default')
     expect(connectionBadgeVariant('reconnecting')).toBe('secondary')
     expect(connectionBadgeVariant('disconnected')).toBe('destructive')
+  })
+
+  test('formats worker activity timestamp safely', () => {
+    expect(formatLastActivity(undefined)).toBe('—')
+    expect(formatLastActivity('not-a-date')).toBe('—')
+    expect(formatLastActivity('2026-04-04T19:00:00.000Z')).not.toBe('—')
   })
 })

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -37,6 +37,10 @@ export const IPC_CHANNELS = {
   symphonyStop: 'symphony:stop',
   symphonyRestart: 'symphony:restart',
   symphonyStatus: 'symphony:status',
+  symphonyGetDashboard: 'symphony:get-dashboard',
+  symphonyRefreshDashboard: 'symphony:refresh-dashboard',
+  symphonyRespondEscalation: 'symphony:respond-escalation',
+  symphonyDashboardSnapshot: 'symphony:dashboard-snapshot',
 } as const
 
 export type PermissionMode = 'explore' | 'ask' | 'auto'
@@ -763,6 +767,74 @@ export interface SymphonyRuntimeStatusResponse {
   status: SymphonyRuntimeStatus
 }
 
+export type SymphonyOperatorConnectionState = 'connected' | 'reconnecting' | 'disconnected'
+
+export type SymphonyOperatorFreshnessStatus = 'fresh' | 'stale'
+
+export interface SymphonyOperatorWorkerRow {
+  issueId: string
+  identifier: string
+  issueTitle: string
+  state: string
+  toolName: string
+  model: string
+  lastActivityAt?: string
+  lastError?: string
+}
+
+export interface SymphonyOperatorEscalationItem {
+  requestId: string
+  issueId: string
+  issueIdentifier: string
+  issueTitle: string
+  questionPreview: string
+  createdAt: string
+  timeoutMs: number
+}
+
+export interface SymphonyEscalationResponseResult {
+  requestId: string
+  ok: boolean
+  status: number
+  message: string
+  submittedAt: string
+  completedAt: string
+}
+
+export interface SymphonyOperatorSnapshot {
+  fetchedAt: string
+  queueCount: number
+  completedCount: number
+  workers: SymphonyOperatorWorkerRow[]
+  escalations: SymphonyOperatorEscalationItem[]
+  connection: {
+    state: SymphonyOperatorConnectionState
+    updatedAt: string
+    lastError?: string
+    lastEventSequence?: number
+    lastBaselineRefreshAt?: string
+  }
+  freshness: {
+    status: SymphonyOperatorFreshnessStatus
+    staleReason?: string
+  }
+  response: {
+    submittingRequestId?: string
+    lastResult?: SymphonyEscalationResponseResult
+  }
+}
+
+export interface SymphonyOperatorSnapshotResponse {
+  success: boolean
+  snapshot: SymphonyOperatorSnapshot
+}
+
+export interface SymphonyEscalationResponseCommandResult {
+  success: boolean
+  snapshot: SymphonyOperatorSnapshot
+  result?: SymphonyEscalationResponseResult
+}
+
 export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context' | 'slice'
 
 export type RoadmapRisk = 'high' | 'medium' | 'low'
@@ -883,6 +955,13 @@ export interface DesktopApi {
     stop: () => Promise<SymphonyRuntimeCommandResult>
     restart: () => Promise<SymphonyRuntimeCommandResult>
     onStatus: (listener: (status: SymphonyRuntimeStatus) => void) => () => void
+    getDashboardSnapshot: () => Promise<SymphonyOperatorSnapshotResponse>
+    refreshDashboardSnapshot: () => Promise<SymphonyOperatorSnapshotResponse>
+    respondToEscalation: (
+      requestId: string,
+      responseText: string,
+    ) => Promise<SymphonyEscalationResponseCommandResult>
+    onDashboardSnapshot: (listener: (snapshot: SymphonyOperatorSnapshot) => void) => () => void
   }
 }
 


### PR DESCRIPTION
## Summary
- normalize Symphony operator state in the Electron main process with `/api/v1/state` baseline + `/api/v1/events` reconciliation
- wire typed Symphony dashboard + `respondToEscalation` APIs through main IPC and preload
- ship renderer Symphony dashboard UI (worker table, queue/completion summary, escalation cards, inline response states)
- add deterministic Electron e2e coverage and S02 live smoke checklist docs
- harden operator service test coverage for reconnect, sorting, malformed stream, and error branches

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/symphony-operator-service.test.ts src/main/__tests__/symphony-ipc.test.ts src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/symphony-dashboard.e2e.ts`
- pre-push gate: `turbo run lint typecheck test --affected`

Closes KAT-2338.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Symphony Dashboard added to Settings: live worker table, escalation queue, inline escalation responses, refresh button, real-time snapshot pushes, connection-state badge, and stale/error alerts.
  * Desktop-to-dashboard APIs and runtime operator service added to fetch/refresh snapshots and submit escalation responses; graceful cleanup on app shutdown.
  * Expanded mock modes for testing: includes reconnecting and response-failure scenarios.

* **Tests**
  * New E2E and unit tests covering dashboard UI flows, reconnecting and response-failure behavior, and operator service WebSocket/refresh logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the M004 Symphony operator surface for Kata Desktop: a live dashboard embedded in the Settings → Symphony tab that renders workers, queue/completion counts, pending escalations with inline response forms, and real-time connection state. State is normalized in the Electron main process via a new `SymphonyOperatorService` that fetches a REST baseline (`/api/v1/state` + `/api/v1/escalations`) on startup and reconciles it incrementally through a WebSocket event stream (`/api/v1/events`). Typed IPC channels wire the service to the renderer via push events and request/response handlers; the renderer side is driven by Jotai atoms that subscribe to the push channel and expose imperative actions for refresh and escalation response.

Key additions:
- `SymphonyOperatorService` — stateful EventEmitter that manages baseline fetching, WebSocket lifecycle, reconnect backoff, mock mode, and escalation submission
- `ipc.ts` — three new `ipcMain.handle` routes and a snapshot push path; clean symmetric teardown in the returned unregister function
- `symphony-dashboard.ts` atoms — Jotai state layer connecting IPC push to UI atoms, including a cancellation-safe initial fetch
- `SymphonyDashboard`, `WorkerTable`, `EscalationList` — new UI components with comprehensive `data-testid` attributes
- 15 Vitest unit tests for `SymphonyOperatorService` covering reconnect, sorting, mock branches, malformed payloads, and timer lifecycle
- 3 Playwright e2e suites covering happy path, reconnect feedback, and response failure

Minor issues found:
- **Duplicate alert text**: when data goes stale due to a connection error, `refreshFreshness` sets `staleReason` to `lastError`, causing both the "Dashboard is stale" alert and the "Connection issue" alert to render with identical body text simultaneously
- **Missing `off` type override**: `on` and `emit` are typed against `OperatorEvents` but `off`/`removeListener` are not, weakening type safety for unsubscription
- **Silently discarded promise**: `void respond({ requestId })` in `SymphonyDashboard` will swallow unexpected IPC-level rejections with no user feedback

<h3>Confidence Score: 4/5</h3>

Safe to merge — no data-loss or security issues found; all three findings are style/UX suggestions.

The architecture is sound and well-tested: 15 unit tests cover the full state machine of SymphonyOperatorService (reconnect timers, malformed payloads, mock modes, sort ordering), and 3 e2e suites cover the three mock scenarios end-to-end. IPC teardown is symmetric and the service is properly disposed on before-quit. The only non-trivial UX issue is the duplicate alert messages when stale due to a connection error; the other two findings are type hygiene and a defensiveness gap for a code path that rarely throws in practice.

Focus attention on SymphonyDashboard.tsx (duplicate alert rendering) and symphony-operator-service.ts (missing off type override).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/symphony-operator-service.ts | New core service: normalizes state from REST baseline + WebSocket event reconciliation; handles reconnect, mock modes, escalation response, and freshness tracking. Missing typed `off` override. |
| apps/desktop/src/main/ipc.ts | Wires three new IPC handlers (get/refresh dashboard, respond to escalation) and adds snapshot push channel; clean teardown/registration symmetry. |
| apps/desktop/src/renderer/atoms/symphony-dashboard.ts | Jotai atoms for dashboard snapshot, loading, escalation drafts, and the bridge hook that wires IPC push events to renderer state; escalation submit silently discards IPC errors. |
| apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx | Main dashboard card with connection badge, summary stats, worker table, and escalation list; stale + connection-error alerts can display duplicate message text. |
| apps/desktop/src/renderer/components/symphony/EscalationList.tsx | Pure presentational component rendering pending escalation cards with textarea drafts, submit buttons, and last-result alert; correctly test-id'd for e2e. |
| apps/desktop/src/renderer/components/symphony/WorkerTable.tsx | Straightforward worker rows table; keyed on `issueId` which is validated non-empty at mapping time. |
| apps/desktop/src/preload/index.ts | Extends preload API with four Symphony dashboard methods; all return types align with shared types; unsubscribe pattern matches existing `onStatus` idiom. |
| apps/desktop/src/main/__tests__/symphony-operator-service.test.ts | Comprehensive 15-test suite covering baseline normalization, stream reconciliation, reconnect timer lifecycle, mock modes, malformed payloads, and sort ordering. |
| apps/desktop/e2e/tests/symphony-dashboard.e2e.ts | Three deterministic e2e test suites covering the happy path (worker/escalation render + inline response), reconnect state, and response-failure state using mock mode fixtures. |
| apps/desktop/src/shared/types.ts | Adds four new IPC channels and seven typed interfaces for the operator snapshot domain; `DesktopApi` extended with four matching method signatures. |
| apps/desktop/src/main/index.ts | Instantiates `SymphonyOperatorService` at app startup with `process.env`, passes it to IPC registration, and calls `dispose()` on `before-quit`. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer
    participant PL as Preload
    participant IPC as Main IPC
    participant OPS as OperatorService
    participant SYM as Symphony HTTP/WS

    Note over R,SYM: Startup
    IPC->>OPS: syncRuntimeStatus(initialStatus)
    OPS->>SYM: GET /api/v1/state
    OPS->>SYM: GET /api/v1/escalations
    SYM-->>OPS: state + escalations
    OPS->>OPS: applyStatePayload()
    OPS->>IPC: emit('snapshot', snapshot)
    IPC->>PL: send(symphonyDashboardSnapshot)
    PL->>R: onDashboardSnapshot callback
    OPS->>SYM: WS /api/v1/events
    SYM-->>OPS: onopen
    OPS->>IPC: emit('snapshot', snapshot)
    IPC->>PL: send(symphonyDashboardSnapshot)
    PL->>R: onDashboardSnapshot callback

    Note over R,SYM: Live stream event
    SYM-->>OPS: escalation_created (WS message)
    OPS->>OPS: applyStreamEvent()
    OPS->>IPC: emit('snapshot', snapshot)
    IPC->>PL: send(symphonyDashboardSnapshot)
    PL->>R: onDashboardSnapshot callback

    Note over R,SYM: Escalation response
    R->>PL: respondToEscalation(id, text)
    PL->>IPC: invoke(symphonyRespondEscalation)
    IPC->>OPS: respondToEscalation(id, text)
    OPS->>SYM: POST /api/v1/escalations/{id}/respond
    SYM-->>OPS: 200 OK
    OPS->>SYM: GET /api/v1/state (refresh)
    SYM-->>OPS: updated state
    OPS->>IPC: emit('snapshot', snapshot)
    IPC->>PL: send(symphonyDashboardSnapshot)
    PL->>R: onDashboardSnapshot callback
    OPS-->>IPC: {success:true, snapshot}
    IPC-->>PL: result
    PL-->>R: SymphonyEscalationResponseCommandResult

    Note over R,SYM: WebSocket disconnect and reconnect
    SYM-->>OPS: onclose
    OPS->>OPS: reconnectTimer (1s)
    OPS->>SYM: GET /api/v1/state (refreshBaseline)
    SYM-->>OPS: state
    OPS->>SYM: WS /api/v1/events (reconnect)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
Line: 66-78

Comment:
**Duplicate error messages when stale due to connection failure**

`refreshFreshness` falls back to `this.snapshot.connection.lastError` when no explicit `reason` is given:

```ts
this.snapshot.freshness.staleReason = isStale ? reason ?? this.snapshot.connection.lastError ?? 'No recent updates.' : undefined
```

This means whenever data goes stale because of a connection error, `staleReason` equals `lastError` verbatim. The UI then renders both alerts simultaneously with identical body text — once under "Dashboard is stale" and again under "Connection issue" — which is confusing and redundant.

Consider suppressing the stale alert when the connection error already explains the staleness:

```suggestion
        {snapshot.freshness.status === 'stale' && !snapshot.connection.lastError ? (
          <Alert variant="destructive" data-testid="symphony-dashboard-stale">
            <AlertTitle>Dashboard is stale</AlertTitle>
            <AlertDescription>{snapshot.freshness.staleReason ?? 'No recent updates from Symphony.'}</AlertDescription>
          </Alert>
        ) : null}

        {snapshot.connection.lastError ? (
          <Alert variant="destructive" data-testid="symphony-dashboard-error">
            <AlertTitle>Connection issue</AlertTitle>
            <AlertDescription>{snapshot.connection.lastError}</AlertDescription>
          </Alert>
        ) : null}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/symphony-operator-service.ts
Line: 74-80

Comment:
**Missing `off` typed override alongside `on` and `emit`**

`on` and `emit` are both overridden with strongly-typed `OperatorEvents` signatures, but `off` (and `removeListener`) is left untyped. Callers using `service.off(...)` receive no compile-time validation that the event name or listener signature matches `OperatorEvents`, which undermines the typed event contract established by the other two overrides.

```ts
override off<K extends keyof OperatorEvents>(event: K, listener: OperatorEvents[K]): this {
  return super.off(event, listener)
}
```

Adding this gives complete type safety for the subscribe/unsubscribe lifecycle (already used in `ipc.ts`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
Line: 88

Comment:
**Silently discarded promise from escalation submit**

`void respond({ requestId })` discards the returned promise entirely. The service-layer `respondToEscalation` catches all errors internally and always resolves, so in practice this is safe. However, if the IPC channel itself throws (e.g., main process restart, channel teardown), the rejection is silently swallowed with no user-visible feedback — the button will un-render its "Submitting…" state but no error alert will appear.

Consider wrapping with a try/catch that surfaces a local error state, or at minimum logging the failure:

```ts
onSubmit={(requestId) => {
  respond({ requestId }).catch((err) => {
    console.error('[SymphonyDashboard] escalation submit failed', err)
  })
}}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): KAT-2338 cover reconnect/..."](https://github.com/gannonh/kata/commit/e4ec179e99385ed80d8dc328a97680e90de01bfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27364263)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->