### PR TITLE
KAT-2339: enrich kanban cards with Symphony execution context

### DIFF
--- a/apps/desktop/docs/uat/M004/S03-KANBAN-SMOKE.md
+++ b/apps/desktop/docs/uat/M004/S03-KANBAN-SMOKE.md
@@ -1,0 +1,37 @@
+# S03 Kanban Convergence Smoke (M004)
+
+## Goal
+
+Verify the same workflow item can be traced between Symphony dashboard state and kanban card metadata in Kata Desktop, including stale and disconnected degradation.
+
+## Preconditions
+
+- Kata Desktop built and running.
+- Workspace configured for a live workflow board.
+- Symphony runtime reachable and dashboard populated.
+
+## Live Smoke Checklist
+
+1. Open **Settings → Symphony** and start Symphony from Desktop.
+2. Confirm dashboard shows at least one active worker row and (optionally) pending escalations.
+3. Switch to the kanban pane and locate the same slice/task by identifier.
+4. Verify card-level metadata convergence:
+   - Worker assignment appears on the card/task.
+   - Execution state/tool hint is visible.
+   - Pending escalation count is visible when applicable.
+5. Confirm board header convergence status includes Symphony freshness summary and worker/escalation counts.
+6. Trigger or wait for stale state (pause updates / stale snapshot path) and verify:
+   - Header shows stale indicator.
+   - Card remains in its workflow column.
+   - Stale warning text appears without hiding workflow data.
+7. Trigger runtime disconnect (stop Symphony) and verify:
+   - Header shows disconnected indicator.
+   - Cards still render workflow placement.
+   - Card-level hint states runtime disconnected (no false active certainty).
+8. Restart Symphony and refresh board; confirm convergence returns to live state.
+
+## Pass Criteria
+
+- The same slice/task can be correlated between dashboard and kanban by identifier.
+- Assignment/execution/escalation metadata is visible on cards/tasks without duplicating full dashboard payload.
+- Stale and disconnected states are explicit and truthful while preserving readable workflow data.

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -71,7 +71,15 @@ type DesktopFixtures = {
   workspaceDir: string
   mainWindow: Page
   readyWindow: Page
-  symphonyMockMode: 'ready' | 'config_error' | 'readiness_error' | 'response_failure' | 'reconnecting'
+  symphonyMockMode:
+    | 'ready'
+    | 'config_error'
+    | 'readiness_error'
+    | 'response_failure'
+    | 'reconnecting'
+    | 'kanban_assigned'
+    | 'kanban_stale'
+    | 'kanban_disconnected'
 }
 
 export const test = base.extend<DesktopFixtures>({

--- a/apps/desktop/e2e/tests/symphony-kanban.e2e.ts
+++ b/apps/desktop/e2e/tests/symphony-kanban.e2e.ts
@@ -1,0 +1,48 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from '../fixtures/electron.fixture'
+
+async function startMockRuntime(page: Page) {
+  await page.evaluate(async () => {
+    await window.api.symphony.start()
+  })
+  await page.getByRole('button', { name: /Refresh workflow board/i }).click()
+}
+
+test.describe('Symphony-aware kanban convergence', () => {
+  test.use({ symphonyMockMode: 'kanban_assigned' })
+
+  test('projects assignment and escalation metadata onto matching cards', async ({ readyWindow }) => {
+    await startMockRuntime(readyWindow)
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: live · 2 workers · 1 escalation')
+    await expect(readyWindow.getByTestId('slice-symphony-KAT-2247')).toContainText('Execution: edit')
+    await expect(readyWindow.getByText('1 escalation')).toBeVisible()
+
+    await readyWindow.getByRole('button', { name: /Show tasks/i }).click()
+    await expect(readyWindow.getByText('Worker KAT-2252')).toBeVisible()
+  })
+})
+
+test.describe('Symphony stale and disconnected degradation', () => {
+  test.use({ symphonyMockMode: 'kanban_stale' })
+
+  test('surfaces stale operator context without hiding workflow cards', async ({ readyWindow }) => {
+    await startMockRuntime(readyWindow)
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: stale')
+    await expect(readyWindow.getByTestId('workflow-board-symphony-stale')).toContainText('Snapshot is old.')
+    await expect(readyWindow.getByText(/KAT-2247 · \[S01\]/i)).toBeVisible()
+  })
+})
+
+test.describe('Symphony disconnected projection', () => {
+  test.use({ symphonyMockMode: 'kanban_disconnected' })
+
+  test('marks runtime-disconnected state on kanban metadata', async ({ readyWindow }) => {
+    await startMockRuntime(readyWindow)
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: disconnected')
+    await expect(readyWindow.getByTestId('slice-symphony-KAT-2247')).toContainText('Symphony runtime disconnected')
+    await expect(readyWindow.getByText(/KAT-2247 · \[S01\]/i)).toBeVisible()
+  })
+})

--- a/apps/desktop/e2e/tests/symphony-kanban.e2e.ts
+++ b/apps/desktop/e2e/tests/symphony-kanban.e2e.ts
@@ -2,6 +2,8 @@ import type { Page } from '@playwright/test'
 import { expect, test } from '../fixtures/electron.fixture'
 
 async function startMockRuntime(page: Page) {
+  await expect(page.getByRole('heading', { name: /Workflow Board/i })).toBeVisible()
+
   await page.evaluate(async () => {
     await window.api.symphony.start()
   })
@@ -16,8 +18,6 @@ test.describe('Symphony-aware kanban convergence', () => {
 
     await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: live · 2 workers · 1 escalation')
     await expect(readyWindow.getByTestId('slice-symphony-KAT-2247')).toContainText('Execution: edit')
-    await expect(readyWindow.getByText('1 escalation')).toBeVisible()
-
     await readyWindow.getByRole('button', { name: /Show tasks/i }).click()
     await expect(readyWindow.getByText('Worker KAT-2252')).toBeVisible()
   })
@@ -30,7 +30,7 @@ test.describe('Symphony stale and disconnected degradation', () => {
     await startMockRuntime(readyWindow)
 
     await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: stale')
-    await expect(readyWindow.getByTestId('workflow-board-symphony-stale')).toContainText('Snapshot is old.')
+    await expect(readyWindow.getByTestId('workflow-board-symphony-stale')).toContainText('No recent updates.')
     await expect(readyWindow.getByText(/KAT-2247 · \[S01\]/i)).toBeVisible()
   })
 })

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -182,6 +182,137 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.symphony?.diagnostics.correlationMisses).toContain('worker:KAT-9999')
   })
 
