### PR TITLE
feat(desktop): MCP server management UI in settings (KAT-2387)

### DIFF
--- a/apps/desktop/docs/uat/M005/S03-MCP-SMOKE.md
+++ b/apps/desktop/docs/uat/M005/S03-MCP-SMOKE.md
@@ -1,0 +1,93 @@
+# S03 MCP Settings Smoke (M005)
+
+## Scope & Truth Boundaries
+
+This smoke validates **shared global MCP config management** in Kata Desktop only.
+
+- ✅ In scope: inspect/add/edit/remove servers in `~/.kata-cli/agent/mcp.json`, refresh/reconnect status, tool list visibility, malformed/unreachable error surfaces.
+- ✅ In scope: stdio and HTTP/bearer style entries that do not require OAuth onboarding.
+- ❌ Out of scope: project-local overlay editing (`.kata-cli/mcp.json`), OAuth consent flows, full M005 assembled walkthrough (covered by S04).
+
+---
+
+## Preconditions
+
+1. Desktop app built and runnable (`cd apps/desktop && bun run build`).
+2. A safe local stdio MCP fixture server script is available, e.g.:
+   - `apps/desktop/e2e/fixtures/mcp-stdio-server.mjs`
+3. You can restore your original MCP config after testing.
+
+---
+
+## Backup / Restore Procedure
+
+```bash
+MCP_PATH="$HOME/.kata-cli/agent/mcp.json"
+BACKUP_PATH="/tmp/kata-mcp.json.backup.$(date +%s)"
+
+mkdir -p "$(dirname "$MCP_PATH")"
+if [ -f "$MCP_PATH" ]; then
+  cp "$MCP_PATH" "$BACKUP_PATH"
+else
+  printf '{\n  "imports": [],\n  "settings": { "toolPrefix": "server", "idleTimeout": 10 },\n  "mcpServers": {}\n}\n' > "$MCP_PATH"
+fi
+
+echo "Backup: $BACKUP_PATH"
+```
+
+After smoke completion:
+
+```bash
+if [ -f "$BACKUP_PATH" ]; then
+  cp "$BACKUP_PATH" "$MCP_PATH"
+fi
+```
+
+---
+
+## Happy-path Smoke
+
+1. Open Desktop → **Settings → MCP**.
+2. Confirm existing shared servers load and provenance badge shows global config context.
+3. Click **Add server** and create a stdio entry:
+   - Name: `smoke-local`
+   - Command: Node executable (`node` or full `process.execPath`)
+   - Args: `apps/desktop/e2e/fixtures/mcp-stdio-server.mjs`
+4. Save and confirm the row appears.
+5. Click **Refresh** and confirm:
+   - Status badge shows **Connected**.
+   - Tool summary appears (e.g., `echo`, `ping`).
+6. Click **Edit**, change args (e.g., add `--alt`), save, refresh again, confirm updated tool names.
+7. Click **Remove** then **Confirm remove**, confirm row is gone.
+
+---
+
+## Failure-path Smoke
+
+### Reconnect failure (row-scoped)
+
+1. Re-add `smoke-local` entry.
+2. Edit command to a non-existent binary, e.g. `not-a-real-command-xyz`.
+3. Click **Reconnect**.
+4. Confirm only that row shows an error badge/code (e.g. `COMMAND_NOT_FOUND`) and error message; rest of panel remains interactive.
+
+### Malformed config (panel-scoped)
+
+1. Corrupt `~/.kata-cli/agent/mcp.json` intentionally:
+
+```bash
+printf '{bad-json' > "$HOME/.kata-cli/agent/mcp.json"
+```
+
+2. In Desktop MCP panel, click **Refresh**.
+3. Confirm malformed-config error appears in panel.
+4. Restore valid JSON (from backup) and refresh; panel recovers.
+
+---
+
+## Evidence to capture
+
+- Screenshot of MCP panel with connected status + tools.
+- Screenshot of reconnect failure badge/message.
+- Screenshot of malformed-config error surface.
+- Final note confirming backup restore completed.

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -13,6 +13,7 @@ const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true'
 function createIsolatedDataDir(): string {
   const dataDir = mkdtempSync(path.join(tmpdir(), 'kata-desktop-e2e-'))
   mkdirSync(path.join(dataDir, 'workspace'), { recursive: true })
+  mkdirSync(path.join(dataDir, '.kata-cli', 'agent'), { recursive: true })
   return dataDir
 }
 
@@ -69,6 +70,7 @@ async function dismissOnboardingIfPresent(window: Page): Promise<void> {
 type DesktopFixtures = {
   electronApp: ElectronApplication
   workspaceDir: string
+  mcpConfigPath: string
   mainWindow: Page
   readyWindow: Page
   symphonyMockMode:
@@ -95,7 +97,7 @@ export const test = base.extend<DesktopFixtures>({
       try { rmSync(dataDir, { recursive: true, force: true }) } catch { /* noop */ }
     }
   },
-  electronApp: async ({ workspaceDir, symphonyMockMode }, use) => {
+  electronApp: async ({ workspaceDir, symphonyMockMode, mcpConfigPath }, use) => {
     const dataDir = path.dirname(workspaceDir)
     const mainEntry = path.join(__dirname, '../../dist/main.cjs')
     const preloadEntry = path.join(__dirname, '../../dist/preload.cjs')
@@ -128,6 +130,8 @@ export const test = base.extend<DesktopFixtures>({
         KATA_DESKTOP_SYMPHONY_MOCK: symphonyMockMode,
         KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: symphonyMockMode,
         KATA_SYMPHONY_URL: 'http://127.0.0.1:8080',
+        KATA_DESKTOP_MCP_CONFIG_PATH: mcpConfigPath,
+        VITE_DEV_SERVER_URL: '',
         // Don't override HOME — that breaks CLI binary discovery and auth.json lookup.
         // The --user-data-dir flag isolates Electron's own data (localStorage, cookies).
       },
@@ -146,6 +150,11 @@ export const test = base.extend<DesktopFixtures>({
         try { process.kill(pid, 'SIGKILL') } catch { /* already dead */ }
       }
     }
+  },
+
+  mcpConfigPath: async ({ workspaceDir }, use) => {
+    const configPath = path.join(path.dirname(workspaceDir), '.kata-cli', 'agent', 'mcp.json')
+    await use(configPath)
   },
 
   mainWindow: async ({ electronApp }, use) => {

--- a/apps/desktop/e2e/fixtures/mcp-stdio-server.mjs
+++ b/apps/desktop/e2e/fixtures/mcp-stdio-server.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+const toolSet = process.argv.includes('--alt')
+  ? ['alt_echo', 'alt_ping']
+  : ['echo', 'ping']
+
+let buffer = Buffer.alloc(0)
+
+process.stdin.on('data', (chunk) => {
+  buffer = Buffer.concat([buffer, chunk])
+
+  while (buffer.length > 0) {
+    const separatorIndex = buffer.indexOf('\r\n\r\n')
+    if (separatorIndex === -1) {
+      return
+    }
+
+    const headers = buffer.slice(0, separatorIndex).toString('utf8')
+    const lengthMatch = headers.match(/Content-Length:\s*(\d+)/i)
+    if (!lengthMatch) {
+      buffer = Buffer.alloc(0)
+      return
+    }
+
+    const bodyLength = Number(lengthMatch[1])
+    const frameLength = separatorIndex + 4 + bodyLength
+    if (buffer.length < frameLength) {
+      return
+    }
+
+    const body = buffer.slice(separatorIndex + 4, frameLength).toString('utf8')
+    buffer = buffer.slice(frameLength)
+
+    const message = JSON.parse(body)
+
+    if (message.method === 'initialize') {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          serverInfo: {
+            name: 'desktop-e2e-fixture',
+            version: '1.0.0',
+          },
+        },
+      })
+      continue
+    }
+
+    if (message.method === 'tools/list') {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          tools: toolSet.map((name) => ({ name })),
+        },
+      })
+      continue
+    }
+
+    if (message.id !== undefined) {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        error: {
+          code: -32601,
+          message: 'Method not found',
+        },
+      })
+    }
+  }
+})
+
+function send(payload) {
+  const body = JSON.stringify(payload)
+  const frame = `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`
+  process.stdout.write(frame)
+}

--- a/apps/desktop/e2e/tests/app-shell.e2e.ts
+++ b/apps/desktop/e2e/tests/app-shell.e2e.ts
@@ -29,10 +29,11 @@ test.describe('App shell', () => {
     await expect(readyWindow.getByRole('heading', { name: /^Settings$/i })).toBeVisible()
   })
 
