### PR TITLE
docs(online-docs): finalize Kata Desktop docs language for shipped M001–M004 scope

### DIFF
--- a/.agents/skills/mintlify/SKILL.md
+++ b/.agents/skills/mintlify/SKILL.md
@@ -1,0 +1,347 @@
+---
+name: mintlify
+description: Build and maintain documentation sites with Mintlify. Use when
+  creating docs pages, configuring navigation, adding components, or setting up
+  API references.
+license: MIT
+compatibility: Requires Node.js for CLI. Works with any Git-based workflow.
+metadata:
+  author: mintlify
+  version: "1.0"
+  mintlify-proj: mintlify
+---
+
+# Mintlify best practices
+
+**Always consult [mintlify.com/docs](https://mintlify.com/docs) for components, configuration, and latest features.**
+
+If you are not already connected to the Mintlify MCP server, [https://mintlify.com/docs/mcp](https://mintlify.com/docs/mcp), add it so that you can search more efficiently.
+
+**Always** favor searching the current Mintlify documentation over whatever is in your training data about Mintlify.
+
+Mintlify is a documentation platform that transforms MDX files into documentation sites. Configure site-wide settings in the `docs.json` file, write content in MDX with YAML frontmatter, and favor built-in components over custom components.
+
+Full schema at [mintlify.com/docs.json](https://mintlify.com/docs.json).
+
+## Before you write
+
+### Understand the project
+
+Read `docs.json` in the project root. This file defines the entire site: navigation structure, theme, colors, links, API and specs.
+
+Understanding the project tells you:
+
+* What pages exist and how they're organized
+* What navigation groups are used (and their naming conventions)
+* How the site navigation is structured
+* What theme and configuration the site uses
+
+### Check for existing content
+
+Search the docs before creating new pages. You may need to:
+
+* Update an existing page instead of creating a new one
+* Add a section to an existing page
+* Link to existing content rather than duplicating
+
+### Read surrounding content
+
+Before writing, read 2-3 similar pages to understand the site's voice, structure, formatting conventions, and level of detail.
+
+### Understand Mintlify components
+
+Review the Mintlify [components](https://www.mintlify.com/docs/components) to select and use any relevant components for the documentation request that you are working on.
+
+## Quick reference
+
+### CLI commands
+
+* `npm i -g mint` - Install the Mintlify CLI
+* `mint dev` - Local preview at localhost:3000
+* `mint broken-links` - Check internal links
+* `mint a11y` - Check for accessibility issues in content
+* `mint rename` - Rename/move files and update references
+* `mint validate` - Validate documentation builds
+
+### Required files
+
+* `docs.json` - Site configuration (navigation, theme, integrations, etc.). See [global settings](https://mintlify.com/docs/settings/global) for all options.
+* `*.mdx` files - Documentation pages with YAML frontmatter
+
+### Example file structure
+
+```
+project/
+├── docs.json           # Site configuration
+├── introduction.mdx
+├── quickstart.mdx
+├── guides/
+│   └── example.mdx
+├── openapi.yml         # API specification
+├── images/             # Static assets
+│   └── example.png
+└── snippets/           # Reusable components
+    └── component.jsx
+```
+
+## Page frontmatter
+
+Every page requires `title` in its frontmatter. Include `description` for SEO and navigation.
+
+```yaml theme={null}
+---
+title: "Clear, descriptive title"
+description: "Concise summary for SEO and navigation."
+---
+```
+
+Optional frontmatter fields:
+
+* `sidebarTitle`: Short title for sidebar navigation.
+* `icon`: Lucide or Font Awesome icon name, URL, or file path.
+* `tag`: Label next to the page title in the sidebar (for example, "NEW").
+* `mode`: Page layout mode (`default`, `wide`, `custom`).
+* `keywords`: Array of terms related to the page content for local search and SEO.
+* Any custom YAML fields for use with personalization or conditional content.
+
+## File conventions
+
+* Match existing naming patterns in the directory
+* If there are no existing files or inconsistent file naming patterns, use kebab-case: `getting-started.mdx`, `api-reference.mdx`
+* Use root-relative paths without file extensions for internal links: `/getting-started/quickstart`
+* Do not use relative paths (`../`) or absolute URLs for internal pages
+* When you create a new page, add it to `docs.json` navigation or it won't appear in the sidebar
+
+## Organize content
+
+When a user asks about anything related to site-wide configurations, start by understanding the [global settings](https://www.mintlify.com/docs/organize/settings). See if a setting in the `docs.json` file can be updated to achieve what the user wants.
+
+### Navigation
+
+The `navigation` property in `docs.json` controls site structure. Choose one primary pattern at the root level, then nest others within it.
+
+**Choose your primary pattern:**
+
+| Pattern       | When to use                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------- |
+| **Groups**    | Default. Single audience, straightforward hierarchy                                            |
+| **Tabs**      | Distinct sections with different audiences (Guides vs API Reference) or content types          |
+| **Anchors**   | Want persistent section links at sidebar top. Good for separating docs from external resources |
+| **Dropdowns** | Multiple doc sections users switch between, but not distinct enough for tabs                   |
+| **Products**  | Multi-product company with separate documentation per product                                  |
+| **Versions**  | Maintaining docs for multiple API/product versions simultaneously                              |
+| **Languages** | Localized content                                                                              |
+
+**Within your primary pattern:**
+
+* **Groups** - Organize related pages. Can nest groups within groups, but keep hierarchy shallow
+* **Menus** - Add dropdown navigation within tabs for quick jumps to specific pages
+* **`expanded: false`** - Collapse nested groups by default. Use for reference sections users browse selectively
+* **`openapi`** - Auto-generate pages from OpenAPI spec. Add at group/tab level to inherit
+
+**Common combinations:**
+
+* Tabs containing groups (most common for docs with API reference)
+* Products containing tabs (multi-product SaaS)
+* Versions containing tabs (versioned API docs)
+* Anchors containing groups (simple docs with external resource links)
+
+### Links and paths
+
+* **Internal links:** Root-relative, no extension: `/getting-started/quickstart`
+* **Images:** Store in `/images`, reference as `/images/example.png`
+* **External links:** Use full URLs, they open in new tabs automatically
+
+## Customize docs sites
+
+**What to customize where:**
+
+* **Brand colors, fonts, logo** → `docs.json`. See [global settings](https://mintlify.com/docs/settings/global)
+* **Component styling, layout tweaks** → `custom.css` at project root
+* **Dark mode** → Enabled by default. Only disable with `"appearance": "light"` in `docs.json` if brand requires it
+
+Start with `docs.json`. Only add `custom.css` when you need styling that config doesn't support.
+
+## Write content
+
+### Components
+
+The [components overview](https://mintlify.com/docs/components) organizes all components by purpose: structure content, draw attention, show/hide content, document APIs, link to pages, and add visual context. Start there to find the right component.
+
+**Common decision points:**
+
+| Need                       | Use                     |
+| -------------------------- | ----------------------- |
+| Hide optional details      | `<Accordion>`           |
+| Long code examples         | `<Expandable>`          |
+| User chooses one option    | `<Tabs>`                |
+| Linked navigation cards    | `<Card>` in `<Columns>` |
+| Sequential instructions    | `<Steps>`               |
+| Code in multiple languages | `<CodeGroup>`           |
+| API parameters             | `<ParamField>`          |
+| API response fields        | `<ResponseField>`       |
+
+**Callouts by severity:**
+
+* `<Note>` - Supplementary info, safe to skip
+* `<Info>` - Helpful context such as permissions
+* `<Tip>` - Recommendations or best practices
+* `<Warning>` - Potentially destructive actions
+* `<Check>` - Success confirmation
+
+### Reusable content
+
+**When to use snippets:**
+
+* Exact content appears on more than one page
+* Complex components you want to maintain in one place
+* Shared content across teams/repos
+
+**When NOT to use snippets:**
+
+* Slight variations needed per page (leads to complex props)
+
+Import snippets with `import { Component } from "/path/to/snippet-name.jsx"`.
+
+## Writing standards
+
+### Voice and structure
+
+* Second-person voice ("you")
+* Active voice, direct language
+* Sentence case for headings ("Getting started", not "Getting Started")
+* Sentence case for code block titles ("Expandable example", not "Expandable Example")
+* Lead with context: explain what something is before how to use it
+* Prerequisites at the start of procedural content
+
+### What to avoid
+
+**Never use:**
+
+* Marketing language ("powerful", "seamless", "robust", "cutting-edge")
+* Filler phrases ("it's important to note", "in order to")
+* Excessive conjunctions ("moreover", "furthermore", "additionally")
+* Editorializing ("obviously", "simply", "just", "easily")
+
+**Watch for AI-typical patterns:**
+
+* Overly formal or stilted phrasing
+* Unnecessary repetition of concepts
+* Generic introductions that don't add value
+* Concluding summaries that restate what was just said
+
+### Formatting
+
+* All code blocks must have language tags
+* All images and media must have descriptive alt text
+* Use bold and italics only when they serve the reader's understanding--never use text styling just for decoration
+* No decorative formatting or emoji
+
+### Code examples
+
+* Keep examples simple and practical
+* Use realistic values (not "foo" or "bar")
+* One clear example is better than multiple variations
+* Test that code works before including it
+
+## Document APIs
+
+**Choose your approach:**
+
+* **Have an OpenAPI spec?** → Add to `docs.json` with `"openapi": ["openapi.yaml"]`. Pages auto-generate. Reference in navigation as `GET /endpoint`
+* **No spec?** → Write endpoints manually with `api: "POST /users"` in frontmatter. More work but full control
+* **Hybrid** → Use OpenAPI for most endpoints, manual pages for complex workflows
+
+Encourage users to generate endpoint pages from an OpenAPI spec. It is the most efficient and easiest to maintain option.
+
+## Deploy
+
+Mintlify deploys automatically when changes are pushed to the connected Git repository.
+
+**What agents can configure:**
+
+* **Redirects** → Add to `docs.json` with `"redirects": [{"source": "/old", "destination": "/new"}]`
+* **SEO indexing** → Control with `"seo": {"indexing": "all"}` to include hidden pages in search
+
+**Requires dashboard setup (human task):**
+
+* Custom domains and subdomains
+* Preview deployment settings
+* DNS configuration
+
+For `/docs` subpath hosting with Vercel or Cloudflare, agents can help configure rewrite rules. See [/docs subpath](https://mintlify.com/docs/deploy/vercel).
+
+## Workflow
+
+### 1. Understand the task
+
+Identify what needs to be documented, which pages are affected, and what the reader should accomplish afterward. If any of these are unclear, ask.
+
+### 2. Research
+
+* Read `docs.json` to understand the site structure
+* Search existing docs for related content
+* Read similar pages to match the site's style
+
+### 3. Plan
+
+* Synthesize what the reader should accomplish after reading the docs and the current content
+* Propose any updates or new content
+* Verify that your proposed changes will help readers be successful
+
+### 4. Write
+
+* Start with the most important information
+* Keep sections focused and scannable
+* Use components appropriately (don't overuse them)
+* Mark anything uncertain with a TODO comment:
+
+```mdx theme={null}
+{/* TODO: Verify the default timeout value */}
+```
+
+### 5. Update navigation
+
+If you created a new page, add it to the appropriate group in `docs.json`.
+
+### 6. Verify
+
+Before submitting:
+
+* [ ] Frontmatter includes title and description
+* [ ] All code blocks have language tags
+* [ ] Internal links use root-relative paths without file extensions
+* [ ] New pages are added to `docs.json` navigation
+* [ ] Content matches the style of surrounding pages
+* [ ] No marketing language or filler phrases
+* [ ] TODOs are clearly marked for anything uncertain
+* [ ] Run `mint broken-links` to check links
+* [ ] Run `mint validate` to find any errors
+
+## Edge cases
+
+### Migrations
+
+If a user asks about migrating to Mintlify, ask if they are using ReadMe or Docusaurus. If they are, use the [@mintlify/scraping](https://www.npmjs.com/package/@mintlify/scraping) CLI to migrate content. If they are using a different platform to host their documentation, help them manually convert their content to MDX pages using Mintlify components.
+
+### Hidden pages
+
+Any page that is not included in the `docs.json` navigation is hidden. Use hidden pages for content that should be accessible by URL or indexed for the assistant or search, but not discoverable through the sidebar navigation.
+
+### Exclude pages
+
+The `.mintignore` file is used to exclude files from a documentation repository from being processed.
+
+## Common gotchas
+
+1. **Component imports** - JSX components need explicit import, MDX components don't
+2. **Frontmatter required** - Every MDX file needs `title` at minimum
+3. **Code block language** - Always specify language identifier
+4. **Never use `mint.json`** - `mint.json` is deprecated. Only ever use `docs.json`
+
+## Resources
+
+* [Documentation](https://mintlify.com/docs)
+* [Configuration schema](https://mintlify.com/docs.json)
+* [Feature requests](https://github.com/orgs/mintlify/discussions/categories/feature-requests)
+* [Bugs and feedback](https://github.com/orgs/mintlify/discussions/categories/bugs-feedback)

--- a/.agents/skills/sym-address-comments/scripts/fetch_comments.py
+++ b/.agents/skills/sym-address-comments/scripts/fetch_comments.py
@@ -14,7 +14,9 @@ Usage:
 
 Notes:
   - Thread comments are fetched with `comments(first: 100)` per review thread.
-    The script does not currently paginate nested thread comments beyond 100.
+    If a thread has more than 100 comments, the thread is returned with
+    `commentsTruncated: true` and metadata (`commentsTotalCount`,
+    `commentsRemainingCount`) so callers can detect the truncation.
 """
 
 from __future__ import annotations
@@ -80,6 +82,8 @@ query(
           originalStartLine
           resolvedBy { login }
           comments(first: 100) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
             nodes {
               id
               body
@@ -216,17 +220,34 @@ def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
         if not comments_done:
             conversation_comments.extend(c.get("nodes") or [])
             comments_done = not c["pageInfo"]["hasNextPage"]
-            comments_cursor = None if comments_done else c["pageInfo"]["endCursor"]
+            if not comments_done:
+                comments_cursor = c["pageInfo"]["endCursor"]
 
         if not reviews_done:
             reviews.extend(r.get("nodes") or [])
             reviews_done = not r["pageInfo"]["hasNextPage"]
-            reviews_cursor = None if reviews_done else r["pageInfo"]["endCursor"]
+            if not reviews_done:
+                reviews_cursor = r["pageInfo"]["endCursor"]
 
         if not threads_done:
-            review_threads.extend(t.get("nodes") or [])
+            for raw_thread in t.get("nodes") or []:
+                thread = dict(raw_thread)
+                thread_comments = thread.get("comments") or {}
+                page_info = thread_comments.get("pageInfo") or {}
+                total_count = thread_comments.get("totalCount")
+                loaded_count = len((thread_comments.get("nodes") or []))
+                has_more_comments = bool(page_info.get("hasNextPage"))
+                if has_more_comments:
+                    thread["commentsTruncated"] = True
+                    if isinstance(total_count, int):
+                        thread["commentsTotalCount"] = total_count
+                        thread["commentsRemainingCount"] = max(total_count - loaded_count, 0)
+                    else:
+                        thread["commentsRemainingCount"] = None
+                review_threads.append(thread)
             threads_done = not t["pageInfo"]["hasNextPage"]
-            threads_cursor = None if threads_done else t["pageInfo"]["endCursor"]
+            if not threads_done:
+                threads_cursor = t["pageInfo"]["endCursor"]
 
     assert pr_meta is not None
     return {

--- a/.agents/skills/sym-land/SKILL.md
+++ b/.agents/skills/sym-land/SKILL.md
@@ -117,7 +117,6 @@ Exit codes:
 - 2: Review comments detected (address feedback)
 - 3: CI checks failed
 - 4: PR head updated (autofix commit detected)
-- 5: Merge conflicts detected (`is_merge_conflicting` path in `watch_pr`/head monitor) — resolve/rebase against `main` and push
 
 ## Failure Handling
 

--- a/.agents/skills/sym-land/SKILL.md
+++ b/.agents/skills/sym-land/SKILL.md
@@ -117,6 +117,7 @@ Exit codes:
 - 2: Review comments detected (address feedback)
 - 3: CI checks failed
 - 4: PR head updated (autofix commit detected)
+- 5: Merge conflict detected (run conflict-resolution flow)
 
 ## Failure Handling
 

--- a/.agents/skills/sym-land/land_watch.py
+++ b/.agents/skills/sym-land/land_watch.py
@@ -276,8 +276,6 @@ def latest_codex_issue_reply_time(
 ) -> datetime | None:
     latest: datetime | None = None
     for comment in comments:
-        if not is_codex_bot_user(comment.get("user", {})):
-            continue
         body = (comment.get("body") or "").strip()
         if not is_codex_reply_body(body):
             continue
@@ -296,6 +294,10 @@ def filter_human_issue_comments(comments: list[dict[str, Any]]) -> list[dict[str
         if is_bot_user(comment.get("user", {})):
             continue
         body = (comment.get("body") or "").strip()
+        if is_codex_reply_body(body):
+            continue
+        if is_codex_review_body(body):
+            continue
         if "@codex review" in body:
             continue
         created_time = comment_time(comment)
@@ -311,23 +313,14 @@ def filter_human_issue_comments(comments: list[dict[str, Any]]) -> list[dict[str
 
 def filter_codex_review_issue_comments(
     comments: list[dict[str, Any]],
-    review_request_at: datetime | None,
 ) -> list[dict[str, Any]]:
     latest_ack = latest_codex_issue_reply_time(comments)
     filtered: list[dict[str, Any]] = []
     for comment in comments:
-        if not is_codex_bot_user(comment.get("user", {})):
-            continue
         body = (comment.get("body") or "").strip()
         if not is_codex_review_body(body):
             continue
         created_time = comment_time(comment)
-        if (
-            review_request_at is not None
-            and created_time is not None
-            and created_time <= review_request_at
-        ):
-            continue
         if (
             latest_ack is not None
             and created_time is not None
@@ -485,10 +478,7 @@ def raise_on_human_feedback(
     review_request_at: datetime | None,
 ) -> None:
     human_issue_comments = filter_human_issue_comments(issue_comments)
-    codex_review_comments = filter_codex_review_issue_comments(
-        issue_comments,
-        review_request_at,
-    )
+    codex_review_comments = filter_codex_review_issue_comments(issue_comments)
     human_review_comments = filter_human_review_comments(review_comments)
     if human_issue_comments or human_review_comments or codex_review_comments:
         print("Review comments detected. Address before merge.")

--- a/apps/online-docs/desktop/overview.mdx
+++ b/apps/online-docs/desktop/overview.mdx
@@ -1,104 +1,87 @@
 ---
 title: "Kata Desktop"
-description: "Electron-based desktop app for working with AI agents. Multi-session management, MCP integrations, permission controls, and a document-centric workflow."
+description: "Desktop UI for Kata CLI: streaming chat, planning artifacts, workflow kanban, and Symphony operator controls."
 ---
 
-Kata Desktop is a productivity app for working with AI agents. Built on the Claude Agent SDK, it enables intuitive multitasking, seamless connection to APIs and services, and a document-centric workflow in a polished, natural language driven UI. It's like Claude Code meets Slack.
+Kata Desktop is the native Electron app for Kata. It runs the same agent runtime as Kata CLI (`kata --mode rpc`) and adds a visual interface for everyday operation.
 
-## Features
+Today’s shipped experience covers milestones **M001–M004**:
+
+- **M001 Chat Foundation**
+- **M002 Planning View**
+- **M003 Workflow Kanban**
+- **M004 Symphony Integration**
+
+## What you can do today
 
 <CardGroup cols={2}>
-  <Card title="Multi-session inbox" icon="inbox">
-    Manage sessions by workflow status with flagging, archiving, and a full status lifecycle from Todo to Done.
+  <Card title="Streaming chat" icon="message">
+    Work in a desktop chat UI with streaming responses, thinking blocks, and inline tool output.
   </Card>
-  <Card title="Claude Code experience" icon="bolt">
-    Streaming responses, tool call visualization, and real-time updates in a familiar coding-focused interface.
+  <Card title="Session sidebar" icon="inbox">
+    Create sessions, switch between sessions, and resume existing work from persisted session history.
   </Card>
-  <Card title="Git integration" icon="code-branch">
-    Live branch badge, PR status display, real-time updates via file watching, and worktree/submodule support.
+  <Card title="Workspace picker" icon="folder-open">
+    Point Desktop at any local workspace and keep session lists scoped to that workspace.
   </Card>
-  <Card title="Agent skills" icon="graduation-cap">
-    Specialized agent instructions stored per-workspace to tailor behavior for each project.
+  <Card title="Provider settings" icon="key">
+    Configure provider credentials from the UI using the shared Kata auth store.
   </Card>
-  <Card title="MCP integration" icon="plug">
-    Connect to any MCP server — Linear, GitHub, Notion, and custom servers — directly from the app.
+  <Card title="Planning artifact pane" icon="file-lines">
+    View ROADMAP, REQUIREMENTS, DECISIONS, CONTEXT, and SLICE artifacts in the right pane during planning.
   </Card>
-  <Card title="Sources" icon="database">
-    Connect to REST APIs (Google, Slack, Microsoft) and local filesystems to give agents live context.
+  <Card title="Workflow kanban" icon="table-columns">
+    Track active slice/task execution state in a kanban board with Linear/GitHub-backed workflow data.
   </Card>
-  <Card title="Permission modes" icon="shield">
-    Three-level system (Explore, Ask to Edit, Auto) to control how much the agent can do autonomously.
+  <Card title="Symphony runtime controls" icon="play">
+    Start, stop, and restart Symphony from **Settings → Symphony** when running in managed mode.
   </Card>
-  <Card title="Background tasks" icon="clock">
-    Run long-running operations with progress tracking while continuing other work.
-  </Card>
-  <Card title="Dynamic status system" icon="list-check">
-    Customizable session workflow states — Todo, In Progress, Needs Review, Done, and more.
-  </Card>
-  <Card title="Theme system" icon="palette">
-    Cascading themes set at the app level or overridden per workspace.
-  </Card>
-  <Card title="Multi-file diff" icon="code-compare">
-    VS Code-style diff window to review all file changes produced in a single agent turn.
-  </Card>
-  <Card title="File attachments" icon="paperclip">
-    Drag and drop images, PDFs, and Office documents with automatic conversion.
+  <Card title="Live operator dashboard" icon="activity">
+    Monitor workers, queue, and escalations, then submit escalation responses directly from Desktop.
   </Card>
 </CardGroup>
 
 ## Installation
 
-### Download from GitHub Releases
+### Build from source (current monorepo)
 
-Download the latest release for your platform from [GitHub Releases](https://github.com/gannonh/kata/releases).
-
-<Tabs>
-  <Tab title="macOS (Apple Silicon)">
-    Download `Kata-Desktop-arm64.dmg` and open the installer.
-  </Tab>
-  <Tab title="macOS (Intel)">
-    Download `Kata-Desktop-x64.dmg` and open the installer.
-  </Tab>
-  <Tab title="Windows">
-    Download `Kata-Desktop-x64.exe` and run the installer.
-  </Tab>
-  <Tab title="Linux">
-    Download `Kata-Desktop-x64.AppImage`, make it executable, and run it:
-
-    ```bash
-    chmod +x Kata-Desktop-x64.AppImage
-    ./Kata-Desktop-x64.AppImage
-    ```
-  </Tab>
-</Tabs>
-
-### Build from source
+From the repository root:
 
 ```bash
-git clone https://github.com/gannonh/kata.git
-cd kata
 bun install
-bun run githooks:install
-bun run electron:start
+bun run desktop:dev
+```
+
+For a packaged macOS artifact:
+
+```bash
+bun run desktop:dist:mac
+```
+
+### Run from `apps/desktop`
+
+```bash
+cd apps/desktop
+bun run desktop:dev
 ```
 
 ## Quick start
 
 <Steps>
-  <Step title="Launch the app">
-    Open Kata Desktop after installation.
+  <Step title="Launch Desktop">
+    Start the app in dev mode or open the packaged app.
   </Step>
-  <Step title="Choose an API connection">
-    Connect your Anthropic API key or Claude Max subscription when prompted.
+  <Step title="Complete onboarding">
+    Follow the real onboarding flow: **provider selection → API key setup → model selection → ready state**.
   </Step>
-  <Step title="Create a workspace">
-    Set up a workspace to organize your sessions and store per-project configuration.
-  </Step>
-  <Step title="Connect sources (optional)">
-    Add MCP servers, REST APIs, or local filesystems to give agents additional context.
+  <Step title="Pick your workspace">
+    Use the workspace picker in the app shell and point Desktop at your project folder.
   </Step>
   <Step title="Start chatting">
-    Create a session and start interacting with Claude.
+    Create a session and send your first prompt.
+  </Step>
+  <Step title="Open the right pane contextually">
+    During planning, the right pane shows planning artifacts. During execution, it switches to workflow kanban.
   </Step>
 </Steps>
 
@@ -106,20 +89,32 @@ bun run electron:start
 
 | Layer | Technology |
 |---|---|
-| Runtime | [Bun](https://bun.sh/) |
-| AI | [@anthropic-ai/claude-agent-sdk](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) |
-| Desktop | [Electron](https://www.electronjs.org/) + React |
-| UI | [shadcn/ui](https://ui.shadcn.com/) + Tailwind CSS v4 |
-| Build | esbuild (main) + Vite (renderer) |
-| Credentials | AES-256-GCM encrypted file storage |
+| Runtime | Electron (Node.js main process + Chromium renderer) |
+| Agent runtime | Kata CLI subprocess (`kata --mode rpc`) |
+| UI | React 19 + Tailwind CSS v4 + Radix UI + Jotai |
+| Build | esbuild (main/preload) + Vite (renderer) + electron-builder |
+| Shared auth | `~/.kata-cli/agent/auth.json` |
+| Session store | `~/.kata-cli/sessions/*.jsonl` |
+
+## Known boundaries in M001–M004
+
+- Desktop does **not** yet ship a full MCP/source-management UI in settings.
+- General and Appearance settings tabs are present as placeholders for future slices.
+- The product is **Kata Desktop** (not the legacy Craft Agents app).
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Sessions and workspaces" icon="window" href="/desktop/sessions-workspaces">
-    Session management, permission modes, Git integration, and keyboard shortcuts.
+    Session lifecycle, persistence model, and workspace switching behavior.
   </Card>
-  <Card title="Sources and MCP" icon="plug" href="/desktop/sources-mcp">
-    Connect MCP servers, REST APIs, local filesystems, and Slack channels.
+  <Card title="Planning and kanban" icon="table-columns" href="/desktop/planning-kanban">
+    How the right pane switches between planning artifacts and workflow execution state.
+  </Card>
+  <Card title="Symphony integration" icon="music" href="/desktop/symphony">
+    Managed vs external Symphony, dashboard signals, and escalation handling.
+  </Card>
+  <Card title="Providers and integrations" icon="plug" href="/desktop/sources-mcp">
+    What integrations are available now and where to configure them.
   </Card>
 </CardGroup>

--- a/apps/online-docs/desktop/overview.mdx
+++ b/apps/online-docs/desktop/overview.mdx
@@ -100,7 +100,6 @@ bun run desktop:dev
 
 - Desktop does **not** yet ship a full MCP/source-management UI in settings.
 - General and Appearance settings tabs are present as placeholders for future slices.
-- The product is **Kata Desktop** (not the legacy Craft Agents app).
 
 ## Next steps
 

--- a/apps/online-docs/desktop/planning-kanban.mdx
+++ b/apps/online-docs/desktop/planning-kanban.mdx
@@ -1,0 +1,65 @@
+---
+title: "Planning and workflow kanban"
+description: "How the right pane works in Kata Desktop: planning artifact viewer during planning, workflow kanban during execution."
+---
+
+Kata Desktop uses a contextual right pane that switches between planning and execution views.
+
+## Planning view (M002)
+
+During `/kata plan` activity, the right pane renders planning artifacts fetched from workflow backing state.
+
+Common artifacts:
+
+- `ROADMAP`
+- `REQUIREMENTS`
+- `DECISIONS`
+- `CONTEXT`
+- Slice-level planning documents (for active slice/task)
+
+The planning pane supports:
+
+- Artifact tabs
+- Structured parsing for roadmap/requirements/decisions when possible
+- Fallback raw markdown rendering
+- Stale-data indicator when cached content is shown
+
+## Workflow kanban (M003)
+
+During execution, the right pane switches to a kanban board representing the active workflow state.
+
+### What the board shows
+
+- Active milestone and slices
+- Columns: backlog, todo, in-progress, review phases, done
+- Slice cards with child task summaries
+- Backend status (Linear or GitHub-backed workflow source)
+
+### Symphony convergence metadata (M004)
+
+When Symphony integration is active, cards also include convergence hints such as:
+
+- active worker assignment
+- latest tool activity
+- pending escalation count
+- stale/disconnected runtime indicators
+
+This lets you correlate orchestration state with workflow placement without leaving Desktop.
+
+## Automatic and manual mode switching
+
+Right-pane mode is context-driven:
+
+- Planning context → planning pane
+- Execution context → kanban pane
+
+Users can still override pane mode from UI controls and switch back when needed.
+
+## Failure and stale states
+
+Both panes are designed to fail truthfully:
+
+- planning fetch errors surface explicit messages
+- cached planning artifacts are marked stale
+- workflow board fetch failures show status/error metadata instead of blank content
+- Symphony disconnects do not erase workflow cards; they annotate runtime freshness

--- a/apps/online-docs/desktop/sessions-workspaces.mdx
+++ b/apps/online-docs/desktop/sessions-workspaces.mdx
@@ -1,101 +1,75 @@
 ---
 title: "Sessions and workspaces"
-description: "Manage sessions with status workflows, Git integration, and permission modes. Understand how Kata Desktop stores configuration on disk."
+description: "How Kata Desktop manages session history, workspace scoping, and switching between active conversations."
 ---
 
-## Session management
+## Session model
 
-Every conversation with an agent is a **session**. Sessions live inside a workspace and persist their full conversation history to disk.
+In Kata Desktop, each chat is a **session** backed by a Kata CLI JSONL session file.
 
-### Inbox and archive
+- New sessions are created from the sidebar.
+- Existing sessions are listed per workspace.
+- Switching sessions restores chat history in the main pane.
 
-Sessions are organized by workflow status into two views:
+Desktop reads sessions from:
 
-- **Inbox** — active sessions in any working state (Todo, In Progress, Needs Review)
-- **Archive** — completed or dismissed sessions (Done)
-
-You can also **flag** individual sessions to pin them for quick access regardless of their status.
-
-### Status workflow
-
-Sessions move through a configurable status lifecycle:
-
-```
-Todo → In Progress → Needs Review → Done
+```text
+~/.kata-cli/sessions/
 ```
 
-You can customize the available statuses per workspace. Status configuration is stored at `~/.kata/workspaces/{id}/statuses/`.
+It filters that global store by session header `cwd` so the sidebar only shows sessions for the active workspace.
 
-### Session naming
+## Sidebar behavior
 
-Session titles are either AI-generated from the conversation content or set manually. You can rename any session at any time.
+The session sidebar supports:
 
-### Session persistence
+- **New Session** button
+- **Refresh** action
+- Sorted session list (most recently modified first)
+- Corruption warnings when malformed JSONL files are skipped
 
-All conversation history is saved to disk as JSONL files under `~/.kata/workspaces/{id}/sessions/`. Sessions survive app restarts and can be resumed at any point.
+This is intentionally lightweight in M001–M004: there is no custom per-workspace status workflow UI yet.
+
+## Workspace switching
+
+Use the workspace button in the app shell to switch directories.
+
+When you change workspace:
+
+1. Desktop updates the active `cwd` for the agent subprocess.
+2. Session list re-scopes to sessions from that workspace.
+3. The workflow/planning scope refreshes to match the new project.
+
+Your most recent workspace is persisted so Desktop can restore it on next launch.
+
+## Persistence and shared state
+
+| Item | Location | Notes |
+|---|---|---|
+| Session transcripts | `~/.kata-cli/sessions/*.jsonl` | Shared with Kata CLI |
+| Auth records | `~/.kata-cli/agent/auth.json` | Provider credentials used by Desktop and CLI |
+| Desktop settings | Electron user data + app settings files | UI-level preferences |
+| Workflow preferences | `<workspace>/.kata/preferences.md` | Used for planning/workflow/Symphony behavior |
 
 ## Permission modes
 
-Permission modes control how much the agent is allowed to do autonomously. You can change the mode per session at any time.
+Desktop exposes three runtime permission modes in the chat toolbar:
 
-| Mode | Display | Behavior |
-|---|---|---|
-| `safe` | Explore | Read-only — blocks all write operations |
-| `ask` | Ask to Edit | Prompts for approval before making changes (default) |
-| `allow-all` | Auto | Auto-approves all commands without prompting |
-
-Press **SHIFT+TAB** in the chat interface to cycle through modes.
-
-<Note>
-  `ask` (Ask to Edit) is the default mode for new sessions. Start with this mode unless you have a specific reason to grant broader permissions.
-</Note>
-
-## Git integration
-
-When a workspace is pointed at a Git repository, Kata Desktop displays live Git context in the chat input toolbar and injects it into each agent message.
-
-| Feature | Description |
+| Mode | Behavior |
 |---|---|
-| Branch badge | Shows the current branch name, updated in real-time via file watching |
-| PR badge | Shows linked pull request title and status (open, draft, merged, closed) — click to open in browser |
-| AI awareness | Agent receives branch and PR context with every message |
-| Worktree/submodule support | Handles `.git` file gitdir pointers transparently |
-| Graceful degradation | No Git indicator for non-Git directories; a helpful message appears when the `gh` CLI is unavailable |
+| Explore | Read-only tool behavior |
+| Ask to Edit | Prompt before write operations |
+| Auto | Automatically approve operations |
+
+Use **Ask to Edit** as the default unless you explicitly want autonomous execution.
 
 ## Keyboard shortcuts
 
 | Shortcut | Action |
 |---|---|
-| `Cmd+N` | New chat |
-| `Cmd+1` / `Cmd+2` / `Cmd+3` | Focus sidebar / session list / chat panel |
-| `Cmd+/` | Open keyboard shortcuts dialog |
-| `SHIFT+TAB` | Cycle through permission modes |
+| `Cmd+N` | New session |
+| `Cmd+1` / `Cmd+2` / `Cmd+3` | Focus key app regions |
+| `Cmd+/` | Open shortcuts dialog |
+| `Shift+Tab` | Cycle permission mode |
 | `Enter` | Send message |
-| `Shift+Enter` | Insert a new line |
-
-## Configuration storage
-
-All configuration is stored under `~/.kata/`:
-
-```
-~/.kata/
-├── config.json              # Main config (workspaces, auth type)
-├── credentials.enc          # Encrypted credentials (AES-256-GCM)
-├── preferences.json         # User preferences
-├── theme.json               # App-level theme
-└── workspaces/
-    └── {id}/
-        ├── config.json      # Workspace settings
-        ├── theme.json       # Workspace theme override
-        ├── sessions/        # Session data (JSONL)
-        ├── sources/         # Connected sources
-        ├── skills/          # Custom agent skills
-        └── statuses/        # Status configuration
-```
-
-- **`config.json`** — workspace registry and authentication type (API key vs. Claude Max)
-- **`credentials.enc`** — all OAuth tokens and API keys, encrypted with AES-256-GCM
-- **`preferences.json`** — UI preferences such as theme selection
-- **`theme.json`** — app-level theme; overridden at the workspace level by `workspaces/{id}/theme.json`
-- **`workspaces/{id}/sessions/`** — one JSONL file per session with full message history
-- **`workspaces/{id}/skills/`** — Markdown files containing specialized agent instructions for this workspace
+| `Shift+Enter` | New line |

--- a/apps/online-docs/desktop/sessions-workspaces.mdx
+++ b/apps/online-docs/desktop/sessions-workspaces.mdx
@@ -32,7 +32,7 @@ This is intentionally lightweight in M001–M004: there is no custom per-workspa
 
 ## Workspace switching
 
-Use the workspace button in the app shell to switch directories.
+Use the **Workspace** button in the app shell to switch directories.
 
 When you change workspace:
 

--- a/apps/online-docs/desktop/sources-mcp.mdx
+++ b/apps/online-docs/desktop/sources-mcp.mdx
@@ -29,9 +29,9 @@ If you already use Kata CLI with MCP/Linear/GitHub integrations configured, Desk
 
 ## Practical setup flow
 
-1. Configure providers in Desktop (**Settings → Providers**) or via Kata CLI.
-2. Configure MCP servers in `~/.kata-cli/agent/mcp.json`.
-3. Configure workspace workflow preferences in `.kata/preferences.md`.
+1. Set up providers in Desktop (**Settings → Providers**) or via Kata CLI.
+2. Add MCP servers in `~/.kata-cli/agent/mcp.json`.
+3. Define workspace workflow preferences in `.kata/preferences.md`.
 4. Open the same workspace in Desktop and start a session.
 
 ## Security notes

--- a/apps/online-docs/desktop/sources-mcp.mdx
+++ b/apps/online-docs/desktop/sources-mcp.mdx
@@ -1,97 +1,45 @@
 ---
-title: "Sources and MCP"
-description: "Connect MCP servers, REST APIs, local filesystems, and Slack channels to your Kata Desktop workspaces."
+title: "Providers and integrations"
+description: "Current integration surface in Kata Desktop M001–M004 and how it relates to Kata CLI configuration."
 ---
 
-Sources let you connect external data and services to a workspace so that agents can read, query, and act on live information beyond the local filesystem.
+This page replaces the legacy “Sources and MCP” guidance that assumed a shipped source-management UI.
 
-## Source types
+## What is available in Desktop today
 
-| Type | Examples |
-|---|---|
-| **MCP servers** | Linear, GitHub, Notion, custom servers |
-| **REST APIs** | Google (Gmail, Calendar, Drive), Slack, Microsoft |
-| **Local files** | Filesystem directories, Obsidian vaults, Git repos |
+In milestones M001–M004, Desktop ships:
 
-Sources are configured per workspace and stored at `~/.kata/workspaces/{id}/sources/`.
+- **Provider credential management** in **Settings → Providers**
+- **Symphony runtime and dashboard** in **Settings → Symphony**
+- **Planning + workflow views** that consume existing project configuration
 
-## MCP server setup
+Desktop does **not** yet provide a full UI to add/edit MCP servers, REST sources, or channel connectors directly.
 
-Kata Desktop supports both stdio-based (local subprocess) and HTTP/SSE-based (remote) MCP servers.
+## Where integrations are configured today
 
-<Steps>
-  <Step title="Open Sources settings">
-    Navigate to **Settings → Sources** in the app.
-  </Step>
-  <Step title="Add an MCP server">
-    Click **Add source**, select **MCP Server**, and provide the server command or URL.
-  </Step>
-  <Step title="Configure environment variables (if needed)">
-    Use the `env` field in the source config to pass any variables the server requires. See the security note below for which variables are blocked by default.
-  </Step>
-  <Step title="Save and connect">
-    Save the source. Kata Desktop will start the server and make its tools available to agents in this workspace.
-  </Step>
-</Steps>
+Because Desktop runs Kata CLI as a subprocess, it uses the same underlying configuration files:
 
-## REST API sources
-
-Google (Gmail, Calendar, Drive), Slack, and Microsoft services are connected via OAuth. OAuth credentials are stored encrypted at `~/.kata/credentials.enc`.
-
-To enable these integrations when building from source, add the required OAuth credentials to a `.env` file:
-
-```bash
-GOOGLE_OAUTH_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GOOGLE_OAUTH_CLIENT_SECRET=your-google-client-secret
-SLACK_OAUTH_CLIENT_ID=your-slack-client-id
-SLACK_OAUTH_CLIENT_SECRET=your-slack-client-secret
-MICROSOFT_OAUTH_CLIENT_ID=your-client-id
-```
-
-See the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) to create OAuth credentials for Google integrations.
-
-## Channels
-
-Channels connect communication platforms for always-on, background message processing.
-
-| Channel | Mode | Features |
+| Integration type | Configure in | Consumed by Desktop |
 |---|---|---|
-| **Slack** | Poll + Subscribe | Channel messages, slash commands |
+| Model/provider auth | `~/.kata-cli/agent/auth.json` (via Settings → Providers UI) | Yes |
+| MCP servers | `~/.kata-cli/agent/mcp.json` | Yes (through CLI runtime) |
+| Workflow + Symphony preferences | `<workspace>/.kata/preferences.md` | Yes |
 
-Slack channels can be connected to a workspace to allow agents to monitor and respond to messages in the background. When a message matches a configured trigger, Kata Desktop creates or resumes a session automatically.
+If you already use Kata CLI with MCP/Linear/GitHub integrations configured, Desktop inherits that runtime behavior.
 
-## Agent skills
+## Practical setup flow
 
-Agent skills are workspace-scoped Markdown files stored at `~/.kata/workspaces/{id}/skills/`. Each skill file contains specialized instructions that are automatically included in the agent's system prompt for sessions in that workspace.
+1. Configure providers in Desktop (**Settings → Providers**) or via Kata CLI.
+2. Configure MCP servers in `~/.kata-cli/agent/mcp.json`.
+3. Configure workspace workflow preferences in `.kata/preferences.md`.
+4. Open the same workspace in Desktop and start a session.
 
-Use skills to encode project-specific conventions, preferred tools, or recurring task patterns without repeating them in every session.
+## Security notes
 
-## Security: MCP server isolation
+- Secrets stay in shared Kata auth/config stores.
+- Desktop surfaces masked credentials in UI where applicable.
+- Symphony runtime status/errors are shown without printing secret values.
 
-<Warning>
-  When Kata Desktop spawns a local MCP server (stdio transport), it filters sensitive environment variables from the subprocess environment to prevent credential leakage.
-</Warning>
+## What is coming later
 
-The following variables are blocked by default:
-
-- `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`
-- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`
-- `GITHUB_TOKEN`, `GH_TOKEN`
-- `OPENAI_API_KEY`, `GOOGLE_API_KEY`
-- `STRIPE_SECRET_KEY`, `NPM_TOKEN`
-
-To pass a variable to a specific MCP server, add it explicitly using the `env` field in that server's source config. This grants access only to that server and does not affect the rest of the environment.
-
-## Deep linking
-
-External apps and scripts can navigate directly to Kata Desktop views using `kata://` URLs:
-
-| URL | Destination |
-|---|---|
-| `kata://allChats` | All chats view |
-| `kata://allChats/chat/{sessionId}` | Specific chat session |
-| `kata://settings` | Settings |
-| `kata://sources/source/{sourceId}` | Source detail view |
-| `kata://action/new-chat` | Create a new chat |
-
-These URLs can be used from browser links, scripts, or other applications to open specific views in the running Kata Desktop instance.
+A richer in-app integrations management surface (MCP/source editing UX) is planned for later milestones (post-M004).

--- a/apps/online-docs/desktop/sources-mcp.mdx
+++ b/apps/online-docs/desktop/sources-mcp.mdx
@@ -3,7 +3,7 @@ title: "Providers and integrations"
 description: "Current integration surface in Kata Desktop M001–M004 and how it relates to Kata CLI configuration."
 ---
 
-This page replaces the legacy “Sources and MCP” guidance that assumed a shipped source-management UI.
+This page documents the currently shipped integration surface in Kata Desktop.
 
 ## What is available in Desktop today
 
@@ -40,6 +40,6 @@ If you already use Kata CLI with MCP/Linear/GitHub integrations configured, Desk
 - Desktop surfaces masked credentials in UI where applicable.
 - Symphony runtime status/errors are shown without printing secret values.
 
-## What is coming later
+## Current boundary
 
-A richer in-app integrations management surface (MCP/source editing UX) is planned for later milestones (post-M004).
+A richer in-app integrations management surface (MCP/source editing UX) is not part of M001–M004.

--- a/apps/online-docs/desktop/symphony.mdx
+++ b/apps/online-docs/desktop/symphony.mdx
@@ -1,0 +1,77 @@
+---
+title: "Symphony integration"
+description: "Operate Symphony from Kata Desktop: runtime controls, live dashboard, and escalation response workflow."
+---
+
+Kata Desktop M004 adds a built-in Symphony operator surface in **Settings → Symphony**.
+
+## Two operating modes
+
+Desktop supports both managed and external Symphony setups.
+
+### Managed Symphony (Desktop controls process)
+
+Use Start/Stop/Restart controls in Desktop.
+
+Desktop resolves launch configuration from workspace preferences and environment, then runs Symphony as a managed subprocess.
+
+### External Symphony (Desktop observes remote runtime)
+
+If Symphony is already running elsewhere, Desktop can connect to the configured URL and render live dashboard data without owning process lifecycle.
+
+## Runtime panel
+
+The runtime panel shows lifecycle state such as:
+
+- `Starting`
+- `Ready`
+- `Restarting`
+- `Stopping`
+- `Stopped`
+- `Disconnected`
+- `Config Error`
+- `Failed`
+
+It also exposes concise diagnostics to help debug startup/readiness issues.
+
+## Live dashboard
+
+The dashboard shows real operator signals:
+
+- worker rows (issue, state, tool, model, last activity)
+- queue and completion counts
+- pending escalations
+- connection freshness (connected/reconnecting/disconnected, stale vs fresh)
+
+## Escalation handling flow
+
+1. Worker escalates with a question.
+2. Escalation appears in Desktop with issue identifier and preview.
+3. Operator submits a response inline.
+4. Desktop sends the response to Symphony and refreshes dashboard state.
+
+This keeps human-in-the-loop decisions inside the same UI used for coding sessions.
+
+## Configuration
+
+Symphony config is workspace-driven. Typical source:
+
+```text
+<workspace>/.kata/preferences.md
+```
+
+Common fields:
+
+- `symphony.url`
+- `symphony.workflow_path`
+
+If config is missing or invalid, Desktop surfaces a `Config Error` with actionable text.
+
+## Relation to kanban
+
+Symphony dashboard state is correlated into workflow kanban card metadata so you can track both:
+
+- **workflow state** (where the slice/task is in process)
+- **execution state** (what Symphony workers are doing now)
+
+See [Planning and workflow kanban](/desktop/planning-kanban) for the right-pane behavior details.

--- a/apps/online-docs/docs.json
+++ b/apps/online-docs/docs.json
@@ -56,6 +56,8 @@
             "pages": [
               "desktop/overview",
               "desktop/sessions-workspaces",
+              "desktop/planning-kanban",
+              "desktop/symphony",
               "desktop/sources-mcp"
             ]
           },

--- a/apps/online-docs/index.mdx
+++ b/apps/online-docs/index.mdx
@@ -13,7 +13,7 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
     Headless orchestrator that polls Linear or GitHub and runs parallel agent sessions to close tickets end-to-end.
   </Card>
   <Card title="Kata Desktop" icon="desktop" href="/desktop/overview">
-    Electron app for multi-session agent work with MCP integrations, permission controls, and workspace management.
+    Electron app for multi-session agent work with workspace management, planning/kanban views, and Symphony controls.
   </Card>
   <Card title="Kata Orchestrator" icon="diagram-project" href="/orchestrator/overview">
     Spec-driven workflow harness for Claude Code, OpenCode, Gemini CLI, and Codex. Installs slash commands into your existing runtime.

--- a/apps/online-docs/introduction.mdx
+++ b/apps/online-docs/introduction.mdx
@@ -13,7 +13,7 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
     Headless orchestrator that polls Linear, dispatches parallel agent sessions, and manages the full ticket-to-merge lifecycle.
   </Card>
   <Card title="Kata Desktop" icon="desktop" href="/desktop/overview">
-    Electron app for multi-session agent work with workspaces, permission controls, MCP integrations, and external sources.
+    Electron app for multi-session agent work with workspace switching, planning/kanban right pane, and Symphony operations.
   </Card>
   <Card title="Kata Orchestrator" icon="diagram-project" href="/orchestrator/overview">
     Spec-driven workflow harness for Claude Code, OpenCode, Gemini CLI, and Codex. Installs slash commands into your existing runtime.
@@ -49,7 +49,7 @@ Symphony runs on a server or in CI. Kata CLI provides a built-in operator surfac
 
 ### Kata Desktop
 
-Kata Desktop is an Electron app for working with AI agents across multiple sessions and workspaces. It includes Git context, permission modes for read, edit, and autonomous actions, MCP server integrations, external sources, background tasks, file attachments, and persistent session state.
+Kata Desktop is an Electron app for working with AI agents across multiple sessions and workspaces. It includes streamed chat, workspace-scoped session history, permission modes (Explore / Ask to Edit / Auto), a planning artifact view, a workflow kanban board, and Symphony runtime/dashboard controls.
 
 ### Kata Orchestrator
 

--- a/apps/online-docs/package.json
+++ b/apps/online-docs/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@kata/online-docs",
+  "private": true,
+  "scripts": {
+    "dev": "npx -y mint dev --no-open",
+    "docs:dev": "npx -y mint dev --no-open --port 3001",
+    "broken-links": "npx -y mint broken-links"
+  }
+}

--- a/apps/symphony/.gitignore
+++ b/apps/symphony/.gitignore
@@ -6,5 +6,4 @@ WORKFLOW-cli.md
 WORKFLOW-*.md
 !docs/WORKFLOW-*.md
 !docs/WORKFLOW-REFERENCE.md
-prompts/repo-desktop.md
 

--- a/apps/symphony/prompts/repo-desktop.md
+++ b/apps/symphony/prompts/repo-desktop.md
@@ -1,0 +1,5 @@
+## Repository context
+
+This is the **kata-mono** monorepo. The Desktop app lives at `apps/desktop/`.
+
+Read `apps/desktop/AGENTS.md` for full context.


### PR DESCRIPTION
## Summary
- remove remaining legacy/Craft wording from Desktop overview and integrations pages
- keep Desktop docs aligned to shipped M001–M004 behavior only
- clarify integrations page boundary language without implying unshipped UI exists

## Files changed
- `apps/online-docs/desktop/overview.mdx`
- `apps/online-docs/desktop/sources-mcp.mdx`

## Validation
- `cd apps/online-docs && bun run docs:dev` (verified Desktop pages render at port 3001)
- `cd apps/online-docs && bun run broken-links`
- `rg -n "Craft Agents|\\bCraft\\b|legacy app|multi-file diff|file attachments|dynamic status|shadcn/ui" apps/online-docs/desktop -g '*.mdx'` (no matches)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Symphony integration with managed and external runtime modes for operator dashboards
  * Introduced planning-kanban view for workflow execution and artifact tracking
  * Updated session persistence using Kata CLI architecture

* **Bug Fixes**
  * Improved review thread comment pagination and truncation detection
  * Refined Codex comment identification logic

* **Documentation**
  * Updated Desktop overview with current capabilities and setup instructions
  * Added comprehensive Symphony integration guide
  * Clarified sessions, workspaces, and provider configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refocuses all Kata Desktop documentation on the concrete M001–M004 shipped scope, replacing legacy "Craft Agents" language and unshipped feature descriptions with accurate behavior. It also adds two new documentation pages (`planning-kanban.mdx`, `symphony.mdx`), registers them in navigation, adds a `package.json` for the docs app, and bundles agent-skill improvements for PR comment fetching and merge watching.

Key changes:
- `overview.mdx`, `sources-mcp.mdx`, `sessions-workspaces.mdx`: rewritten to remove legacy OAuth/sources/multi-file-diff/file-attachment language and replace with current Desktop capabilities
- `planning-kanban.mdx`, `symphony.mdx`: new reference pages for M002–M004 features
- `docs.json`: navigation updated to include new pages
- `.agents/skills/sym-address-comments/scripts/fetch_comments.py`: adds thread-comment truncation metadata for threads with >100 comments
- `.agents/skills/sym-land/land_watch.py`: removes Codex bot-user authorship requirement from review-body comment filters — any comment matching the Codex body patterns is now matched regardless of author

<h3>Confidence Score: 3/5</h3>

Mostly safe documentation changes, but two factual conflicts with CLAUDE.md (app path and React version) could mislead contributors, and land_watch.py has a behavioral edge case worth confirming.

The bulk of the PR (documentation rewrites) is well-scoped and intentional. The score is lowered primarily because overview.mdx references `apps/desktop` and `bun run desktop:dev` which directly contradict CLAUDE.md's `apps/electron` and `electron:dev` commands — a developer following the docs literally will hit missing-path errors. The React 19 vs React 18 discrepancy is a secondary factual concern. The land_watch.py bot-author removal is deliberate but introduces a misclassification edge case worth acknowledging.

apps/online-docs/desktop/overview.mdx (path/command mismatch with CLAUDE.md, React version); .agents/skills/sym-land/land_watch.py (bot-author check removal); apps/symphony/prompts/repo-desktop.md (references apps/desktop which may not exist)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/online-docs/desktop/overview.mdx | Desktop overview rewritten for M001-M004 scope; references `apps/desktop` and `bun run desktop:dev` which conflict with CLAUDE.md (`apps/electron`, `electron:dev`); also lists React 19 where CLAUDE.md says React 18 |
| apps/online-docs/desktop/sources-mcp.mdx | Renamed to 'Providers and integrations'; legacy OAuth/MCP setup docs replaced with accurate boundary language matching shipped M001-M004 scope |
| apps/online-docs/desktop/planning-kanban.mdx | New page documenting planning artifact pane (M002) and workflow kanban behavior (M003) with failure-state handling |
| apps/online-docs/desktop/sessions-workspaces.mdx | Session model and workspace switching rewritten to reflect JSONL-backed persistence and actual sidebar behavior in M001-M004 |
| apps/online-docs/desktop/symphony.mdx | New page documenting M004 Symphony integration: managed/external modes, runtime panel states, live dashboard, and escalation workflow |
| apps/online-docs/docs.json | Navigation updated to include new planning-kanban and symphony pages in Desktop section |
| apps/online-docs/index.mdx | Desktop card description updated to reflect planning/kanban/Symphony features instead of MCP/sources language |
| apps/online-docs/introduction.mdx | Desktop description updated to list streamed chat, planning artifact view, workflow kanban, and Symphony controls |
| apps/online-docs/package.json | New package.json adding dev and broken-links scripts for the online-docs Mintlify app |
| apps/symphony/.gitignore | Removed prompts/repo-desktop.md from gitignore so the new prompt context file can be committed |
| apps/symphony/prompts/repo-desktop.md | New prompt context file pointing agents to apps/desktop/AGENTS.md — path may be incorrect if the Electron app is still at apps/electron |
| .agents/skills/sym-address-comments/scripts/fetch_comments.py | Adds truncation metadata for threads with >100 comments and refactors cursor-update logic to avoid unconditional None assignments |
| .agents/skills/sym-land/SKILL.md | Removed exit-code-5 (merge conflicts) entry from the exit code table |
| .agents/skills/sym-land/land_watch.py | Removes bot-user authorship checks from Codex comment filters; now any comment matching Codex body patterns counts regardless of author — subtle misclassification risk for human comments |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer opens Desktop docs] --> B{Which page?}
    B -->|overview| C[overview.mdx\nM001-M004 feature list\nInstallation + Quick Start]
    B -->|sessions| D[sessions-workspaces.mdx\nSession model / Workspace switching]
    B -->|planning| E[planning-kanban.mdx\nPlanning artifact pane / Kanban board]
    B -->|symphony| F[symphony.mdx\nManaged vs External / Escalations]
    B -->|integrations| G[sources-mcp.mdx\nProvider config / MCP config location]
    C -->|install section| H["⚠️ cd apps/desktop\nbun run desktop:dev\n(CLAUDE.md says apps/electron + electron:dev)"]
    E --> I[Right-pane mode\nPlanning context → Planning pane\nExecution context → Kanban pane]
    F --> J[Escalation flow\nWorker escalates → Desktop shows preview\n→ Operator responds inline → Symphony refreshes]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.agents/skills/sym-land/land_watch.py`, line 314-331 ([link](https://github.com/gannonh/kata/blob/4ea75be7e1beb1071c9e06933913872885e07045/.agents/skills/sym-land/land_watch.py#L314-L331)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Bot-author check removed from `filter_codex_review_issue_comments`**

   Previously this function only matched comments posted by a Codex bot user (`is_codex_bot_user` guard). After this change it matches **any** comment whose body starts with `## Codex Review`, regardless of who posted it.

   Combined with the symmetric change in `filter_human_issue_comments` (which now explicitly excludes `is_codex_review_body` matches), a human who opens a comment beginning with `## Codex Review` will be:

   1. **Excluded** from `human_issue_comments` — silently dropped from the human-feedback list.
   2. **Included** in `codex_review_comments` — the merge will still be blocked, but it is attributed to a Codex review rather than human feedback.

   The merge block is preserved, but the misclassification could make it hard to debug why a human comment is invisible in the human-feedback list. If this behavior is intentional (matching review-body format regardless of author), a brief comment in the source explaining the rationale would prevent future confusion.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .agents/skills/sym-land/land_watch.py
   Line: 314-331

   Comment:
   **Bot-author check removed from `filter_codex_review_issue_comments`**

   Previously this function only matched comments posted by a Codex bot user (`is_codex_bot_user` guard). After this change it matches **any** comment whose body starts with `## Codex Review`, regardless of who posted it.

   Combined with the symmetric change in `filter_human_issue_comments` (which now explicitly excludes `is_codex_review_body` matches), a human who opens a comment beginning with `## Codex Review` will be:

   1. **Excluded** from `human_issue_comments` — silently dropped from the human-feedback list.
   2. **Included** in `codex_review_comments` — the merge will still be blocked, but it is attributed to a Codex review rather than human feedback.

   The merge block is preserved, but the misclassification could make it hard to debug why a human comment is invisible in the human-feedback list. If this behavior is intentional (matching review-body format regardless of author), a brief comment in the source explaining the rationale would prevent future confusion.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/online-docs/desktop/overview.mdx
Line: 50-66

Comment:
**Incorrect app path and script names**

The docs reference `apps/desktop` and `bun run desktop:dev` / `bun run desktop:dist:mac`, but `CLAUDE.md` (the project instructions checked into the repo) places the Electron app at `apps/electron/` and defines the commands as `bun run electron:dev` and `bun run electron:dist:mac`. The custom review guide instructions also reference `apps/electron/AGENTS.md` and `apps/electron/e2e/AGENTS.md`.

A developer following these docs will `cd apps/desktop` into a directory that does not exist and run a script (`desktop:dev`) that is not in the root `package.json`. If the electron app directory was recently renamed from `apps/electron` to `apps/desktop`, `CLAUDE.md` should be updated at the same time to keep the two sources of truth consistent.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/online-docs/desktop/overview.mdx
Line: 94

Comment:
**React version mismatch**

The tech stack table lists `React 19`, but `CLAUDE.md` explicitly states the UI layer uses `React 18 + Vite + Tailwind CSS v4 + Radix UI`. If the project has genuinely upgraded to React 19, `CLAUDE.md` should reflect that. If not, this is a documentation error that will mislead contributors checking compatibility or upgrade paths.

```suggestion
| UI | React 18 + Tailwind CSS v4 + Radix UI + Jotai |
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .agents/skills/sym-land/land_watch.py
Line: 314-331

Comment:
**Bot-author check removed from `filter_codex_review_issue_comments`**

Previously this function only matched comments posted by a Codex bot user (`is_codex_bot_user` guard). After this change it matches **any** comment whose body starts with `## Codex Review`, regardless of who posted it.

Combined with the symmetric change in `filter_human_issue_comments` (which now explicitly excludes `is_codex_review_body` matches), a human who opens a comment beginning with `## Codex Review` will be:

1. **Excluded** from `human_issue_comments` — silently dropped from the human-feedback list.
2. **Included** in `codex_review_comments` — the merge will still be blocked, but it is attributed to a Codex review rather than human feedback.

The merge block is preserved, but the misclassification could make it hard to debug why a human comment is invisible in the human-feedback list. If this behavior is intentional (matching review-body format regardless of author), a brief comment in the source explaining the rationale would prevent future confusion.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(online-docs): align desktop docs wi..."](https://github.com/gannonh/kata/commit/4ea75be7e1beb1071c9e06933913872885e07045) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27401892)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->