+  test('falls back to issueId correlation when identifiers are missing', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-issue-id-correlation-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(path.join(workspacePath, '.kata', 'preferences.md'), ['---', 'projectSlug: project-ref', '---', ''].join('\n'), 'utf8')
+
+    const symphonySnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [
+        {
+          issueId: 'slice-issue-id',
+          identifier: 'KAT-0000',
+          issueTitle: 'Issue id join',
+          state: 'in_progress',
+          toolName: 'edit',
+          model: 'claude-sonnet-4-6',
+        },
+      ],
+      escalations: [
+        {
+          requestId: 'req-issue-id',
+          issueId: 'slice-issue-id',
+          issueIdentifier: '',
+          issueTitle: 'Issue id join',
+          questionPreview: 'Need review',
+          createdAt: new Date().toISOString(),
+          timeoutMs: 300000,
+        },
+      ],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+      getSymphonySnapshot: () => symphonySnapshot,
+    })
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(async () => ({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'fresh',
+      source: { projectId: 'project-ref', activeMilestoneId: 'm1' },
+      activeMilestone: { id: 'm1', name: '[M001] Demo' },
+      columns: [
+        {
+          id: 'todo',
+          title: 'Todo',
+          cards: [
+            {
+              id: 'slice-issue-id',
+              identifier: '',
+              title: 'Issue id join card',
+              columnId: 'todo',
+              stateName: 'Todo',
+              stateType: 'unstarted',
+              milestoneId: 'm1',
+              milestoneName: '[M001] Demo',
+              taskCounts: { total: 0, done: 0 },
+              tasks: [],
+            },
+          ],
+        },
+      ],
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    }))
+
+    service.setActive(true)
+    const response = await service.refreshBoard()
+    const matchedCard = response.snapshot.columns[0]?.cards[0]
+
+    expect(matchedCard?.symphony?.assignmentState).toBe('assigned')
+    expect(matchedCard?.symphony?.pendingEscalations).toBe(1)
+    expect(response.snapshot.symphony?.diagnostics.correlationMisses).toEqual([])
+  })
+
+  test('maps reconnecting and unknown connection states to truthful provenance', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const reconnectingSnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [],
+      escalations: [],
+      connection: {
+        state: 'reconnecting',
+        updatedAt: new Date().toISOString(),
+        lastError: 'Retrying stream.',
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const unknownConnectionSnapshot: SymphonyOperatorSnapshot = {
+      ...reconnectingSnapshot,
+      connection: {
+        ...(reconnectingSnapshot.connection as any),
+        state: 'mystery',
+      } as any,
+      freshness: {
+        status: 'fresh',
+      },
+    }
+
+    const reconnectingService = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot: () => reconnectingSnapshot,
+    })
+
+    const unknownService = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot: () => unknownConnectionSnapshot,
+    })
+
+    expect((await reconnectingService.getBoard()).snapshot.symphony?.provenance).toBe('operator-stale')
+    expect((await unknownService.getBoard()).snapshot.symphony?.provenance).toBe('unavailable')
+  })
+
   test('returns NOT_CONFIGURED when preferences are missing', async () => {
     const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-missing-'))
     const service = new WorkflowBoardService({

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { SymphonyOperatorSnapshot } from '@shared/types'
 import { WorkflowBoardService } from '../workflow-board-service'
 
 const originalFixtureFlag = process.env.KATA_TEST_WORKFLOW_FIXTURE
@@ -39,6 +40,146 @@ describe('WorkflowBoardService', () => {
     expect(response.success).toBe(true)
     expect(response.snapshot.status).toBe('fresh')
     expect(response.snapshot.columns.find((column) => column.id === 'todo')?.cards).toHaveLength(1)
+    expect(response.snapshot.symphony?.provenance).toBe('unavailable')
+  })
+
+  test('enriches workflow cards with symphony worker assignments and escalations', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const symphonySnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 1,
+      completedCount: 0,
+      workers: [
+        {
+          issueId: 'slice-1',
+          identifier: 'KAT-2247',
+          issueTitle: 'Slice',
+          state: 'in_progress',
+          toolName: 'edit',
+          model: 'claude-sonnet-4-6',
+          lastActivityAt: new Date().toISOString(),
+        },
+      ],
+      escalations: [
+        {
+          requestId: 'req-123',
+          issueId: 'slice-1',
+          issueIdentifier: 'KAT-2247',
+          issueTitle: 'Slice',
+          questionPreview: 'Need review',
+          createdAt: new Date().toISOString(),
+          timeoutMs: 300000,
+        },
+      ],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot: () => symphonySnapshot,
+    })
+
+    const response = await service.getBoard()
+    const todoCard = response.snapshot.columns.find((column) => column.id === 'todo')?.cards[0]
+
+    expect(response.snapshot.symphony?.provenance).toBe('dashboard-derived')
+    expect(todoCard?.symphony?.assignmentState).toBe('assigned')
+    expect(todoCard?.symphony?.pendingEscalations).toBe(1)
+  })
+
+  test('marks operator-stale and runtime-disconnected symphony board envelopes', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const staleSnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date(Date.now() - 60_000).toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [],
+      escalations: [],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'stale',
+        staleReason: 'Snapshot is old.',
+      },
+      response: {},
+    }
+
+    const disconnectedSnapshot: SymphonyOperatorSnapshot = {
+      ...staleSnapshot,
+      connection: {
+        state: 'disconnected',
+        updatedAt: new Date().toISOString(),
+        lastError: 'Runtime disconnected.',
+      },
+      freshness: {
+        status: 'stale',
+      },
+    }
+
+    const staleService = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot: () => staleSnapshot,
+    })
+
+    const disconnectedService = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot: () => disconnectedSnapshot,
+    })
+
+    expect((await staleService.getBoard()).snapshot.symphony?.provenance).toBe('operator-stale')
+    expect((await disconnectedService.getBoard()).snapshot.symphony?.provenance).toBe('runtime-disconnected')
+  })
+
+  test('reports symphony correlation misses for unmatched workers', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const symphonySnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [
+        {
+          issueId: 'unknown',
+          identifier: 'KAT-9999',
+          issueTitle: 'Unknown issue',
+          state: 'in_progress',
+          toolName: 'edit',
+          model: 'claude-sonnet-4-6',
+        },
+      ],
+      escalations: [],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot: () => symphonySnapshot,
+    })
+
+    const response = await service.getBoard()
+    expect(response.snapshot.symphony?.diagnostics.correlationMisses).toContain('worker:KAT-9999')
   })
 
   test('returns NOT_CONFIGURED when preferences are missing', async () => {

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -586,6 +586,34 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.lastError?.message).toContain('Workflow board inactive')
   })
 
+  test('returns inactive snapshot when deactivated during a failing in-flight refresh', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-inactive-failing-refresh-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectSlug: project-ref', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      throw new Error('network down')
+    })
+
+    service.setActive(true)
+    const refreshPromise = service.refreshBoard()
+    service.setActive(false)
+
+    const response = await refreshPromise
+    expect(response.snapshot.status).toBe('error')
+    expect(response.snapshot.lastError?.message).toContain('Workflow board inactive')
+  })
+
   test('does not let stale in-flight refresh overwrite a newer scope snapshot', async () => {
     const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-scope-race-'))
     mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -43,6 +43,21 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.symphony?.provenance).toBe('unavailable')
   })
 
+  test('omits staleReason when symphony snapshot is unavailable', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot: () => null,
+    })
+
+    const response = await service.getBoard()
+
+    expect(response.snapshot.symphony?.provenance).toBe('unavailable')
+    expect(response.snapshot.symphony?.staleReason).toBeUndefined()
+  })
+
   test('enriches workflow cards with symphony worker assignments and escalations', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
 
@@ -263,6 +278,79 @@ describe('WorkflowBoardService', () => {
 
     expect(matchedCard?.symphony?.assignmentState).toBe('assigned')
     expect(matchedCard?.symphony?.pendingEscalations).toBe(1)
+    expect(response.snapshot.symphony?.diagnostics.correlationMisses).toEqual([])
+  })
+
+  test('does not report false correlation misses when escalation joins by issue id', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-escalation-issue-id-join-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(path.join(workspacePath, '.kata', 'preferences.md'), ['---', 'projectSlug: project-ref', '---', ''].join('\n'), 'utf8')
+
+    const symphonySnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [],
+      escalations: [
+        {
+          requestId: 'req-issue-id-only',
+          issueId: 'slice-issue-id',
+          issueIdentifier: '',
+          issueTitle: 'Issue id join',
+          questionPreview: 'Need review',
+          createdAt: new Date().toISOString(),
+          timeoutMs: 300000,
+        },
+      ],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+      getSymphonySnapshot: () => symphonySnapshot,
+    })
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(async () => ({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'fresh',
+      source: { projectId: 'project-ref', activeMilestoneId: 'm1' },
+      activeMilestone: { id: 'm1', name: '[M001] Demo' },
+      columns: [
+        {
+          id: 'todo',
+          title: 'Todo',
+          cards: [
+            {
+              id: 'slice-issue-id',
+              identifier: 'KAT-2247',
+              title: 'Issue id join card',
+              columnId: 'todo',
+              stateName: 'Todo',
+              stateType: 'unstarted',
+              milestoneId: 'm1',
+              milestoneName: '[M001] Demo',
+              taskCounts: { total: 0, done: 0 },
+              tasks: [],
+            },
+          ],
+        },
+      ],
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    }))
+
+    service.setActive(true)
+    const response = await service.refreshBoard()
+
+    expect(response.snapshot.columns[0]?.cards[0]?.symphony?.pendingEscalations).toBe(1)
     expect(response.snapshot.symphony?.diagnostics.correlationMisses).toEqual([])
   })
 

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -58,6 +58,53 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.symphony?.staleReason).toBeUndefined()
   })
 
+  test('clears per-item symphony projections when the snapshot becomes unavailable', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    let symphonySnapshot: SymphonyOperatorSnapshot | null = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 1,
+      completedCount: 0,
+      workers: [
+        {
+          issueId: 'slice-1',
+          identifier: 'KAT-2247',
+          issueTitle: 'Slice',
+          state: 'in_progress',
+          toolName: 'edit',
+          model: 'claude-sonnet-4-6',
+          lastActivityAt: new Date().toISOString(),
+        },
+      ],
+      escalations: [],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot: () => symphonySnapshot,
+    })
+
+    const assigned = await service.getBoard()
+    const assignedCard = assigned.snapshot.columns.flatMap((column) => column.cards)[0]
+    expect(assignedCard?.symphony?.assignmentState).toBe('assigned')
+
+    symphonySnapshot = null
+
+    const unavailable = await service.getBoard()
+    const unavailableCard = unavailable.snapshot.columns.flatMap((column) => column.cards)[0]
+    expect(unavailable.snapshot.symphony?.provenance).toBe('unavailable')
+    expect(unavailableCard?.symphony).toBeUndefined()
+  })
+
   test('enriches workflow cards with symphony worker assignments and escalations', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
 
@@ -351,6 +398,88 @@ describe('WorkflowBoardService', () => {
     const response = await service.refreshBoard()
 
     expect(response.snapshot.columns[0]?.cards[0]?.symphony?.pendingEscalations).toBe(1)
+    expect(response.snapshot.symphony?.diagnostics.correlationMisses).toEqual([])
+  })
+
+  test('counts identifier and issue-id escalation matches together without false misses', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-escalation-mixed-join-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(path.join(workspacePath, '.kata', 'preferences.md'), ['---', 'projectSlug: project-ref', '---', ''].join('\n'), 'utf8')
+
+    const symphonySnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [],
+      escalations: [
+        {
+          requestId: 'req-identifier',
+          issueId: 'slice-issue-id',
+          issueIdentifier: 'KAT-2247',
+          issueTitle: 'Issue id join',
+          questionPreview: 'Need review',
+          createdAt: new Date().toISOString(),
+          timeoutMs: 300000,
+        },
+        {
+          requestId: 'req-issue-id',
+          issueId: 'slice-issue-id',
+          issueIdentifier: '',
+          issueTitle: 'Issue id join',
+          questionPreview: 'Need review',
+          createdAt: new Date().toISOString(),
+          timeoutMs: 300000,
+        },
+      ],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+      getSymphonySnapshot: () => symphonySnapshot,
+    })
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(async () => ({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'fresh',
+      source: { projectId: 'project-ref', activeMilestoneId: 'm1' },
+      activeMilestone: { id: 'm1', name: '[M001] Demo' },
+      columns: [
+        {
+          id: 'todo',
+          title: 'Todo',
+          cards: [
+            {
+              id: 'slice-issue-id',
+              identifier: 'KAT-2247',
+              title: 'Issue id join card',
+              columnId: 'todo',
+              stateName: 'Todo',
+              stateType: 'unstarted',
+              milestoneId: 'm1',
+              milestoneName: '[M001] Demo',
+              taskCounts: { total: 0, done: 0 },
+              tasks: [],
+            },
+          ],
+        },
+      ],
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    }))
+
+    service.setActive(true)
+    const response = await service.refreshBoard()
+
+    expect(response.snapshot.columns[0]?.cards[0]?.symphony?.pendingEscalations).toBe(2)
     expect(response.snapshot.symphony?.diagnostics.correlationMisses).toEqual([])
   })
 

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -58,6 +58,21 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.symphony?.staleReason).toBeUndefined()
   })
 