-  test('shows Providers, General, and Appearance settings tabs', async ({ readyWindow }) => {
+  test('shows Providers, MCP, General, and Appearance settings tabs', async ({ readyWindow }) => {
     await readyWindow.getByRole('button', { name: /Settings/i }).click()
 
     await expect(readyWindow.getByRole('tab', { name: /^Providers$/i })).toBeVisible()
+    await expect(readyWindow.getByRole('tab', { name: /^MCP$/i })).toBeVisible()
     await expect(readyWindow.getByRole('tab', { name: /^General$/i })).toBeVisible()
     await expect(readyWindow.getByRole('tab', { name: /^Appearance$/i })).toBeVisible()
   })

--- a/apps/desktop/e2e/tests/mcp-settings.e2e.ts
+++ b/apps/desktop/e2e/tests/mcp-settings.e2e.ts
@@ -1,0 +1,98 @@
+import { existsSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Page } from '@playwright/test'
+import { expect, test } from '../fixtures/electron.fixture'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const MCP_FIXTURE_SCRIPT = path.resolve(__dirname, '../fixtures/mcp-stdio-server.mjs')
+
+function writeMcpConfig(
+  mcpConfigPath: string,
+  config: {
+    mcpServers?: Record<string, Record<string, unknown>>
+  },
+): void {
+  writeFileSync(
+    mcpConfigPath,
+    `${JSON.stringify(
+      {
+        imports: [],
+        settings: {
+          toolPrefix: 'server',
+          idleTimeout: 10,
+        },
+        ...config,
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  )
+}
+
+async function openMcpSettings(window: Page) {
+  await window.getByRole('button', { name: /Settings/i }).click()
+  await window.getByRole('tab', { name: /^MCP$/i }).click()
+  await expect(window.getByTestId('mcp-settings-panel')).toBeVisible()
+}
+
+test.describe('MCP settings e2e', () => {
+  test('covers empty, malformed, add/edit/delete, and reconnect failure paths', async ({
+    readyWindow,
+    mcpConfigPath,
+  }) => {
+    if (existsSync(mcpConfigPath)) {
+      rmSync(mcpConfigPath)
+    }
+
+    await openMcpSettings(readyWindow)
+
+    await expect(readyWindow.getByTestId('mcp-empty-state')).toBeVisible()
+    await expect(readyWindow.getByTestId('mcp-provenance-badge')).toContainText('Global shared config')
+
+    await readyWindow.getByTestId('mcp-add-server').click()
+    await readyWindow.getByTestId('mcp-editor-name').fill('fixture-local')
+    await readyWindow.getByTestId('mcp-editor-command').fill(process.execPath)
+    await readyWindow.getByTestId('mcp-editor-args').fill(MCP_FIXTURE_SCRIPT)
+    await readyWindow.getByTestId('mcp-editor-save').click()
+
+    await expect(readyWindow.getByTestId('mcp-server-row-fixture-local')).toBeVisible()
+
+    await readyWindow.getByTestId('mcp-refresh-fixture-local').click()
+    await expect(readyWindow.getByTestId('mcp-status-badge-fixture-local')).toContainText('Connected')
+    await expect(readyWindow.getByTestId('mcp-tools-fixture-local')).toContainText('echo, ping')
+
+    await readyWindow.getByTestId('mcp-edit-fixture-local').click()
+    await readyWindow.getByTestId('mcp-editor-args').fill(`${MCP_FIXTURE_SCRIPT} --alt`)
+    await readyWindow.getByTestId('mcp-editor-save').click()
+
+    await readyWindow.getByTestId('mcp-refresh-fixture-local').click()
+    await expect(readyWindow.getByTestId('mcp-tools-fixture-local')).toContainText('alt_echo, alt_ping')
+
+    await readyWindow.getByTestId('mcp-edit-fixture-local').click()
+    await readyWindow.getByTestId('mcp-editor-command').fill('not-a-real-command-xyz')
+    await readyWindow.getByTestId('mcp-editor-save').click()
+
+    await readyWindow.getByTestId('mcp-reconnect-fixture-local').click()
+    await expect(readyWindow.getByTestId('mcp-status-badge-fixture-local')).toContainText('COMMAND_NOT_FOUND')
+
+    await readyWindow.getByTestId('mcp-edit-fixture-local').click()
+    await readyWindow.getByTestId('mcp-editor-command').fill(process.execPath)
+    await readyWindow.getByTestId('mcp-editor-args').fill(MCP_FIXTURE_SCRIPT)
+    await readyWindow.getByTestId('mcp-editor-save').click()
+
+    await readyWindow.getByTestId('mcp-delete-fixture-local').click()
+    await readyWindow.getByTestId('mcp-confirm-delete-fixture-local').click()
+    await expect(readyWindow.getByTestId('mcp-empty-state')).toBeVisible()
+
+    writeFileSync(mcpConfigPath, '{bad-json', 'utf8')
+    await readyWindow.getByTestId('mcp-refresh-config').click()
+    await expect(readyWindow.getByTestId('mcp-config-error')).toBeVisible()
+
+    writeMcpConfig(mcpConfigPath, { mcpServers: {} })
+    await readyWindow.getByTestId('mcp-refresh-config').click()
+    await expect(readyWindow.getByTestId('mcp-empty-state')).toBeVisible()
+  })
+})

--- a/apps/desktop/src/main/__tests__/mcp-config-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-config-bridge.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { promises as fs } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { McpConfigBridge } from '../mcp-config-bridge'
 
 describe('McpConfigBridge', () => {
@@ -19,6 +19,7 @@ describe('McpConfigBridge', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     rmSync(tempDir, { recursive: true, force: true })
   })
 
@@ -48,34 +49,36 @@ describe('McpConfigBridge', () => {
     expect(response.servers).toEqual([])
   })
 
+  test('surfaces invalid top-level config shape as malformed error', async () => {
+    await writeConfig(['not-an-object'])
+
+    const bridge = new McpConfigBridge({ configPath })
+    const response = await bridge.listServers()
+
+    expect(response.success).toBe(false)
+    expect(response.error?.code).toBe('MALFORMED_CONFIG')
+    expect(response.error?.message).toContain('Top-level MCP config must be a JSON object')
+  })
+
   test('redacts env values and inline bearer tokens from renderer summaries', async () => {
-    await fs.mkdir(path.dirname(configPath), { recursive: true })
-    await fs.writeFile(
-      configPath,
-      JSON.stringify(
-        {
-          mcpServers: {
-            local: {
-              command: 'node',
-              args: ['server.js'],
-              env: {
-                SECRET_KEY: 'hidden',
-                PUBLIC_FLAG: 'true',
-              },
-            },
-            remote: {
-              url: 'https://mcp.example.com',
-              auth: 'bearer',
-              bearerToken: 'super-secret-token',
-              bearerTokenEnv: 'MCP_TOKEN',
-            },
+    await writeConfig({
+      mcpServers: {
+        local: {
+          command: 'node',
+          args: ['server.js'],
+          env: {
+            SECRET_KEY: 'hidden',
+            PUBLIC_FLAG: 'true',
           },
         },
-        null,
-        2,
-      ),
-      'utf8',
-    )
+        remote: {
+          url: 'https://mcp.example.com',
+          auth: 'bearer',
+          bearerToken: 'super-secret-token',
+          bearerTokenEnv: 'MCP_TOKEN',
+        },
+      },
+    })
 
     const bridge = new McpConfigBridge({ configPath })
     const response = await bridge.listServers()
@@ -99,34 +102,25 @@ describe('McpConfigBridge', () => {
   })
 
   test('preserves unknown fields during save and verifies readback', async () => {
-    await fs.mkdir(path.dirname(configPath), { recursive: true })
-    await fs.writeFile(
-      configPath,
-      JSON.stringify(
-        {
-          settings: {
-            toolPrefix: 'server',
-            idleTimeout: 10,
-            customSetting: 'preserve-me',
-          },
-          mcpServers: {
-            local: {
-              command: 'node',
-              args: ['old.js'],
-              metadata: {
-                owner: 'desktop-team',
-              },
-            },
-          },
-          customTopLevel: {
-            keep: true,
+    await writeConfig({
+      settings: {
+        toolPrefix: 'server',
+        idleTimeout: 10,
+        customSetting: 'preserve-me',
+      },
+      mcpServers: {
+        local: {
+          command: 'node',
+          args: ['old.js'],
+          metadata: {
+            owner: 'desktop-team',
           },
         },
-        null,
-        2,
-      ),
-      'utf8',
-    )
+      },
+      customTopLevel: {
+        keep: true,
+      },
+    })
 
     const bridge = new McpConfigBridge({ configPath })
     const saveResponse = await bridge.saveServer({
@@ -169,4 +163,300 @@ describe('McpConfigBridge', () => {
     expect(response.provenance.overlayConfigPath).toBe(path.join(workspaceDir, '.kata-cli', 'mcp.json'))
     expect(response.provenance.warning).toContain('Desktop only edits the shared global MCP config')
   })
+
+  test('getServer returns server_not_found for unknown entries', async () => {
+    const bridge = new McpConfigBridge({ configPath })
+
+    const response = await bridge.getServer('missing-server')
+
+    expect(response.success).toBe(false)
+    expect(response.error?.code).toBe('SERVER_NOT_FOUND')
+  })
+
+  test('getServer returns http summary with default auth and disabled flag', async () => {
+    await writeConfig({
+      mcpServers: {
+        httpRemote: {
+          url: 'https://example.com/mcp',
+          disabled: true,
+        },
+      },
+    })
+
+    const bridge = new McpConfigBridge({ configPath })
+    const response = await bridge.getServer('httpRemote')
+
+    expect(response.success).toBe(true)
+    expect(response.server?.enabled).toBe(false)
+    expect(response.server?.summary.transport).toBe('http')
+    if (response.server?.summary.transport === 'http') {
+      expect(response.server.summary.auth).toBe('none')
+      expect(response.server.summary.url).toBe('https://example.com/mcp')
+      expect(response.server.summary.hasInlineBearerToken).toBe(false)
+    }
+  })
+
+  test('saveServer returns validation errors for invalid payloads', async () => {
+    const bridge = new McpConfigBridge({ configPath })
+
+    const stdioValidation = await bridge.saveServer({
+      name: 'bad name with spaces',
+      transport: 'stdio',
+      command: '   ',
+    })
+
+    expect(stdioValidation.success).toBe(false)
+    expect(stdioValidation.error?.code).toBe('VALIDATION_FAILED')
+    expect(stdioValidation.validationErrors?.map((error) => error.field)).toEqual(expect.arrayContaining(['name', 'command']))
+
+    const httpValidation = await bridge.saveServer({
+      name: 'remote',
+      transport: 'http',
+      url: 'ftp://example.com',
+      auth: 'bearer',
+      bearerToken: '   ',
+      bearerTokenEnv: '   ',
+    })
+
+    expect(httpValidation.success).toBe(false)
+    expect(httpValidation.validationErrors?.map((error) => error.field)).toEqual(expect.arrayContaining(['url', 'bearer']))
+  })
+
+  test('saveServer normalizes stdio servers and strips http-only fields', async () => {
+    await writeConfig({
+      mcpServers: {
+        local: {
+          command: 'node',
+          args: ['old.js'],
+          url: 'https://old.example.com/mcp',
+          auth: 'bearer',
+          bearerToken: 'old-token',
+          bearerTokenEnv: 'OLD_TOKEN',
+        },
+      },
+    })
+
+    const bridge = new McpConfigBridge({ configPath })
+    const response = await bridge.saveServer({
+      name: 'local',
+      transport: 'stdio',
+      command: 'node',
+      args: [' index.mjs ', '', ' --verbose '],
+      env: {
+        '': 'drop-me',
+        API_KEY: 'secret',
+      },
+      cwd: '  ',
+      enabled: false,
+    })
+
+    expect(response.success).toBe(true)
+    expect(response.server?.enabled).toBe(false)
+
+    const persisted = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, Record<string, unknown>>
+    }
+
+    expect(persisted.mcpServers.local?.command).toBe('node')
+    expect(persisted.mcpServers.local?.args).toEqual(['index.mjs', '--verbose'])
+    expect(persisted.mcpServers.local?.disabled).toBe(true)
+    expect(persisted.mcpServers.local?.env).toEqual({ API_KEY: 'secret' })
+    expect(persisted.mcpServers.local?.cwd).toBeUndefined()
+    expect(persisted.mcpServers.local?.url).toBeUndefined()
+    expect(persisted.mcpServers.local?.auth).toBeUndefined()
+    expect(persisted.mcpServers.local?.bearerToken).toBeUndefined()
+    expect(persisted.mcpServers.local?.bearerTokenEnv).toBeUndefined()
+  })
+
+  test('saveServer normalizes http servers and strips stdio-only fields', async () => {
+    await writeConfig({
+      mcpServers: {
+        remote: {
+          command: 'node',
+          args: ['stdio.js'],
+          cwd: '/tmp/work',
+          env: {
+            TOKEN: 'secret',
+          },
+          auth: 'none',
+          customField: 'preserve-me',
+        },
+      },
+    })
+
+    const bridge = new McpConfigBridge({ configPath })
+    const firstSave = await bridge.saveServer({
+      name: 'remote',
+      transport: 'http',
+      url: 'https://mcp.example.com',
+      auth: 'bearer',
+      bearerTokenEnv: ' MCP_TOKEN ',
+      enabled: true,
+    })
+
+    expect(firstSave.success).toBe(true)
+    if (firstSave.success && firstSave.server?.summary.transport === 'http') {
+      expect(firstSave.server.summary.auth).toBe('bearer')
+      expect(firstSave.server.summary.bearerTokenEnv).toBe('MCP_TOKEN')
+    }
+
+    const secondSave = await bridge.saveServer({
+      name: 'remote',
+      transport: 'http',
+      url: 'https://mcp.example.com/v2',
+      auth: 'none',
+      bearerTokenEnv: '   ',
+      bearerToken: '   ',
+    })
+
+    expect(secondSave.success).toBe(true)
+
+    const persisted = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, Record<string, unknown>>
+    }
+
+    expect(persisted.mcpServers.remote?.url).toBe('https://mcp.example.com/v2')
+    expect(persisted.mcpServers.remote?.auth).toBe('none')
+    expect(persisted.mcpServers.remote?.customField).toBe('preserve-me')
+    expect(persisted.mcpServers.remote?.command).toBeUndefined()
+    expect(persisted.mcpServers.remote?.args).toBeUndefined()
+    expect(persisted.mcpServers.remote?.env).toBeUndefined()
+    expect(persisted.mcpServers.remote?.cwd).toBeUndefined()
+    expect(persisted.mcpServers.remote?.bearerToken).toBeUndefined()
+    expect(persisted.mcpServers.remote?.bearerTokenEnv).toBeUndefined()
+  })
+
+  test('deleteServer removes an existing server and returns not-found for unknown entries', async () => {
+    await writeConfig({
+      mcpServers: {
+        local: {
+          command: 'node',
+        },
+      },
+    })
+
+    const bridge = new McpConfigBridge({ configPath })
+
+    const missing = await bridge.deleteServer('missing')
+    expect(missing.success).toBe(false)
+    expect(missing.error?.code).toBe('SERVER_NOT_FOUND')
+
+    const deleted = await bridge.deleteServer('local')
+    expect(deleted.success).toBe(true)
+    expect(deleted.deletedServerName).toBe('local')
+
+    const persisted = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, unknown>
+    }
+    expect(persisted.mcpServers).toEqual({})
+  })
+
+  test('getRuntimeServer returns unredacted stdio and http details', async () => {
+    await writeConfig({
+      mcpServers: {
+        local: {
+          command: 'node',
+          args: ['server.js'],
+          cwd: '/tmp/work',
+          env: {
+            API_KEY: 'secret-value',
+          },
+        },
+        remote: {
+          url: 'https://mcp.example.com',
+          auth: 'bearer',
+          bearerToken: 'inline-token',
+          bearerTokenEnv: 'MCP_TOKEN_ENV',
+        },
+      },
+    })
+
+    const bridge = new McpConfigBridge({ configPath })
+
+    const stdioRuntime = await bridge.getRuntimeServer('local')
+    expect(stdioRuntime.success).toBe(true)
+    if (stdioRuntime.success && stdioRuntime.server.transport === 'stdio') {
+      expect(stdioRuntime.server.env).toEqual({ API_KEY: 'secret-value' })
+      expect(stdioRuntime.server.cwd).toBe('/tmp/work')
+    }
+
+    const httpRuntime = await bridge.getRuntimeServer('remote')
+    expect(httpRuntime.success).toBe(true)
+    if (httpRuntime.success && httpRuntime.server.transport === 'http') {
+      expect(httpRuntime.server.bearerToken).toBe('inline-token')
+      expect(httpRuntime.server.bearerTokenEnv).toBe('MCP_TOKEN_ENV')
+      expect(httpRuntime.server.auth).toBe('bearer')
+    }
+
+    const missingRuntime = await bridge.getRuntimeServer('missing')
+    expect(missingRuntime.success).toBe(false)
+    if (!missingRuntime.success) {
+      expect(missingRuntime.error.code).toBe('SERVER_NOT_FOUND')
+    }
+  })
+
+  test('returns CONFIG_UNREADABLE when config path cannot be read', async () => {
+    await fs.mkdir(configPath, { recursive: true })
+
+    const bridge = new McpConfigBridge({ configPath })
+    const response = await bridge.listServers()
+
+    expect(response.success).toBe(false)
+    expect(response.error?.code).toBe('CONFIG_UNREADABLE')
+  })
+
+  test('returns WRITE_FAILED when filesystem write fails', async () => {
+    await writeConfig({ mcpServers: {} })
+
+    const renameSpy = vi.spyOn(fs, 'rename').mockRejectedValueOnce(new Error('rename failed'))
+
+    const bridge = new McpConfigBridge({ configPath })
+    const response = await bridge.saveServer({
+      name: 'local',
+      transport: 'stdio',
+      command: 'node',
+    })
+
+    expect(response.success).toBe(false)
+    expect(response.error?.code).toBe('WRITE_FAILED')
+    expect(response.error?.message).toContain('rename failed')
+
+    renameSpy.mockRestore()
+  })
+
+  test('returns READBACK_FAILED when written config cannot be parsed on readback', async () => {
+    await writeConfig({ mcpServers: {} })
+
+    const originalReadFile = fs.readFile.bind(fs)
+    let configReadCount = 0
+
+    const readSpy = vi.spyOn(fs, 'readFile').mockImplementation(async (...args: any[]) => {
+      const filePath = args[0]
+      if (typeof filePath === 'string' && path.resolve(filePath) === path.resolve(configPath)) {
+        configReadCount += 1
+        if (configReadCount >= 2) {
+          return '{bad-json'
+        }
+      }
+
+      return (await originalReadFile(...(args as Parameters<typeof fs.readFile>))) as any
+    })
+
+    const bridge = new McpConfigBridge({ configPath })
+    const response = await bridge.saveServer({
+      name: 'local',
+      transport: 'stdio',
+      command: 'node',
+    })
+
+    expect(response.success).toBe(false)
+    expect(response.error?.code).toBe('READBACK_FAILED')
+
+    readSpy.mockRestore()
+  })
+
+  async function writeConfig(value: unknown): Promise<void> {
+    await fs.mkdir(path.dirname(configPath), { recursive: true })
+    await fs.writeFile(configPath, JSON.stringify(value, null, 2), 'utf8')
+  }
 })

--- a/apps/desktop/src/main/__tests__/mcp-config-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-config-bridge.test.ts
@@ -268,6 +268,41 @@ describe('McpConfigBridge', () => {
     expect(persisted.mcpServers.local?.bearerTokenEnv).toBeUndefined()
   })
 
+  test('saveServer allows bearer updates without re-entering an existing inline token', async () => {
+    await writeConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://mcp.example.com',
+          auth: 'bearer',
+          bearerToken: 'existing-inline-token',
+        },
+      },
+    })
+
+    const bridge = new McpConfigBridge({ configPath })
+    const response = await bridge.saveServer({
+      name: 'remote',
+      transport: 'http',
+      url: 'https://mcp.example.com/v2',
+      auth: 'bearer',
+      bearerTokenEnv: '   ',
+    })
+
+    expect(response.success).toBe(true)
+    if (response.success && response.server?.summary.transport === 'http') {
+      expect(response.server.summary.hasInlineBearerToken).toBe(true)
+      expect(response.server.summary.auth).toBe('bearer')
+    }
+
+    const persisted = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, Record<string, unknown>>
+    }
+
+    expect(persisted.mcpServers.remote?.url).toBe('https://mcp.example.com/v2')
+    expect(persisted.mcpServers.remote?.bearerToken).toBe('existing-inline-token')
+    expect(persisted.mcpServers.remote?.bearerTokenEnv).toBeUndefined()
+  })
+
   test('saveServer normalizes http servers and strips stdio-only fields', async () => {
     await writeConfig({
       mcpServers: {

--- a/apps/desktop/src/main/__tests__/mcp-config-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-config-bridge.test.ts
@@ -1,0 +1,172 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { McpConfigBridge } from '../mcp-config-bridge'
+
+describe('McpConfigBridge', () => {
+  let tempDir: string
+  let workspaceDir: string
+  let configPath: string
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'kata-desktop-mcp-bridge-'))
+    workspaceDir = path.join(tempDir, 'workspace')
+    configPath = path.join(tempDir, 'agent', 'mcp.json')
+
+    await fs.mkdir(workspaceDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test('returns starter defaults when config file does not exist', async () => {
+    const bridge = new McpConfigBridge({
+      configPath,
+      getWorkspacePath: () => workspaceDir,
+    })
+
+    const response = await bridge.listServers()
+
+    expect(response.success).toBe(true)
+    expect(response.servers).toEqual([])
+    expect(response.provenance.mode).toBe('global_only')
+    expect(response.provenance.globalConfigPath).toBe(configPath)
+  })
+
+  test('surfaces malformed config as typed error', async () => {
+    await fs.mkdir(path.dirname(configPath), { recursive: true })
+    await fs.writeFile(configPath, '{not-json', 'utf8')
+
+    const bridge = new McpConfigBridge({ configPath })
+    const response = await bridge.listServers()
+
+    expect(response.success).toBe(false)
+    expect(response.error?.code).toBe('MALFORMED_CONFIG')
+    expect(response.servers).toEqual([])
+  })
+
+  test('redacts env values and inline bearer tokens from renderer summaries', async () => {
+    await fs.mkdir(path.dirname(configPath), { recursive: true })
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            local: {
+              command: 'node',
+              args: ['server.js'],
+              env: {
+                SECRET_KEY: 'hidden',
+                PUBLIC_FLAG: 'true',
+              },
+            },
+            remote: {
+              url: 'https://mcp.example.com',
+              auth: 'bearer',
+              bearerToken: 'super-secret-token',
+              bearerTokenEnv: 'MCP_TOKEN',
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    const bridge = new McpConfigBridge({ configPath })
+    const response = await bridge.listServers()
+
+    expect(response.success).toBe(true)
+
+    const local = response.servers.find((server) => server.name === 'local')
+    expect(local?.summary.transport).toBe('stdio')
+    if (local?.summary.transport === 'stdio') {
+      expect(local.summary.envKeys).toEqual(['PUBLIC_FLAG', 'SECRET_KEY'])
+      expect('env' in local.summary).toBe(false)
+    }
+
+    const remote = response.servers.find((server) => server.name === 'remote')
+    expect(remote?.summary.transport).toBe('http')
+    if (remote?.summary.transport === 'http') {
+      expect(remote.summary.hasInlineBearerToken).toBe(true)
+      expect(remote.summary.bearerTokenEnv).toBe('MCP_TOKEN')
+      expect('bearerToken' in remote.summary).toBe(false)
+    }
+  })
+
+  test('preserves unknown fields during save and verifies readback', async () => {
+    await fs.mkdir(path.dirname(configPath), { recursive: true })
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          settings: {
+            toolPrefix: 'server',
+            idleTimeout: 10,
+            customSetting: 'preserve-me',
+          },
+          mcpServers: {
+            local: {
+              command: 'node',
+              args: ['old.js'],
+              metadata: {
+                owner: 'desktop-team',
+              },
+            },
+          },
+          customTopLevel: {
+            keep: true,
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    const bridge = new McpConfigBridge({ configPath })
+    const saveResponse = await bridge.saveServer({
+      name: 'local',
+      transport: 'stdio',
+      command: 'node',
+      args: ['new.js'],
+      enabled: true,
+    })
+
+    expect(saveResponse.success).toBe(true)
+
+    const persisted = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      settings: Record<string, unknown>
+      mcpServers: Record<string, Record<string, unknown>>
+      customTopLevel: Record<string, unknown>
+    }
+
+    expect(persisted.settings.customSetting).toBe('preserve-me')
+    expect(persisted.customTopLevel.keep).toBe(true)
+    const persistedLocalServer = persisted.mcpServers.local
+    expect(persistedLocalServer).toBeDefined()
+    expect(persistedLocalServer?.metadata).toEqual({ owner: 'desktop-team' })
+    expect(persistedLocalServer?.args).toEqual(['new.js'])
+  })
+
+  test('reports overlay provenance when project-local overlay exists', async () => {
+    await fs.mkdir(path.join(workspaceDir, '.kata-cli'), { recursive: true })
+    await fs.writeFile(path.join(workspaceDir, '.kata-cli', 'mcp.json'), '{"mcpServers":{}}\n', 'utf8')
+
+    const bridge = new McpConfigBridge({
+      configPath,
+      getWorkspacePath: () => workspaceDir,
+    })
+
+    const response = await bridge.listServers()
+
+    expect(response.success).toBe(true)
+    expect(response.provenance.mode).toBe('overlay_present')
+    expect(response.provenance.overlayConfigPath).toBe(path.join(workspaceDir, '.kata-cli', 'mcp.json'))
+    expect(response.provenance.warning).toContain('Desktop only edits the shared global MCP config')
+  })
+})

--- a/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
@@ -105,6 +105,11 @@ describe('mcp ipc handlers', () => {
       })),
     } as any
 
+    const mcpService = {
+      refreshStatus: vi.fn(async () => ({ success: true, status: { serverName: 'local', phase: 'connected', checkedAt: new Date().toISOString(), toolNames: ['read'], toolCount: 1 } })),
+      reconnectServer: vi.fn(async () => ({ success: true, status: { serverName: 'local', phase: 'connected', checkedAt: new Date().toISOString(), toolNames: ['read'], toolCount: 1 } })),
+    } as any
+
     const unregister = registerSessionIpc({
       bridge,
       authBridge: {
@@ -120,6 +125,7 @@ describe('mcp ipc handlers', () => {
       } as any,
       window: createWindowStub(),
       mcpConfigBridge,
+      mcpService,
     })
 
     await handlers.get(IPC_CHANNELS.mcpListServers)?.({})
@@ -135,7 +141,38 @@ describe('mcp ipc handlers', () => {
     unregister()
   })
 
-  test('returns typed placeholder response for status methods before mcp service wiring', async () => {
+  test('routes mcp refresh/reconnect handlers through mcp service', async () => {
+    const mcpService = {
+      refreshStatus: vi.fn(async () => ({
+        success: true,
+        status: {
+          serverName: 'server-a',
+          phase: 'connected',
+          checkedAt: new Date().toISOString(),
+          toolNames: ['tool-a'],
+          toolCount: 1,
+        },
+      })),
+      reconnectServer: vi.fn(async () => ({
+        success: false,
+        status: {
+          serverName: 'server-a',
+          phase: 'error',
+          checkedAt: new Date().toISOString(),
+          toolNames: [],
+          toolCount: 0,
+          error: {
+            code: 'CONNECTION_FAILED',
+            message: 'unable to connect',
+          },
+        },
+        error: {
+          code: 'CONNECTION_FAILED',
+          message: 'unable to connect',
+        },
+      })),
+    } as any
+
     const unregister = registerSessionIpc({
       bridge: createBridgeStub(),
       authBridge: {
@@ -156,13 +193,15 @@ describe('mcp ipc handlers', () => {
         saveServer: vi.fn(),
         deleteServer: vi.fn(),
       } as any,
+      mcpService,
     })
 
     const refreshResult = await handlers.get(IPC_CHANNELS.mcpRefreshStatus)?.({}, 'server-a')
     const reconnectResult = await handlers.get(IPC_CHANNELS.mcpReconnectServer)?.({}, 'server-a')
 
-    expect(refreshResult.success).toBe(false)
-    expect(refreshResult.error?.message).toContain('not available yet')
+    expect(mcpService.refreshStatus).toHaveBeenCalledWith('server-a')
+    expect(mcpService.reconnectServer).toHaveBeenCalledWith('server-a')
+    expect(refreshResult.success).toBe(true)
     expect(reconnectResult.success).toBe(false)
 
     unregister()

--- a/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
@@ -1,0 +1,170 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { IPC_CHANNELS } from '@shared/types'
+
+const handlers = new Map<string, (...args: any[]) => any>()
+
+vi.mock('electron', () => {
+  return {
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+        handlers.set(channel, handler)
+      }),
+      removeHandler: vi.fn((channel: string) => {
+        handlers.delete(channel)
+      }),
+    },
+    dialog: {
+      showOpenDialog: vi.fn(async () => ({ canceled: true, filePaths: [] })),
+    },
+  }
+})
+
+import { registerSessionIpc } from '../ipc'
+
+function createBridgeStub() {
+  const emitter = new EventEmitter()
+
+  return Object.assign(emitter, {
+    getState: vi.fn(() => ({ status: 'running', pid: 1, running: true })),
+    getWorkspacePath: vi.fn(() => process.cwd()),
+    prompt: vi.fn(),
+    abort: vi.fn(),
+    restart: vi.fn(),
+    sendExtensionUIResponse: vi.fn(),
+    setPermissionMode: vi.fn(),
+    getAvailableModels: vi.fn(async () => []),
+    setModel: vi.fn(),
+    setThinkingLevel: vi.fn(),
+    send: vi.fn(async () => ({ data: {} })),
+    switchSession: vi.fn(async () => true),
+    switchWorkspace: vi.fn(async () => undefined),
+  }) as any
+}
+
+function createWindowStub() {
+  return {
+    isDestroyed: () => false,
+    webContents: {
+      isDestroyed: () => false,
+      send: vi.fn(),
+    },
+  } as any
+}
+
+describe('mcp ipc handlers', () => {
+  beforeEach(() => {
+    handlers.clear()
+  })
+
+  test('routes mcp config CRUD handlers through the config bridge', async () => {
+    const bridge = createBridgeStub()
+
+    const mcpConfigBridge = {
+      listServers: vi.fn(async () => ({
+        success: true,
+        provenance: {
+          mode: 'global_only',
+          globalConfigPath: '/tmp/mcp.json',
+        },
+        servers: [],
+      })),
+      getServer: vi.fn(async (name: string) => ({
+        success: true,
+        provenance: {
+          mode: 'global_only',
+          globalConfigPath: '/tmp/mcp.json',
+        },
+        server: {
+          name,
+          transport: 'stdio',
+          enabled: true,
+          summary: {
+            transport: 'stdio',
+            command: 'node',
+            args: [],
+            envKeys: [],
+          },
+        },
+      })),
+      saveServer: vi.fn(async (input: unknown) => ({
+        success: true,
+        provenance: {
+          mode: 'global_only',
+          globalConfigPath: '/tmp/mcp.json',
+        },
+        server: input,
+      })),
+      deleteServer: vi.fn(async (name: string) => ({
+        success: true,
+        provenance: {
+          mode: 'global_only',
+          globalConfigPath: '/tmp/mcp.json',
+        },
+        deletedServerName: name,
+      })),
+    } as any
+
+    const unregister = registerSessionIpc({
+      bridge,
+      authBridge: {
+        getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+        setProviderKey: vi.fn(),
+        removeProviderKey: vi.fn(),
+        validateKey: vi.fn(),
+      } as any,
+      sessionManager: {
+        listSessions: vi.fn(async () => ({ sessions: [], warnings: [], directory: process.cwd() })),
+        getSessionInfo: vi.fn(),
+        resolveSessionPathById: vi.fn(async () => null),
+      } as any,
+      window: createWindowStub(),
+      mcpConfigBridge,
+    })
+
+    await handlers.get(IPC_CHANNELS.mcpListServers)?.({})
+    await handlers.get(IPC_CHANNELS.mcpGetServer)?.({}, 'local')
+    await handlers.get(IPC_CHANNELS.mcpSaveServer)?.({}, { name: 'local', transport: 'stdio' })
+    const deleteResponse = await handlers.get(IPC_CHANNELS.mcpDeleteServer)?.({}, 'local')
+
+    expect(mcpConfigBridge.listServers).toHaveBeenCalledTimes(1)
+    expect(mcpConfigBridge.getServer).toHaveBeenCalledWith('local')
+    expect(mcpConfigBridge.saveServer).toHaveBeenCalledWith({ name: 'local', transport: 'stdio' })
+    expect(deleteResponse.deletedServerName).toBe('local')
+
+    unregister()
+  })
+
+  test('returns typed placeholder response for status methods before mcp service wiring', async () => {
+    const unregister = registerSessionIpc({
+      bridge: createBridgeStub(),
+      authBridge: {
+        getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+        setProviderKey: vi.fn(),
+        removeProviderKey: vi.fn(),
+        validateKey: vi.fn(),
+      } as any,
+      sessionManager: {
+        listSessions: vi.fn(async () => ({ sessions: [], warnings: [], directory: process.cwd() })),
+        getSessionInfo: vi.fn(),
+        resolveSessionPathById: vi.fn(async () => null),
+      } as any,
+      window: createWindowStub(),
+      mcpConfigBridge: {
+        listServers: vi.fn(async () => ({ success: true, provenance: { mode: 'global_only', globalConfigPath: '/tmp/mcp.json' }, servers: [] })),
+        getServer: vi.fn(),
+        saveServer: vi.fn(),
+        deleteServer: vi.fn(),
+      } as any,
+    })
+
+    const refreshResult = await handlers.get(IPC_CHANNELS.mcpRefreshStatus)?.({}, 'server-a')
+    const reconnectResult = await handlers.get(IPC_CHANNELS.mcpReconnectServer)?.({}, 'server-a')
+
+    expect(refreshResult.success).toBe(false)
+    expect(refreshResult.error?.message).toContain('not available yet')
+    expect(reconnectResult.success).toBe(false)
+
+    unregister()
+  })
+})

--- a/apps/desktop/src/main/__tests__/mcp-service.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-service.test.ts
@@ -156,6 +156,7 @@ describe('McpService', () => {
   })
 
   test('inspects HTTP server with bearer token resolved from env and lists tools', async () => {
+    const originalToken = process.env.MCP_HTTP_TOKEN
     const httpServer = await startJsonRpcHttpServer((request) => {
       if (request.method === 'initialize') {
         return {
@@ -195,30 +196,101 @@ describe('McpService', () => {
       }
     })
 
-    process.env.MCP_HTTP_TOKEN = 'token-from-env'
+    try {
+      process.env.MCP_HTTP_TOKEN = 'token-from-env'
 
-    await writeConfig({
-      mcpServers: {
-        remote: {
-          url: httpServer.url,
-          auth: 'bearer',
-          bearerTokenEnv: 'MCP_HTTP_TOKEN',
+      await writeConfig({
+        mcpServers: {
+          remote: {
+            url: httpServer.url,
+            auth: 'bearer',
+            bearerTokenEnv: 'MCP_HTTP_TOKEN',
+          },
         },
-      },
+      })
+
+      const service = createService(3_000)
+      const response = await service.refreshStatus('remote')
+
+      expect(response.success).toBe(true)
+      expect(response.status?.phase).toBe('connected')
+      expect(response.status?.toolNames).toEqual(['search', 'lookup'])
+
+      const initializeRequest = httpServer.requests.find((request) => request.body?.method === 'initialize')
+      expect(initializeRequest?.headers.authorization).toBe('Bearer token-from-env')
+    } finally {
+      if (originalToken === undefined) {
+        delete process.env.MCP_HTTP_TOKEN
+      } else {
+        process.env.MCP_HTTP_TOKEN = originalToken
+      }
+      await httpServer.close()
+    }
+  })
+  test('accepts 204 empty responses for notifications/initialized', async () => {
+    const httpServer = await startJsonRpcHttpServer((request) => {
+      if (request.method === 'initialize') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request.id,
+            result: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              serverInfo: {
+                name: 'fixture-http',
+                version: '1.0.0',
+              },
+            },
+          },
+        }
+      }
+
+      if (request.method === 'notifications/initialized') {
+        return {
+          status: 204,
+        }
+      }
+
+      if (request.method === 'tools/list') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request.id,
+            result: {
+              tools: [{ name: 'search' }],
+            },
+          },
+        }
+      }
+
+      return {
+        body: {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: {},
+        },
+      }
     })
 
-    const service = createService(3_000)
-    const response = await service.refreshStatus('remote')
+    try {
+      await writeConfig({
+        mcpServers: {
+          remote: {
+            url: httpServer.url,
+          },
+        },
+      })
 
-    expect(response.success).toBe(true)
-    expect(response.status?.phase).toBe('connected')
-    expect(response.status?.toolNames).toEqual(['search', 'lookup'])
+      const service = createService(3_000)
+      const response = await service.refreshStatus('remote')
 
-    const initializeRequest = httpServer.requests.find((request) => request.body?.method === 'initialize')
-    expect(initializeRequest?.headers.authorization).toBe('Bearer token-from-env')
-
-    delete process.env.MCP_HTTP_TOKEN
-    await httpServer.close()
+      expect(response.success).toBe(true)
+      expect(response.status?.phase).toBe('connected')
+      expect(response.status?.toolNames).toEqual(['search'])
+    } finally {
+      await httpServer.close()
+    }
   })
 
   test('returns missing-bearer-token when HTTP bearer auth has no token source', async () => {
@@ -428,7 +500,15 @@ async function startJsonRpcHttpServer(
     }
 
     const rawBody = Buffer.concat(chunks).toString('utf8')
-    const parsedBody = rawBody ? (JSON.parse(rawBody) as JsonRpcRequest) : null
+    let parsedBody: JsonRpcRequest | null = null
+
+    if (rawBody) {
+      try {
+        parsedBody = JSON.parse(rawBody) as JsonRpcRequest
+      } catch {
+        parsedBody = null
+      }
+    }
 
     requests.push({
       headers: req.headers,
@@ -437,15 +517,20 @@ async function startJsonRpcHttpServer(
 
     const scenario = handler(parsedBody ?? {})
     const status = scenario.status ?? 200
-    const body = scenario.body ?? {}
 
     if (scenario.delayMs && scenario.delayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, scenario.delayMs))
     }
 
     res.statusCode = status
+
+    if (scenario.body === undefined || status === 204) {
+      res.end()
+      return
+    }
+
     res.setHeader('content-type', 'application/json')
-    res.end(JSON.stringify(body))
+    res.end(JSON.stringify(scenario.body))
   })
 
   await new Promise<void>((resolve) => {

--- a/apps/desktop/src/main/__tests__/mcp-service.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-service.test.ts
@@ -1,0 +1,178 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { McpConfigBridge } from '../mcp-config-bridge'
+import { McpService } from '../mcp-service'
+
+describe('McpService', () => {
+  let tempDir: string
+  let configPath: string
+  let fixtureScriptPath: string
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'kata-desktop-mcp-service-'))
+    configPath = path.join(tempDir, 'agent', 'mcp.json')
+    fixtureScriptPath = path.join(tempDir, 'fixture-mcp-server.mjs')
+
+    await fs.mkdir(path.dirname(configPath), { recursive: true })
+    await fs.writeFile(fixtureScriptPath, MCP_STDIO_FIXTURE_SERVER, 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test('refreshStatus connects to local stdio server and returns tool list', async () => {
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            local: {
+              command: process.execPath,
+              args: [fixtureScriptPath],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    const configBridge = new McpConfigBridge({ configPath })
+    const service = new McpService({ configBridge, requestTimeoutMs: 5_000 })
+
+    const response = await service.refreshStatus('local')
+
+    expect(response.success).toBe(true)
+    expect(response.status?.phase).toBe('connected')
+    expect(response.status?.toolNames).toEqual(['echo', 'ping'])
+    expect(response.status?.toolCount).toBe(2)
+  })
+
+  test('returns malformed-config status when config is invalid JSON', async () => {
+    await fs.writeFile(configPath, '{bad-json', 'utf8')
+
+    const configBridge = new McpConfigBridge({ configPath })
+    const service = new McpService({ configBridge, requestTimeoutMs: 3_000 })
+
+    const response = await service.refreshStatus('local')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.phase).toBe('error')
+    expect(response.status?.error?.code).toBe('MALFORMED_CONFIG')
+  })
+
+  test('returns command-not-found status for unreachable stdio command', async () => {
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            unreachable: {
+              command: 'not-a-real-command-xyz',
+              args: [],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    const configBridge = new McpConfigBridge({ configPath })
+    const service = new McpService({ configBridge, requestTimeoutMs: 3_000 })
+
+    const response = await service.reconnectServer('unreachable')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.phase).toBe('error')
+    expect(response.status?.error?.code).toBe('COMMAND_NOT_FOUND')
+  })
+})
+
+const MCP_STDIO_FIXTURE_SERVER = `
+import process from 'node:process'
+
+let buffer = Buffer.alloc(0)
+
+process.stdin.on('data', (chunk) => {
+  buffer = Buffer.concat([buffer, chunk])
+
+  while (buffer.length > 0) {
+    const separatorIndex = buffer.indexOf('\\r\\n\\r\\n')
+    if (separatorIndex === -1) {
+      return
+    }
+
+    const headers = buffer.slice(0, separatorIndex).toString('utf8')
+    const lengthMatch = headers.match(/Content-Length:\\s*(\\d+)/i)
+    if (!lengthMatch) {
+      buffer = Buffer.alloc(0)
+      return
+    }
+
+    const bodyLength = Number(lengthMatch[1])
+    const frameLength = separatorIndex + 4 + bodyLength
+    if (buffer.length < frameLength) {
+      return
+    }
+
+    const body = buffer.slice(separatorIndex + 4, frameLength).toString('utf8')
+    buffer = buffer.slice(frameLength)
+
+    const message = JSON.parse(body)
+
+    if (message.method === 'initialize') {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          serverInfo: {
+            name: 'fixture-mcp-server',
+            version: '1.0.0',
+          },
+        },
+      })
+      continue
+    }
+
+    if (message.method === 'tools/list') {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          tools: [
+            { name: 'echo' },
+            { name: 'ping' },
+          ],
+        },
+      })
+      continue
+    }
+
+    if (message.id !== undefined) {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        error: {
+          code: -32601,
+          message: 'Method not found',
+        },
+      })
+    }
+  }
+})
+
+function send(payload) {
+  const body = JSON.stringify(payload)
+  const frame = 'Content-Length: ' + Buffer.byteLength(body, 'utf8') + '\\r\\n\\r\\n' + body
+  process.stdout.write(frame)
+}
+`

--- a/apps/desktop/src/main/__tests__/mcp-service.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-service.test.ts
@@ -1,8 +1,9 @@
 import { mkdtempSync, rmSync } from 'node:fs'
 import { promises as fs } from 'node:fs'
+import { createServer, type IncomingHttpHeaders } from 'node:http'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { McpConfigBridge } from '../mcp-config-bridge'
 import { McpService } from '../mcp-service'
 
@@ -21,30 +22,21 @@ describe('McpService', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     rmSync(tempDir, { recursive: true, force: true })
   })
 
   test('refreshStatus connects to local stdio server and returns tool list', async () => {
-    await fs.writeFile(
-      configPath,
-      JSON.stringify(
-        {
-          mcpServers: {
-            local: {
-              command: process.execPath,
-              args: [fixtureScriptPath],
-            },
-          },
+    await writeConfig({
+      mcpServers: {
+        local: {
+          command: process.execPath,
+          args: [fixtureScriptPath, 'ok'],
         },
-        null,
-        2,
-      ),
-      'utf8',
-    )
+      },
+    })
 
-    const configBridge = new McpConfigBridge({ configPath })
-    const service = new McpService({ configBridge, requestTimeoutMs: 5_000 })
-
+    const service = createService(5_000)
     const response = await service.refreshStatus('local')
 
     expect(response.success).toBe(true)
@@ -56,9 +48,7 @@ describe('McpService', () => {
   test('returns malformed-config status when config is invalid JSON', async () => {
     await fs.writeFile(configPath, '{bad-json', 'utf8')
 
-    const configBridge = new McpConfigBridge({ configPath })
-    const service = new McpService({ configBridge, requestTimeoutMs: 3_000 })
-
+    const service = createService(3_000)
     const response = await service.refreshStatus('local')
 
     expect(response.success).toBe(false)
@@ -67,36 +57,432 @@ describe('McpService', () => {
   })
 
   test('returns command-not-found status for unreachable stdio command', async () => {
-    await fs.writeFile(
-      configPath,
-      JSON.stringify(
-        {
-          mcpServers: {
-            unreachable: {
-              command: 'not-a-real-command-xyz',
-              args: [],
-            },
-          },
+    await writeConfig({
+      mcpServers: {
+        unreachable: {
+          command: 'not-a-real-command-xyz',
+          args: [],
         },
-        null,
-        2,
-      ),
-      'utf8',
-    )
+      },
+    })
 
-    const configBridge = new McpConfigBridge({ configPath })
-    const service = new McpService({ configBridge, requestTimeoutMs: 3_000 })
-
+    const service = createService(3_000)
     const response = await service.reconnectServer('unreachable')
 
     expect(response.success).toBe(false)
     expect(response.status?.phase).toBe('error')
     expect(response.status?.error?.code).toBe('COMMAND_NOT_FOUND')
   })
+
+  test('returns unsupported when server is disabled', async () => {
+    await writeConfig({
+      mcpServers: {
+        local: {
+          command: process.execPath,
+          args: [fixtureScriptPath, 'ok'],
+          disabled: true,
+        },
+      },
+    })
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('local')
+
+    expect(response.success).toBe(true)
+    expect(response.status?.phase).toBe('unsupported')
+    expect(response.status?.toolCount).toBe(0)
+  })
+
+  test('returns server-not-found when runtime server is missing', async () => {
+    await writeConfig({ mcpServers: {} })
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('missing')
+
+    expect(response.success).toBe(false)
+    expect(response.error?.code).toBe('SERVER_NOT_FOUND')
+  })
+
+  test('maps stdio initialize RPC errors to protocol_error', async () => {
+    await writeConfig({
+      mcpServers: {
+        local: {
+          command: process.execPath,
+          args: [fixtureScriptPath, 'initialize-error'],
+        },
+      },
+    })
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('local')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.phase).toBe('error')
+    expect(response.status?.error?.code).toBe('PROTOCOL_ERROR')
+  })
+
+  test('maps stdio process exits to connection_failed', async () => {
+    await writeConfig({
+      mcpServers: {
+        local: {
+          command: process.execPath,
+          args: [fixtureScriptPath, 'exit'],
+        },
+      },
+    })
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('local')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.error?.code).toBe('CONNECTION_FAILED')
+  })
+
+  test('maps stdio request timeout to timeout error', async () => {
+    await writeConfig({
+      mcpServers: {
+        local: {
+          command: process.execPath,
+          args: [fixtureScriptPath, 'timeout'],
+        },
+      },
+    })
+
+    const service = createService(150)
+    const response = await service.refreshStatus('local')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.error?.code).toBe('TIMEOUT')
+  })
+
+  test('inspects HTTP server with bearer token resolved from env and lists tools', async () => {
+    const httpServer = await startJsonRpcHttpServer((request) => {
+      if (request.method === 'initialize') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request.id,
+            result: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              serverInfo: {
+                name: 'fixture-http',
+                version: '1.0.0',
+              },
+            },
+          },
+        }
+      }
+
+      if (request.method === 'tools/list') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request.id,
+            result: {
+              tools: [{ name: 'search' }, { name: 'lookup' }],
+            },
+          },
+        }
+      }
+
+      return {
+        body: {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: {},
+        },
+      }
+    })
+
+    process.env.MCP_HTTP_TOKEN = 'token-from-env'
+
+    await writeConfig({
+      mcpServers: {
+        remote: {
+          url: httpServer.url,
+          auth: 'bearer',
+          bearerTokenEnv: 'MCP_HTTP_TOKEN',
+        },
+      },
+    })
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('remote')
+
+    expect(response.success).toBe(true)
+    expect(response.status?.phase).toBe('connected')
+    expect(response.status?.toolNames).toEqual(['search', 'lookup'])
+
+    const initializeRequest = httpServer.requests.find((request) => request.body?.method === 'initialize')
+    expect(initializeRequest?.headers.authorization).toBe('Bearer token-from-env')
+
+    delete process.env.MCP_HTTP_TOKEN
+    await httpServer.close()
+  })
+
+  test('returns missing-bearer-token when HTTP bearer auth has no token source', async () => {
+    await writeConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://example.invalid/mcp',
+          auth: 'bearer',
+        },
+      },
+    })
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('remote')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.error?.code).toBe('MISSING_BEARER_TOKEN')
+  })
+
+  test('returns connection-failed when HTTP initialize returns JSON-RPC error', async () => {
+    const httpServer = await startJsonRpcHttpServer((request) => {
+      if (request.method === 'initialize') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request.id,
+            error: {
+              code: -32000,
+              message: 'initialize failed',
+            },
+          },
+        }
+      }
+
+      return {
+        body: {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: {},
+        },
+      }
+    })
+
+    await writeConfig({
+      mcpServers: {
+        remote: {
+          url: httpServer.url,
+        },
+      },
+    })
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('remote')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.error?.code).toBe('CONNECTION_FAILED')
+    expect(response.status?.error?.message).toContain('initialize failed')
+
+    await httpServer.close()
+  })
+
+  test('returns connection-failed when HTTP tools/list returns JSON-RPC error', async () => {
+    const httpServer = await startJsonRpcHttpServer((request) => {
+      if (request.method === 'initialize') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request.id,
+            result: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              serverInfo: {
+                name: 'fixture-http',
+                version: '1.0.0',
+              },
+            },
+          },
+        }
+      }
+
+      if (request.method === 'tools/list') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request.id,
+            error: {
+              code: -32001,
+              message: 'tools unavailable',
+            },
+          },
+        }
+      }
+
+      return {
+        body: {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: {},
+        },
+      }
+    })
+
+    await writeConfig({
+      mcpServers: {
+        remote: {
+          url: httpServer.url,
+        },
+      },
+    })
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('remote')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.error?.code).toBe('CONNECTION_FAILED')
+    expect(response.status?.error?.message).toContain('tools unavailable')
+
+    await httpServer.close()
+  })
+
+  test('returns unreachable when HTTP endpoint returns non-200 status', async () => {
+    const httpServer = await startJsonRpcHttpServer(() => ({
+      status: 500,
+      body: {
+        message: 'boom',
+      },
+    }))
+
+    await writeConfig({
+      mcpServers: {
+        remote: {
+          url: httpServer.url,
+        },
+      },
+    })
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('remote')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.error?.code).toBe('UNREACHABLE')
+
+    await httpServer.close()
+  })
+
+  test('returns timeout when fetch throws timeout-like errors', async () => {
+    await writeConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://example.invalid/mcp',
+        },
+      },
+    })
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('timeout while connecting'))
+
+    const service = createService(3_000)
+    const response = await service.refreshStatus('remote')
+
+    expect(response.success).toBe(false)
+    expect(response.status?.error?.code).toBe('TIMEOUT')
+
+    fetchSpy.mockRestore()
+  })
+
+  function createService(timeoutMs: number): McpService {
+    const configBridge = new McpConfigBridge({ configPath })
+    return new McpService({ configBridge, requestTimeoutMs: timeoutMs })
+  }
+
+  async function writeConfig(value: unknown): Promise<void> {
+    await fs.mkdir(path.dirname(configPath), { recursive: true })
+    await fs.writeFile(configPath, JSON.stringify(value, null, 2), 'utf8')
+  }
 })
+
+interface JsonRpcRequest {
+  method?: string
+  id?: number
+  params?: unknown
+}
+
+interface HttpScenarioResponse {
+  status?: number
+  body?: unknown
+  delayMs?: number
+}
+
+interface RecordedRequest {
+  headers: IncomingHttpHeaders
+  body: JsonRpcRequest | null
+}
+
+async function startJsonRpcHttpServer(
+  handler: (request: JsonRpcRequest) => HttpScenarioResponse,
+): Promise<{
+  url: string
+  requests: RecordedRequest[]
+  close: () => Promise<void>
+}> {
+  const requests: RecordedRequest[] = []
+
+  const server = createServer(async (req, res) => {
+    const chunks: Buffer[] = []
+    for await (const chunk of req) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+
+    const rawBody = Buffer.concat(chunks).toString('utf8')
+    const parsedBody = rawBody ? (JSON.parse(rawBody) as JsonRpcRequest) : null
+
+    requests.push({
+      headers: req.headers,
+      body: parsedBody,
+    })
+
+    const scenario = handler(parsedBody ?? {})
+    const status = scenario.status ?? 200
+    const body = scenario.body ?? {}
+
+    if (scenario.delayMs && scenario.delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, scenario.delayMs))
+    }
+
+    res.statusCode = status
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify(body))
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to resolve HTTP server address')
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+
+          resolve()
+        })
+      })
+    },
+  }
+}
 
 const MCP_STDIO_FIXTURE_SERVER = `
 import process from 'node:process'
