### PR TITLE
fix(desktop): add Symphony URL and workflow path to preferences

### DIFF
--- a/apps/desktop/.kata/preferences.md
+++ b/apps/desktop/.kata/preferences.md
@@ -19,7 +19,9 @@ custom_instructions: []
 models: {}
 skill_discovery: suggest
 auto_supervisor: {}
-symphony: {}
+symphony:
+  url: http://localhost:8080
+  workflow_path: /Volumes/EVO/kata/kata-mono.worktrees/wt-desktop/apps/symphony/WORKFLOW-desktop.md
 ---
 
 # Kata Preferences


### PR DESCRIPTION
Missed in #275 — adds `symphony.url` and `symphony.workflow_path` to `apps/desktop/.kata/preferences.md` so Desktop can connect to and manage Symphony out of the box.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `symphony.url` and `symphony.workflow_path` to `apps/desktop/.kata/preferences.md` so Desktop can connect to and manage Symphony out of the box. The `symphony.url` addition is correct, but `symphony.workflow_path` is set to a hardcoded absolute path on the author's local machine that does not exist in the repository and will silently fail for every other developer.

- **P1**: `workflow_path: /Volumes/EVO/kata/kata-mono.worktrees/wt-desktop/apps/symphony/WORKFLOW-desktop.md` is a machine-local path — the referenced `WORKFLOW-desktop.md` file does not exist anywhere in the repo, and the `/Volumes/EVO/…` prefix is specific to the author's filesystem.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is — the committed workflow_path will silently fail for all other developers.

One clear P1: the workflow_path is a machine-local absolute path pointing to a file that doesn't exist in the repo. The symphony.url default is fine. Score is 4 (not 3) because the blast radius is limited to Desktop's Symphony integration, not a crash or data-loss scenario.

apps/desktop/.kata/preferences.md — line 24 workflow_path must be replaced with a portable path or omitted before this is useful to other developers

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/.kata/preferences.md | Adds symphony.url (fine) and symphony.workflow_path (hardcoded to author's local filesystem path that doesn't exist in the repo) |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[apps/desktop/.kata/preferences.md] -->|symphony.url = http://localhost:8080| B[Symphony HTTP Server]
    A -->|symphony.workflow_path| C{Path resolves?}
    C -->|Yes — author's machine only| D[Symphony loads WORKFLOW-desktop.md]
    C -->|No — every other developer| E[Silent failure / missing workflow error]
    B --> F[Desktop ↔ Symphony connection]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/.kata/preferences.md
Line: 24

Comment:
**Hardcoded machine-local path committed to the repo**

The `workflow_path` value (`/Volumes/EVO/kata/kata-mono.worktrees/wt-desktop/apps/symphony/WORKFLOW-desktop.md`) is an absolute path that only exists on the author's machine. The referenced file `WORKFLOW-desktop.md` does not exist anywhere in the repository, so every other developer will silently get a missing-workflow failure when Desktop tries to connect to Symphony. Either omit this field (each developer sets it locally) or point it at the workflow file that actually ships with the repo.

```suggestion
  workflow_path: apps/symphony/WORKFLOW.md
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): add Symphony URL and workf..."](https://github.com/gannonh/kata/commit/06d5f50d045af2496f195f92ebf6d8bf2262c862) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27403060)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->