### PR TITLE
feat(desktop): complete S01 kanban interaction closure proof (KAT-2362)

### DIFF
--- a/apps/desktop/docs/uat/M005/S01-KANBAN-INTERACTION-SMOKE.md
+++ b/apps/desktop/docs/uat/M005/S01-KANBAN-INTERACTION-SMOKE.md
@@ -1,0 +1,58 @@
+# M005 / S01 — Kanban Interaction Smoke
+
+## Scope
+
+Validate **interaction closure only** for the workflow board:
+
+- Scope switching (Active / Project / Milestone)
+- Inline escalation response from a card
+- Collapsible columns with persisted presentation
+- Direct Linear issue opening from a card
+
+> Out of scope for this smoke: card move/create/edit workflow mutation. Those are intentionally deferred to **S02**.
+
+## Preconditions
+
+- Kata Desktop built and running in test/runtime mode.
+- Symphony connection available (or mock mode) with at least one pending escalation mapped to a visible card.
+- Workflow board visible in right pane.
+
+## Smoke Steps
+
+1. **Board scope switching**
+   - Click `Active` scope.
+   - Confirm header status reads `Scope: Active` (or explicit fallback message if operator state is stale/disconnected).
+   - Click `Project` and `Milestone` scopes.
+   - Confirm status updates reflect each selection.
+
+2. **Column collapse + hidden-work visibility**
+   - Collapse a column containing cards (e.g., Todo).
+   - Confirm collapsed chip/badge indicates hidden card count.
+   - Reload Desktop and confirm collapse state persists for the same workspace+scope.
+   - Click `Expand N columns` and confirm all columns restore.
+
+3. **Inline escalation response on card**
+   - On a card with an escalation badge, open `Respond to escalation`.
+   - Enter response text and submit.
+   - Confirm card-level result message shows success/failure explicitly.
+   - If success, confirm pending escalation count drops after refresh.
+   - If failure, confirm failure remains visible (no silent success).
+
+4. **Direct issue action**
+   - Click `Open Linear issue` on a card.
+   - Confirm card-level status message indicates open action result.
+
+5. **Truthful stale/disconnected notice behavior**
+   - Force stale/disconnected operator state (or use a mock mode).
+   - Confirm board keeps workflow cards visible and displays explicit stale/disconnected notice.
+   - Confirm inline escalation submit controls become disabled when active operator state is not fresh.
+
+## Pass/Fail Criteria
+
+- **PASS** when all four interaction flows above work and each user action reports explicit success/failure state.
+- **FAIL** if any interaction silently no-ops, hides failure, or loses visibility of stale/disconnected state.
+
+## Reviewer Notes
+
+- This smoke intentionally does **not** assert real workflow mutation (move/create/edit).
+- Mutation verification belongs to S02 acceptance.

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -128,6 +128,9 @@ export const test = base.extend<DesktopFixtures>({
         KATA_DESKTOP_SYMPHONY_MOCK: symphonyMockMode,
         KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: symphonyMockMode,
         KATA_SYMPHONY_URL: 'http://127.0.0.1:8080',
+        // Force packaged-file mode for deterministic e2e: if a parent shell exported
+        // VITE_DEV_SERVER_URL we would silently bind to an arbitrary dev server.
+        VITE_DEV_SERVER_URL: '',
         // Don't override HOME — that breaks CLI binary discovery and auth.json lookup.
         // The --user-data-dir flag isolates Electron's own data (localStorage, cookies).
       },

--- a/apps/desktop/e2e/tests/workflow-board-interactions.e2e.ts
+++ b/apps/desktop/e2e/tests/workflow-board-interactions.e2e.ts
@@ -1,0 +1,64 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from '../fixtures/electron.fixture'
+
+async function startMockRuntime(page: Page) {
+  await expect(page.getByRole('heading', { name: /Workflow Board/i })).toBeVisible()
+
+  await page.evaluate(async () => {
+    await window.api.symphony.start()
+  })
+
+  await page.getByRole('button', { name: /Refresh workflow board/i }).click()
+}
+
+test.describe('workflow board interaction closure', () => {
+  test.use({ symphonyMockMode: 'kanban_assigned' })
+
+  test('supports scope switching, column collapse persistence, inline escalation response, and issue actions', async ({
+    readyWindow,
+  }) => {
+    await startMockRuntime(readyWindow)
+
+    await readyWindow.getByRole('button', { name: /Show Active scope/i }).click()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Scope: Active')
+
+    await readyWindow.getByRole('button', { name: /Show Project scope/i }).click()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Scope: Project')
+
+    await readyWindow.getByRole('button', { name: /Show Milestone scope/i }).click()
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('Scope: Milestone')
+
+    await readyWindow.getByTestId('kanban-column-toggle-todo').click()
+    await expect(readyWindow.getByTestId('kanban-column-hidden-todo')).toContainText('1 hidden')
+
+    await readyWindow.reload()
+    await expect(readyWindow.getByTestId('kanban-column-hidden-todo')).toContainText('1 hidden')
+
+    await readyWindow.getByTestId('kanban-expand-all-columns').click()
+    await expect(readyWindow.getByTestId('kanban-column-hidden-todo')).toBeHidden()
+
+    await readyWindow.getByTestId('slice-open-issue-KAT-2247').click()
+    await expect(readyWindow.getByTestId('slice-issue-action-KAT-2247')).toContainText('Opened KAT-2247 in browser')
+
+    await readyWindow.getByTestId('slice-escalation-toggle-KAT-2247').click()
+    await readyWindow.getByTestId('slice-escalation-input-req-123').fill('Proceed with the current milestone scope.')
+    await readyWindow.getByTestId('slice-escalation-submit-req-123').click()
+
+    await expect(readyWindow.getByTestId('workflow-board-status')).toContainText('0 escalations')
+    await expect(readyWindow.getByTestId('slice-escalation-toggle-KAT-2247')).toBeHidden()
+  })
+})
+
+test.describe('workflow board escalation failure visibility', () => {
+  test.use({ symphonyMockMode: 'response_failure' })
+
+  test('surfaces failed inline escalation responses without silent success', async ({ readyWindow }) => {
+    await startMockRuntime(readyWindow)
+
+    await readyWindow.getByTestId('slice-escalation-toggle-KAT-2247').click()
+    await readyWindow.getByTestId('slice-escalation-input-req-123').fill('Try failing this response path.')
+    await readyWindow.getByTestId('slice-escalation-submit-req-123').click()
+
+    await expect(readyWindow.getByTestId('slice-escalation-result-KAT-2247')).toContainText('Mocked response failure')
+  })
+})

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -23,6 +23,7 @@ vi.mock('electron', () => {
   }
 })
 
+import { shell } from 'electron'
 import { registerSessionIpc } from '../ipc'
 
 function createBridgeStub() {
@@ -129,6 +130,16 @@ describe('symphony ipc handlers', () => {
       'req-1',
       'Proceed',
     )
+    const workflowRespondResult = await handlers.get(IPC_CHANNELS.workflowRespondEscalation)?.({}, {
+      cardId: 'slice-1',
+      requestId: 'req-1',
+      responseText: 'Proceed',
+    })
+    const workflowOpenIssueResult = await handlers.get(IPC_CHANNELS.workflowOpenIssue)?.({}, {
+      cardId: 'slice-1',
+      url: 'https://linear.app/kata-sh/issue/KAT-2362/s01-kanban-interaction-closure',
+      identifier: 'KAT-2362',
+    })
 
     expect(supervisor.start).toHaveBeenCalledTimes(1)
     expect(supervisor.stop).toHaveBeenCalledTimes(1)
@@ -139,6 +150,14 @@ describe('symphony ipc handlers', () => {
     expect(operatorService.refreshBaseline).toHaveBeenCalledTimes(1)
     expect(operatorService.respondToEscalation).toHaveBeenCalledWith('req-1', 'Proceed')
     expect(respondResult.success).toBe(true)
+    expect(workflowRespondResult.success).toBe(true)
+    expect(workflowRespondResult.code).toBe('SUBMITTED')
+
+    expect((shell.openExternal as any)).toHaveBeenCalledWith(
+      'https://linear.app/kata-sh/issue/KAT-2362/s01-kanban-interaction-closure',
+    )
+    expect(workflowOpenIssueResult.success).toBe(true)
+    expect(workflowOpenIssueResult.code).toBe('OPENED')
 
     unregister()
   })

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -17,6 +17,9 @@ vi.mock('electron', () => {
     dialog: {
       showOpenDialog: vi.fn(async () => ({ canceled: true, filePaths: [] })),
     },
+    shell: {
+      openExternal: vi.fn(async () => undefined),
+    },
   }
 })
 

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -810,6 +810,215 @@ describe('WorkflowBoardService', () => {
     expect(second.snapshot.status).toBe('empty')
   })
 
+  test('filters active scope to cards with live symphony assignments', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-active-scope-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectSlug: project-ref', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const symphonySnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 1,
+      completedCount: 0,
+      workers: [
+        {
+          issueId: 'slice-1',
+          identifier: 'KAT-2247',
+          issueTitle: 'Slice 1',
+          state: 'in_progress',
+          toolName: 'edit',
+          model: 'claude-sonnet-4-6',
+        },
+      ],
+      escalations: [],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+      getSymphonySnapshot: () => symphonySnapshot,
+    })
+
+    ;(service as any).linearClient.fetchProjectSnapshot = vi.fn(async () => ({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'fresh',
+      source: { projectId: 'project-ref', activeMilestoneId: 'm1' },
+      activeMilestone: { id: 'm1', name: '[M001] Demo' },
+      columns: [
+        {
+          id: 'todo',
+          title: 'Todo',
+          cards: [
+            {
+              id: 'slice-1',
+              identifier: 'KAT-2247',
+              title: 'Active card',
+              columnId: 'todo',
+              stateName: 'Todo',
+              stateType: 'unstarted',
+              milestoneId: 'm1',
+              milestoneName: '[M001] Demo',
+              taskCounts: { total: 0, done: 0 },
+              tasks: [],
+            },
+            {
+              id: 'slice-2',
+              identifier: 'KAT-2248',
+              title: 'Inactive card',
+              columnId: 'todo',
+              stateName: 'Todo',
+              stateType: 'unstarted',
+              milestoneId: 'm1',
+              milestoneName: '[M001] Demo',
+              taskCounts: { total: 0, done: 0 },
+              tasks: [],
+            },
+          ],
+        },
+      ],
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    }))
+
+    service.setActive(true)
+    service.setScope({ scopeKey: 'workspace:a::session:b', requestedScope: 'active' })
+
+    const response = await service.refreshBoard()
+    const todoCards = response.snapshot.columns.find((column) => column.id === 'todo')?.cards ?? []
+
+    expect(response.snapshot.scope?.requested).toBe('active')
+    expect(response.snapshot.scope?.resolved).toBe('active')
+    expect(todoCards.map((card) => card.identifier)).toEqual(['KAT-2247'])
+  })
+
+  test('falls back from active scope when operator state is stale', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-active-fallback-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectSlug: project-ref', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const symphonySnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date(Date.now() - 120_000).toISOString(),
+      queueCount: 1,
+      completedCount: 0,
+      workers: [],
+      escalations: [],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'stale',
+        staleReason: 'No recent operator update.',
+      },
+      response: {},
+    }
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+      getSymphonySnapshot: () => symphonySnapshot,
+    })
+
+    ;(service as any).linearClient.fetchProjectSnapshot = vi.fn(async () => ({
+      backend: 'linear',
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'fresh',
+      source: { projectId: 'project-ref', activeMilestoneId: 'm1' },
+      activeMilestone: { id: 'm1', name: '[M001] Demo' },
+      columns: [
+        {
+          id: 'todo',
+          title: 'Todo',
+          cards: [
+            {
+              id: 'slice-1',
+              identifier: 'KAT-2247',
+              title: 'Card still visible during fallback',
+              columnId: 'todo',
+              stateName: 'Todo',
+              stateType: 'unstarted',
+              milestoneId: 'm1',
+              milestoneName: '[M001] Demo',
+              taskCounts: { total: 0, done: 0 },
+              tasks: [],
+            },
+          ],
+        },
+      ],
+      poll: { status: 'success', backend: 'linear', lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    }))
+
+    service.setActive(true)
+    service.setScope({ scopeKey: 'workspace:a::session:b', requestedScope: 'active' })
+
+    const response = await service.refreshBoard()
+
+    expect(response.snapshot.scope?.requested).toBe('active')
+    expect(response.snapshot.scope?.resolved).toBe('project')
+    expect(response.snapshot.scope?.reason).toBe('operator_state_stale')
+    expect(response.snapshot.columns.find((column) => column.id === 'todo')?.cards.length).toBe(1)
+  })
+
+  test('switches fetch strategy between milestone and project scopes', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-scope-fetch-strategy-'))
+    mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })
+    writeFileSync(
+      path.join(workspacePath, '.kata', 'preferences.md'),
+      ['---', 'projectSlug: project-ref', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => 'lin_api_test') } as never,
+      getWorkspacePath: () => workspacePath,
+    })
+
+    const milestoneSnapshot = {
+      backend: 'linear' as const,
+      fetchedAt: '2026-04-04T00:00:00.000Z',
+      status: 'fresh' as const,
+      source: { projectId: 'project-ref', activeMilestoneId: 'm1' },
+      activeMilestone: { id: 'm1', name: '[M001] Demo' },
+      columns: [],
+      poll: { status: 'success' as const, backend: 'linear' as const, lastAttemptAt: '2026-04-04T00:00:00.000Z' },
+    }
+
+    const projectSnapshot = {
+      ...milestoneSnapshot,
+      source: { projectId: 'project-ref', activeMilestoneId: 'm2' },
+      activeMilestone: { id: 'm2', name: '[M002] Demo' },
+    }
+
+    ;(service as any).linearClient.fetchActiveMilestoneSnapshot = vi.fn(async () => milestoneSnapshot)
+    ;(service as any).linearClient.fetchProjectSnapshot = vi.fn(async () => projectSnapshot)
+
+    service.setActive(true)
+
+    service.setScope({ scopeKey: 'workspace:a::session:b', requestedScope: 'milestone' })
+    await service.refreshBoard()
+
+    service.setScope({ scopeKey: 'workspace:a::session:b', requestedScope: 'project' })
+    await service.refreshBoard()
+
+    expect((service as any).linearClient.fetchActiveMilestoneSnapshot).toHaveBeenCalledTimes(1)
+    expect((service as any).linearClient.fetchProjectSnapshot).toHaveBeenCalledTimes(1)
+  })
+
   test('deduplicates concurrent refresh requests to a single Linear fetch', async () => {
     const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-concurrent-'))
     mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
-import { dialog, ipcMain, type BrowserWindow } from 'electron'
+import { dialog, ipcMain, shell, type BrowserWindow } from 'electron'
 import log from './logger'
 import { AuthBridge } from './auth-bridge'
 import { LinearDocumentClient } from './linear-document-client'
@@ -44,7 +44,12 @@ import {
   type ArtifactType,
   type WorkflowBoardSnapshotResponse,
   type WorkflowBoardLifecycleResponse,
+  type WorkflowBoardScopeRequest,
   type WorkflowBoardScopeResponse,
+  type WorkflowBoardEscalationResponseRequest,
+  type WorkflowBoardEscalationResponseResult,
+  type WorkflowBoardOpenIssueRequest,
+  type WorkflowBoardOpenIssueResult,
   type WorkflowContextResponse,
   type SymphonyRuntimeStatus,
   type SymphonyRuntimeCommandResult,
@@ -562,6 +567,8 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.workflowRefreshBoard)
   ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
   ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
   ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyGetStatus)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyStart)