+
+const mode = process.argv[2] ?? 'ok'
+
+if (mode === 'exit') {
+  process.exit(1)
+}
 
 let buffer = Buffer.alloc(0)
 
@@ -128,6 +514,22 @@ process.stdin.on('data', (chunk) => {
     const message = JSON.parse(body)
 
     if (message.method === 'initialize') {
+      if (mode === 'timeout') {
+        continue
+      }
+
+      if (mode === 'initialize-error') {
+        send({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: {
+            code: -32000,
+            message: 'initialize failed',
+          },
+        })
+        continue
+      }
+
       send({
         jsonrpc: '2.0',
         id: message.id,

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -11,6 +11,7 @@ import { DesktopSessionManager } from './session-manager'
 import { SessionHistoryLoader } from './session-history-loader'
 import { WorkflowBoardService } from './workflow-board-service'
 import { McpConfigBridge } from './mcp-config-bridge'
+import { McpService } from './mcp-service'
 import type { SymphonySupervisor } from './symphony-supervisor'
 import type { SymphonyOperatorService } from './symphony-operator-service'
 import {
@@ -71,6 +72,7 @@ interface RegisterIpcOptions {
   symphonySupervisor?: SymphonySupervisor
   symphonyOperatorService?: SymphonyOperatorService
   mcpConfigBridge?: McpConfigBridge
+  mcpService?: McpService
 }
 
 export function registerSessionIpc({
@@ -83,6 +85,7 @@ export function registerSessionIpc({
   symphonySupervisor,
   symphonyOperatorService,
   mcpConfigBridge,
+  mcpService,
 }: RegisterIpcOptions): () => void {
   const adapter = new RpcEventAdapter()
   const planningToolDetector = new PlanningToolDetector()
@@ -99,6 +102,7 @@ export function registerSessionIpc({
       configPath: process.env.KATA_DESKTOP_MCP_CONFIG_PATH,
       getWorkspacePath: () => bridge.getWorkspacePath(),
     })
+  const resolvedMcpService = mcpService ?? new McpService({ configBridge: resolvedMcpConfigBridge })
 
   const planningArtifactsByKey = new Map<string, PlanningArtifact>()
   const planningMetadataByKey = new Map<string, PlanningArtifactEvent>()
@@ -1342,25 +1346,17 @@ export function registerSessionIpc({
     },
   )
 
-  const unsupportedStatusResponse = (name: string): McpServerStatusResponse => ({
-    success: false,
-    error: {
-      code: 'UNKNOWN',
-      message: `MCP status actions are not available yet for "${name}".`,
-    },
-  })
-
   ipcMain.handle(
     IPC_CHANNELS.mcpRefreshStatus,
     async (_event, name: string): Promise<McpServerStatusResponse> => {
-      return unsupportedStatusResponse(name)
+      return resolvedMcpService.refreshStatus(name)
     },
   )
 
   ipcMain.handle(
     IPC_CHANNELS.mcpReconnectServer,
     async (_event, name: string): Promise<McpServerStatusResponse> => {
-      return unsupportedStatusResponse(name)
+      return resolvedMcpService.reconnectServer(name)
     },
   )
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -10,6 +10,7 @@ import { RpcEventAdapter } from './rpc-event-adapter'
 import { DesktopSessionManager } from './session-manager'
 import { SessionHistoryLoader } from './session-history-loader'
 import { WorkflowBoardService } from './workflow-board-service'
+import { McpConfigBridge } from './mcp-config-bridge'
 import type { SymphonySupervisor } from './symphony-supervisor'
 import type { SymphonyOperatorService } from './symphony-operator-service'
 import {
@@ -52,6 +53,12 @@ import {
   type SymphonyOperatorSnapshot,
   type SymphonyOperatorSnapshotResponse,
   type SymphonyEscalationResponseCommandResult,
+  type McpConfigReadResponse,
+  type McpServerDeleteResponse,
+  type McpServerInput,
+  type McpServerMutationResponse,
+  type McpServerResponse,
+  type McpServerStatusResponse,
 } from '../shared/types'
 
 interface RegisterIpcOptions {
@@ -63,6 +70,7 @@ interface RegisterIpcOptions {
   onWorkspaceSelected?: (workspacePath: string) => Promise<void> | void
   symphonySupervisor?: SymphonySupervisor
   symphonyOperatorService?: SymphonyOperatorService
+  mcpConfigBridge?: McpConfigBridge
 }
 
 export function registerSessionIpc({
@@ -74,6 +82,7 @@ export function registerSessionIpc({
   onWorkspaceSelected,
   symphonySupervisor,
   symphonyOperatorService,
+  mcpConfigBridge,
 }: RegisterIpcOptions): () => void {
   const adapter = new RpcEventAdapter()
   const planningToolDetector = new PlanningToolDetector()
@@ -84,6 +93,12 @@ export function registerSessionIpc({
     getWorkspacePath: () => bridge.getWorkspacePath(),
     getSymphonySnapshot: () => symphonyOperatorService?.getSnapshot() ?? null,
   })
+  const resolvedMcpConfigBridge =
+    mcpConfigBridge ??
+    new McpConfigBridge({
+      configPath: process.env.KATA_DESKTOP_MCP_CONFIG_PATH,
+      getWorkspacePath: () => bridge.getWorkspacePath(),
+    })
 
   const planningArtifactsByKey = new Map<string, PlanningArtifact>()
   const planningMetadataByKey = new Map<string, PlanningArtifactEvent>()
@@ -570,6 +585,12 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.symphonyGetDashboard)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyRefreshDashboard)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyRespondEscalation)
+  ipcMain.removeHandler(IPC_CHANNELS.mcpListServers)
+  ipcMain.removeHandler(IPC_CHANNELS.mcpGetServer)
+  ipcMain.removeHandler(IPC_CHANNELS.mcpSaveServer)
+  ipcMain.removeHandler(IPC_CHANNELS.mcpDeleteServer)
+  ipcMain.removeHandler(IPC_CHANNELS.mcpRefreshStatus)
+  ipcMain.removeHandler(IPC_CHANNELS.mcpReconnectServer)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -1299,6 +1320,50 @@ export function registerSessionIpc({
     },
   )
 
+  ipcMain.handle(IPC_CHANNELS.mcpListServers, async (): Promise<McpConfigReadResponse> => {
+    return resolvedMcpConfigBridge.listServers()
+  })
+
+  ipcMain.handle(IPC_CHANNELS.mcpGetServer, async (_event, name: string): Promise<McpServerResponse> => {
+    return resolvedMcpConfigBridge.getServer(name)
+  })
+
+  ipcMain.handle(
+    IPC_CHANNELS.mcpSaveServer,
+    async (_event, input: McpServerInput): Promise<McpServerMutationResponse> => {
+      return resolvedMcpConfigBridge.saveServer(input)
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.mcpDeleteServer,
+    async (_event, name: string): Promise<McpServerDeleteResponse> => {
+      return resolvedMcpConfigBridge.deleteServer(name)
+    },
+  )
+
+  const unsupportedStatusResponse = (name: string): McpServerStatusResponse => ({
+    success: false,
+    error: {
+      code: 'UNKNOWN',
+      message: `MCP status actions are not available yet for "${name}".`,
+    },
+  })
+
+  ipcMain.handle(
+    IPC_CHANNELS.mcpRefreshStatus,
+    async (_event, name: string): Promise<McpServerStatusResponse> => {
+      return unsupportedStatusResponse(name)
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.mcpReconnectServer,
+    async (_event, name: string): Promise<McpServerStatusResponse> => {
+      return unsupportedStatusResponse(name)
+    },
+  )
+
   return () => {
     bridge.off('rpc-event', onRpcEvent)
     bridge.off('extension-ui-request', onExtensionUiRequest)
@@ -1344,6 +1409,12 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.symphonyGetDashboard)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyRefreshDashboard)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyRespondEscalation)
+    ipcMain.removeHandler(IPC_CHANNELS.mcpListServers)
+    ipcMain.removeHandler(IPC_CHANNELS.mcpGetServer)
+    ipcMain.removeHandler(IPC_CHANNELS.mcpSaveServer)
+    ipcMain.removeHandler(IPC_CHANNELS.mcpDeleteServer)
+    ipcMain.removeHandler(IPC_CHANNELS.mcpRefreshStatus)
+    ipcMain.removeHandler(IPC_CHANNELS.mcpReconnectServer)
   }
 }
 

--- a/apps/desktop/src/main/mcp-config-bridge.ts
+++ b/apps/desktop/src/main/mcp-config-bridge.ts
@@ -122,7 +122,10 @@ export class McpConfigBridge {
       return loaded.response
     }
 
-    const validationErrors = validateServerInput(input)
+    const name = input.name.trim()
+    const existingServer = asObject(loaded.config.mcpServers[name])
+
+    const validationErrors = validateServerInput(input, existingServer)
     if (validationErrors.length > 0) {
       return {
         success: false,
@@ -135,8 +138,6 @@ export class McpConfigBridge {
       }
     }
 
-    const name = input.name.trim()
-    const existingServer = asObject(loaded.config.mcpServers[name])
     const nextServer = normalizeServerForWrite(existingServer, input)
 
     const nextConfig: JsonObject = {
@@ -508,7 +509,7 @@ export class McpConfigBridge {
   }
 }
 
-function validateServerInput(input: McpServerInput): McpValidationError[] {
+function validateServerInput(input: McpServerInput, existingServer: JsonObject = {}): McpValidationError[] {
   const errors: McpValidationError[] = []
 
   const name = input.name.trim()
@@ -562,11 +563,14 @@ function validateServerInput(input: McpServerInput): McpValidationError[] {
       }
     }
 
-    const auth = input.auth ?? 'none'
+    const auth = input.auth ?? normalizeAuthMode(existingServer.auth)
     if (auth === 'bearer') {
       const token = input.bearerToken?.trim()
       const tokenEnv = input.bearerTokenEnv?.trim()
-      if (!token && !tokenEnv) {
+      const existingToken = asNonEmptyString(existingServer.bearerToken)
+      const existingTokenEnv = asNonEmptyString(existingServer.bearerTokenEnv)
+
+      if (!token && !tokenEnv && !existingToken && !existingTokenEnv) {
         errors.push({
           field: 'bearer',
           code: 'REQUIRED',
@@ -613,28 +617,35 @@ function normalizeServerForWrite(existingServer: JsonObject, input: McpServerInp
 }
 
 function normalizeHttpServerForWrite(existingServer: JsonObject, input: McpHttpServerInput): JsonObject {
+  const auth = input.auth ?? normalizeAuthMode(existingServer.auth)
+
   const nextHttpServer: JsonObject = {
     ...existingServer,
     url: input.url.trim(),
-    auth: input.auth ?? normalizeAuthMode(existingServer.auth),
+    auth,
     disabled: input.enabled === undefined ? toBoolean(existingServer.disabled) : !input.enabled,
   }
 
-  if (input.bearerToken !== undefined) {
-    const token = input.bearerToken.trim()
-    if (token) {
-      nextHttpServer.bearerToken = token
-    } else {
-      delete nextHttpServer.bearerToken
+  if (auth !== 'bearer') {
+    delete nextHttpServer.bearerToken
+    delete nextHttpServer.bearerTokenEnv
+  } else {
+    if (input.bearerToken !== undefined) {
+      const token = input.bearerToken.trim()
+      if (token) {
+        nextHttpServer.bearerToken = token
+      } else {
+        delete nextHttpServer.bearerToken
+      }
     }
-  }
 
-  if (input.bearerTokenEnv !== undefined) {
-    const tokenEnv = input.bearerTokenEnv.trim()
-    if (tokenEnv) {
-      nextHttpServer.bearerTokenEnv = tokenEnv
-    } else {
-      delete nextHttpServer.bearerTokenEnv
+    if (input.bearerTokenEnv !== undefined) {
+      const tokenEnv = input.bearerTokenEnv.trim()
+      if (tokenEnv) {
+        nextHttpServer.bearerTokenEnv = tokenEnv
+      } else {
+        delete nextHttpServer.bearerTokenEnv
+      }
     }
   }
 

--- a/apps/desktop/src/main/mcp-config-bridge.ts
+++ b/apps/desktop/src/main/mcp-config-bridge.ts
@@ -1,0 +1,762 @@
+import { promises as fs } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import log from './logger'
+import type {
+  McpConfigProvenance,
+  McpConfigReadResponse,
+  McpHttpServerInput,
+  McpServerDeleteResponse,
+  McpServerInput,
+  McpServerMutationResponse,
+  McpServerResponse,
+  McpServerSummary,
+  McpValidationError,
+} from '../shared/types'
+
+type McpBridgeErrorCode = NonNullable<McpServerMutationResponse['error']>['code']
+
+const DEFAULT_MCP_CONFIG_PATH = path.join(homedir(), '.kata-cli', 'agent', 'mcp.json')
+
+const STARTER_MCP_CONFIG = {
+  imports: [] as string[],
+  settings: {
+    toolPrefix: 'server',
+    idleTimeout: 10,
+  },
+  mcpServers: {} as Record<string, unknown>,
+}
+
+type JsonObject = Record<string, unknown>
+
+export interface McpRuntimeStdioServer {
+  name: string
+  transport: 'stdio'
+  enabled: boolean
+  command: string
+  args: string[]
+  cwd?: string
+  env: Record<string, string>
+}
+
+export interface McpRuntimeHttpServer {
+  name: string
+  transport: 'http'
+  enabled: boolean
+  url: string
+  auth: 'none' | 'bearer'
+  bearerToken?: string
+  bearerTokenEnv?: string
+}
+
+export type McpRuntimeServerConfig = McpRuntimeStdioServer | McpRuntimeHttpServer
+
+interface McpLoadedConfig {
+  configPath: string
+  rawConfig: JsonObject
+  mcpServers: Record<string, unknown>
+  provenance: McpConfigProvenance
+}
+
+interface McpBridgeOptions {
+  configPath?: string
+  getWorkspacePath?: () => string | null
+}
+
+export class McpConfigBridge {
+  private readonly configPath: string
+  private readonly getWorkspacePath?: () => string | null
+
+  constructor(options?: McpBridgeOptions) {
+    this.configPath = options?.configPath?.trim() || DEFAULT_MCP_CONFIG_PATH
+    this.getWorkspacePath = options?.getWorkspacePath
+  }
+
+  public getConfigPath(): string {
+    return this.configPath
+  }
+
+  public async listServers(): Promise<McpConfigReadResponse> {
+    const loaded = await this.loadConfig()
+    if (!loaded.success) {
+      return loaded.response
+    }
+
+    return {
+      success: true,
+      provenance: loaded.config.provenance,
+      servers: this.toServerSummaries(loaded.config.mcpServers),
+    }
+  }
+
+  public async getServer(name: string): Promise<McpServerResponse> {
+    const loaded = await this.loadConfig()
+    if (!loaded.success) {
+      return loaded.response
+    }
+
+    const normalizedName = name.trim()
+    const rawServer = loaded.config.mcpServers[normalizedName]
+
+    if (!normalizedName || !isObject(rawServer)) {
+      return {
+        success: false,
+        provenance: loaded.config.provenance,
+        error: {
+          code: 'SERVER_NOT_FOUND',
+          message: `MCP server "${normalizedName || name}" was not found.`,
+        },
+      }
+    }
+
+    return {
+      success: true,
+      provenance: loaded.config.provenance,
+      server: this.toServerSummary(normalizedName, rawServer),
+    }
+  }
+
+  public async saveServer(input: McpServerInput): Promise<McpServerMutationResponse> {
+    const loaded = await this.loadConfig()
+    if (!loaded.success) {
+      return loaded.response
+    }
+
+    const validationErrors = validateServerInput(input)
+    if (validationErrors.length > 0) {
+      return {
+        success: false,
+        provenance: loaded.config.provenance,
+        validationErrors,
+        error: {
+          code: 'VALIDATION_FAILED',
+          message: 'Server configuration contains validation errors.',
+        },
+      }
+    }
+
+    const name = input.name.trim()
+    const existingServer = asObject(loaded.config.mcpServers[name])
+    const nextServer = normalizeServerForWrite(existingServer, input)
+
+    const nextConfig: JsonObject = {
+      ...loaded.config.rawConfig,
+      mcpServers: {
+        ...loaded.config.mcpServers,
+        [name]: nextServer,
+      },
+    }
+
+    const writeResult = await this.writeConfig(nextConfig)
+    if (!writeResult.success) {
+      return {
+        success: false,
+        provenance: loaded.config.provenance,
+        error: writeResult.error,
+      }
+    }
+
+    return {
+      success: true,
+      provenance: loaded.config.provenance,
+      server: this.toServerSummary(name, nextServer),
+    }
+  }
+
+  public async deleteServer(name: string): Promise<McpServerDeleteResponse> {
+    const loaded = await this.loadConfig()
+    if (!loaded.success) {
+      return {
+        success: false,
+        provenance: loaded.response.provenance,
+        error: toDeleteResponseError(loaded.response.error),
+      }
+    }
+
+    const normalizedName = name.trim()
+    if (!normalizedName || !Object.prototype.hasOwnProperty.call(loaded.config.mcpServers, normalizedName)) {
+      return {
+        success: false,
+        provenance: loaded.config.provenance,
+        error: {
+          code: 'SERVER_NOT_FOUND',
+          message: `MCP server "${normalizedName || name}" was not found.`,
+        },
+      }
+    }
+
+    const nextServers = { ...loaded.config.mcpServers }
+    delete nextServers[normalizedName]
+
+    const nextConfig: JsonObject = {
+      ...loaded.config.rawConfig,
+      mcpServers: nextServers,
+    }
+
+    const writeResult = await this.writeConfig(nextConfig)
+    if (!writeResult.success) {
+      return {
+        success: false,
+        provenance: loaded.config.provenance,
+        error: writeResult.error,
+      }
+    }
+
+    return {
+      success: true,
+      provenance: loaded.config.provenance,
+      deletedServerName: normalizedName,
+    }
+  }
+
+  public async getRuntimeServer(name: string): Promise<
+    | {
+        success: true
+        provenance: McpConfigProvenance
+        server: McpRuntimeServerConfig
+      }
+    | {
+        success: false
+        provenance: McpConfigProvenance
+        error: {
+          code: McpBridgeErrorCode
+          message: string
+        }
+      }
+  > {
+    const loaded = await this.loadConfig()
+    if (!loaded.success) {
+      return {
+        success: false,
+        provenance: loaded.response.provenance,
+        error: loaded.response.error ?? {
+          code: 'UNKNOWN',
+          message: 'Unable to read MCP configuration.',
+        },
+      }
+    }
+
+    const normalizedName = name.trim()
+    const rawServer = loaded.config.mcpServers[normalizedName]
+
+    if (!normalizedName || !isObject(rawServer)) {
+      return {
+        success: false,
+        provenance: loaded.config.provenance,
+        error: {
+          code: 'SERVER_NOT_FOUND',
+          message: `MCP server "${normalizedName || name}" was not found.`,
+        },
+      }
+    }
+
+    const runtimeServer = this.toRuntimeServer(normalizedName, rawServer)
+
+    return {
+      success: true,
+      provenance: loaded.config.provenance,
+      server: runtimeServer,
+    }
+  }
+
+  private async loadConfig(): Promise<
+    | {
+        success: true
+        config: McpLoadedConfig
+      }
+    | {
+        success: false
+        response: McpConfigReadResponse
+      }
+  > {
+    const provenance = await this.getProvenance()
+
+    try {
+      const content = await fs.readFile(this.configPath, 'utf8')
+      const parsed = parseConfig(content)
+
+      if (!parsed.success) {
+        return {
+          success: false,
+          response: {
+            success: false,
+            provenance,
+            servers: [],
+            error: {
+              code: 'MALFORMED_CONFIG',
+              message: parsed.error,
+            },
+          },
+        }
+      }
+
+      const mcpServers = asObject(parsed.value.mcpServers)
+
+      return {
+        success: true,
+        config: {
+          configPath: this.configPath,
+          rawConfig: parsed.value,
+          mcpServers,
+          provenance,
+        },
+      }
+    } catch (error) {
+      if (isFileNotFoundError(error)) {
+        const starter = structuredClone(STARTER_MCP_CONFIG) as JsonObject
+        return {
+          success: true,
+          config: {
+            configPath: this.configPath,
+            rawConfig: starter,
+            mcpServers: asObject(starter.mcpServers),
+            provenance,
+          },
+        }
+      }
+
+      const message = error instanceof Error ? error.message : String(error)
+
+      log.error('[mcp-config-bridge] failed to read config', {
+        configPath: this.configPath,
+        error: message,
+      })
+
+      return {
+        success: false,
+        response: {
+          success: false,
+          provenance,
+          servers: [],
+          error: {
+            code: 'CONFIG_UNREADABLE',
+            message: `Unable to read MCP config: ${message}`,
+          },
+        },
+      }
+    }
+  }
+
+  private async writeConfig(nextConfig: JsonObject): Promise<
+    | {
+        success: true
+      }
+    | {
+        success: false
+        error: {
+          code: 'WRITE_FAILED' | 'READBACK_FAILED'
+          message: string
+        }
+      }
+  > {
+    try {
+      const directory = path.dirname(this.configPath)
+      await fs.mkdir(directory, { recursive: true })
+
+      const tempPath = path.join(directory, `${path.basename(this.configPath)}.${process.pid}.${Date.now()}.tmp`)
+      const serialized = `${JSON.stringify(nextConfig, null, 2)}\n`
+
+      await fs.writeFile(tempPath, serialized, { mode: 0o600 })
+      await fs.rename(tempPath, this.configPath)
+
+      const readbackContent = await fs.readFile(this.configPath, 'utf8')
+      const parsedReadback = parseConfig(readbackContent)
+
+      if (!parsedReadback.success) {
+        return {
+          success: false,
+          error: {
+            code: 'READBACK_FAILED',
+            message: `Config write completed but readback parse failed: ${parsedReadback.error}`,
+          },
+        }
+      }
+
+      return {
+        success: true,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+
+      log.error('[mcp-config-bridge] failed to write config', {
+        configPath: this.configPath,
+        error: message,
+      })
+
+      return {
+        success: false,
+        error: {
+          code: 'WRITE_FAILED',
+          message: `Unable to write MCP config: ${message}`,
+        },
+      }
+    }
+  }
+
+  private toServerSummaries(mcpServers: Record<string, unknown>): McpServerSummary[] {
+    return Object.entries(mcpServers)
+      .filter(([, value]) => isObject(value))
+      .map(([name, value]) => this.toServerSummary(name, value as JsonObject))
+      .sort((left, right) => left.name.localeCompare(right.name))
+  }
+
+  private toServerSummary(name: string, rawServer: JsonObject): McpServerSummary {
+    const transport = inferTransport(rawServer)
+    const enabled = !toBoolean(rawServer.disabled)
+
+    if (transport === 'http') {
+      const auth = normalizeAuthMode(rawServer.auth)
+      const bearerTokenEnv = asNonEmptyString(rawServer.bearerTokenEnv)
+      const inlineBearerToken = asNonEmptyString(rawServer.bearerToken)
+
+      return {
+        name,
+        transport,
+        enabled,
+        summary: {
+          transport,
+          url: asNonEmptyString(rawServer.url) ?? '',
+          auth,
+          bearerTokenEnv: bearerTokenEnv ?? undefined,
+          hasInlineBearerToken: Boolean(inlineBearerToken),
+        },
+      }
+    }
+
+    const env = asObject(rawServer.env)
+
+    return {
+      name,
+      transport: 'stdio',
+      enabled,
+      summary: {
+        transport: 'stdio',
+        command: asNonEmptyString(rawServer.command) ?? '',
+        args: asStringArray(rawServer.args),
+        cwd: asNonEmptyString(rawServer.cwd) ?? undefined,
+        envKeys: Object.keys(env).sort((left, right) => left.localeCompare(right)),
+      },
+    }
+  }
+
+  private toRuntimeServer(name: string, rawServer: JsonObject): McpRuntimeServerConfig {
+    const transport = inferTransport(rawServer)
+    const enabled = !toBoolean(rawServer.disabled)
+
+    if (transport === 'http') {
+      return {
+        name,
+        transport,
+        enabled,
+        url: asNonEmptyString(rawServer.url) ?? '',
+        auth: normalizeAuthMode(rawServer.auth),
+        bearerToken: asNonEmptyString(rawServer.bearerToken) ?? undefined,
+        bearerTokenEnv: asNonEmptyString(rawServer.bearerTokenEnv) ?? undefined,
+      }
+    }
+
+    const env = asObject(rawServer.env)
+    const normalizedEnv: Record<string, string> = {}
+
+    for (const [key, value] of Object.entries(env)) {
+      if (typeof value === 'string') {
+        normalizedEnv[key] = value
+      }
+    }
+
+    return {
+      name,
+      transport: 'stdio',
+      enabled,
+      command: asNonEmptyString(rawServer.command) ?? '',
+      args: asStringArray(rawServer.args),
+      cwd: asNonEmptyString(rawServer.cwd) ?? undefined,
+      env: normalizedEnv,
+    }
+  }
+
+  private async getProvenance(): Promise<McpConfigProvenance> {
+    const workspacePath = this.getWorkspacePath?.()?.trim()
+    const overlayConfigPath = workspacePath
+      ? path.join(workspacePath, '.kata-cli', 'mcp.json')
+      : undefined
+
+    let overlayPresent = false
+    if (overlayConfigPath) {
+      try {
+        await fs.access(overlayConfigPath)
+        overlayPresent = true
+      } catch {
+        overlayPresent = false
+      }
+    }
+
+    if (!overlayPresent || !overlayConfigPath) {
+      return {
+        mode: 'global_only',
+        globalConfigPath: this.configPath,
+      }
+    }
+
+    return {
+      mode: 'overlay_present',
+      globalConfigPath: this.configPath,
+      overlayConfigPath,
+      warning:
+        'Project-local .kata-cli/mcp.json overlay detected. Desktop only edits the shared global MCP config.',
+    }
+  }
+}
+
+function validateServerInput(input: McpServerInput): McpValidationError[] {
+  const errors: McpValidationError[] = []
+
+  const name = input.name.trim()
+  if (!name) {
+    errors.push({
+      field: 'name',
+      code: 'REQUIRED',
+      message: 'Server name is required.',
+    })
+  } else if (!/^[a-zA-Z0-9_.-]{1,64}$/.test(name)) {
+    errors.push({
+      field: 'name',
+      code: 'INVALID_FORMAT',
+      message: 'Server name must match ^[a-zA-Z0-9_.-]{1,64}$.',
+    })
+  }
+
+  if (input.transport === 'stdio') {
+    if (!input.command.trim()) {
+      errors.push({
+        field: 'command',
+        code: 'REQUIRED',
+        message: 'Command is required for stdio servers.',
+      })
+    }
+  }
+
+  if (input.transport === 'http') {
+    if (!input.url.trim()) {
+      errors.push({
+        field: 'url',
+        code: 'REQUIRED',
+        message: 'URL is required for HTTP servers.',
+      })
+    } else {
+      try {
+        const parsedUrl = new URL(input.url.trim())
+        if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+          errors.push({
+            field: 'url',
+            code: 'INVALID_VALUE',
+            message: 'URL protocol must be http or https.',
+          })
+        }
+      } catch {
+        errors.push({
+          field: 'url',
+          code: 'INVALID_FORMAT',
+          message: 'URL must be valid.',
+        })
+      }
+    }
+
+    const auth = input.auth ?? 'none'
+    if (auth === 'bearer') {
+      const token = input.bearerToken?.trim()
+      const tokenEnv = input.bearerTokenEnv?.trim()
+      if (!token && !tokenEnv) {
+        errors.push({
+          field: 'bearer',
+          code: 'REQUIRED',
+          message: 'Bearer auth requires a token or bearer token env key.',
+        })
+      }
+    }
+  }
+
+  return errors
+}
+
+function normalizeServerForWrite(existingServer: JsonObject, input: McpServerInput): JsonObject {
+  if (input.transport === 'stdio') {
+    const nextStdioServer: JsonObject = {
+      ...existingServer,
+      command: input.command.trim(),
+      args: input.args ? input.args.map((arg) => arg.trim()).filter(Boolean) : asStringArray(existingServer.args),
+      disabled: input.enabled === undefined ? toBoolean(existingServer.disabled) : !input.enabled,
+    }
+
+    if (input.cwd !== undefined) {
+      const cwd = input.cwd.trim()
+      if (cwd) {
+        nextStdioServer.cwd = cwd
+      } else {
+        delete nextStdioServer.cwd
+      }
+    }
+
+    if (input.env !== undefined) {
+      nextStdioServer.env = sanitizeEnvMap(input.env)
+    }
+
+    delete nextStdioServer.url
+    delete nextStdioServer.auth
+    delete nextStdioServer.bearerToken
+    delete nextStdioServer.bearerTokenEnv
+
+    return nextStdioServer
+  }
+
+  return normalizeHttpServerForWrite(existingServer, input)
+}
+
+function normalizeHttpServerForWrite(existingServer: JsonObject, input: McpHttpServerInput): JsonObject {
+  const nextHttpServer: JsonObject = {
+    ...existingServer,
+    url: input.url.trim(),
+    auth: input.auth ?? normalizeAuthMode(existingServer.auth),
+    disabled: input.enabled === undefined ? toBoolean(existingServer.disabled) : !input.enabled,
+  }
+
+  if (input.bearerToken !== undefined) {
+    const token = input.bearerToken.trim()
+    if (token) {
+      nextHttpServer.bearerToken = token
+    } else {
+      delete nextHttpServer.bearerToken
+    }
+  }
+
+  if (input.bearerTokenEnv !== undefined) {
+    const tokenEnv = input.bearerTokenEnv.trim()
+    if (tokenEnv) {
+      nextHttpServer.bearerTokenEnv = tokenEnv
+    } else {
+      delete nextHttpServer.bearerTokenEnv
+    }
+  }
+
+  delete nextHttpServer.command
+  delete nextHttpServer.args
+  delete nextHttpServer.env
+  delete nextHttpServer.cwd
+
+  return nextHttpServer
+}
+
+function sanitizeEnvMap(value: Record<string, string>): Record<string, string> {
+  const next: Record<string, string> = {}
+
+  for (const [key, envValue] of Object.entries(value)) {
+    const normalizedKey = key.trim()
+    if (!normalizedKey) {
+      continue
+    }
+
+    next[normalizedKey] = envValue
+  }
+
+  return next
+}
+
+function toDeleteResponseError(
+  error: McpConfigReadResponse['error'] | undefined,
+): McpServerDeleteResponse['error'] | undefined {
+  if (!error) {
+    return undefined
+  }
+
+  if (error.code === 'VALIDATION_FAILED') {
+    return {
+      code: 'UNKNOWN',
+      message: error.message,
+    }
+  }
+
+  return {
+    code: error.code,
+    message: error.message,
+  }
+}
+
+function parseConfig(content: string): { success: true; value: JsonObject } | { success: false; error: string } {
+  if (!content.trim()) {
+    return {
+      success: true,
+      value: structuredClone(STARTER_MCP_CONFIG) as JsonObject,
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(content)
+    if (!isObject(parsed)) {
+      return {
+        success: false,
+        error: 'Top-level MCP config must be a JSON object.',
+      }
+    }
+
+    return {
+      success: true,
+      value: parsed,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+function inferTransport(server: JsonObject): 'stdio' | 'http' {
+  const url = asNonEmptyString(server.url)
+  return url ? 'http' : 'stdio'
+}
+
+function normalizeAuthMode(value: unknown): 'none' | 'bearer' {
+  return value === 'bearer' ? 'bearer' : 'none'
+}
+
+function asObject(value: unknown): JsonObject {
+  if (!isObject(value)) {
+    return {}
+  }
+
+  return value
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim()
+  return normalized ? normalized : null
+}
+
+function toBoolean(value: unknown): boolean {
+  return value === true
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: string }).code === 'ENOENT'
+  )
+}

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -189,11 +189,22 @@ export class McpService {
         )
       }
 
-      await postJsonRpc(server.url, {
-        jsonrpc: '2.0',
-        method: 'notifications/initialized',
-        params: {},
-      }, headers, this.requestTimeoutMs)
+      void postJsonRpcNotification(
+        server.url,
+        {
+          jsonrpc: '2.0',
+          method: 'notifications/initialized',
+          params: {},
+        },
+        headers,
+        this.requestTimeoutMs,
+      ).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error)
+        log.warn('[mcp-service] notifications/initialized failed', {
+          serverName: server.name,
+          error: message,
+        })
+      })
 
       const toolsResponse = await postJsonRpc(server.url, {
         jsonrpc: '2.0',
@@ -528,6 +539,33 @@ async function postJsonRpc(
   headers: Record<string, string>,
   timeoutMs: number,
 ): Promise<{ result?: unknown; error?: unknown }> {
+  const response = await postJson(url, payload, headers, timeoutMs)
+
+  const body = (await response.json()) as {
+    result?: unknown
+    error?: unknown
+  }
+
+  return body
+}
+
+async function postJsonRpcNotification(
+  url: string,
+  payload: Record<string, unknown>,
+  headers: Record<string, string>,
+  timeoutMs: number,
+): Promise<void> {
+  // JSON-RPC notifications may return 204/empty bodies (or no meaningful payload).
+  // We only care that the request is delivered; response content is intentionally ignored.
+  await postJson(url, payload, headers, timeoutMs)
+}
+
+async function postJson(
+  url: string,
+  payload: Record<string, unknown>,
+  headers: Record<string, string>,
+  timeoutMs: number,
+): Promise<Response> {
   const abortController = new AbortController()
   const timeout = setTimeout(() => {
     abortController.abort()
@@ -545,12 +583,7 @@ async function postJsonRpc(
       throw new Error(`HTTP ${response.status} from ${url}`)
     }
 
-    const body = (await response.json()) as {
-      result?: unknown
-      error?: unknown
-    }
-
-    return body
+    return response
   } finally {
     clearTimeout(timeout)
   }

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -1,0 +1,629 @@
+import { spawn } from 'node:child_process'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import log from './logger'
+import { McpConfigBridge, type McpRuntimeHttpServer, type McpRuntimeServerConfig, type McpRuntimeStdioServer } from './mcp-config-bridge'
+import type { McpServerStatus, McpServerStatusResponse } from '../shared/types'
+
+interface McpServiceOptions {
+  configBridge: McpConfigBridge
+  requestTimeoutMs?: number
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000
+
+export class McpService {
+  private readonly configBridge: McpConfigBridge
+  private readonly requestTimeoutMs: number
+
+  constructor(options: McpServiceOptions) {
+    this.configBridge = options.configBridge
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+  }
+
+  public async refreshStatus(serverName: string): Promise<McpServerStatusResponse> {
+    return this.inspectServer(serverName, 'refresh')
+  }
+
+  public async reconnectServer(serverName: string): Promise<McpServerStatusResponse> {
+    return this.inspectServer(serverName, 'reconnect')
+  }
+
+  private async inspectServer(
+    serverName: string,
+    action: 'refresh' | 'reconnect',
+  ): Promise<McpServerStatusResponse> {
+    const runtimeServerResponse = await this.configBridge.getRuntimeServer(serverName)
+
+    if (!runtimeServerResponse.success) {
+      const status = this.createErrorStatus(serverName, mapBridgeErrorCode(runtimeServerResponse.error.code), runtimeServerResponse.error.message)
+      return {
+        success: false,
+        status,
+        error: status.error,
+      }
+    }
+
+    const runtimeServer = runtimeServerResponse.server
+
+    if (!runtimeServer.enabled) {
+      const status: McpServerStatus = {
+        serverName: runtimeServer.name,
+        phase: 'unsupported',
+        checkedAt: new Date().toISOString(),
+        toolNames: [],
+        toolCount: 0,
+      }
+
+      return {
+        success: true,
+        status,
+      }
+    }
+
+    try {
+      const status =
+        runtimeServer.transport === 'stdio'
+          ? await this.inspectStdioServer(runtimeServer)
+          : await this.inspectHttpServer(runtimeServer)
+
+      const success = status.phase === 'connected' || status.phase === 'unsupported'
+
+      log.info('[mcp-service] status check completed', {
+        action,
+        serverName: runtimeServer.name,
+        phase: status.phase,
+        toolCount: status.toolCount,
+        errorCode: status.error?.code,
+      })
+
+      return {
+        success,
+        status,
+        error: success ? undefined : status.error,
+      }
+    } catch (error) {
+      const status = this.createErrorStatus(
+        runtimeServer.name,
+        'UNKNOWN',
+        error instanceof Error ? error.message : String(error),
+      )
+
+      log.error('[mcp-service] status check crashed', {
+        action,
+        serverName: runtimeServer.name,
+        error: status.error?.message,
+      })
+
+      return {
+        success: false,
+        status,
+        error: status.error,
+      }
+    }
+  }
+
+  private async inspectStdioServer(server: McpRuntimeStdioServer): Promise<McpServerStatus> {
+    const startedAt = new Date().toISOString()
+
+    try {
+      const client = await createStdioRpcClient(server)
+
+      try {
+        await client.request(
+          'initialize',
+          {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: {
+              name: 'kata-desktop',
+              version: '0.1.0',
+            },
+          },
+          this.requestTimeoutMs,
+        )
+
+        await client.notify('notifications/initialized', {})
+
+        const toolsResult = await client.request('tools/list', {}, this.requestTimeoutMs)
+        const toolNames = extractToolNames(toolsResult)
+
+        return {
+          serverName: server.name,
+          phase: 'connected',
+          checkedAt: startedAt,
+          toolNames,
+          toolCount: toolNames.length,
+        }
+      } finally {
+        await client.dispose()
+      }
+    } catch (error) {
+      const mapped = mapTransportError(error)
+      return this.createErrorStatus(server.name, mapped.code, mapped.message, startedAt)
+    }
+  }
+
+  private async inspectHttpServer(server: McpRuntimeHttpServer): Promise<McpServerStatus> {
+    const checkedAt = new Date().toISOString()
+
+    try {
+      const headers: Record<string, string> = {
+        'content-type': 'application/json',
+      }
+
+      if (server.auth === 'bearer') {
+        const resolvedToken = resolveBearerToken(server)
+
+        if (!resolvedToken) {
+          return this.createErrorStatus(
+            server.name,
+            'MISSING_BEARER_TOKEN',
+            'Bearer auth requires a token value or configured env key.',
+            checkedAt,
+          )
+        }
+
+        headers.authorization = `Bearer ${resolvedToken}`
+      }
+
+      const initializeResponse = await postJsonRpc(server.url, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: {
+            name: 'kata-desktop',
+            version: '0.1.0',
+          },
+        },
+      }, headers, this.requestTimeoutMs)
+
+      if (initializeResponse.error) {
+        return this.createErrorStatus(
+          server.name,
+          'CONNECTION_FAILED',
+          formatJsonRpcError('initialize', initializeResponse.error),
+          checkedAt,
+        )
+      }
+
+      await postJsonRpc(server.url, {
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+        params: {},
+      }, headers, this.requestTimeoutMs)
+
+      const toolsResponse = await postJsonRpc(server.url, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      }, headers, this.requestTimeoutMs)
+
+      if (toolsResponse.error) {
+        return this.createErrorStatus(
+          server.name,
+          'CONNECTION_FAILED',
+          formatJsonRpcError('tools/list', toolsResponse.error),
+          checkedAt,
+        )
+      }
+
+      const toolNames = extractToolNames(toolsResponse.result)
+
+      return {
+        serverName: server.name,
+        phase: 'connected',
+        checkedAt,
+        toolNames,
+        toolCount: toolNames.length,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const code = message.toLowerCase().includes('timeout') ? 'TIMEOUT' : 'UNREACHABLE'
+
+      return this.createErrorStatus(server.name, code, message, checkedAt)
+    }
+  }
+
+  private createErrorStatus(
+    serverName: string,
+    code: NonNullable<McpServerStatus['error']>['code'],
+    message: string,
+    checkedAt = new Date().toISOString(),
+  ): McpServerStatus {
+    return {
+      serverName,
+      phase: 'error',
+      checkedAt,
+      toolNames: [],
+      toolCount: 0,
+      error: {
+        code,
+        message,
+      },
+    }
+  }
+}
+
+interface StdioRpcClient {
+  request: (method: string, params: unknown, timeoutMs: number) => Promise<unknown>
+  notify: (method: string, params: unknown) => Promise<void>
+  dispose: () => Promise<void>
+}
+
+async function createStdioRpcClient(server: McpRuntimeStdioServer): Promise<StdioRpcClient> {
+  const child = spawn(server.command, server.args, {
+    cwd: server.cwd,
+    env: {
+      ...process.env,
+      ...server.env,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) as ChildProcessWithoutNullStreams
+
+  const transport = new FramedRpcTransport(child)
+  await transport.waitForSpawn()
+
+  return {
+    request: async (method, params, timeoutMs) => transport.request(method, params, timeoutMs),
+    notify: async (method, params) => {
+      await transport.notify(method, params)
+    },
+    dispose: async () => {
+      await transport.dispose()
+    },
+  }
+}
+
+class FramedRpcTransport {
+  private readonly child: ChildProcessWithoutNullStreams
+  private readonly pending = new Map<
+    number,
+    {
+      resolve: (value: unknown) => void
+      reject: (error: Error) => void
+      timeoutId: ReturnType<typeof setTimeout>
+    }
+  >()
+  private nextRequestId = 1
+  private buffer = Buffer.alloc(0)
+  private stderrOutput = ''
+  private closed = false
+  private spawnResolved = false
+  private spawnWaiters: Array<{ resolve: () => void; reject: (error: Error) => void }> = []
+
+  constructor(child: ChildProcessWithoutNullStreams) {
+    this.child = child
+
+    child.on('spawn', () => {
+      this.spawnResolved = true
+      for (const waiter of this.spawnWaiters) {
+        waiter.resolve()
+      }
+      this.spawnWaiters = []
+    })
+
+    child.on('error', (error) => {
+      this.rejectPending(new Error(error.message))
+      if (!this.spawnResolved) {
+        for (const waiter of this.spawnWaiters) {
+          waiter.reject(error)
+        }
+        this.spawnWaiters = []
+      }
+    })
+
+    child.on('exit', (code, signal) => {
+      const stderrSummary = this.stderrOutput.trim().split('\n')[0]
+      const reason = stderrSummary || `Process exited (${code ?? 'null'}${signal ? `, ${signal}` : ''})`
+      this.rejectPending(new Error(reason))
+    })
+
+    child.stderr.on('data', (chunk) => {
+      this.stderrOutput = `${this.stderrOutput}${chunk.toString('utf8')}`.slice(-16_384)
+    })
+
+    child.stdout.on('data', (chunk) => {
+      this.buffer = Buffer.concat([this.buffer, chunk])
+      this.processBuffer()
+    })
+  }
+
+  public async waitForSpawn(): Promise<void> {
+    if (this.spawnResolved) {
+      return
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      this.spawnWaiters.push({ resolve, reject })
+    })
+  }
+
+  public async request(method: string, params: unknown, timeoutMs: number): Promise<unknown> {
+    const requestId = this.nextRequestId++
+
+    const responsePromise = new Promise<unknown>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.pending.delete(requestId)
+        reject(new Error(`Timeout waiting for ${method} response`))
+      }, timeoutMs)
+
+      this.pending.set(requestId, { resolve, reject, timeoutId })
+    })
+
+    await this.writeFrame({
+      jsonrpc: '2.0',
+      id: requestId,
+      method,
+      params,
+    })
+
+    return responsePromise
+  }
+
+  public async notify(method: string, params: unknown): Promise<void> {
+    await this.writeFrame({
+      jsonrpc: '2.0',
+      method,
+      params,
+    })
+  }
+
+  public async dispose(): Promise<void> {
+    if (this.closed) {
+      return
+    }
+
+    this.closed = true
+
+    if (!this.child.killed) {
+      this.child.kill('SIGTERM')
+
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          if (!this.child.killed) {
+            this.child.kill('SIGKILL')
+          }
+          resolve()
+        }, 500)
+
+        this.child.once('exit', () => {
+          clearTimeout(timeout)
+          resolve()
+        })
+      })
+    }
+
+    this.rejectPending(new Error('MCP stdio client closed'))
+  }
+
+  private async writeFrame(payload: Record<string, unknown>): Promise<void> {
+    const body = JSON.stringify(payload)
+    const frame = `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`
+
+    await new Promise<void>((resolve, reject) => {
+      this.child.stdin.write(frame, (error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve()
+      })
+    })
+  }
+
+  private processBuffer(): void {
+    while (this.buffer.length > 0) {
+      const separatorIndex = this.buffer.indexOf('\r\n\r\n')
+      if (separatorIndex === -1) {
+        return
+      }
+
+      const headerText = this.buffer.slice(0, separatorIndex).toString('utf8')
+      const lengthMatch = headerText.match(/Content-Length:\s*(\d+)/i)
+
+      if (!lengthMatch?.[1]) {
+        this.rejectPending(new Error('Invalid MCP frame: missing Content-Length header'))
+        this.buffer = Buffer.alloc(0)
+        return
+      }
+
+      const bodyLength = Number(lengthMatch[1])
+      if (!Number.isFinite(bodyLength) || bodyLength < 0) {
+        this.rejectPending(new Error('Invalid MCP frame: malformed Content-Length header'))
+        this.buffer = Buffer.alloc(0)
+        return
+      }
+
+      const frameLength = separatorIndex + 4 + bodyLength
+      if (this.buffer.length < frameLength) {
+        return
+      }
+
+      const body = this.buffer.slice(separatorIndex + 4, frameLength).toString('utf8')
+      this.buffer = this.buffer.slice(frameLength)
+
+      let parsed: Record<string, unknown>
+      try {
+        parsed = JSON.parse(body) as Record<string, unknown>
+      } catch {
+        this.rejectPending(new Error('Invalid MCP frame: JSON parse failed'))
+        continue
+      }
+
+      const id = parsed.id
+      if (typeof id !== 'number') {
+        continue
+      }
+
+      const pendingRequest = this.pending.get(id)
+      if (!pendingRequest) {
+        continue
+      }
+
+      clearTimeout(pendingRequest.timeoutId)
+      this.pending.delete(id)
+
+      if (parsed.error) {
+        pendingRequest.reject(new Error(formatJsonRpcError('request', parsed.error)))
+      } else {
+        pendingRequest.resolve(parsed.result)
+      }
+    }
+  }
+
+  private rejectPending(error: Error): void {
+    for (const [requestId, pendingRequest] of this.pending.entries()) {
+      clearTimeout(pendingRequest.timeoutId)
+      pendingRequest.reject(error)
+      this.pending.delete(requestId)
+    }
+  }
+}
+
+function extractToolNames(result: unknown): string[] {
+  if (!result || typeof result !== 'object') {
+    return []
+  }
+
+  const tools = (result as { tools?: unknown }).tools
+  if (!Array.isArray(tools)) {
+    return []
+  }
+
+  return tools
+    .map((tool) => {
+      if (!tool || typeof tool !== 'object') {
+        return null
+      }
+
+      const name = (tool as { name?: unknown }).name
+      return typeof name === 'string' ? name : null
+    })
+    .filter((name): name is string => Boolean(name))
+}
+
+function resolveBearerToken(server: McpRuntimeHttpServer): string | null {
+  if (server.bearerToken?.trim()) {
+    return server.bearerToken.trim()
+  }
+
+  if (server.bearerTokenEnv?.trim()) {
+    const fromEnv = process.env[server.bearerTokenEnv.trim()]
+    if (fromEnv?.trim()) {
+      return fromEnv.trim()
+    }
+  }
+
+  return null
+}
+
+async function postJsonRpc(
+  url: string,
+  payload: Record<string, unknown>,
+  headers: Record<string, string>,
+  timeoutMs: number,
+): Promise<{ result?: unknown; error?: unknown }> {
+  const abortController = new AbortController()
+  const timeout = setTimeout(() => {
+    abortController.abort()
+  }, timeoutMs)
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+      signal: abortController.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} from ${url}`)
+    }
+
+    const body = (await response.json()) as {
+      result?: unknown
+      error?: unknown
+    }
+
+    return body
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function formatJsonRpcError(method: string, error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return `${method} failed`
+  }
+
+  const code = (error as { code?: unknown }).code
+  const message = (error as { message?: unknown }).message
+
+  if (typeof code === 'number' && typeof message === 'string') {
+    return `${method} failed (${code}): ${message}`
+  }
+
+  if (typeof message === 'string') {
+    return `${method} failed: ${message}`
+  }
+
+  return `${method} failed`
+}
+
+function mapBridgeErrorCode(code: string): NonNullable<McpServerStatus['error']>['code'] {
+  if (code === 'MALFORMED_CONFIG') {
+    return 'MALFORMED_CONFIG'
+  }
+
+  if (code === 'SERVER_NOT_FOUND') {
+    return 'SERVER_NOT_FOUND'
+  }
+
+  return 'UNKNOWN'
+}
+
+function mapTransportError(error: unknown): {
+  code: NonNullable<McpServerStatus['error']>['code']
+  message: string
+} {
+  if (error instanceof Error) {
+    const message = error.message
+    const lower = message.toLowerCase()
+
+    if (lower.includes('enoent') || lower.includes('not found')) {
+      return {
+        code: 'COMMAND_NOT_FOUND',
+        message,
+      }
+    }
+
+    if (lower.includes('timeout')) {
+      return {
+        code: 'TIMEOUT',
+        message,
+      }
+    }
+
+    if (lower.includes('content-length') || lower.includes('json parse') || lower.includes('request failed')) {
+      return {
+        code: 'PROTOCOL_ERROR',
+        message,
+      }
+    }
+
+    return {
+      code: 'CONNECTION_FAILED',
+      message,
+    }
+  }
+
+  return {
+    code: 'UNKNOWN',
+    message: String(error),
+  }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -212,6 +212,26 @@ const api: DesktopApi = {
       }
     },
   },
+  mcp: {
+    listServers: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.mcpListServers)
+    },
+    getServer: async (name: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.mcpGetServer, name)
+    },
+    saveServer: async (input: Parameters<DesktopApi['mcp']['saveServer']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.mcpSaveServer, input)
+    },
+    deleteServer: async (name: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.mcpDeleteServer, name)
+    },
+    refreshStatus: async (name: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.mcpRefreshStatus, name)
+    },
+    reconnectServer: async (name: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.mcpReconnectServer, name)
+    },
+  },
 }
 
 contextBridge.exposeInMainWorld('api', api)

--- a/apps/desktop/src/renderer/atoms/mcp.ts
+++ b/apps/desktop/src/renderer/atoms/mcp.ts
@@ -1,0 +1,178 @@
+import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { useEffect } from 'react'
+import type {
+  McpConfigProvenance,
+  McpServerInput,
+  McpServerStatus,
+  McpServerSummary,
+} from '@shared/types'
+
+interface McpConfigState {
+  servers: McpServerSummary[]
+  provenance: McpConfigProvenance | null
+  error: string | null
+}
+
+const EMPTY_CONFIG_STATE: McpConfigState = {
+  servers: [],
+  provenance: null,
+  error: null,
+}
+
+export const mcpConfigStateAtom = atom<McpConfigState>(EMPTY_CONFIG_STATE)
+export const mcpConfigLoadingAtom = atom<boolean>(false)
+export const mcpMutationPendingAtom = atom<boolean>(false)
+export const mcpMutationErrorAtom = atom<string | null>(null)
+export const mcpMutationSuccessAtom = atom<string | null>(null)
+export const mcpServerStatusesAtom = atom<Record<string, McpServerStatus>>({})
+export const mcpStatusPendingByServerAtom = atom<Record<string, boolean>>({})
+
+export const loadMcpConfigAtom = atom(null, async (_get, set) => {
+  set(mcpConfigLoadingAtom, true)
+
+  try {
+    const response = await window.api.mcp.listServers()
+
+    set(mcpConfigStateAtom, {
+      servers: response.servers,
+      provenance: response.provenance,
+      error: response.success ? null : response.error?.message ?? 'Unable to load MCP config.',
+    })
+  } catch (error) {
+    set(mcpConfigStateAtom, {
+      servers: [],
+      provenance: null,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  } finally {
+    set(mcpConfigLoadingAtom, false)
+  }
+})
+
+export const saveMcpServerAtom = atom(null, async (_get, set, input: McpServerInput) => {
+  set(mcpMutationPendingAtom, true)
+  set(mcpMutationErrorAtom, null)
+  set(mcpMutationSuccessAtom, null)
+
+  try {
+    const response = await window.api.mcp.saveServer(input)
+    if (!response.success) {
+      const validationMessage = response.validationErrors?.[0]?.message
+      set(mcpMutationErrorAtom, validationMessage ?? response.error?.message ?? 'Unable to save MCP server.')
+      return response
+    }
+
+    set(mcpMutationSuccessAtom, `Saved MCP server “${input.name}”.`)
+    await set(loadMcpConfigAtom)
+    return response
+  } finally {
+    set(mcpMutationPendingAtom, false)
+  }
+})
+
+export const deleteMcpServerAtom = atom(null, async (_get, set, name: string) => {
+  set(mcpMutationPendingAtom, true)
+  set(mcpMutationErrorAtom, null)
+  set(mcpMutationSuccessAtom, null)
+
+  try {
+    const response = await window.api.mcp.deleteServer(name)
+    if (!response.success) {
+      set(mcpMutationErrorAtom, response.error?.message ?? 'Unable to delete MCP server.')
+      return response
+    }
+
+    set(mcpMutationSuccessAtom, `Deleted MCP server “${name}”.`)
+
+    set(mcpServerStatusesAtom, (previous) => {
+      const next = { ...previous }
+      delete next[name]
+      return next
+    })
+
+    await set(loadMcpConfigAtom)
+    return response
+  } finally {
+    set(mcpMutationPendingAtom, false)
+  }
+})
+
+const runServerStatusAction = atom(
+  null,
+  async (
+    _get,
+    set,
+    options: {
+      serverName: string
+      action: 'refresh' | 'reconnect'
+    },
+  ) => {
+    const { serverName, action } = options
+
+    set(mcpStatusPendingByServerAtom, (previous) => ({
+      ...previous,
+      [serverName]: true,
+    }))
+
+    try {
+      const response =
+        action === 'refresh'
+          ? await window.api.mcp.refreshStatus(serverName)
+          : await window.api.mcp.reconnectServer(serverName)
+
+      if (response.status) {
+        set(mcpServerStatusesAtom, (previous) => ({
+          ...previous,
+          [serverName]: response.status!,
+        }))
+      }
+
+      if (!response.success && response.error) {
+        set(mcpServerStatusesAtom, (previous) => ({
+          ...previous,
+          [serverName]: {
+            serverName,
+            phase: 'error',
+            checkedAt: new Date().toISOString(),
+            toolNames: [],
+            toolCount: 0,
+            error: response.error,
+          },
+        }))
+      }
+
+      return response
+    } finally {
+      set(mcpStatusPendingByServerAtom, (previous) => ({
+        ...previous,
+        [serverName]: false,
+      }))
+    }
+  },
+)
+
+export const refreshMcpServerStatusAtom = atom(
+  null,
+  async (_get, set, serverName: string) => {
+    return set(runServerStatusAction, { serverName, action: 'refresh' })
+  },
+)
+
+export const reconnectMcpServerAtom = atom(
+  null,
+  async (_get, set, serverName: string) => {
+    return set(runServerStatusAction, { serverName, action: 'reconnect' })
+  },
+)
+
+export function useMcpConfigBridge(): void {
+  const loadConfig = useSetAtom(loadMcpConfigAtom)
+
+  useEffect(() => {
+    void loadConfig()
+  }, [loadConfig])
+}
+
+export function useMcpConfigState(): McpConfigState {
+  return useAtomValue(mcpConfigStateAtom)
+}

--- a/apps/desktop/src/renderer/components/settings/McpServerEditorDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerEditorDialog.tsx
@@ -72,7 +72,7 @@ export function createMcpServerEditorDraft(server?: McpServerSummary): McpServer
     transport: 'stdio',
     enabled: server.enabled,
     command: server.summary.command,
-    argsText: server.summary.args.join(' '),
+    argsText: formatArgsForEditor(server.summary.args),
     cwd: server.summary.cwd ?? '',
     envText: '',
     envKeyHints: server.summary.envKeys,
@@ -122,11 +122,91 @@ export function validateMcpServerDraft(draft: McpServerEditorDraft): string[] {
   return errors
 }
 
-function parseArgs(argsText: string): string[] {
-  return argsText
-    .split(/\s+/)
-    .map((arg) => arg.trim())
-    .filter(Boolean)
+export function parseArgs(argsText: string): string[] {
+  const args: string[] = []
+  let current = ''
+  let quote: 'single' | 'double' | null = null
+
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      args.push(current)
+      current = ''
+    }
+  }
+
+  for (let index = 0; index < argsText.length; index += 1) {
+    const char = argsText[index] ?? ''
+    const nextChar = argsText[index + 1]
+
+    if (quote === null) {
+      if (/\s/.test(char)) {
+        pushCurrent()
+        continue
+      }
+
+      if (char === '"') {
+        quote = 'double'
+        continue
+      }
+
+      if (char === "'") {
+        quote = 'single'
+        continue
+      }
+
+      if (char === '\\' && nextChar && (/\s/.test(nextChar) || ['"', "'", '\\'].includes(nextChar))) {
+        current += nextChar
+        index += 1
+        continue
+      }
+
+      current += char
+      continue
+    }
+
+    if (quote === 'single') {
+      if (char === "'") {
+        quote = null
+      } else {
+        current += char
+      }
+      continue
+    }
+
+    if (char === '"') {
+      quote = null
+      continue
+    }
+
+    if (char === '\\' && nextChar && ['"', '\\'].includes(nextChar)) {
+      current += nextChar
+      index += 1
+      continue
+    }
+
+    current += char
+  }
+
+  pushCurrent()
+
+  return args
+}
+
+function formatArgsForEditor(args: string[]): string {
+  return args
+    .map((arg) => {
+      if (!arg) {
+        return '""'
+      }
+
+      if (/^[^\s"']+$/.test(arg)) {
+        return arg
+      }
+
+      const escaped = arg.replace(/"/g, '\\"')
+      return `"${escaped}"`
+    })
+    .join(' ')
 }
 
 function parseEnv(envText: string): Record<string, string> | undefined {
@@ -162,15 +242,28 @@ function parseEnv(envText: string): Record<string, string> | undefined {
 
 function toServerInput(draft: McpServerEditorDraft): McpServerInput {
   if (draft.transport === 'http') {
-    return {
+    const input: McpServerInput = {
       name: draft.name.trim(),
       transport: 'http',
       enabled: draft.enabled,
       url: draft.url.trim(),
       auth: draft.auth,
-      bearerToken: draft.bearerToken,
-      bearerTokenEnv: draft.bearerTokenEnv,
     }
+
+    if (draft.auth === 'bearer') {
+      if (draft.bearerToken.trim()) {
+        input.bearerToken = draft.bearerToken
+      } else if (!draft.hasStoredInlineBearerToken) {
+        input.bearerToken = ''
+      }
+
+      input.bearerTokenEnv = draft.bearerTokenEnv
+    } else {
+      input.bearerToken = ''
+      input.bearerTokenEnv = ''
+    }
+
+    return input
   }
 
   return {

--- a/apps/desktop/src/renderer/components/settings/McpServerEditorDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerEditorDialog.tsx
@@ -1,0 +1,461 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { McpServerInput, McpServerSummary, McpServerTransport } from '@shared/types'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+
+export interface McpServerEditorDraft {
+  name: string
+  transport: McpServerTransport
+  enabled: boolean
+  command: string
+  argsText: string
+  cwd: string
+  envText: string
+  envKeyHints: string[]
+  url: string
+  auth: 'none' | 'bearer'
+  bearerToken: string
+  bearerTokenEnv: string
+  hasStoredInlineBearerToken: boolean
+}
+
+export function createMcpServerEditorDraft(server?: McpServerSummary): McpServerEditorDraft {
+  if (!server) {
+    return {
+      name: '',
+      transport: 'stdio',
+      enabled: true,
+      command: '',
+      argsText: '',
+      cwd: '',
+      envText: '',
+      envKeyHints: [],
+      url: '',
+      auth: 'none',
+      bearerToken: '',
+      bearerTokenEnv: '',
+      hasStoredInlineBearerToken: false,
+    }
+  }
+
+  if (server.summary.transport === 'http') {
+    return {
+      name: server.name,
+      transport: 'http',
+      enabled: server.enabled,
+      command: '',
+      argsText: '',
+      cwd: '',
+      envText: '',
+      envKeyHints: [],
+      url: server.summary.url,
+      auth: server.summary.auth,
+      bearerToken: '',
+      bearerTokenEnv: server.summary.bearerTokenEnv ?? '',
+      hasStoredInlineBearerToken: server.summary.hasInlineBearerToken,
+    }
+  }
+
+  return {
+    name: server.name,
+    transport: 'stdio',
+    enabled: server.enabled,
+    command: server.summary.command,
+    argsText: server.summary.args.join(' '),
+    cwd: server.summary.cwd ?? '',
+    envText: '',
+    envKeyHints: server.summary.envKeys,
+    url: '',
+    auth: 'none',
+    bearerToken: '',
+    bearerTokenEnv: '',
+    hasStoredInlineBearerToken: false,
+  }
+}
+
+export function validateMcpServerDraft(draft: McpServerEditorDraft): string[] {
+  const errors: string[] = []
+
+  if (!draft.name.trim()) {
+    errors.push('Server name is required.')
+  }
+
+  if (draft.transport === 'stdio' && !draft.command.trim()) {
+    errors.push('Command is required for stdio servers.')
+  }
+
+  if (draft.transport === 'http') {
+    if (!draft.url.trim()) {
+      errors.push('URL is required for HTTP servers.')
+    } else {
+      try {
+        const parsed = new URL(draft.url.trim())
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          errors.push('URL must use http or https.')
+        }
+      } catch {
+        errors.push('URL must be valid.')
+      }
+    }
+
+    if (
+      draft.auth === 'bearer' &&
+      !draft.bearerToken.trim() &&
+      !draft.bearerTokenEnv.trim() &&
+      !draft.hasStoredInlineBearerToken
+    ) {
+      errors.push('Bearer auth requires a token or token env key.')
+    }
+  }
+
+  return errors
+}
+
+function parseArgs(argsText: string): string[] {
+  return argsText
+    .split(/\s+/)
+    .map((arg) => arg.trim())
+    .filter(Boolean)
+}
+
+function parseEnv(envText: string): Record<string, string> | undefined {
+  const lines = envText
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+  if (lines.length === 0) {
+    return undefined
+  }
+
+  const env: Record<string, string> = {}
+
+  for (const line of lines) {
+    const separatorIndex = line.indexOf('=')
+    if (separatorIndex <= 0) {
+      continue
+    }
+
+    const key = line.slice(0, separatorIndex).trim()
+    const value = line.slice(separatorIndex + 1)
+
+    if (!key) {
+      continue
+    }
+
+    env[key] = value
+  }
+
+  return Object.keys(env).length > 0 ? env : undefined
+}
+
+function toServerInput(draft: McpServerEditorDraft): McpServerInput {
+  if (draft.transport === 'http') {
+    return {
+      name: draft.name.trim(),
+      transport: 'http',
+      enabled: draft.enabled,
+      url: draft.url.trim(),
+      auth: draft.auth,
+      bearerToken: draft.bearerToken,
+      bearerTokenEnv: draft.bearerTokenEnv,
+    }
+  }
+
+  return {
+    name: draft.name.trim(),
+    transport: 'stdio',
+    enabled: draft.enabled,
+    command: draft.command.trim(),
+    args: parseArgs(draft.argsText),
+    cwd: draft.cwd.trim(),
+    env: parseEnv(draft.envText),
+  }
+}
+
+interface McpServerEditorDialogProps {
+  open: boolean
+  server?: McpServerSummary
+  saving?: boolean
+  errorMessage?: string | null
+  onOpenChange: (open: boolean) => void
+  onSave: (input: McpServerInput) => Promise<void>
+}
+
+export function McpServerEditorDialog({
+  open,
+  server,
+  saving,
+  errorMessage,
+  onOpenChange,
+  onSave,
+}: McpServerEditorDialogProps) {
+  const [draft, setDraft] = useState<McpServerEditorDraft>(() => createMcpServerEditorDraft(server))
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setDraft(createMcpServerEditorDraft(server))
+      setLocalError(null)
+    }
+  }, [open, server])
+
+  const isEditing = Boolean(server)
+
+  const validationErrors = useMemo(() => validateMcpServerDraft(draft), [draft])
+
+  const handleSave = async () => {
+    if (validationErrors.length > 0) {
+      setLocalError(validationErrors[0] ?? null)
+      return
+    }
+
+    setLocalError(null)
+    await onSave(toServerInput(draft))
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(44rem,95vw)] max-w-[min(44rem,95vw)]" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{isEditing ? `Edit ${server?.name}` : 'Add MCP server'}</DialogTitle>
+          <DialogDescription>
+            Configure stdio or HTTP MCP servers without hand-editing mcp.json.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="mcp-server-name">Server name</Label>
+            <Input
+              id="mcp-server-name"
+              value={draft.name}
+              onChange={(event) => setDraft((previous) => ({ ...previous, name: event.target.value }))}
+              disabled={isEditing}
+              data-testid="mcp-editor-name"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="grid gap-1.5">
+              <Label htmlFor="mcp-server-transport">Transport</Label>
+              <Select
+                value={draft.transport}
+                onValueChange={(value) =>
+                  setDraft((previous) => ({
+                    ...previous,
+                    transport: value as McpServerTransport,
+                  }))
+                }
+                disabled={isEditing}
+              >
+                <SelectTrigger id="mcp-server-transport" className="w-48" data-testid="mcp-editor-transport">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="stdio">stdio</SelectItem>
+                  <SelectItem value="http">http</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <label className="flex items-center gap-2 text-sm text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={draft.enabled}
+                onChange={(event) =>
+                  setDraft((previous) => ({
+                    ...previous,
+                    enabled: event.target.checked,
+                  }))
+                }
+              />
+              Enabled
+            </label>
+          </div>
+
+          {draft.transport === 'stdio' ? (
+            <>
+              <div className="grid gap-1.5">
+                <Label htmlFor="mcp-server-command">Command</Label>
+                <Input
+                  id="mcp-server-command"
+                  value={draft.command}
+                  onChange={(event) =>
+                    setDraft((previous) => ({
+                      ...previous,
+                      command: event.target.value,
+                    }))
+                  }
+                  placeholder="npx"
+                  data-testid="mcp-editor-command"
+                />
+              </div>
+
+              <div className="grid gap-1.5">
+                <Label htmlFor="mcp-server-args">Arguments</Label>
+                <Input
+                  id="mcp-server-args"
+                  value={draft.argsText}
+                  onChange={(event) =>
+                    setDraft((previous) => ({
+                      ...previous,
+                      argsText: event.target.value,
+                    }))
+                  }
+                  placeholder="-y mcp-remote https://mcp.linear.app/mcp"
+                  data-testid="mcp-editor-args"
+                />
+              </div>
+
+              <div className="grid gap-1.5">
+                <Label htmlFor="mcp-server-cwd">Working directory (optional)</Label>
+                <Input
+                  id="mcp-server-cwd"
+                  value={draft.cwd}
+                  onChange={(event) =>
+                    setDraft((previous) => ({
+                      ...previous,
+                      cwd: event.target.value,
+                    }))
+                  }
+                  placeholder="/absolute/path"
+                />
+              </div>
+
+              <div className="grid gap-1.5">
+                <Label htmlFor="mcp-server-env">Environment overrides (KEY=VALUE per line)</Label>
+                <Textarea
+                  id="mcp-server-env"
+                  value={draft.envText}
+                  onChange={(event) =>
+                    setDraft((previous) => ({
+                      ...previous,
+                      envText: event.target.value,
+                    }))
+                  }
+                  placeholder="API_KEY=${MY_API_KEY}"
+                />
+
+                {draft.envKeyHints.length > 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    Existing env keys (values hidden): <span className="font-mono">{draft.envKeyHints.join(', ')}</span>
+                  </p>
+                ) : null}
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="grid gap-1.5">
+                <Label htmlFor="mcp-server-url">Server URL</Label>
+                <Input
+                  id="mcp-server-url"
+                  value={draft.url}
+                  onChange={(event) =>
+                    setDraft((previous) => ({
+                      ...previous,
+                      url: event.target.value,
+                    }))
+                  }
+                  placeholder="https://example.com/mcp"
+                  data-testid="mcp-editor-url"
+                />
+              </div>
+
+              <div className="grid gap-1.5">
+                <Label htmlFor="mcp-server-auth">Auth mode</Label>
+                <Select
+                  value={draft.auth}
+                  onValueChange={(value) =>
+                    setDraft((previous) => ({
+                      ...previous,
+                      auth: value as 'none' | 'bearer',
+                    }))
+                  }
+                >
+                  <SelectTrigger id="mcp-server-auth" className="w-48">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">none</SelectItem>
+                    <SelectItem value="bearer">bearer</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {draft.auth === 'bearer' ? (
+                <>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="mcp-server-bearer-token">Bearer token (optional)</Label>
+                    <Input
+                      id="mcp-server-bearer-token"
+                      type="password"
+                      value={draft.bearerToken}
+                      onChange={(event) =>
+                        setDraft((previous) => ({
+                          ...previous,
+                          bearerToken: event.target.value,
+                        }))
+                      }
+                      placeholder={
+                        draft.hasStoredInlineBearerToken ? 'Existing token is stored (redacted)' : 'Paste token'
+                      }
+                    />
+                    {draft.hasStoredInlineBearerToken ? (
+                      <p className="text-xs text-muted-foreground">Existing inline token remains unless replaced.</p>
+                    ) : null}
+                  </div>
+
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="mcp-server-bearer-token-env">Token env key (optional)</Label>
+                    <Input
+                      id="mcp-server-bearer-token-env"
+                      value={draft.bearerTokenEnv}
+                      onChange={(event) =>
+                        setDraft((previous) => ({
+                          ...previous,
+                          bearerTokenEnv: event.target.value,
+                        }))
+                      }
+                      placeholder="MCP_BEARER_TOKEN"
+                    />
+                  </div>
+                </>
+              ) : null}
+            </>
+          )}
+
+          {localError ? <p className="text-xs text-destructive">{localError}</p> : null}
+          {errorMessage ? <p className="text-xs text-destructive">{errorMessage}</p> : null}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={Boolean(saving)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              void handleSave()
+            }}
+            disabled={Boolean(saving)}
+            data-testid="mcp-editor-save"
+          >
+            {saving ? 'Saving…' : isEditing ? 'Save changes' : 'Add server'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
@@ -1,0 +1,189 @@
+import { useMemo, useState } from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import type { McpServerSummary } from '@shared/types'
+import {
+  deleteMcpServerAtom,
+  loadMcpConfigAtom,
+  mcpConfigLoadingAtom,
+  mcpConfigStateAtom,
+  mcpMutationErrorAtom,
+  mcpMutationPendingAtom,
+  mcpMutationSuccessAtom,
+  mcpServerStatusesAtom,
+  mcpStatusPendingByServerAtom,
+  reconnectMcpServerAtom,
+  saveMcpServerAtom,
+  useMcpConfigBridge,
+  refreshMcpServerStatusAtom,
+} from '@/atoms/mcp'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { McpServerEditorDialog } from './McpServerEditorDialog'
+import { McpServerRow } from './McpServerRow'
+
+export function formatMcpProvenanceLabel(mode: 'global_only' | 'overlay_present' | undefined): string {
+  if (mode === 'overlay_present') {
+    return 'Global config (overlay detected)'
+  }
+
+  return 'Global shared config'
+}
+
+export function McpServerPanel() {
+  useMcpConfigBridge()
+
+  const configState = useAtomValue(mcpConfigStateAtom)
+  const loading = useAtomValue(mcpConfigLoadingAtom)
+  const mutationPending = useAtomValue(mcpMutationPendingAtom)
+  const mutationError = useAtomValue(mcpMutationErrorAtom)
+  const mutationSuccess = useAtomValue(mcpMutationSuccessAtom)
+  const statuses = useAtomValue(mcpServerStatusesAtom)
+  const statusPendingByServer = useAtomValue(mcpStatusPendingByServerAtom)
+
+  const refreshConfig = useSetAtom(loadMcpConfigAtom)
+  const saveServer = useSetAtom(saveMcpServerAtom)
+  const deleteServer = useSetAtom(deleteMcpServerAtom)
+  const refreshStatus = useSetAtom(refreshMcpServerStatusAtom)
+  const reconnectServer = useSetAtom(reconnectMcpServerAtom)
+
+  const [editorOpen, setEditorOpen] = useState(false)
+  const [editingServer, setEditingServer] = useState<McpServerSummary | undefined>(undefined)
+  const [pendingDeleteName, setPendingDeleteName] = useState<string | null>(null)
+
+  const servers = useMemo(() => configState.servers, [configState.servers])
+
+  const openCreateDialog = () => {
+    setEditingServer(undefined)
+    setEditorOpen(true)
+  }
+
+  const openEditDialog = (server: McpServerSummary) => {
+    setEditingServer(server)
+    setEditorOpen(true)
+  }
+
+  return (
+    <Card className="border border-border bg-card/60 py-0" data-testid="mcp-settings-panel">
+      <CardHeader className="px-4 pt-4 pb-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-sm text-foreground">MCP Servers</CardTitle>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Manage shared MCP servers stored in <span className="font-mono">~/.kata-cli/agent/mcp.json</span>.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline" data-testid="mcp-provenance-badge">
+              {formatMcpProvenanceLabel(configState.provenance?.mode)}
+            </Badge>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                void refreshConfig()
+              }}
+              disabled={loading}
+              data-testid="mcp-refresh-config"
+            >
+              {loading ? 'Refreshing…' : 'Refresh'}
+            </Button>
+            <Button type="button" size="sm" onClick={openCreateDialog} data-testid="mcp-add-server">
+              Add server
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3 p-4 pt-2 text-xs">
+        {configState.provenance?.warning ? (
+          <Alert data-testid="mcp-overlay-warning">
+            <AlertTitle>Project overlay detected</AlertTitle>
+            <AlertDescription>
+              {configState.provenance.warning}
+              {configState.provenance.overlayConfigPath ? (
+                <span className="mt-1 block font-mono text-[11px]">{configState.provenance.overlayConfigPath}</span>
+              ) : null}
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {configState.error ? (
+          <Alert variant="destructive" data-testid="mcp-config-error">
+            <AlertTitle>Unable to load MCP config</AlertTitle>
+            <AlertDescription>{configState.error}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {mutationError ? (
+          <Alert variant="destructive" data-testid="mcp-mutation-error">
+            <AlertTitle>MCP update failed</AlertTitle>
+            <AlertDescription>{mutationError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {mutationSuccess ? (
+          <Alert data-testid="mcp-mutation-success">
+            <AlertTitle>MCP config updated</AlertTitle>
+            <AlertDescription>{mutationSuccess}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {servers.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border bg-background/30 p-4 text-muted-foreground" data-testid="mcp-empty-state">
+            No MCP servers configured yet.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {servers.map((server) => (
+              <McpServerRow
+                key={server.name}
+                server={server}
+                status={statuses[server.name]}
+                statusPending={statusPendingByServer[server.name]}
+                pendingDelete={pendingDeleteName === server.name}
+                mutationPending={mutationPending}
+                onEdit={openEditDialog}
+                onRequestDelete={setPendingDeleteName}
+                onConfirmDelete={(name) => {
+                  void deleteServer(name)
+                  setPendingDeleteName(null)
+                }}
+                onCancelDelete={() => setPendingDeleteName(null)}
+                onRefresh={(name) => {
+                  void refreshStatus(name)
+                }}
+                onReconnect={(name) => {
+                  void reconnectServer(name)
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <McpServerEditorDialog
+        open={editorOpen}
+        server={editingServer}
+        saving={mutationPending}
+        errorMessage={mutationError}
+        onOpenChange={(open) => {
+          setEditorOpen(open)
+          if (!open) {
+            setEditingServer(undefined)
+          }
+        }}
+        onSave={async (input) => {
+          const result = await saveServer(input)
+          if (result?.success) {
+            setEditorOpen(false)
+            setEditingServer(undefined)
+          }
+        }}
+      />
+    </Card>
+  )
+}

--- a/apps/desktop/src/renderer/components/settings/McpServerRow.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerRow.tsx
@@ -1,0 +1,206 @@
+import type { McpServerStatus, McpServerSummary } from '@shared/types'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+
+export function formatMcpStatusLabel(status: McpServerStatus | undefined): string {
+  if (!status) {
+    return 'Not checked'
+  }
+
+  if (status.phase === 'connected') {
+    return 'Connected'
+  }
+
+  if (status.phase === 'unsupported') {
+    return 'Unsupported'
+  }
+
+  return status.error?.code ?? 'Error'
+}
+
+export function mcpStatusBadgeVariant(
+  status: McpServerStatus | undefined,
+): 'default' | 'secondary' | 'outline' | 'destructive' {
+  if (!status) {
+    return 'outline'
+  }
+
+  if (status.phase === 'connected') {
+    return 'default'
+  }
+
+  if (status.phase === 'unsupported') {
+    return 'secondary'
+  }
+
+  return 'destructive'
+}
+
+export function summarizeMcpServer(server: McpServerSummary): string {
+  if (server.summary.transport === 'stdio') {
+    const args = server.summary.args.join(' ')
+    return `${server.summary.command}${args ? ` ${args}` : ''}`
+  }
+
+  return server.summary.url
+}
+
+interface McpServerRowProps {
+  server: McpServerSummary
+  status?: McpServerStatus
+  statusPending?: boolean
+  pendingDelete?: boolean
+  onEdit: (server: McpServerSummary) => void
+  onRequestDelete: (name: string) => void
+  onConfirmDelete: (name: string) => void
+  onCancelDelete: () => void
+  onRefresh: (name: string) => void
+  onReconnect: (name: string) => void
+  mutationPending?: boolean
+}
+
+export function McpServerRow({
+  server,
+  status,
+  statusPending,
+  pendingDelete,
+  onEdit,
+  onRequestDelete,
+  onConfirmDelete,
+  onCancelDelete,
+  onRefresh,
+  onReconnect,
+  mutationPending,
+}: McpServerRowProps) {
+  return (
+    <article
+      className="rounded-lg border border-border bg-background/40 p-3"
+      data-testid={`mcp-server-row-${server.name}`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm font-medium text-foreground">{server.name}</h3>
+            <Badge variant="secondary" className="uppercase">
+              {server.transport}
+            </Badge>
+            {!server.enabled ? <Badge variant="outline">Disabled</Badge> : null}
+          </div>
+
+          <p className="font-mono text-xs text-muted-foreground">{summarizeMcpServer(server)}</p>
+
+          {server.summary.transport === 'http' && server.summary.auth === 'bearer' ? (
+            <p className="text-xs text-muted-foreground">
+              Auth: bearer
+              {server.summary.bearerTokenEnv
+                ? ` (${server.summary.bearerTokenEnv})`
+                : server.summary.hasInlineBearerToken
+                  ? ' (inline token set)'
+                  : ''}
+            </p>
+          ) : null}
+
+          {server.summary.transport === 'stdio' && server.summary.envKeys.length > 0 ? (
+            <p className="text-xs text-muted-foreground">
+              Env keys: <span className="font-mono">{server.summary.envKeys.join(', ')}</span>
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge
+            variant={mcpStatusBadgeVariant(status)}
+            data-testid={`mcp-status-badge-${server.name}`}
+          >
+            {statusPending ? 'Checking…' : formatMcpStatusLabel(status)}
+          </Badge>
+
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => onRefresh(server.name)}
+            disabled={Boolean(statusPending)}
+            data-testid={`mcp-refresh-${server.name}`}
+          >
+            Refresh
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => onReconnect(server.name)}
+            disabled={Boolean(statusPending)}
+            data-testid={`mcp-reconnect-${server.name}`}
+          >
+            Reconnect
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => onEdit(server)}
+            disabled={Boolean(mutationPending)}
+            data-testid={`mcp-edit-${server.name}`}
+          >
+            Edit
+          </Button>
+
+          {!pendingDelete ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              onClick={() => onRequestDelete(server.name)}
+              disabled={Boolean(mutationPending)}
+              data-testid={`mcp-delete-${server.name}`}
+            >
+              Remove
+            </Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                size="sm"
+                variant="destructive"
+                onClick={() => onConfirmDelete(server.name)}
+                disabled={Boolean(mutationPending)}
+                data-testid={`mcp-confirm-delete-${server.name}`}
+              >
+                Confirm remove
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={onCancelDelete}
+                disabled={Boolean(mutationPending)}
+                data-testid={`mcp-cancel-delete-${server.name}`}
+              >
+                Cancel
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {status?.error ? (
+        <p className="mt-2 text-xs text-destructive" data-testid={`mcp-status-error-${server.name}`}>
+          {status.error.message}
+        </p>
+      ) : null}
+
+      {status?.toolCount ? (
+        <p className="mt-2 text-xs text-muted-foreground" data-testid={`mcp-tools-${server.name}`}>
+          Tools ({status.toolCount}): {status.toolNames.join(', ')}
+        </p>
+      ) : null}
+
+      {status?.checkedAt ? (
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Last checked: {new Date(status.checkedAt).toLocaleString()}
+        </p>
+      ) : null}
+    </article>
+  )
+}

--- a/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
@@ -14,8 +14,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ProviderAuthPanel } from './ProviderAuthPanel'
 import { SymphonyRuntimePanel } from './SymphonyRuntimePanel'
 import { SymphonyDashboard } from '../symphony/SymphonyDashboard'
+import { McpServerPanel } from './McpServerPanel'
 
-type SettingsTab = 'providers' | 'general' | 'appearance' | 'symphony'
+type SettingsTab = 'providers' | 'mcp' | 'general' | 'appearance' | 'symphony'
 
 interface SettingsPanelProps {
   open: boolean
@@ -24,6 +25,7 @@ interface SettingsPanelProps {
 
 const SETTINGS_TABS: Array<{ id: SettingsTab; label: string }> = [
   { id: 'providers', label: 'Providers' },
+  { id: 'mcp', label: 'MCP' },
   { id: 'symphony', label: 'Symphony' },
   { id: 'general', label: 'General' },
   { id: 'appearance', label: 'Appearance' },
@@ -78,6 +80,10 @@ export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
           <div className="flex-1 overflow-hidden">
             <TabsContent value="providers" className="mt-0 h-full overflow-auto p-4">
               <ProviderAuthPanel />
+            </TabsContent>
+
+            <TabsContent value="mcp" className="mt-0 h-full overflow-auto p-4">
+              <McpServerPanel />
             </TabsContent>
 
             <TabsContent value="symphony" className="mt-0 h-full overflow-auto p-4">

--- a/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'vitest'
+import { createMcpServerEditorDraft, validateMcpServerDraft } from '../McpServerEditorDialog'
+import { formatMcpProvenanceLabel } from '../McpServerPanel'
+import {
+  formatMcpStatusLabel,
+  mcpStatusBadgeVariant,
+  summarizeMcpServer,
+} from '../McpServerRow'
+
+describe('MCP settings helpers', () => {
+  test('formats provenance labels with overlay awareness', () => {
+    expect(formatMcpProvenanceLabel('global_only')).toBe('Global shared config')
+    expect(formatMcpProvenanceLabel('overlay_present')).toBe('Global config (overlay detected)')
+    expect(formatMcpProvenanceLabel(undefined)).toBe('Global shared config')
+  })
+
+  test('summarizes stdio and http server rows for compact display', () => {
+    expect(
+      summarizeMcpServer({
+        name: 'local',
+        transport: 'stdio',
+        enabled: true,
+        summary: {
+          transport: 'stdio',
+          command: 'npx',
+          args: ['-y', 'mcp-remote'],
+          envKeys: [],
+        },
+      }),
+    ).toBe('npx -y mcp-remote')
+
+    expect(
+      summarizeMcpServer({
+        name: 'remote',
+        transport: 'http',
+        enabled: true,
+        summary: {
+          transport: 'http',
+          url: 'https://example.com/mcp',
+          auth: 'none',
+          hasInlineBearerToken: false,
+        },
+      }),
+    ).toBe('https://example.com/mcp')
+  })
+
+  test('maps status labels and badge variants for connected/error/unknown states', () => {
+    expect(formatMcpStatusLabel(undefined)).toBe('Not checked')
+    expect(mcpStatusBadgeVariant(undefined)).toBe('outline')
+
+    expect(
+      formatMcpStatusLabel({
+        serverName: 'local',
+        phase: 'connected',
+        checkedAt: new Date().toISOString(),
+        toolNames: ['read'],
+        toolCount: 1,
+      }),
+    ).toBe('Connected')
+
+    expect(
+      mcpStatusBadgeVariant({
+        serverName: 'local',
+        phase: 'connected',
+        checkedAt: new Date().toISOString(),
+        toolNames: ['read'],
+        toolCount: 1,
+      }),
+    ).toBe('default')
+
+    expect(
+      formatMcpStatusLabel({
+        serverName: 'local',
+        phase: 'error',
+        checkedAt: new Date().toISOString(),
+        toolNames: [],
+        toolCount: 0,
+        error: {
+          code: 'CONNECTION_FAILED',
+          message: 'Unable to connect',
+        },
+      }),
+    ).toBe('CONNECTION_FAILED')
+  })
+
+  test('builds editor drafts with redacted hints for existing servers', () => {
+    const stdioDraft = createMcpServerEditorDraft({
+      name: 'local',
+      transport: 'stdio',
+      enabled: true,
+      summary: {
+        transport: 'stdio',
+        command: 'node',
+        args: ['server.js'],
+        envKeys: ['API_KEY'],
+      },
+    })
+
+    expect(stdioDraft.name).toBe('local')
+    expect(stdioDraft.command).toBe('node')
+    expect(stdioDraft.envKeyHints).toEqual(['API_KEY'])
+
+    const httpDraft = createMcpServerEditorDraft({
+      name: 'remote',
+      transport: 'http',
+      enabled: true,
+      summary: {
+        transport: 'http',
+        url: 'https://example.com/mcp',
+        auth: 'bearer',
+        bearerTokenEnv: 'MCP_TOKEN',
+        hasInlineBearerToken: true,
+      },
+    })
+
+    expect(httpDraft.transport).toBe('http')
+    expect(httpDraft.bearerToken).toBe('')
+    expect(httpDraft.bearerTokenEnv).toBe('MCP_TOKEN')
+    expect(httpDraft.hasStoredInlineBearerToken).toBe(true)
+  })
+
+  test('validates transport-aware editor requirements', () => {
+    expect(
+      validateMcpServerDraft({
+        ...createMcpServerEditorDraft(),
+        transport: 'stdio',
+      }),
+    ).toContain('Server name is required.')
+
+    expect(
+      validateMcpServerDraft({
+        ...createMcpServerEditorDraft(),
+        name: 'remote',
+        transport: 'http',
+        url: 'notaurl',
+      }),
+    ).toContain('URL must be valid.')
+
+    expect(
+      validateMcpServerDraft({
+        ...createMcpServerEditorDraft(),
+        name: 'remote',
+        transport: 'http',
+        url: 'https://example.com/mcp',
+        auth: 'bearer',
+      }),
+    ).toContain('Bearer auth requires a token or token env key.')
+  })
+})

--- a/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { createMcpServerEditorDraft, validateMcpServerDraft } from '../McpServerEditorDialog'
+import { createMcpServerEditorDraft, parseArgs, validateMcpServerDraft } from '../McpServerEditorDialog'
 import { formatMcpProvenanceLabel } from '../McpServerPanel'
 import {
   formatMcpStatusLabel,
@@ -96,9 +96,23 @@ describe('MCP settings helpers', () => {
       },
     })
 
+    const quotedArgsDraft = createMcpServerEditorDraft({
+      name: 'quoted',
+      transport: 'stdio',
+      enabled: true,
+      summary: {
+        transport: 'stdio',
+        command: 'node',
+        args: ['--path', 'C:\\Program Files\\MCP Server\\entry.mjs', '--label="alpha beta"'],
+        envKeys: [],
+      },
+    })
+
     expect(stdioDraft.name).toBe('local')
     expect(stdioDraft.command).toBe('node')
     expect(stdioDraft.envKeyHints).toEqual(['API_KEY'])
+
+    expect(quotedArgsDraft.argsText).toBe('--path "C:\\Program Files\\MCP Server\\entry.mjs" "--label=\\"alpha beta\\""')
 
     const httpDraft = createMcpServerEditorDraft({
       name: 'remote',
@@ -117,6 +131,12 @@ describe('MCP settings helpers', () => {
     expect(httpDraft.bearerToken).toBe('')
     expect(httpDraft.bearerTokenEnv).toBe('MCP_TOKEN')
     expect(httpDraft.hasStoredInlineBearerToken).toBe(true)
+  })
+
+  test('parses quoted argument text without splitting embedded spaces', () => {
+    const parsed = parseArgs('--path "C:\\Program Files\\MCP Server\\entry.mjs" --name "alpha beta"')
+
+    expect(parsed).toEqual(['--path', 'C:\\Program Files\\MCP Server\\entry.mjs', '--name', 'alpha beta'])
   })
 
   test('validates transport-aware editor requirements', () => {
@@ -145,5 +165,16 @@ describe('MCP settings helpers', () => {
         auth: 'bearer',
       }),
     ).toContain('Bearer auth requires a token or token env key.')
+
+    expect(
+      validateMcpServerDraft({
+        ...createMcpServerEditorDraft(),
+        name: 'remote',
+        transport: 'http',
+        url: 'https://example.com/mcp',
+        auth: 'bearer',
+        hasStoredInlineBearerToken: true,
+      }),
+    ).toEqual([])
   })
 })

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -41,6 +41,12 @@ export const IPC_CHANNELS = {
   symphonyRefreshDashboard: 'symphony:refresh-dashboard',
   symphonyRespondEscalation: 'symphony:respond-escalation',
   symphonyDashboardSnapshot: 'symphony:dashboard-snapshot',
+  mcpListServers: 'mcp:list-servers',
+  mcpGetServer: 'mcp:get-server',
+  mcpSaveServer: 'mcp:save-server',
+  mcpDeleteServer: 'mcp:delete-server',
+  mcpRefreshStatus: 'mcp:refresh-status',
+  mcpReconnectServer: 'mcp:reconnect-server',
 } as const
 
 export type PermissionMode = 'explore' | 'ask' | 'auto'
@@ -874,6 +880,182 @@ export interface SymphonyEscalationResponseCommandResult {
   result?: SymphonyEscalationResponseResult
 }
 
+export type McpServerTransport = 'stdio' | 'http'
+
+export type McpServerAuthMode = 'none' | 'bearer'
+
+export interface McpConfigProvenance {
+  mode: 'global_only' | 'overlay_present'
+  globalConfigPath: string
+  overlayConfigPath?: string
+  warning?: string
+}
+
+export interface McpValidationError {
+  field: string
+  code: 'REQUIRED' | 'INVALID_FORMAT' | 'INVALID_VALUE'
+  message: string
+}
+
+export interface McpStdioServerSummary {
+  transport: 'stdio'
+  command: string
+  args: string[]
+  envKeys: string[]
+  cwd?: string
+}
+
+export interface McpHttpServerSummary {
+  transport: 'http'
+  url: string
+  auth: McpServerAuthMode
+  bearerTokenEnv?: string
+  hasInlineBearerToken: boolean
+}
+
+export type McpServerSummaryTransport = McpStdioServerSummary | McpHttpServerSummary
+
+export interface McpServerSummary {
+  name: string
+  transport: McpServerTransport
+  enabled: boolean
+  summary: McpServerSummaryTransport
+}
+
+export interface McpStdioServerInput {
+  name: string
+  transport: 'stdio'
+  command: string
+  args?: string[]
+  env?: Record<string, string>
+  cwd?: string
+  enabled?: boolean
+}
+
+export interface McpHttpServerInput {
+  name: string
+  transport: 'http'
+  url: string
+  auth?: McpServerAuthMode
+  bearerToken?: string
+  bearerTokenEnv?: string
+  enabled?: boolean
+}
+
+export type McpServerInput = McpStdioServerInput | McpHttpServerInput
+
+export interface McpConfigReadResponse {
+  success: boolean
+  provenance: McpConfigProvenance
+  servers: McpServerSummary[]
+  error?: {
+    code:
+      | 'CONFIG_UNREADABLE'
+      | 'MALFORMED_CONFIG'
+      | 'INVALID_CONFIG_SHAPE'
+      | 'SERVER_NOT_FOUND'
+      | 'WRITE_FAILED'
+      | 'READBACK_FAILED'
+      | 'VALIDATION_FAILED'
+      | 'UNKNOWN'
+    message: string
+  }
+}
+
+export interface McpServerResponse {
+  success: boolean
+  provenance: McpConfigProvenance
+  server?: McpServerSummary
+  validationErrors?: McpValidationError[]
+  error?: {
+    code:
+      | 'CONFIG_UNREADABLE'
+      | 'MALFORMED_CONFIG'
+      | 'INVALID_CONFIG_SHAPE'
+      | 'SERVER_NOT_FOUND'
+      | 'WRITE_FAILED'
+      | 'READBACK_FAILED'
+      | 'VALIDATION_FAILED'
+      | 'UNKNOWN'
+    message: string
+  }
+}
+
+export interface McpServerMutationResponse {
+  success: boolean
+  provenance: McpConfigProvenance
+  server?: McpServerSummary
+  validationErrors?: McpValidationError[]
+  error?: {
+    code:
+      | 'CONFIG_UNREADABLE'
+      | 'MALFORMED_CONFIG'
+      | 'INVALID_CONFIG_SHAPE'
+      | 'SERVER_NOT_FOUND'
+      | 'WRITE_FAILED'
+      | 'READBACK_FAILED'
+      | 'VALIDATION_FAILED'
+      | 'UNKNOWN'
+    message: string
+  }
+}
+
+export interface McpServerDeleteResponse {
+  success: boolean
+  provenance: McpConfigProvenance
+  deletedServerName?: string
+  error?: {
+    code:
+      | 'CONFIG_UNREADABLE'
+      | 'MALFORMED_CONFIG'
+      | 'INVALID_CONFIG_SHAPE'
+      | 'SERVER_NOT_FOUND'
+      | 'WRITE_FAILED'
+      | 'READBACK_FAILED'
+      | 'UNKNOWN'
+    message: string
+  }
+}
+
+export interface McpServerStatus {
+  serverName: string
+  phase: 'connected' | 'error' | 'unsupported'
+  checkedAt: string
+  toolNames: string[]
+  toolCount: number
+  error?: {
+    code:
+      | 'MALFORMED_CONFIG'
+      | 'SERVER_NOT_FOUND'
+      | 'COMMAND_NOT_FOUND'
+      | 'CONNECTION_FAILED'
+      | 'TIMEOUT'
+      | 'UNREACHABLE'
+      | 'MISSING_BEARER_TOKEN'
+      | 'PROTOCOL_ERROR'
+      | 'UNKNOWN'
+    message: string
+  }
+}
+
+export interface McpServerStatusResponse {
+  success: boolean
+  status?: McpServerStatus
+  error?: {
+    code:
+      | 'MALFORMED_CONFIG'
+      | 'SERVER_NOT_FOUND'
+      | 'COMMAND_NOT_FOUND'
+      | 'CONNECTION_FAILED'
+      | 'TIMEOUT'
+      | 'UNREACHABLE'
+      | 'MISSING_BEARER_TOKEN'
+      | 'PROTOCOL_ERROR'
+      | 'UNKNOWN'
+    message: string
+  }
+}
+
 export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context' | 'slice'
 
 export type RoadmapRisk = 'high' | 'medium' | 'low'
@@ -1001,6 +1183,14 @@ export interface DesktopApi {
       responseText: string,
     ) => Promise<SymphonyEscalationResponseCommandResult>
     onDashboardSnapshot: (listener: (snapshot: SymphonyOperatorSnapshot) => void) => () => void
+  }
+  mcp: {
+    listServers: () => Promise<McpConfigReadResponse>
+    getServer: (name: string) => Promise<McpServerResponse>
+    saveServer: (input: McpServerInput) => Promise<McpServerMutationResponse>
+    deleteServer: (name: string) => Promise<McpServerDeleteResponse>
+    refreshStatus: (name: string) => Promise<McpServerStatusResponse>
+    reconnectServer: (name: string) => Promise<McpServerStatusResponse>
   }
 }
 


### PR DESCRIPTION
## Summary
- add a main-process MCP config bridge with typed CRUD, redaction, provenance, and atomic write/readback behavior
- add Settings → MCP UI with guided stdio/HTTP bearer editor, row actions, and provenance/warning surfaces
- wire live MCP refresh/reconnect status inspection and available-tools reporting through IPC/preload into renderer state
- add deterministic Electron e2e MCP settings coverage and S03 live smoke documentation
- expand MCP bridge/service unit coverage to satisfy desktop coverage thresholds in pre-push validation

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/mcp-config-bridge.test.ts src/main/__tests__/mcp-service.test.ts src/main/__tests__/mcp-ipc.test.ts src/renderer/components/settings/__tests__/McpServerPanel.test.tsx`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/mcp-settings.e2e.ts`
- `cd apps/desktop && KATA_SYMPHONY_BIN_PATH= bun run test`

## Scope notes
- shared global `~/.kata-cli/agent/mcp.json` management only (project overlay remains read-only provenance warning)
- non-OAuth stdio/http-bearer entries only; no full OAuth onboarding claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP server management interface in Settings with a new "MCP" tab.
  * Users can create, configure, edit, and delete MCP server entries.
  * Real-time server connectivity status monitoring with tool discovery display.
  * Support for both stdio and HTTP-based server configurations.
  * Bearer token authentication for HTTP servers with environment variable support.

* **Tests**
  * Added comprehensive test coverage for MCP settings, configuration, and server connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the complete MCP server management feature for Kata Desktop: a config bridge for `~/.kata-cli/agent/mcp.json` CRUD with atomic writes and redaction, an editor dialog, a settings panel, a status-refresh/reconnect service, IPC wiring, and unit + E2E coverage. Two defects need attention before merge:

- **Bearer token erasure on edit** (`McpServerEditorDialog.tsx` line 170): editing an existing HTTP server and saving without entering a new token silently deletes the stored credential. `toServerInput` passes `bearerToken: ''` (not `undefined`), causing `normalizeHttpServerForWrite` to `delete nextHttpServer.bearerToken` on every blank-field save — directly contradicting the UI hint that says \"Existing inline token remains unless replaced.\" Fix: `bearerToken: draft.bearerToken || undefined`.
- **HTTP `notifications/initialized` breaks on 204** (`mcp-service.ts` lines 192-196): `postJsonRpc` throws on any non-2xx status and calls `response.json()` unconditionally; a spec-compliant server returning `204 No Content` to a notification will be misreported as unreachable.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is: bearer token data loss and HTTP 204 handling break real-world workflows

Two P1 defects with clear reproduction paths: (1) users editing an HTTP server and leaving the bearer token blank silently lose their stored credentials — the UI's own hint contradicts the actual behaviour; (2) spec-compliant MCP HTTP servers returning 204 to notifications/initialized will be false-reported as unreachable. Both are one-to-three line fixes with no architectural risk.

McpServerEditorDialog.tsx (line 170) and mcp-service.ts (lines 192-196)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/settings/McpServerEditorDialog.tsx | Root of bearer-token data-loss: toServerInput passes bearerToken:'' instead of undefined on edit, causing normalizeHttpServerForWrite to delete the stored credential |
| apps/desktop/src/main/mcp-service.ts | inspectHttpServer awaits postJsonRpc for notifications/initialized; spec-compliant servers returning 204 No Content will throw, misreporting healthy servers as unreachable |
| apps/desktop/src/main/mcp-config-bridge.ts | Atomic temp-file write/readback and redaction logic are correct; normalizeHttpServerForWrite correctly handles undefined but is exposed to the editor passing empty string |
| apps/desktop/src/main/ipc.ts | MCP IPC handlers (list, get, save, delete, refresh, reconnect) registered and cleaned up correctly; no issues found |
| apps/desktop/src/preload/index.ts | MCP preload methods correctly forward all six IPC channels to the renderer via contextBridge |
| apps/desktop/src/shared/types.ts | McpServerInput, McpHttpServerInput, status types, and IPC_CHANNELS are well-defined; bearerToken correctly typed as optional |
| apps/desktop/src/renderer/atoms/mcp.ts | Jotai write atoms for load, save, delete, and status actions correctly manage loading/error/success state |
| apps/desktop/src/renderer/components/settings/McpServerPanel.tsx | Panel correctly wires load, save, delete, refresh, and reconnect; provenance warning and error alerts render correctly |
| apps/desktop/src/renderer/components/settings/McpServerRow.tsx | Row component correctly renders server info, status badge, and two-step delete confirmation; no issues found |
| apps/desktop/src/renderer/components/settings/SettingsPanel.tsx | MCP tab correctly wired alongside existing provider/symphony/general/appearance tabs |
| apps/desktop/src/main/__tests__/mcp-config-bridge.test.ts | Good CRUD, redaction, and provenance coverage; missing a test for save-with-empty-bearerToken to catch the editor bug |
| apps/desktop/src/main/__tests__/mcp-ipc.test.ts | IPC routing tests correctly verify handler delegation to config bridge and service stubs |
| apps/desktop/src/main/__tests__/mcp-service.test.ts | Service tests cover refresh and reconnect paths; 204 No Content edge case for HTTP notifications not tested |
| apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx | Helper function tests cover provenance labels, server summarization, status labels, and draft creation |
| apps/desktop/e2e/tests/mcp-settings.e2e.ts | E2E covers stdio add/edit/delete, reconnect failure, and malformed config; HTTP bearer token round-trip not covered |
| apps/desktop/e2e/fixtures/electron.fixture.ts | mcpConfigPath fixture correctly isolates test config in a temp dir via KATA_DESKTOP_MCP_CONFIG_PATH env var |
| apps/desktop/e2e/fixtures/mcp-stdio-server.mjs | Minimal stdio MCP fixture server correctly implements initialize and tools/list with framed JSON-RPC |
| apps/desktop/e2e/tests/app-shell.e2e.ts | Minimal addition of MCP tab navigation assertion to existing shell test; no issues |
| apps/desktop/docs/uat/M005/S03-MCP-SMOKE.md | UAT smoke checklist document; no code issues |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (Edit Dialog)
    participant D as McpServerEditorDialog
    participant B as McpConfigBridge
    participant F as mcp.json

    U->>D: Opens edit for HTTP server (stored bearerToken)
    Note over D: draft.bearerToken = '' (not loaded for security)
    U->>D: Leaves bearer field blank, clicks Save
    D->>D: toServerInput() → bearerToken: '' (not undefined)
    D->>B: saveServer({ bearerToken: '' })
    B->>B: normalizeHttpServerForWrite()<br/>'' !== undefined → enters block<br/>''.trim() falsy → delete bearerToken
    B->>F: Writes config WITHOUT bearerToken
    Note over F: Stored credential lost!

    Note over D,B: Fix: bearerToken: draft.bearerToken || undefined<br/>→ undefined skips the delete block → token preserved
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/settings/McpServerEditorDialog.tsx
Line: 163-185

Comment:
**Bearer token silently erased on edit**

When editing an existing HTTP server that has a stored inline bearer token, `draft.bearerToken` is initialised to `''` (the token is never loaded back into the form). `toServerInput` passes `bearerToken: draft.bearerToken`, so the saved input always carries `bearerToken: ''` — not `undefined`.

In `normalizeHttpServerForWrite` (`mcp-config-bridge.ts` lines 623-629), the guard `if (input.bearerToken !== undefined)` is `true` for `''`, so the code enters the block, finds `''.trim()` falsy, and runs `delete nextHttpServer.bearerToken` — erasing the stored credential on every save where the user leaves the field blank. The UI hint at line 416 — "Existing inline token remains unless replaced." — describes the intended behaviour, not what actually happens.

```suggestion
  if (draft.transport === 'http') {
    return {
      name: draft.name.trim(),
      transport: 'http',
      enabled: draft.enabled,
      url: draft.url.trim(),
      auth: draft.auth,
      bearerToken: draft.bearerToken || undefined,
      bearerTokenEnv: draft.bearerTokenEnv,
    }
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/mcp-service.ts
Line: 192-196

Comment:
**HTTP `notifications/initialized` crashes on spec-compliant 204 responses**

`postJsonRpc` is called for a JSON-RPC notification. Per JSON-RPC 2.0 and the MCP HTTP transport spec, servers MUST NOT reply to notifications, or may reply with `204 No Content`. But `postJsonRpc` (line 544) throws on `!response.ok` (204 is not OK per the Fetch API), and line 548 calls `response.json()` unconditionally, which throws on an empty body. A spec-compliant MCP HTTP server will be misreported as unreachable despite being healthy.

Fire-and-forget the notification instead:
```ts
// notifications/initialized: fire-and-forget per JSON-RPC 2.0
void fetch(server.url, {
  method: 'POST',
  headers,
  body: JSON.stringify({
    jsonrpc: '2.0',
    method: 'notifications/initialized',
    params: {},
  }),
  signal: AbortSignal.timeout(this.requestTimeoutMs),
}).catch(() => { /* ignore — notification responses are not required */ })
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): harden MCP bridge/service..."](https://github.com/gannonh/kata/commit/229174b754606eff9f43c6d95fbb85b6de3051b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27485037)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->