### PR TITLE
feat(desktop): complete S04 end-to-end Symphony operation proof

### DIFF
--- a/.agents/skills/sym-address-comments/SKILL.md
+++ b/.agents/skills/sym-address-comments/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: sym-address-comments
+description: Help address review/issue comments on the open GitHub PR for the current branch using gh CLI; verify gh auth first and prompt the user to authenticate if not logged in.
+metadata:
+  short-description: Address comments in a GitHub PR review
+---
+
+# PR Comment Handler
+
+Guide to find the open PR for the current branch and address its comments with gh CLI. Run all `gh` commands with elevated network access.
+
+## Preflight
+
+1. Create a structured task list of the following steps 
+2. Inform the user of what you are doing
+
+You should endeavor to run this entire workflow autonomously, only engaging the user if issues arise or uncertain how to best proceed.
+
+### Step 1: Inspect comments needing attention
+
+- Run `<path-to-skill>/scripts/fetch_comments.py` which will print out all the comments and review threads on the PR
+
+### Step 2: Enumarate issues identified in comments and review threads
+
+- Number all the review threads and comments 
+- Provide a short summary of each "issue candidate," including any suggested fixes from the reviewer
+
+### Step 3: Identify actionable issues to address
+
+- For each issue candidate, analyze against the codebase to distinguish actionable items from false positives or comments that do not require code changes (for example, questions, suggestions, or style comments).
+
+### Step 4: Apply fixes to all actionable issues & resolve/address comments
+
+- Use TDD when possible: write a failing test that captures the issue, then apply the fix to make the test pass.
+- Resolve or reply to those threads in the GitHub UI as you address them. For comments not addressed, reply to reviewers with your reasoning and ask for any clarification if needed.
+
+### Step 5: Run checks, commit and push changes
+
+- After applying fixes, run the relevant tests and checks locally to confirm the issue is resolved.
+- Summarize the changes made, commit with a clear message referencing the PR and issue numbers, and push the changes to the PR branch.
+
+### Step 6: Monitor CI Actions and address any new failures
+
+- After pushing, monitor the PR's CI checks for any new failures that may arise from the changes.
+- If new failures occur, use the `fix-ci` skill to analyze the CI logs, identify the root cause, and apply necessary fixes.
+
+## Final verification and summary
+
+- Double check that all comments have been addressed and resolved in the GitHub UI.
+- Summarize the outcome of the comment addressing process, including any remaining open questions or follow-ups needed with reviewers.
+
+Notes:
+
+- If gh hits auth/rate issues mid-run, prompt the user to re-authenticate with `gh auth login`, then retry.
+- If sandboxing blocks `gh auth status`, rerun it with `sandbox_permissions=require_escalated`.

--- a/.agents/skills/sym-address-comments/scripts/fetch_comments.py
+++ b/.agents/skills/sym-address-comments/scripts/fetch_comments.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Fetch all PR conversation comments + reviews + review threads (inline threads)
+for the PR associated with the current git branch, by shelling out to:
+
+  gh api graphql
+
+Requires:
+  - `gh auth login` already set up
+  - current branch has an associated (open) PR
+
+Usage:
+  python fetch_comments.py > pr_comments.json
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+QUERY = """\
+query(
+  $owner: String!,
+  $repo: String!,
+  $number: Int!,
+  $commentsCursor: String,
+  $reviewsCursor: String,
+  $threadsCursor: String
+) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      number
+      url
+      title
+      state
+
+      # Top-level "Conversation" comments (issue comments on the PR)
+      comments(first: 100, after: $commentsCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          body
+          createdAt
+          updatedAt
+          author { login }
+        }
+      }
+
+      # Review submissions (Approve / Request changes / Comment), with body if present
+      reviews(first: 100, after: $reviewsCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          state
+          body
+          submittedAt
+          author { login }
+        }
+      }
+
+      # Inline review threads (grouped), includes resolved state
+      reviewThreads(first: 100, after: $threadsCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          diffSide
+          startLine
+          startDiffSide
+          originalLine
+          originalStartLine
+          resolvedBy { login }
+          comments(first: 100) {
+            nodes {
+              id
+              body
+              createdAt
+              updatedAt
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _run(cmd: list[str], stdin: str | None = None) -> str:
+    p = subprocess.run(cmd, input=stdin, capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError(f"Command failed: {' '.join(cmd)}\n{p.stderr}")
+    return p.stdout
+
+
+def _run_json(cmd: list[str], stdin: str | None = None) -> dict[str, Any]:
+    out = _run(cmd, stdin=stdin)
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Failed to parse JSON from command output: {e}\nRaw:\n{out}") from e
+
+
+def _ensure_gh_authenticated() -> None:
+    try:
+        _run(["gh", "auth", "status"])
+    except RuntimeError:
+        print("run `gh auth login` to authenticate the GitHub CLI", file=sys.stderr)
+        raise RuntimeError("gh auth status failed; run `gh auth login` to authenticate the GitHub CLI") from None
+
+
+def gh_pr_view_json(fields: str) -> dict[str, Any]:
+    # fields is a comma-separated list like: "number,headRepositoryOwner,headRepository"
+    return _run_json(["gh", "pr", "view", "--json", fields])
+
+
+def get_current_pr_ref() -> tuple[str, str, int]:
+    """
+    Resolve the PR for the current branch (whatever gh considers associated).
+    Works for cross-repo PRs too, by reading head repository owner/name.
+    """
+    pr = gh_pr_view_json("number,headRepositoryOwner,headRepository")
+    owner = pr["headRepositoryOwner"]["login"]
+    repo = pr["headRepository"]["name"]
+    number = int(pr["number"])
+    return owner, repo, number
+
+
+def gh_api_graphql(
+    owner: str,
+    repo: str,
+    number: int,
+    comments_cursor: str | None = None,
+    reviews_cursor: str | None = None,
+    threads_cursor: str | None = None,
+) -> dict[str, Any]:
+    """
+    Call `gh api graphql` using -F variables, avoiding JSON blobs with nulls.
+    Query is passed via stdin using query=@- to avoid shell newline/quoting issues.
+    """
+    cmd = [
+        "gh",
+        "api",
+        "graphql",
+        "-F",
+        "query=@-",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"repo={repo}",
+        "-F",
+        f"number={number}",
+    ]
+    if comments_cursor:
+        cmd += ["-F", f"commentsCursor={comments_cursor}"]
+    if reviews_cursor:
+        cmd += ["-F", f"reviewsCursor={reviews_cursor}"]
+    if threads_cursor:
+        cmd += ["-F", f"threadsCursor={threads_cursor}"]
+
+    return _run_json(cmd, stdin=QUERY)
+
+
+def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
+    conversation_comments: list[dict[str, Any]] = []
+    reviews: list[dict[str, Any]] = []
+    review_threads: list[dict[str, Any]] = []
+
+    comments_cursor: str | None = None
+    reviews_cursor: str | None = None
+    threads_cursor: str | None = None
+
+    pr_meta: dict[str, Any] | None = None
+
+    while True:
+        payload = gh_api_graphql(
+            owner=owner,
+            repo=repo,
+            number=number,
+            comments_cursor=comments_cursor,
+            reviews_cursor=reviews_cursor,
+            threads_cursor=threads_cursor,
+        )
+
+        if "errors" in payload and payload["errors"]:
+            raise RuntimeError(f"GitHub GraphQL errors:\n{json.dumps(payload['errors'], indent=2)}")
+
+        pr = payload["data"]["repository"]["pullRequest"]
+        if pr_meta is None:
+            pr_meta = {
+                "number": pr["number"],
+                "url": pr["url"],
+                "title": pr["title"],
+                "state": pr["state"],
+                "owner": owner,
+                "repo": repo,
+            }
+
+        c = pr["comments"]
+        r = pr["reviews"]
+        t = pr["reviewThreads"]
+
+        conversation_comments.extend(c.get("nodes") or [])
+        reviews.extend(r.get("nodes") or [])
+        review_threads.extend(t.get("nodes") or [])
+
+        comments_cursor = c["pageInfo"]["endCursor"] if c["pageInfo"]["hasNextPage"] else None
+        reviews_cursor = r["pageInfo"]["endCursor"] if r["pageInfo"]["hasNextPage"] else None
+        threads_cursor = t["pageInfo"]["endCursor"] if t["pageInfo"]["hasNextPage"] else None
+
+        if not (comments_cursor or reviews_cursor or threads_cursor):
+            break
+
+    assert pr_meta is not None
+    return {
+        "pull_request": pr_meta,
+        "conversation_comments": conversation_comments,
+        "reviews": reviews,
+        "review_threads": review_threads,
+    }
+
+
+def main() -> None:
+    _ensure_gh_authenticated()
+    owner, repo, number = get_current_pr_ref()
+    result = fetch_all(owner, repo, number)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/sym-address-comments/scripts/fetch_comments.py
+++ b/.agents/skills/sym-address-comments/scripts/fetch_comments.py
@@ -11,6 +11,10 @@ Requires:
 
 Usage:
   python fetch_comments.py > pr_comments.json
+
+Notes:
+  - Thread comments are fetched with `comments(first: 100)` per review thread.
+    The script does not currently paginate nested thread comments beyond 100.
 """
 
 from __future__ import annotations
@@ -116,18 +120,18 @@ def _ensure_gh_authenticated() -> None:
 
 
 def gh_pr_view_json(fields: str) -> dict[str, Any]:
-    # fields is a comma-separated list like: "number,headRepositoryOwner,headRepository"
+    # fields is a comma-separated list like: "number,baseRepositoryOwner,baseRepository"
     return _run_json(["gh", "pr", "view", "--json", fields])
 
 
 def get_current_pr_ref() -> tuple[str, str, int]:
     """
     Resolve the PR for the current branch (whatever gh considers associated).
-    Works for cross-repo PRs too, by reading head repository owner/name.
+    Works for cross-repo PRs too, using the base repository owner/name.
     """
-    pr = gh_pr_view_json("number,headRepositoryOwner,headRepository")
-    owner = pr["headRepositoryOwner"]["login"]
-    repo = pr["headRepository"]["name"]
+    pr = gh_pr_view_json("number,baseRepositoryOwner,baseRepository")
+    owner = pr["baseRepositoryOwner"]["login"]
+    repo = pr["baseRepository"]["name"]
     number = int(pr["number"])
     return owner, repo, number
 
@@ -175,10 +179,13 @@ def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
     comments_cursor: str | None = None
     reviews_cursor: str | None = None
     threads_cursor: str | None = None
+    comments_done = False
+    reviews_done = False
+    threads_done = False
 
     pr_meta: dict[str, Any] | None = None
 