@@ -1169,8 +1176,112 @@ export function registerSessionIpc({
 
   ipcMain.handle(
     IPC_CHANNELS.workflowSetScope,
-    async (_event, scopeKey: string): Promise<WorkflowBoardScopeResponse> => {
-      return workflowBoardService.setScope(scopeKey)
+    async (_event, request: WorkflowBoardScopeRequest | string): Promise<WorkflowBoardScopeResponse> => {
+      return workflowBoardService.setScope(request)
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.workflowRespondEscalation,
+    async (_event, request: WorkflowBoardEscalationResponseRequest): Promise<WorkflowBoardEscalationResponseResult> => {
+      if (!symphonyOperatorService) {
+        const nowIso = new Date().toISOString()
+        return {
+          success: false,
+          cardId: request.cardId,
+          requestId: request.requestId,
+          status: 'disabled',
+          code: 'UNAVAILABLE',
+          message: 'Symphony operator service is unavailable.',
+          submittedAt: nowIso,
+          completedAt: nowIso,
+          refreshBoard: false,
+        }
+      }
+
+      const submittedAt = new Date().toISOString()
+      const response = await symphonyOperatorService.respondToEscalation(request.requestId, request.responseText)
+      const completedAt = new Date().toISOString()
+
+      return {
+        success: response.success,
+        cardId: request.cardId,
+        requestId: request.requestId,
+        status: response.success ? 'success' : 'error',
+        code: response.success ? 'SUBMITTED' : 'FAILED',
+        message:
+          response.result?.message ??
+          (response.success ? 'Escalation response submitted.' : 'Escalation response failed.'),
+        submittedAt,
+        completedAt,
+        refreshBoard: true,
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.workflowOpenIssue,
+    async (_event, request: WorkflowBoardOpenIssueRequest): Promise<WorkflowBoardOpenIssueResult> => {
+      const openedAt = new Date().toISOString()
+      const trimmedUrl = request.url.trim()
+      if (!trimmedUrl) {
+        return {
+          success: false,
+          cardId: request.cardId,
+          url: request.url,
+          status: 'disabled',
+          code: 'INVALID_URL',
+          message: 'Issue URL is missing.',
+          openedAt,
+        }
+      }
+
+      if (!/^https?:\/\//i.test(trimmedUrl)) {
+        return {
+          success: false,
+          cardId: request.cardId,
+          url: request.url,
+          status: 'disabled',
+          code: 'INVALID_URL',
+          message: 'Issue URL must use http or https.',
+          openedAt,
+        }
+      }
+
+      if (process.env.KATA_TEST_MODE === '1') {
+        return {
+          success: true,
+          cardId: request.cardId,
+          url: trimmedUrl,
+          status: 'success',
+          code: 'OPENED',
+          message: `Opened ${request.identifier ?? 'issue'} in browser.`,
+          openedAt,
+        }
+      }
+
+      try {
+        await shell.openExternal(trimmedUrl)
+        return {
+          success: true,
+          cardId: request.cardId,
+          url: trimmedUrl,
+          status: 'success',
+          code: 'OPENED',
+          message: `Opened ${request.identifier ?? 'issue'} in browser.`,
+          openedAt,
+        }
+      } catch (error) {
+        return {
+          success: false,
+          cardId: request.cardId,
+          url: trimmedUrl,
+          status: 'error',
+          code: 'FAILED',
+          message: error instanceof Error ? error.message : String(error),
+          openedAt,
+        }
+      }
     },
   )
 
@@ -1336,6 +1447,8 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.workflowRefreshBoard)
     ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
     ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
     ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyGetStatus)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyStart)

--- a/apps/desktop/src/main/linear-workflow-client.ts
+++ b/apps/desktop/src/main/linear-workflow-client.ts
@@ -132,11 +132,52 @@ export class LinearWorkflowClient {
       milestoneId: activeMilestone?.id,
       milestoneName: activeMilestone?.name,
       issues: sliceIssues,
+      scope: 'milestone',
     })
 
     log.info('[linear-workflow-client] workflow:fetch', {
       projectRef,
       projectId,
+      scope: 'milestone',
+      milestoneId: snapshot.activeMilestone?.id,
+      status: snapshot.status,
+      cardCount: snapshot.columns.reduce((count, column) => count + column.cards.length, 0),
+      latencyMs: Date.now() - startedAt,
+    })
+
+    return snapshot
+  }
+
+  async fetchProjectSnapshot(options: FetchLinearBoardOptions): Promise<WorkflowBoardSnapshot> {
+    const projectRef = options.projectRef.trim()
+    if (!projectRef) {
+      throw new LinearWorkflowClientError('NOT_CONFIGURED', 'Linear project reference is required')
+    }
+
+    const startedAt = Date.now()
+    const apiKey = await this.requireApiKey()
+    const projectId = await this.resolveProjectId(apiKey, projectRef)
+
+    if (!projectId) {
+      throw new LinearWorkflowClientError('NOT_FOUND', `Linear project "${projectRef}" was not found`)
+    }
+
+    const allIssues = await this.fetchAllIssuesForProject(apiKey, projectId)
+    const sliceIssues = allIssues.filter((issue) => !issue.parent?.id)
+    const activeMilestone = chooseActiveMilestone(sliceIssues)
+
+    const snapshot = normalizeLinearBoard({
+      projectId,
+      issues: sliceIssues,
+      scope: 'project',
+      activeMilestoneId: activeMilestone?.id,
+      activeMilestoneName: activeMilestone?.name,
+    })
+
+    log.info('[linear-workflow-client] workflow:fetch', {
+      projectRef,
+      projectId,
+      scope: 'project',
       milestoneId: snapshot.activeMilestone?.id,
       status: snapshot.status,
       cardCount: snapshot.columns.reduce((count, column) => count + column.cards.length, 0),
@@ -482,12 +523,19 @@ export function normalizeLinearBoard(input: {
   milestoneId?: string
   milestoneName?: string
   issues: LinearWorkflowIssue[]
+  scope?: 'milestone' | 'project'
+  activeMilestoneId?: string
+  activeMilestoneName?: string
 }): WorkflowBoardSnapshot {
   const columns = createEmptyWorkflowColumns()
+  const scope = input.scope ?? 'milestone'
 
-  const scopedIssues = input.milestoneId
-    ? input.issues.filter((issue) => issue.projectMilestone?.id === input.milestoneId)
-    : []
+  const scopedIssues =
+    scope === 'project'
+      ? input.issues
+      : input.milestoneId
+        ? input.issues.filter((issue) => issue.projectMilestone?.id === input.milestoneId)
+        : []
 
   const sliceCards = scopedIssues
     .filter((issue) => issue.id && issue.identifier && issue.title)
@@ -508,6 +556,8 @@ export function normalizeLinearBoard(input: {
 
       const columnId = mapLinearStateToColumnId(issue.state?.name, issue.state?.type)
       const doneTasks = tasks.filter((task) => task.columnId === 'done').length
+      const milestoneId = issue.projectMilestone?.id?.trim()
+      const milestoneName = issue.projectMilestone?.name?.trim()
 
       return {
         id: issue.id as string,
@@ -516,8 +566,8 @@ export function normalizeLinearBoard(input: {
         columnId,
         stateName: issue.state?.name?.trim() || 'Unknown',
         stateType: issue.state?.type?.trim() || 'unknown',
-        milestoneId: input.milestoneId ?? 'none',
-        milestoneName: input.milestoneName ?? 'No active milestone',
+        milestoneId: milestoneId ?? input.milestoneId ?? 'none',
+        milestoneName: milestoneName ?? input.milestoneName ?? 'No active milestone',
         taskCounts: {
           total: tasks.length,
           done: doneTasks,
@@ -536,6 +586,8 @@ export function normalizeLinearBoard(input: {
   }
 
   const hasCards = columns.some((column) => column.cards.length > 0)
+  const activeMilestoneId = scope === 'project' ? input.activeMilestoneId : input.milestoneId
+  const activeMilestoneName = scope === 'project' ? input.activeMilestoneName : input.milestoneName
 
   return {
     backend: 'linear',
@@ -543,17 +595,22 @@ export function normalizeLinearBoard(input: {
     status: hasCards ? 'fresh' : 'empty',
     source: {
       projectId: input.projectId,
-      activeMilestoneId: input.milestoneId,
+      activeMilestoneId,
     },
     activeMilestone:
-      input.milestoneId && input.milestoneName
+      activeMilestoneId && activeMilestoneName
         ? {
-            id: input.milestoneId,
-            name: input.milestoneName,
+            id: activeMilestoneId,
+            name: activeMilestoneName,
           }
         : null,
     columns,
-    emptyReason: hasCards ? undefined : 'No slices found in the active milestone.',
+    emptyReason:
+      hasCards
+        ? undefined
+        : scope === 'project'
+          ? 'No slices found in this project.'
+          : 'No slices found in the active milestone.',
     poll: {
       status: 'success',
       backend: 'linear',

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -500,7 +500,10 @@ export class SymphonyOperatorService extends EventEmitter {
     const staleFetchedAt = new Date(Date.now() - STALE_AFTER_MS - 5_000).toISOString()
 
     const isLegacyKanbanMode =
-      mockMode === 'kanban_assigned' || mockMode === 'kanban_stale' || mockMode === 'kanban_disconnected'
+      mockMode === 'kanban_assigned' ||
+      mockMode === 'kanban_stale' ||
+      mockMode === 'kanban_disconnected' ||
+      mockMode === 'response_failure'
     const isAssembledMode = mockMode === 'assembled_healthy' || mockMode === 'assembled_failure_recovery'
     const isKanbanMode = isLegacyKanbanMode || isAssembledMode
 

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -760,21 +760,21 @@ export class WorkflowBoardService {
       }
     }
 
-    const escalationsByIdentifier = new Map<string, Set<string>>()
-    const escalationsByIssueId = new Map<string, Set<string>>()
+    const escalationsByIdentifier = new Map<string, SymphonyOperatorSnapshot['escalations']>()
+    const escalationsByIssueId = new Map<string, SymphonyOperatorSnapshot['escalations']>()
     for (const escalation of operatorSnapshot.escalations) {
       const normalizedIdentifier = normalizeIdentifier(escalation.issueIdentifier)
       if (normalizedIdentifier) {
-        const requestIds = escalationsByIdentifier.get(normalizedIdentifier) ?? new Set<string>()
-        requestIds.add(escalation.requestId)
-        escalationsByIdentifier.set(normalizedIdentifier, requestIds)
+        const entries = escalationsByIdentifier.get(normalizedIdentifier) ?? []
+        entries.push(escalation)
+        escalationsByIdentifier.set(normalizedIdentifier, entries)
       }
 
       const normalizedIssueId = normalizeIdentifier(escalation.issueId)
       if (normalizedIssueId) {
-        const requestIds = escalationsByIssueId.get(normalizedIssueId) ?? new Set<string>()
-        requestIds.add(escalation.requestId)
-        escalationsByIssueId.set(normalizedIssueId, requestIds)
+        const entries = escalationsByIssueId.get(normalizedIssueId) ?? []
+        entries.push(escalation)
+        escalationsByIssueId.set(normalizedIssueId, entries)
       }
     }
 
@@ -791,14 +791,16 @@ export class WorkflowBoardService {
       const workerByIssueId = normalizedIssueId ? workersByIssueId.get(normalizedIssueId) : undefined
       const worker = workerByIdentifier ?? workerByIssueId
 
-      const escalationRequestIds = new Set<string>()
-      for (const requestId of normalizedIdentifier ? escalationsByIdentifier.get(normalizedIdentifier) ?? [] : []) {
-        escalationRequestIds.add(requestId)
+      const matchedEscalationsByRequestId = new Map<string, SymphonyOperatorSnapshot['escalations'][number]>()
+      for (const escalation of normalizedIdentifier ? escalationsByIdentifier.get(normalizedIdentifier) ?? [] : []) {
+        matchedEscalationsByRequestId.set(escalation.requestId, escalation)
       }
-      for (const requestId of normalizedIssueId ? escalationsByIssueId.get(normalizedIssueId) ?? [] : []) {
-        escalationRequestIds.add(requestId)
+      for (const escalation of normalizedIssueId ? escalationsByIssueId.get(normalizedIssueId) ?? [] : []) {
+        matchedEscalationsByRequestId.set(escalation.requestId, escalation)
       }
-      const pendingEscalations = escalationRequestIds.size
+
+      const matchedEscalations = Array.from(matchedEscalationsByRequestId.values())
+      const pendingEscalations = matchedEscalations.length
 
       if (workerByIdentifier && normalizedIdentifier) {
         matchedWorkerKeys.add(`identifier:${normalizedIdentifier}`)
@@ -806,8 +808,8 @@ export class WorkflowBoardService {
         matchedWorkerKeys.add(`issue:${normalizedIssueId}`)
       }
 
-      for (const requestId of escalationRequestIds) {
-        matchedEscalationRequestIds.add(requestId)
+      for (const escalation of matchedEscalations) {
+        matchedEscalationRequestIds.add(escalation.requestId)
       }
 
       return {
@@ -819,6 +821,12 @@ export class WorkflowBoardService {
         lastActivityAt: worker?.lastActivityAt,
         lastError: worker?.lastError,
         pendingEscalations,
+        pendingEscalationRequests: matchedEscalations.map((escalation) => ({
+          requestId: escalation.requestId,
+          questionPreview: escalation.questionPreview,
+          createdAt: escalation.createdAt,
+          timeoutMs: escalation.timeoutMs,
+        })),
         assignmentState: worker ? ('assigned' as const) : ('unassigned' as const),
         freshness,
         provenance,

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -50,6 +50,7 @@ const TEST_LINEAR_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
           stateType: 'unstarted',
           milestoneId: 'm003',
           milestoneName: '[M003] Workflow Kanban',
+          url: 'https://linear.app/kata-sh/issue/KAT-2247',
           taskCounts: { total: 2, done: 1 },
           tasks: [
             {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -8,6 +8,11 @@ import { WorkflowContextService } from './workflow-context-service'
 import { readWorkspaceWorkflowTrackerConfig } from './workflow-config-reader'
 import type {
   SymphonyOperatorSnapshot,
+  WorkflowBoardScope,
+  WorkflowBoardScopeDiagnostics,
+  WorkflowBoardScopeRequest,
+  WorkflowBoardScopeResolutionReason,
+  WorkflowBoardScopeResponse,
   WorkflowBoardSliceCard,
   WorkflowBoardSnapshot,
   WorkflowBoardSnapshotResponse,
@@ -287,6 +292,12 @@ export class WorkflowBoardService {
   private active = false
   private planningActive = false
   private scopeKey = 'workspace:none::session:none'
+  private requestedScope: WorkflowBoardScope = 'milestone'
+  private lastScopeDiagnostics: WorkflowBoardScopeDiagnostics = {
+    requested: 'milestone',
+    resolved: 'milestone',
+    reason: 'requested',
+  }
   private trackerConfigured = false
   private testScenario: WorkflowTestScenario | null = null
 
@@ -301,22 +312,40 @@ export class WorkflowBoardService {
     return { success: true, active: this.active }
   }
 
-  setScope(scopeKey: string): { success: true; scopeKey: string } {
-    const normalized = scopeKey.trim() || 'workspace:none::session:none'
-    const nextScenario = parseWorkflowTestScenario(normalized)
+  setScope(request: WorkflowBoardScopeRequest | string): WorkflowBoardScopeResponse {
+    const parsed = parseScopeRequest(request)
+    const normalizedScopeKey = parsed.scopeKey || 'workspace:none::session:none'
+    const nextScenario = parseWorkflowTestScenario(normalizedScopeKey)
+    const nextRequestedScope = parsed.requestedScope
 
-    if (this.scopeKey !== normalized || this.testScenario !== nextScenario) {
-      this.scopeKey = normalized
+    if (
+      this.scopeKey !== normalizedScopeKey ||
+      this.testScenario !== nextScenario ||
+      this.requestedScope !== nextRequestedScope
+    ) {
+      this.scopeKey = normalizedScopeKey
       this.testScenario = nextScenario
+      this.requestedScope = nextRequestedScope
       this.lastSnapshot = null
       this.lastSuccessSnapshot = null
       this.lastEnrichedSnapshot = null
       this.lastEnrichedInputSnapshot = null
       this.lastEnrichedSymphonyKey = null
+      this.lastScopeDiagnostics = {
+        requested: nextRequestedScope,
+        resolved: nextRequestedScope,
+        reason: 'requested',
+      }
     }
 
     this.syncContextSnapshot()
-    return { success: true, scopeKey: this.scopeKey }
+    return {
+      success: true,
+      scopeKey: this.scopeKey,
+      requestedScope: this.requestedScope,
+      resolvedScope: this.lastScopeDiagnostics.resolved,
+      resolutionReason: this.lastScopeDiagnostics.reason,
+    }
   }
 
   setPlanningActive(active: boolean): void {
@@ -342,7 +371,7 @@ export class WorkflowBoardService {
 
   async getBoard(): Promise<WorkflowBoardSnapshotResponse> {
     if (this.lastSnapshot) {
-      const snapshot = this.getCachedOrEnrichedSnapshot(this.lastSnapshot)
+      const snapshot = this.resolveScope(this.getCachedOrEnrichedSnapshot(this.lastSnapshot))
       this.syncContextSnapshot()
       return { success: true, snapshot }
     }
@@ -373,7 +402,7 @@ export class WorkflowBoardService {
 
   private async performRefreshBoard(capturedScopeKey: string): Promise<WorkflowBoardSnapshotResponse> {
     if (this.testScenario) {
-      const scenarioSnapshot = this.enrichWithSymphonyContext(this.buildScenarioSnapshot(this.testScenario))
+      const scenarioSnapshot = this.resolveScope(this.enrichWithSymphonyContext(this.buildScenarioSnapshot(this.testScenario)))
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = scenarioSnapshot
         if (scenarioSnapshot.status === 'fresh' || scenarioSnapshot.status === 'empty') {
@@ -386,7 +415,7 @@ export class WorkflowBoardService {
     }
 
     if (process.env.KATA_TEST_WORKFLOW_FIXTURE === '1') {
-      const fixture = this.enrichWithSymphonyContext(withFreshTimestamps(this.resolveTestLinearFixture()))
+      const fixture = this.resolveScope(this.enrichWithSymphonyContext(withFreshTimestamps(this.resolveTestLinearFixture())))
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = fixture
         this.lastSuccessSnapshot = fixture
@@ -398,18 +427,20 @@ export class WorkflowBoardService {
 
     if (!this.active && this.lastSnapshot) {
       this.syncContextSnapshot()
-      return { success: true, snapshot: this.enrichWithSymphonyContext(this.lastSnapshot) }
+      return { success: true, snapshot: this.resolveScope(this.enrichWithSymphonyContext(this.lastSnapshot)) }
     }
 
     if (!this.active) {
-      const inactive = this.enrichWithSymphonyContext(
-        this.toErrorSnapshot({
-          nowIso: new Date().toISOString(),
-          projectId: 'unknown',
-          backend: 'linear',
-          code: 'UNKNOWN',
-          message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
-        }),
+      const inactive = this.resolveScope(
+        this.enrichWithSymphonyContext(
+          this.toErrorSnapshot({
+            nowIso: new Date().toISOString(),
+            projectId: 'unknown',
+            backend: 'linear',
+            code: 'UNKNOWN',
+            message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
+          }),
+        ),
       )
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = inactive
@@ -423,14 +454,16 @@ export class WorkflowBoardService {
 
     const trackerResolution = await this.resolveTrackerConfig(workspacePath)
     if (trackerResolution.error) {
-      const snapshot = this.enrichWithSymphonyContext(
-        this.toErrorSnapshot({
-          nowIso,
-          projectId: 'unknown',
-          backend: 'linear',
-          code: trackerResolution.error.code,
-          message: trackerResolution.error.message,
-        }),
+      const snapshot = this.resolveScope(
+        this.enrichWithSymphonyContext(
+          this.toErrorSnapshot({
+            nowIso,
+            projectId: 'unknown',
+            backend: 'linear',
+            code: trackerResolution.error.code,
+            message: trackerResolution.error.message,
+          }),
+        ),
       )
 
       if (capturedScopeKey === this.scopeKey) {
@@ -444,14 +477,16 @@ export class WorkflowBoardService {
     const tracker = trackerResolution.config
 
     if (!tracker) {
-      const snapshot = this.enrichWithSymphonyContext(
-        this.toErrorSnapshot({
-          nowIso,
-          projectId: 'unknown',
-          backend: 'linear',
-          code: 'NOT_CONFIGURED',
-          message: 'Workflow board tracker is not configured in WORKFLOW.md or .kata/preferences.md.',
-        }),
+      const snapshot = this.resolveScope(
+        this.enrichWithSymphonyContext(
+          this.toErrorSnapshot({
+            nowIso,
+            projectId: 'unknown',
+            backend: 'linear',
+            code: 'NOT_CONFIGURED',
+            message: 'Workflow board tracker is not configured in WORKFLOW.md or .kata/preferences.md.',
+          }),
+        ),
       )
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = snapshot
@@ -462,7 +497,7 @@ export class WorkflowBoardService {
     }
 
     if (isWorkflowFixtureEnabled()) {
-      const fixture = this.enrichWithSymphonyContext(withFreshTimestamps(this.fixtureForTracker(tracker)))
+      const fixture = this.resolveScope(this.enrichWithSymphonyContext(withFreshTimestamps(this.fixtureForTracker(tracker))))
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = fixture
         this.lastSuccessSnapshot = fixture
@@ -480,25 +515,31 @@ export class WorkflowBoardService {
       const fetchedSnapshot =
         tracker.kind === 'github'
           ? await this.githubClient.fetchSnapshot({ config: tracker })
-          : await this.linearClient.fetchActiveMilestoneSnapshot({ projectRef: tracker.projectRef })
+          : this.requestedScope === 'project' || this.requestedScope === 'active'
+            ? await this.linearClient.fetchProjectSnapshot({ projectRef: tracker.projectRef })
+            : await this.linearClient.fetchActiveMilestoneSnapshot({ projectRef: tracker.projectRef })
 
-      const snapshot: WorkflowBoardSnapshot = this.enrichWithSymphonyContext({
-        ...fetchedSnapshot,
-        poll: {
-          ...fetchedSnapshot.poll,
-          lastSuccessAt: fetchedSnapshot.fetchedAt,
-        },
-      })
+      const snapshot: WorkflowBoardSnapshot = this.resolveScope(
+        this.enrichWithSymphonyContext({
+          ...fetchedSnapshot,
+          poll: {
+            ...fetchedSnapshot.poll,
+            lastSuccessAt: fetchedSnapshot.fetchedAt,
+          },
+        }),
+      )
 
       if (!this.active) {
-        const inactive = this.enrichWithSymphonyContext(
-          this.toErrorSnapshot({
-            nowIso,
-            projectId: boardProjectId,
-            backend: snapshot.backend,
-            code: 'UNKNOWN',
-            message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
-          }),
+        const inactive = this.resolveScope(
+          this.enrichWithSymphonyContext(
+            this.toErrorSnapshot({
+              nowIso,
+              projectId: boardProjectId,
+              backend: snapshot.backend,
+              code: 'UNKNOWN',
+              message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
+            }),
+          ),
         )
         if (capturedScopeKey === this.scopeKey) {
           this.lastSnapshot = inactive
@@ -516,14 +557,16 @@ export class WorkflowBoardService {
       return { success: true, snapshot }
     } catch (error) {
       if (!this.active) {
-        const inactive = this.enrichWithSymphonyContext(
-          this.toErrorSnapshot({
-            nowIso,
-            projectId: boardProjectId,
-            backend: tracker.kind === 'github' ? 'github' : 'linear',
-            code: 'UNKNOWN',
-            message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
-          }),
+        const inactive = this.resolveScope(
+          this.enrichWithSymphonyContext(
+            this.toErrorSnapshot({
+              nowIso,
+              projectId: boardProjectId,
+              backend: tracker.kind === 'github' ? 'github' : 'linear',
+              code: 'UNKNOWN',
+              message: 'Workflow board inactive. Activate kanban pane to fetch execution state.',
+            }),
+          ),
         )
         if (capturedScopeKey === this.scopeKey) {
           this.lastSnapshot = inactive
@@ -537,25 +580,27 @@ export class WorkflowBoardService {
           ? GithubWorkflowClient.toWorkflowError(error)
           : LinearWorkflowClient.toWorkflowError(error)
 
-      const staleSnapshot: WorkflowBoardSnapshot = this.enrichWithSymphonyContext(
-        this.lastSuccessSnapshot
-          ? {
-              ...this.lastSuccessSnapshot,
-              status: 'stale',
-              lastError: workflowError,
-              poll: {
-                ...this.lastSuccessSnapshot.poll,
-                status: 'error',
-                lastAttemptAt: nowIso,
-              },
-            }
-          : this.toErrorSnapshot({
-              nowIso,
-              projectId: boardProjectId,
-              backend: tracker.kind === 'github' ? 'github' : 'linear',
-              code: workflowError.code,
-              message: workflowError.message,
-            }),
+      const staleSnapshot: WorkflowBoardSnapshot = this.resolveScope(
+        this.enrichWithSymphonyContext(
+          this.lastSuccessSnapshot
+            ? {
+                ...this.lastSuccessSnapshot,
+                status: 'stale',
+                lastError: workflowError,
+                poll: {
+                  ...this.lastSuccessSnapshot.poll,
+                  status: 'error',
+                  lastAttemptAt: nowIso,
+                },
+              }
+            : this.toErrorSnapshot({
+                nowIso,
+                projectId: boardProjectId,
+                backend: tracker.kind === 'github' ? 'github' : 'linear',
+                code: workflowError.code,
+                message: workflowError.message,
+              }),
+        ),
       )
 
       if (capturedScopeKey === this.scopeKey) {
@@ -594,6 +639,62 @@ export class WorkflowBoardService {
     this.lastEnrichedSymphonyKey = symphonyKey
 
     return enriched
+  }
+
+  private resolveScope(snapshot: WorkflowBoardSnapshot): WorkflowBoardSnapshot {
+    let resolvedScope: WorkflowBoardScope = this.requestedScope
+    let resolutionReason: WorkflowBoardScopeResolutionReason = 'requested'
+    let note: string | undefined
+
+    if (this.requestedScope === 'milestone' && snapshot.backend === 'github') {
+      resolvedScope = 'project'
+      resolutionReason = 'milestone_scope_not_supported'
+      note = 'Milestone scope is unavailable for GitHub trackers. Showing project scope.'
+    }
+
+    if (this.requestedScope === 'active') {
+      const symphonyEnvelope = snapshot.symphony
+      if (!symphonyEnvelope || symphonyEnvelope.provenance === 'unavailable') {
+        resolvedScope = 'project'
+        resolutionReason = 'operator_state_unavailable'
+        note = 'Active scope requires Symphony operator state. Showing broader workflow scope.'
+      } else if (symphonyEnvelope.freshness === 'stale') {
+        resolvedScope = 'project'
+        resolutionReason = 'operator_state_stale'
+        note = symphonyEnvelope.staleReason ?? 'Symphony operator state is stale. Showing broader workflow scope.'
+      } else if (symphonyEnvelope.freshness === 'disconnected') {
+        resolvedScope = 'project'
+        resolutionReason = 'operator_state_disconnected'
+        note = symphonyEnvelope.staleReason ?? 'Symphony runtime is disconnected. Showing broader workflow scope.'
+      }
+    }
+
+    let scopedSnapshot = snapshot
+    let activeMatchIdentifiers: string[] | undefined
+    let activeMatchCount: number | undefined
+
+    if (resolvedScope === 'active') {
+      const activeOnly = projectActiveScope(snapshot)
+      scopedSnapshot = activeOnly.snapshot
+      activeMatchCount = activeOnly.matchIdentifiers.length
+      activeMatchIdentifiers = activeOnly.matchIdentifiers
+    }
+
+    const diagnostics: WorkflowBoardScopeDiagnostics = {
+      requested: this.requestedScope,
+      resolved: resolvedScope,
+      reason: resolutionReason,
+      operatorFreshness: snapshot.symphony?.freshness,
+      ...(activeMatchCount !== undefined ? { activeMatchCount } : {}),
+      ...(activeMatchIdentifiers ? { activeMatchIdentifiers } : {}),
+      ...(note ? { note } : {}),
+    }
+
+    this.lastScopeDiagnostics = diagnostics
+    return {
+      ...scopedSnapshot,
+      scope: diagnostics,
+    }
   }
 
   private toSymphonyCacheKey(operatorSnapshot: SymphonyOperatorSnapshot | null): string {
@@ -973,6 +1074,76 @@ export class WorkflowBoardService {
       },
     }
   }
+}
+
+function parseScopeRequest(request: WorkflowBoardScopeRequest | string): WorkflowBoardScopeRequest & { requestedScope: WorkflowBoardScope } {
+  if (typeof request === 'string') {
+    const normalized = request.trim() || 'workspace:none::session:none'
+    const requestedScope = parseScopeToken(normalized)
+    return {
+      scopeKey: normalized,
+      requestedScope,
+    }
+  }
+
+  const normalizedScopeKey = request.scopeKey.trim() || 'workspace:none::session:none'
+  return {
+    scopeKey: normalizedScopeKey,
+    requestedScope: request.requestedScope ?? parseScopeToken(normalizedScopeKey),
+  }
+}
+
+function parseScopeToken(scopeKey: string): WorkflowBoardScope {
+  const marker = 'scope:'
+  const markerIndex = scopeKey.indexOf(marker)
+  if (markerIndex < 0) {
+    return 'milestone'
+  }
+
+  const rawScope = scopeKey.slice(markerIndex + marker.length).trim().toLowerCase()
+  if (rawScope === 'active' || rawScope === 'project' || rawScope === 'milestone') {
+    return rawScope
+  }
+
+  return 'milestone'
+}
+
+function projectActiveScope(snapshot: WorkflowBoardSnapshot): {
+  snapshot: WorkflowBoardSnapshot
+  matchIdentifiers: string[]
+} {
+  const columns = snapshot.columns.map((column) => ({
+    ...column,
+    cards: column.cards.filter((card) => {
+      if (isExecutionActive(card.symphony)) {
+        return true
+      }
+
+      return card.tasks.some((task) => isExecutionActive(task.symphony))
+    }),
+  }))
+
+  const matchIdentifiers = columns.flatMap((column) => column.cards.map((card) => card.identifier)).filter(Boolean)
+
+  const hasCards = columns.some((column) => column.cards.length > 0)
+
+  return {
+    snapshot: {
+      ...snapshot,
+      columns,
+      status: hasCards ? snapshot.status : snapshot.status === 'error' ? 'error' : 'empty',
+      emptyReason: hasCards ? snapshot.emptyReason : 'No active Symphony work matched this board scope.',
+    },
+    matchIdentifiers,
+  }
+}
+
+function isExecutionActive(summary: WorkflowBoardTask['symphony'] | WorkflowBoardSliceCard['symphony'] | undefined): boolean {
+  if (!summary) {
+    return false
+  }
+
+  return summary.assignmentState === 'assigned' || summary.pendingEscalations > 0
 }
 
 function deriveSymphonyEnvelope(operatorSnapshot: SymphonyOperatorSnapshot): {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -160,8 +160,14 @@ const api: DesktopApi = {
     setBoardActive: async (active: boolean) => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowSetBoardActive, active)
     },
-    setScope: async (scopeKey: string) => {
-      return ipcRenderer.invoke(IPC_CHANNELS.workflowSetScope, scopeKey)
+    setScope: async (request: Parameters<DesktopApi['workflow']['setScope']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowSetScope, request)
+    },
+    respondToEscalation: async (request: Parameters<DesktopApi['workflow']['respondToEscalation']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowRespondEscalation, request)
+    },
+    openIssue: async (request: Parameters<DesktopApi['workflow']['openIssue']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowOpenIssue, request)
     },
     getContext: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowGetContext)

--- a/apps/desktop/src/renderer/atoms/__tests__/workflow-board.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/workflow-board.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+import { shouldRefreshAfterScopeSync } from '../workflow-board'
+
+describe('workflow board scope sync refresh guard', () => {
+  test('does not refresh while kanban activation is not ready', () => {
+    expect(
+      shouldRefreshAfterScopeSync({
+        rightPaneMode: 'kanban',
+        boardActivationReady: false,
+      }),
+    ).toBe(false)
+  })
+
+  test('refreshes when kanban is active and activation handshake completed', () => {
+    expect(
+      shouldRefreshAfterScopeSync({
+        rightPaneMode: 'kanban',
+        boardActivationReady: true,
+      }),
+    ).toBe(true)
+  })
+
+  test('never refreshes for planning mode', () => {
+    expect(
+      shouldRefreshAfterScopeSync({
+        rightPaneMode: 'planning',
+        boardActivationReady: true,
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -19,6 +19,21 @@ export const workflowBoardRefreshingAtom = atom<boolean>(false)
 export const workflowBoardErrorAtom = atom<string | null>(null)
 export const workflowBoardActiveAtom = atom<boolean>(false)
 
+type EscalationActionState = {
+  status: 'idle' | 'submitting' | 'success' | 'error' | 'disabled'
+  message?: string
+  updatedAt: string
+}
+
+type IssueActionState = {
+  status: 'idle' | 'opening' | 'success' | 'error' | 'disabled'
+  message?: string
+  updatedAt: string
+}
+
+export const workflowEscalationActionStateAtom = atom<Record<string, EscalationActionState>>({})
+export const workflowIssueActionStateAtom = atom<Record<string, IssueActionState>>({})
+
 const workflowBoardScopePreferencesAtom = atomWithStorage<ScopePreferenceMap>(
   WORKFLOW_BOARD_SCOPE_STORAGE_KEY,
   {},
@@ -112,6 +127,77 @@ export const refreshWorkflowBoardAtom = atom(null, async (_get, set) => {
     set(workflowBoardRefreshingAtom, false)
   }
 })
+
+export const respondToWorkflowEscalationAtom = atom(
+  null,
+  async (_get, set, input: { cardId: string; requestId: string; responseText: string }) => {
+    const actionKey = `${input.cardId}:${input.requestId}`
+    const nowIso = new Date().toISOString()
+    set(workflowEscalationActionStateAtom, (previous) => ({
+      ...previous,
+      [actionKey]: {
+        status: 'submitting',
+        message: 'Submitting escalation response…',
+        updatedAt: nowIso,
+      },
+    }))
+
+    const result = await window.api.workflow.respondToEscalation({
+      cardId: input.cardId,
+      requestId: input.requestId,
+      responseText: input.responseText,
+    })
+
+    set(workflowEscalationActionStateAtom, (previous) => ({
+      ...previous,
+      [actionKey]: {
+        status: result.status,
+        message: result.message,
+        updatedAt: result.completedAt,
+      },
+    }))
+
+    if (result.refreshBoard) {
+      const boardResponse = await window.api.workflow.refreshBoard()
+      set(workflowBoardAtom, boardResponse.snapshot)
+      set(workflowBoardErrorAtom, boardResponse.snapshot.lastError?.message ?? null)
+    }
+
+    return result
+  },
+)
+
+export const openWorkflowIssueAtom = atom(
+  null,
+  async (_get, set, input: { cardId: string; url: string; identifier?: string }) => {
+    const nowIso = new Date().toISOString()
+    set(workflowIssueActionStateAtom, (previous) => ({
+      ...previous,
+      [input.cardId]: {
+        status: 'opening',
+        message: 'Opening issue link…',
+        updatedAt: nowIso,
+      },
+    }))
+
+    const result = await window.api.workflow.openIssue({
+      cardId: input.cardId,
+      url: input.url,
+      identifier: input.identifier,
+    })
+
+    set(workflowIssueActionStateAtom, (previous) => ({
+      ...previous,
+      [input.cardId]: {
+        status: result.status,
+        message: result.message,
+        updatedAt: result.openedAt,
+      },
+    }))
+
+    return result
+  },
+)
 
 function buildScopeKey(params: {
   workspacePath: string

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -1,16 +1,94 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
 import { useEffect, useRef } from 'react'
-import type { WorkflowBoardSnapshot } from '@shared/types'
+import type { WorkflowBoardSnapshot, WorkflowBoardScope, WorkflowColumnId } from '@shared/types'
 import { currentSessionIdAtom, workingDirectoryAtom } from './session'
 import { rightPaneModeAtom, setWorkflowContextAtom } from './right-pane'
 
 const REFRESH_INTERVAL_MS = 30_000
+
+const WORKFLOW_BOARD_SCOPE_STORAGE_KEY = 'kata-desktop:workflow-board-scope-by-workspace'
+const WORKFLOW_BOARD_COLLAPSE_STORAGE_KEY = 'kata-desktop:workflow-board-collapsed-columns'
+
+type ScopePreferenceMap = Record<string, WorkflowBoardScope>
+type CollapsedColumnsMap = Record<string, WorkflowColumnId[]>
 
 export const workflowBoardAtom = atom<WorkflowBoardSnapshot | null>(null)
 export const workflowBoardLoadingAtom = atom<boolean>(false)
 export const workflowBoardRefreshingAtom = atom<boolean>(false)
 export const workflowBoardErrorAtom = atom<string | null>(null)
 export const workflowBoardActiveAtom = atom<boolean>(false)
+
+const workflowBoardScopePreferencesAtom = atomWithStorage<ScopePreferenceMap>(
+  WORKFLOW_BOARD_SCOPE_STORAGE_KEY,
+  {},
+)
+
+const workflowBoardCollapsedColumnsAtom = atomWithStorage<CollapsedColumnsMap>(
+  WORKFLOW_BOARD_COLLAPSE_STORAGE_KEY,
+  {},
+)
+
+const workflowBoardWorkspaceKeyAtom = atom((get) => get(workingDirectoryAtom) || 'workspace:none')
+
+export const workflowBoardScopeAtom = atom<WorkflowBoardScope, [WorkflowBoardScope], void>(
+  (get) => {
+    const workspaceKey = get(workflowBoardWorkspaceKeyAtom)
+    return get(workflowBoardScopePreferencesAtom)[workspaceKey] ?? 'milestone'
+  },
+  (get, set, nextScope) => {
+    const workspaceKey = get(workflowBoardWorkspaceKeyAtom)
+    const existing = get(workflowBoardScopePreferencesAtom)
+    set(workflowBoardScopePreferencesAtom, {
+      ...existing,
+      [workspaceKey]: nextScope,
+    })
+  },
+)
+
+const workflowBoardCollapseKeyAtom = atom((get) => {
+  const workspaceKey = get(workflowBoardWorkspaceKeyAtom)
+  const scope = get(workflowBoardScopeAtom)
+  return `${workspaceKey}::scope:${scope}`
+})
+
+export const collapsedWorkflowColumnsAtom = atom((get) => {
+  const collapseKey = get(workflowBoardCollapseKeyAtom)
+  const collapsed = get(workflowBoardCollapsedColumnsAtom)[collapseKey] ?? []
+  return new Set<WorkflowColumnId>(collapsed)
+})
+
+export const toggleWorkflowColumnCollapsedAtom = atom(
+  null,
+  (get, set, columnId: WorkflowColumnId) => {
+    const collapseKey = get(workflowBoardCollapseKeyAtom)
+    const existingMap = get(workflowBoardCollapsedColumnsAtom)
+    const current = new Set(existingMap[collapseKey] ?? [])
+
+    if (current.has(columnId)) {
+      current.delete(columnId)
+    } else {
+      current.add(columnId)
+    }
+
+    set(workflowBoardCollapsedColumnsAtom, {
+      ...existingMap,
+      [collapseKey]: Array.from(current),
+    })
+  },
+)
+
+export const resetWorkflowCollapsedColumnsAtom = atom(null, (get, set) => {
+  const collapseKey = get(workflowBoardCollapseKeyAtom)
+  const existingMap = get(workflowBoardCollapsedColumnsAtom)
+  if (!(collapseKey in existingMap)) {
+    return
+  }
+
+  const next = { ...existingMap }
+  delete next[collapseKey]
+  set(workflowBoardCollapsedColumnsAtom, next)
+})
 
 export const workflowBoardHasCardsAtom = atom((get) => {
   const snapshot = get(workflowBoardAtom)
@@ -35,10 +113,19 @@ export const refreshWorkflowBoardAtom = atom(null, async (_get, set) => {
   }
 })
 
+function buildScopeKey(params: {
+  workspacePath: string
+  sessionId: string
+  scope: WorkflowBoardScope
+}): string {
+  return `${params.workspacePath}::${params.sessionId}::scope:${params.scope}`
+}
+
 export function useWorkflowBoardBridge(): void {
   const rightPaneMode = useAtomValue(rightPaneModeAtom)
   const workspacePath = useAtomValue(workingDirectoryAtom)
   const sessionId = useAtomValue(currentSessionIdAtom)
+  const requestedScope = useAtomValue(workflowBoardScopeAtom)
 
   const setBoard = useSetAtom(workflowBoardAtom)
   const setLoading = useSetAtom(workflowBoardLoadingAtom)
@@ -50,27 +137,55 @@ export function useWorkflowBoardBridge(): void {
   const intervalIdRef = useRef<number | null>(null)
   const activeRef = useRef(false)
   const activationVersionRef = useRef(0)
-  const scopeKey = `${workspacePath || 'workspace:none'}::${sessionId || 'session:none'}`
+
+  const normalizedWorkspacePath = workspacePath || 'workspace:none'
+  const normalizedSessionId = sessionId || 'session:none'
+  const scopeKey = buildScopeKey({
+    workspacePath: normalizedWorkspacePath,
+    sessionId: normalizedSessionId,
+    scope: requestedScope,
+  })
 
   useEffect(() => {
     let cancelled = false
 
     void (async () => {
       try {
-        await window.api.workflow.setScope(scopeKey)
-        const response = await window.api.workflow.getContext()
+        await window.api.workflow.setScope({
+          scopeKey,
+          requestedScope,
+        })
+
+        const contextResponse = await window.api.workflow.getContext()
         if (!cancelled) {
-          setWorkflowContext(response.context)
+          setWorkflowContext(contextResponse.context)
         }
-      } catch {
-        // best-effort scope/context sync
+
+        if (rightPaneMode !== 'kanban') {
+          return
+        }
+
+        setRefreshing(true)
+        const response = await window.api.workflow.refreshBoard()
+        if (!cancelled) {
+          setBoard(response.snapshot)
+          setError(response.snapshot.lastError?.message ?? null)
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setError(error instanceof Error ? error.message : String(error))
+        }
+      } finally {
+        if (!cancelled) {
+          setRefreshing(false)
+        }
       }
     })()
 
     return () => {
       cancelled = true
     }
-  }, [scopeKey, setWorkflowContext])
+  }, [requestedScope, rightPaneMode, scopeKey, setBoard, setError, setRefreshing, setWorkflowContext])
 
   useEffect(() => {
 

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -207,6 +207,13 @@ function buildScopeKey(params: {
   return `${params.workspacePath}::${params.sessionId}::scope:${params.scope}`
 }
 
+export function shouldRefreshAfterScopeSync(params: {
+  rightPaneMode: 'planning' | 'kanban'
+  boardActivationReady: boolean
+}): boolean {
+  return params.rightPaneMode === 'kanban' && params.boardActivationReady
+}
+
 export function useWorkflowBoardBridge(): void {
   const rightPaneMode = useAtomValue(rightPaneModeAtom)
   const workspacePath = useAtomValue(workingDirectoryAtom)
@@ -222,6 +229,7 @@ export function useWorkflowBoardBridge(): void {
 
   const intervalIdRef = useRef<number | null>(null)
   const activeRef = useRef(false)
+  const boardActivationReadyRef = useRef(false)
   const activationVersionRef = useRef(0)
 
   const normalizedWorkspacePath = workspacePath || 'workspace:none'
@@ -247,7 +255,12 @@ export function useWorkflowBoardBridge(): void {
           setWorkflowContext(contextResponse.context)
         }
 
-        if (rightPaneMode !== 'kanban') {
+        if (
+          !shouldRefreshAfterScopeSync({
+            rightPaneMode,
+            boardActivationReady: boardActivationReadyRef.current,
+          })
+        ) {
           return
         }
 
@@ -284,6 +297,7 @@ export function useWorkflowBoardBridge(): void {
 
     const deactivatePolling = async () => {
       activeRef.current = false
+      boardActivationReadyRef.current = false
       activationVersionRef.current += 1
       setActive(false)
       deactivateInterval()
@@ -298,11 +312,13 @@ export function useWorkflowBoardBridge(): void {
       setActive(true)
       activeRef.current = true
 
+      boardActivationReadyRef.current = false
       await window.api.workflow.setBoardActive(true)
       if (!isCurrentActivation()) {
         return
       }
 
+      boardActivationReadyRef.current = true
       setLoading(true)
       try {
         const initial = await window.api.workflow.getBoard()
@@ -377,6 +393,7 @@ export function useWorkflowBoardBridge(): void {
 
     return () => {
       activeRef.current = false
+      boardActivationReadyRef.current = false
       activationVersionRef.current += 1
       deactivateInterval()
       void window.api.workflow.setBoardActive(false)

--- a/apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx
+++ b/apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx
@@ -1,0 +1,58 @@
+import type { WorkflowBoardSnapshot } from '@shared/types'
+
+interface BoardStateNoticeProps {
+  board: WorkflowBoardSnapshot | null
+  error: string | null
+}
+
+export function BoardStateNotice({ board, error }: BoardStateNoticeProps) {
+  const notices: Array<{ id: string; tone: 'error' | 'warning'; message: string }> = []
+
+  if (error) {
+    notices.push({
+      id: 'board-error',
+      tone: 'error',
+      message: error,
+    })
+  }
+
+  if (board?.scope?.requested === 'active' && board.scope.resolved !== 'active') {
+    notices.push({
+      id: 'active-fallback',
+      tone: 'warning',
+      message:
+        board.scope.note ??
+        `Active scope is unavailable (${board.scope.reason}). Showing ${board.scope.resolved} scope instead.`,
+    })
+  }
+
+  if (board?.symphony?.staleReason) {
+    notices.push({
+      id: 'symphony-stale',
+      tone: 'warning',
+      message: board.symphony.staleReason,
+    })
+  }
+
+  if (notices.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-1 px-4 pt-2" data-testid="board-state-notice">
+      {notices.map((notice) => (
+        <div
+          key={notice.id}
+          className={
+            notice.tone === 'error'
+              ? 'rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive'
+              : 'rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-200'
+          }
+          data-testid={`board-state-notice-${notice.id}`}
+        >
+          {notice.message}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanColumn.tsx
@@ -1,16 +1,66 @@
+import { ChevronsLeftRightEllipsis } from 'lucide-react'
 import type { WorkflowBoardColumn } from '@shared/types'
 import { SliceCard } from '@/components/kanban/SliceCard'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 
 interface KanbanColumnProps {
   column: WorkflowBoardColumn
+  collapsed: boolean
+  onToggleCollapse: () => void
 }
 
-export function KanbanColumn({ column }: KanbanColumnProps) {
+export function KanbanColumn({ column, collapsed, onToggleCollapse }: KanbanColumnProps) {
+  if (collapsed) {
+    return (
+      <section
+        className="flex min-h-0 w-20 flex-col items-center rounded-xl border border-border/70 bg-muted/20 p-2"
+        data-testid={`kanban-column-${column.id}`}
+      >
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="size-6"
+          onClick={onToggleCollapse}
+          aria-label={`Expand ${column.title} column`}
+          data-testid={`kanban-column-toggle-${column.id}`}
+        >
+          <ChevronsLeftRightEllipsis className="size-3.5" />
+        </Button>
+
+        <p className="mt-2 text-center text-[11px] font-semibold leading-tight text-muted-foreground">{column.title}</p>
+
+        {column.cards.length > 0 ? (
+          <Badge variant="secondary" className="mt-2 text-[10px]" data-testid={`kanban-column-hidden-${column.id}`}>
+            {column.cards.length} hidden
+          </Badge>
+        ) : null}
+      </section>
+    )
+  }
+
   return (
-    <section className="flex min-h-0 min-w-[260px] max-w-[320px] flex-1 flex-col rounded-xl border border-border/70 bg-muted/20">
-      <header className="flex items-center justify-between border-b border-border/70 px-3 py-2">
-        <h3 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">{column.title}</h3>
-        <span className="text-xs text-muted-foreground">{column.cards.length}</span>
+    <section
+      className="flex min-h-0 min-w-[260px] max-w-[320px] flex-1 flex-col rounded-xl border border-border/70 bg-muted/20"
+      data-testid={`kanban-column-${column.id}`}
+    >
+      <header className="flex items-center justify-between gap-2 border-b border-border/70 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <h3 className="truncate text-xs font-semibold tracking-wide uppercase text-muted-foreground">{column.title}</h3>
+          <span className="text-xs text-muted-foreground">{column.cards.length}</span>
+        </div>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="size-6"
+          onClick={onToggleCollapse}
+          aria-label={`Collapse ${column.title} column`}
+          data-testid={`kanban-column-toggle-${column.id}`}
+        >
+          <ChevronsLeftRightEllipsis className="size-3.5" />
+        </Button>
       </header>
 
       <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">

--- a/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
@@ -1,7 +1,19 @@
 import { LayoutGrid, RefreshCcw } from 'lucide-react'
-import type { RightPaneResolution, RightPaneOverride, WorkflowBoardSnapshot, WorkflowContextSnapshot } from '@shared/types'
+import type {
+  RightPaneResolution,
+  RightPaneOverride,
+  WorkflowBoardScope,
+  WorkflowBoardSnapshot,
+  WorkflowContextSnapshot,
+} from '@shared/types'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
+
+const SCOPE_OPTIONS: Array<{ scope: WorkflowBoardScope; label: string }> = [
+  { scope: 'active', label: 'Active' },
+  { scope: 'project', label: 'Project' },
+  { scope: 'milestone', label: 'Milestone' },
+]
 
 function formatPaneResolutionReason(reason: string): string {
   const labels: Record<string, string> = {
@@ -32,6 +44,39 @@ function formatBoardSource(snapshot: WorkflowBoardSnapshot | null): string {
   }
 
   return snapshot.backend
+}
+
+function scopeLabel(scope: WorkflowBoardScope): string {
+  return SCOPE_OPTIONS.find((entry) => entry.scope === scope)?.label ?? scope
+}
+
+function formatScopeReason(reason: string): string {
+  const labels: Record<string, string> = {
+    requested: 'requested',
+    milestone_scope_not_supported: 'milestone unavailable for this tracker',
+    operator_state_unavailable: 'operator state unavailable',
+    operator_state_stale: 'operator state stale',
+    operator_state_disconnected: 'operator disconnected',
+  }
+
+  return labels[reason] ?? reason
+}
+
+export function formatScopeStatus(board: WorkflowBoardSnapshot | null, selectedScope: WorkflowBoardScope): string {
+  const scope = board?.scope
+  if (!scope) {
+    return `Scope: ${scopeLabel(selectedScope)}`
+  }
+
+  if (scope.requested === scope.resolved) {
+    const activeLabel =
+      scope.resolved === 'active' && typeof scope.activeMatchCount === 'number'
+        ? ` · ${scope.activeMatchCount} active match${scope.activeMatchCount === 1 ? '' : 'es'}`
+        : ''
+    return `Scope: ${scopeLabel(scope.resolved)}${activeLabel}`
+  }
+
+  return `Scope: ${scopeLabel(scope.requested)} → ${scopeLabel(scope.resolved)} (${formatScopeReason(scope.reason)})`
 }
 
 export function formatWorkflowBoardStatus(input: {
@@ -95,9 +140,11 @@ interface KanbanHeaderProps {
   board: WorkflowBoardSnapshot | null
   loading: boolean
   refreshing: boolean
+  selectedScope: WorkflowBoardScope
   rightPaneOverride: RightPaneOverride
   paneResolution: RightPaneResolution
   workflowContext: WorkflowContextSnapshot
+  onScopeChange: (scope: WorkflowBoardScope) => void
   onOpenPlanningView: () => void
   onRefresh: () => void
   onClearOverride: () => void
@@ -107,9 +154,11 @@ export function KanbanHeader({
   board,
   loading,
   refreshing,
+  selectedScope,
   rightPaneOverride,
   paneResolution,
   workflowContext,
+  onScopeChange,
   onOpenPlanningView,
   onRefresh,
   onClearOverride,
@@ -125,6 +174,22 @@ export function KanbanHeader({
         </div>
 
         <div className="flex items-center gap-1">
+          <div className="mr-1 flex items-center rounded-md border border-border/70 bg-background/70 p-0.5">
+            {SCOPE_OPTIONS.map((option) => (
+              <Button
+                key={option.scope}
+                type="button"
+                size="sm"
+                variant={selectedScope === option.scope ? 'secondary' : 'ghost'}
+                className="h-7 px-2 text-[11px]"
+                aria-label={`Show ${option.label} scope`}
+                onClick={() => onScopeChange(option.scope)}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+
           <Button type="button" size="icon" variant="ghost" aria-label="Open planning view" onClick={onOpenPlanningView}>
             <LayoutGrid className="size-4" />
           </Button>
@@ -144,6 +209,8 @@ export function KanbanHeader({
         {' · '}
         {`Context: ${workflowContext.mode}`}
         {' · '}
+        {formatScopeStatus(board, selectedScope)}
+        {' · '}
         {formatWorkflowBoardStatus({
           loading,
           boardStatus: board?.status,
@@ -154,6 +221,12 @@ export function KanbanHeader({
         {' · '}
         {formatSymphonyBoardStatus(board)}
       </div>
+
+      {board?.scope?.note ? (
+        <div className="border-b border-border bg-muted/60 px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-scope-note">
+          {board.scope.note}
+        </div>
+      ) : null}
 
       {board?.symphony?.staleReason ? (
         <div className="border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-900 dark:text-amber-200" data-testid="workflow-board-symphony-stale">

--- a/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
@@ -141,10 +141,13 @@ interface KanbanHeaderProps {
   loading: boolean
   refreshing: boolean
   selectedScope: WorkflowBoardScope
+  collapsedColumnCount: number
+  hiddenCardCount: number
   rightPaneOverride: RightPaneOverride
   paneResolution: RightPaneResolution
   workflowContext: WorkflowContextSnapshot
   onScopeChange: (scope: WorkflowBoardScope) => void
+  onExpandAllColumns: () => void
   onOpenPlanningView: () => void
   onRefresh: () => void
   onClearOverride: () => void
@@ -155,10 +158,13 @@ export function KanbanHeader({
   loading,
   refreshing,
   selectedScope,
+  collapsedColumnCount,
+  hiddenCardCount,
   rightPaneOverride,
   paneResolution,
   workflowContext,
   onScopeChange,
+  onExpandAllColumns,
   onOpenPlanningView,
   onRefresh,
   onClearOverride,
@@ -190,6 +196,19 @@ export function KanbanHeader({
             ))}
           </div>
 
+          {collapsedColumnCount > 0 ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="mr-1 h-7 px-2 text-[11px]"
+              onClick={onExpandAllColumns}
+              data-testid="kanban-expand-all-columns"
+            >
+              Expand {collapsedColumnCount} column{collapsedColumnCount === 1 ? '' : 's'}
+            </Button>
+          ) : null}
+
           <Button type="button" size="icon" variant="ghost" aria-label="Open planning view" onClick={onOpenPlanningView}>
             <LayoutGrid className="size-4" />
           </Button>
@@ -211,6 +230,10 @@ export function KanbanHeader({
         {' · '}
         {formatScopeStatus(board, selectedScope)}
         {' · '}
+        {collapsedColumnCount > 0
+          ? `Columns: ${collapsedColumnCount} collapsed · ${hiddenCardCount} hidden card${hiddenCardCount === 1 ? '' : 's'}`
+          : 'Columns: all expanded'}
+        {' · '}
         {formatWorkflowBoardStatus({
           loading,
           boardStatus: board?.status,
@@ -225,12 +248,6 @@ export function KanbanHeader({
       {board?.scope?.note ? (
         <div className="border-b border-border bg-muted/60 px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-scope-note">
           {board.scope.note}
-        </div>
-      ) : null}
-
-      {board?.symphony?.staleReason ? (
-        <div className="border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-900 dark:text-amber-200" data-testid="workflow-board-symphony-stale">
-          {board.symphony.staleReason}
         </div>
       ) : null}
 

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -1,7 +1,11 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { Loader2 } from 'lucide-react'
+import type { WorkflowBoardColumn, WorkflowColumnId } from '@shared/types'
 import {
+  collapsedWorkflowColumnsAtom,
   refreshWorkflowBoardAtom,
+  resetWorkflowCollapsedColumnsAtom,
+  toggleWorkflowColumnCollapsedAtom,
   workflowBoardAtom,
   workflowBoardErrorAtom,
   workflowBoardLoadingAtom,
@@ -15,9 +19,28 @@ import {
   setRightPaneOverrideAtom,
   workflowContextAtom,
 } from '@/atoms/right-pane'
+import { BoardStateNotice } from '@/components/kanban/BoardStateNotice'
 import { KanbanColumn } from '@/components/kanban/KanbanColumn'
 import { KanbanHeader } from '@/components/kanban/KanbanHeader'
 import { normalizeWorkflowColumns } from '@/lib/workflow-board'
+
+export function summarizeColumnPresentation(
+  columns: WorkflowBoardColumn[],
+  collapsedColumns: Set<WorkflowColumnId>,
+): { collapsedColumnCount: number; hiddenCardCount: number } {
+  let hiddenCardCount = 0
+
+  for (const column of columns) {
+    if (collapsedColumns.has(column.id)) {
+      hiddenCardCount += column.cards.length
+    }
+  }
+
+  return {
+    collapsedColumnCount: collapsedColumns.size,
+    hiddenCardCount,
+  }
+}
 
 export function KanbanPane() {
   const board = useAtomValue(workflowBoardAtom)
@@ -25,15 +48,21 @@ export function KanbanPane() {
   const refreshing = useAtomValue(workflowBoardRefreshingAtom)
   const error = useAtomValue(workflowBoardErrorAtom)
   const selectedScope = useAtomValue(workflowBoardScopeAtom)
+  const collapsedColumns = useAtomValue(collapsedWorkflowColumnsAtom)
+
   const setRightPaneOverride = useSetAtom(setRightPaneOverrideAtom)
   const setScope = useSetAtom(workflowBoardScopeAtom)
   const clearOverride = useSetAtom(clearRightPaneOverrideAtom)
+  const toggleCollapsedColumn = useSetAtom(toggleWorkflowColumnCollapsedAtom)
+  const resetCollapsedColumns = useSetAtom(resetWorkflowCollapsedColumnsAtom)
+
   const rightPaneOverride = useAtomValue(rightPaneOverrideAtom)
   const paneResolution = useAtomValue(rightPaneResolutionAtom)
   const workflowContext = useAtomValue(workflowContextAtom)
   const refreshBoard = useSetAtom(refreshWorkflowBoardAtom)
 
   const columns = board ? normalizeWorkflowColumns(board) : []
+  const presentation = summarizeColumnPresentation(columns, collapsedColumns)
 
   return (
     <aside className="flex h-full flex-col bg-muted/40" data-testid="workflow-kanban-pane">
@@ -42,11 +71,16 @@ export function KanbanPane() {
         loading={loading}
         refreshing={refreshing}
         selectedScope={selectedScope}
+        collapsedColumnCount={presentation.collapsedColumnCount}
+        hiddenCardCount={presentation.hiddenCardCount}
         rightPaneOverride={rightPaneOverride}
         paneResolution={paneResolution}
         workflowContext={workflowContext}
         onScopeChange={(scope) => {
           setScope(scope)
+        }}
+        onExpandAllColumns={() => {
+          resetCollapsedColumns()
         }}
         onOpenPlanningView={() => setRightPaneOverride('planning')}
         onRefresh={() => {
@@ -55,9 +89,7 @@ export function KanbanPane() {
         onClearOverride={() => clearOverride()}
       />
 
-      {error ? (
-        <div className="border-b border-border bg-destructive/10 px-4 py-2 text-xs text-destructive">{error}</div>
-      ) : null}
+      <BoardStateNotice board={board} error={error} />
 
       <div className="min-h-0 flex-1 overflow-x-auto px-3 py-3">
         {loading ? (
@@ -68,7 +100,14 @@ export function KanbanPane() {
         ) : (
           <div className="flex h-full min-w-max gap-3">
             {columns.map((column) => (
-              <KanbanColumn key={column.id} column={column} />
+              <KanbanColumn
+                key={column.id}
+                column={column}
+                collapsed={collapsedColumns.has(column.id)}
+                onToggleCollapse={() => {
+                  toggleCollapsedColumn(column.id)
+                }}
+              />
             ))}
           </div>
         )}

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -6,6 +6,7 @@ import {
   workflowBoardErrorAtom,
   workflowBoardLoadingAtom,
   workflowBoardRefreshingAtom,
+  workflowBoardScopeAtom,
 } from '@/atoms/workflow-board'
 import {
   clearRightPaneOverrideAtom,
@@ -23,7 +24,9 @@ export function KanbanPane() {
   const loading = useAtomValue(workflowBoardLoadingAtom)
   const refreshing = useAtomValue(workflowBoardRefreshingAtom)
   const error = useAtomValue(workflowBoardErrorAtom)
+  const selectedScope = useAtomValue(workflowBoardScopeAtom)
   const setRightPaneOverride = useSetAtom(setRightPaneOverrideAtom)
+  const setScope = useSetAtom(workflowBoardScopeAtom)
   const clearOverride = useSetAtom(clearRightPaneOverrideAtom)
   const rightPaneOverride = useAtomValue(rightPaneOverrideAtom)
   const paneResolution = useAtomValue(rightPaneResolutionAtom)
@@ -38,9 +41,13 @@ export function KanbanPane() {
         board={board}
         loading={loading}
         refreshing={refreshing}
+        selectedScope={selectedScope}
         rightPaneOverride={rightPaneOverride}
         paneResolution={paneResolution}
         workflowContext={workflowContext}
+        onScopeChange={(scope) => {
+          setScope(scope)
+        }}
         onOpenPlanningView={() => setRightPaneOverride('planning')}
         onRefresh={() => {
           void refreshBoard()

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -1,10 +1,19 @@
-import { ChevronDown } from 'lucide-react'
-import { useState } from 'react'
-import type { WorkflowBoardSliceCard } from '@shared/types'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { AlertCircle, ChevronDown, MessageSquareText } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { WorkflowBoardEscalationRequest, WorkflowBoardSliceCard, WorkflowBoardTask } from '@shared/types'
+import {
+  openWorkflowIssueAtom,
+  respondToWorkflowEscalationAtom,
+  workflowEscalationActionStateAtom,
+  workflowIssueActionStateAtom,
+} from '@/atoms/workflow-board'
 import { TaskList } from '@/components/kanban/TaskList'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Input } from '@/components/ui/input'
 
 interface SliceCardProps {
   card: WorkflowBoardSliceCard
@@ -37,21 +46,88 @@ export function formatSliceSymphonyHint(symphony: WorkflowBoardSliceCard['sympho
   return 'No active Symphony execution'
 }
 
+function escalationActionKey(cardId: string, requestId: string): string {
+  return `${cardId}:${requestId}`
+}
+
+export function isInlineEscalationEnabled(symphony: WorkflowBoardSliceCard['symphony']): boolean {
+  if (!symphony) {
+    return false
+  }
+
+  return symphony.freshness === 'fresh' && symphony.provenance === 'dashboard-derived'
+}
+
 export function SliceCard({ card }: SliceCardProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const [showEscalationComposer, setShowEscalationComposer] = useState(false)
+  const [responseDraftByRequestId, setResponseDraftByRequestId] = useState<Record<string, string>>({})
+
   const symphony = card.symphony
+  const issueActions = useAtomValue(workflowIssueActionStateAtom)
+  const escalationActions = useAtomValue(workflowEscalationActionStateAtom)
+  const openIssue = useSetAtom(openWorkflowIssueAtom)
+  const respondToEscalation = useSetAtom(respondToWorkflowEscalationAtom)
+
+  const pendingEscalations = useMemo(
+    () => symphony?.pendingEscalationRequests ?? [],
+    [symphony?.pendingEscalationRequests],
+  )
+
+  const canRespondInline = isInlineEscalationEnabled(symphony) && pendingEscalations.length > 0
+
+  const issueAction = issueActions[card.id]
+  const latestEscalationActionMessage = pendingEscalations
+    .map((request) => escalationActions[escalationActionKey(card.id, request.requestId)]?.message)
+    .find(Boolean)
+
+  const submitEscalationResponse = async (request: WorkflowBoardEscalationRequest) => {
+    const responseText = responseDraftByRequestId[request.requestId]?.trim()
+    if (!responseText) {
+      return
+    }
+
+    await respondToEscalation({
+      cardId: card.id,
+      requestId: request.requestId,
+      responseText,
+    })
+
+    setResponseDraftByRequestId((current) => ({
+      ...current,
+      [request.requestId]: '',
+    }))
+  }
+
+  const openCardIssue = () => {
+    if (!card.url) {
+      return
+    }
+
+    void openIssue({
+      cardId: card.id,
+      url: card.url,
+      identifier: card.identifier,
+    })
+  }
+
+  const openTaskIssue = (task: WorkflowBoardTask) => {
+    if (!task.url) {
+      return
+    }
+
+    void openIssue({
+      cardId: task.id,
+      url: task.url,
+      identifier: task.identifier ?? card.identifier,
+    })
+  }
 
   return (
     <Card size="sm" className="gap-3 rounded-xl border border-border/70 py-3 shadow-none">
       <CardHeader className="px-3 pb-0">
         <CardTitle className="text-sm leading-tight">
-          {card.url ? (
-            <a href={card.url} target="_blank" rel="noreferrer" className="hover:underline">
-              {card.identifier} · {card.title}
-            </a>
-          ) : (
-            <>{card.identifier} · {card.title}</>
-          )}
+          {card.identifier} · {card.title}
         </CardTitle>
       </CardHeader>
 
@@ -88,13 +164,105 @@ export function SliceCard({ card }: SliceCardProps) {
           </div>
         ) : null}
 
+        <div className="flex flex-wrap items-center gap-1.5">
+          {card.url ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-[11px]"
+              onClick={openCardIssue}
+              data-testid={`slice-open-issue-${card.identifier}`}
+              disabled={issueAction?.status === 'opening'}
+            >
+              Open Linear issue
+            </Button>
+          ) : null}
+
+          {pendingEscalations.length > 0 ? (
+            <Button
+              type="button"
+              size="sm"
+              variant={showEscalationComposer ? 'secondary' : 'outline'}
+              className="h-7 px-2 text-[11px]"
+              data-testid={`slice-escalation-toggle-${card.identifier}`}
+              onClick={() => setShowEscalationComposer((current) => !current)}
+            >
+              <MessageSquareText className="mr-1 size-3" />
+              Respond to escalation
+            </Button>
+          ) : null}
+        </div>
+
+        {issueAction?.message ? (
+          <p className="text-[11px] text-muted-foreground" data-testid={`slice-issue-action-${card.identifier}`}>
+            {issueAction.message}
+          </p>
+        ) : null}
+
+        {showEscalationComposer && pendingEscalations.length > 0 ? (
+          <div className="space-y-2 rounded-md border border-border/70 bg-background/70 p-2">
+            {!canRespondInline ? (
+              <div className="flex items-start gap-1 text-[11px] text-amber-700 dark:text-amber-300">
+                <AlertCircle className="mt-0.5 size-3" />
+                <p>Inline responses are disabled while Symphony context is stale or disconnected.</p>
+              </div>
+            ) : null}
+
+            {pendingEscalations.map((request) => {
+              const actionState = escalationActions[escalationActionKey(card.id, request.requestId)]
+              const draft = responseDraftByRequestId[request.requestId] ?? ''
+              const isSubmitting = actionState?.status === 'submitting'
+
+              return (
+                <div key={request.requestId} className="space-y-1 rounded border border-border/50 p-2">
+                  <p className="text-[11px] font-medium text-foreground">{request.questionPreview}</p>
+                  <Input
+                    value={draft}
+                    onChange={(event) => {
+                      const value = event.target.value
+                      setResponseDraftByRequestId((current) => ({
+                        ...current,
+                        [request.requestId]: value,
+                      }))
+                    }}
+                    placeholder="Enter escalation response"
+                    data-testid={`slice-escalation-input-${request.requestId}`}
+                  />
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="h-7 px-2 text-[11px]"
+                      data-testid={`slice-escalation-submit-${request.requestId}`}
+                      disabled={!canRespondInline || !draft.trim() || isSubmitting}
+                      onClick={() => {
+                        void submitEscalationResponse(request)
+                      }}
+                    >
+                      {isSubmitting ? 'Submitting…' : 'Submit response'}
+                    </Button>
+                    {actionState?.message ? <p className="text-[11px] text-muted-foreground">{actionState.message}</p> : null}
+                  </div>
+                </div>
+              )
+            })}
+
+            {latestEscalationActionMessage ? (
+              <p className="text-[11px] text-muted-foreground" data-testid={`slice-escalation-result-${card.identifier}`}>
+                {latestEscalationActionMessage}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
         <Collapsible open={isOpen} onOpenChange={setIsOpen}>
           <CollapsibleTrigger className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
             <ChevronDown className={`size-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
             {isOpen ? 'Hide tasks' : 'Show tasks'}
           </CollapsibleTrigger>
           <CollapsibleContent className="pt-2">
-            <TaskList tasks={card.tasks} />
+            <TaskList tasks={card.tasks} issueActions={issueActions} onOpenIssue={openTaskIssue} />
           </CollapsibleContent>
         </Collapsible>
       </CardContent>

--- a/apps/desktop/src/renderer/components/kanban/TaskList.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskList.tsx
@@ -1,9 +1,12 @@
 import type { WorkflowBoardTask } from '@shared/types'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 interface TaskListProps {
   tasks: WorkflowBoardTask[]
+  issueActions?: Record<string, { status: 'idle' | 'opening' | 'success' | 'error' | 'disabled'; message?: string }>
+  onOpenIssue?: (task: WorkflowBoardTask) => void
 }
 
 const DEFAULT_TASK_TONE = 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200'
@@ -18,44 +21,67 @@ const TASK_STATE_TONE: Record<WorkflowBoardTask['columnId'], string> = {
   done: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
 }
 
-export function TaskList({ tasks }: TaskListProps) {
+export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProps) {
   if (tasks.length === 0) {
     return <p className="text-xs text-muted-foreground">No child tasks</p>
   }
 
   return (
     <ul className="space-y-2">
-      {tasks.map((task) => (
-        <li key={task.id} className="rounded-md border border-border/60 bg-background/50 px-2 py-1.5">
-          <div className="flex items-center justify-between gap-2">
-            <p className="truncate text-xs font-medium text-foreground">
-              {task.identifier ? `${task.identifier} · ` : ''}
-              {task.title}
-            </p>
-            <Badge
-              variant="outline"
-              className={cn('border-transparent text-[10px]', TASK_STATE_TONE[task.columnId] ?? DEFAULT_TASK_TONE)}
-            >
-              {task.stateName}
-            </Badge>
-          </div>
-          {task.symphony ? (
-            <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
-              <span>
-                {task.symphony.assignmentState === 'assigned'
-                  ? `Worker ${task.symphony.identifier ?? '(unknown)'}`
-                  : 'Unassigned'}
-              </span>
-              {task.symphony.workerState ? <span>· {task.symphony.workerState}</span> : null}
-              {task.symphony.pendingEscalations > 0 ? (
-                <Badge variant="destructive" className="text-[10px]">
-                  {task.symphony.pendingEscalations} escalation{task.symphony.pendingEscalations === 1 ? '' : 's'}
-                </Badge>
-              ) : null}
+      {tasks.map((task) => {
+        const issueAction = issueActions[task.id]
+
+        return (
+          <li key={task.id} className="rounded-md border border-border/60 bg-background/50 px-2 py-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <p className="truncate text-xs font-medium text-foreground">
+                {task.identifier ? `${task.identifier} · ` : ''}
+                {task.title}
+              </p>
+              <Badge
+                variant="outline"
+                className={cn('border-transparent text-[10px]', TASK_STATE_TONE[task.columnId] ?? DEFAULT_TASK_TONE)}
+              >
+                {task.stateName}
+              </Badge>
             </div>
-          ) : null}
-        </li>
-      ))}
+            {task.symphony ? (
+              <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
+                <span>
+                  {task.symphony.assignmentState === 'assigned'
+                    ? `Worker ${task.symphony.identifier ?? '(unknown)'}`
+                    : 'Unassigned'}
+                </span>
+                {task.symphony.workerState ? <span>· {task.symphony.workerState}</span> : null}
+                {task.symphony.pendingEscalations > 0 ? (
+                  <Badge variant="destructive" className="text-[10px]">
+                    {task.symphony.pendingEscalations} escalation{task.symphony.pendingEscalations === 1 ? '' : 's'}
+                  </Badge>
+                ) : null}
+              </div>
+            ) : null}
+
+            {task.url && onOpenIssue ? (
+              <div className="mt-1.5">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-6 px-2 text-[10px]"
+                  data-testid={`task-open-issue-${task.identifier ?? task.id}`}
+                  onClick={() => onOpenIssue(task)}
+                  disabled={issueAction?.status === 'opening'}
+                >
+                  Open issue
+                </Button>
+                {issueAction?.message ? (
+                  <p className="mt-1 text-[10px] text-muted-foreground">{issueAction.message}</p>
+                ) : null}
+              </div>
+            ) : null}
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
-import { formatSymphonyBoardStatus, formatWorkflowBoardStatus } from '../KanbanHeader'
+import { formatScopeStatus, formatSymphonyBoardStatus, formatWorkflowBoardStatus } from '../KanbanHeader'
+import { summarizeColumnPresentation } from '../KanbanPane'
 
 describe('KanbanPane status formatting', () => {
   test('renders loading state', () => {
@@ -45,6 +46,32 @@ describe('KanbanPane status formatting', () => {
         refreshing: false,
       }),
     ).toBe('No slices in active milestone')
+  })
+
+  test('renders scope fallback details when requested scope is unresolved', () => {
+    expect(
+      formatScopeStatus(
+        {
+          backend: 'linear',
+          fetchedAt: '2026-04-04T00:00:00.000Z',
+          status: 'fresh',
+          source: { projectId: 'test-project' },
+          activeMilestone: null,
+          columns: [],
+          poll: {
+            status: 'success',
+            backend: 'linear',
+            lastAttemptAt: '2026-04-04T00:00:00.000Z',
+          },
+          scope: {
+            requested: 'active',
+            resolved: 'project',
+            reason: 'operator_state_stale',
+          },
+        },
+        'active',
+      ),
+    ).toContain('Scope: Active → Project')
   })
 
   test('renders symphony as unavailable when provenance is unavailable', () => {
@@ -129,5 +156,21 @@ describe('KanbanPane status formatting', () => {
         },
       }),
     ).toContain('Symphony: live · 1 worker · 3 escalations · 2 correlation misses')
+  })
+})
+
+describe('KanbanPane presentation persistence helpers', () => {
+  test('summarizes collapsed columns and hidden work counts', () => {
+    const summary = summarizeColumnPresentation(
+      [
+        { id: 'todo', title: 'Todo', cards: [{ id: '1' } as any, { id: '2' } as any] },
+        { id: 'in_progress', title: 'In Progress', cards: [{ id: '3' } as any] },
+        { id: 'done', title: 'Done', cards: [] },
+      ],
+      new Set(['todo', 'done']),
+    )
+
+    expect(summary.collapsedColumnCount).toBe(2)
+    expect(summary.hiddenCardCount).toBe(2)
   })
 })

--- a/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { WorkflowBoardSliceCard } from '@shared/types'
-import { formatSliceSymphonyHint } from '../SliceCard'
+import { formatSliceSymphonyHint, isInlineEscalationEnabled } from '../SliceCard'
 
 describe('SliceCard symphony hint formatting', () => {
   test('shows unavailable hint when context is missing', () => {
@@ -68,5 +68,36 @@ describe('SliceCard symphony hint formatting', () => {
         provenance: 'dashboard-derived',
       }),
     ).toBe('Execution: active')
+  })
+})
+
+describe('SliceCard inline escalation affordance', () => {
+  test('enables inline responses only for fresh dashboard-derived state', () => {
+    expect(
+      isInlineEscalationEnabled({
+        assignmentState: 'assigned',
+        pendingEscalations: 1,
+        freshness: 'fresh',
+        provenance: 'dashboard-derived',
+      }),
+    ).toBe(true)
+
+    expect(
+      isInlineEscalationEnabled({
+        assignmentState: 'assigned',
+        pendingEscalations: 1,
+        freshness: 'stale',
+        provenance: 'operator-stale',
+      }),
+    ).toBe(false)
+
+    expect(
+      isInlineEscalationEnabled({
+        assignmentState: 'assigned',
+        pendingEscalations: 1,
+        freshness: 'disconnected',
+        provenance: 'runtime-disconnected',
+      }),
+    ).toBe(false)
   })
 })

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -31,6 +31,8 @@ export const IPC_CHANNELS = {
   workflowRefreshBoard: 'workflow:refresh-board',
   workflowSetBoardActive: 'workflow:set-board-active',
   workflowSetScope: 'workflow:set-scope',
+  workflowRespondEscalation: 'workflow:respond-escalation',
+  workflowOpenIssue: 'workflow:open-issue',
   workflowGetContext: 'workflow:get-context',
   symphonyGetStatus: 'symphony:get-status',
   symphonyStart: 'symphony:start',
@@ -560,6 +562,25 @@ export type WorkflowTrackerConfig =
 
 export type WorkflowBoardStatus = 'fresh' | 'stale' | 'empty' | 'error'
 
+export type WorkflowBoardScope = 'active' | 'project' | 'milestone'
+
+export type WorkflowBoardScopeResolutionReason =
+  | 'requested'
+  | 'milestone_scope_not_supported'
+  | 'operator_state_unavailable'
+  | 'operator_state_stale'
+  | 'operator_state_disconnected'
+
+export interface WorkflowBoardScopeDiagnostics {
+  requested: WorkflowBoardScope
+  resolved: WorkflowBoardScope
+  reason: WorkflowBoardScopeResolutionReason
+  operatorFreshness?: WorkflowSymphonyExecutionFreshness
+  activeMatchCount?: number
+  activeMatchIdentifiers?: string[]
+  note?: string
+}
+
 export type WorkflowContextMode = 'planning' | 'execution' | 'unknown'
 
 export type WorkflowContextReason =
@@ -612,6 +633,13 @@ export type WorkflowSymphonyExecutionProvenance =
 
 export type WorkflowSymphonyExecutionFreshness = 'fresh' | 'stale' | 'disconnected' | 'unknown'
 
+export interface WorkflowBoardEscalationRequest {
+  requestId: string
+  questionPreview: string
+  createdAt?: string
+  timeoutMs?: number
+}
+
 export interface WorkflowSymphonyExecutionSummary {
   issueId?: string
   identifier?: string
@@ -621,6 +649,7 @@ export interface WorkflowSymphonyExecutionSummary {
   lastActivityAt?: string
   lastError?: string
   pendingEscalations: number
+  pendingEscalationRequests?: WorkflowBoardEscalationRequest[]
   assignmentState: 'assigned' | 'unassigned'
   freshness: WorkflowSymphonyExecutionFreshness
   provenance: WorkflowSymphonyExecutionProvenance
@@ -694,6 +723,7 @@ export interface WorkflowBoardSnapshot {
     repoOwner?: string
     repoName?: string
   }
+  scope?: WorkflowBoardScopeDiagnostics
   activeMilestone:
     | {
         id: string
@@ -721,9 +751,59 @@ export interface WorkflowBoardLifecycleResponse {
   active: boolean
 }
 
+export interface WorkflowBoardScopeRequest {
+  scopeKey: string
+  requestedScope?: WorkflowBoardScope
+}
+
 export interface WorkflowBoardScopeResponse {
   success: boolean
   scopeKey: string
+  requestedScope: WorkflowBoardScope
+  resolvedScope: WorkflowBoardScope
+  resolutionReason: WorkflowBoardScopeResolutionReason
+}
+
+export interface WorkflowBoardEscalationResponseRequest {
+  cardId: string
+  requestId: string
+  responseText: string
+}
+
+export type WorkflowBoardEscalationResponseCode =
+  | 'SUBMITTED'
+  | 'UNAVAILABLE'
+  | 'INVALID_REQUEST'
+  | 'FAILED'
+
+export interface WorkflowBoardEscalationResponseResult {
+  success: boolean
+  cardId: string
+  requestId: string
+  status: 'success' | 'error' | 'disabled'
+  code: WorkflowBoardEscalationResponseCode
+  message: string
+  submittedAt: string
+  completedAt: string
+  refreshBoard: boolean
+}
+
+export interface WorkflowBoardOpenIssueRequest {
+  cardId: string
+  url: string
+  identifier?: string
+}
+
+export type WorkflowBoardOpenIssueCode = 'OPENED' | 'INVALID_URL' | 'UNAVAILABLE' | 'FAILED'
+
+export interface WorkflowBoardOpenIssueResult {
+  success: boolean
+  cardId: string
+  url: string
+  status: 'success' | 'error' | 'disabled'
+  code: WorkflowBoardOpenIssueCode
+  message: string
+  openedAt: string
 }
 
 export interface WorkflowContextResponse {
@@ -985,7 +1065,11 @@ export interface DesktopApi {
     getBoard: () => Promise<WorkflowBoardSnapshotResponse>
     refreshBoard: () => Promise<WorkflowBoardSnapshotResponse>
     setBoardActive: (active: boolean) => Promise<WorkflowBoardLifecycleResponse>
-    setScope: (scopeKey: string) => Promise<WorkflowBoardScopeResponse>
+    setScope: (request: WorkflowBoardScopeRequest | string) => Promise<WorkflowBoardScopeResponse>
+    respondToEscalation: (
+      request: WorkflowBoardEscalationResponseRequest,
+    ) => Promise<WorkflowBoardEscalationResponseResult>
+    openIssue: (request: WorkflowBoardOpenIssueRequest) => Promise<WorkflowBoardOpenIssueResult>
     getContext: () => Promise<WorkflowContextResponse>
   }
   symphony: {


### PR DESCRIPTION
## Summary
- add deterministic Electron interaction coverage for workflow-board scope switching, collapsible column persistence, inline escalation actions, and issue-link behavior
- add focused UAT smoke checklist at `apps/desktop/docs/uat/M005/S01-KANBAN-INTERACTION-SMOKE.md` with explicit S01 boundary (mutation deferred to S02)
- harden desktop e2e fixture isolation by clearing inherited `VITE_DEV_SERVER_URL` so tests always exercise built app artifacts
- extend mock kanban data for issue-link coverage (`KAT-2247` URL) and treat `response_failure` as a kanban mock mode

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/workflow-board-service.test.ts src/main/__tests__/symphony-ipc.test.ts src/renderer/components/kanban/__tests__/KanbanPane.test.tsx src/renderer/components/kanban/__tests__/SliceCard.test.tsx`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/workflow-board-interactions.e2e.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workflow board scope switching between Active, Project, and Milestone views
  * Added column collapse/expand controls for kanban board layout persistence
  * Added inline escalation response capability with composer UI
  * Added ability to open Linear issues directly from workflow board cards
  * Added board state notices displaying scope resolution and system status

* **Tests**
  * Added comprehensive end-to-end tests for workflow board interactions
  * Extended test coverage for scope resolution and board service functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds deterministic Playwright e2e coverage for the kanban workflow board: scope switching (Active/Project/Milestone), collapsible column state persisted via `atomWithStorage`, inline escalation response, and issue-link opening. New IPC handlers (`workflowRespondEscalation`, `workflowOpenIssue`) are wired end-to-end through shared types, preload, main, and renderer layers. The scope fallback logic in `WorkflowBoardService.resolveScope` handles stale/disconnected/unavailable Symphony operator state gracefully and is thoroughly unit-tested with 215 lines of new tests.

Key changes:
- **IPC**: Two new handlers with URL validation, `KATA_TEST_MODE` guard for e2e safety, and typed `WorkflowBoardEscalationResponseResult` / `WorkflowBoardOpenIssueResult` responses
- **Scope resolution**: Active scope falls back to project when operator state is stale/disconnected/unavailable; the reason is surfaced in `scope.note` and `scope.reason`
- **Column collapse**: Per-workspace, per-scope collapse state persisted in `localStorage` via `atomWithStorage`, with `Expand N columns` button and hidden-card count badge
- **Mock hardening**: `response_failure` added to `isLegacyKanbanMode` for failure-visibility e2e coverage; `VITE_DEV_SERVER_URL` cleared in the e2e fixture to prevent accidental dev-server binding
- **Three style-level issues found**: (1) `BoardStateNotice` renders the same stale reason text twice when active scope falls back; (2) `symphony-ipc.test.ts` assertion for `shell.openExternal` silently fails if `KATA_TEST_MODE=1` is in the environment; (3) both `useEffect`s in `useWorkflowBoardBridge` trigger board fetches when the kanban pane first opens, producing a brief blank-board flash

<h3>Confidence Score: 4/5</h3>

Safe to merge; all three flagged issues are style/UX concerns with no runtime-breaking impact

Well-tested PR with end-to-end type safety and solid unit + e2e coverage. Score is 4 rather than 5 due to the duplicate stale reason notice (UX regression in BoardStateNotice), the fragile unit test assertion that silently fails under KATA_TEST_MODE=1, and the double-fetch loading state inconsistency on kanban pane activation. None are blockers.

apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx (duplicate notices), apps/desktop/src/main/__tests__/symphony-ipc.test.ts (missing KATA_TEST_MODE guard), apps/desktop/src/renderer/atoms/workflow-board.ts (double board fetch on pane open)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/docs/uat/M005/S01-KANBAN-INTERACTION-SMOKE.md | New UAT smoke checklist for S01 kanban interactions with explicit pass/fail criteria and S02 mutation boundary |
| apps/desktop/e2e/fixtures/electron.fixture.ts | Adds VITE_DEV_SERVER_URL='' to ensure packaged-file mode in e2e; adds response_failure to symphonyMockMode union type |
| apps/desktop/e2e/tests/workflow-board-interactions.e2e.ts | New e2e tests for scope switching, column collapse persistence across reload, issue-open, escalation response, and failure visibility |
| apps/desktop/src/main/__tests__/symphony-ipc.test.ts | Adds IPC coverage for workflowRespondEscalation and workflowOpenIssue; shell.openExternal assertion fragile if KATA_TEST_MODE=1 is in environment |
| apps/desktop/src/main/__tests__/workflow-board-service.test.ts | 215 lines of new unit tests covering active scope filtering, stale fallback, scope fetch strategy, and concurrent deduplication |
| apps/desktop/src/main/ipc.ts | Adds workflowRespondEscalation and workflowOpenIssue handlers with URL validation, KATA_TEST_MODE guard, and typed results |
| apps/desktop/src/main/linear-workflow-client.ts | Adds fetchProjectSnapshot and extends normalizeLinearBoard with scope/activeMilestone parameters for project-scoped board fetching |
| apps/desktop/src/main/symphony-operator-service.ts | Adds response_failure to isLegacyKanbanMode so KAT-2247 mock data with escalations is available for the failure-visibility e2e test |
| apps/desktop/src/main/workflow-board-service.ts | Adds resolveScope method with active/project/milestone fallback logic; enriches cards with per-escalation request details for inline response UI |
| apps/desktop/src/preload/index.ts | Adds respondToEscalation and openIssue to workflow section of preload bridge; clean minimal change |
| apps/desktop/src/renderer/atoms/workflow-board.ts | Adds scope/collapse persistence atoms (atomWithStorage), escalation/issue action atoms, and scope-aware sync hook; double-fetch concern on pane activation |
| apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx | New board state notice component; active-fallback and symphony-stale notices can display identical stale reason text when active scope falls back |
| apps/desktop/src/renderer/components/kanban/KanbanColumn.tsx | Adds collapsed prop with compact vertical view, hidden-card count badge, and aria-labelled toggle button |
| apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx | Adds scope switcher (Active/Project/Milestone), collapse counter button, and exported scope status formatting functions |
| apps/desktop/src/renderer/components/kanban/KanbanPane.tsx | Integrates collapse atoms and replaces inline error div with the new BoardStateNotice component |
| apps/desktop/src/renderer/components/kanban/SliceCard.tsx | Adds collapsible inline escalation response UI and issue-open button with action state feedback and data-testid attributes |
| apps/desktop/src/renderer/components/kanban/TaskList.tsx | Adds optional issueActions record and onOpenIssue callback for per-task issue-open button with disabled/loading states |
| apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx | New unit tests for formatWorkflowBoardStatus, formatScopeStatus, formatSymphonyBoardStatus, and summarizeColumnPresentation |
| apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx | New unit tests for formatSliceSymphonyHint and isInlineEscalationEnabled across all freshness/provenance combinations |
| apps/desktop/src/shared/types.ts | Adds workflowRespondEscalation and workflowOpenIssue IPC channels plus all associated request/result types |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer (SliceCard)
    participant A as Jotai Atoms
    participant P as Preload Bridge
    participant M as Main (ipc.ts)
    participant S as SymphonyOperatorService

    Note over R,S: Inline Escalation Response Flow
    R->>A: click Submit → respondToWorkflowEscalationAtom
    A->>A: set status=submitting
    A->>P: window.api.workflow.respondToEscalation(request)
    P->>M: ipcRenderer.invoke(workflowRespondEscalation)
    M->>S: symphonyOperatorService.respondToEscalation(requestId, text)
    S-->>M: {success, result.message}
    M-->>A: WorkflowBoardEscalationResponseResult
    A->>A: set status=success|error, message
    alt result.refreshBoard === true
        A->>P: window.api.workflow.refreshBoard()
        P->>M: ipcRenderer.invoke(workflowRefreshBoard)
        M-->>A: updated WorkflowBoardSnapshot
        A->>A: update workflowBoardAtom
    end
    A-->>R: re-render with action state feedback

    Note over R,S: Issue Open Flow
    R->>A: click Open Issue → openWorkflowIssueAtom
    A->>A: set status=opening
    A->>P: window.api.workflow.openIssue(request)
    P->>M: ipcRenderer.invoke(workflowOpenIssue)
    M->>M: validate URL (empty check, http/https regex)
    alt KATA_TEST_MODE === 1
        M-->>A: early return {success:true, code:OPENED}
    else production
        M->>M: shell.openExternal(trimmedUrl)
        M-->>A: WorkflowBoardOpenIssueResult
    end
    A->>A: set status=success|error|disabled
    A-->>R: re-render with issue action message
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/__tests__/symphony-ipc.test.ts`, line 191-194 ([link](https://github.com/gannonh/kata/blob/7be904f7e69a2d532e226df514ccf6772114ca63/apps/desktop/src/main/__tests__/symphony-ipc.test.ts#L191-L194)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`shell.openExternal` assertion fragile if `KATA_TEST_MODE=1` is in the shell environment**

   The `workflowOpenIssue` handler in `ipc.ts` early-returns with `code: 'OPENED'` — bypassing `shell.openExternal` — when `process.env.KATA_TEST_MODE === '1'`. This test file never clears `KATA_TEST_MODE`.

   If a developer has `KATA_TEST_MODE=1` exported in their shell (common after running the e2e suite, which sets it via the fixture), vitest picks it up and the handler never calls `shell.openExternal`, silently breaking this assertion.

   The same PR's `workflow-board-service.test.ts` demonstrates the correct pattern — save/restore the env var in `beforeEach`/`afterEach`. Apply the same guard here:

   ```typescript
   const savedTestMode = process.env.KATA_TEST_MODE
   beforeEach(() => { delete process.env.KATA_TEST_MODE })
   afterEach(() => {
     if (savedTestMode !== undefined) {
       process.env.KATA_TEST_MODE = savedTestMode
     } else {
       delete process.env.KATA_TEST_MODE
     }
   })
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/__tests__/symphony-ipc.test.ts
   Line: 191-194

   Comment:
   **`shell.openExternal` assertion fragile if `KATA_TEST_MODE=1` is in the shell environment**

   The `workflowOpenIssue` handler in `ipc.ts` early-returns with `code: 'OPENED'` — bypassing `shell.openExternal` — when `process.env.KATA_TEST_MODE === '1'`. This test file never clears `KATA_TEST_MODE`.

   If a developer has `KATA_TEST_MODE=1` exported in their shell (common after running the e2e suite, which sets it via the fixture), vitest picks it up and the handler never calls `shell.openExternal`, silently breaking this assertion.

   The same PR's `workflow-board-service.test.ts` demonstrates the correct pattern — save/restore the env var in `beforeEach`/`afterEach`. Apply the same guard here:

   ```typescript
   const savedTestMode = process.env.KATA_TEST_MODE
   beforeEach(() => { delete process.env.KATA_TEST_MODE })
   afterEach(() => {
     if (savedTestMode !== undefined) {
       process.env.KATA_TEST_MODE = savedTestMode
     } else {
       delete process.env.KATA_TEST_MODE
     }
   })
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx
Line: 19-35

Comment:
**Duplicate stale reason displayed twice in notices**

When `requestedScope === 'active'` and the operator is stale, both the `active-fallback` and `symphony-stale` notices push the same message to the array.

In `workflow-board-service.ts`, `scope.note` is assigned `symphonyEnvelope.staleReason` inside the active-scope fallback block, so `board.scope.note === board.symphony.staleReason`. This means:
- The `active-fallback` notice renders `board.scope.note` (the stale reason)
- The `symphony-stale` notice renders `board.symphony.staleReason` (identical text)

Additionally, `KanbanHeader` also renders `board.scope.note` in the `workflow-board-scope-note` bar, so the same string can appear up to three times in the UI.

Consider deduplicating before pushing the `symphony-stale` notice:

```suggestion
  if (board?.symphony?.staleReason) {
    const alreadyShown = notices.some((n) => n.message === board.symphony!.staleReason)
    if (!alreadyShown) {
      notices.push({
        id: 'symphony-stale',
        tone: 'warning',
        message: board.symphony.staleReason,
      })
    }
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/__tests__/symphony-ipc.test.ts
Line: 191-194

Comment:
**`shell.openExternal` assertion fragile if `KATA_TEST_MODE=1` is in the shell environment**

The `workflowOpenIssue` handler in `ipc.ts` early-returns with `code: 'OPENED'` — bypassing `shell.openExternal` — when `process.env.KATA_TEST_MODE === '1'`. This test file never clears `KATA_TEST_MODE`.

If a developer has `KATA_TEST_MODE=1` exported in their shell (common after running the e2e suite, which sets it via the fixture), vitest picks it up and the handler never calls `shell.openExternal`, silently breaking this assertion.

The same PR's `workflow-board-service.test.ts` demonstrates the correct pattern — save/restore the env var in `beforeEach`/`afterEach`. Apply the same guard here:

```typescript
const savedTestMode = process.env.KATA_TEST_MODE
beforeEach(() => { delete process.env.KATA_TEST_MODE })
afterEach(() => {
  if (savedTestMode !== undefined) {
    process.env.KATA_TEST_MODE = savedTestMode
  } else {
    delete process.env.KATA_TEST_MODE
  }
})
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/workflow-board.ts
Line: 235-274

Comment:
**Double board fetch causes brief blank-board flash on initial kanban pane activation**

When `rightPaneMode` transitions to `'kanban'`, both `useEffect`s fire on the same render cycle:

- **Effect 1** (this block, deps include `rightPaneMode`): sets scope → gets context → calls `refreshBoard()` (async remote fetch).
- **Effect 2** (polling effect below, deps also include `rightPaneMode`): calls `activatePolling()` → `setLoading(true)` → `getBoard()` (cache or empty) → `setLoading(false)` → starts interval.

Because `getBoard()` in Effect 2 resolves immediately when the cache is empty, the observable sequence becomes:
1. `loading = true` (Effect 2)
2. `loading = false`, board atom is `null` — board renders blank (Effect 2: `getBoard()` returns empty)
3. `refreshing = true` (Effect 1: `refreshBoard()` starts)
4. Fresh data arrives, `refreshing = false` (Effect 1 completes)

The blank content at step 2 before step 4 produces a jarring flash. This only occurs on pane activation — scope changes work cleanly because only Effect 1 fires then.

One option: remove `rightPaneMode` from Effect 1's dependency array (reverting to pre-PR behavior for pane-open) so Effect 2 alone drives the initial load. Effect 1 would still handle scope-change refreshes via the `requestedScope`/`scopeKey` dependencies.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): gate scope refresh until b..."](https://github.com/gannonh/kata/commit/7be904f7e69a2d532e226df514ccf6772114ca63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27486530)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->