### PR TITLE
CLI v0.15.3

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.15.3
+
+### Changes
+
+- Upgrade `pi-coding-agent` to 0.65.0
+- Migrate to `createAgentSessionRuntime` API (session runtime replaces direct session creation)
+- MCP config injected via `extensionFlagValues` instead of post-hoc resource loader mutation
+
 ## 0.15.2
 
 ### Bug Fixes

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
CLI release 0.15.3 — upgrades pi-coding-agent to 0.65.0.

### Changes
- Upgrade `pi-coding-agent` 0.64.0 → 0.65.0
- Migrate to `createAgentSessionRuntime` API
- MCP config injected via `extensionFlagValues`

Code changes already on main from #277. This PR is just the version bump + changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch release version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR releases CLI v0.15.3, bumping `@mariozechner/pi-coding-agent` from `0.64.0` to `0.65.0` to adopt the new `createAgentSessionRuntime` API and MCP config injection via `extensionFlagValues`. The underlying code changes were already merged via PR #277; this PR contains only the version bump and changelog update.

- `apps/cli/package.json`: Version bumped to `0.15.3`; `pi-coding-agent` dependency upgraded to `^0.65.0`
- `apps/cli/CHANGELOG.md`: New `0.15.3` section added documenting the upgrade and API migration
- **Potential concern**: `@mariozechner/pi-tui` remains at `^0.64.0` while `pi-coding-agent` moves to `^0.65.0`. The 0.11.0 changelog explicitly records that this exact type of version mismatch previously caused a silent extension load failure. Worth verifying whether `pi-tui@0.65.0` was co-released and if alignment is needed.

<h3>Confidence Score: 3/5</h3>

Mostly safe to merge, but the pi-tui/pi-coding-agent version delta warrants verification before publishing to npm

The changes are minimal — a version bump and changelog only. However, leaving @mariozechner/pi-tui at ^0.64.0 while pi-coding-agent moves to ^0.65.0 is a documented risk pattern (the 0.11.0 changelog specifically records this caused a silent extension load failure). If pi-tui 0.65.0 was co-released, npm consumers will get mismatched minor versions and could hit the same failure mode.

apps/cli/package.json — verify whether pi-tui 0.65.0 was released and whether it should be aligned with pi-coding-agent 0.65.0

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/package.json | Version bumped to 0.15.3, pi-coding-agent upgraded to ^0.65.0, but pi-tui remains at ^0.64.0 — potential version mismatch risk |
| apps/cli/CHANGELOG.md | New 0.15.3 changelog section added documenting the pi-coding-agent upgrade and API migration |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as Kata CLI
    participant RT as createAgentSessionRuntime
    participant MCP as MCP Config (extensionFlagValues)
    participant Agent as pi-coding-agent 0.65.0

    CLI->>RT: createAgentSessionRuntime(config)
    CLI->>MCP: inject MCP config via extensionFlagValues
    RT->>Agent: initialize session with flags
    Agent-->>CLI: session ready
    MCP-->>Agent: MCP servers resolved at init (no post-hoc mutation)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/cli/package.json`, line 49 ([link](https://github.com/gannonh/kata/blob/93a0f46eec9db72065894f0d19107eded61a9c66/apps/cli/package.json#L49)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`pi-tui` version may lag behind `pi-coding-agent`**

   `@mariozechner/pi-coding-agent` was bumped to `^0.65.0` but `@mariozechner/pi-tui` remains at `^0.64.0`. The 0.11.0 changelog entry explicitly documents that a prior version mismatch between these two packages caused a **"silent extension load failure"**, which was fixed only by bumping `pi-tui` to match `pi-coding-agent`. If `pi-tui@0.65.0` was released alongside `pi-coding-agent@0.65.0`, leaving this at `^0.64.0` risks reproducing that same silent failure for consumers who install this package.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/package.json
   Line: 49

   Comment:
   **`pi-tui` version may lag behind `pi-coding-agent`**

   `@mariozechner/pi-coding-agent` was bumped to `^0.65.0` but `@mariozechner/pi-tui` remains at `^0.64.0`. The 0.11.0 changelog entry explicitly documents that a prior version mismatch between these two packages caused a **"silent extension load failure"**, which was fixed only by bumping `pi-tui` to match `pi-coding-agent`. If `pi-tui@0.65.0` was released alongside `pi-coding-agent@0.65.0`, leaving this at `^0.64.0` risks reproducing that same silent failure for consumers who install this package.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/package.json
Line: 49

Comment:
**`pi-tui` version may lag behind `pi-coding-agent`**

`@mariozechner/pi-coding-agent` was bumped to `^0.65.0` but `@mariozechner/pi-tui` remains at `^0.64.0`. The 0.11.0 changelog entry explicitly documents that a prior version mismatch between these two packages caused a **"silent extension load failure"**, which was fixed only by bumping `pi-tui` to match `pi-coding-agent`. If `pi-tui@0.65.0` was released alongside `pi-coding-agent@0.65.0`, leaving this at `^0.64.0` risks reproducing that same silent failure for consumers who install this package.

```suggestion
    "@mariozechner/pi-tui": "^0.65.0",
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump cli to 0.15.3"](https://github.com/gannonh/kata/commit/93a0f46eec9db72065894f0d19107eded61a9c66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27416247)</sub>

<!-- /greptile_comment -->