### PR TITLE
fix(ci): use electron-builder directly — fix OOM, signing, and symlinks

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -141,72 +141,10 @@ jobs:
       - name: Build Desktop app
         run: cd apps/desktop && bun run build
 
-      - name: Prepare builder app
-        run: cd apps/desktop && bun run prepare:builder-app
-
       - name: Package for macOS ${{ matrix.arch }}
         run: |
           cd apps/desktop
-          APP_VERSION="$(node -p "require('./package.json').version")"
-          ELECTRON_VERSION="$(node -p "const v=require('./package.json').devDependencies?.electron ?? ''; v.replace(/^[^0-9]*/, '').replace(/[^0-9.].*$/, '')")"
-
-          bunx electron-packager \
-            .bundle-app \
-            "Kata Desktop" \
-            --platform=darwin \
-            --arch=${{ matrix.arch }} \
-            --out=release \
-            --overwrite \
-            --icon=resources/AppIcon.icns \
-            --app-version="$APP_VERSION" \
-            --electron-version="$ELECTRON_VERSION"
-
-          APP_DIR="release/Kata Desktop-darwin-${{ matrix.arch }}/Kata Desktop.app"
-          RESOURCES_DIR="$APP_DIR/Contents/Resources"
-
-          cp vendor/kata "$RESOURCES_DIR/kata"
-          cp -R vendor/kata-runtime "$RESOURCES_DIR/kata-runtime"
-          cp -R vendor/bun "$RESOURCES_DIR/bun"
-          chmod +x "$RESOURCES_DIR/kata" "$RESOURCES_DIR/bun/bun"
-
-          if [ -f vendor/symphony ]; then
-            cp vendor/symphony "$RESOURCES_DIR/symphony"
-            chmod +x "$RESOURCES_DIR/symphony"
-          fi
-
-          if [ -f resources/liquid-glass/Assets.car ]; then
-            cp resources/liquid-glass/Assets.car "$RESOURCES_DIR/Assets.car"
-          fi
-
-          /usr/libexec/PlistBuddy -c "Add :CFBundleIconName string AppIcon" "$APP_DIR/Contents/Info.plist" 2>/dev/null || \
-            /usr/libexec/PlistBuddy -c "Set :CFBundleIconName AppIcon" "$APP_DIR/Contents/Info.plist"
-
-          # Strip executable bit from JS/script files to prevent notarization hangs
-          find "$APP_DIR" -type f \( -name "*.js" -o -name "*.mjs" -o -name "*.sh" \) -perm +111 -exec chmod -x {} \; 2>/dev/null || true
-          find "$APP_DIR" -path "*/node_modules/*/bin/*" -type f -perm +111 -exec chmod -x {} \; 2>/dev/null || true
-
-          # Sign vendor binaries so notarization passes.
-          # electron-packager signs the Electron framework but not files added after packaging.
-          SIGN_ID="${CSC_IDENTITY_AUTO_DISCOVERY:-}"
-          if [ -z "$SIGN_ID" ]; then
-            SIGN_ID=$(security find-identity -v -p codesigning | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
-          fi
-          if [ -n "$SIGN_ID" ]; then
-            echo "Signing vendor binaries with: $SIGN_ID"
-            for BIN in "$RESOURCES_DIR/kata" "$RESOURCES_DIR/bun/bun" "$RESOURCES_DIR/symphony"; do
-              if [ -f "$BIN" ]; then
-                codesign --force --options runtime --sign "$SIGN_ID" "$BIN"
-                echo "  signed: $(basename "$BIN")"
-              fi
-            done
-            # Re-sign the app bundle to capture the new binaries
-            codesign --force --deep --options runtime --sign "$SIGN_ID" "$APP_DIR"
-            echo "App bundle re-signed"
-          else
-            echo "::warning::No signing identity found — vendor binaries unsigned"
-          fi
-
-          bunx electron-builder --config electron-builder.yml --prepackaged "$APP_DIR" --mac dmg
+          bunx electron-builder --config electron-builder.yml --mac dmg --${{ matrix.arch }}
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -181,6 +181,31 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :CFBundleIconName string AppIcon" "$APP_DIR/Contents/Info.plist" 2>/dev/null || \
             /usr/libexec/PlistBuddy -c "Set :CFBundleIconName AppIcon" "$APP_DIR/Contents/Info.plist"
 
+          # Strip executable bit from JS/script files to prevent notarization hangs
+          find "$APP_DIR" -type f \( -name "*.js" -o -name "*.mjs" -o -name "*.sh" \) -perm +111 -exec chmod -x {} \; 2>/dev/null || true
+          find "$APP_DIR" -path "*/node_modules/*/bin/*" -type f -perm +111 -exec chmod -x {} \; 2>/dev/null || true
+
+          # Sign vendor binaries so notarization passes.
+          # electron-packager signs the Electron framework but not files added after packaging.
+          SIGN_ID="${CSC_IDENTITY_AUTO_DISCOVERY:-}"
+          if [ -z "$SIGN_ID" ]; then
+            SIGN_ID=$(security find-identity -v -p codesigning | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+          fi
+          if [ -n "$SIGN_ID" ]; then
+            echo "Signing vendor binaries with: $SIGN_ID"
+            for BIN in "$RESOURCES_DIR/kata" "$RESOURCES_DIR/bun/bun" "$RESOURCES_DIR/symphony"; do
+              if [ -f "$BIN" ]; then
+                codesign --force --options runtime --sign "$SIGN_ID" "$BIN"
+                echo "  signed: $(basename "$BIN")"
+              fi
+            done
+            # Re-sign the app bundle to capture the new binaries
+            codesign --force --deep --options runtime --sign "$SIGN_ID" "$APP_DIR"
+            echo "App bundle re-signed"
+          else
+            echo "::warning::No signing identity found — vendor binaries unsigned"
+          fi
+
           bunx electron-builder --config electron-builder.yml --prepackaged "$APP_DIR" --mac dmg
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -2,17 +2,23 @@ appId: sh.kata.desktop
 productName: Kata Desktop
 copyright: Copyright © 2026 Kata Contributors
 
+beforeBuild: scripts/beforeBuild.cjs
+afterPack: scripts/afterPack.cjs
+
 directories:
-  app: .bundle-app
   output: release
   buildResources: resources
 
 files:
   - dist/**/*
-  - package.json
+  - "!dist/renderer/src/**"
   - "!**/*.map"
   - "!**/*.test.*"
   - "!**/__tests__/**"
+  - "!**/*.sh"
+  - "!**/scripts/**"
+  - "!node_modules"
+  - package.json
 
 extraMetadata:
   main: dist/main.cjs

--- a/apps/desktop/scripts/afterPack.cjs
+++ b/apps/desktop/scripts/afterPack.cjs
@@ -86,8 +86,16 @@ module.exports = async function afterPack(context) {
   // 1. Copy vendor runtime resources
   copyVendorResources(projectDir, resourcesDir);
 
+  // Remove .bin symlinks from kata-runtime — they point to relative targets
+  // that codesign rejects as "invalid destination for symbolic link in bundle"
+  const binDir = path.join(resourcesDir, 'kata-runtime', 'node_modules', '.bin');
+  if (fs.existsSync(binDir)) {
+    fs.rmSync(binDir, { recursive: true });
+    console.log('afterPack: removed kata-runtime/node_modules/.bin symlinks');
+  }
+
   // 2. Copy Liquid Glass icon (Assets.car)
-  const precompiledAssets = path.join(projectDir, 'resources', 'Assets.car');
+  const precompiledAssets = path.join(projectDir, 'resources', 'liquid-glass', 'Assets.car');
   if (fs.existsSync(precompiledAssets)) {
     fs.copyFileSync(precompiledAssets, path.join(resourcesDir, 'Assets.car'));
     console.log('afterPack: Liquid Glass icon (Assets.car) copied');

--- a/apps/desktop/scripts/beforeBuild.cjs
+++ b/apps/desktop/scripts/beforeBuild.cjs
@@ -1,0 +1,13 @@
+/**
+ * electron-builder beforeBuild hook
+ *
+ * Returns false to skip the dependency install/rebuild phase.
+ * Our app is fully bundled (esbuild → dist/main.cjs) with no runtime
+ * node_modules dependencies. Without this hook, electron-builder's
+ * NPM module collector crawls up from the app directory through the
+ * Bun monorepo and OOMs trying to resolve the entire dependency tree.
+ */
+module.exports = async function beforeBuild() {
+  console.log('beforeBuild: skipping dependency collection (app is fully bundled)');
+  return false;
+};

--- a/apps/desktop/scripts/package-mac.sh
+++ b/apps/desktop/scripts/package-mac.sh
@@ -8,76 +8,19 @@ cd "$DESKTOP_DIR"
 
 bun run bundle:cli
 bun run desktop:build
-bun run prepare:builder-app
 
-APP_PARENT_DIR="$DESKTOP_DIR/release"
 APP_VERSION="$(node -p "require('./package.json').version")"
-ELECTRON_VERSION="$(node -p "const v=require('./package.json').devDependencies?.electron ?? ''; v.replace(/^[^0-9]*/, '').replace(/[^0-9.].*$/, '')")"
 
 if [[ -z "$APP_VERSION" ]]; then
   echo "[package-mac] Failed to determine app version from apps/desktop/package.json" >&2
   exit 1
 fi
 
-if [[ -z "$ELECTRON_VERSION" ]]; then
-  echo "[package-mac] Failed to determine Electron version from apps/desktop/package.json" >&2
-  exit 1
-fi
+echo "[package-mac] Building Kata Desktop v$APP_VERSION"
 
-rm -rf "$APP_PARENT_DIR/Kata Desktop-darwin-arm64"
-find "$APP_PARENT_DIR" -maxdepth 1 -name 'Kata Desktop-*.dmg' -delete 2>/dev/null || true
-find "$APP_PARENT_DIR" -maxdepth 1 -name 'Kata-Desktop-*.dmg' -delete 2>/dev/null || true
+# electron-builder handles everything: .app creation, code signing, DMG.
+# afterPack.cjs copies vendor resources (kata, bun, symphony, Assets.car)
+# into Contents/Resources after the app is built.
+bunx electron-builder --config electron-builder.yml --mac dmg --arm64
 
-echo "[package-mac] Building Kata Desktop v$APP_VERSION (Electron $ELECTRON_VERSION)"
-
-# Temporarily hide .icon directory from electron-packager.
-# electron-packager auto-detects .icon files and calls actool, which fails on macOS < 26.
-# We handle the Liquid Glass icon manually via Assets.car after packaging.
-LIQUID_GLASS_DIR="$DESKTOP_DIR/resources/liquid-glass"
-if [[ -d "$LIQUID_GLASS_DIR/AppIcon.icon" ]]; then
-  ICON_HIDDEN=true
-else
-  ICON_HIDDEN=false
-fi
-
-bunx electron-packager \
-  .bundle-app \
-  "Kata Desktop" \
-  --platform=darwin \
-  --arch=arm64 \
-  --out=release \
-  --overwrite \
-  --icon="$DESKTOP_DIR/resources/AppIcon.icns" \
-  --app-version="$APP_VERSION" \
-  --electron-version="$ELECTRON_VERSION"
-
-APP_DIR="$APP_PARENT_DIR/Kata Desktop-darwin-arm64/Kata Desktop.app"
-RESOURCES_DIR="$APP_DIR/Contents/Resources"
-
-# Copy bundled runtime resources
-cp "$DESKTOP_DIR/vendor/kata" "$RESOURCES_DIR/kata"
-cp -R "$DESKTOP_DIR/vendor/kata-runtime" "$RESOURCES_DIR/kata-runtime"
-cp -R "$DESKTOP_DIR/vendor/bun" "$RESOURCES_DIR/bun"
-chmod +x "$RESOURCES_DIR/kata" "$RESOURCES_DIR/bun/bun"
-
-# Bundle Symphony binary if available
-if [[ -f "$DESKTOP_DIR/vendor/symphony" ]]; then
-  cp "$DESKTOP_DIR/vendor/symphony" "$RESOURCES_DIR/symphony"
-  chmod +x "$RESOURCES_DIR/symphony"
-  echo "[package-mac] bundled Symphony binary"
-fi
-
-# Copy pre-compiled Liquid Glass icon (Assets.car) for macOS 26+
-if [[ -f "$LIQUID_GLASS_DIR/Assets.car" ]]; then
-  cp "$LIQUID_GLASS_DIR/Assets.car" "$RESOURCES_DIR/Assets.car"
-  echo "[package-mac] bundled Liquid Glass icon (Assets.car)"
-fi
-
-# Set CFBundleIconName in Info.plist for macOS 26+ Liquid Glass resolution
-/usr/libexec/PlistBuddy -c "Add :CFBundleIconName string AppIcon" "$APP_DIR/Contents/Info.plist" 2>/dev/null || \
-  /usr/libexec/PlistBuddy -c "Set :CFBundleIconName AppIcon" "$APP_DIR/Contents/Info.plist"
-
-# Create DMG using electron-builder (--prepackaged skips the module collector)
-bunx electron-builder --config electron-builder.yml --prepackaged "$APP_DIR" --mac dmg
-
-echo "[package-mac] DMG ready in $APP_PARENT_DIR"
+echo "[package-mac] DMG ready in $DESKTOP_DIR/release"


### PR DESCRIPTION
Fixes desktop-release.yml — replaces the electron-packager + manual codesign approach with electron-builder directly, matching the legacy app's build pattern.

**Problems solved:**
1. **OOM** — electron-builder's NPM module collector crawled the Bun monorepo and ran out of memory. Fix: `beforeBuild.cjs` returns `false` to skip dependency collection (app is fully bundled via esbuild, zero runtime node_modules).
2. **Unsigned binaries** — vendor resources (kata, bun, symphony, native addons) were added after electron-packager ran, bypassing code signing. Fix: `afterPack.cjs` copies vendor resources before electron-builder's signing pass.
3. **Symlink codesign errors** — `kata-runtime/node_modules/.bin/` contained relative symlinks that `codesign --deep --strict` rejected. Fix: `afterPack.cjs` removes `.bin` directory.
4. **Liquid Glass icon** — `afterPack.cjs` copies `Assets.car` from `resources/liquid-glass/` and the plist already has `CFBundleIconName: AppIcon`.

**Verified locally:** signed with Developer ID, `codesign --verify --deep --strict` passes, 183MB DMG, Liquid Glass dock icon on macOS 26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined macOS application packaging process by consolidating build configuration and removing manual post-processing steps.
  * Added build lifecycle hooks to optimize dependency collection and artifact packaging during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the fragile electron-packager + manual codesign shell approach with electron-builder's native hook system, matching the legacy app's build pattern. It introduces two new hooks (`beforeBuild.cjs` and `afterPack.cjs` enhancements) and simplifies the CI workflow packaging step to a single `bunx electron-builder` invocation.

**Key changes:**
- **OOM fix:** `beforeBuild.cjs` returns `false` to skip electron-builder's NPM module collector, which was OOM-ing by crawling the entire Bun monorepo
- **Signing fix:** `afterPack.cjs` now copies vendor resources (kata, bun, symphony, kata-runtime) *before* electron-builder's signing pass, ensuring all binaries are signed
- **Symlink codesign fix:** `afterPack.cjs` removes `kata-runtime/node_modules/.bin` after the vendor copy — these relative symlinks were rejected by `codesign --deep --strict`
- **Assets.car path fix:** Corrected from `resources/Assets.car` to `resources/liquid-glass/Assets.car`
- **CI workflow:** Collapsed ~40 lines of manual packaging shell into a single electron-builder invocation; the notarization step and artifact uploads are unchanged

<h3>Confidence Score: 4/5</h3>

Safe to merge — all three documented bugs are correctly addressed and the approach has been verified locally with codesign and DMG creation

The logic in afterPack.cjs is sound (correct ordering of vendor copy then .bin removal), beforeBuild.cjs uses the documented electron-builder API, and the workflow simplification is straightforward. Minor uncertainty around latest-mac.yml generation with publish: null (not a regression) and the absence of integration-level CI validation for the new build path keep this at 4 rather than 5.

apps/desktop/electron-builder.yml — confirm whether latest-mac.yml generation with publish: null matches auto-update expectations

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/desktop-release.yml | Packaging step simplified to a single electron-builder call; notarization and artifact upload steps are unchanged and compatible with the new output layout |
| apps/desktop/electron-builder.yml | Adds beforeBuild/afterPack hooks, removes .bundle-app directory reference, updates file exclusions; publish: null may suppress latest-mac.yml generation |
| apps/desktop/scripts/afterPack.cjs | Correctly ordered: vendor copy → .bin removal → Assets.car copy → permission strip; fixes codesign symlink rejection and Liquid Glass icon path |
| apps/desktop/scripts/beforeBuild.cjs | New hook returning false to skip npm module collection, preventing OOM in the Bun monorepo; correct use of electron-builder's documented beforeBuild API |
| apps/desktop/scripts/package-mac.sh | Simplified local build script using electron-builder directly; hard-codes --arm64 (fine for local dev) and uses desktop:build alias which is equivalent to build |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main] --> B[check-version job]
    B -->|version changed| C[build-macos matrix\narm64 / x64]
    C --> D[bun install]
    D --> E[bundle:cli\n→ vendor/ binaries]
    E --> F[bun run build\n→ dist/]
    F --> G[bunx electron-builder\n--mac dmg --arch]
    G --> H[beforeBuild.cjs\nreturns false]
    H -->|skip npm collector\nprevent OOM| I[electron-builder packs\ndist + package.json into .app]
    I --> J[afterPack.cjs]
    J --> K[copyVendorResources\n→ Contents/Resources]
    K --> L[rm kata-runtime/node_modules/.bin\nremove bad codesign symlinks]
    L --> M[copy liquid-glass/Assets.car\n→ Contents/Resources]
    M --> N[stripScriptExecutablePermissions\nchmod -x js/mjs/sh files]
    N --> O[electron-builder signs .app\n+ creates DMG]
    O --> P[Notarize step\nxcrun notarytool submit --wait]
    P --> Q[xcrun stapler staple .app]
    Q --> R[Rebuild DMG with\nnotarized .app]
    R --> S[Upload artifacts\nDMG + ZIP]
    S --> T[release job\nCreate GitHub Release]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/desktop-release.yml`, line 249-256 ([link](https://github.com/gannonh/kata/blob/f3b9e10d697dfcd3bcd8e0dd8859a5e8f001d9c4/.github/workflows/desktop-release.yml#L249-L256)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`latest-mac.yml` may not be generated with `publish: null`**

   With `publish: null` set in `electron-builder.yml`, electron-builder suppresses publishing and may not emit `latest-mac.yml`. The upload-artifact action will just warn (default `if-no-files-found: warn`) and the prepare-release step uses `|| true`, so CI won't fail. However, if `electron-updater` is used for auto-updates, the absence of `latest-mac.yml` in the GitHub release would silently break that feature.

   This behaviour existed in the previous `--prepackaged` approach too, so it's not a regression introduced by this PR — but worth confirming whether auto-updates are expected to work from this release workflow.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/desktop-release.yml
   Line: 249-256

   Comment:
   **`latest-mac.yml` may not be generated with `publish: null`**

   With `publish: null` set in `electron-builder.yml`, electron-builder suppresses publishing and may not emit `latest-mac.yml`. The upload-artifact action will just warn (default `if-no-files-found: warn`) and the prepare-release step uses `|| true`, so CI won't fail. However, if `electron-updater` is used for auto-updates, the absence of `latest-mac.yml` in the GitHub release would silently break that feature.

   This behaviour existed in the previous `--prepackaged` approach too, so it's not a regression introduced by this PR — but worth confirming whether auto-updates are expected to work from this release workflow.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/electron-builder.yml
Line: 21

Comment:
**`!node_modules` exclusion pattern**

The pattern `!node_modules` excludes the top-level directory entry, but the conventional electron-builder form is `"!node_modules/**"`. In practice both have the same effect since excluding the directory prevents its contents from being collected, and `beforeBuild` returning `false` means node_modules won't be collected anyway. Still, aligning with the explicit glob form avoids any ambiguity.

```suggestion
  - "!node_modules/**"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/desktop-release.yml
Line: 249-256

Comment:
**`latest-mac.yml` may not be generated with `publish: null`**

With `publish: null` set in `electron-builder.yml`, electron-builder suppresses publishing and may not emit `latest-mac.yml`. The upload-artifact action will just warn (default `if-no-files-found: warn`) and the prepare-release step uses `|| true`, so CI won't fail. However, if `electron-updater` is used for auto-updates, the absence of `latest-mac.yml` in the GitHub release would silently break that feature.

This behaviour existed in the previous `--prepackaged` approach too, so it's not a regression introduced by this PR — but worth confirming whether auto-updates are expected to work from this release workflow.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/scripts/package-mac.sh
Line: 24

Comment:
**Hard-coded `--arm64` flag**

The script unconditionally passes `--arm64`, so it cannot be used to produce an x64 build locally without editing the file. A small parameterisation would make it reusable across architectures:

```suggestion
bunx electron-builder --config electron-builder.yml --mac dmg --${ARCH:-arm64}
```

This is non-critical for a dev-convenience script, but CI already handles the matrix, so this would only matter for engineers doing local x64 cross-builds.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): use electron-builder directly w..."](https://github.com/gannonh/kata/commit/f3b9e10d697dfcd3bcd8e0dd8859a5e8f001d9c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27411271)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->