+  test('reads unavailable symphony snapshot once per enrichment pass', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const getSymphonySnapshot = vi.fn(() => null)
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot,
+    })
+
+    await service.getBoard()
+
+    expect(getSymphonySnapshot).toHaveBeenCalledTimes(1)
+  })
+
   test('clears per-item symphony projections when the snapshot becomes unavailable', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -82,6 +82,7 @@ export function registerSessionIpc({
   const workflowBoardService = new WorkflowBoardService({
     authBridge,
     getWorkspacePath: () => bridge.getWorkspacePath(),
+    getSymphonySnapshot: () => symphonyOperatorService?.getSnapshot() ?? null,
   })
 
   const planningArtifactsByKey = new Map<string, PlanningArtifact>()

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -468,39 +468,69 @@ export class SymphonyOperatorService extends EventEmitter {
 
   private applyMockBaseline(mockMode: string): void {
     const nowIso = new Date().toISOString()
+    const staleFetchedAt = new Date(Date.now() - STALE_AFTER_MS - 5_000).toISOString()
 
-    this.snapshot.fetchedAt = nowIso
+    const isKanbanMode =
+      mockMode === 'kanban_assigned' || mockMode === 'kanban_stale' || mockMode === 'kanban_disconnected'
+
+    this.snapshot.fetchedAt = mockMode === 'kanban_stale' ? staleFetchedAt : nowIso
     this.snapshot.queueCount = mockMode === 'reconnecting' ? 2 : 1
     this.snapshot.completedCount = 3
     this.snapshot.workers = [
       {
-        issueId: '1',
-        identifier: 'KAT-2338',
-        issueTitle: 'Live Worker Dashboard and Escalation Handling',
+        issueId: isKanbanMode ? 'slice-1' : '1',
+        identifier: isKanbanMode ? 'KAT-2247' : 'KAT-2338',
+        issueTitle: isKanbanMode
+          ? '[S01] Linear Workflow Board in the Right Pane'
+          : 'Live Worker Dashboard and Escalation Handling',
         state: mockMode === 'reconnecting' ? 'reconnecting' : 'in_progress',
         toolName: 'edit',
         model: 'claude-sonnet-4-6',
         lastActivityAt: nowIso,
       },
+      ...(isKanbanMode
+        ? [
+            {
+              issueId: 'task-2',
+              identifier: 'KAT-2252',
+              issueTitle: '[T02] Wire workflow board service through IPC',
+              state: 'in_progress',
+              toolName: 'bash',
+              model: 'claude-sonnet-4-6',
+              lastActivityAt: nowIso,
+            },
+          ]
+        : []),
     ]
 
     this.snapshot.escalations = [
       {
         requestId: 'req-123',
-        issueId: '1',
-        issueIdentifier: 'KAT-2338',
-        issueTitle: 'Live Worker Dashboard and Escalation Handling',
+        issueId: isKanbanMode ? 'slice-1' : '1',
+        issueIdentifier: isKanbanMode ? 'KAT-2247' : 'KAT-2338',
+        issueTitle: isKanbanMode
+          ? '[S01] Linear Workflow Board in the Right Pane'
+          : 'Live Worker Dashboard and Escalation Handling',
         questionPreview: 'Need clarification on dashboard failure state copy.',
         createdAt: new Date(Date.now() - 15_000).toISOString(),
         timeoutMs: 300_000,
       },
     ]
 
-    this.snapshot.connection.state = mockMode === 'reconnecting' ? 'reconnecting' : 'connected'
+    this.snapshot.connection.state =
+      mockMode === 'reconnecting'
+        ? 'reconnecting'
+        : mockMode === 'kanban_disconnected'
+          ? 'disconnected'
+          : 'connected'
     this.snapshot.connection.updatedAt = nowIso
     this.snapshot.connection.lastBaselineRefreshAt = nowIso
     this.snapshot.connection.lastError =
-      mockMode === 'reconnecting' ? 'Mocked reconnect in progress.' : undefined
+      mockMode === 'reconnecting'
+        ? 'Mocked reconnect in progress.'
+        : mockMode === 'kanban_disconnected'
+          ? 'Mocked runtime disconnect.'
+          : undefined
     this.refreshFreshness()
     this.emitSnapshot()
   }

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -7,10 +7,15 @@ import log from './logger'
 import { WorkflowContextService } from './workflow-context-service'
 import { readWorkspaceWorkflowTrackerConfig } from './workflow-config-reader'
 import type {
+  SymphonyOperatorSnapshot,
+  WorkflowBoardSliceCard,
   WorkflowBoardSnapshot,
   WorkflowBoardSnapshotResponse,
+  WorkflowBoardTask,
   WorkflowContextSnapshot,
   WorkflowTrackerConfig,
+  WorkflowSymphonyExecutionFreshness,
+  WorkflowSymphonyExecutionProvenance,
 } from '../shared/types'
 
 const TEST_LINEAR_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
@@ -209,6 +214,7 @@ const TEST_GITHUB_PROJECTS_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
 interface WorkflowBoardServiceOptions {
   authBridge: AuthBridge
   getWorkspacePath: () => string
+  getSymphonySnapshot?: () => SymphonyOperatorSnapshot | null
 }
 
 export class WorkflowBoardService {
@@ -276,8 +282,10 @@ export class WorkflowBoardService {
 
   async getBoard(): Promise<WorkflowBoardSnapshotResponse> {
     if (this.lastSnapshot) {
+      const snapshot = this.enrichWithSymphonyContext(this.lastSnapshot)
+      this.lastSnapshot = snapshot
       this.syncContextSnapshot()
-      return { success: true, snapshot: this.lastSnapshot }
+      return { success: true, snapshot }
     }
 
     return this.refreshBoard()
@@ -306,7 +314,7 @@ export class WorkflowBoardService {
 
   private async performRefreshBoard(capturedScopeKey: string): Promise<WorkflowBoardSnapshotResponse> {
     if (this.testScenario) {
-      const scenarioSnapshot = this.buildScenarioSnapshot(this.testScenario)
+      const scenarioSnapshot = this.enrichWithSymphonyContext(this.buildScenarioSnapshot(this.testScenario))
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = scenarioSnapshot
         if (scenarioSnapshot.status === 'fresh' || scenarioSnapshot.status === 'empty') {
@@ -319,7 +327,7 @@ export class WorkflowBoardService {
     }
 
     if (process.env.KATA_TEST_WORKFLOW_FIXTURE === '1') {
-      const fixture = withFreshTimestamps(TEST_LINEAR_WORKFLOW_FIXTURE)
+      const fixture = this.enrichWithSymphonyContext(withFreshTimestamps(TEST_LINEAR_WORKFLOW_FIXTURE))
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = fixture
         this.lastSuccessSnapshot = fixture
@@ -331,17 +339,19 @@ export class WorkflowBoardService {
 
     if (!this.active && this.lastSnapshot) {
       this.syncContextSnapshot()
-      return { success: true, snapshot: this.lastSnapshot }
+      return { success: true, snapshot: this.enrichWithSymphonyContext(this.lastSnapshot) }
     }
 
     if (!this.active) {
-      const inactive = this.toErrorSnapshot({
-        nowIso: new Date().toISOString(),
-        projectId: 'unknown',
-        backend: 'linear',
-        code: 'UNKNOWN',
-        message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
-      })
+      const inactive = this.enrichWithSymphonyContext(
+        this.toErrorSnapshot({
+          nowIso: new Date().toISOString(),
+          projectId: 'unknown',
+          backend: 'linear',
+          code: 'UNKNOWN',
+          message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
+        }),
+      )
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = inactive
         this.syncContextSnapshot()
@@ -354,13 +364,15 @@ export class WorkflowBoardService {
 
     const trackerResolution = await this.resolveTrackerConfig(workspacePath)
     if (trackerResolution.error) {
-      const snapshot = this.toErrorSnapshot({
-        nowIso,
-        projectId: 'unknown',
-        backend: 'linear',
-        code: trackerResolution.error.code,
-        message: trackerResolution.error.message,
-      })
+      const snapshot = this.enrichWithSymphonyContext(
+        this.toErrorSnapshot({
+          nowIso,
+          projectId: 'unknown',
+          backend: 'linear',
+          code: trackerResolution.error.code,
+          message: trackerResolution.error.message,
+        }),
+      )
 
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = snapshot
@@ -373,13 +385,15 @@ export class WorkflowBoardService {
     const tracker = trackerResolution.config
 
     if (!tracker) {
-      const snapshot = this.toErrorSnapshot({
-        nowIso,
-        projectId: 'unknown',
-        backend: 'linear',
-        code: 'NOT_CONFIGURED',
-        message: 'Workflow board tracker is not configured in WORKFLOW.md or .kata/preferences.md.',
-      })
+      const snapshot = this.enrichWithSymphonyContext(
+        this.toErrorSnapshot({
+          nowIso,
+          projectId: 'unknown',
+          backend: 'linear',
+          code: 'NOT_CONFIGURED',
+          message: 'Workflow board tracker is not configured in WORKFLOW.md or .kata/preferences.md.',
+        }),
+      )
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = snapshot
         this.trackerConfigured = false
@@ -389,7 +403,7 @@ export class WorkflowBoardService {
     }
 
     if (isWorkflowFixtureEnabled()) {
-      const fixture = withFreshTimestamps(this.fixtureForTracker(tracker))
+      const fixture = this.enrichWithSymphonyContext(withFreshTimestamps(this.fixtureForTracker(tracker)))
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = fixture
         this.lastSuccessSnapshot = fixture
@@ -409,22 +423,24 @@ export class WorkflowBoardService {
           ? await this.githubClient.fetchSnapshot({ config: tracker })
           : await this.linearClient.fetchActiveMilestoneSnapshot({ projectRef: tracker.projectRef })
 
-      const snapshot: WorkflowBoardSnapshot = {
+      const snapshot: WorkflowBoardSnapshot = this.enrichWithSymphonyContext({
         ...fetchedSnapshot,
         poll: {
           ...fetchedSnapshot.poll,
           lastSuccessAt: fetchedSnapshot.fetchedAt,
         },
-      }
+      })
 
       if (!this.active) {
-        const inactive = this.toErrorSnapshot({
-          nowIso,
-          projectId: boardProjectId,
-          backend: snapshot.backend,
-          code: 'UNKNOWN',
-          message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
-        })
+        const inactive = this.enrichWithSymphonyContext(
+          this.toErrorSnapshot({
+            nowIso,
+            projectId: boardProjectId,
+            backend: snapshot.backend,
+            code: 'UNKNOWN',
+            message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
+          }),
+        )
         if (capturedScopeKey === this.scopeKey) {
           this.lastSnapshot = inactive
           this.syncContextSnapshot()
@@ -441,13 +457,15 @@ export class WorkflowBoardService {
       return { success: true, snapshot }
     } catch (error) {
       if (!this.active) {
-        const inactive = this.toErrorSnapshot({
-          nowIso,
-          projectId: boardProjectId,
-          backend: tracker.kind === 'github' ? 'github' : 'linear',
-          code: 'UNKNOWN',
-          message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
-        })
+        const inactive = this.enrichWithSymphonyContext(
+          this.toErrorSnapshot({
+            nowIso,
+            projectId: boardProjectId,
+            backend: tracker.kind === 'github' ? 'github' : 'linear',
+            code: 'UNKNOWN',
+            message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
+          }),
+        )
         if (capturedScopeKey === this.scopeKey) {
           this.lastSnapshot = inactive
           this.syncContextSnapshot()
@@ -460,24 +478,26 @@ export class WorkflowBoardService {
           ? GithubWorkflowClient.toWorkflowError(error)
           : LinearWorkflowClient.toWorkflowError(error)
 
-      const staleSnapshot: WorkflowBoardSnapshot = this.lastSuccessSnapshot
-        ? {
-            ...this.lastSuccessSnapshot,
-            status: 'stale',
-            lastError: workflowError,
-            poll: {
-              ...this.lastSuccessSnapshot.poll,
-              status: 'error',
-              lastAttemptAt: nowIso,
-            },
-          }
-        : this.toErrorSnapshot({
-            nowIso,
-            projectId: boardProjectId,
-            backend: tracker.kind === 'github' ? 'github' : 'linear',
-            code: workflowError.code,
-            message: workflowError.message,
-          })
+      const staleSnapshot: WorkflowBoardSnapshot = this.enrichWithSymphonyContext(
+        this.lastSuccessSnapshot
+          ? {
+              ...this.lastSuccessSnapshot,
+              status: 'stale',
+              lastError: workflowError,
+              poll: {
+                ...this.lastSuccessSnapshot.poll,
+                status: 'error',
+                lastAttemptAt: nowIso,
+              },
+            }
+          : this.toErrorSnapshot({
+              nowIso,
+              projectId: boardProjectId,
+              backend: tracker.kind === 'github' ? 'github' : 'linear',
+              code: workflowError.code,
+              message: workflowError.message,
+            }),
+      )
 
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = staleSnapshot
@@ -494,6 +514,159 @@ export class WorkflowBoardService {
         this.syncContextSnapshot()
       }
       return { success: true, snapshot: staleSnapshot }
+    }
+  }
+
+  private enrichWithSymphonyContext(snapshot: WorkflowBoardSnapshot): WorkflowBoardSnapshot {
+    const operatorSnapshot = this.options.getSymphonySnapshot?.() ?? null
+
+    if (!operatorSnapshot) {
+      return {
+        ...snapshot,
+        symphony: {
+          connectionState: 'unknown',
+          freshness: 'unknown',
+          provenance: 'unavailable',
+          staleReason: 'Symphony operator snapshot unavailable.',
+          workerCount: 0,
+          escalationCount: 0,
+          diagnostics: {
+            correlationMisses: [],
+          },
+        },
+      }
+    }
+
+    const { freshness, provenance, staleReason } = deriveSymphonyEnvelope(operatorSnapshot)
+
+    const workersByIdentifier = new Map<string, SymphonyOperatorSnapshot['workers'][number]>()
+    const workersByIssueId = new Map<string, SymphonyOperatorSnapshot['workers'][number]>()
+    for (const worker of operatorSnapshot.workers) {
+      const normalizedIdentifier = normalizeIdentifier(worker.identifier)
+      if (normalizedIdentifier) {
+        workersByIdentifier.set(normalizedIdentifier, worker)
+      }
+
+      const normalizedIssueId = normalizeIdentifier(worker.issueId)
+      if (normalizedIssueId) {
+        workersByIssueId.set(normalizedIssueId, worker)
+      }
+    }
+
+    const escalationsByIdentifier = new Map<string, number>()
+    const escalationsByIssueId = new Map<string, number>()
+    for (const escalation of operatorSnapshot.escalations) {
+      const normalizedIdentifier = normalizeIdentifier(escalation.issueIdentifier)
+      if (normalizedIdentifier) {
+        escalationsByIdentifier.set(
+          normalizedIdentifier,
+          (escalationsByIdentifier.get(normalizedIdentifier) ?? 0) + 1,
+        )
+      }
+
+      const normalizedIssueId = normalizeIdentifier(escalation.issueId)
+      if (normalizedIssueId) {
+        escalationsByIssueId.set(normalizedIssueId, (escalationsByIssueId.get(normalizedIssueId) ?? 0) + 1)
+      }
+    }
+
+    const matchedWorkerKeys = new Set<string>()
+    const matchedEscalationKeys = new Set<string>()
+
+    const enrichItem = (
+      item: Pick<WorkflowBoardSliceCard, 'id' | 'identifier'> | Pick<WorkflowBoardTask, 'id' | 'identifier'>,
+    ) => {
+      const normalizedIdentifier = normalizeIdentifier(item.identifier)
+      const normalizedIssueId = normalizeIdentifier(item.id)
+
+      const worker =
+        (normalizedIdentifier ? workersByIdentifier.get(normalizedIdentifier) : undefined) ??
+        (normalizedIssueId ? workersByIssueId.get(normalizedIssueId) : undefined)
+
+      const pendingEscalations =
+        (normalizedIdentifier ? escalationsByIdentifier.get(normalizedIdentifier) : undefined) ??
+        (normalizedIssueId ? escalationsByIssueId.get(normalizedIssueId) : undefined) ??
+        0
+
+      if (worker) {
+        const workerKey = normalizeIdentifier(worker.identifier)
+        if (workerKey) {
+          matchedWorkerKeys.add(workerKey)
+        }
+      }
+
+      if (pendingEscalations > 0) {
+        if (normalizedIdentifier) {
+          matchedEscalationKeys.add(normalizedIdentifier)
+        } else if (normalizedIssueId) {
+          matchedEscalationKeys.add(normalizedIssueId)
+        }
+      }
+
+      return {
+        issueId: worker?.issueId,
+        identifier: worker?.identifier ?? item.identifier,
+        workerState: worker?.state,
+        toolName: worker?.toolName,
+        model: worker?.model,
+        lastActivityAt: worker?.lastActivityAt,
+        lastError: worker?.lastError,
+        pendingEscalations,
+        assignmentState: worker ? ('assigned' as const) : ('unassigned' as const),
+        freshness,
+        provenance,
+        staleReason,
+      }
+    }
+
+    const columns = snapshot.columns.map((column) => ({
+      ...column,
+      cards: column.cards.map((card) => ({
+        ...card,
+        symphony: enrichItem(card),
+        tasks: card.tasks.map((task) => ({
+          ...task,
+          symphony: enrichItem(task),
+        })),
+      })),
+    }))
+
+    const correlationMisses: string[] = []
+
+    for (const worker of operatorSnapshot.workers) {
+      const key = normalizeIdentifier(worker.identifier)
+      if (key && !matchedWorkerKeys.has(key)) {
+        correlationMisses.push(`worker:${worker.identifier}`)
+      }
+    }
+
+    for (const escalation of operatorSnapshot.escalations) {
+      const identifierKey = normalizeIdentifier(escalation.issueIdentifier)
+      const issueKey = normalizeIdentifier(escalation.issueId)
+      if (
+        (identifierKey && matchedEscalationKeys.has(identifierKey)) ||
+        (issueKey && matchedEscalationKeys.has(issueKey))
+      ) {
+        continue
+      }
+      correlationMisses.push(`escalation:${escalation.requestId}`)
+    }
+
+    return {
+      ...snapshot,
+      columns,
+      symphony: {
+        connectionState: operatorSnapshot.connection.state,
+        freshness,
+        provenance,
+        staleReason,
+        fetchedAt: operatorSnapshot.fetchedAt,
+        workerCount: operatorSnapshot.workers.length,
+        escalationCount: operatorSnapshot.escalations.length,
+        diagnostics: {
+          correlationMisses,
+        },
+      },
     }
   }
 
@@ -685,6 +858,55 @@ export class WorkflowBoardService {
       },
     }
   }
+}
+
+function deriveSymphonyEnvelope(operatorSnapshot: SymphonyOperatorSnapshot): {
+  freshness: WorkflowSymphonyExecutionFreshness
+  provenance: WorkflowSymphonyExecutionProvenance
+  staleReason?: string
+} {
+  if (operatorSnapshot.connection.state === 'disconnected') {
+    return {
+      freshness: 'disconnected',
+      provenance: 'runtime-disconnected',
+      staleReason:
+        operatorSnapshot.connection.lastError ??
+        operatorSnapshot.freshness.staleReason ??
+        'Symphony runtime is disconnected.',
+    }
+  }
+
+  if (
+    operatorSnapshot.connection.state === 'reconnecting' ||
+    operatorSnapshot.freshness.status === 'stale'
+  ) {
+    return {
+      freshness: 'stale',
+      provenance: 'operator-stale',
+      staleReason:
+        operatorSnapshot.freshness.staleReason ??
+        operatorSnapshot.connection.lastError ??
+        'Symphony operator data is stale.',
+    }
+  }
+
+  if (operatorSnapshot.connection.state === 'connected') {
+    return {
+      freshness: 'fresh',
+      provenance: 'dashboard-derived',
+    }
+  }
+
+  return {
+    freshness: 'unknown',
+    provenance: 'unavailable',
+    staleReason: operatorSnapshot.connection.lastError ?? operatorSnapshot.freshness.staleReason,
+  }
+}
+
+function normalizeIdentifier(value: string | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized ? normalized.toUpperCase() : null
 }
 
 function isWorkflowFixtureEnabled(): boolean {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -564,8 +564,17 @@ export class WorkflowBoardService {
     const operatorSnapshot = cachedOperatorSnapshot ?? this.options.getSymphonySnapshot?.() ?? null
 
     if (!operatorSnapshot) {
+      const columns = snapshot.columns.map((column) => ({
+        ...column,
+        cards: column.cards.map(({ symphony: _cardSymphony, tasks, ...card }) => ({
+          ...card,
+          tasks: tasks.map(({ symphony: _taskSymphony, ...task }) => task),
+        })),
+      }))
+
       return {
         ...snapshot,
+        columns,
         symphony: {
           connectionState: 'unknown',
           freshness: 'unknown',
@@ -595,25 +604,26 @@ export class WorkflowBoardService {
       }
     }
 
-    const escalationsByIdentifier = new Map<string, number>()
-    const escalationsByIssueId = new Map<string, number>()
+    const escalationsByIdentifier = new Map<string, Set<string>>()
+    const escalationsByIssueId = new Map<string, Set<string>>()
     for (const escalation of operatorSnapshot.escalations) {
       const normalizedIdentifier = normalizeIdentifier(escalation.issueIdentifier)
       if (normalizedIdentifier) {
-        escalationsByIdentifier.set(
-          normalizedIdentifier,
-          (escalationsByIdentifier.get(normalizedIdentifier) ?? 0) + 1,
-        )
+        const requestIds = escalationsByIdentifier.get(normalizedIdentifier) ?? new Set<string>()
+        requestIds.add(escalation.requestId)
+        escalationsByIdentifier.set(normalizedIdentifier, requestIds)
       }
 
       const normalizedIssueId = normalizeIdentifier(escalation.issueId)
       if (normalizedIssueId) {
-        escalationsByIssueId.set(normalizedIssueId, (escalationsByIssueId.get(normalizedIssueId) ?? 0) + 1)
+        const requestIds = escalationsByIssueId.get(normalizedIssueId) ?? new Set<string>()
+        requestIds.add(escalation.requestId)
+        escalationsByIssueId.set(normalizedIssueId, requestIds)
       }
     }
 
     const matchedWorkerKeys = new Set<string>()
-    const matchedEscalationKeys = new Set<string>()
+    const matchedEscalationRequestIds = new Set<string>()
 
     const enrichItem = (
       item: Pick<WorkflowBoardSliceCard, 'id' | 'identifier'> | Pick<WorkflowBoardTask, 'id' | 'identifier'>,
@@ -621,31 +631,27 @@ export class WorkflowBoardService {
       const normalizedIdentifier = normalizeIdentifier(item.identifier)
       const normalizedIssueId = normalizeIdentifier(item.id)
 
-      const worker =
-        (normalizedIdentifier ? workersByIdentifier.get(normalizedIdentifier) : undefined) ??
-        (normalizedIssueId ? workersByIssueId.get(normalizedIssueId) : undefined)
+      const workerByIdentifier = normalizedIdentifier ? workersByIdentifier.get(normalizedIdentifier) : undefined
+      const workerByIssueId = normalizedIssueId ? workersByIssueId.get(normalizedIssueId) : undefined
+      const worker = workerByIdentifier ?? workerByIssueId
 
-      const escalationsMatchedByIdentifier = normalizedIdentifier
-        ? escalationsByIdentifier.get(normalizedIdentifier)
-        : undefined
-      const escalationsMatchedByIssueId = normalizedIssueId ? escalationsByIssueId.get(normalizedIssueId) : undefined
-      const pendingEscalations = escalationsMatchedByIdentifier ?? escalationsMatchedByIssueId ?? 0
+      const escalationRequestIds = new Set<string>()
+      for (const requestId of normalizedIdentifier ? escalationsByIdentifier.get(normalizedIdentifier) ?? [] : []) {
+        escalationRequestIds.add(requestId)
+      }
+      for (const requestId of normalizedIssueId ? escalationsByIssueId.get(normalizedIssueId) ?? [] : []) {
+        escalationRequestIds.add(requestId)
+      }
+      const pendingEscalations = escalationRequestIds.size
 
-      if (worker) {
-        const workerKey = normalizeIdentifier(worker.identifier)
-        if (workerKey) {
-          matchedWorkerKeys.add(workerKey)
-        }
+      if (workerByIdentifier && normalizedIdentifier) {
+        matchedWorkerKeys.add(`identifier:${normalizedIdentifier}`)
+      } else if (workerByIssueId && normalizedIssueId) {
+        matchedWorkerKeys.add(`issue:${normalizedIssueId}`)
       }
 
-      if (pendingEscalations > 0) {
-        if (escalationsMatchedByIdentifier && normalizedIdentifier) {
-          matchedEscalationKeys.add(normalizedIdentifier)
-        }
-
-        if (escalationsMatchedByIssueId && normalizedIssueId) {
-          matchedEscalationKeys.add(normalizedIssueId)
-        }
+      for (const requestId of escalationRequestIds) {
+        matchedEscalationRequestIds.add(requestId)
       }
 
       return {
@@ -679,19 +685,19 @@ export class WorkflowBoardService {
     const correlationMisses: string[] = []
 
     for (const worker of operatorSnapshot.workers) {
-      const key = normalizeIdentifier(worker.identifier)
-      if (key && !matchedWorkerKeys.has(key)) {
-        correlationMisses.push(`worker:${worker.identifier}`)
+      const identifierKey = normalizeIdentifier(worker.identifier)
+      const issueKey = normalizeIdentifier(worker.issueId)
+      if (
+        (identifierKey && matchedWorkerKeys.has(`identifier:${identifierKey}`)) ||
+        (issueKey && matchedWorkerKeys.has(`issue:${issueKey}`))
+      ) {
+        continue
       }
+      correlationMisses.push(`worker:${worker.identifier || worker.issueId}`)
     }
 
     for (const escalation of operatorSnapshot.escalations) {
-      const identifierKey = normalizeIdentifier(escalation.issueIdentifier)
-      const issueKey = normalizeIdentifier(escalation.issueId)
-      if (
-        (identifierKey && matchedEscalationKeys.has(identifierKey)) ||
-        (issueKey && matchedEscalationKeys.has(issueKey))
-      ) {
+      if (matchedEscalationRequestIds.has(escalation.requestId)) {
         continue
       }
       correlationMisses.push(`escalation:${escalation.requestId}`)

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -559,9 +559,10 @@ export class WorkflowBoardService {
 
   private enrichWithSymphonyContext(
     snapshot: WorkflowBoardSnapshot,
-    cachedOperatorSnapshot?: SymphonyOperatorSnapshot | null,
+    cachedOperatorSnapshot: SymphonyOperatorSnapshot | null | undefined = undefined,
   ): WorkflowBoardSnapshot {
-    const operatorSnapshot = cachedOperatorSnapshot ?? this.options.getSymphonySnapshot?.() ?? null
+    const operatorSnapshot =
+      cachedOperatorSnapshot === undefined ? (this.options.getSymphonySnapshot?.() ?? null) : cachedOperatorSnapshot
 
     if (!operatorSnapshot) {
       const columns = snapshot.columns.map((column) => ({

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -224,6 +224,9 @@ export class WorkflowBoardService {
 
   private lastSnapshot: WorkflowBoardSnapshot | null = null
   private lastSuccessSnapshot: WorkflowBoardSnapshot | null = null
+  private lastEnrichedSnapshot: WorkflowBoardSnapshot | null = null
+  private lastEnrichedInputSnapshot: WorkflowBoardSnapshot | null = null
+  private lastEnrichedSymphonyKey: string | null = null
   private inFlightRefresh: Promise<WorkflowBoardSnapshotResponse> | null = null
   private inFlightScopeKey: string | null = null
 
@@ -253,6 +256,9 @@ export class WorkflowBoardService {
       this.testScenario = nextScenario
       this.lastSnapshot = null
       this.lastSuccessSnapshot = null
+      this.lastEnrichedSnapshot = null
+      this.lastEnrichedInputSnapshot = null
+      this.lastEnrichedSymphonyKey = null
     }
 
     this.syncContextSnapshot()
@@ -282,8 +288,7 @@ export class WorkflowBoardService {
 
   async getBoard(): Promise<WorkflowBoardSnapshotResponse> {
     if (this.lastSnapshot) {
-      const snapshot = this.enrichWithSymphonyContext(this.lastSnapshot)
-      this.lastSnapshot = snapshot
+      const snapshot = this.getCachedOrEnrichedSnapshot(this.lastSnapshot)
       this.syncContextSnapshot()
       return { success: true, snapshot }
     }
@@ -517,8 +522,46 @@ export class WorkflowBoardService {
     }
   }
 
-  private enrichWithSymphonyContext(snapshot: WorkflowBoardSnapshot): WorkflowBoardSnapshot {
+  private getCachedOrEnrichedSnapshot(snapshot: WorkflowBoardSnapshot): WorkflowBoardSnapshot {
     const operatorSnapshot = this.options.getSymphonySnapshot?.() ?? null
+    const symphonyKey = this.toSymphonyCacheKey(operatorSnapshot)
+
+    if (
+      this.lastEnrichedSnapshot &&
+      this.lastEnrichedInputSnapshot === snapshot &&
+      this.lastEnrichedSymphonyKey === symphonyKey
+    ) {
+      return this.lastEnrichedSnapshot
+    }
+
+    const enriched = this.enrichWithSymphonyContext(snapshot, operatorSnapshot)
+    this.lastEnrichedSnapshot = enriched
+    this.lastEnrichedInputSnapshot = snapshot
+    this.lastEnrichedSymphonyKey = symphonyKey
+
+    return enriched
+  }
+
+  private toSymphonyCacheKey(operatorSnapshot: SymphonyOperatorSnapshot | null): string {
+    if (!operatorSnapshot) {
+      return 'none'
+    }
+
+    return [
+      operatorSnapshot.fetchedAt,
+      operatorSnapshot.connection.state,
+      operatorSnapshot.connection.updatedAt,
+      operatorSnapshot.freshness.status,
+      operatorSnapshot.workers.length,
+      operatorSnapshot.escalations.length,
+    ].join('|')
+  }
+
+  private enrichWithSymphonyContext(
+    snapshot: WorkflowBoardSnapshot,
+    cachedOperatorSnapshot?: SymphonyOperatorSnapshot | null,
+  ): WorkflowBoardSnapshot {
+    const operatorSnapshot = cachedOperatorSnapshot ?? this.options.getSymphonySnapshot?.() ?? null
 
     if (!operatorSnapshot) {
       return {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -570,7 +570,6 @@ export class WorkflowBoardService {
           connectionState: 'unknown',
           freshness: 'unknown',
           provenance: 'unavailable',
-          staleReason: 'Symphony operator snapshot unavailable.',
           workerCount: 0,
           escalationCount: 0,
           diagnostics: {
@@ -626,10 +625,11 @@ export class WorkflowBoardService {
         (normalizedIdentifier ? workersByIdentifier.get(normalizedIdentifier) : undefined) ??
         (normalizedIssueId ? workersByIssueId.get(normalizedIssueId) : undefined)
 
-      const pendingEscalations =
-        (normalizedIdentifier ? escalationsByIdentifier.get(normalizedIdentifier) : undefined) ??
-        (normalizedIssueId ? escalationsByIssueId.get(normalizedIssueId) : undefined) ??
-        0
+      const escalationsMatchedByIdentifier = normalizedIdentifier
+        ? escalationsByIdentifier.get(normalizedIdentifier)
+        : undefined
+      const escalationsMatchedByIssueId = normalizedIssueId ? escalationsByIssueId.get(normalizedIssueId) : undefined
+      const pendingEscalations = escalationsMatchedByIdentifier ?? escalationsMatchedByIssueId ?? 0
 
       if (worker) {
         const workerKey = normalizeIdentifier(worker.identifier)
@@ -639,9 +639,11 @@ export class WorkflowBoardService {
       }
 
       if (pendingEscalations > 0) {
-        if (normalizedIdentifier) {
+        if (escalationsMatchedByIdentifier && normalizedIdentifier) {
           matchedEscalationKeys.add(normalizedIdentifier)
-        } else if (normalizedIssueId) {
+        }
+
+        if (escalationsMatchedByIssueId && normalizedIssueId) {
           matchedEscalationKeys.add(normalizedIssueId)
         }
       }

--- a/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
@@ -63,6 +63,34 @@ export function formatWorkflowBoardStatus(input: {
   return input.refreshing ? `${status} · Refreshing…` : status
 }
 
+export function formatSymphonyBoardStatus(board: WorkflowBoardSnapshot | null): string {
+  if (!board?.symphony) {
+    return 'Symphony: unavailable'
+  }
+
+  const symphony = board.symphony
+  const statusLabel =
+    symphony.freshness === 'fresh'
+      ? 'live'
+      : symphony.freshness === 'stale'
+        ? 'stale'
+        : symphony.freshness === 'disconnected'
+          ? 'disconnected'
+          : 'unknown'
+
+  const mismatchLabel =
+    symphony.diagnostics.correlationMisses.length > 0
+      ? ` · ${symphony.diagnostics.correlationMisses.length} correlation miss${
+          symphony.diagnostics.correlationMisses.length === 1 ? '' : 'es'
+        }`
+      : ''
+
+  const workerLabel = `${symphony.workerCount} worker${symphony.workerCount === 1 ? '' : 's'}`
+  const escalationLabel = `${symphony.escalationCount} escalation${symphony.escalationCount === 1 ? '' : 's'}`
+
+  return `Symphony: ${statusLabel} · ${workerLabel} · ${escalationLabel}${mismatchLabel}`
+}
+
 interface KanbanHeaderProps {
   board: WorkflowBoardSnapshot | null
   loading: boolean
@@ -123,7 +151,15 @@ export function KanbanHeader({
           emptyReason: board?.emptyReason,
           refreshing,
         })}
+        {' · '}
+        {formatSymphonyBoardStatus(board)}
       </div>
+
+      {board?.symphony?.staleReason ? (
+        <div className="border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-900 dark:text-amber-200" data-testid="workflow-board-symphony-stale">
+          {board.symphony.staleReason}
+        </div>
+      ) : null}
 
       {rightPaneOverride ? (
         <div className="border-b border-border bg-muted/70 px-4 py-2 text-xs text-muted-foreground">

--- a/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
@@ -64,7 +64,7 @@ export function formatWorkflowBoardStatus(input: {
 }
 
 export function formatSymphonyBoardStatus(board: WorkflowBoardSnapshot | null): string {
-  if (!board?.symphony) {
+  if (!board?.symphony || board.symphony.provenance === 'unavailable') {
     return 'Symphony: unavailable'
   }
 

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -10,8 +10,36 @@ interface SliceCardProps {
   card: WorkflowBoardSliceCard
 }
 
+function executionTone(freshness: 'fresh' | 'stale' | 'disconnected' | 'unknown'): string {
+  if (freshness === 'fresh') return 'text-emerald-700 dark:text-emerald-300'
+  if (freshness === 'stale') return 'text-amber-700 dark:text-amber-300'
+  if (freshness === 'disconnected') return 'text-destructive'
+  return 'text-muted-foreground'
+}
+
+export function formatSliceSymphonyHint(symphony: WorkflowBoardSliceCard['symphony']): string {
+  if (!symphony) {
+    return 'Symphony context unavailable'
+  }
+
+  if (symphony.provenance === 'runtime-disconnected') {
+    return 'Symphony runtime disconnected'
+  }
+
+  if (symphony.provenance === 'operator-stale') {
+    return 'Symphony context is stale'
+  }
+
+  if (symphony.assignmentState === 'assigned') {
+    return `Execution: ${symphony.toolName ?? 'active'}`
+  }
+
+  return 'No active Symphony execution'
+}
+
 export function SliceCard({ card }: SliceCardProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const symphony = card.symphony
 
   return (
     <Card size="sm" className="gap-3 rounded-xl border border-border/70 py-3 shadow-none">
@@ -34,6 +62,31 @@ export function SliceCard({ card }: SliceCardProps) {
             {card.taskCounts.done}/{card.taskCounts.total} tasks done
           </Badge>
         </div>
+
+        {symphony ? (
+          <div className="space-y-1 text-[11px]">
+            <div className="flex flex-wrap items-center gap-1">
+              <Badge variant={symphony.assignmentState === 'assigned' ? 'default' : 'outline'} className="text-[10px]">
+                {symphony.assignmentState === 'assigned'
+                  ? `Worker ${symphony.identifier ?? 'assigned'}`
+                  : 'Unassigned'}
+              </Badge>
+              {symphony.workerState ? (
+                <Badge variant="outline" className="text-[10px]">
+                  {symphony.workerState}
+                </Badge>
+              ) : null}
+              {symphony.pendingEscalations > 0 ? (
+                <Badge variant="destructive" className="text-[10px]">
+                  {symphony.pendingEscalations} escalation{symphony.pendingEscalations === 1 ? '' : 's'}
+                </Badge>
+              ) : null}
+            </div>
+            <p className={executionTone(symphony.freshness)} data-testid={`slice-symphony-${card.identifier}`}>
+              {formatSliceSymphonyHint(symphony)}
+            </p>
+          </div>
+        ) : null}
 
         <Collapsible open={isOpen} onOpenChange={setIsOpen}>
           <CollapsibleTrigger className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">

--- a/apps/desktop/src/renderer/components/kanban/TaskList.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskList.tsx
@@ -43,7 +43,7 @@ export function TaskList({ tasks }: TaskListProps) {
             <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
               <span>
                 {task.symphony.assignmentState === 'assigned'
-                  ? `Worker ${task.symphony.identifier ?? 'assigned'}`
+                  ? `Worker ${task.symphony.identifier ?? '(unknown)'}`
                   : 'Unassigned'}
               </span>
               {task.symphony.workerState ? <span>· {task.symphony.workerState}</span> : null}

--- a/apps/desktop/src/renderer/components/kanban/TaskList.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskList.tsx
@@ -39,6 +39,21 @@ export function TaskList({ tasks }: TaskListProps) {
               {task.stateName}
             </Badge>
           </div>
+          {task.symphony ? (
+            <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
+              <span>
+                {task.symphony.assignmentState === 'assigned'
+                  ? `Worker ${task.symphony.identifier ?? 'assigned'}`
+                  : 'Unassigned'}
+              </span>
+              {task.symphony.workerState ? <span>· {task.symphony.workerState}</span> : null}
+              {task.symphony.pendingEscalations > 0 ? (
+                <Badge variant="destructive" className="text-[10px]">
+                  {task.symphony.pendingEscalations} escalation{task.symphony.pendingEscalations === 1 ? '' : 's'}
+                </Badge>
+              ) : null}
+            </div>
+          ) : null}
         </li>
       ))}
     </ul>

--- a/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { formatWorkflowBoardStatus } from '../KanbanHeader'
+import { formatSymphonyBoardStatus, formatWorkflowBoardStatus } from '../KanbanHeader'
 
 describe('KanbanPane status formatting', () => {
   test('renders loading state', () => {
@@ -45,5 +45,33 @@ describe('KanbanPane status formatting', () => {
         refreshing: false,
       }),
     ).toBe('No slices in active milestone')
+  })
+
+  test('renders symphony convergence summary with correlation misses', () => {
+    expect(
+      formatSymphonyBoardStatus({
+        backend: 'linear',
+        fetchedAt: '2026-04-04T00:00:00.000Z',
+        status: 'fresh',
+        source: { projectId: 'test-project' },
+        activeMilestone: null,
+        columns: [],
+        poll: {
+          status: 'success',
+          backend: 'linear',
+          lastAttemptAt: '2026-04-04T00:00:00.000Z',
+        },
+        symphony: {
+          connectionState: 'connected',
+          freshness: 'fresh',
+          provenance: 'dashboard-derived',
+          workerCount: 2,
+          escalationCount: 1,
+          diagnostics: {
+            correlationMisses: ['worker:KAT-9999'],
+          },
+        },
+      }),
+    ).toContain('Symphony: live · 2 workers · 1 escalation · 1 correlation miss')
   })
 })

--- a/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
@@ -47,6 +47,34 @@ describe('KanbanPane status formatting', () => {
     ).toBe('No slices in active milestone')
   })
 
+  test('renders symphony as unavailable when provenance is unavailable', () => {
+    expect(
+      formatSymphonyBoardStatus({
+        backend: 'linear',
+        fetchedAt: '2026-04-04T00:00:00.000Z',
+        status: 'fresh',
+        source: { projectId: 'test-project' },
+        activeMilestone: null,
+        columns: [],
+        poll: {
+          status: 'success',
+          backend: 'linear',
+          lastAttemptAt: '2026-04-04T00:00:00.000Z',
+        },
+        symphony: {
+          connectionState: 'unknown',
+          freshness: 'unknown',
+          provenance: 'unavailable',
+          workerCount: 0,
+          escalationCount: 0,
+          diagnostics: {
+            correlationMisses: [],
+          },
+        },
+      }),
+    ).toBe('Symphony: unavailable')
+  })
+
   test('renders symphony convergence summary with correlation misses', () => {
     expect(
       formatSymphonyBoardStatus({

--- a/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
@@ -74,4 +74,32 @@ describe('KanbanPane status formatting', () => {
       }),
     ).toContain('Symphony: live · 2 workers · 1 escalation · 1 correlation miss')
   })
+
+  test('renders pluralized escalation and correlation miss labels', () => {
+    expect(
+      formatSymphonyBoardStatus({
+        backend: 'linear',
+        fetchedAt: '2026-04-04T00:00:00.000Z',
+        status: 'fresh',
+        source: { projectId: 'test-project' },
+        activeMilestone: null,
+        columns: [],
+        poll: {
+          status: 'success',
+          backend: 'linear',
+          lastAttemptAt: '2026-04-04T00:00:00.000Z',
+        },
+        symphony: {
+          connectionState: 'connected',
+          freshness: 'fresh',
+          provenance: 'dashboard-derived',
+          workerCount: 1,
+          escalationCount: 3,
+          diagnostics: {
+            correlationMisses: ['worker:KAT-1', 'worker:KAT-2'],
+          },
+        },
+      }),
+    ).toContain('Symphony: live · 1 worker · 3 escalations · 2 correlation misses')
+  })
 })

--- a/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest'
+import type { WorkflowBoardSliceCard } from '@shared/types'
+import { formatSliceSymphonyHint } from '../SliceCard'
+
+describe('SliceCard symphony hint formatting', () => {
+  test('shows disconnected hint when runtime is disconnected', () => {
+    expect(
+      formatSliceSymphonyHint({
+        assignmentState: 'unassigned',
+        pendingEscalations: 0,
+        freshness: 'disconnected',
+        provenance: 'runtime-disconnected',
+      }),
+    ).toBe('Symphony runtime disconnected')
+  })
+
+  test('shows stale hint when operator freshness is stale', () => {
+    expect(
+      formatSliceSymphonyHint({
+        assignmentState: 'assigned',
+        identifier: 'KAT-2247',
+        pendingEscalations: 1,
+        freshness: 'stale',
+        provenance: 'operator-stale',
+        toolName: 'edit',
+      }),
+    ).toBe('Symphony context is stale')
+  })
+
+  test('shows execution tool when assigned and fresh', () => {
+    const symphony: WorkflowBoardSliceCard['symphony'] = {
+      assignmentState: 'assigned',
+      identifier: 'KAT-2247',
+      pendingEscalations: 0,
+      freshness: 'fresh',
+      provenance: 'dashboard-derived',
+      toolName: 'bash',
+    }
+
+    expect(formatSliceSymphonyHint(symphony)).toBe('Execution: bash')
+  })
+})

--- a/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
@@ -3,6 +3,13 @@ import type { WorkflowBoardSliceCard } from '@shared/types'
 import { formatSliceSymphonyHint } from '../SliceCard'
 
 describe('SliceCard symphony hint formatting', () => {
+  test('shows unavailable hint when context is missing', () => {
+    expect(formatSliceSymphonyHint(null as unknown as WorkflowBoardSliceCard['symphony'])).toBe(
+      'Symphony context unavailable',
+    )
+    expect(formatSliceSymphonyHint(undefined)).toBe('Symphony context unavailable')
+  })
+
   test('shows disconnected hint when runtime is disconnected', () => {
     expect(
       formatSliceSymphonyHint({
@@ -27,6 +34,17 @@ describe('SliceCard symphony hint formatting', () => {
     ).toBe('Symphony context is stale')
   })
 
+  test('shows no active execution when unassigned and fresh', () => {
+    expect(
+      formatSliceSymphonyHint({
+        assignmentState: 'unassigned',
+        pendingEscalations: 0,
+        freshness: 'fresh',
+        provenance: 'dashboard-derived',
+      }),
+    ).toBe('No active Symphony execution')
+  })
+
   test('shows execution tool when assigned and fresh', () => {
     const symphony: WorkflowBoardSliceCard['symphony'] = {
       assignmentState: 'assigned',
@@ -38,5 +56,17 @@ describe('SliceCard symphony hint formatting', () => {
     }
 
     expect(formatSliceSymphonyHint(symphony)).toBe('Execution: bash')
+  })
+
+  test('falls back to active execution label when tool name is missing', () => {
+    expect(
+      formatSliceSymphonyHint({
+        assignmentState: 'assigned',
+        identifier: 'KAT-2247',
+        pendingEscalations: 0,
+        freshness: 'fresh',
+        provenance: 'dashboard-derived',
+      }),
+    ).toBe('Execution: active')
   })
 })

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -604,6 +604,42 @@ export interface WorkflowBoardError {
   message: string
 }
 
+export type WorkflowSymphonyExecutionProvenance =
+  | 'dashboard-derived'
+  | 'operator-stale'
+  | 'runtime-disconnected'
+  | 'unavailable'
+
+export type WorkflowSymphonyExecutionFreshness = 'fresh' | 'stale' | 'disconnected' | 'unknown'
+
+export interface WorkflowSymphonyExecutionSummary {
+  issueId?: string
+  identifier?: string
+  workerState?: string
+  toolName?: string
+  model?: string
+  lastActivityAt?: string
+  lastError?: string
+  pendingEscalations: number
+  assignmentState: 'assigned' | 'unassigned'
+  freshness: WorkflowSymphonyExecutionFreshness
+  provenance: WorkflowSymphonyExecutionProvenance
+  staleReason?: string
+}
+
+export interface WorkflowBoardSymphonySnapshot {
+  connectionState: SymphonyOperatorConnectionState | 'unknown'
+  freshness: WorkflowSymphonyExecutionFreshness
+  provenance: WorkflowSymphonyExecutionProvenance
+  staleReason?: string
+  fetchedAt?: string
+  workerCount: number
+  escalationCount: number
+  diagnostics: {
+    correlationMisses: string[]
+  }
+}
+
 export interface WorkflowBoardTask {
   id: string
   identifier?: string
@@ -612,6 +648,7 @@ export interface WorkflowBoardTask {
   stateName: string
   stateType: string
   url?: string
+  symphony?: WorkflowSymphonyExecutionSummary
 }
 
 export interface WorkflowBoardSliceCard {
@@ -629,6 +666,7 @@ export interface WorkflowBoardSliceCard {
     done: number
   }
   tasks: WorkflowBoardTask[]
+  symphony?: WorkflowSymphonyExecutionSummary
 }
 
 export interface WorkflowBoardColumn {
@@ -663,6 +701,7 @@ export interface WorkflowBoardSnapshot {
       }
     | null
   columns: WorkflowBoardColumn[]
+  symphony?: WorkflowBoardSymphonySnapshot
   emptyReason?: string
   lastError?: WorkflowBoardError
   poll: WorkflowBoardPollMetadata


### PR DESCRIPTION
## Summary
- extend WorkflowBoardSnapshot with optional Symphony execution metadata for cards/tasks plus board-level freshness/provenance diagnostics
- join normalized operator snapshot onto workflow cards in the main process using stable identifiers (identifier + issue id fallback), including correlation miss diagnostics
- render compact assignment/execution/escalation/freshness hints in kanban header/cards/tasks
- add deterministic Electron seams + symphony-kanban.e2e.ts convergence coverage and S03 live smoke checklist doc

## Validation
- cd apps/desktop && npx vitest run src/main/__tests__/workflow-board-service.test.ts src/renderer/components/kanban/__tests__/KanbanPane.test.tsx src/renderer/components/kanban/__tests__/SliceCard.test.tsx
- cd apps/desktop && bun run typecheck
- cd apps/desktop && npx playwright test e2e/tests/symphony-kanban.e2e.ts *(fails locally in this environment: Electron failed to install correctly)*
- pre-push gate passed: turbo run lint typecheck test --affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Symphony runtime context integrated into workflow boards: header shows live/stale/disconnected status with worker & escalation counts and correlation-miss indicator.
  * Slice cards and task items display Symphony info (assignment, worker state, pending escalations) and a visible stale-reason banner when present.

* **Tests**
  * Added E2E and unit tests covering assigned, stale, and disconnected Symphony scenarios and related UI formatting/visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enriches kanban board cards and tasks with Symphony execution metadata (worker assignment, tool name, escalation counts, freshness/provenance) by joining the `SymphonyOperatorSnapshot` onto `WorkflowBoardSnapshot` in the main process, then rendering compact status hints in `KanbanHeader`, `SliceCard`, and `TaskList`. The correlation logic is solid and the test coverage is thorough.

- **P1:** `enrichWithSymphonyContext` sets `staleReason: 'Symphony operator snapshot unavailable.'` when `getSymphonySnapshot` returns `null`, causing a persistent amber warning banner in `KanbanHeader` for every user who has not configured or started Symphony — even when that is the expected/normal state.
- **P2:** The `'Symphony: unavailable'` early-return in `formatSymphonyBoardStatus` is now unreachable because `symphony` is always set on enriched snapshots; unconfigured users see `'Symphony: unknown · 0 workers · 0 escalations'` in the header bar instead.
- **P2:** The new E2E `startMockRuntime` helper assumes the kanban pane is already visible without a navigation/activation step, which may cause intermittent failures depending on the app's default pane state after onboarding.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the unconditional `staleReason` in the null-operator branch, which currently shows a misleading amber warning to all non-Symphony users.

One P1 present: the `'Symphony operator snapshot unavailable.'` staleReason is emitted even when Symphony is simply not configured, producing a persistent orange banner for users who don't use Symphony. The remaining findings are P2 (unreachable status-bar early-return and unguarded kanban-pane assumption in E2E). The core enrichment logic, type definitions, unit tests, and mock infrastructure are all sound.

apps/desktop/src/main/workflow-board-service.ts (null-operator staleReason), apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx (unreachable early-return)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/workflow-board-service.ts | New `enrichWithSymphonyContext` method joins operator snapshot onto board cards; the `!operatorSnapshot` branch sets `staleReason` unconditionally, causing a misleading amber banner for non-Symphony users (P1). Also mutates `lastSnapshot` as a side effect of `getBoard()`. |
| apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx | Adds `formatSymphonyBoardStatus` helper and renders a Symphony status line plus amber stale-reason banner; the `'Symphony: unavailable'` early-return is now unreachable, so unconfigured Symphony shows `'unknown · 0 workers · 0 escalations'` instead. |
| apps/desktop/src/shared/types.ts | Adds `WorkflowSymphonyExecutionSummary`, `WorkflowBoardSymphonySnapshot`, and related types; all well-typed with appropriate optionals. |
| apps/desktop/e2e/tests/symphony-kanban.e2e.ts | New convergence E2E suite covering assigned, stale, and disconnected modes; `startMockRuntime` assumes kanban pane is already visible without a navigation/activation step, which may cause flaky failures. |
| apps/desktop/src/main/__tests__/workflow-board-service.test.ts | Comprehensive unit test additions covering enrichment, stale/disconnected provenance, correlation misses, issueId fallback, and inactive-deactivation race; well-structured. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer (kanban)
    participant IPC as IPC (main process)
    participant WBS as WorkflowBoardService
    participant SOS as SymphonyOperatorService

    R->>IPC: getBoard()
    IPC->>WBS: getBoard()
    WBS->>SOS: getSymphonySnapshot()
    SOS-->>WBS: SymphonyOperatorSnapshot (or null)
    WBS->>WBS: enrichWithSymphonyContext(lastSnapshot)
    note over WBS: Builds workersByIdentifier & workersByIssueId maps<br/>Joins escalations onto cards/tasks<br/>Computes provenance + freshness envelope<br/>Tracks correlation misses
    WBS-->>IPC: WorkflowBoardSnapshot (with .symphony)
    IPC-->>R: snapshot
    R->>R: KanbanHeader renders formatSymphonyBoardStatus()
    R->>R: SliceCard renders formatSliceSymphonyHint() per card
    R->>R: TaskList renders assignment/escalation per task
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/e2e/tests/symphony-kanban.e2e.ts`, line 74-79 ([link](https://github.com/gannonh/kata/blob/15a72831bfe5ddb38263bda15a5015fe01dc5ed6/apps/desktop/e2e/tests/symphony-kanban.e2e.ts#L74-L79)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Kanban pane visibility assumed but never asserted**

   `startMockRuntime` clicks "Refresh workflow board" immediately after starting Symphony, but doesn't first navigate to or assert the kanban pane is open. After `readyWindow` dismisses onboarding the app is typically in chat mode; if the right pane is inactive or collapsed the button lookup will time out. The existing e2e suites (`app-shell.e2e.ts`) use explicit pane-activation steps before interacting with right-pane controls — the same pattern should apply here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/e2e/tests/symphony-kanban.e2e.ts
   Line: 74-79

   Comment:
   **Kanban pane visibility assumed but never asserted**

   `startMockRuntime` clicks "Refresh workflow board" immediately after starting Symphony, but doesn't first navigate to or assert the kanban pane is open. After `readyWindow` dismisses onboarding the app is typically in chat mode; if the right pane is inactive or collapsed the button lookup will time out. The existing e2e suites (`app-shell.e2e.ts`) use explicit pane-activation steps before interacting with right-pane controls — the same pattern should apply here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/workflow-board-service.ts
Line: 523-537

Comment:
**Amber banner fires when Symphony is simply not configured**

When `getSymphonySnapshot` returns `null` (Symphony not started / service absent), `staleReason` is set to `'Symphony operator snapshot unavailable.'`. Because `KanbanHeader` renders the amber banner for any truthy `board.symphony.staleReason`, every user who hasn't configured Symphony sees a persistent orange warning saying the snapshot is unavailable — even though there's no actual problem.

The `provenance: 'unavailable'` path should suppress `staleReason`, or the header guard should check `provenance !== 'unavailable'` before rendering the banner.

```ts
// Option A: don't emit staleReason for the unavailable case
if (!operatorSnapshot) {
  return {
    ...snapshot,
    symphony: {
      connectionState: 'unknown',
      freshness: 'unknown',
      provenance: 'unavailable',
      // staleReason omitted — this is not a fault, just unconfigured
      workerCount: 0,
      escalationCount: 0,
      diagnostics: { correlationMisses: [] },
    },
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/workflow-board-service.ts
Line: 283-289

Comment:
**`getBoard()` side-effects `lastSnapshot` on every read**

`getBoard()` enriches the cached snapshot and immediately writes the result back to `this.lastSnapshot`. This means a plain read path mutates persisted state — if `getSymphonySnapshot()` changes between calls (e.g. the service reconnects), consecutive `getBoard()` calls silently overwrite the last-known snapshot with freshly-enriched data, which also diverges `lastSnapshot` from `lastSuccessSnapshot`. The enrichment is fresh each call so display correctness is preserved, but the mutation makes reasoning about snapshot lifetime harder and breaks the invariant that `getBoard()` is a non-mutating read when a cached snapshot exists.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
Line: 66-92

Comment:
**`'Symphony: unavailable'` early-return is now unreachable**

The `!board?.symphony` guard returns `'Symphony: unavailable'` only when `symphony` is absent. After this PR, every enriched snapshot always carries a `symphony` object (even the `provenance: 'unavailable'` case sets it). The fallback will never fire for live snapshots, so a board without Symphony configured instead renders `'Symphony: unknown · 0 workers · 0 escalations'` — cluttering the status bar for every kanban user.

A simple guard can restore the intended behaviour:

```ts
if (!board?.symphony || board.symphony.provenance === 'unavailable') {
  return 'Symphony: unavailable'
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/e2e/tests/symphony-kanban.e2e.ts
Line: 74-79

Comment:
**Kanban pane visibility assumed but never asserted**

`startMockRuntime` clicks "Refresh workflow board" immediately after starting Symphony, but doesn't first navigate to or assert the kanban pane is open. After `readyWindow` dismisses onboarding the app is typically in chat mode; if the right pane is inactive or collapsed the button lookup will time out. The existing e2e suites (`app-shell.e2e.ts`) use explicit pane-activation steps before interacting with right-pane controls — the same pattern should apply here.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): harden inactive refresh f..."](https://github.com/gannonh/kata/commit/15a72831bfe5ddb38263bda15a5015fe01dc5ed6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27368373)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->