-    while True:
+    while not (comments_done and reviews_done and threads_done):
         payload = gh_api_graphql(
             owner=owner,
             repo=repo,
@@ -206,16 +213,20 @@ def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
         r = pr["reviews"]
         t = pr["reviewThreads"]
 
-        conversation_comments.extend(c.get("nodes") or [])
-        reviews.extend(r.get("nodes") or [])
-        review_threads.extend(t.get("nodes") or [])
+        if not comments_done:
+            conversation_comments.extend(c.get("nodes") or [])
+            comments_done = not c["pageInfo"]["hasNextPage"]
+            comments_cursor = None if comments_done else c["pageInfo"]["endCursor"]
 
-        comments_cursor = c["pageInfo"]["endCursor"] if c["pageInfo"]["hasNextPage"] else None
-        reviews_cursor = r["pageInfo"]["endCursor"] if r["pageInfo"]["hasNextPage"] else None
-        threads_cursor = t["pageInfo"]["endCursor"] if t["pageInfo"]["hasNextPage"] else None
+        if not reviews_done:
+            reviews.extend(r.get("nodes") or [])
+            reviews_done = not r["pageInfo"]["hasNextPage"]
+            reviews_cursor = None if reviews_done else r["pageInfo"]["endCursor"]
 
-        if not (comments_cursor or reviews_cursor or threads_cursor):
-            break
+        if not threads_done:
+            review_threads.extend(t.get("nodes") or [])
+            threads_done = not t["pageInfo"]["hasNextPage"]
+            threads_cursor = None if threads_done else t["pageInfo"]["endCursor"]
 
     assert pr_meta is not None
     return {

--- a/.agents/skills/sym-commit/SKILL.md
+++ b/.agents/skills/sym-commit/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: sym-commit
+description:
+  Create a well-formed git commit from current changes using session history for
+  rationale and summary; use when asked to commit, prepare a commit message, or
+  finalize staged work.
+---
+
+# Commit
+
+## Goals
+
+- Produce a commit that reflects the actual code changes and the session
+  context.
+- Follow common git conventions (type prefix, short subject, wrapped body).
+- Include both summary and rationale in the body.
+
+## Inputs
+
+- Codex session history for intent and rationale.
+- `git status`, `git diff`, and `git diff --staged` for actual changes.
+- Repo-specific commit conventions if documented.
+
+## Steps
+
+1. Read session history to identify scope, intent, and rationale.
+2. Inspect the working tree and staged changes (`git status`, `git diff`,
+   `git diff --staged`).
+3. Stage intended changes, including new files (`git add -A`) after confirming
+   scope.
+4. Sanity-check newly added files; if anything looks random or likely ignored
+   (build artifacts, logs, temp files), flag it to the user before committing.
+5. If staging is incomplete or includes unrelated files, fix the index or ask
+   for confirmation.
+6. Choose a conventional type and optional scope that match the change (e.g.,
+   `feat(scope): ...`, `fix(scope): ...`, `refactor(scope): ...`).
+7. Write a subject line in imperative mood, <= 72 characters, no trailing
+   period.
+8. Write a body that includes:
+   - Summary of key changes (what changed).
+   - Rationale and trade-offs (why it changed).
+   - Tests or validation run (or explicit note if not run).
+9. Append a `Co-authored-by` trailer for Codex using `Codex <codex@openai.com>`
+   unless the user explicitly requests a different identity.
+10. Wrap body lines at 72 characters.
+11. Create the commit message with a here-doc or temp file and use
+    `git commit -F <file>` so newlines are literal (avoid `-m` with `\n`).
+12. Commit only when the message matches the staged changes: if the staged diff
+    includes unrelated files or the message describes work that isn't staged,
+    fix the index or revise the message before committing.
+
+## Output
+
+- A single commit created with `git commit` whose message reflects the session.
+
+## Template
+
+Type and scope are examples only; adjust to fit the repo and changes.
+
+```
+<type>(<scope>): <short summary>
+
+Summary:
+- <what changed>
+- <what changed>
+
+Rationale:
+- <why>
+- <why>
+
+Tests:
+- <command or "not run (reason)">
+
+Co-authored-by: Codex <codex@openai.com>
+```

--- a/.agents/skills/sym-debug/SKILL.md
+++ b/.agents/skills/sym-debug/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: sym-debug
+description:
+  Investigate stuck runs and execution failures by tracing Symphony and Codex
+  logs with issue/session identifiers; use when runs stall, retry repeatedly, or
+  fail unexpectedly.
+---
+
+# Debug
+
+## Goals
+
+- Find why a run is stuck, retrying, or failing.
+- Correlate Linear issue identity to a Codex session quickly.
+- Read the right logs in the right order to isolate root cause.
+
+## Log Sources
+
+- Primary runtime log file: `<logs-root>/log/symphony.log`
+  - When Symphony runs with `--logs-root`, it writes rotating JSON logs under
+    this path (see `apps/symphony/README.md`).
+  - Includes orchestrator, agent runner, and Codex app-server lifecycle logs.
+- Rotated runtime logs: `<logs-root>/log/symphony.log*`
+  - Check these when the relevant run is older than the active file.
+- Stdout fallback: structured JSON log stream
+  - Without `--logs-root`, logs stream to stdout instead of a file.
+
+## Correlation Keys
+
+- `issue_identifier`: human ticket key (example: `MT-625`)
+- `issue_id`: Linear UUID (stable internal ID)
+- `session_id`: Codex thread-turn pair (`<thread_id>-<turn_id>`)
+
+These fields are emitted by Symphony runtime lifecycle logs (notably in
+`apps/symphony/src/orchestrator.rs` and `apps/symphony/src/codex/app_server.rs`).
+Use them as your join keys during debugging.
+
+## Quick Triage (Stuck Run)
+
+1. Confirm scheduler/worker symptoms for the ticket.
+2. Find recent lines for the ticket (`issue_identifier` first).
+3. Extract `session_id` from matching lines.
+4. Trace that `session_id` across start, stream, completion/failure, and stall
+   handling logs.
+5. Decide class of failure: timeout/stall, app-server startup failure, turn
+   failure, or orchestrator retry loop.
+
+## Commands
+
+```bash
+# File-log mode (`--logs-root` enabled): expand to active + rotated files.
+LOG_PATHS=( ${LOG_GLOB:-log/symphony.log*} )
+
+# 1) Narrow by ticket key (fastest entry point)
+rg -n "issue_identifier=MT-625" "${LOG_PATHS[@]}"
+
+# 2) If needed, narrow by Linear UUID
+rg -n "issue_id=<linear-uuid>" "${LOG_PATHS[@]}"
+
+# 3) Pull session IDs seen for that ticket
+rg -o "session_id=[^ ;]+" "${LOG_PATHS[@]}" | sort -u
+
+# 4) Trace one session end-to-end
+rg -n "session_id=<thread>-<turn>" "${LOG_PATHS[@]}"
+
+# 5) Focus on stuck/retry signals
+rg -n "Issue stalled|scheduling retry|turn_timeout|turn_failed|Codex session failed|Codex session ended with error" "${LOG_PATHS[@]}"
+
+# Stdout mode (startup banner shows `Logs: stdout`): use your runtime stream.
+journalctl -u symphony --since "30 minutes ago" --no-pager \
+  | rg -n "issue_identifier=MT-625|issue_id=<linear-uuid>|session_id=<thread>-<turn>|Issue stalled|scheduling retry|turn_timeout|turn_failed|Codex session failed|Codex session ended with error"
+
+# Containerized deploys can use docker logs instead of journalctl.
+docker logs <symphony-container> --since 30m 2>&1 \
+  | rg -n "issue_identifier=MT-625|issue_id=<linear-uuid>|session_id=<thread>-<turn>|Issue stalled|scheduling retry|turn_timeout|turn_failed|Codex session failed|Codex session ended with error"
+```
+
+## Investigation Flow
+
+1. Locate the ticket slice:
+    - Search by `issue_identifier=<KEY>`.
+    - If noise is high, add `issue_id=<UUID>`.
+2. Establish timeline:
+    - Identify first `Codex session started ... session_id=...`.
+    - Follow with `Codex session completed`, `ended with error`, or worker exit
+      lines.
+3. Classify the problem:
+    - Stall loop: `Issue stalled ... restarting with backoff`.
+    - App-server startup: `Codex session failed ...`.
+    - Turn execution failure: `turn_failed`, `turn_cancelled`, `turn_timeout`, or
+      `ended with error`.
+    - Worker crash: `Agent task exited ... reason=...`.
+4. Validate scope:
+    - Check whether failures are isolated to one issue/session or repeating across
+      multiple tickets.
+5. Capture evidence:
+    - Save key log lines with timestamps, `issue_identifier`, `issue_id`, and
+      `session_id`.
+    - Record probable root cause and the exact failing stage.
+
+## Reading Codex Session Logs
+
+In Symphony, Codex session diagnostics are emitted into `log/symphony.log` and
+keyed by `session_id`. Read them as a lifecycle:
+
+1. `Codex session started ... session_id=...`
+2. Session stream/lifecycle events for the same `session_id`
+3. Terminal event:
+    - `Codex session completed ...`, or
+    - `Codex session ended with error ...`, or
+    - `Issue stalled ... restarting with backoff`
+
+For one specific session investigation, keep the trace narrow:
+
+1. Capture one `session_id` for the ticket.
+2. Build a timestamped slice for only that session:
+    - `rg -n "session_id=<thread>-<turn>" "$LOG_GLOB"`
+3. Mark the exact failing stage:
+    - Startup failure before stream events (`Codex session failed ...`).
+    - Turn/runtime failure after stream events (`turn_*` / `ended with error`).
+    - Stall recovery (`Issue stalled ... restarting with backoff`).
+4. Pair findings with `issue_identifier` and `issue_id` from nearby lines to
+   confirm you are not mixing concurrent retries.
+
+Always pair session findings with `issue_identifier`/`issue_id` to avoid mixing
+concurrent runs.
+
+## Notes
+
+- Prefer `rg` over `grep` for speed on large logs.
+- Check rotated logs (`<logs-root>/log/symphony.log*`) before concluding data is
+  missing.
+- If required context fields are missing in new log statements, align with
+  existing structured lifecycle logging in
+  `apps/symphony/src/orchestrator.rs` and
+  `apps/symphony/src/codex/app_server.rs`.

--- a/.agents/skills/sym-fix-ci/SKILL.md
+++ b/.agents/skills/sym-fix-ci/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: sym-fix-ci
+description: "Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions. Trigger words include: 'fix CI', 'debug GitHub Actions', 'gh pr checks', 'CI is red', 'GitHub Actions failed', 'fix the build', and similar phrases indicating a need to investigate and resolve CI failures in a GitHub-hosted repository."
+---
+
+## Overview
+
+Use gh to locate failing PR checks, fetch GitHub Actions logs for actionable failures, summarize the failures, and implement fixes.
+
+## Inputs
+
+- `repo`: path inside the repo (default `.`)
+- `pr`: PR number or URL (optional; defaults to current branch PR)
+- `gh` authentication for the repo host
+
+## Quick start
+
+- `python3 "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --pr "<number-or-url>"`
+- Add `--json` if you want machine-friendly output for summarization.
+
+## Workflow
+
+1. Verify gh authentication.
+   - Run `gh auth status` in the repo.
+   - If unauthenticated, ask the user to run `gh auth login` (ensuring repo + workflow scopes) before proceeding.
+2. Resolve the PR.
+   - Prefer the current branch PR: `gh pr view --json number,url`.
+   - If the user provides a PR number or URL, use that directly.
+3. Inspect failing checks (GitHub Actions only).
+   - Preferred: run the bundled script (handles gh field drift and job-log fallbacks):
+     - `python3 "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --pr "<number-or-url>"`
+     - Add `--json` for machine-friendly output.
+   - Manual fallback:
+     - `gh pr checks <pr> --json name,state,bucket,link,startedAt,completedAt,workflow`
+       - If a field is rejected, rerun with the available fields reported by `gh`.
+     - For each failing check, extract the run id from `detailsUrl` and run:
+       - `gh run view <run_id> --json name,workflowName,conclusion,status,url,event,headBranch,headSha`
+       - `gh run view <run_id> --log`
+     - If the run log says it is still in progress, fetch job logs directly:
+       - `gh api "/repos/<owner>/<repo>/actions/jobs/<job_id>/logs" > "<path>"`
+4. Scope non-GitHub Actions checks.
+   - If `detailsUrl` is not a GitHub Actions run, label it as external and only report the URL.
+   - Do not attempt Buildkite or other providers; keep the workflow lean.
+5. Summarize failures.
+   - Provide the failing check name, run URL (if any), and a concise log snippet.
+   - Call out missing logs explicitly.
+6. Create a plan.
+   - Use the `create-plan` skill to draft a concise plan.
+7. Implement plan.
+   - Apply the plan, summarize diffs/tests, commit and push changes.
+8. Recheck status.
+   - After changes, re-run the relevant tests and `gh pr checks` to confirm.
+   - If new or existing failures remain, repeat the workflow until CI passes
+9. Summarize outcome.
+   - Once CI checks pass, summarize the fix and confirm with the user before merging or proceeding to the next steps in their workflow.
+
+## Bundled Resources
+
+### <path-to-skill>/scripts/inspect_pr_checks.py
+
+Fetch failing PR checks, pull GitHub Actions logs, and extract a failure snippet. Exits non-zero when failures remain so it can be used in automation.
+
+Usage examples:
+
+- `python3 "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --pr "123"`
+- `python3 "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --pr "https://github.com/org/repo/pull/123" --json`
+- `python3 "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --max-lines 200 --context 40`

--- a/.agents/skills/sym-fix-ci/scripts/inspect_pr_checks.py
+++ b/.agents/skills/sym-fix-ci/scripts/inspect_pr_checks.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from shutil import which
+from typing import Any, Iterable, Sequence
+
+FAILURE_CONCLUSIONS = {
+    "failure",
+    "cancelled",
+    "timed_out",
+    "action_required",
+}
+
+FAILURE_STATES = {
+    "failure",
+    "error",
+    "cancelled",
+    "timed_out",
+    "action_required",
+}
+
+FAILURE_BUCKETS = {"fail"}
+
+FAILURE_MARKERS = (
+    "error",
+    "fail",
+    "failed",
+    "traceback",
+    "exception",
+    "assert",
+    "panic",
+    "fatal",
+    "timeout",
+    "segmentation fault",
+)
+
+DEFAULT_MAX_LINES = 160
+DEFAULT_CONTEXT_LINES = 30
+PENDING_LOG_MARKERS = (
+    "still in progress",
+    "log will be available when it is complete",
+)
+
+
+class GhResult:
+    def __init__(self, returncode: int, stdout: str, stderr: str):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def run_gh_command(args: Sequence[str], cwd: Path) -> GhResult:
+    process = subprocess.run(
+        ["gh", *args],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+    )
+    return GhResult(process.returncode, process.stdout, process.stderr)
+
+
+def run_gh_command_raw(args: Sequence[str], cwd: Path) -> tuple[int, bytes, str]:
+    process = subprocess.run(
+        ["gh", *args],
+        cwd=cwd,
+        capture_output=True,
+    )
+    stderr = process.stderr.decode(errors="replace")
+    return process.returncode, process.stdout, stderr
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect failing GitHub PR checks, fetch GitHub Actions logs, and extract a "
+            "failure snippet."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--repo", default=".", help="Path inside the target Git repository.")
+    parser.add_argument(
+        "--pr", default=None, help="PR number or URL (defaults to current branch PR)."
+    )
+    parser.add_argument("--max-lines", type=int, default=DEFAULT_MAX_LINES)
+    parser.add_argument("--context", type=int, default=DEFAULT_CONTEXT_LINES)
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text output.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = find_git_root(Path(args.repo))
+    if repo_root is None:
+        print("Error: not inside a Git repository.", file=sys.stderr)
+        return 1
+
+    if not ensure_gh_available(repo_root):
+        return 1
+
+    pr_value = resolve_pr(args.pr, repo_root)
+    if pr_value is None:
+        return 1
+
+    checks = fetch_checks(pr_value, repo_root)
+    if checks is None:
+        return 1
+
+    failing = [c for c in checks if is_failing(c)]
+    if not failing:
+        print(f"PR #{pr_value}: no failing checks detected.")
+        return 0
+
+    results = []
+    for check in failing:
+        results.append(
+            analyze_check(
+                check,
+                repo_root=repo_root,
+                max_lines=max(1, args.max_lines),
+                context=max(1, args.context),
+            )
+        )
+
+    if args.json:
+        print(json.dumps({"pr": pr_value, "results": results}, indent=2))
+    else:
+        render_results(pr_value, results)
+
+    return 1
+
+
+def find_git_root(start: Path) -> Path | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=start,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def ensure_gh_available(repo_root: Path) -> bool:
+    if which("gh") is None:
+        print("Error: gh is not installed or not on PATH.", file=sys.stderr)
+        return False
+    result = run_gh_command(["auth", "status"], cwd=repo_root)
+    if result.returncode == 0:
+        return True
+    message = (result.stderr or result.stdout or "").strip()
+    print(message or "Error: gh not authenticated.", file=sys.stderr)
+    return False
+
+
+def resolve_pr(pr_value: str | None, repo_root: Path) -> str | None:
+    if pr_value:
+        return pr_value
+    result = run_gh_command(["pr", "view", "--json", "number"], cwd=repo_root)
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout or "").strip()
+        print(message or "Error: unable to resolve PR.", file=sys.stderr)
+        return None
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        print("Error: unable to parse PR JSON.", file=sys.stderr)
+        return None
+    number = data.get("number")
+    if not number:
+        print("Error: no PR number found.", file=sys.stderr)
+        return None
+    return str(number)
+
+
+def fetch_checks(pr_value: str, repo_root: Path) -> list[dict[str, Any]] | None:
+    primary_fields = ["name", "state", "conclusion", "detailsUrl", "startedAt", "completedAt"]
+    result = run_gh_command(
+        ["pr", "checks", pr_value, "--json", ",".join(primary_fields)],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        message = "\n".join(filter(None, [result.stderr, result.stdout])).strip()
+        available_fields = parse_available_fields(message)
+        if available_fields:
+            fallback_fields = [
+                "name",
+                "state",
+                "bucket",
+                "link",
+                "startedAt",
+                "completedAt",
+                "workflow",
+            ]
+            selected_fields = [field for field in fallback_fields if field in available_fields]
+            if not selected_fields:
+                print("Error: no usable fields available for gh pr checks.", file=sys.stderr)
+                return None
+            result = run_gh_command(
+                ["pr", "checks", pr_value, "--json", ",".join(selected_fields)],
+                cwd=repo_root,
+            )
+            if result.returncode != 0:
+                message = (result.stderr or result.stdout or "").strip()
+                print(message or "Error: gh pr checks failed.", file=sys.stderr)
+                return None
+        else:
+            print(message or "Error: gh pr checks failed.", file=sys.stderr)
+            return None
+    try:
+        data = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        print("Error: unable to parse checks JSON.", file=sys.stderr)
+        return None
+    if not isinstance(data, list):
+        print("Error: unexpected checks JSON shape.", file=sys.stderr)
+        return None
+    return data
+
+
+def is_failing(check: dict[str, Any]) -> bool:
+    conclusion = normalize_field(check.get("conclusion"))
+    if conclusion in FAILURE_CONCLUSIONS:
+        return True
+    state = normalize_field(check.get("state") or check.get("status"))
+    if state in FAILURE_STATES:
+        return True
+    bucket = normalize_field(check.get("bucket"))
+    return bucket in FAILURE_BUCKETS
+
+
+def analyze_check(
+    check: dict[str, Any],
+    repo_root: Path,
+    max_lines: int,
+    context: int,
+) -> dict[str, Any]:
+    url = check.get("detailsUrl") or check.get("link") or ""
+    run_id = extract_run_id(url)
+    job_id = extract_job_id(url)
+    base: dict[str, Any] = {
+        "name": check.get("name", ""),
+        "detailsUrl": url,
+        "runId": run_id,
+        "jobId": job_id,
+    }
+
+    if run_id is None:
+        base["status"] = "external"
+        base["note"] = "No GitHub Actions run id detected in detailsUrl."
+        return base
+
+    metadata = fetch_run_metadata(run_id, repo_root)
+    log_text, log_error, log_status = fetch_check_log(
+        run_id=run_id,
+        job_id=job_id,
+        repo_root=repo_root,
+    )
+
+    if log_status == "pending":
+        base["status"] = "log_pending"
+        base["note"] = log_error or "Logs are not available yet."
+        if metadata:
+            base["run"] = metadata
+        return base
+
+    if log_error:
+        base["status"] = "log_unavailable"
+        base["error"] = log_error
+        if metadata:
+            base["run"] = metadata
+        return base
+
+    snippet = extract_failure_snippet(log_text, max_lines=max_lines, context=context)
+    base["status"] = "ok"
+    base["run"] = metadata or {}
+    base["logSnippet"] = snippet
+    base["logTail"] = tail_lines(log_text, max_lines)
+    return base
+
+
+def extract_run_id(url: str) -> str | None:
+    if not url:
+        return None
+    for pattern in (r"/actions/runs/(\d+)", r"/runs/(\d+)"):
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1)
+    return None
+
+
+def extract_job_id(url: str) -> str | None:
+    if not url:
+        return None
+    match = re.search(r"/actions/runs/\d+/job/(\d+)", url)
+    if match:
+        return match.group(1)
+    match = re.search(r"/job/(\d+)", url)
+    if match:
+        return match.group(1)
+    return None
+
+
+def fetch_run_metadata(run_id: str, repo_root: Path) -> dict[str, Any] | None:
+    fields = [
+        "conclusion",
+        "status",
+        "workflowName",
+        "name",
+        "event",
+        "headBranch",
+        "headSha",
+        "url",
+    ]
+    result = run_gh_command(["run", "view", run_id, "--json", ",".join(fields)], cwd=repo_root)
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def fetch_check_log(
+    run_id: str,
+    job_id: str | None,
+    repo_root: Path,
+) -> tuple[str, str, str]:
+    log_text, log_error = fetch_run_log(run_id, repo_root)
+    if not log_error:
+        return log_text, "", "ok"
+
+    if is_log_pending_message(log_error) and job_id:
+        job_log, job_error = fetch_job_log(job_id, repo_root)
+        if job_log:
+            return job_log, "", "ok"
+        if job_error and is_log_pending_message(job_error):
+            return "", job_error, "pending"
+        if job_error:
+            return "", job_error, "error"
+        return "", log_error, "pending"
+
+    if is_log_pending_message(log_error):
+        return "", log_error, "pending"
+
+    return "", log_error, "error"
+
+
+def fetch_run_log(run_id: str, repo_root: Path) -> tuple[str, str]:
+    result = run_gh_command(["run", "view", run_id, "--log"], cwd=repo_root)
+    if result.returncode != 0:
+        error = (result.stderr or result.stdout or "").strip()
+        return "", error or "gh run view failed"
+    return result.stdout, ""
+
+
+def fetch_job_log(job_id: str, repo_root: Path) -> tuple[str, str]:
+    repo_slug = fetch_repo_slug(repo_root)
+    if not repo_slug:
+        return "", "Error: unable to resolve repository name for job logs."
+    endpoint = f"/repos/{repo_slug}/actions/jobs/{job_id}/logs"
+    returncode, stdout_bytes, stderr = run_gh_command_raw(["api", endpoint], cwd=repo_root)
+    if returncode != 0:
+        message = (stderr or stdout_bytes.decode(errors="replace")).strip()
+        return "", message or "gh api job logs failed"
+    if is_zip_payload(stdout_bytes):
+        return "", "Job logs returned a zip archive; unable to parse."
+    return stdout_bytes.decode(errors="replace"), ""
+
+
+def fetch_repo_slug(repo_root: Path) -> str | None:
+    result = run_gh_command(["repo", "view", "--json", "nameWithOwner"], cwd=repo_root)
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    name_with_owner = data.get("nameWithOwner")
+    if not name_with_owner:
+        return None
+    return str(name_with_owner)
+
+
+def normalize_field(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
+def parse_available_fields(message: str) -> list[str]:
+    if "Available fields:" not in message:
+        return []
+    fields: list[str] = []
+    collecting = False
+    for line in message.splitlines():
+        if "Available fields:" in line:
+            collecting = True
+            continue
+        if not collecting:
+            continue
+        field = line.strip()
+        if not field:
+            continue
+        fields.append(field)
+    return fields
+
+
+def is_log_pending_message(message: str) -> bool:
+    lowered = message.lower()
+    return any(marker in lowered for marker in PENDING_LOG_MARKERS)
+
+
+def is_zip_payload(payload: bytes) -> bool:
+    return payload.startswith(b"PK")
+
+
+def extract_failure_snippet(log_text: str, max_lines: int, context: int) -> str:
+    lines = log_text.splitlines()
+    if not lines:
+        return ""
+
+    marker_index = find_failure_index(lines)
+    if marker_index is None:
+        return "\n".join(lines[-max_lines:])
+
+    start = max(0, marker_index - context)
+    end = min(len(lines), marker_index + context)
+    window = lines[start:end]
+    if len(window) > max_lines:
+        window = window[-max_lines:]
+    return "\n".join(window)
+
+
+def find_failure_index(lines: Sequence[str]) -> int | None:
+    for idx in range(len(lines) - 1, -1, -1):
+        lowered = lines[idx].lower()
+        if any(marker in lowered for marker in FAILURE_MARKERS):
+            return idx
+    return None
+
+
+def tail_lines(text: str, max_lines: int) -> str:
+    if max_lines <= 0:
+        return ""
+    lines = text.splitlines()
+    return "\n".join(lines[-max_lines:])
+
+
+def render_results(pr_number: str, results: Iterable[dict[str, Any]]) -> None:
+    results_list = list(results)
+    print(f"PR #{pr_number}: {len(results_list)} failing checks analyzed.")
+    for result in results_list:
+        print("-" * 60)
+        print(f"Check: {result.get('name', '')}")
+        if result.get("detailsUrl"):
+            print(f"Details: {result['detailsUrl']}")
+        run_id = result.get("runId")
+        if run_id:
+            print(f"Run ID: {run_id}")
+        job_id = result.get("jobId")
+        if job_id:
+            print(f"Job ID: {job_id}")
+        status = result.get("status", "unknown")
+        print(f"Status: {status}")
+
+        run_meta = result.get("run", {})
+        if run_meta:
+            branch = run_meta.get("headBranch", "")
+            sha = (run_meta.get("headSha") or "")[:12]
+            workflow = run_meta.get("workflowName") or run_meta.get("name") or ""
+            conclusion = run_meta.get("conclusion") or run_meta.get("status") or ""
+            print(f"Workflow: {workflow} ({conclusion})")
+            if branch or sha:
+                print(f"Branch/SHA: {branch} {sha}")
+            if run_meta.get("url"):
+                print(f"Run URL: {run_meta['url']}")
+
+        if result.get("note"):
+            print(f"Note: {result['note']}")
+
+        if result.get("error"):
+            print(f"Error fetching logs: {result['error']}")
+            continue
+
+        snippet = result.get("logSnippet") or ""
+        if snippet:
+            print("Failure snippet:")
+            print(indent_block(snippet, prefix="  "))
+        else:
+            print("No snippet available.")
+    print("-" * 60)
+
+
+def indent_block(text: str, prefix: str = "  ") -> str:
+    return "\n".join(f"{prefix}{line}" for line in text.splitlines())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/sym-fix-ci/scripts/inspect_pr_checks.py
+++ b/.agents/skills/sym-fix-ci/scripts/inspect_pr_checks.py
@@ -113,7 +113,10 @@ def main() -> int:
 
     failing = [c for c in checks if is_failing(c)]
     if not failing:
-        print(f"PR #{pr_value}: no failing checks detected.")
+        if args.json:
+            print(json.dumps({"pr": pr_value, "results": []}, indent=2))
+        else:
+            print(f"PR #{pr_value}: no failing checks detected.")
         return 0
 
     results = []
@@ -136,9 +139,16 @@ def main() -> int:
 
 
 def find_git_root(start: Path) -> Path | None:
+    resolved = start.resolve()
+    if not resolved.exists():
+        return None
+    cwd = resolved if resolved.is_dir() else resolved.parent
+    if not cwd.exists() or not cwd.is_dir():
+        return None
+
     result = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
-        cwd=start,
+        cwd=cwd,
         text=True,
         capture_output=True,
     )
@@ -434,7 +444,7 @@ def extract_failure_snippet(log_text: str, max_lines: int, context: int) -> str:
         return "\n".join(lines[-max_lines:])
 
     start = max(0, marker_index - context)
-    end = min(len(lines), marker_index + context)
+    end = min(len(lines), marker_index + context + 1)
     window = lines[start:end]
     if len(window) > max_lines:
         window = window[-max_lines:]

--- a/.agents/skills/sym-land/SKILL.md
+++ b/.agents/skills/sym-land/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: sym-land
+description:
+  Land a PR by monitoring conflicts, resolving them, waiting for checks, and
+  squash-merging when green; use when asked to land, merge, or shepherd a PR to
+  completion.
+---
+
+# Land
+
+## Goals
+
+- Ensure the PR is conflict-free with the configured base branch (default:
+  `main`).
+- Keep CI green and fix failures when they occur.
+- Squash-merge the PR once checks pass.
+- Do not yield to the user until the PR is merged; keep the watcher loop running
+  unless blocked.
+- No need to delete remote branches after merge; the repo auto-deletes head
+  branches.
+
+## Preconditions
+
+- `gh` CLI is authenticated.
+- You are on the PR branch with a clean working tree.
+
+## Steps
+
+1. Locate the PR for the current branch.
+2. Confirm the full gauntlet is green locally before any push.
+3. If the working tree has uncommitted changes, commit with the `commit` skill
+   and push with the `push` skill before proceeding.
+4. Determine the target base branch from task context (for Symphony workflows,
+   use `workspace.base_branch`; otherwise default to `main`), then check
+   mergeability/conflicts against that base branch.
+5. If conflicts exist, use the `pull` skill to fetch/merge
+   `origin/<base-branch>` and resolve conflicts, then use the `push` skill to
+   publish the updated branch.
+6. Ensure Codex review comments (if present) are acknowledged and any required
+   fixes are handled before merging.
+7. Watch checks until complete.
+8. If checks fail, pull logs, fix the issue, commit with the `commit` skill,
+   push with the `push` skill, and re-run checks.
+9. When all checks are green and review feedback is addressed, squash-merge and
+   delete the branch using the PR title/body for the merge subject/body.
+10. **Context guard:** Before implementing review feedback, confirm it does not
+    conflict with the user’s stated intent or task context. If it conflicts,
+    respond inline with a justification and ask the user before changing code.
+11. **Pushback template:** When disagreeing, reply inline with: acknowledge +
+    rationale + offer alternative.
+12. **Ambiguity gate:** When ambiguity blocks progress, use the clarification
+    flow (assign PR to current GH user, mention them, wait for response). Do not
+    implement until ambiguity is resolved.
+    - If you are confident you know better than the reviewer, you may proceed
+      without asking the user, but reply inline with your rationale.
+13. **Per-comment mode:** For each review comment, choose one of: accept,
+    clarify, or push back. Reply inline (or in the issue thread for Codex
+    reviews) stating the mode before changing code.
+14. **Reply before change:** Always respond with intended action before pushing
+    code changes (inline for review comments, issue thread for Codex reviews).
+
+## Commands
+
+```
+# Ensure branch and PR context
+branch=$(git branch --show-current)
+base_branch="${BASE_BRANCH:-main}"
+pr_number=$(gh pr view --json number -q .number)
+pr_title=$(gh pr view --json title -q .title)
+pr_body=$(gh pr view --json body -q .body)
+
+# Check mergeability and conflicts
+mergeable=$(gh pr view --json mergeable -q .mergeable)
+
+if [ "$mergeable" = "CONFLICTING" ]; then
+  # Run the `pull` skill to handle fetch + merge + conflict resolution.
+  # Then run the `push` skill to publish the updated branch.
+fi
+
+# Preferred: use the Async Watch Helper below. The manual loop is a fallback
+# when Python cannot run or the helper script is unavailable.
+# Wait for review feedback: Codex reviews arrive as issue comments that start
+# with "## Codex Review — <persona>". Treat them like reviewer feedback: reply
+# with a `[codex]` issue comment acknowledging the findings and whether you're
+# addressing or deferring them.
+while true; do
+  gh api repos/{owner}/{repo}/issues/"$pr_number"/comments \
+    --jq '.[] | select(.body | startswith("## Codex Review")) | .id' | rg -q '.' \
+    && break
+  sleep 10
+done
+
+# Watch checks
+if ! gh pr checks --watch; then
+  gh pr checks
+  # Identify failing run and inspect logs
+  # gh run list --branch "$branch"
+  # gh run view <run-id> --log
+  exit 1
+fi
+
+# Squash-merge (remote branches auto-delete on merge in this repo)
+gh pr merge --squash --subject "$pr_title" --body "$pr_body"
+```
+
+## Async Watch Helper
+
+Preferred: use the asyncio watcher to monitor review comments, CI, and head
+updates in parallel:
+
+```
+python3 .agents/skills/sym-land/land_watch.py
+```
+
+Exit codes:
+
+- 2: Review comments detected (address feedback)
+- 3: CI checks failed
+- 4: PR head updated (autofix commit detected)
+
+## Failure Handling
+
+- If checks fail, pull details with `gh pr checks` and `gh run view --log`, then
+  fix locally, commit with the `commit` skill, push with the `push` skill, and
+  re-run the watch.
+- Use judgment to identify flaky failures. If a failure is a flake (e.g., a
+  timeout on only one platform), you may proceed without fixing it.
+- If CI pushes an auto-fix commit (authored by GitHub Actions), it does not
+  trigger a fresh CI run. Detect the updated PR head, pull locally, merge
+  `origin/<base-branch>` if needed, add a real author commit, and force-push to
+  retrigger CI, then restart the checks loop.
+- If all jobs fail with corrupted pnpm lockfile errors on the merge commit, the
+  remediation is to fetch latest `origin/<base-branch>`, merge, force-push, and
+  rerun CI.
+- If mergeability is `UNKNOWN`, wait and re-check.
+- Do not merge while review comments (human or Codex review) are outstanding.
+- Codex review jobs retry on failure and are non-blocking; use the presence of
+  `## Codex Review — <persona>` issue comments (not job status) as the signal
+  that review feedback is available.
+- Do not enable auto-merge; this repo has no required checks so auto-merge can
+  skip tests.
+- If the remote PR branch advanced due to your own prior force-push or merge,
+  avoid redundant merges; re-run the formatter locally if needed and
+  `git push --force-with-lease`.
+
+## Review Handling
+
+- Codex reviews now arrive as issue comments posted by GitHub Actions. They
+  start with `## Codex Review — <persona>` and include the reviewer’s
+  methodology + guardrails used. Treat these as feedback that must be
+  acknowledged before merge.
+- Human review comments are blocking and must be addressed (responded to and
+  resolved) before requesting a new review or merging.
+- If multiple reviewers comment in the same thread, respond to each comment
+  (batching is fine) before closing the thread.
+- Fetch review comments via `gh api` and reply with a prefixed comment.
+- Use review comment endpoints (not issue comments) to find inline feedback:
+  - List PR review comments:
+    ```
+    gh api repos/{owner}/{repo}/pulls/<pr_number>/comments
+    ```
+  - PR issue comments (top-level discussion):
+    ```
+    gh api repos/{owner}/{repo}/issues/<pr_number>/comments
+    ```
+  - Reply to a specific review comment:
+    ```
+    gh api -X POST /repos/{owner}/{repo}/pulls/<pr_number>/comments \
+      -f body='[codex] <response>' -F in_reply_to=<comment_id>
+    ```
+- `in_reply_to` must be the numeric review comment id (e.g., `2710521800`), not
+  the GraphQL node id (e.g., `PRRC_...`), and the endpoint must include the PR
+  number (`/pulls/<pr_number>/comments`).
+- If GraphQL review reply mutation is forbidden, use REST.
+- A 404 on reply typically means the wrong endpoint (missing PR number) or
+  insufficient scope; verify by listing comments first.
+- All GitHub comments generated by this agent must be prefixed with `[codex]`.
+- For Codex review issue comments, reply in the issue thread (not a review
+  thread) with `[codex]` and state whether you will address the feedback now or
+  defer it (include rationale).
+- If feedback requires changes:
+  - For inline review comments (human), reply with intended fixes
+    (`[codex] ...`) **as an inline reply to the original review comment** using
+    the review comment endpoint and `in_reply_to` (do not use issue comments for
+    this).
+  - Implement fixes, commit, push.
+  - Reply with the fix details and commit sha (`[codex] ...`) in the same place
+    you acknowledged the feedback (issue comment for Codex reviews, inline reply
+    for review comments).
+  - The land watcher treats Codex review issue comments as unresolved until a
+    newer `[codex]` issue comment is posted acknowledging the findings.
+- Only request a new Codex review when you need a rerun (e.g., after new
+  commits). Do not request one without changes since the last review.
+  - Before requesting a new Codex review, re-run the land watcher and ensure
+    there are zero outstanding review comments (all have `[codex]` inline
+    replies).
+  - After pushing new commits, the Codex review workflow will rerun on PR
+    synchronization (or you can re-run the workflow manually). Post a concise
+    root-level summary comment so reviewers have the latest delta:
+    ```
+    [codex] Changes since last review:
+    - <short bullets of deltas>
+    Commits: <sha>, <sha>
+    Tests: <commands run>
+    ```
+  - Only request a new review if there is at least one new commit since the
+    previous request.
+  - Wait for the next Codex review comment before merging.
+
+## Scope + PR Metadata
+
+- The PR title and description should reflect the full scope of the change, not
+  just the most recent fix.
+- If review feedback expands scope, decide whether to include it now or defer
+  it. You can accept, defer, or decline feedback. If deferring or declining,
+  call it out in the root-level `[codex]` update with a brief reason (e.g.,
+  out-of-scope, conflicts with intent, unnecessary).
+- Correctness issues raised in review comments should be addressed. If you plan
+  to defer or decline a correctness concern, validate first and explain why the
+  concern does not apply.
+- Classify each review comment as one of: correctness, design, style,
+  clarification, scope.
+- For correctness feedback, provide concrete validation (test, log, or
+  reasoning) before closing it.
+- When accepting feedback, include a one-line rationale in the root-level
+  update.
+- When declining feedback, offer a brief alternative or follow-up trigger.
+- Prefer a single consolidated "review addressed" root-level comment after a
+  batch of fixes instead of many small updates.
+- For doc feedback, confirm the doc change matches behavior (no doc-only edits
+  to appease review).

--- a/.agents/skills/sym-land/SKILL.md
+++ b/.agents/skills/sym-land/SKILL.md
@@ -117,6 +117,7 @@ Exit codes:
 - 2: Review comments detected (address feedback)
 - 3: CI checks failed
 - 4: PR head updated (autofix commit detected)
+- 5: Merge conflicts detected (`is_merge_conflicting` path in `watch_pr`/head monitor) — resolve/rebase against `main` and push
 
 ## Failure Handling
 

--- a/.agents/skills/sym-land/land_watch.py
+++ b/.agents/skills/sym-land/land_watch.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import random
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+POLL_SECONDS = 10
+CHECKS_APPEAR_TIMEOUT_SECONDS = 120
+CODEX_BOTS = {
+    "chatgpt-codex-connector[bot]",
+    "github-actions[bot]",
+    "codex-gc-app[bot]",
+    "app/codex-gc-app",
+}
+MAX_GH_RETRIES = 5
+BASE_GH_BACKOFF_SECONDS = 2
+
+
+@dataclass
+class PrInfo:
+    number: int
+    url: str
+    head_sha: str
+    mergeable: str | None
+    merge_state: str | None
+
+
+class RateLimitError(RuntimeError):
+    pass
+
+
+def is_rate_limit_error(error: str) -> bool:
+    return "HTTP 429" in error or "rate limit" in error.lower()
+
+
+async def run_gh(*args: str) -> str:
+    max_delay = BASE_GH_BACKOFF_SECONDS * (2 ** (MAX_GH_RETRIES - 1))
+    delay_seconds = BASE_GH_BACKOFF_SECONDS
+    last_error = "gh command failed"
+    for attempt in range(1, MAX_GH_RETRIES + 1):
+        proc = await asyncio.create_subprocess_exec(
+            "gh",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode == 0:
+            return stdout.decode()
+        error = stderr.decode().strip() or "gh command failed"
+        if not is_rate_limit_error(error):
+            raise RuntimeError(error)
+        last_error = error
+        if attempt >= MAX_GH_RETRIES:
+            break
+        jitter = random.uniform(0, delay_seconds)
+        await asyncio.sleep(min(delay_seconds + jitter, max_delay))
+        delay_seconds = min(delay_seconds * 2, max_delay)
+    raise RateLimitError(last_error)
+
+
+async def get_pr_info() -> PrInfo:
+    data = await run_gh(
+        "pr",
+        "view",
+        "--json",
+        "number,url,headRefOid,mergeable,mergeStateStatus",
+    )
+    parsed = json.loads(data)
+    return PrInfo(
+        number=parsed["number"],
+        url=parsed["url"],
+        head_sha=parsed["headRefOid"],
+        mergeable=parsed.get("mergeable"),
+        merge_state=parsed.get("mergeStateStatus"),
+    )
+
+
+async def get_paginated_list(endpoint: str) -> list[dict[str, Any]]:
+    page = 1
+    items: list[dict[str, Any]] = []
+    while True:
+        data = await run_gh(
+            "api",
+            "--method",
+            "GET",
+            endpoint,
+            "-f",
+            "per_page=100",
+            "-f",
+            f"page={page}",
+        )
+        batch = json.loads(data)
+        if not batch:
+            break
+        items.extend(batch)
+        page += 1
+    return items
+
+
+async def get_issue_comments(pr_number: int) -> list[dict[str, Any]]:
+    return await get_paginated_list(
+        f"repos/{{owner}}/{{repo}}/issues/{pr_number}/comments",
+    )
+
+
+async def get_review_comments(pr_number: int) -> list[dict[str, Any]]:
+    return await get_paginated_list(
+        f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/comments",
+    )
+
+
+async def get_reviews(pr_number: int) -> list[dict[str, Any]]:
+    page = 1
+    reviews: list[dict[str, Any]] = []
+    while True:
+        data = await run_gh(
+            "api",
+            "--method",
+            "GET",
+            f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/reviews",
+            "-f",
+            "per_page=100",
+            "-f",
+            f"page={page}",
+        )
+        batch = json.loads(data)
+        if not batch:
+            break
+        reviews.extend(batch)
+        page += 1
+    return reviews
+
+
+async def get_check_runs(head_sha: str) -> list[dict[str, Any]]:
+    page = 1
+    check_runs: list[dict[str, Any]] = []
+    while True:
+        data = await run_gh(
+            "api",
+            "--method",
+            "GET",
+            f"repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs",
+            "-f",
+            "per_page=100",
+            "-f",
+            f"page={page}",
+        )
+        payload = json.loads(data)
+        batch = payload.get("check_runs", [])
+        if not batch:
+            break
+        check_runs.extend(batch)
+        total_count = payload.get("total_count")
+        if total_count is not None and len(check_runs) >= total_count:
+            break
+        page += 1
+    return check_runs
+
+
+def parse_time(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized)
+
+
+CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def sanitize_terminal_output(value: str) -> str:
+    return CONTROL_CHARS_RE.sub("", value)
+
+
+def check_timestamp(check: dict[str, Any]) -> datetime | None:
+    for key in ("completed_at", "started_at", "run_started_at", "created_at"):
+        value = check.get(key)
+        if value:
+            return parse_time(value)
+    return None
+
+
+def dedupe_check_runs(check_runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_name: dict[str, dict[str, Any]] = {}
+    for check in check_runs:
+        name = check.get("name", "unknown")
+        timestamp = check_timestamp(check)
+        if name not in latest_by_name:
+            latest_by_name[name] = check
+            continue
+        existing = latest_by_name[name]
+        existing_timestamp = check_timestamp(existing)
+        if timestamp is None:
+            continue
+        if existing_timestamp is None or timestamp > existing_timestamp:
+            latest_by_name[name] = check
+    return list(latest_by_name.values())
+
+
+def summarize_checks(check_runs: list[dict[str, Any]]) -> tuple[bool, bool, list[str]]:
+    if not check_runs:
+        return True, False, ["no checks reported"]
+    check_runs = dedupe_check_runs(check_runs)
+    pending = False
+    failed = False
+    failures: list[str] = []
+    for check in check_runs:
+        status = check.get("status")
+        conclusion = check.get("conclusion")
+        name = check.get("name", "unknown")
+        if status != "completed":
+            pending = True
+            continue
+        if conclusion not in ("success", "skipped", "neutral"):
+            failed = True
+            failures.append(f"{name}: {conclusion}")
+    return pending, failed, failures
+
+
+def latest_review_request_at(comments: list[dict[str, Any]]) -> datetime | None:
+    latest: datetime | None = None
+    for comment in comments:
+        if is_codex_bot_user(comment.get("user", {})):
+            continue
+        body = comment.get("body") or ""
+        if "@codex review" not in body:
+            continue
+        timestamp = comment_time(comment)
+        if timestamp is None:
+            continue
+        if latest is None or timestamp > latest:
+            latest = timestamp
+    return latest
+
+
+def filter_codex_comments(
+    comments: list[dict[str, Any]],
+    review_requested_at: datetime | None,
+) -> list[dict[str, Any]]:
+    latest_codex_reply = latest_codex_reply_by_thread(comments)
+    latest_issue_ack = latest_codex_issue_reply_time(comments)
+    codex_comments = [c for c in comments if is_codex_bot_user(c.get("user", {}))]
+    filtered: list[dict[str, Any]] = []
+    for comment in codex_comments:
+        created_time = comment_time(comment)
+        if created_time is None:
+            continue
+        if review_requested_at is not None and created_time <= review_requested_at:
+            continue
+        is_threaded = bool(
+            comment.get("in_reply_to_id") or comment.get("pull_request_review_id")
+        )
+        if not is_threaded:
+            if latest_issue_ack is not None and created_time <= latest_issue_ack:
+                continue
+        else:
+            thread_root = thread_root_id(comment)
+            last_reply = None
+            if thread_root is not None:
+                last_reply = latest_codex_reply.get(thread_root)
+            if last_reply and last_reply > created_time:
+                continue
+        filtered.append(comment)
+    return filtered
+
+
+def is_codex_bot_user(user: dict[str, Any]) -> bool:
+    login = user.get("login") or ""
+    return login in CODEX_BOTS
+
+
+def is_bot_user(user: dict[str, Any]) -> bool:
+    login = user.get("login") or ""
+    if is_codex_bot_user(user):
+        return True
+    if user.get("type") == "Bot":
+        return True
+    return login.endswith("[bot]")
+
+
+def is_codex_reply_body(body: str) -> bool:
+    return body.startswith("[codex]")
+
+
+def is_codex_review_body(body: str) -> bool:
+    return body.startswith("## Codex Review")
+
+
+def latest_codex_issue_reply_time(
+    comments: list[dict[str, Any]],
+) -> datetime | None:
+    latest: datetime | None = None
+    for comment in comments:
+        body = (comment.get("body") or "").strip()
+        if not is_codex_reply_body(body):
+            continue
+        created_time = comment_time(comment)
+        if created_time is None:
+            continue
+        if latest is None or created_time > latest:
+            latest = created_time
+    return latest
+
+
+def filter_human_issue_comments(comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_ack = latest_codex_issue_reply_time(comments)
+    filtered: list[dict[str, Any]] = []
+    for comment in comments:
+        if is_bot_user(comment.get("user", {})):
+            continue
+        body = (comment.get("body") or "").strip()
+        if is_codex_reply_body(body):
+            continue
+        if is_codex_review_body(body):
+            continue
+        if "@codex review" in body:
+            continue
+        created_time = comment_time(comment)
+        if (
+            latest_ack is not None
+            and created_time is not None
+            and created_time <= latest_ack
+        ):
+            continue
+        filtered.append(comment)
+    return filtered
+
+
+def filter_codex_review_issue_comments(
+    comments: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    latest_ack = latest_codex_issue_reply_time(comments)
+    filtered: list[dict[str, Any]] = []
+    for comment in comments:
+        body = (comment.get("body") or "").strip()
+        if not is_codex_review_body(body):
+            continue
+        created_time = comment_time(comment)
+        if (
+            latest_ack is not None
+            and created_time is not None
+            and created_time <= latest_ack
+        ):
+            continue
+        filtered.append(comment)
+    return filtered
+
+
+def thread_root_id(comment: dict[str, Any]) -> int | None:
+    return comment.get("in_reply_to_id") or comment.get("id")
+
+
+def comment_time(comment: dict[str, Any]) -> datetime | None:
+    timestamp = comment.get("updated_at") or comment.get("created_at")
+    if not timestamp:
+        return None
+    return parse_time(timestamp)
+
+
+def latest_codex_reply_by_thread(
+    comments: list[dict[str, Any]],
+) -> dict[int, datetime]:
+    latest: dict[int, datetime] = {}
+    for comment in comments:
+        body = (comment.get("body") or "").strip()
+        if not is_codex_reply_body(body):
+            continue
+        thread_root = thread_root_id(comment)
+        created_time = comment_time(comment)
+        if thread_root is None or created_time is None:
+            continue
+        existing = latest.get(thread_root)
+        if existing is None or created_time > existing:
+            latest[thread_root] = created_time
+    return latest
+
+
+def filter_human_review_comments(
+    comments: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    latest_codex_reply = latest_codex_reply_by_thread(comments)
+    filtered: list[dict[str, Any]] = []
+    for comment in comments:
+        if is_bot_user(comment.get("user", {})):
+            continue
+        body = (comment.get("body") or "").strip()
+        if is_codex_reply_body(body):
+            continue
+        thread_root = thread_root_id(comment)
+        created_time = comment_time(comment)
+        last_codex_reply = None
+        if thread_root is not None:
+            last_codex_reply = latest_codex_reply.get(thread_root)
+        if last_codex_reply and created_time and created_time <= last_codex_reply:
+            continue
+        filtered.append(comment)
+    return filtered
+
+
+def is_blocking_review(
+    review: dict[str, Any],
+    review_requested_at: datetime | None,
+) -> bool:
+    created_at = review.get("submitted_at") or review.get("created_at")
+    if not created_at:
+        return False
+    user_login = review.get("user", {}).get("login")
+    created_time = parse_time(created_at)
+    if (
+        user_login in CODEX_BOTS
+        and review_requested_at is not None
+        and created_time <= review_requested_at
+    ):
+        return False
+    body = (review.get("body") or "").strip()
+    state = review.get("state")
+    if user_login in CODEX_BOTS:
+        return state == "CHANGES_REQUESTED"
+    if body.startswith("[codex]") or state in ("APPROVED", "DISMISSED"):
+        return False
+    blocking = False
+    if body or state == "CHANGES_REQUESTED":
+        blocking = True
+    elif state == "COMMENTED":
+        blocking = False
+    elif state:
+        blocking = state not in ("APPROVED", "DISMISSED")
+    return blocking
+
+
+def review_timestamp(review: dict[str, Any]) -> datetime | None:
+    created_at = review.get("submitted_at") or review.get("created_at")
+    if not created_at:
+        return None
+    return parse_time(created_at)
+
+
+def dedupe_reviews(reviews: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_user: dict[str, dict[str, Any]] = {}
+    for review in reviews:
+        user_login = review.get("user", {}).get("login")
+        if not user_login:
+            continue
+        timestamp = review_timestamp(review)
+        if user_login not in latest_by_user:
+            latest_by_user[user_login] = review
+            continue
+        existing = latest_by_user[user_login]
+        existing_timestamp = review_timestamp(existing)
+        if timestamp is None:
+            continue
+        if existing_timestamp is None or timestamp > existing_timestamp:
+            latest_by_user[user_login] = review
+    return list(latest_by_user.values())
+
+
+def filter_blocking_reviews(
+    reviews: list[dict[str, Any]],
+    review_requested_at: datetime | None,
+) -> list[dict[str, Any]]:
+    return [
+        review
+        for review in dedupe_reviews(reviews)
+        if is_blocking_review(review, review_requested_at)
+    ]
+
+
+def is_merge_conflicting(pr: PrInfo) -> bool:
+    return pr.mergeable == "CONFLICTING" or pr.merge_state == "DIRTY"
+
+
+async def fetch_review_context(
+    pr_number: int,
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    datetime | None,
+]:
+    issue_comments = await get_issue_comments(pr_number)
+    review_request_at = latest_review_request_at(issue_comments)
+    review_comments = await get_review_comments(pr_number)
+    reviews = await get_reviews(pr_number)
+    return issue_comments, review_comments, reviews, review_request_at
+
+
+def raise_on_human_feedback(
+    issue_comments: list[dict[str, Any]],
+    review_comments: list[dict[str, Any]],
+    reviews: list[dict[str, Any]],
+    review_request_at: datetime | None,
+) -> None:
+    human_issue_comments = filter_human_issue_comments(issue_comments)
+    codex_review_comments = filter_codex_review_issue_comments(issue_comments)
+    human_review_comments = filter_human_review_comments(review_comments)
+    if human_issue_comments or human_review_comments or codex_review_comments:
+        print("Review comments detected. Address before merge.")
+        print(
+            "Reminder: decide whether feedback stays in scope; defer if needed "
+            "and note in your root-level update.",
+        )
+        raise SystemExit(2)
+    blocking_reviews = filter_blocking_reviews(reviews, review_request_at)
+    if blocking_reviews:
+        print("Review states/comments detected. Address before merge.")
+        print(
+            "Reminder: keep PR title/description aligned with the full scope "
+            "when changes expand.",
+        )
+        raise SystemExit(2)
+
+
+async def wait_for_codex(pr_number: int, checks_done: asyncio.Event) -> None:
+    print("Waiting for review feedback...", flush=True)
+    while True:
+        (
+            issue_comments,
+            review_comments,
+            reviews,
+            review_request_at,
+        ) = await fetch_review_context(pr_number)
+        bot_issue_comments = filter_codex_comments(issue_comments, review_request_at)
+        bot_review_comments = filter_codex_comments(review_comments, review_request_at)
+        bot_comments = bot_issue_comments + bot_review_comments
+        raise_on_human_feedback(
+            issue_comments,
+            review_comments,
+            reviews,
+            review_request_at,
+        )
+        if bot_comments:
+            latest = max(
+                bot_comments,
+                key=lambda comment: parse_time(comment["created_at"]),
+            )
+            body = sanitize_terminal_output(latest.get("body") or "").strip()
+            if body:
+                print("Codex left comments. Address feedback before merge.")
+                print(body)
+                raise SystemExit(2)
+        if checks_done.is_set():
+            return
+        await asyncio.sleep(POLL_SECONDS)
+
+
+async def wait_for_checks(head_sha: str, checks_done: asyncio.Event) -> None:
+    print("Waiting for CI checks...", flush=True)
+    empty_seconds = 0
+    while True:
+        check_runs = await get_check_runs(head_sha)
+        if not check_runs:
+            empty_seconds += POLL_SECONDS
+            if empty_seconds >= CHECKS_APPEAR_TIMEOUT_SECONDS:
+                print(
+                    "No checks detected after 120s; check CI configuration",
+                )
+                raise SystemExit(3)
+            await asyncio.sleep(POLL_SECONDS)
+            continue
+        empty_seconds = 0
+        pending, failed, failures = summarize_checks(check_runs)
+        if failed:
+            print("Checks failed:")
+            for failure in failures:
+                print(f"- {failure}")
+            raise SystemExit(3)
+        if not pending:
+            print("Checks passed")
+            checks_done.set()
+            return
+        await asyncio.sleep(POLL_SECONDS)
+
+
+async def watch_pr() -> None:
+    pr = await get_pr_info()
+    if is_merge_conflicting(pr):
+        print(
+            "PR has merge conflicts. Resolve/rebase against main and push before "
+            "running land_watch again.",
+        )
+        raise SystemExit(5)
+    head_sha = pr.head_sha
+    checks_done = asyncio.Event()
+    codex_task = asyncio.create_task(wait_for_codex(pr.number, checks_done))
+    checks_task = asyncio.create_task(wait_for_checks(head_sha, checks_done))
+
+    async def head_monitor() -> None:
+        while True:
+            current = await get_pr_info()
+            if is_merge_conflicting(current):
+                print(
+                    "PR has merge conflicts. Resolve/rebase against main and push "
+                    "before running land_watch again.",
+                )
+                raise SystemExit(5)
+            if current.head_sha != head_sha:
+                print("PR head updated; pull/amend/force-push to retrigger CI")
+                raise SystemExit(4)
+            await asyncio.sleep(POLL_SECONDS)
+
+    monitor_task = asyncio.create_task(head_monitor())
+    success_task = asyncio.gather(codex_task, checks_task)
+
+    done, pending = await asyncio.wait(
+        [monitor_task, success_task],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    for task in pending:
+        task.cancel()
+    for task in done:
+        exc = task.exception()
+        if exc:
+            raise exc
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(watch_pr())
+    except SystemExit as exc:
+        raise SystemExit(exc.code) from None

--- a/.agents/skills/sym-land/land_watch.py
+++ b/.agents/skills/sym-land/land_watch.py
@@ -4,7 +4,7 @@ import json
 import random
 import re
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 POLL_SECONDS = 10
@@ -354,6 +354,8 @@ def latest_codex_reply_by_thread(
 ) -> dict[int, datetime]:
     latest: dict[int, datetime] = {}
     for comment in comments:
+        if not is_codex_bot_user(comment.get("user", {})):
+            continue
         body = (comment.get("body") or "").strip()
         if not is_codex_reply_body(body):
             continue
@@ -526,7 +528,8 @@ async def wait_for_codex(pr_number: int, checks_done: asyncio.Event) -> None:
         if bot_comments:
             latest = max(
                 bot_comments,
-                key=lambda comment: comment_time(comment) or datetime.min,
+                key=lambda comment: comment_time(comment)
+                or datetime.min.replace(tzinfo=timezone.utc),
             )
             body = sanitize_terminal_output(latest.get("body") or "").strip()
             if body:

--- a/.agents/skills/sym-land/land_watch.py
+++ b/.agents/skills/sym-land/land_watch.py
@@ -114,25 +114,9 @@ async def get_review_comments(pr_number: int) -> list[dict[str, Any]]:
 
 
 async def get_reviews(pr_number: int) -> list[dict[str, Any]]:
-    page = 1
-    reviews: list[dict[str, Any]] = []
-    while True:
-        data = await run_gh(
-            "api",
-            "--method",
-            "GET",
-            f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/reviews",
-            "-f",
-            "per_page=100",
-            "-f",
-            f"page={page}",
-        )
-        batch = json.loads(data)
-        if not batch:
-            break
-        reviews.extend(batch)
-        page += 1
-    return reviews
+    return await get_paginated_list(
+        f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/reviews",
+    )
 
 
 async def get_check_runs(head_sha: str) -> list[dict[str, Any]]:
@@ -532,7 +516,7 @@ async def wait_for_codex(pr_number: int, checks_done: asyncio.Event) -> None:
         if bot_comments:
             latest = max(
                 bot_comments,
-                key=lambda comment: parse_time(comment["created_at"]),
+                key=lambda comment: comment_time(comment) or datetime.min,
             )
             body = sanitize_terminal_output(latest.get("body") or "").strip()
             if body:

--- a/.agents/skills/sym-land/land_watch.py
+++ b/.agents/skills/sym-land/land_watch.py
@@ -276,6 +276,8 @@ def latest_codex_issue_reply_time(
 ) -> datetime | None:
     latest: datetime | None = None
     for comment in comments:
+        if not is_codex_bot_user(comment.get("user", {})):
+            continue
         body = (comment.get("body") or "").strip()
         if not is_codex_reply_body(body):
             continue
@@ -294,10 +296,6 @@ def filter_human_issue_comments(comments: list[dict[str, Any]]) -> list[dict[str
         if is_bot_user(comment.get("user", {})):
             continue
         body = (comment.get("body") or "").strip()
-        if is_codex_reply_body(body):
-            continue
-        if is_codex_review_body(body):
-            continue
         if "@codex review" in body:
             continue
         created_time = comment_time(comment)
@@ -313,14 +311,23 @@ def filter_human_issue_comments(comments: list[dict[str, Any]]) -> list[dict[str
 
 def filter_codex_review_issue_comments(
     comments: list[dict[str, Any]],
+    review_request_at: datetime | None,
 ) -> list[dict[str, Any]]:
     latest_ack = latest_codex_issue_reply_time(comments)
     filtered: list[dict[str, Any]] = []
     for comment in comments:
+        if not is_codex_bot_user(comment.get("user", {})):
+            continue
         body = (comment.get("body") or "").strip()
         if not is_codex_review_body(body):
             continue
         created_time = comment_time(comment)
+        if (
+            review_request_at is not None
+            and created_time is not None
+            and created_time <= review_request_at
+        ):
+            continue
         if (
             latest_ack is not None
             and created_time is not None
@@ -476,7 +483,10 @@ def raise_on_human_feedback(
     review_request_at: datetime | None,
 ) -> None:
     human_issue_comments = filter_human_issue_comments(issue_comments)
-    codex_review_comments = filter_codex_review_issue_comments(issue_comments)
+    codex_review_comments = filter_codex_review_issue_comments(
+        issue_comments,
+        review_request_at,
+    )
     human_review_comments = filter_human_review_comments(review_comments)
     if human_issue_comments or human_review_comments or codex_review_comments:
         print("Review comments detected. Address before merge.")

--- a/.agents/skills/sym-linear/SKILL.md
+++ b/.agents/skills/sym-linear/SKILL.md
@@ -1,0 +1,551 @@
+---
+name: sym-linear
+description: |
+  Use Symphony's `linear_graphql` client tool for raw Linear GraphQL
+  operations such as comment editing and upload flows.
+---
+
+# Linear GraphQL
+
+Use this skill for raw Linear GraphQL work during Symphony app-server sessions.
+
+## Primary tool
+
+Use the `linear_graphql` client tool exposed by Symphony's app-server session.
+It reuses Symphony's configured Linear auth for the session.
+
+Tool input:
+
+```json
+{
+  "query": "query or mutation document",
+  "variables": {
+    "optional": "graphql variables object"
+  }
+}
+```
+
+Tool behavior:
+
+- Send one GraphQL operation per tool call.
+- Treat a top-level `errors` array as a failed GraphQL operation even if the
+  tool call itself completed.
+- Keep queries/mutations narrowly scoped; ask only for the fields you need.
+
+## Discovering unfamiliar operations
+
+When you need an unfamiliar mutation, input type, or object field, use targeted
+introspection through `linear_graphql`.
+
+List mutation names:
+
+```graphql
+query ListMutations {
+  __type(name: "Mutation") {
+    fields {
+      name
+    }
+  }
+}
+```
+
+Inspect a specific input object:
+
+```graphql
+query CommentCreateInputShape {
+  __type(name: "CommentCreateInput") {
+    inputFields {
+      name
+      type {
+        kind
+        name
+        ofType {
+          kind
+          name
+        }
+      }
+    }
+  }
+}
+```
+
+## Common workflows
+
+### Query an issue by key, identifier, or id
+
+Use these progressively:
+
+- Start with `issue(id: $identifier)` when you have a ticket key such as
+  `MT-686` or `KAT-857`.
+- If you must use `issues(filter: ...)`, split `TEAM-NUMBER` and filter with
+  `team.key` + `number` (do not use `IssueFilter.identifier`; it does not
+  exist).
+- Once you have the internal issue id, prefer `issue(id: $id)` for narrower reads.
+
+Lookup by issue key/identifier:
+
+```graphql
+query IssueByIdentifier($identifier: String!) {
+  issue(id: $identifier) {
+    id
+    identifier
+    title
+    state {
+      id
+      name
+      type
+    }
+    project {
+      id
+      name
+    }
+    branchName
+    url
+    description
+    updatedAt
+  }
+}
+```
+
+Lookup by identifier with `issues(filter: ...)` (valid syntax):
+
+```graphql
+query IssueByTeamKeyAndNumber($teamKey: String!, $number: Float!) {
+  issues(
+    filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }
+    first: 1
+  ) {
+    nodes {
+      id
+      identifier
+      title
+      state {
+        id
+        name
+        type
+      }
+      project {
+        id
+        name
+      }
+      branchName
+      url
+      description
+      updatedAt
+    }
+  }
+}
+```
+
+Given `KAT-857`, use `teamKey = "KAT"` and `number = 857`.
+
+Resolve a key to an internal id:
+
+```graphql
+query IssueByIdOrKey($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+  }
+}
+```
+
+Read the issue once the internal id is known:
+
+```graphql
+query IssueDetails($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+    url
+    description
+    state {
+      id
+      name
+      type
+    }
+    project {
+      id
+      name
+    }
+    attachments {
+      nodes {
+        id
+        title
+        url
+        sourceType
+      }
+    }
+  }
+}
+```
+
+### Query slice hierarchy and planning documents
+
+Use these when an issue represents a parent slice with child tasks and attached
+plan docs.
+
+Get child issues of a slice:
+
+```graphql
+query SliceChildren($id: String!) {
+  issue(id: $id) {
+    children {
+      nodes {
+        id
+        identifier
+        title
+        state {
+          name
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+Get documents attached to an issue:
+
+```graphql
+query IssueDocuments($id: String!) {
+  issue(id: $id) {
+    documents {
+      nodes {
+        id
+        title
+        content
+      }
+    }
+  }
+}
+```
+
+Get project documents:
+
+```graphql
+query ProjectDocuments($id: String!) {
+  project(id: $id) {
+    documents {
+      nodes {
+        id
+        title
+        content
+      }
+    }
+  }
+}
+```
+
+Get milestone from issue:
+
+```graphql
+query IssueMilestone($id: String!) {
+  issue(id: $id) {
+    projectMilestone {
+      id
+      name
+    }
+  }
+}
+```
+
+Get milestone documents:
+
+```graphql
+query MilestoneDocuments($id: String!) {
+  projectMilestone(id: $id) {
+    documents {
+      nodes {
+        id
+        title
+        content
+      }
+    }
+  }
+}
+```
+
+### Query team workflow states for an issue
+
+Use this before changing issue state when you need the exact `stateId`:
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    id
+    team {
+      id
+      key
+      name
+      states {
+        nodes {
+          id
+          name
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+### Move an issue to a named state (resolve `stateId` first)
+
+Use a two-step flow:
+
+1. Query `issue(id: ...) { team { states { nodes { id name type } } } }`.
+2. Pick the state whose `name` exactly matches your target and pass that
+   `stateId` to `issueUpdate`.
+
+```graphql
+mutation MoveIssueToState($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue {
+      id
+      identifier
+      state {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
+### Edit an existing comment
+
+Use `commentUpdate` through `linear_graphql`:
+
+```graphql
+mutation UpdateComment($id: String!, $body: String!) {
+  commentUpdate(id: $id, input: { body: $body }) {
+    success
+    comment {
+      id
+      body
+    }
+  }
+}
+```
+
+### Create a comment
+
+Use `commentCreate` through `linear_graphql`:
+
+```graphql
+mutation CreateComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment {
+      id
+      url
+    }
+  }
+}
+```
+
+### Create an attachment/link on an issue
+
+Use the GitHub-specific attachment mutation when linking a PR:
+
+```graphql
+mutation AttachGitHubPR($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkGitHubPR(
+    issueId: $issueId
+    url: $url
+    title: $title
+    linkKind: links
+  ) {
+    success
+    attachment {
+      id
+      title
+      url
+    }
+  }
+}
+```
+
+If you only need a plain URL attachment and do not care about GitHub-specific
+link metadata, use:
+
+```graphql
+mutation AttachURL($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
+    success
+    attachment {
+      id
+      title
+      url
+    }
+  }
+}
+```
+
+### Query issue attachments and relations
+
+```graphql
+query IssueAttachmentsAndRelations($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    attachments(first: 20) {
+      nodes {
+        id
+        title
+        url
+        sourceType
+      }
+    }
+    relations(first: 20) {
+      nodes {
+        id
+        type
+        relatedIssue {
+          id
+          identifier
+          title
+          state {
+            name
+            type
+          }
+        }
+      }
+    }
+    inverseRelations(first: 20) {
+      nodes {
+        id
+        type
+        issue {
+          id
+          identifier
+          title
+          state {
+            name
+            type
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Common valid `IssueFilter` fields
+
+Use these common fields inside `issues(filter: ...)`:
+
+- `id`
+- `number` (pair with `team.key` for identifier-style lookups)
+- `team`
+- `state`
+- `project`
+- `assignee`
+- `title`
+- `searchableContent`
+- `createdAt`
+- `updatedAt`
+- `and` / `or`
+
+`IssueFilter.identifier` is invalid.
+
+### Introspection patterns used during schema discovery
+
+Use these when the exact field or mutation shape is unclear:
+
+```graphql
+query QueryFields {
+  __type(name: "Query") {
+    fields {
+      name
+    }
+  }
+}
+```
+
+```graphql
+query IssueFieldArgs {
+  __type(name: "Query") {
+    fields {
+      name
+      args {
+        name
+        type {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Upload a video to a comment
+
+Do this in three steps:
+
+1. Call `linear_graphql` with `fileUpload` to get `uploadUrl`, `assetUrl`, and
+   any required upload headers.
+2. Upload the local file bytes to `uploadUrl` with `curl -X PUT` and the exact
+   headers returned by `fileUpload`.
+3. Call `linear_graphql` again with `commentCreate` (or `commentUpdate`) and
+   include the resulting `assetUrl` in the comment body.
+
+Useful mutations:
+
+```graphql
+mutation FileUpload(
+  $filename: String!
+  $contentType: String!
+  $size: Int!
+  $makePublic: Boolean
+) {
+  fileUpload(
+    filename: $filename
+    contentType: $contentType
+    size: $size
+    makePublic: $makePublic
+  ) {
+    success
+    uploadFile {
+      uploadUrl
+      assetUrl
+      headers {
+        key
+        value
+      }
+    }
+  }
+}
+```
+
+## Usage rules
+
+- Use `linear_graphql` for comment edits, uploads, and ad-hoc Linear API
+  queries.
+- Prefer the narrowest issue lookup that matches what you already know:
+  `issue(id: TEAM-NUMBER)` -> `issues(filter: { team.key + number })` ->
+  internal id.
+- Do not query `Issue.links`; use `Issue.attachments`, `Issue.relations`, and
+  `Issue.inverseRelations` instead.
+- Do not use `IssueFilter.identifier`; use `IssueFilter.number` with
+  `IssueFilter.team.key` when you need identifier-style filtering.
+- For state transitions, fetch team states first and use the exact `stateId`
+  instead of hardcoding names inside mutations.
+- Prefer `attachmentLinkGitHubPR` over a generic URL attachment when linking a
+  GitHub PR to a Linear issue.
+- Do not introduce new raw-token shell helpers for GraphQL access.
+- If you need shell work for uploads, only use it for signed upload URLs
+  returned by `fileUpload`; those URLs already carry the needed authorization.

--- a/.agents/skills/sym-pull/SKILL.md
+++ b/.agents/skills/sym-pull/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: sym-pull
+description:
+  Pull latest origin/<base-branch> into the current local branch and resolve
+  merge conflicts (aka update-branch). Use when Codex needs to sync a feature
+  branch with origin, perform a merge-based update (not rebase), and guide
+  conflict resolution best practices.
+---
+
+# Pull
+
+## Workflow
+
+1. Verify git status is clean or commit/stash changes before merging.
+2. Ensure rerere is enabled locally:
+   - `git config rerere.enabled true`
+   - `git config rerere.autoupdate true`
+3. Confirm remotes and branches:
+   - Ensure the `origin` remote exists.
+   - Ensure the current branch is the one to receive the merge.
+4. Determine the base branch merge target:
+   - Use a workflow-configured base branch when the task context provides one
+     (for Symphony workflows, this is `workspace.base_branch`).
+   - Default to `main` when no explicit base branch is available.
+   - Shell helper: `base_branch="${BASE_BRANCH:-main}"`.
+5. Fetch latest refs:
+   - `git fetch origin`
+6. Sync the remote feature branch first:
+   - `git pull --ff-only origin $(git branch --show-current)`
+   - This pulls branch updates made remotely (for example, a GitHub auto-commit)
+     before merging `origin/$base_branch`.
+7. Merge in order:
+   - Prefer `git -c merge.conflictstyle=zdiff3 merge "origin/$base_branch"` for
+     clearer conflict context.
+8. If conflicts appear, resolve them (see conflict guidance below), then:
+   - `git add <files>`
+   - `git commit` (or `git merge --continue` if the merge is paused)
+9. Verify with project checks (follow repo policy in `AGENTS.md`).
+10. Summarize the merge:
+   - Call out the most challenging conflicts/files and how they were resolved.
+   - Note any assumptions or follow-ups.
+
+## Conflict Resolution Guidance (Best Practices)
+
+- Inspect context before editing:
+  - Use `git status` to list conflicted files.
+  - Use `git diff` or `git diff --merge` to see conflict hunks.
+  - Use `git diff :1:path/to/file :2:path/to/file` and
+    `git diff :1:path/to/file :3:path/to/file` to compare base vs ours/theirs
+    for a file-level view of intent.
+  - With `merge.conflictstyle=zdiff3`, conflict markers include:
+    - `<<<<<<<` ours, `|||||||` base, `=======` split, `>>>>>>>` theirs.
+    - Matching lines near the start/end are trimmed out of the conflict region,
+      so focus on the differing core.
+  - Summarize the intent of both changes, decide the semantically correct
+    outcome, then edit:
+    - State what each side is trying to achieve (bug fix, refactor, rename,
+      behavior change).
+    - Identify the shared goal, if any, and whether one side supersedes the
+      other.
+    - Decide the final behavior first; only then craft the code to match that
+      decision.
+    - Prefer preserving invariants, API contracts, and user-visible behavior
+      unless the conflict clearly indicates a deliberate change.
+  - Open files and understand intent on both sides before choosing a resolution.
+- Prefer minimal, intention-preserving edits:
+  - Keep behavior consistent with the branch’s purpose.
+  - Avoid accidental deletions or silent behavior changes.
+- Resolve one file at a time and rerun tests after each logical batch.
+- Use `ours/theirs` only when you are certain one side should win entirely.
+- For complex conflicts, search for related files or definitions to align with
+  the rest of the codebase.
+- For generated files, resolve non-generated conflicts first, then regenerate:
+  - Prefer resolving source files and handwritten logic before touching
+    generated artifacts.
+  - Run the CLI/tooling command that produced the generated file to recreate it
+    cleanly, then stage the regenerated output.
+- For import conflicts where intent is unclear, accept both sides first:
+  - Keep all candidate imports temporarily, finish the merge, then run lint/type
+    checks to remove unused or incorrect imports safely.
+- After resolving, ensure no conflict markers remain:
+  - `git diff --check`
+- When unsure, note assumptions and ask for confirmation before finalizing the
+  merge.
+
+## When To Ask The User (Keep To A Minimum)
+
+Do not ask for input unless there is no safe, reversible alternative. Prefer
+making a best-effort decision, documenting the rationale, and proceeding.
+
+Ask the user only when:
+
+- The correct resolution depends on product intent or behavior not inferable
+  from code, tests, or nearby documentation.
+- The conflict crosses a user-visible contract, API surface, or migration where
+  choosing incorrectly could break external consumers.
+- A conflict requires selecting between two mutually exclusive designs with
+  equivalent technical merit and no clear local signal.
+- The merge introduces data loss, schema changes, or irreversible side effects
+  without an obvious safe default.
+- The branch is not the intended target, or the remote/branch names do not exist
+  and cannot be determined locally.
+
+Otherwise, proceed with the merge, explain the decision briefly in notes, and
+leave a clear, reviewable commit history.

--- a/.agents/skills/sym-push/SKILL.md
+++ b/.agents/skills/sym-push/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: sym-push
+description:
+  Push current branch changes to origin and create or update the corresponding
+  pull request (with the correct base branch); use when asked to push, publish
+  updates, or create pull request.
+---
+
+# Push
+
+## Prerequisites
+
+- `gh` CLI is installed and available in `PATH`.
+- `gh auth status` succeeds for GitHub operations in this repo.
+
+## Goals
+
+- Push current branch changes to `origin` safely.
+- Create a PR if none exists for the branch, otherwise update the existing PR.
+- Keep branch history clean when remote has moved.
+
+## Related Skills
+
+- `pull`: use this when push is rejected or sync is not clean (non-fast-forward,
+  merge conflict risk, or stale branch).
+
+## Steps
+
+1. Identify current branch and confirm remote state.
+2. Determine the PR/merge base branch:
+   - Use a workflow-configured base branch when task context provides one (for
+     Symphony workflows, this is `workspace.base_branch`).
+   - Default to `main` when no explicit base branch is available.
+3. Run local validation (`cd apps/symphony && cargo test && cargo clippy -- -D warnings`) before pushing.
+4. Push branch to `origin` using explicit first-push upstream setup:
+   - first publish of a new branch: `git push -u origin "$branch"`
+   - subsequent updates: `git push`
+   Use whatever remote URL is already configured.
+5. If push is not clean/rejected:
+   - If the failure is a non-fast-forward or sync problem, run the `pull`
+     skill to merge `origin/<base-branch>`, resolve conflicts, and rerun
+     validation.
+   - Retry with `git push -u origin "$branch"` so upstream is set even when the
+     first push failed before tracking was recorded.
+   - Use `--force-with-lease` only when history was rewritten.
+   - If the failure is due to auth, permissions, or workflow restrictions on
+     the configured remote, stop and surface the exact error instead of
+     rewriting remotes or switching protocols as a workaround.
+
+6. Ensure a PR exists for the branch:
+   - If no PR exists, create one.
+   - If a PR exists and is open, update it.
+   - If branch is tied to a closed/merged PR, create a new branch + PR.
+   - Write a proper PR title that clearly describes the change outcome
+   - For branch updates, explicitly reconsider whether current PR title still
+     matches the latest scope; update it if it no longer does.
+7. Write/update PR body explicitly using `.github/pull_request_template.md`:
+   - Fill every section with concrete content for this change.
+   - Replace all placeholder comments (`<!-- ... -->`).
+   - Keep bullets/checkboxes where template expects them.
+   - If PR already exists, refresh body content so it reflects the total PR
+     scope (all intended work on the branch), not just the newest commits,
+     including newly added work, removed work, or changed approach.
+   - Do not reuse stale description text from earlier iterations.
+8. Reply with the PR URL from `gh pr view`.
+
+## Commands
+
+```sh
+# Identify branch
+branch=$(git branch --show-current)
+base_branch="${BASE_BRANCH:-main}"
+
+# Minimal validation gate
+cd apps/symphony && cargo test && cargo clippy -- -D warnings
+
+# Initial push for a new branch: set upstream explicitly.
+git push -u origin "$branch"
+
+# If that failed because the remote moved, use the pull skill. After
+# pull-skill resolution and re-validation, retry the normal push:
+git push -u origin "$branch"
+
+# After upstream is set, routine branch updates can use:
+git push
+
+# If the configured remote rejects the push for auth, permissions, or workflow
+# restrictions, stop and surface the exact error.
+
+# Only if history was rewritten locally:
+git push --force-with-lease origin HEAD
+
+# Ensure a PR exists (create only if missing)
+pr_state=$(gh pr view --json state -q .state 2>/dev/null || true)
+if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
+  echo "Current branch is tied to a closed PR; create a new branch + PR." >&2
+  exit 1
+fi
+
+# Write a clear, human-friendly title that summarizes the shipped change.
+pr_title="<clear PR title written for this change>"
+if [ -z "$pr_state" ]; then
+  gh pr create --base "$base_branch" --title "$pr_title"
+else
+  # Reconsider title on every branch update; edit if scope shifted.
+  gh pr edit --base "$base_branch" --title "$pr_title"
+fi
+
+# Write/edit PR body to match .github/pull_request_template.md before validation.
+# Example workflow:
+# 1) open the template and draft body content for this PR
+# 2) gh pr edit --body-file /tmp/pr_body.md
+# 3) for branch updates, re-check that title/body still match current diff
+
+tmp_pr_body=$(mktemp)
+gh pr view --json body -q .body > "$tmp_pr_body"
+rm -f "$tmp_pr_body"
+
+# Show PR URL for the reply
+gh pr view --json url -q .url
+```
+
+## Notes
+
+- Do not use `--force`; only use `--force-with-lease` as the last resort.
+- Distinguish sync problems from remote auth/permission problems:
+  - Use the `pull` skill for non-fast-forward or stale-branch issues.
+  - Surface auth, permissions, or workflow restrictions directly instead of
+    changing remotes or protocols.

--- a/apps/desktop/docs/uat/M004/S04-END-TO-END-SMOKE.md
+++ b/apps/desktop/docs/uat/M004/S04-END-TO-END-SMOKE.md
@@ -1,0 +1,90 @@
+# S04 End-to-End Desktop Symphony Smoke (M004)
+
+## Goal
+
+Validate the full assembled M004 operator path in one real Electron session:
+
+1. Desktop manages Symphony runtime lifecycle.
+2. Dashboard shows live worker/escalation state.
+3. Operator responds to a pending escalation in GUI.
+4. Kanban reflects the same work item convergence.
+5. Truthful stale/disconnected behavior is visible and recoverable.
+
+---
+
+## Preconditions
+
+- Desktop is built from this branch.
+- Symphony is configured for the workspace (`symphony.url`, `symphony.workflow_path`).
+- A test workflow can produce at least one pending escalation.
+- No secrets are captured in screenshots/log excerpts.
+
+---
+
+## Automated milestone proof (deterministic fixture path)
+
+```bash
+cd apps/desktop
+bun run build
+npx playwright test e2e/tests/symphony-end-to-end.e2e.ts
+```
+
+Targeted subsets:
+
+```bash
+cd apps/desktop
+npx playwright test e2e/tests/symphony-end-to-end.e2e.ts --grep "scenario control"
+npx playwright test e2e/tests/symphony-end-to-end.e2e.ts --grep "healthy assembled flow"
+npx playwright test e2e/tests/symphony-end-to-end.e2e.ts --grep "failure-path truthfulness"
+```
+
+---
+
+## Live acceptance walkthrough (real runtime)
+
+1. Launch Kata Desktop.
+2. Open **Settings → Symphony**.
+3. Click **Start** in runtime panel.
+4. Confirm runtime reaches **Ready** and app-shell badge reports `Symphony: Ready`.
+5. Confirm dashboard connection is `connected` and worker table has live activity.
+6. Capture `workers`, `queue`, `completed`, and `escalations` summary values.
+7. Wait for or trigger a real escalation.
+8. Submit escalation response from GUI.
+9. Confirm success banner and escalation list update.
+10. Close settings and open kanban surface.
+11. Confirm the **same issue identifier** seen in dashboard is visible on the board card/task metadata.
+12. Confirm board status line shows live Symphony freshness and counts.
+13. Trigger disconnect or stale condition (stop runtime or disrupt connectivity).
+14. Confirm dashboard/board show truthful `stale` or `disconnected` states while workflow cards remain visible.
+15. Restore runtime/connection.
+16. Confirm dashboard and board return to aligned live state.
+17. Stop Symphony from Desktop and confirm truthful stopped/disconnected state.
+
+---
+
+## Packaged / packaged-like smoke
+
+1. Build packaged (or packaged-like) Desktop output.
+2. Launch packaged app.
+3. Repeat the same assembled flow from **Live acceptance walkthrough**.
+4. Verify Start/Respond/Converge/Disconnect/Recover/Stop behavior matches dev-mode expectations.
+5. Record any parity differences between dev and packaged runs.
+
+---
+
+## Evidence requirements
+
+Attach references in `S04-UAT-REPORT.md`:
+
+- Runtime ready state screenshot
+- Dashboard connected + active work screenshot
+- Pending escalation screenshot
+- Post-response success screenshot
+- Kanban convergence screenshot for same work item
+- Disconnected/stale truthfulness screenshot
+- Recovery screenshot
+- Runtime stopped/disconnected final screenshot
+- Packaged run equivalents (or explicit fail reason)
+
+Allowed evidence fields: safe identifiers, timestamps, worker labels, UI state.
+Never include secrets, auth headers, or raw escalation payload bodies.

--- a/apps/desktop/docs/uat/M004/S04-UAT-REPORT.md
+++ b/apps/desktop/docs/uat/M004/S04-UAT-REPORT.md
@@ -1,0 +1,74 @@
+# S04 UAT Report — End-to-End Desktop Symphony Operation
+
+- Slice: **KAT-2337 / S04**
+- Milestone: **M004 Symphony Integration**
+- Commit SHA:
+- Date:
+- Tester:
+- Environment: (dev-mode / packaged / packaged-like)
+
+## Run matrix
+
+| Flow | Mode | Result | Notes |
+| --- | --- | --- | --- |
+| Automated assembled proof (`symphony-end-to-end.e2e.ts`) | Fixture | ☐ Pass ☐ Fail | |
+| Live acceptance walkthrough | Dev-mode | ☐ Pass ☐ Fail | |
+| Packaged smoke walkthrough | Packaged / packaged-like | ☐ Pass ☐ Fail | |
+
+## Validation command results
+
+```bash
+cd apps/desktop && npx playwright test e2e/tests/symphony-end-to-end.e2e.ts
+cd apps/desktop && bun run typecheck
+cd apps/desktop && npx vitest run src/main/__tests__/symphony-supervisor.test.ts src/main/__tests__/symphony-operator-service.test.ts src/main/__tests__/workflow-board-service.test.ts
+```
+
+- `playwright`: 
+- `typecheck`: 
+- `vitest`: 
+
+## Live walkthrough checklist
+
+- [ ] Start Symphony from Desktop settings panel
+- [ ] Runtime reaches Ready and badge reflects healthy state
+- [ ] Dashboard shows live worker activity
+- [ ] Escalation appears and can be answered from GUI
+- [ ] Response success state is visible
+- [ ] Same work item converges in kanban metadata
+- [ ] Disconnect/stale behavior remains truthful while workflow data stays visible
+- [ ] Recovery restores aligned dashboard + board state without app restart
+- [ ] Runtime can be stopped cleanly from Desktop
+
+## Evidence index
+
+| Step | Screenshot / Artifact | Pass/Fail | Notes |
+| --- | --- | --- | --- |
+| Runtime Ready |  |  |  |
+| Dashboard Live Activity |  |  |  |
+| Escalation Pending |  |  |  |
+| Escalation Response Submitted |  |  |  |
+| Kanban Convergence (same identifier) |  |  |  |
+| Disconnected/Stale Truthfulness |  |  |  |
+| Recovery |  |  |  |
+| Runtime Stopped |  |  |  |
+| Packaged Ready |  |  |  |
+| Packaged Convergence |  |  |  |
+
+## Failure localization
+
+Document exact checkpoint if failed:
+
+- [ ] runtime-ready
+- [ ] dashboard-connected
+- [ ] escalation-submitted
+- [ ] escalation-refresh-complete
+- [ ] board-convergence-confirmed
+- [ ] runtime-stopped
+
+Root cause summary:
+
+## Final assessment
+
+- M004 S04 assembled flow readiness: ☐ Ready ☐ Not ready
+- Blocking defects:
+- Follow-up tickets (if any):

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -80,6 +80,8 @@ type DesktopFixtures = {
     | 'kanban_assigned'
     | 'kanban_stale'
     | 'kanban_disconnected'
+    | 'assembled_healthy'
+    | 'assembled_failure_recovery'
 }
 
 export const test = base.extend<DesktopFixtures>({

--- a/apps/desktop/e2e/tests/symphony-end-to-end.e2e.ts
+++ b/apps/desktop/e2e/tests/symphony-end-to-end.e2e.ts
@@ -75,8 +75,7 @@ test.describe('failure-path truthfulness', () => {
     await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('connected')
     await closeSettings(readyWindow)
 
-    await readyWindow.getByRole('button', { name: /Settings/i }).click()
-    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+    await openSymphonySettings(readyWindow)
 
     await readyWindow.getByTestId('symphony-dashboard-refresh').click()
     await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('disconnected')
@@ -89,8 +88,7 @@ test.describe('failure-path truthfulness', () => {
     await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: disconnected')
     await expect(readyWindow.getByTestId('slice-symphony-KAT-2337')).toContainText('Symphony runtime disconnected')
 
-    await readyWindow.getByRole('button', { name: /Settings/i }).click()
-    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+    await openSymphonySettings(readyWindow)
     await readyWindow.getByTestId('symphony-dashboard-refresh').click()
     await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('connected')
 

--- a/apps/desktop/e2e/tests/symphony-end-to-end.e2e.ts
+++ b/apps/desktop/e2e/tests/symphony-end-to-end.e2e.ts
@@ -1,0 +1,99 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from '../fixtures/electron.fixture'
+
+async function openSymphonySettings(window: Page) {
+  await window.getByRole('button', { name: /Settings/i }).click()
+  await window.getByRole('tab', { name: /^Symphony$/i }).click()
+}
+
+async function startRuntimeFromUi(window: Page) {
+  await openSymphonySettings(window)
+  await window.getByTestId('symphony-start-button').click()
+  await expect(window.getByTestId('symphony-phase-badge')).toContainText('Ready')
+}
+
+async function closeSettings(window: Page) {
+  await window.getByRole('button', { name: /^Close$/i }).click()
+  await expect(window.getByRole('dialog', { name: /Settings/i })).toBeHidden()
+}
+
+test.describe('scenario control', () => {
+  test.use({ symphonyMockMode: 'assembled_healthy' })
+
+  test('keeps runtime, dashboard, and board aligned for assembled scenario control', async ({ readyWindow }) => {
+    await startRuntimeFromUi(readyWindow)
+
+    await expect(readyWindow.getByTestId('symphony-dashboard-panel')).toBeVisible()
+    await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('connected')
+    await expect(readyWindow.getByTestId('symphony-summary-workers')).toContainText('2')
+    await expect(readyWindow.getByTestId('symphony-worker-table').getByText('KAT-2337')).toBeVisible()
+
+    await closeSettings(readyWindow)
+
+    await expect(readyWindow.getByRole('heading', { name: /Workflow Board/i })).toBeVisible()
+    await readyWindow.getByRole('button', { name: /Refresh workflow board/i }).click()
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: live')
+    await expect(readyWindow.getByText(/KAT-2337 · \[S04\]/i)).toBeVisible()
+    await expect(readyWindow.getByTestId('slice-symphony-KAT-2337')).toContainText('Execution: edit')
+  })
+})
+
+test.describe('healthy assembled flow', () => {
+  test.use({ symphonyMockMode: 'assembled_healthy' })
+
+  test('proves runtime to dashboard to escalation response to board convergence', async ({ readyWindow }) => {
+    await startRuntimeFromUi(readyWindow)
+
+    await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('connected')
+    await expect(readyWindow.getByTestId('symphony-summary-escalations')).toContainText('1')
+
+    await readyWindow.getByTestId('symphony-escalation-input-req-assembled-1').fill('Acknowledge and move to Agent Review.')
+    await readyWindow.getByTestId('symphony-escalation-submit-req-assembled-1').click()
+
+    await expect(readyWindow.getByTestId('symphony-escalation-result')).toContainText('Escalation response sent')
+    await expect(readyWindow.getByTestId('symphony-summary-escalations')).toContainText('0')
+    await expect(readyWindow.getByTestId('symphony-worker-table').getByText('KAT-2337')).toBeVisible()
+
+    await closeSettings(readyWindow)
+
+    await readyWindow.getByRole('button', { name: /Refresh workflow board/i }).click()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: live')
+    await expect(readyWindow.getByTestId('slice-symphony-KAT-2337')).toContainText('Execution: idle')
+  })
+})
+
+test.describe('failure-path truthfulness', () => {
+  test.use({ symphonyMockMode: 'assembled_failure_recovery' })
+
+  test('surfaces disconnect truthfully and recovers without app restart', async ({ readyWindow }) => {
+    await startRuntimeFromUi(readyWindow)
+
+    await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('connected')
+    await closeSettings(readyWindow)
+
+    await readyWindow.getByRole('button', { name: /Settings/i }).click()
+    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+
+    await readyWindow.getByTestId('symphony-dashboard-refresh').click()
+    await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('disconnected')
+    await expect(readyWindow.getByTestId('symphony-dashboard-error')).toContainText('Mocked runtime disconnect.')
+
+    await closeSettings(readyWindow)
+
+    await readyWindow.getByRole('button', { name: /Refresh workflow board/i }).click()
+    await expect(readyWindow.getByText(/KAT-2337 · \[S04\]/i)).toBeVisible()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: disconnected')
+    await expect(readyWindow.getByTestId('slice-symphony-KAT-2337')).toContainText('Symphony runtime disconnected')
+
+    await readyWindow.getByRole('button', { name: /Settings/i }).click()
+    await readyWindow.getByRole('tab', { name: /^Symphony$/i }).click()
+    await readyWindow.getByTestId('symphony-dashboard-refresh').click()
+    await expect(readyWindow.getByTestId('symphony-dashboard-connection')).toContainText('connected')
+
+    await closeSettings(readyWindow)
+
+    await readyWindow.getByRole('button', { name: /Refresh workflow board/i }).click()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Symphony: live')
+  })
+})

--- a/apps/desktop/e2e/tests/symphony-end-to-end.e2e.ts
+++ b/apps/desktop/e2e/tests/symphony-end-to-end.e2e.ts
@@ -39,6 +39,9 @@ test.describe('scenario control', () => {
   })
 })
 
+// This suite intentionally overlaps startup assertions with `scenario control`.
+// `scenario control` validates integrated test harness alignment (runtime + dashboard + board),
+// while this suite proves the user-visible escalation response → kanban convergence contract.
 test.describe('healthy assembled flow', () => {
   test.use({ symphonyMockMode: 'assembled_healthy' })
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,7 @@
     "test": "npx vitest run --coverage",
     "test:watch": "npx vitest",
     "test:e2e": "npx playwright test",
+    "test:e2e:symphony-end-to-end": "npx playwright test e2e/tests/symphony-end-to-end.e2e.ts",
     "test:e2e:headed": "npx playwright test --headed"
   },
   "dependencies": {

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -273,6 +273,18 @@ describe('SymphonyOperatorService', () => {
     expect(response.result?.message).toContain('URL is unavailable')
   })
 
+  test('preserves legacy kanban mock identifiers for board correlation', async () => {
+    const service = new SymphonyOperatorService({
+      env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'kanban_assigned' },
+      createWebSocket: () => fakeSocket,
+    })
+
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    expect(service.getSnapshot().workers.some((worker) => worker.identifier === 'KAT-2247')).toBe(true)
+    expect(service.getSnapshot().escalations[0]?.issueIdentifier).toBe('KAT-2247')
+  })
+
   test('supports assembled mocked healthy flow updates after escalation response', async () => {
     const service = new SymphonyOperatorService({
       env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'assembled_healthy' },

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -273,6 +273,42 @@ describe('SymphonyOperatorService', () => {
     expect(response.result?.message).toContain('URL is unavailable')
   })
 
+  test('supports assembled mocked healthy flow updates after escalation response', async () => {
+    const service = new SymphonyOperatorService({
+      env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'assembled_healthy' },
+      createWebSocket: () => fakeSocket,
+    })
+
+    await service.syncRuntimeStatus(READY_STATUS)
+    expect(service.getSnapshot().workers.some((worker) => worker.identifier === 'KAT-2337')).toBe(true)
+    expect(service.getSnapshot().escalations[0]?.requestId).toBe('req-assembled-1')
+
+    const result = await service.respondToEscalation('req-assembled-1', 'Move to agent review')
+    expect(result.success).toBe(true)
+
+    const updatedWorker = service.getSnapshot().workers.find((worker) => worker.identifier === 'KAT-2337')
+    expect(updatedWorker?.state).toBe('agent_review')
+    expect(updatedWorker?.toolName).toBe('idle')
+    expect(service.getSnapshot().escalations).toHaveLength(0)
+  })
+
+  test('supports assembled failure-recovery mocked baseline sequencing', async () => {
+    const service = new SymphonyOperatorService({
+      env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'assembled_failure_recovery' },
+      createWebSocket: () => fakeSocket,
+    })
+
+    await service.syncRuntimeStatus(READY_STATUS)
+    expect(service.getSnapshot().connection.state).toBe('connected')
+
+    await service.refreshBaseline()
+    expect(service.getSnapshot().connection.state).toBe('disconnected')
+
+    await service.refreshBaseline()
+    expect(service.getSnapshot().connection.state).toBe('connected')
+    expect(service.getSnapshot().escalations).toHaveLength(0)
+  })
+
   test('supports mocked dashboard baselines and mocked response failure/success branches', async () => {
     const reconnectingService = new SymphonyOperatorService({
       env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'reconnecting' },

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -302,6 +302,13 @@ describe('SymphonyOperatorService', () => {
     expect(updatedWorker?.state).toBe('agent_review')
     expect(updatedWorker?.toolName).toBe('idle')
     expect(service.getSnapshot().escalations).toHaveLength(0)
+
+    await service.refreshBaseline({ advanceMockScenario: false })
+    const refreshedWorker = service.getSnapshot().workers.find((worker) => worker.identifier === 'KAT-2337')
+    expect(refreshedWorker?.state).toBe('agent_review')
+    expect(refreshedWorker?.toolName).toBe('idle')
+    expect(service.getSnapshot().completedCount).toBe(4)
+    expect(service.getSnapshot().escalations).toHaveLength(0)
   })
 
   test('supports assembled failure-recovery mocked baseline sequencing', async () => {
@@ -311,6 +318,9 @@ describe('SymphonyOperatorService', () => {
     })
 
     await service.syncRuntimeStatus(READY_STATUS)
+    expect(service.getSnapshot().connection.state).toBe('connected')
+
+    await service.refreshBaseline({ advanceMockScenario: false })
     expect(service.getSnapshot().connection.state).toBe('connected')
 
     await service.refreshBaseline()

--- a/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
@@ -185,6 +185,25 @@ describe('SymphonySupervisor', () => {
     expect(supervisor.getStatus().phase).toBe('stopped')
   })
 
+  test('supports assembled mocked scenario mode with runtime checkpoints', async () => {
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    const supervisor = new SymphonySupervisor({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_DESKTOP_SYMPHONY_MOCK: 'assembled_healthy',
+      },
+    })
+
+    const started = await supervisor.start()
+    expect(started.success).toBe(true)
+    expect(supervisor.getStatus().launch?.command).toBe('mock-symphony-assembled')
+    expect(supervisor.getStatus().diagnostics.stdout[0]).toContain('checkpoint:runtime-ready:assembled_healthy')
+  })
+
   test('supports mocked config and readiness failure modes', async () => {
     const workspace = createWorkspace()
     cleanups.push(workspace.cleanup)

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -8,6 +8,7 @@ import { WorkflowBoardService } from '../workflow-board-service'
 
 const originalFixtureFlag = process.env.KATA_TEST_WORKFLOW_FIXTURE
 const originalTestModeFlag = process.env.KATA_TEST_MODE
+const originalSymphonyDashboardMockFlag = process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK
 
 describe('WorkflowBoardService', () => {
   beforeEach(() => {
@@ -26,6 +27,12 @@ describe('WorkflowBoardService', () => {
     } else {
       delete process.env.KATA_TEST_MODE
     }
+
+    if (originalSymphonyDashboardMockFlag !== undefined) {
+      process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK = originalSymphonyDashboardMockFlag
+    } else {
+      delete process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK
+    }
   })
 
   test('returns deterministic fixture snapshot when fixture mode is enabled', async () => {
@@ -41,6 +48,23 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.status).toBe('fresh')
     expect(response.snapshot.columns.find((column) => column.id === 'todo')?.cards).toHaveLength(1)
     expect(response.snapshot.symphony?.provenance).toBe('unavailable')
+  })
+
+  test('uses assembled linear fixture in test mode when assembled symphony mock is active', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+    process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK = 'assembled_healthy'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const response = await service.getBoard()
+    const inProgressCards = response.snapshot.columns.find((column) => column.id === 'in_progress')?.cards ?? []
+
+    expect(inProgressCards[0]?.identifier).toBe('KAT-2337')
+
+    delete process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK
   })
 
   test('omits staleReason when symphony snapshot is unavailable', async () => {

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -54,15 +54,66 @@ describe('WorkflowBoardService', () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
     process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK = 'assembled_healthy'
 
+    const symphonySnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 1,
+      completedCount: 3,
+      workers: [
+        {
+          issueId: 'slice-s04',
+          identifier: 'KAT-2337',
+          issueTitle: '[S04] End-to-End Desktop Symphony Operation',
+          state: 'in_progress',
+          toolName: 'edit',
+          model: 'claude-sonnet-4-6',
+          lastActivityAt: new Date().toISOString(),
+        },
+        {
+          issueId: 'task-s04-2',
+          identifier: 'KAT-2356',
+          issueTitle: '[T02] Prove the healthy assembled operator flow in Electron',
+          state: 'in_progress',
+          toolName: 'bash',
+          model: 'claude-sonnet-4-6',
+          lastActivityAt: new Date().toISOString(),
+        },
+      ],
+      escalations: [
+        {
+          requestId: 'req-assembled-1',
+          issueId: 'slice-s04',
+          issueIdentifier: 'KAT-2337',
+          issueTitle: '[S04] End-to-End Desktop Symphony Operation',
+          questionPreview: 'Need clarification on dashboard failure state copy.',
+          createdAt: new Date().toISOString(),
+          timeoutMs: 300000,
+        },
+      ],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
     const service = new WorkflowBoardService({
       authBridge: { getApiKey: vi.fn(async () => null) } as never,
       getWorkspacePath: () => '/tmp/workspace',
+      getSymphonySnapshot: () => symphonySnapshot,
     })
 
     const response = await service.getBoard()
     const inProgressCards = response.snapshot.columns.find((column) => column.id === 'in_progress')?.cards ?? []
+    const assembledCard = inProgressCards.find((card) => card.identifier === 'KAT-2337')
+    const assembledTask = assembledCard?.tasks.find((task) => task.identifier === 'KAT-2356')
 
-    expect(inProgressCards[0]?.identifier).toBe('KAT-2337')
+    expect(assembledCard?.identifier).toBe('KAT-2337')
+    expect(assembledCard?.symphony?.assignmentState).toBe('assigned')
+    expect(assembledTask?.symphony?.assignmentState).toBe('assigned')
+    expect(response.snapshot.symphony?.diagnostics.correlationMisses).toEqual([])
 
     delete process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK
   })

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -492,26 +492,28 @@ export class SymphonyOperatorService extends EventEmitter {
     const nowIso = new Date().toISOString()
     const staleFetchedAt = new Date(Date.now() - STALE_AFTER_MS - 5_000).toISOString()
 
-    const isKanbanMode =
-      mockMode === 'kanban_assigned' ||
-      mockMode === 'kanban_stale' ||
-      mockMode === 'kanban_disconnected' ||
-      mockMode === 'assembled_healthy' ||
-      mockMode === 'assembled_failure_recovery'
+    const isLegacyKanbanMode =
+      mockMode === 'kanban_assigned' || mockMode === 'kanban_stale' || mockMode === 'kanban_disconnected'
+    const isAssembledMode = mockMode === 'assembled_healthy' || mockMode === 'assembled_failure_recovery'
+    const isKanbanMode = isLegacyKanbanMode || isAssembledMode
 
-    const assembledIssue = {
-      issueId: 'slice-s04',
-      identifier: 'KAT-2337',
-      issueTitle: '[S04] End-to-End Desktop Symphony Operation',
-    }
-
-    const defaultIssue = isKanbanMode
-      ? assembledIssue
-      : {
-          issueId: '1',
-          identifier: 'KAT-2338',
-          issueTitle: 'Live Worker Dashboard and Escalation Handling',
+    const defaultIssue = isAssembledMode
+      ? {
+          issueId: 'slice-s04',
+          identifier: 'KAT-2337',
+          issueTitle: '[S04] End-to-End Desktop Symphony Operation',
         }
+      : isLegacyKanbanMode
+        ? {
+            issueId: 'slice-1',
+            identifier: 'KAT-2247',
+            issueTitle: '[S01] Linear Workflow Board in the Right Pane',
+          }
+        : {
+            issueId: '1',
+            identifier: 'KAT-2338',
+            issueTitle: 'Live Worker Dashboard and Escalation Handling',
+          }
 
     const isFailureDisconnectionPhase = mockMode === 'assembled_failure_recovery' && step === 1
     const isFailureRecoveredPhase = mockMode === 'assembled_failure_recovery' && step >= 2

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -57,6 +57,7 @@ export class SymphonyOperatorService extends EventEmitter {
   private runtimeSyncRevision = 0
   private readonly snapshot: SymphonyOperatorSnapshot = createEmptySnapshot()
   private mockBaselineStep = 0
+  private mockAssembledHealthyResolved = false
 
   constructor(options: SymphonyOperatorServiceOptions = {}) {
     super()
@@ -91,7 +92,7 @@ export class SymphonyOperatorService extends EventEmitter {
     return this.snapshot
   }
 
-  public async refreshBaseline(): Promise<SymphonyOperatorSnapshot> {
+  public async refreshBaseline(options: { advanceMockScenario?: boolean } = {}): Promise<SymphonyOperatorSnapshot> {
     const url = this.activeUrl ?? this.runtimeStatus?.url
     if (!url) {
       this.markDisconnected('Symphony URL is unavailable.')
@@ -99,10 +100,11 @@ export class SymphonyOperatorService extends EventEmitter {
     }
 
     if (this.mockMode) {
-      this.applyMockBaseline(this.mockMode, this.mockBaselineStep)
-      if (this.mockMode === 'assembled_failure_recovery' && this.mockBaselineStep < 2) {
+      const shouldAdvanceScenario = options.advanceMockScenario ?? true
+      if (this.mockMode === 'assembled_failure_recovery' && shouldAdvanceScenario && this.mockBaselineStep < 2) {
         this.mockBaselineStep += 1
       }
+      this.applyMockBaseline(this.mockMode, this.mockBaselineStep)
       return this.snapshot
     }
 
@@ -183,8 +185,10 @@ export class SymphonyOperatorService extends EventEmitter {
       )
 
       if (this.mockMode === 'assembled_healthy') {
+        this.mockAssembledHealthyResolved = true
+        const primaryIdentifier = this.snapshot.workers[0]?.identifier
         this.snapshot.workers = this.snapshot.workers.map((worker) =>
-          worker.identifier === 'KAT-2337'
+          worker.identifier === primaryIdentifier
             ? {
                 ...worker,
                 state: 'agent_review',
@@ -266,6 +270,7 @@ export class SymphonyOperatorService extends EventEmitter {
     this.activeUrl = status.url
     if (this.mockMode && status.phase !== 'ready') {
       this.mockBaselineStep = 0
+      this.mockAssembledHealthyResolved = false
     }
     const syncRevision = ++this.runtimeSyncRevision
 
@@ -276,7 +281,7 @@ export class SymphonyOperatorService extends EventEmitter {
     }
 
     if (status.phase === 'ready') {
-      await this.refreshBaseline()
+      await this.refreshBaseline({ advanceMockScenario: false })
       const latestStatus = this.runtimeStatus
       if (
         syncRevision !== this.runtimeSyncRevision ||
@@ -392,7 +397,7 @@ export class SymphonyOperatorService extends EventEmitter {
           const reconnectUrl = this.activeUrl
           this.reconnectTimer = setTimeout(async () => {
             this.reconnectTimer = null
-            await this.refreshBaseline()
+            await this.refreshBaseline({ advanceMockScenario: false })
             if (this.runtimeStatus?.phase === 'ready' && this.activeUrl === reconnectUrl) {
               this.connectStream(reconnectUrl)
             }
@@ -517,10 +522,11 @@ export class SymphonyOperatorService extends EventEmitter {
 
     const isFailureDisconnectionPhase = mockMode === 'assembled_failure_recovery' && step === 1
     const isFailureRecoveredPhase = mockMode === 'assembled_failure_recovery' && step >= 2
+    const isAssembledHealthyResolved = mockMode === 'assembled_healthy' && this.mockAssembledHealthyResolved
 
     this.snapshot.fetchedAt = mockMode === 'kanban_stale' || isFailureDisconnectionPhase ? staleFetchedAt : nowIso
     this.snapshot.queueCount = mockMode === 'reconnecting' ? 2 : isFailureDisconnectionPhase ? 3 : 1
-    this.snapshot.completedCount = isFailureRecoveredPhase ? 4 : 3
+    this.snapshot.completedCount = isFailureRecoveredPhase || isAssembledHealthyResolved ? 4 : 3
     this.snapshot.workers = [
       {
         issueId: defaultIssue.issueId,
@@ -531,10 +537,10 @@ export class SymphonyOperatorService extends EventEmitter {
             ? 'reconnecting'
             : isFailureDisconnectionPhase
               ? 'blocked'
-              : isFailureRecoveredPhase
+              : isFailureRecoveredPhase || isAssembledHealthyResolved
                 ? 'agent_review'
                 : 'in_progress',
-        toolName: isFailureRecoveredPhase ? 'idle' : 'edit',
+        toolName: isFailureRecoveredPhase || isAssembledHealthyResolved ? 'idle' : 'edit',
         model: 'claude-sonnet-4-6',
         lastActivityAt: nowIso,
       },
@@ -553,7 +559,7 @@ export class SymphonyOperatorService extends EventEmitter {
         : []),
     ]
 
-    this.snapshot.escalations = isFailureRecoveredPhase
+    this.snapshot.escalations = isFailureRecoveredPhase || isAssembledHealthyResolved
       ? []
       : [
           {

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -200,9 +200,11 @@ export class SymphonyOperatorService extends EventEmitter {
         this.snapshot.completedCount += 1
       }
 
+      const nowIso = new Date().toISOString()
+      this.snapshot.fetchedAt = nowIso
       this.snapshot.response.submittingRequestId = undefined
       this.snapshot.response.lastResult = result
-      this.snapshot.connection.lastBaselineRefreshAt = new Date().toISOString()
+      this.snapshot.connection.lastBaselineRefreshAt = nowIso
       this.refreshFreshness()
       this.emitSnapshot()
       return { success: true, snapshot: this.snapshot, result }
@@ -547,9 +549,11 @@ export class SymphonyOperatorService extends EventEmitter {
       ...(isKanbanMode
         ? [
             {
-              issueId: 'task-2',
-              identifier: 'KAT-2252',
-              issueTitle: '[T02] Wire workflow board service through IPC',
+              issueId: isAssembledMode ? 'task-s04-2' : 'task-2',
+              identifier: isAssembledMode ? 'KAT-2356' : 'KAT-2252',
+              issueTitle: isAssembledMode
+                ? '[T02] Prove the healthy assembled operator flow in Electron'
+                : '[T02] Wire workflow board service through IPC',
               state: isFailureRecoveredPhase ? 'done' : 'in_progress',
               toolName: isFailureRecoveredPhase ? 'idle' : 'bash',
               model: 'claude-sonnet-4-6',

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -56,6 +56,7 @@ export class SymphonyOperatorService extends EventEmitter {
   private reconnectTimer: NodeJS.Timeout | null = null
   private runtimeSyncRevision = 0
   private readonly snapshot: SymphonyOperatorSnapshot = createEmptySnapshot()
+  private mockBaselineStep = 0
 
   constructor(options: SymphonyOperatorServiceOptions = {}) {
     super()
@@ -98,7 +99,10 @@ export class SymphonyOperatorService extends EventEmitter {
     }
 
     if (this.mockMode) {
-      this.applyMockBaseline(this.mockMode)
+      this.applyMockBaseline(this.mockMode, this.mockBaselineStep)
+      if (this.mockMode === 'assembled_failure_recovery' && this.mockBaselineStep < 2) {
+        this.mockBaselineStep += 1
+      }
       return this.snapshot
     }
 
@@ -177,6 +181,21 @@ export class SymphonyOperatorService extends EventEmitter {
       this.snapshot.escalations = this.snapshot.escalations.filter(
         (escalation) => escalation.requestId !== trimmedRequestId,
       )
+
+      if (this.mockMode === 'assembled_healthy') {
+        this.snapshot.workers = this.snapshot.workers.map((worker) =>
+          worker.identifier === 'KAT-2337'
+            ? {
+                ...worker,
+                state: 'agent_review',
+                toolName: 'idle',
+                lastActivityAt: new Date().toISOString(),
+              }
+            : worker,
+        )
+        this.snapshot.completedCount += 1
+      }
+
       this.snapshot.response.submittingRequestId = undefined
       this.snapshot.response.lastResult = result
       this.snapshot.connection.lastBaselineRefreshAt = new Date().toISOString()
@@ -245,6 +264,9 @@ export class SymphonyOperatorService extends EventEmitter {
   public async syncRuntimeStatus(status: SymphonyRuntimeStatus): Promise<void> {
     this.runtimeStatus = status
     this.activeUrl = status.url
+    if (this.mockMode && status.phase !== 'ready') {
+      this.mockBaselineStep = 0
+    }
     const syncRevision = ++this.runtimeSyncRevision
 
     if (!status.url || status.phase === 'config_error' || status.phase === 'failed') {
@@ -466,25 +488,51 @@ export class SymphonyOperatorService extends EventEmitter {
     this.emitSnapshot()
   }
 
-  private applyMockBaseline(mockMode: string): void {
+  private applyMockBaseline(mockMode: string, step = 0): void {
     const nowIso = new Date().toISOString()
     const staleFetchedAt = new Date(Date.now() - STALE_AFTER_MS - 5_000).toISOString()
 
     const isKanbanMode =
-      mockMode === 'kanban_assigned' || mockMode === 'kanban_stale' || mockMode === 'kanban_disconnected'
+      mockMode === 'kanban_assigned' ||
+      mockMode === 'kanban_stale' ||
+      mockMode === 'kanban_disconnected' ||
+      mockMode === 'assembled_healthy' ||
+      mockMode === 'assembled_failure_recovery'
 
-    this.snapshot.fetchedAt = mockMode === 'kanban_stale' ? staleFetchedAt : nowIso
-    this.snapshot.queueCount = mockMode === 'reconnecting' ? 2 : 1
-    this.snapshot.completedCount = 3
+    const assembledIssue = {
+      issueId: 'slice-s04',
+      identifier: 'KAT-2337',
+      issueTitle: '[S04] End-to-End Desktop Symphony Operation',
+    }
+
+    const defaultIssue = isKanbanMode
+      ? assembledIssue
+      : {
+          issueId: '1',
+          identifier: 'KAT-2338',
+          issueTitle: 'Live Worker Dashboard and Escalation Handling',
+        }
+
+    const isFailureDisconnectionPhase = mockMode === 'assembled_failure_recovery' && step === 1
+    const isFailureRecoveredPhase = mockMode === 'assembled_failure_recovery' && step >= 2
+
+    this.snapshot.fetchedAt = mockMode === 'kanban_stale' || isFailureDisconnectionPhase ? staleFetchedAt : nowIso
+    this.snapshot.queueCount = mockMode === 'reconnecting' ? 2 : isFailureDisconnectionPhase ? 3 : 1
+    this.snapshot.completedCount = isFailureRecoveredPhase ? 4 : 3
     this.snapshot.workers = [
       {
-        issueId: isKanbanMode ? 'slice-1' : '1',
-        identifier: isKanbanMode ? 'KAT-2247' : 'KAT-2338',
-        issueTitle: isKanbanMode
-          ? '[S01] Linear Workflow Board in the Right Pane'
-          : 'Live Worker Dashboard and Escalation Handling',
-        state: mockMode === 'reconnecting' ? 'reconnecting' : 'in_progress',
-        toolName: 'edit',
+        issueId: defaultIssue.issueId,
+        identifier: defaultIssue.identifier,
+        issueTitle: defaultIssue.issueTitle,
+        state:
+          mockMode === 'reconnecting'
+            ? 'reconnecting'
+            : isFailureDisconnectionPhase
+              ? 'blocked'
+              : isFailureRecoveredPhase
+                ? 'agent_review'
+                : 'in_progress',
+        toolName: isFailureRecoveredPhase ? 'idle' : 'edit',
         model: 'claude-sonnet-4-6',
         lastActivityAt: nowIso,
       },
@@ -494,8 +542,8 @@ export class SymphonyOperatorService extends EventEmitter {
               issueId: 'task-2',
               identifier: 'KAT-2252',
               issueTitle: '[T02] Wire workflow board service through IPC',
-              state: 'in_progress',
-              toolName: 'bash',
+              state: isFailureRecoveredPhase ? 'done' : 'in_progress',
+              toolName: isFailureRecoveredPhase ? 'idle' : 'bash',
               model: 'claude-sonnet-4-6',
               lastActivityAt: nowIso,
             },
@@ -503,24 +551,27 @@ export class SymphonyOperatorService extends EventEmitter {
         : []),
     ]
 
-    this.snapshot.escalations = [
-      {
-        requestId: 'req-123',
-        issueId: isKanbanMode ? 'slice-1' : '1',
-        issueIdentifier: isKanbanMode ? 'KAT-2247' : 'KAT-2338',
-        issueTitle: isKanbanMode
-          ? '[S01] Linear Workflow Board in the Right Pane'
-          : 'Live Worker Dashboard and Escalation Handling',
-        questionPreview: 'Need clarification on dashboard failure state copy.',
-        createdAt: new Date(Date.now() - 15_000).toISOString(),
-        timeoutMs: 300_000,
-      },
-    ]
+    this.snapshot.escalations = isFailureRecoveredPhase
+      ? []
+      : [
+          {
+            requestId: mockMode.startsWith('assembled_') ? 'req-assembled-1' : 'req-123',
+            issueId: defaultIssue.issueId,
+            issueIdentifier: defaultIssue.identifier,
+            issueTitle: defaultIssue.issueTitle,
+            questionPreview:
+              isFailureDisconnectionPhase
+                ? 'Symphony stream dropped. Confirm retry strategy.'
+                : 'Need clarification on dashboard failure state copy.',
+            createdAt: new Date(Date.now() - 15_000).toISOString(),
+            timeoutMs: 300_000,
+          },
+        ]
 
     this.snapshot.connection.state =
       mockMode === 'reconnecting'
         ? 'reconnecting'
-        : mockMode === 'kanban_disconnected'
+        : mockMode === 'kanban_disconnected' || isFailureDisconnectionPhase
           ? 'disconnected'
           : 'connected'
     this.snapshot.connection.updatedAt = nowIso
@@ -528,7 +579,7 @@ export class SymphonyOperatorService extends EventEmitter {
     this.snapshot.connection.lastError =
       mockMode === 'reconnecting'
         ? 'Mocked reconnect in progress.'
-        : mockMode === 'kanban_disconnected'
+        : mockMode === 'kanban_disconnected' || isFailureDisconnectionPhase
           ? 'Mocked runtime disconnect.'
           : undefined
     this.refreshFreshness()

--- a/apps/desktop/src/main/symphony-supervisor.ts
+++ b/apps/desktop/src/main/symphony-supervisor.ts
@@ -371,6 +371,8 @@ export class SymphonySupervisor extends EventEmitter {
 
   private async startMockedRuntime(mockMode: string): Promise<SymphonyRuntimeCommandResult> {
     const mockUrl = (this.options.env ?? process.env).KATA_SYMPHONY_URL ?? 'http://127.0.0.1:8080'
+    const isAssembledScenario =
+      mockMode === 'assembled_healthy' || mockMode === 'assembled_failure_recovery'
 
     this.updateStatus({
       phase: 'starting',
@@ -378,7 +380,12 @@ export class SymphonySupervisor extends EventEmitter {
       pid: null,
       url: mockUrl,
       lastError: undefined,
-      diagnostics: { stdout: [], stderr: [] },
+      diagnostics: {
+        stdout: isAssembledScenario
+          ? [`checkpoint:runtime-starting:${mockMode}`]
+          : [],
+        stderr: [],
+      },
     })
 
     await delay(25)
@@ -425,10 +432,16 @@ export class SymphonySupervisor extends EventEmitter {
       lastReadyAt: nowIso,
       lastReadinessCheckAt: nowIso,
       launch: {
-        command: 'mock-symphony',
+        command: isAssembledScenario ? 'mock-symphony-assembled' : 'mock-symphony',
         args: ['WORKFLOW.md', '--no-tui', '--port', '8080'],
         source: 'env',
       },
+      diagnostics: isAssembledScenario
+        ? {
+            stdout: [`checkpoint:runtime-ready:${mockMode}`],
+            stderr: [],
+          }
+        : this.status.diagnostics,
     })
 
     return { success: true, status: this.status }

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -80,6 +80,60 @@ const TEST_LINEAR_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
   },
 }
 
+const TEST_LINEAR_ASSEMBLED_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
+  backend: 'linear',
+  fetchedAt: '2026-04-04T00:00:00.000Z',
+  status: 'fresh',
+  source: {
+    projectId: 'test-project',
+    activeMilestoneId: 'm004',
+  },
+  activeMilestone: {
+    id: 'm004',
+    name: '[M004] Symphony Integration',
+  },
+  columns: [
+    { id: 'backlog', title: 'Backlog', cards: [] },
+    {
+      id: 'in_progress',
+      title: 'In Progress',
+      cards: [
+        {
+          id: 'slice-s04',
+          identifier: 'KAT-2337',
+          title: '[S04] End-to-End Desktop Symphony Operation',
+          columnId: 'in_progress',
+          stateName: 'In Progress',
+          stateType: 'started',
+          milestoneId: 'm004',
+          milestoneName: '[M004] Symphony Integration',
+          taskCounts: { total: 4, done: 1 },
+          tasks: [
+            {
+              id: 'task-s04-2',
+              identifier: 'KAT-2356',
+              title: '[T02] Prove the healthy assembled operator flow in Electron',
+              columnId: 'in_progress',
+              stateName: 'In Progress',
+              stateType: 'started',
+            },
+          ],
+        },
+      ],
+    },
+    { id: 'todo', title: 'Todo', cards: [] },
+    { id: 'agent_review', title: 'Agent Review', cards: [] },
+    { id: 'human_review', title: 'Human Review', cards: [] },
+    { id: 'merging', title: 'Merging', cards: [] },
+    { id: 'done', title: 'Done', cards: [] },
+  ],
+  poll: {
+    status: 'success',
+    backend: 'linear',
+    lastAttemptAt: '2026-04-04T00:00:00.000Z',
+  },
+}
+
 const TEST_GITHUB_LABELS_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
   backend: 'github',
   fetchedAt: '2026-04-04T00:00:00.000Z',
@@ -332,7 +386,7 @@ export class WorkflowBoardService {
     }
 
     if (process.env.KATA_TEST_WORKFLOW_FIXTURE === '1') {
-      const fixture = this.enrichWithSymphonyContext(withFreshTimestamps(TEST_LINEAR_WORKFLOW_FIXTURE))
+      const fixture = this.enrichWithSymphonyContext(withFreshTimestamps(this.resolveTestLinearFixture()))
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = fixture
         this.lastSuccessSnapshot = fixture
@@ -866,6 +920,15 @@ export class WorkflowBoardService {
     return { config: null }
   }
 
+  private resolveTestLinearFixture(): WorkflowBoardSnapshot {
+    const mode = process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK?.trim()
+    if (mode === 'assembled_healthy' || mode === 'assembled_failure_recovery') {
+      return TEST_LINEAR_ASSEMBLED_WORKFLOW_FIXTURE
+    }
+
+    return TEST_LINEAR_WORKFLOW_FIXTURE
+  }
+
   private fixtureForTracker(
     tracker:
       | ({ kind: 'github' } & Extract<WorkflowTrackerConfig, { kind: 'github' }>)
@@ -877,7 +940,7 @@ export class WorkflowBoardService {
         : TEST_GITHUB_LABELS_WORKFLOW_FIXTURE
     }
 
-    return TEST_LINEAR_WORKFLOW_FIXTURE
+    return this.resolveTestLinearFixture()
   }
 
   private toErrorSnapshot(input: {

--- a/apps/symphony/skills/sym-address-comments/scripts/fetch_comments.py
+++ b/apps/symphony/skills/sym-address-comments/scripts/fetch_comments.py
@@ -11,6 +11,10 @@ Requires:
 
 Usage:
   python fetch_comments.py > pr_comments.json
+
+Notes:
+  - Thread comments are fetched with `comments(first: 100)` per review thread.
+    The script does not currently paginate nested thread comments beyond 100.
 """
 
 from __future__ import annotations
@@ -116,18 +120,18 @@ def _ensure_gh_authenticated() -> None:
 
 
 def gh_pr_view_json(fields: str) -> dict[str, Any]:
-    # fields is a comma-separated list like: "number,headRepositoryOwner,headRepository"
+    # fields is a comma-separated list like: "number,baseRepositoryOwner,baseRepository"
     return _run_json(["gh", "pr", "view", "--json", fields])
 
 
 def get_current_pr_ref() -> tuple[str, str, int]:
     """
     Resolve the PR for the current branch (whatever gh considers associated).
-    Works for cross-repo PRs too, by reading head repository owner/name.
+    Works for cross-repo PRs too, using the base repository owner/name.
     """
-    pr = gh_pr_view_json("number,headRepositoryOwner,headRepository")
-    owner = pr["headRepositoryOwner"]["login"]
-    repo = pr["headRepository"]["name"]
+    pr = gh_pr_view_json("number,baseRepositoryOwner,baseRepository")
+    owner = pr["baseRepositoryOwner"]["login"]
+    repo = pr["baseRepository"]["name"]
     number = int(pr["number"])
     return owner, repo, number
 
@@ -175,10 +179,13 @@ def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
     comments_cursor: str | None = None
     reviews_cursor: str | None = None
     threads_cursor: str | None = None
+    comments_done = False
+    reviews_done = False
+    threads_done = False
 
     pr_meta: dict[str, Any] | None = None
 
-    while True:
+    while not (comments_done and reviews_done and threads_done):
         payload = gh_api_graphql(
             owner=owner,
             repo=repo,
@@ -206,16 +213,20 @@ def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
         r = pr["reviews"]
         t = pr["reviewThreads"]
 
-        conversation_comments.extend(c.get("nodes") or [])
-        reviews.extend(r.get("nodes") or [])
-        review_threads.extend(t.get("nodes") or [])
+        if not comments_done:
+            conversation_comments.extend(c.get("nodes") or [])
+            comments_done = not c["pageInfo"]["hasNextPage"]
+            comments_cursor = None if comments_done else c["pageInfo"]["endCursor"]
 
-        comments_cursor = c["pageInfo"]["endCursor"] if c["pageInfo"]["hasNextPage"] else None
-        reviews_cursor = r["pageInfo"]["endCursor"] if r["pageInfo"]["hasNextPage"] else None
-        threads_cursor = t["pageInfo"]["endCursor"] if t["pageInfo"]["hasNextPage"] else None
+        if not reviews_done:
+            reviews.extend(r.get("nodes") or [])
+            reviews_done = not r["pageInfo"]["hasNextPage"]
+            reviews_cursor = None if reviews_done else r["pageInfo"]["endCursor"]
 
-        if not (comments_cursor or reviews_cursor or threads_cursor):
-            break
+        if not threads_done:
+            review_threads.extend(t.get("nodes") or [])
+            threads_done = not t["pageInfo"]["hasNextPage"]
+            threads_cursor = None if threads_done else t["pageInfo"]["endCursor"]
 
     assert pr_meta is not None
     return {

--- a/apps/symphony/skills/sym-address-comments/scripts/fetch_comments.py
+++ b/apps/symphony/skills/sym-address-comments/scripts/fetch_comments.py
@@ -14,7 +14,9 @@ Usage:
 
 Notes:
   - Thread comments are fetched with `comments(first: 100)` per review thread.
-    The script does not currently paginate nested thread comments beyond 100.
+    If a thread has more than 100 comments, the thread is returned with
+    `commentsTruncated: true` and metadata (`commentsTotalCount`,
+    `commentsRemainingCount`) so callers can detect the truncation.
 """
 
 from __future__ import annotations
@@ -80,6 +82,8 @@ query(
           originalStartLine
           resolvedBy { login }
           comments(first: 100) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
             nodes {
               id
               body
@@ -216,17 +220,34 @@ def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
         if not comments_done:
             conversation_comments.extend(c.get("nodes") or [])
             comments_done = not c["pageInfo"]["hasNextPage"]
-            comments_cursor = None if comments_done else c["pageInfo"]["endCursor"]
+            if not comments_done:
+                comments_cursor = c["pageInfo"]["endCursor"]
 
         if not reviews_done:
             reviews.extend(r.get("nodes") or [])
             reviews_done = not r["pageInfo"]["hasNextPage"]
-            reviews_cursor = None if reviews_done else r["pageInfo"]["endCursor"]
+            if not reviews_done:
+                reviews_cursor = r["pageInfo"]["endCursor"]
 
         if not threads_done:
-            review_threads.extend(t.get("nodes") or [])
+            for raw_thread in t.get("nodes") or []:
+                thread = dict(raw_thread)
+                thread_comments = thread.get("comments") or {}
+                page_info = thread_comments.get("pageInfo") or {}
+                total_count = thread_comments.get("totalCount")
+                loaded_count = len((thread_comments.get("nodes") or []))
+                has_more_comments = bool(page_info.get("hasNextPage"))
+                if has_more_comments:
+                    thread["commentsTruncated"] = True
+                    if isinstance(total_count, int):
+                        thread["commentsTotalCount"] = total_count
+                        thread["commentsRemainingCount"] = max(total_count - loaded_count, 0)
+                    else:
+                        thread["commentsRemainingCount"] = None
+                review_threads.append(thread)
             threads_done = not t["pageInfo"]["hasNextPage"]
-            threads_cursor = None if threads_done else t["pageInfo"]["endCursor"]
+            if not threads_done:
+                threads_cursor = t["pageInfo"]["endCursor"]
 
     assert pr_meta is not None
     return {

--- a/apps/symphony/skills/sym-fix-ci/scripts/inspect_pr_checks.py
+++ b/apps/symphony/skills/sym-fix-ci/scripts/inspect_pr_checks.py
@@ -113,7 +113,10 @@ def main() -> int:
 
     failing = [c for c in checks if is_failing(c)]
     if not failing:
-        print(f"PR #{pr_value}: no failing checks detected.")
+        if args.json:
+            print(json.dumps({"pr": pr_value, "results": []}, indent=2))
+        else:
+            print(f"PR #{pr_value}: no failing checks detected.")
         return 0
 
     results = []
@@ -136,9 +139,16 @@ def main() -> int:
 
 
 def find_git_root(start: Path) -> Path | None:
+    resolved = start.resolve()
+    if not resolved.exists():
+        return None
+    cwd = resolved if resolved.is_dir() else resolved.parent
+    if not cwd.exists() or not cwd.is_dir():
+        return None
+
     result = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
-        cwd=start,
+        cwd=cwd,
         text=True,
         capture_output=True,
     )
@@ -434,7 +444,7 @@ def extract_failure_snippet(log_text: str, max_lines: int, context: int) -> str:
         return "\n".join(lines[-max_lines:])
 
     start = max(0, marker_index - context)
-    end = min(len(lines), marker_index + context)
+    end = min(len(lines), marker_index + context + 1)
     window = lines[start:end]
     if len(window) > max_lines:
         window = window[-max_lines:]

--- a/apps/symphony/skills/sym-land/land_watch.py
+++ b/apps/symphony/skills/sym-land/land_watch.py
@@ -114,25 +114,9 @@ async def get_review_comments(pr_number: int) -> list[dict[str, Any]]:
 
 
 async def get_reviews(pr_number: int) -> list[dict[str, Any]]:
-    page = 1
-    reviews: list[dict[str, Any]] = []
-    while True:
-        data = await run_gh(
-            "api",
-            "--method",
-            "GET",
-            f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/reviews",
-            "-f",
-            "per_page=100",
-            "-f",
-            f"page={page}",
-        )
-        batch = json.loads(data)
-        if not batch:
-            break
-        reviews.extend(batch)
-        page += 1
-    return reviews
+    return await get_paginated_list(
+        f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/reviews",
+    )
 
 
 async def get_check_runs(head_sha: str) -> list[dict[str, Any]]:
@@ -532,7 +516,7 @@ async def wait_for_codex(pr_number: int, checks_done: asyncio.Event) -> None:
         if bot_comments:
             latest = max(
                 bot_comments,
-                key=lambda comment: parse_time(comment["created_at"]),
+                key=lambda comment: comment_time(comment) or datetime.min,
             )
             body = sanitize_terminal_output(latest.get("body") or "").strip()
             if body:

--- a/apps/symphony/skills/sym-land/land_watch.py
+++ b/apps/symphony/skills/sym-land/land_watch.py
@@ -4,7 +4,7 @@ import json
 import random
 import re
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 POLL_SECONDS = 10
@@ -347,6 +347,8 @@ def latest_codex_reply_by_thread(
 ) -> dict[int, datetime]:
     latest: dict[int, datetime] = {}
     for comment in comments:
+        if not is_codex_bot_user(comment.get("user", {})):
+            continue
         body = (comment.get("body") or "").strip()
         if not is_codex_reply_body(body):
             continue
@@ -516,7 +518,8 @@ async def wait_for_codex(pr_number: int, checks_done: asyncio.Event) -> None:
         if bot_comments:
             latest = max(
                 bot_comments,
-                key=lambda comment: comment_time(comment) or datetime.min,
+                key=lambda comment: comment_time(comment)
+                or datetime.min.replace(tzinfo=timezone.utc),
             )
             body = sanitize_terminal_output(latest.get("body") or "").strip()
             if body:


### PR DESCRIPTION
## Summary
- add integrated assembled Symphony mock scenario controls spanning supervisor, operator snapshot, and board fixture enrichment
- add milestone-level Electron proof suite covering scenario control, healthy runtime→dashboard→escalation→board convergence, and failure-path truthfulness/recovery
- add S04 smoke checklist + UAT report artifacts for live and packaged-like acceptance evidence
- commit injected `sym-*` skill files required by workspace tooling

## Validation
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/symphony-end-to-end.e2e.ts --grep "scenario control"`
- `cd apps/desktop && npx playwright test e2e/tests/symphony-end-to-end.e2e.ts --grep "healthy assembled flow"`
- `cd apps/desktop && npx playwright test e2e/tests/symphony-end-to-end.e2e.ts --grep "failure-path truthfulness"`
- `cd apps/desktop && npx playwright test e2e/tests/symphony-end-to-end.e2e.ts`
- `cd apps/desktop && npx vitest run src/main/__tests__/symphony-supervisor.test.ts src/main/__tests__/symphony-operator-service.test.ts src/main/__tests__/workflow-board-service.test.ts`
- pre-push gate: `turbo run lint typecheck test --affected`

Closes KAT-2337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Playwright end-to-end suites for Symphony healthy, assembled, and failure-recovery flows; new unit tests validating assembled scenarios and supervisor behavior; extended fixtures with two new Symphony mock modes.

* **Chores**
  * Added CLI utilities to fetch PR conversations, inspect PR/CI checks, and monitor PR landability.
  * Added an npm script to run the new Symphony e2e test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the S04 end-to-end Symphony operation proof by adding two new assembled mock scenarios (`assembled_healthy` and `assembled_failure_recovery`) across the supervisor, operator service, and workflow board service, backed by new unit tests and a new Playwright e2e suite.

**Key changes:**
- **`symphony-supervisor.ts`**: Detects assembled scenarios and emits `checkpoint:runtime-starting/ready` diagnostics with a distinct `mock-symphony-assembled` launch command identifier.
- **`symphony-operator-service.ts`**: Introduces `mockBaselineStep` — a step counter that sequences `assembled_failure_recovery` through connected → disconnected → recovered phases. Also adds post-escalation worker state mutation in `respondToEscalation` for `assembled_healthy` mode.
- **`workflow-board-service.ts`**: Adds `TEST_LINEAR_ASSEMBLED_WORKFLOW_FIXTURE` (KAT-2337 slice in `in_progress`) and routes assembled mock modes to it via `resolveTestLinearFixture()`.
- **E2E suite**: New `symphony-end-to-end.e2e.ts` with three describe blocks proving runtime→dashboard→board convergence and failure-path truthfulness.

**Issues found:**
- The `respondToEscalation` side-effects for `assembled_healthy` are unconditionally overwritten on the next `refreshBaseline` call since `applyMockBaseline` rebuilds the entire snapshot from scratch, making the post-escalation state ephemeral.
- `mockBaselineStep` increments on every `refreshBaseline` regardless of origin; additional internally-triggered refreshes would drift the step counter silently.

<h3>Confidence Score: 3/5</h3>

Safe to merge with awareness of mock state inconsistency; the assembled_healthy post-escalation state is ephemeral and will silently reset on next refreshBaseline, which could cause E2E flakiness if auto-polling is added later.

The core mock infrastructure is well-structured and unit tests pass a clear sequencing contract. However, the respondToEscalation state mutation for assembled_healthy is fundamentally at odds with applyMockBaseline rebuilding the full snapshot from scratch — the two code paths are not coordinated. Additionally, mockBaselineStep has no guard against accidental over-consumption from internally-triggered refreshes. Both issues are confined to mock/test code paths but affect the reliability of the proof suite this PR is specifically introducing.

apps/desktop/src/main/symphony-operator-service.ts — the respondToEscalation assembled_healthy mutation and mockBaselineStep increment logic both need attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/symphony-operator-service.ts | Adds assembled scenario mock support with mockBaselineStep counter for failure_recovery sequencing and respondToEscalation mutation for assembled_healthy — but mutations are silently overwritten on next refreshBaseline call. |
| apps/desktop/src/main/symphony-supervisor.ts | Adds assembled scenario detection to emit runtime checkpoints into diagnostics stdout and surface a distinct mock-symphony-assembled launch command; minimal and correct. |
| apps/desktop/src/main/workflow-board-service.ts | Adds TEST_LINEAR_ASSEMBLED_WORKFLOW_FIXTURE with KAT-2337 slice and routes assembled mock modes to it via resolveTestLinearFixture(); withFreshTimestamps applied consistently. |
| apps/desktop/e2e/tests/symphony-end-to-end.e2e.ts | New e2e test file covering three describe blocks: scenario control, healthy assembled flow, and failure-path truthfulness/recovery; relies on manual refresh which keeps tests deterministic. |
| apps/desktop/e2e/fixtures/electron.fixture.ts | Extends symphonyMockMode union type with two new assembled scenario variants; minimal and correct. |
| apps/desktop/src/main/__tests__/symphony-operator-service.test.ts | Adds two new unit tests covering assembled healthy and failure-recovery mock flows; sequencing test correctly validates the step-based state machine. |
| apps/desktop/package.json | Adds a focused test:e2e:symphony-end-to-end script targeting the new test file. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Electron UI
    participant Sup as SymphonySupervisor
    participant Op as SymphonyOperatorService
    participant Board as WorkflowBoardService

    UI->>Sup: start() [assembled_healthy / assembled_failure_recovery]
    Note over Sup: isAssembledScenario=true
    Sup-->>UI: phase=ready, command=mock-symphony-assembled

    UI->>Op: syncRuntimeStatus(READY)
    Op->>Op: refreshBaseline(step=0)
    Note over Op: connected, escalation added, workers=[KAT-2337 in_progress]
    Op-->>UI: snapshot emitted

    alt assembled_healthy
        UI->>Op: respondToEscalation(req-assembled-1, text)
        Note over Op: escalations filtered, KAT-2337→agent_review
        Op-->>UI: snapshot emitted
        UI->>Board: getBoard()
        Board-->>UI: KAT-2337 in In Progress, Execution: idle
    else assembled_failure_recovery
        UI->>Op: refreshBaseline() [step=1]
        Note over Op: mockBaselineStep=1, disconnected
        Op-->>UI: snapshot emitted (disconnected)
        UI->>Op: refreshBaseline() [step=2]
        Note over Op: mockBaselineStep=2, recovered, escalations=[]
        Op-->>UI: snapshot emitted (connected, recovered)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/symphony-operator-service.ts
Line: 185-197

Comment:
**Mock state mutation overwritten by next `refreshBaseline` call**

`respondToEscalation` in `assembled_healthy` mode mutates `this.snapshot.workers` (worker state → `agent_review`, `toolName` → `idle`) and increments `completedCount`, but `applyMockBaseline` unconditionally overwrites both fields every time `refreshBaseline` is called:

- `this.snapshot.completedCount = isFailureRecoveredPhase ? 4 : 3` always resets to `3` for `assembled_healthy`
- `this.snapshot.workers` is fully replaced with a fresh array where the worker's state is `in_progress` and `toolName` is `edit`

Any subsequent `refreshBaseline` invocation — whether from auto-polling, a manual dashboard refresh, or the `syncRuntimeStatus` path — will silently undo the post-escalation state. The E2E `healthy assembled flow` test passes today because it closes settings before any refresh fires, but the scenario becomes flaky if any auto-refresh is wired in.

Consider tracking post-escalation state in a dedicated flag (e.g. `private mockEscalationResolved = false`) that `applyMockBaseline` reads, so the resolved state survives across baseline refreshes.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/symphony-operator-service.ts
Line: 99-106

Comment:
**`mockBaselineStep` increments on every `refreshBaseline`, not just explicit user-driven refreshes**

`mockBaselineStep` advances for `assembled_failure_recovery` on every call to `refreshBaseline`, whether triggered by `syncRuntimeStatus` or any background polling. The `syncRuntimeStatus` path resets `mockBaselineStep = 0` only when `status.phase !== 'ready'` — so a `READY_STATUS` sync does **not** reset the counter before the first baseline refresh. This means: `syncRuntimeStatus(READY_STATUS)` → internal `refreshBaseline` fires → step `0` consumed → `mockBaselineStep = 1`. The next manual click of `symphony-dashboard-refresh` would then immediately show **disconnected** rather than the intended initial connected state.

The unit test passes because it manually calls `syncRuntimeStatus` (consuming step 0) then two explicit `refreshBaseline()` calls (consuming steps 1 and 2), and the assertions align with this ordering. But if the app's startup triggers any additional internal `refreshBaseline` beyond what the test exercises, the step sequencing drifts silently.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/symphony-operator-service.ts
Line: 186-188

Comment:
**Hardcoded ticket identifier in production service code**

`worker.identifier === 'KAT-2337'` ties production service logic to a specific Linear ticket. While this path only runs under mock mode, having a ticket identifier baked into `symphony-operator-service.ts` means the assembled scenario silently breaks if the primary mock worker is ever updated to a different identifier. Consider deriving the target identifier from the mock baseline state (e.g. `this.snapshot.workers[0]?.identifier`) instead:

```typescript
if (this.mockMode === 'assembled_healthy') {
  const primaryIdentifier = this.snapshot.workers[0]?.identifier
  this.snapshot.workers = this.snapshot.workers.map((worker) =>
    worker.identifier === primaryIdentifier
      ? { ...worker, state: 'agent_review', toolName: 'idle', lastActivityAt: new Date().toISOString() }
      : worker,
  )
  this.snapshot.completedCount += 1
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/e2e/tests/symphony-end-to-end.e2e.ts
Line: 25-45

Comment:
**`scenario control` and `healthy assembled flow` describe blocks share identical mock mode and overlapping assertions**

Both `test.describe('scenario control')` and `test.describe('healthy assembled flow')` use `test.use({ symphonyMockMode: 'assembled_healthy' })` and both verify runtime start, dashboard connection, and KAT-2337 worker visibility. The overlap means any flakiness in the `assembled_healthy` startup path causes both suites to fail, making signal noisier. Consider merging `scenario control` into `healthy assembled flow` as a preliminary step, or at minimum add a comment explaining the distinct contract each describe block is testing.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): cover assembled symphony ..."](https://github.com/gannonh/kata/commit/ac5dc472fe37e0ed1c61901ff8b43911da84431c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27372659)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->