### PR TITLE
feat(desktop): linear read-write workflow board mutations (KAT-2382)

### DIFF
--- a/apps/desktop/docs/uat/M005/S02-LINEAR-MUTATION-SMOKE.md
+++ b/apps/desktop/docs/uat/M005/S02-LINEAR-MUTATION-SMOKE.md
@@ -1,0 +1,62 @@
+# M005 / S02 — Linear Workflow Mutation Smoke
+
+## Scope
+
+Validate **Linear-backed workflow mutation only** from the Desktop board:
+
+- Move a slice card between workflow columns.
+- Trigger a move failure and verify explicit rollback visibility.
+- Create a child task from a slice card.
+- Edit task title/description/state from the board with on-demand detail load.
+
+> Out of scope: GitHub write parity, MCP management, full M005 milestone assembly.
+
+## Preconditions
+
+1. Kata Desktop built and running.
+2. Workspace is Linear-backed (`workflow.mode: linear`) with a visible slice card and child tasks.
+3. Linear API credentials are configured for Desktop runtime.
+4. Symphony state can be stale/disconnected without blocking Linear mutation checks (board remains visible).
+
+## Smoke Steps
+
+1. **Slice move success**
+   - On a visible slice card, use **Move slice** and select a different column.
+   - Confirm card-level message shows pending → success.
+   - Confirm card appears in the target column.
+
+2. **Slice move rollback failure**
+   - Trigger a known failing move path (or simulate backend rejection).
+   - Confirm card-level message shows an explicit failure.
+   - Confirm slice remains in its prior column (rollback visible, no ambiguous state).
+
+3. **Create child task from slice card**
+   - Click **Add task** on the slice card.
+   - Submit title (+ optional description).
+   - Confirm dialog reports success and closes.
+   - Expand task list and confirm new task is visible.
+   - Refresh board and confirm task still exists (no ghost rows).
+
+4. **Edit task from task row**
+   - Click **Edit task** on an existing task row.
+   - Confirm dialog loads current detail before save (title/state prefilled).
+   - Update title/description/state and save.
+   - Confirm row reflects new values after save + refresh.
+
+5. **Validation/error visibility**
+   - Submit create/edit with invalid input (empty title).
+   - Confirm validation remains in dialog and no board mutation occurs.
+   - Trigger backend rejection for create/edit and confirm inline dialog error remains visible.
+
+## Pass/Fail Criteria
+
+- **PASS** when all mutation paths show explicit pending/success/failure states, rollback is visible on failure, and post-write refresh reconciles with persisted Linear truth.
+- **FAIL** if any mutation silently fails, leaves ghost data, or hides rollback/error state.
+
+## Evidence to Capture
+
+- Screenshot: successful slice move status + target column.
+- Screenshot: failed move rollback message.
+- Screenshot: create-task dialog + resulting task row.
+- Screenshot: edit-task dialog + updated row after save.
+- Note any divergence between optimistic UI and refreshed Linear state.

--- a/apps/desktop/e2e/tests/workflow-board-mutations.e2e.ts
+++ b/apps/desktop/e2e/tests/workflow-board-mutations.e2e.ts
@@ -41,7 +41,7 @@ test.describe('workflow board mutation flows', () => {
     await readyWindow.getByTestId('task-mutation-description').fill('Created through Electron mutation e2e flow.')
     await readyWindow.getByTestId('task-mutation-submit').click()
 
-    await readyWindow.getByText('Show tasks').click()
+    await readyWindow.getByTestId('slice-task-toggle-KAT-2247').click()
     await expect(readyWindow.getByText('Created from board mutation test')).toBeVisible()
 
     await readyWindow.getByTestId('task-edit-KAT-2252').click()

--- a/apps/desktop/e2e/tests/workflow-board-mutations.e2e.ts
+++ b/apps/desktop/e2e/tests/workflow-board-mutations.e2e.ts
@@ -1,0 +1,59 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from '../fixtures/electron.fixture'
+
+async function startMockRuntime(page: Page) {
+  await expect(page.getByRole('heading', { name: /Workflow Board/i })).toBeVisible()
+
+  await page.evaluate(async () => {
+    await window.api.symphony.start()
+  })
+
+  await page.getByRole('button', { name: /Refresh workflow board/i }).click()
+}
+
+async function selectMoveOption(page: Page, triggerTestId: string, optionText: string) {
+  await page.getByTestId(triggerTestId).click()
+  await page.getByRole('option', { name: optionText }).click()
+}
+
+test.describe('workflow board mutation flows', () => {
+  test.use({ symphonyMockMode: 'kanban_assigned' })
+
+  test('proves move success and rollback visibility through the Electron runtime boundary', async ({ readyWindow }) => {
+    await startMockRuntime(readyWindow)
+
+    await selectMoveOption(readyWindow, 'slice-move-select-KAT-2247', 'Move to In Progress')
+
+    await expect(readyWindow.getByTestId('slice-move-state-KAT-2247')).toContainText('moved to In Progress')
+    await expect(readyWindow.getByTestId('kanban-column-in_progress')).toContainText('KAT-2247')
+
+    await selectMoveOption(readyWindow, 'slice-move-select-KAT-2247', 'Move to Human Review')
+
+    await expect(readyWindow.getByTestId('slice-move-state-KAT-2247')).toContainText('Mocked Linear move failure')
+    await expect(readyWindow.getByTestId('kanban-column-in_progress')).toContainText('KAT-2247')
+  })
+
+  test('proves create + edit task flows with persisted board reconciliation', async ({ readyWindow }) => {
+    await startMockRuntime(readyWindow)
+
+    await readyWindow.getByTestId('slice-add-task-KAT-2247').click()
+    await readyWindow.getByTestId('task-mutation-title').fill('Created from board mutation test')
+    await readyWindow.getByTestId('task-mutation-description').fill('Created through Electron mutation e2e flow.')
+    await readyWindow.getByTestId('task-mutation-submit').click()
+
+    await readyWindow.getByText('Show tasks').click()
+    await expect(readyWindow.getByText('Created from board mutation test')).toBeVisible()
+
+    await readyWindow.getByTestId('task-edit-KAT-2252').click()
+    await expect(readyWindow.getByTestId('task-mutation-title')).toBeVisible()
+    await readyWindow.getByTestId('task-mutation-title').fill('Edited task title from board')
+
+    await readyWindow.locator('#task-mutation-state').click()
+    await readyWindow.getByRole('option', { name: 'Agent Review' }).click()
+    await readyWindow.getByTestId('task-mutation-submit').click()
+
+    const editedTaskRow = readyWindow.locator('li', { hasText: 'Edited task title from board' })
+    await expect(editedTaskRow).toBeVisible()
+    await expect(editedTaskRow).toContainText('Agent Review')
+  })
+})

--- a/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
@@ -529,6 +529,98 @@ describe('LinearWorkflowClient', () => {
     })
   })
 
+  test('creates a child task using parent slice metadata and mapped initial column state', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                id: 'slice-1',
+                identifier: 'KAT-100',
+                title: 'Slice title',
+                team: { id: 'team-1' },
+                project: { id: 'project-1' },
+                state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              team: {
+                states: {
+                  nodes: [
+                    { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+                    { id: 'state-progress', name: 'In Progress', type: 'started' },
+                  ],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: 'task-1',
+                  identifier: 'KAT-101',
+                  title: 'New task',
+                  team: { id: 'team-1' },
+                  project: { id: 'project-1' },
+                  parent: { id: 'slice-1' },
+                  state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+    const result = await client.createChildTask({
+      parentIssueId: 'slice-1',
+      title: 'New task',
+      description: 'Task details',
+      initialColumnId: 'todo',
+    })
+
+    expect(result).toMatchObject({
+      id: 'task-1',
+      identifier: 'KAT-101',
+      title: 'New task',
+      stateName: 'Todo',
+      stateType: 'unstarted',
+    })
+  })
+
+  test('requires a task title for child task creation', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(
+      client.createChildTask({
+        parentIssueId: 'slice-1',
+        title: '   ',
+      }),
+    ).rejects.toMatchObject({
+      code: 'UNKNOWN',
+    })
+  })
+
   test('exposes structured workflow error codes', () => {
     const mapped = LinearWorkflowClient.toWorkflowError(
       new LinearWorkflowClientError('UNAUTHORIZED', 'bad key', 401),

--- a/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
@@ -655,6 +655,405 @@ describe('LinearWorkflowClient', () => {
     })
   })
 
+  test('requires a parent issue id for child task creation', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(
+      client.createChildTask({
+        parentIssueId: '   ',
+        title: 'Valid title',
+      }),
+    ).rejects.toMatchObject({
+      code: 'UNKNOWN',
+    })
+  })
+
+  test('validates issue id inputs for move/detail/update mutations', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(
+      client.moveIssueToColumn({
+        issueId: '   ',
+        targetColumnId: 'todo',
+      }),
+    ).rejects.toMatchObject({
+      code: 'UNKNOWN',
+    })
+
+    await expect(
+      client.fetchIssueDetail({
+        issueId: '   ',
+      }),
+    ).rejects.toMatchObject({
+      code: 'UNKNOWN',
+    })
+
+    await expect(
+      client.updateTask({
+        issueId: '   ',
+        title: 'Edited title',
+      }),
+    ).rejects.toMatchObject({
+      code: 'UNKNOWN',
+    })
+
+    await expect(
+      client.updateTask({
+        issueId: 'task-1',
+        title: '   ',
+      }),
+    ).rejects.toMatchObject({
+      code: 'UNKNOWN',
+    })
+  })
+
+  test('returns INVALID_CONFIG when move target issue is missing team metadata', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            issue: {
+              id: 'issue-1',
+              identifier: 'KAT-100',
+              title: 'Slice title',
+              project: { id: 'project-1' },
+              state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(
+      client.moveIssueToColumn({
+        issueId: 'issue-1',
+        targetColumnId: 'in_progress',
+      }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_CONFIG',
+    })
+  })
+
+  test('skips mutation when target column already matches current state id', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                id: 'issue-1',
+                identifier: 'KAT-100',
+                title: 'Slice title',
+                team: { id: 'team-1' },
+                project: { id: 'project-1' },
+                state: { id: 'state-progress', name: 'In Progress', type: 'started' },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              team: {
+                states: {
+                  nodes: [{ id: 'state-progress', name: 'In Progress', type: 'started' }],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    globalThis.fetch = fetchMock
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    const result = await client.moveIssueToColumn({
+      issueId: 'issue-1',
+      targetColumnId: 'in_progress',
+    })
+
+    expect(result.id).toBe('issue-1')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('applies mutation-result fallbacks when optional issue fields are missing', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                id: 'issue-1',
+                team: { id: 'team-1' },
+                state: { id: 'state-todo' },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              team: {
+                states: {
+                  nodes: [{ id: 'state-todo', name: 'Todo', type: 'unstarted' }],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    const result = await client.moveIssueToColumn({
+      issueId: 'issue-1',
+      targetColumnId: 'todo',
+    })
+
+    expect(result).toMatchObject({
+      id: 'issue-1',
+      teamId: 'team-1',
+      identifier: undefined,
+      title: undefined,
+      projectId: undefined,
+      stateName: 'Unknown',
+      stateType: 'unknown',
+    })
+  })
+
+  test('uses current state fallback when target column already matches and no state mapping exists', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                id: 'issue-1',
+                identifier: 'KAT-100',
+                title: 'Slice title',
+                team: { id: 'team-1' },
+                project: { id: 'project-1' },
+                state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              team: {
+                states: {
+                  nodes: [{ id: 'state-progress', name: 'Doing', type: 'started' }],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    globalThis.fetch = fetchMock
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    const result = await client.moveIssueToColumn({
+      issueId: 'issue-1',
+      targetColumnId: 'todo',
+    })
+
+    expect(result.stateId).toBe('state-todo')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('maps graphql not-found payloads and non-ok responses to workflow errors', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-1',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            errors: [{ message: 'project not found in workspace' }],
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+    await expect(client.fetchActiveMilestoneSnapshot({ projectRef: 'project-ref' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-1',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 500 })) as unknown as typeof fetch
+
+    await expect(client.fetchActiveMilestoneSnapshot({ projectRef: 'project-ref' })).rejects.toMatchObject({
+      code: 'NETWORK',
+      message: 'Linear API request failed with status 500',
+    })
+  })
+
+  test('returns INVALID_CONFIG when parent slice metadata is incomplete', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            issue: {
+              id: 'slice-1',
+              identifier: 'KAT-100',
+              title: 'Slice title',
+              project: { id: 'project-1' },
+              state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(
+      client.createChildTask({
+        parentIssueId: 'slice-1',
+        title: 'Task title',
+      }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_CONFIG',
+    })
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            issue: {
+              id: 'slice-1',
+              identifier: 'KAT-100',
+              title: 'Slice title',
+              team: { id: 'team-1' },
+              state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch
+
+    await expect(
+      client.createChildTask({
+        parentIssueId: 'slice-1',
+        title: 'Task title',
+      }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_CONFIG',
+    })
+  })
+
+  test('returns NOT_FOUND when task update target column cannot be mapped', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                id: 'task-1',
+                identifier: 'KAT-101',
+                title: 'Task title',
+                description: 'Task description',
+                parent: { id: 'slice-1' },
+                team: { id: 'team-1' },
+                project: { id: 'project-1' },
+                state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              team: {
+                states: {
+                  nodes: [{ id: 'state-progress', name: 'Doing', type: 'started' }],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(
+      client.updateTask({
+        issueId: 'task-1',
+        title: 'Task title',
+        targetColumnId: 'agent_review',
+      }),
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+  })
+
   test('fetches task detail for edit dialogs on demand', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 
@@ -790,6 +1189,12 @@ describe('LinearWorkflowClient', () => {
     expect(timeoutMapped).toEqual({
       code: 'NETWORK',
       message: 'Linear API request timed out',
+    })
+
+    const errorMapped = LinearWorkflowClient.toWorkflowError(new Error('unexpected failure'))
+    expect(errorMapped).toEqual({
+      code: 'UNKNOWN',
+      message: 'unexpected failure',
     })
 
     const unknownMapped = LinearWorkflowClient.toWorkflowError(42 as unknown)

--- a/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
@@ -621,6 +621,121 @@ describe('LinearWorkflowClient', () => {
     })
   })
 
+  test('fetches task detail for edit dialogs on demand', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            issue: {
+              id: 'task-1',
+              identifier: 'KAT-101',
+              title: 'Task title',
+              description: 'Task description',
+              parent: { id: 'slice-1' },
+              team: { id: 'team-1' },
+              project: { id: 'project-1' },
+              state: { id: 'state-progress', name: 'In Progress', type: 'started' },
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+    const detail = await client.fetchIssueDetail({ issueId: 'task-1' })
+
+    expect(detail).toMatchObject({
+      id: 'task-1',
+      parentId: 'slice-1',
+      title: 'Task title',
+      description: 'Task description',
+      columnId: 'in_progress',
+    })
+  })
+
+  test('updates task title/description/state through the Linear update path', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                id: 'task-1',
+                identifier: 'KAT-101',
+                title: 'Task title',
+                description: 'Task description',
+                parent: { id: 'slice-1' },
+                team: { id: 'team-1' },
+                project: { id: 'project-1' },
+                state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              team: {
+                states: {
+                  nodes: [
+                    { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+                    { id: 'state-progress', name: 'In Progress', type: 'started' },
+                  ],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueUpdate: {
+                success: true,
+                issue: {
+                  id: 'task-1',
+                  identifier: 'KAT-101',
+                  title: 'Updated task',
+                  description: 'Updated description',
+                  parent: { id: 'slice-1' },
+                  team: { id: 'team-1' },
+                  project: { id: 'project-1' },
+                  state: { id: 'state-progress', name: 'In Progress', type: 'started' },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+    const result = await client.updateTask({
+      issueId: 'task-1',
+      title: 'Updated task',
+      description: 'Updated description',
+      targetColumnId: 'in_progress',
+    })
+
+    expect(result).toMatchObject({
+      id: 'task-1',
+      title: 'Updated task',
+      description: 'Updated description',
+      columnId: 'in_progress',
+    })
+  })
+
   test('exposes structured workflow error codes', () => {
     const mapped = LinearWorkflowClient.toWorkflowError(
       new LinearWorkflowClientError('UNAUTHORIZED', 'bad key', 401),

--- a/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
@@ -405,6 +405,130 @@ describe('LinearWorkflowClient', () => {
     })
   })
 
+  test('moves an issue to a canonical column through team workflow-state mapping', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                id: 'issue-1',
+                identifier: 'KAT-100',
+                title: 'Slice title',
+                team: { id: 'team-1' },
+                project: { id: 'project-1' },
+                state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              team: {
+                states: {
+                  nodes: [
+                    { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+                    { id: 'state-progress', name: 'In Progress', type: 'started' },
+                  ],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueUpdate: {
+                success: true,
+                issue: {
+                  id: 'issue-1',
+                  identifier: 'KAT-100',
+                  title: 'Slice title',
+                  team: { id: 'team-1' },
+                  project: { id: 'project-1' },
+                  state: { id: 'state-progress', name: 'In Progress', type: 'started' },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+    const result = await client.moveIssueToColumn({
+      issueId: 'issue-1',
+      targetColumnId: 'in_progress',
+    })
+
+    expect(result).toMatchObject({
+      id: 'issue-1',
+      stateName: 'In Progress',
+      stateType: 'started',
+      teamId: 'team-1',
+      projectId: 'project-1',
+    })
+  })
+
+  test('returns NOT_FOUND when no team state maps to the target column', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                id: 'issue-1',
+                identifier: 'KAT-100',
+                title: 'Slice title',
+                team: { id: 'team-1' },
+                project: { id: 'project-1' },
+                state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              team: {
+                states: {
+                  nodes: [{ id: 'state-progress', name: 'Doing', type: 'started' }],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(
+      client.moveIssueToColumn({
+        issueId: 'issue-1',
+        targetColumnId: 'agent_review',
+      }),
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+  })
+
   test('exposes structured workflow error codes', () => {
     const mapped = LinearWorkflowClient.toWorkflowError(
       new LinearWorkflowClientError('UNAUTHORIZED', 'bad key', 401),

--- a/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
@@ -405,6 +405,40 @@ describe('LinearWorkflowClient', () => {
     })
   })
 
+  test('maps non-classified GraphQL payload errors to GRAPHQL', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                id: 'project-1',
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            errors: [{ message: 'workflow exploded' }],
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    await expect(client.fetchActiveMilestoneSnapshot({ projectRef: 'project-ref' })).rejects.toMatchObject({
+      code: 'GRAPHQL',
+      message: 'workflow exploded',
+    })
+  })
+
   test('moves an issue to a canonical column through team workflow-state mapping', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 
@@ -750,6 +784,18 @@ describe('LinearWorkflowClient', () => {
     expect(networkMapped).toEqual({
       code: 'NETWORK',
       message: 'fetch failed',
+    })
+
+    const timeoutMapped = LinearWorkflowClient.toWorkflowError(new DOMException('Aborted', 'AbortError'))
+    expect(timeoutMapped).toEqual({
+      code: 'NETWORK',
+      message: 'Linear API request timed out',
+    })
+
+    const unknownMapped = LinearWorkflowClient.toWorkflowError(42 as unknown)
+    expect(unknownMapped).toEqual({
+      code: 'UNKNOWN',
+      message: '42',
     })
   })
 })

--- a/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/linear-workflow-client.test.ts
@@ -442,7 +442,7 @@ describe('LinearWorkflowClient', () => {
   test('moves an issue to a canonical column through team workflow-state mapping', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 
-    globalThis.fetch = vi
+    const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
         new Response(
@@ -497,7 +497,9 @@ describe('LinearWorkflowClient', () => {
           }),
           { status: 200 },
         ),
-      ) as unknown as typeof fetch
+      )
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch
 
     const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
     const result = await client.moveIssueToColumn({
@@ -511,6 +513,14 @@ describe('LinearWorkflowClient', () => {
       stateType: 'started',
       teamId: 'team-1',
       projectId: 'project-1',
+    })
+
+    const mutationVariables = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body ?? '{}')).variables
+    expect(mutationVariables).toMatchObject({
+      issueId: 'issue-1',
+      input: {
+        stateId: 'state-progress',
+      },
     })
   })
 
@@ -566,7 +576,7 @@ describe('LinearWorkflowClient', () => {
   test('creates a child task using parent slice metadata and mapped initial column state', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 
-    globalThis.fetch = vi
+    const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
         new Response(
@@ -622,7 +632,9 @@ describe('LinearWorkflowClient', () => {
           }),
           { status: 200 },
         ),
-      ) as unknown as typeof fetch
+      )
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch
 
     const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
     const result = await client.createChildTask({
@@ -638,6 +650,18 @@ describe('LinearWorkflowClient', () => {
       title: 'New task',
       stateName: 'Todo',
       stateType: 'unstarted',
+    })
+
+    const mutationVariables = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body ?? '{}')).variables
+    expect(mutationVariables).toMatchObject({
+      input: {
+        title: 'New task',
+        description: 'Task details',
+        parentId: 'slice-1',
+        teamId: 'team-1',
+        projectId: 'project-1',
+        stateId: 'state-todo',
+      },
     })
   })
 
@@ -1092,7 +1116,7 @@ describe('LinearWorkflowClient', () => {
   test('updates task title/description/state through the Linear update path', async () => {
     process.env.LINEAR_API_KEY = 'linear-test-key'
 
-    globalThis.fetch = vi
+    const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
         new Response(
@@ -1151,7 +1175,9 @@ describe('LinearWorkflowClient', () => {
           }),
           { status: 200 },
         ),
-      ) as unknown as typeof fetch
+      )
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch
 
     const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
     const result = await client.updateTask({
@@ -1167,6 +1193,88 @@ describe('LinearWorkflowClient', () => {
       description: 'Updated description',
       columnId: 'in_progress',
     })
+
+    const mutationVariables = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body ?? '{}')).variables
+    expect(mutationVariables).toMatchObject({
+      issueId: 'task-1',
+      input: {
+        title: 'Updated task',
+        description: 'Updated description',
+        stateId: 'state-progress',
+      },
+    })
+  })
+
+  test('omits description from update payload when callers do not provide it', async () => {
+    process.env.LINEAR_API_KEY = 'linear-test-key'
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issue: {
+                id: 'task-1',
+                identifier: 'KAT-101',
+                title: 'Task title',
+                description: 'Existing description',
+                parent: { id: 'slice-1' },
+                team: { id: 'team-1' },
+                project: { id: 'project-1' },
+                state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueUpdate: {
+                success: true,
+                issue: {
+                  id: 'task-1',
+                  identifier: 'KAT-101',
+                  title: 'Title-only update',
+                  description: 'Existing description',
+                  parent: { id: 'slice-1' },
+                  team: { id: 'team-1' },
+                  project: { id: 'project-1' },
+                  state: { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const client = new LinearWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+    const result = await client.updateTask({
+      issueId: 'task-1',
+      title: 'Title-only update',
+    })
+
+    expect(result).toMatchObject({
+      id: 'task-1',
+      title: 'Title-only update',
+      description: 'Existing description',
+      columnId: 'todo',
+    })
+
+    const mutationVariables = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body ?? '{}')).variables
+    expect(mutationVariables).toMatchObject({
+      issueId: 'task-1',
+      input: {
+        title: 'Title-only update',
+      },
+    })
+    expect(mutationVariables.input).not.toHaveProperty('description')
   })
 
   test('exposes structured workflow error codes', () => {

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -50,6 +50,54 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.symphony?.provenance).toBe('unavailable')
   })
 
+  test('applies fixture-mode slice moves and persists them across refreshes', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    await service.getBoard()
+    const result = await service.moveEntity({
+      entityKind: 'slice',
+      entityId: 'slice-1',
+      targetColumnId: 'in_progress',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.code).toBe('COMMITTED')
+
+    const refreshed = await service.refreshBoard()
+    const inProgressCards = refreshed.snapshot.columns.find((column) => column.id === 'in_progress')?.cards ?? []
+    expect(inProgressCards.map((card) => card.id)).toContain('slice-1')
+  })
+
+  test('returns rollback failure for fixture-mode move scenarios and keeps board unchanged', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const baseline = await service.getBoard()
+    const beforeTodoIds = baseline.snapshot.columns.find((column) => column.id === 'todo')?.cards.map((card) => card.id)
+
+    const failed = await service.moveEntity({
+      entityKind: 'slice',
+      entityId: 'slice-1',
+      targetColumnId: 'human_review',
+    })
+
+    expect(failed.success).toBe(false)
+    expect(failed.code).toBe('ROLLED_BACK')
+
+    const after = await service.refreshBoard()
+    const afterTodoIds = after.snapshot.columns.find((column) => column.id === 'todo')?.cards.map((card) => card.id)
+    expect(afterTodoIds).toEqual(beforeTodoIds)
+  })
+
   test('uses assembled linear fixture in test mode when assembled symphony mock is active', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
     process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK = 'assembled_healthy'

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -73,6 +73,35 @@ describe('WorkflowBoardService', () => {
     expect(inProgressCards.map((card) => card.id)).toContain('slice-1')
   })
 
+  test('applies fixture-mode task moves and edit updates without explicit target state', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    await service.getBoard()
+
+    const moveResult = await service.moveEntity({
+      entityKind: 'task',
+      entityId: 'task-2',
+      targetColumnId: 'done',
+    })
+
+    expect(moveResult.success).toBe(true)
+    expect(moveResult.message).toContain('Task moved')
+
+    const updateResult = await service.updateTask({
+      taskId: 'task-2',
+      title: 'Task renamed without state change',
+      description: 'No explicit target column provided',
+    })
+
+    expect(updateResult.success).toBe(true)
+    expect(updateResult.task?.columnId).toBe('done')
+  })
+
   test('returns rollback failure for fixture-mode move scenarios and keeps board unchanged', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
 
@@ -96,6 +125,136 @@ describe('WorkflowBoardService', () => {
     const after = await service.refreshBoard()
     const afterTodoIds = after.snapshot.columns.find((column) => column.id === 'todo')?.cards.map((card) => card.id)
     expect(afterTodoIds).toEqual(beforeTodoIds)
+  })
+
+  test('validates mutation payloads before attempting workflow writes', async () => {
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const move = await service.moveEntity({
+      entityKind: 'slice',
+      entityId: '   ',
+      targetColumnId: 'todo',
+    })
+    expect(move.success).toBe(false)
+    expect(move.code).toBe('VALIDATION_ERROR')
+
+    const createMissingParent = await service.createTask({
+      parentSliceId: '   ',
+      title: 'Task title',
+    })
+    expect(createMissingParent.success).toBe(false)
+    expect(createMissingParent.code).toBe('VALIDATION_ERROR')
+
+    const createMissingTitle = await service.createTask({
+      parentSliceId: 'slice-1',
+      title: '   ',
+    })
+    expect(createMissingTitle.success).toBe(false)
+    expect(createMissingTitle.code).toBe('VALIDATION_ERROR')
+
+    const missingTaskDetail = await service.getTaskDetail({ taskId: '   ' })
+    expect(missingTaskDetail.success).toBe(false)
+    expect(missingTaskDetail.code).toBe('FAILED')
+
+    const updateMissingTaskId = await service.updateTask({
+      taskId: '   ',
+      title: 'Task title',
+    })
+    expect(updateMissingTaskId.success).toBe(false)
+    expect(updateMissingTaskId.code).toBe('VALIDATION_ERROR')
+
+    const updateMissingTitle = await service.updateTask({
+      taskId: 'task-1',
+      title: '   ',
+    })
+    expect(updateMissingTitle.success).toBe(false)
+    expect(updateMissingTitle.code).toBe('VALIDATION_ERROR')
+  })
+
+  test('returns not-found mutation responses when target entities are no longer visible', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    await service.getBoard()
+
+    const moveMissing = await service.moveEntity({
+      entityKind: 'task',
+      entityId: 'missing-task',
+      targetColumnId: 'todo',
+    })
+    expect(moveMissing.success).toBe(false)
+    expect(moveMissing.code).toBe('NOT_FOUND')
+
+    const createMissingParent = await service.createTask({
+      parentSliceId: 'missing-slice',
+      title: 'Task title',
+    })
+    expect(createMissingParent.success).toBe(false)
+    expect(createMissingParent.code).toBe('NOT_FOUND')
+
+    const detailMissing = await service.getTaskDetail({ taskId: 'missing-task' })
+    expect(detailMissing.success).toBe(false)
+    expect(detailMissing.code).toBe('NOT_FOUND')
+
+    const updateMissing = await service.updateTask({
+      taskId: 'missing-task',
+      title: 'Task title',
+    })
+    expect(updateMissing.success).toBe(false)
+    expect(updateMissing.code).toBe('NOT_FOUND')
+  })
+
+  test('returns unsupported mutation responses when board backend is not linear', async () => {
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    ;(service as any).lastSnapshot = {
+      backend: 'github',
+      fetchedAt: '2026-04-06T00:00:00.000Z',
+      status: 'fresh',
+      source: { repository: 'kata-sh/kata', mode: 'labels' },
+      columns: [],
+      poll: {
+        status: 'success',
+        backend: 'github',
+        lastAttemptAt: '2026-04-06T00:00:00.000Z',
+      },
+    }
+
+    const move = await service.moveEntity({
+      entityKind: 'slice',
+      entityId: 'slice-1',
+      targetColumnId: 'todo',
+    })
+    expect(move.success).toBe(false)
+    expect(move.code).toBe('UNSUPPORTED')
+
+    const create = await service.createTask({
+      parentSliceId: 'slice-1',
+      title: 'Task title',
+    })
+    expect(create.success).toBe(false)
+    expect(create.code).toBe('UNSUPPORTED')
+
+    const detail = await service.getTaskDetail({ taskId: 'task-1' })
+    expect(detail.success).toBe(false)
+    expect(detail.code).toBe('UNSUPPORTED')
+
+    const update = await service.updateTask({
+      taskId: 'task-1',
+      title: 'Task title',
+    })
+    expect(update.success).toBe(false)
+    expect(update.code).toBe('UNSUPPORTED')
   })
 
   test('creates fixture-mode child tasks and keeps them visible after refresh', async () => {

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -140,6 +140,68 @@ describe('WorkflowBoardService', () => {
     expect(failed.code).toBe('ROLLED_BACK')
   })
 
+  test('loads fixture-mode task detail for task edit dialog hydration', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    await service.getBoard()
+    const detail = await service.getTaskDetail({ taskId: 'task-2' })
+
+    expect(detail.success).toBe(true)
+    expect(detail.code).toBe('LOADED')
+    expect(detail.task?.id).toBe('task-2')
+    expect(detail.task?.columnId).toBe('in_progress')
+  })
+
+  test('updates fixture-mode tasks and persists edit changes after refresh', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    await service.getBoard()
+    const updated = await service.updateTask({
+      taskId: 'task-2',
+      title: 'Edited task title',
+      description: 'Edited task description',
+      targetColumnId: 'agent_review',
+    })
+
+    expect(updated.success).toBe(true)
+    expect(updated.code).toBe('UPDATED')
+
+    const refreshed = await service.refreshBoard()
+    const parentCard = refreshed.snapshot.columns.flatMap((column) => column.cards).find((card) => card.id === 'slice-1')
+    const editedTask = parentCard?.tasks.find((task) => task.id === 'task-2')
+    expect(editedTask?.title).toBe('Edited task title')
+    expect(editedTask?.columnId).toBe('agent_review')
+  })
+
+  test('returns rollback failure for fixture-mode task edit rejection', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const failed = await service.updateTask({
+      taskId: 'task-2',
+      title: 'fail this edit path',
+      description: 'Should trigger rollback',
+      targetColumnId: 'todo',
+    })
+
+    expect(failed.success).toBe(false)
+    expect(failed.code).toBe('ROLLED_BACK')
+  })
+
   test('uses assembled linear fixture in test mode when assembled symphony mock is active', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
     process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK = 'assembled_healthy'

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -278,7 +278,9 @@ describe('WorkflowBoardService', () => {
 
     const refreshed = await service.refreshBoard()
     const todoCard = refreshed.snapshot.columns.flatMap((column) => column.cards).find((card) => card.id === 'slice-1')
-    expect(todoCard?.tasks.some((task) => task.title === 'Create task from board')).toBe(true)
+    const createdTask = todoCard?.tasks.find((task) => task.title === 'Create task from board')
+    expect(createdTask).toBeDefined()
+    expect(createdTask?.description).toBe('Task details')
   })
 
   test('returns rollback failure for fixture-mode create-task rejection', async () => {
@@ -314,6 +316,7 @@ describe('WorkflowBoardService', () => {
     expect(detail.code).toBe('LOADED')
     expect(detail.task?.id).toBe('task-2')
     expect(detail.task?.columnId).toBe('in_progress')
+    expect(detail.task?.description).toBe('Fixture task used for edit-dialog hydration and mutation coverage.')
   })
 
   test('updates fixture-mode tasks and persists edit changes after refresh', async () => {
@@ -339,6 +342,7 @@ describe('WorkflowBoardService', () => {
     const parentCard = refreshed.snapshot.columns.flatMap((column) => column.cards).find((card) => card.id === 'slice-1')
     const editedTask = parentCard?.tasks.find((task) => task.id === 'task-2')
     expect(editedTask?.title).toBe('Edited task title')
+    expect(editedTask?.description).toBe('Edited task description')
     expect(editedTask?.columnId).toBe('agent_review')
   })
 

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -98,6 +98,48 @@ describe('WorkflowBoardService', () => {
     expect(afterTodoIds).toEqual(beforeTodoIds)
   })
 
+  test('creates fixture-mode child tasks and keeps them visible after refresh', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    await service.getBoard()
+    const result = await service.createTask({
+      parentSliceId: 'slice-1',
+      title: 'Create task from board',
+      description: 'Task details',
+      initialColumnId: 'todo',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.code).toBe('CREATED')
+
+    const refreshed = await service.refreshBoard()
+    const todoCard = refreshed.snapshot.columns.flatMap((column) => column.cards).find((card) => card.id === 'slice-1')
+    expect(todoCard?.tasks.some((task) => task.title === 'Create task from board')).toBe(true)
+  })
+
+  test('returns rollback failure for fixture-mode create-task rejection', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const failed = await service.createTask({
+      parentSliceId: 'slice-1',
+      title: 'fail this create path',
+      description: 'Should trigger rollback',
+    })
+
+    expect(failed.success).toBe(false)
+    expect(failed.code).toBe('ROLLED_BACK')
+  })
+
   test('uses assembled linear fixture in test mode when assembled symphony mock is active', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
     process.env.KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK = 'assembled_healthy'

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -183,6 +183,118 @@ describe('WorkflowBoardService', () => {
     expect(editedTask?.columnId).toBe('agent_review')
   })
 
+  test('maps fixture-mode task updates to backlog and done state types', async () => {
+    process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    await service.getBoard()
+
+    const backlogMove = await service.updateTask({
+      taskId: 'task-2',
+      title: 'Task moved to backlog',
+      description: 'Backlog transition coverage',
+      targetColumnId: 'backlog',
+    })
+
+    expect(backlogMove.success).toBe(true)
+    expect(backlogMove.task?.columnId).toBe('backlog')
+
+    const afterBacklogRefresh = await service.refreshBoard()
+    const cardAfterBacklog = afterBacklogRefresh.snapshot.columns
+      .flatMap((column) => column.cards)
+      .find((card) => card.id === 'slice-1')
+    const taskAfterBacklog = cardAfterBacklog?.tasks.find((task) => task.id === 'task-2')
+
+    expect(taskAfterBacklog?.columnId).toBe('backlog')
+    expect(taskAfterBacklog?.stateType).toBe('backlog')
+
+    const doneMove = await service.updateTask({
+      taskId: 'task-2',
+      title: 'Task moved to done',
+      description: 'Done transition coverage',
+      targetColumnId: 'done',
+    })
+
+    expect(doneMove.success).toBe(true)
+    expect(doneMove.task?.columnId).toBe('done')
+
+    const refreshed = await service.refreshBoard()
+    const parentCard = refreshed.snapshot.columns.flatMap((column) => column.cards).find((card) => card.id === 'slice-1')
+    const updatedTask = parentCard?.tasks.find((task) => task.id === 'task-2')
+
+    expect(updatedTask?.columnId).toBe('done')
+    expect(updatedTask?.stateType).toBe('completed')
+    expect(parentCard?.taskCounts.done).toBeGreaterThanOrEqual(1)
+  })
+
+  test('active-scope projection treats cards without symphony summaries as inactive', async () => {
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    service.setScope({ scopeKey: 'workspace:a::session:b::scope:active', requestedScope: 'active' })
+
+    const scoped = (service as any).resolveScope({
+      backend: 'linear',
+      fetchedAt: '2026-04-06T00:00:00.000Z',
+      status: 'fresh',
+      source: { projectId: 'project-ref' },
+      activeMilestone: { id: 'milestone-1', name: '[M001] Demo' },
+      columns: [
+        {
+          id: 'todo',
+          title: 'Todo',
+          cards: [
+            {
+              id: 'slice-1',
+              identifier: 'KAT-2247',
+              title: 'No symphony card',
+              columnId: 'todo',
+              stateName: 'Todo',
+              stateType: 'unstarted',
+              milestoneId: 'milestone-1',
+              milestoneName: '[M001] Demo',
+              taskCounts: { total: 1, done: 0 },
+              tasks: [
+                {
+                  id: 'task-1',
+                  identifier: 'KAT-2250',
+                  title: 'No symphony task',
+                  columnId: 'todo',
+                  stateName: 'Todo',
+                  stateType: 'unstarted',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      symphony: {
+        provenance: 'dashboard-derived',
+        freshness: 'fresh',
+        fetchedAt: '2026-04-06T00:00:00.000Z',
+        workerCount: 0,
+        escalationCount: 0,
+        diagnostics: { correlationMisses: [] },
+      },
+      poll: {
+        status: 'success',
+        backend: 'linear',
+        lastAttemptAt: '2026-04-06T00:00:00.000Z',
+        lastSuccessAt: '2026-04-06T00:00:00.000Z',
+      },
+    })
+
+    expect(scoped.scope?.requested).toBe('active')
+    expect(scoped.scope?.resolved).toBe('active')
+    expect(scoped.columns.find((column: { id: string }) => column.id === 'todo')?.cards).toHaveLength(0)
+  })
+
   test('returns rollback failure for fixture-mode task edit rejection', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -52,6 +52,10 @@ import {
   type WorkflowMoveEntityResult,
   type WorkflowCreateTaskRequest,
   type WorkflowCreateTaskResult,
+  type WorkflowTaskDetailRequest,
+  type WorkflowTaskDetailResponse,
+  type WorkflowUpdateTaskRequest,
+  type WorkflowUpdateTaskResult,
   type WorkflowBoardEscalationResponseRequest,
   type WorkflowBoardEscalationResponseResult,
   type WorkflowBoardOpenIssueRequest,
@@ -592,6 +596,8 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
   ipcMain.removeHandler(IPC_CHANNELS.workflowMoveEntity)
   ipcMain.removeHandler(IPC_CHANNELS.workflowCreateTask)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowGetTaskDetail)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowUpdateTask)
   ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
   ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
   ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
@@ -1227,6 +1233,20 @@ export function registerSessionIpc({
   )
 
   ipcMain.handle(
+    IPC_CHANNELS.workflowGetTaskDetail,
+    async (_event, request: WorkflowTaskDetailRequest): Promise<WorkflowTaskDetailResponse> => {
+      return workflowBoardService.getTaskDetail(request)
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.workflowUpdateTask,
+    async (_event, request: WorkflowUpdateTaskRequest): Promise<WorkflowUpdateTaskResult> => {
+      return workflowBoardService.updateTask(request)
+    },
+  )
+
+  ipcMain.handle(
     IPC_CHANNELS.workflowRespondEscalation,
     async (_event, request: WorkflowBoardEscalationResponseRequest): Promise<WorkflowBoardEscalationResponseResult> => {
       if (!symphonyOperatorService) {
@@ -1530,6 +1550,8 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
     ipcMain.removeHandler(IPC_CHANNELS.workflowMoveEntity)
     ipcMain.removeHandler(IPC_CHANNELS.workflowCreateTask)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowGetTaskDetail)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowUpdateTask)
     ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
     ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
     ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -48,6 +48,8 @@ import {
   type WorkflowBoardLifecycleResponse,
   type WorkflowBoardScopeRequest,
   type WorkflowBoardScopeResponse,
+  type WorkflowMoveEntityRequest,
+  type WorkflowMoveEntityResult,
   type WorkflowBoardEscalationResponseRequest,
   type WorkflowBoardEscalationResponseResult,
   type WorkflowBoardOpenIssueRequest,
@@ -586,6 +588,7 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.workflowRefreshBoard)
   ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
   ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowMoveEntity)
   ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
   ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
   ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
@@ -1207,6 +1210,13 @@ export function registerSessionIpc({
   )
 
   ipcMain.handle(
+    IPC_CHANNELS.workflowMoveEntity,
+    async (_event, request: WorkflowMoveEntityRequest): Promise<WorkflowMoveEntityResult> => {
+      return workflowBoardService.moveEntity(request)
+    },
+  )
+
+  ipcMain.handle(
     IPC_CHANNELS.workflowRespondEscalation,
     async (_event, request: WorkflowBoardEscalationResponseRequest): Promise<WorkflowBoardEscalationResponseResult> => {
       if (!symphonyOperatorService) {
@@ -1508,6 +1518,7 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.workflowRefreshBoard)
     ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
     ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowMoveEntity)
     ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
     ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
     ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -50,6 +50,8 @@ import {
   type WorkflowBoardScopeResponse,
   type WorkflowMoveEntityRequest,
   type WorkflowMoveEntityResult,
+  type WorkflowCreateTaskRequest,
+  type WorkflowCreateTaskResult,
   type WorkflowBoardEscalationResponseRequest,
   type WorkflowBoardEscalationResponseResult,
   type WorkflowBoardOpenIssueRequest,
@@ -589,6 +591,7 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
   ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
   ipcMain.removeHandler(IPC_CHANNELS.workflowMoveEntity)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowCreateTask)
   ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
   ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
   ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
@@ -1217,6 +1220,13 @@ export function registerSessionIpc({
   )
 
   ipcMain.handle(
+    IPC_CHANNELS.workflowCreateTask,
+    async (_event, request: WorkflowCreateTaskRequest): Promise<WorkflowCreateTaskResult> => {
+      return workflowBoardService.createTask(request)
+    },
+  )
+
+  ipcMain.handle(
     IPC_CHANNELS.workflowRespondEscalation,
     async (_event, request: WorkflowBoardEscalationResponseRequest): Promise<WorkflowBoardEscalationResponseResult> => {
       if (!symphonyOperatorService) {
@@ -1519,6 +1529,7 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.workflowSetBoardActive)
     ipcMain.removeHandler(IPC_CHANNELS.workflowSetScope)
     ipcMain.removeHandler(IPC_CHANNELS.workflowMoveEntity)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowCreateTask)
     ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
     ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
     ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)

--- a/apps/desktop/src/main/linear-workflow-client.ts
+++ b/apps/desktop/src/main/linear-workflow-client.ts
@@ -499,7 +499,7 @@ export class LinearWorkflowClient {
         issueId,
         input: {
           title,
-          description: options.description ?? '',
+          ...(options.description !== undefined ? { description: options.description } : {}),
           ...(stateId ? { stateId } : {}),
         },
       },
@@ -1089,6 +1089,7 @@ export function normalizeLinearBoard(input: {
             id: task.id as string,
             identifier: task.identifier,
             title: task.title as string,
+            description: task.description ?? '',
             columnId: taskColumnId,
             stateId: task.state?.id?.trim() || undefined,
             stateName: task.state?.name?.trim() || 'Unknown',

--- a/apps/desktop/src/main/linear-workflow-client.ts
+++ b/apps/desktop/src/main/linear-workflow-client.ts
@@ -163,6 +163,12 @@ export interface LinearIssueMutationResult {
   projectId?: string
 }
 
+export interface LinearIssueDetailResult extends LinearIssueMutationResult {
+  description: string
+  parentId?: string
+  columnId: WorkflowColumnId
+}
+
 export class LinearWorkflowClientError extends Error {
   constructor(
     public readonly code: WorkflowBoardErrorCode,
@@ -396,6 +402,114 @@ export class LinearWorkflowClient {
     }
 
     return toLinearIssueMutationResult(data.issueCreate.issue)
+  }
+
+  async fetchIssueDetail(options: { issueId: string }): Promise<LinearIssueDetailResult> {
+    const issueId = options.issueId.trim()
+    if (!issueId) {
+      throw new LinearWorkflowClientError('UNKNOWN', 'Issue id is required for task detail fetch')
+    }
+
+    const apiKey = await this.requireApiKey()
+    const issue = await this.fetchIssueForMutation(apiKey, issueId)
+    if (!issue.id?.trim()) {
+      throw new LinearWorkflowClientError('NOT_FOUND', `Issue ${issueId} was not found in Linear`)
+    }
+
+    return toLinearIssueDetailResult(issue)
+  }
+
+  async updateTask(options: {
+    issueId: string
+    title: string
+    description?: string
+    targetColumnId?: WorkflowColumnId
+  }): Promise<LinearIssueDetailResult> {
+    const issueId = options.issueId.trim()
+    if (!issueId) {
+      throw new LinearWorkflowClientError('UNKNOWN', 'Issue id is required for task update')
+    }
+
+    const title = options.title.trim()
+    if (!title) {
+      throw new LinearWorkflowClientError('UNKNOWN', 'Task title is required')
+    }
+
+    const apiKey = await this.requireApiKey()
+    const currentIssue = await this.fetchIssueForMutation(apiKey, issueId)
+    if (!currentIssue.id?.trim()) {
+      throw new LinearWorkflowClientError('NOT_FOUND', `Issue ${issueId} was not found in Linear`)
+    }
+
+    const teamId = currentIssue.team?.id?.trim()
+    if (!teamId) {
+      throw new LinearWorkflowClientError('INVALID_CONFIG', `Issue ${issueId} is missing team metadata`)
+    }
+
+    let stateId: string | undefined
+    if (options.targetColumnId) {
+      stateId =
+        (await this.resolveStateIdForColumn(apiKey, {
+          teamId,
+          targetColumnId: options.targetColumnId,
+          currentStateId: currentIssue.state?.id?.trim(),
+          currentStateName: currentIssue.state?.name?.trim(),
+          currentStateType: currentIssue.state?.type?.trim(),
+        })) ?? undefined
+
+      if (!stateId) {
+        throw new LinearWorkflowClientError(
+          'NOT_FOUND',
+          `No Linear workflow state mapped to column "${options.targetColumnId}" for team ${teamId}`,
+        )
+      }
+    }
+
+    const data = await this.request<IssueUpdateMutationData>(
+      apiKey,
+      `
+        mutation WorkflowTaskUpdate($issueId: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $issueId, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              title
+              description
+              url
+              parent {
+                id
+              }
+              team {
+                id
+              }
+              project {
+                id
+              }
+              state {
+                id
+                name
+                type
+              }
+            }
+          }
+        }
+      `,
+      {
+        issueId,
+        input: {
+          title,
+          description: options.description ?? '',
+          ...(stateId ? { stateId } : {}),
+        },
+      },
+    )
+
+    if (!data.issueUpdate?.success || !data.issueUpdate.issue) {
+      throw new LinearWorkflowClientError('UNKNOWN', `Linear issue update failed for ${issueId}`)
+    }
+
+    return toLinearIssueDetailResult(data.issueUpdate.issue)
   }
 
   static toWorkflowError(error: unknown): { code: WorkflowBoardErrorCode; message: string } {
@@ -924,6 +1038,16 @@ function toLinearIssueMutationResult(issue: LinearWorkflowIssue): LinearIssueMut
     stateType: issue.state?.type?.trim() || 'unknown',
     teamId: issue.team?.id?.trim() || undefined,
     projectId: issue.project?.id?.trim() || undefined,
+  }
+}
+
+function toLinearIssueDetailResult(issue: LinearWorkflowIssue): LinearIssueDetailResult {
+  const mutationResult = toLinearIssueMutationResult(issue)
+  return {
+    ...mutationResult,
+    description: issue.description ?? '',
+    parentId: issue.parent?.id?.trim() || undefined,
+    columnId: mapLinearStateToColumnId(mutationResult.stateName, mutationResult.stateType),
   }
 }
 

--- a/apps/desktop/src/main/linear-workflow-client.ts
+++ b/apps/desktop/src/main/linear-workflow-client.ts
@@ -110,6 +110,13 @@ interface IssueUpdateMutationData {
   } | null
 }
 
+interface IssueCreateMutationData {
+  issueCreate?: {
+    success?: boolean
+    issue?: LinearWorkflowIssue | null
+  } | null
+}
+
 interface ResolveProjectQueryData {
   project?: {
     id?: string
@@ -294,6 +301,101 @@ export class LinearWorkflowClient {
 
     const updatedIssue = await this.updateIssueState(apiKey, issue.id, targetStateId)
     return toLinearIssueMutationResult(updatedIssue)
+  }
+
+  async createChildTask(options: {
+    parentIssueId: string
+    title: string
+    description?: string
+    initialColumnId?: WorkflowColumnId
+  }): Promise<LinearIssueMutationResult> {
+    const parentIssueId = options.parentIssueId.trim()
+    if (!parentIssueId) {
+      throw new LinearWorkflowClientError('UNKNOWN', 'Parent issue id is required for task creation')
+    }
+
+    const title = options.title.trim()
+    if (!title) {
+      throw new LinearWorkflowClientError('UNKNOWN', 'Task title is required')
+    }
+
+    const apiKey = await this.requireApiKey()
+    const parentIssue = await this.fetchIssueForMutation(apiKey, parentIssueId)
+
+    if (!parentIssue.id?.trim()) {
+      throw new LinearWorkflowClientError('NOT_FOUND', `Parent issue ${parentIssueId} was not found`)
+    }
+
+    const teamId = parentIssue.team?.id?.trim()
+    if (!teamId) {
+      throw new LinearWorkflowClientError('INVALID_CONFIG', `Parent issue ${parentIssueId} is missing team metadata`)
+    }
+
+    const projectId = parentIssue.project?.id?.trim()
+    if (!projectId) {
+      throw new LinearWorkflowClientError('INVALID_CONFIG', `Parent issue ${parentIssueId} is missing project metadata`)
+    }
+
+    const initialColumnId = options.initialColumnId ?? 'todo'
+    const stateId = await this.resolveStateIdForColumn(apiKey, {
+      teamId,
+      targetColumnId: initialColumnId,
+    })
+
+    if (!stateId) {
+      throw new LinearWorkflowClientError(
+        'NOT_FOUND',
+        `No Linear workflow state mapped to column "${initialColumnId}" for team ${teamId}`,
+      )
+    }
+
+    const data = await this.request<IssueCreateMutationData>(
+      apiKey,
+      `
+        mutation WorkflowCreateChildTask($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue {
+              id
+              identifier
+              title
+              description
+              url
+              parent {
+                id
+              }
+              team {
+                id
+              }
+              project {
+                id
+              }
+              state {
+                id
+                name
+                type
+              }
+            }
+          }
+        }
+      `,
+      {
+        input: {
+          title,
+          description: options.description?.trim() || undefined,
+          parentId: parentIssue.id,
+          teamId,
+          projectId,
+          stateId,
+        },
+      },
+    )
+
+    if (!data.issueCreate?.success || !data.issueCreate.issue) {
+      throw new LinearWorkflowClientError('UNKNOWN', `Linear issue create failed for parent ${parentIssueId}`)
+    }
+
+    return toLinearIssueMutationResult(data.issueCreate.issue)
   }
 
   static toWorkflowError(error: unknown): { code: WorkflowBoardErrorCode; message: string } {

--- a/apps/desktop/src/main/linear-workflow-client.ts
+++ b/apps/desktop/src/main/linear-workflow-client.ts
@@ -23,12 +23,30 @@ const EXACT_NAME_TO_COLUMN_ID: Record<string, WorkflowColumnId> = {
   done: 'done',
 }
 
+const COLUMN_ID_TO_PREFERRED_STATE_NAMES: Record<WorkflowColumnId, string[]> = {
+  backlog: ['Backlog'],
+  todo: ['Todo'],
+  in_progress: ['In Progress'],
+  agent_review: ['Agent Review'],
+  human_review: ['Human Review'],
+  merging: ['Merging'],
+  done: ['Done'],
+}
+
+const COLUMN_ID_TO_FALLBACK_STATE_TYPES: Partial<Record<WorkflowColumnId, string[]>> = {
+  backlog: ['backlog'],
+  todo: ['unstarted'],
+  in_progress: ['started'],
+  done: ['completed', 'canceled'],
+}
+
 interface GraphQLResponse<TData> {
   data?: TData
   errors?: Array<{ message?: string }>
 }
 
 interface LinearWorkflowState {
+  id?: string
   name?: string
   type?: string
 }
@@ -44,16 +62,51 @@ interface LinearWorkflowPageInfo {
   endCursor?: string | null
 }
 
+interface LinearWorkflowTeamRef {
+  id?: string
+}
+
+interface LinearWorkflowProjectRef {
+  id?: string
+}
+
 interface LinearWorkflowIssue {
   id?: string
   identifier?: string
   title?: string
+  description?: string
+  url?: string
   parent?: { id?: string } | null
+  team?: LinearWorkflowTeamRef | null
+  project?: LinearWorkflowProjectRef | null
   state?: LinearWorkflowState | null
   projectMilestone?: LinearWorkflowMilestone | null
   children?: {
     nodes?: LinearWorkflowIssue[]
     pageInfo?: LinearWorkflowPageInfo
+  } | null
+}
+
+interface WorkflowIssueForMutationQueryData {
+  issue?: LinearWorkflowIssue | null
+}
+
+interface TeamWorkflowStatesQueryData {
+  team?: {
+    states?: {
+      nodes?: Array<{
+        id?: string
+        name?: string
+        type?: string
+      }>
+    } | null
+  } | null
+}
+
+interface IssueUpdateMutationData {
+  issueUpdate?: {
+    success?: boolean
+    issue?: LinearWorkflowIssue | null
   } | null
 }
 
@@ -89,6 +142,18 @@ interface WorkflowIssueChildrenQueryData {
 
 export interface FetchLinearBoardOptions {
   projectRef: string
+}
+
+export interface LinearIssueMutationResult {
+  id: string
+  identifier?: string
+  title?: string
+  url?: string
+  stateId?: string
+  stateName: string
+  stateType: string
+  teamId?: string
+  projectId?: string
 }
 
 export class LinearWorkflowClientError extends Error {
@@ -187,6 +252,50 @@ export class LinearWorkflowClient {
     return snapshot
   }
 
+  async moveIssueToColumn(options: {
+    issueId: string
+    targetColumnId: WorkflowColumnId
+  }): Promise<LinearIssueMutationResult> {
+    const issueId = options.issueId.trim()
+    if (!issueId) {
+      throw new LinearWorkflowClientError('UNKNOWN', 'Issue id is required for workflow mutation')
+    }
+
+    const apiKey = await this.requireApiKey()
+    const issue = await this.fetchIssueForMutation(apiKey, issueId)
+
+    if (!issue.id?.trim()) {
+      throw new LinearWorkflowClientError('NOT_FOUND', `Issue ${issueId} was not found in Linear`)
+    }
+
+    const teamId = issue.team?.id?.trim()
+    if (!teamId) {
+      throw new LinearWorkflowClientError('INVALID_CONFIG', `Issue ${issueId} is missing team metadata`)
+    }
+
+    const targetStateId = await this.resolveStateIdForColumn(apiKey, {
+      teamId,
+      targetColumnId: options.targetColumnId,
+      currentStateId: issue.state?.id?.trim(),
+      currentStateName: issue.state?.name?.trim(),
+      currentStateType: issue.state?.type?.trim(),
+    })
+
+    if (!targetStateId) {
+      throw new LinearWorkflowClientError(
+        'NOT_FOUND',
+        `No Linear workflow state mapped to column "${options.targetColumnId}" for team ${teamId}`,
+      )
+    }
+
+    if (issue.state?.id?.trim() === targetStateId) {
+      return toLinearIssueMutationResult(issue)
+    }
+
+    const updatedIssue = await this.updateIssueState(apiKey, issue.id, targetStateId)
+    return toLinearIssueMutationResult(updatedIssue)
+  }
+
   static toWorkflowError(error: unknown): { code: WorkflowBoardErrorCode; message: string } {
     const mapped = toLinearWorkflowClientError(error)
     return {
@@ -267,10 +376,19 @@ export class LinearWorkflowClient {
                 id
                 identifier
                 title
+                description
+                url
                 parent {
                   id
                 }
+                team {
+                  id
+                }
+                project {
+                  id
+                }
                 state {
+                  id
                   name
                   type
                 }
@@ -284,7 +402,19 @@ export class LinearWorkflowClient {
                     id
                     identifier
                     title
+                    description
+                    url
+                    parent {
+                      id
+                    }
+                    team {
+                      id
+                    }
+                    project {
+                      id
+                    }
                     state {
+                      id
                       name
                       type
                     }
@@ -351,9 +481,20 @@ export class LinearWorkflowClient {
                   identifier
                   title
                   state {
+                    id
                     name
                     type
                   }
+                  team {
+                    id
+                  }
+                  project {
+                    id
+                  }
+                  parent {
+                    id
+                  }
+                  url
                 }
                 pageInfo {
                   hasNextPage
@@ -375,10 +516,143 @@ export class LinearWorkflowClient {
     return children
   }
 
+  private async fetchIssueForMutation(apiKey: string, issueId: string): Promise<LinearWorkflowIssue> {
+    const data = await this.request<WorkflowIssueForMutationQueryData>(
+      apiKey,
+      `
+        query WorkflowIssueForMutation($issueId: String!) {
+          issue(id: $issueId) {
+            id
+            identifier
+            title
+            description
+            url
+            parent {
+              id
+            }
+            team {
+              id
+            }
+            project {
+              id
+            }
+            projectMilestone {
+              id
+              name
+            }
+            state {
+              id
+              name
+              type
+            }
+          }
+        }
+      `,
+      { issueId },
+    )
+
+    return data.issue ?? {}
+  }
+
+  private async resolveStateIdForColumn(
+    apiKey: string,
+    options: {
+      teamId: string
+      targetColumnId: WorkflowColumnId
+      currentStateId?: string
+      currentStateName?: string
+      currentStateType?: string
+    },
+  ): Promise<string | null> {
+    const data = await this.request<TeamWorkflowStatesQueryData>(
+      apiKey,
+      `
+        query WorkflowTeamStates($teamId: String!) {
+          team(id: $teamId) {
+            states {
+              nodes {
+                id
+                name
+                type
+              }
+            }
+          }
+        }
+      `,
+      { teamId: options.teamId },
+    )
+
+    const states = data.team?.states?.nodes ?? []
+    const preferredState = selectWorkflowStateForColumn(states, options.targetColumnId)
+
+    if (preferredState?.id?.trim()) {
+      return preferredState.id.trim()
+    }
+
+    if (options.currentStateId && options.currentStateName) {
+      const currentColumn = mapLinearStateToColumnId(options.currentStateName, options.currentStateType)
+      if (currentColumn === options.targetColumnId) {
+        return options.currentStateId
+      }
+    }
+
+    return null
+  }
+
+  private async updateIssueState(apiKey: string, issueId: string, stateId: string): Promise<LinearWorkflowIssue> {
+    const data = await this.request<IssueUpdateMutationData>(
+      apiKey,
+      `
+        mutation WorkflowIssueMove($issueId: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $issueId, input: $input) {
+            success
+            issue {
+              id
+              identifier
+              title
+              description
+              url
+              parent {
+                id
+              }
+              team {
+                id
+              }
+              project {
+                id
+              }
+              projectMilestone {
+                id
+                name
+              }
+              state {
+                id
+                name
+                type
+              }
+            }
+          }
+        }
+      `,
+      {
+        issueId,
+        input: {
+          stateId,
+        },
+      },
+    )
+
+    if (!data.issueUpdate?.success || !data.issueUpdate.issue) {
+      throw new LinearWorkflowClientError('UNKNOWN', `Linear issue update failed for ${issueId}`)
+    }
+
+    return data.issueUpdate.issue
+  }
+
   private async request<TData>(
     apiKey: string,
     query: string,
-    variables: Record<string, string | null>,
+    variables: Record<string, unknown>,
   ): Promise<TData> {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => {
@@ -510,6 +784,47 @@ export function mapLinearStateToColumnId(
   return 'todo'
 }
 
+function selectWorkflowStateForColumn(
+  states: Array<{ id?: string; name?: string; type?: string }>,
+  targetColumnId: WorkflowColumnId,
+): { id?: string; name?: string; type?: string } | null {
+  if (states.length === 0) {
+    return null
+  }
+
+  const preferredNames = COLUMN_ID_TO_PREFERRED_STATE_NAMES[targetColumnId] ?? []
+  for (const preferredName of preferredNames) {
+    const match = states.find((state) => state.name?.trim().toLowerCase() === preferredName.toLowerCase())
+    if (match?.id?.trim()) {
+      return match
+    }
+  }
+
+  const fallbackTypes = COLUMN_ID_TO_FALLBACK_STATE_TYPES[targetColumnId] ?? []
+  for (const fallbackType of fallbackTypes) {
+    const match = states.find((state) => state.type?.trim().toLowerCase() === fallbackType)
+    if (match?.id?.trim()) {
+      return match
+    }
+  }
+
+  return null
+}
+
+function toLinearIssueMutationResult(issue: LinearWorkflowIssue): LinearIssueMutationResult {
+  return {
+    id: issue.id?.trim() || 'unknown',
+    identifier: issue.identifier?.trim() || undefined,
+    title: issue.title?.trim() || undefined,
+    url: issue.url?.trim() || undefined,
+    stateId: issue.state?.id?.trim() || undefined,
+    stateName: issue.state?.name?.trim() || 'Unknown',
+    stateType: issue.state?.type?.trim() || 'unknown',
+    teamId: issue.team?.id?.trim() || undefined,
+    projectId: issue.project?.id?.trim() || undefined,
+  }
+}
+
 export function createEmptyWorkflowColumns(): WorkflowBoardColumn[] {
   return WORKFLOW_COLUMNS.map((column) => ({
     id: column.id,
@@ -549,8 +864,13 @@ export function normalizeLinearBoard(input: {
             identifier: task.identifier,
             title: task.title as string,
             columnId: taskColumnId,
+            stateId: task.state?.id?.trim() || undefined,
             stateName: task.state?.name?.trim() || 'Unknown',
             stateType: task.state?.type?.trim() || 'unknown',
+            teamId: task.team?.id?.trim() || issue.team?.id?.trim() || undefined,
+            projectId: task.project?.id?.trim() || issue.project?.id?.trim() || undefined,
+            parentSliceId: task.parent?.id?.trim() || issue.id?.trim() || undefined,
+            url: task.url?.trim() || undefined,
           } satisfies WorkflowBoardTask
         })
 
@@ -564,8 +884,12 @@ export function normalizeLinearBoard(input: {
         identifier: issue.identifier as string,
         title: issue.title as string,
         columnId,
+        stateId: issue.state?.id?.trim() || undefined,
         stateName: issue.state?.name?.trim() || 'Unknown',
         stateType: issue.state?.type?.trim() || 'unknown',
+        teamId: issue.team?.id?.trim() || undefined,
+        projectId: issue.project?.id?.trim() || undefined,
+        url: issue.url?.trim() || undefined,
         milestoneId: milestoneId ?? input.milestoneId ?? 'none',
         milestoneName: milestoneName ?? input.milestoneName ?? 'No active milestone',
         taskCounts: {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -23,6 +23,10 @@ import type {
   WorkflowMoveEntityResult,
   WorkflowCreateTaskRequest,
   WorkflowCreateTaskResult,
+  WorkflowTaskDetailRequest,
+  WorkflowTaskDetailResponse,
+  WorkflowUpdateTaskRequest,
+  WorkflowUpdateTaskResult,
   WorkflowTrackerConfig,
   WorkflowColumnId,
   WorkflowSymphonyExecutionFreshness,
@@ -628,6 +632,220 @@ export class WorkflowBoardService {
         parentSliceId,
         status: 'error',
         code,
+        message: workflowError.message,
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+  }
+
+  async getTaskDetail(request: WorkflowTaskDetailRequest): Promise<WorkflowTaskDetailResponse> {
+    const taskId = request.taskId.trim()
+    if (!taskId) {
+      return {
+        success: false,
+        code: 'FAILED',
+        message: 'Task id is required.',
+      }
+    }
+
+    const snapshot = this.lastSnapshot ?? (await this.getBoard()).snapshot
+    if (snapshot.backend !== 'linear') {
+      return {
+        success: false,
+        code: 'UNSUPPORTED',
+        message: 'Task editing is currently supported only for Linear trackers.',
+      }
+    }
+
+    if (isWorkflowFixtureEnabled()) {
+      const task = findWorkflowEntity(snapshot, 'task', taskId)
+      if (!task || 'tasks' in task) {
+        return {
+          success: false,
+          code: 'NOT_FOUND',
+          message: `Task ${taskId} is no longer visible on the board.`,
+        }
+      }
+
+      return {
+        success: true,
+        code: 'LOADED',
+        message: 'Task details loaded.',
+        task: {
+          id: task.id,
+          identifier: task.identifier,
+          parentSliceId: task.parentSliceId,
+          teamId: task.teamId,
+          projectId: task.projectId,
+          stateId: task.stateId,
+          stateName: task.stateName,
+          stateType: task.stateType,
+          columnId: task.columnId,
+          title: task.title,
+          description: '',
+        },
+      }
+    }
+
+    try {
+      const detail = await this.linearClient.fetchIssueDetail({ issueId: taskId })
+      return {
+        success: true,
+        code: 'LOADED',
+        message: 'Task details loaded.',
+        task: {
+          id: detail.id,
+          identifier: detail.identifier,
+          parentSliceId: detail.parentId,
+          teamId: detail.teamId,
+          projectId: detail.projectId,
+          stateId: detail.stateId,
+          stateName: detail.stateName,
+          stateType: detail.stateType,
+          columnId: detail.columnId,
+          title: detail.title ?? '',
+          description: detail.description,
+        },
+      }
+    } catch (error) {
+      const workflowError = LinearWorkflowClient.toWorkflowError(error)
+      return {
+        success: false,
+        code: workflowError.code === 'NOT_FOUND' ? 'NOT_FOUND' : 'FAILED',
+        message: workflowError.message,
+      }
+    }
+  }
+
+  async updateTask(request: WorkflowUpdateTaskRequest): Promise<WorkflowUpdateTaskResult> {
+    const taskId = request.taskId.trim()
+    const updatedAt = new Date().toISOString()
+
+    if (!taskId) {
+      return {
+        success: false,
+        taskId,
+        status: 'error',
+        code: 'VALIDATION_ERROR',
+        message: 'Task id is required.',
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+
+    const title = request.title.trim()
+    if (!title) {
+      return {
+        success: false,
+        taskId,
+        status: 'error',
+        code: 'VALIDATION_ERROR',
+        message: 'Task title is required.',
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+
+    const snapshot = this.lastSnapshot ?? (await this.getBoard()).snapshot
+    if (snapshot.backend !== 'linear') {
+      return {
+        success: false,
+        taskId,
+        status: 'error',
+        code: 'UNSUPPORTED',
+        message: 'Task editing is currently supported only for Linear trackers.',
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+
+    const existingTask = findWorkflowEntity(snapshot, 'task', taskId)
+    if (!existingTask || 'tasks' in existingTask) {
+      return {
+        success: false,
+        taskId,
+        status: 'error',
+        code: 'NOT_FOUND',
+        message: `Task ${taskId} is no longer visible on the board.`,
+        refreshBoard: true,
+        updatedAt,
+      }
+    }
+
+    if (isWorkflowFixtureEnabled()) {
+      if (/fail/i.test(title)) {
+        return {
+          success: false,
+          taskId,
+          status: 'error',
+          code: 'ROLLED_BACK',
+          message: 'Mocked Linear task update failure for rollback coverage.',
+          refreshBoard: false,
+          updatedAt,
+        }
+      }
+
+      const targetColumnId = request.targetColumnId ?? existingTask.columnId
+      const fixtureSnapshot = this.testFixtureSnapshot ?? this.lastSuccessSnapshot ?? this.resolveTestLinearFixture()
+      const updatedSnapshot = applyWorkflowTaskUpdate(fixtureSnapshot, {
+        taskId,
+        title,
+        columnId: targetColumnId,
+      })
+
+      this.testFixtureSnapshot = withFreshTimestamps(updatedSnapshot)
+      const scopedSnapshot = this.resolveScope(this.enrichWithSymphonyContext(this.testFixtureSnapshot))
+      this.lastSnapshot = scopedSnapshot
+      this.lastSuccessSnapshot = scopedSnapshot
+
+      return {
+        success: true,
+        taskId,
+        status: 'success',
+        code: 'UPDATED',
+        message: 'Task updated successfully.',
+        refreshBoard: true,
+        updatedAt,
+        task: {
+          id: taskId,
+          identifier: existingTask.identifier,
+          title,
+          columnId: targetColumnId,
+        },
+      }
+    }
+
+    try {
+      const updatedTask = await this.linearClient.updateTask({
+        issueId: taskId,
+        title,
+        description: request.description,
+        targetColumnId: request.targetColumnId,
+      })
+
+      return {
+        success: true,
+        taskId,
+        status: 'success',
+        code: 'UPDATED',
+        message: 'Task updated successfully.',
+        refreshBoard: true,
+        updatedAt,
+        task: {
+          id: updatedTask.id,
+          identifier: updatedTask.identifier,
+          title: updatedTask.title ?? title,
+          columnId: updatedTask.columnId,
+        },
+      }
+    } catch (error) {
+      const workflowError = LinearWorkflowClient.toWorkflowError(error)
+      return {
+        success: false,
+        taskId,
+        status: 'error',
+        code: workflowError.code === 'NOT_FOUND' ? 'NOT_FOUND' : 'FAILED',
         message: workflowError.message,
         refreshBoard: false,
         updatedAt,
@@ -1552,6 +1770,38 @@ function applyWorkflowTaskCreate(
       card.taskCounts = {
         total: card.tasks.length,
         done: card.tasks.filter((task) => task.columnId === 'done').length,
+      }
+      return next
+    }
+  }
+
+  return next
+}
+
+function applyWorkflowTaskUpdate(
+  snapshot: WorkflowBoardSnapshot,
+  input: {
+    taskId: string
+    title: string
+    columnId: WorkflowColumnId
+  },
+): WorkflowBoardSnapshot {
+  const next = structuredClone(snapshot)
+
+  for (const column of next.columns) {
+    for (const card of column.cards) {
+      const task = card.tasks.find((candidate) => candidate.id === input.taskId)
+      if (!task) {
+        continue
+      }
+
+      task.title = input.title
+      task.columnId = input.columnId
+      task.stateName = toColumnTitle(input.columnId)
+      task.stateType = toColumnStateType(input.columnId)
+      card.taskCounts = {
+        total: card.tasks.length,
+        done: card.tasks.filter((candidate) => candidate.columnId === 'done').length,
       }
       return next
     }

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { WORKFLOW_COLUMNS } from '../shared/types'
 import { AuthBridge } from './auth-bridge'
 import { LinearWorkflowClient } from './linear-workflow-client'
 import { GithubWorkflowClient } from './github-workflow-client'
@@ -18,7 +19,10 @@ import type {
   WorkflowBoardSnapshotResponse,
   WorkflowBoardTask,
   WorkflowContextSnapshot,
+  WorkflowMoveEntityRequest,
+  WorkflowMoveEntityResult,
   WorkflowTrackerConfig,
+  WorkflowColumnId,
   WorkflowSymphonyExecutionFreshness,
   WorkflowSymphonyExecutionProvenance,
 } from '../shared/types'
@@ -301,6 +305,7 @@ export class WorkflowBoardService {
   }
   private trackerConfigured = false
   private testScenario: WorkflowTestScenario | null = null
+  private testFixtureSnapshot: WorkflowBoardSnapshot | null = null
 
   constructor(private readonly options: WorkflowBoardServiceOptions) {
     this.linearClient = new LinearWorkflowClient(options.authBridge)
@@ -337,6 +342,7 @@ export class WorkflowBoardService {
         resolved: nextRequestedScope,
         reason: 'requested',
       }
+      this.testFixtureSnapshot = null
     }
 
     this.syncContextSnapshot()
@@ -346,6 +352,137 @@ export class WorkflowBoardService {
       requestedScope: this.requestedScope,
       resolvedScope: this.lastScopeDiagnostics.resolved,
       resolutionReason: this.lastScopeDiagnostics.reason,
+    }
+  }
+
+  async moveEntity(request: WorkflowMoveEntityRequest): Promise<WorkflowMoveEntityResult> {
+    const entityId = request.entityId.trim()
+    const updatedAt = new Date().toISOString()
+
+    if (!entityId) {
+      return {
+        success: false,
+        entityKind: request.entityKind,
+        entityId,
+        targetColumnId: request.targetColumnId,
+        status: 'error',
+        code: 'VALIDATION_ERROR',
+        phase: 'rolled_back',
+        message: 'Entity id is required for workflow move.',
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+
+    const snapshot = this.lastSnapshot ?? (await this.getBoard()).snapshot
+    if (snapshot.backend !== 'linear') {
+      return {
+        success: false,
+        entityKind: request.entityKind,
+        entityId,
+        targetColumnId: request.targetColumnId,
+        status: 'error',
+        code: 'UNSUPPORTED',
+        phase: 'rolled_back',
+        message: 'Workflow board mutations are currently supported only for Linear trackers.',
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+
+    const entity = findWorkflowEntity(snapshot, request.entityKind, entityId)
+    if (!entity) {
+      return {
+        success: false,
+        entityKind: request.entityKind,
+        entityId,
+        targetColumnId: request.targetColumnId,
+        status: 'error',
+        code: 'NOT_FOUND',
+        phase: 'rolled_back',
+        message: `Workflow entity ${entityId} is no longer visible on the board.`,
+        refreshBoard: true,
+        updatedAt,
+      }
+    }
+
+    if (isWorkflowFixtureEnabled()) {
+      const fixtureSnapshot = this.testFixtureSnapshot ?? this.lastSuccessSnapshot ?? this.resolveTestLinearFixture()
+
+      if (request.targetColumnId === 'human_review') {
+        return {
+          success: false,
+          entityKind: request.entityKind,
+          entityId,
+          targetColumnId: request.targetColumnId,
+          status: 'error',
+          code: 'ROLLED_BACK',
+          phase: 'rolled_back',
+          message: 'Mocked Linear move failure for rollback coverage.',
+          refreshBoard: false,
+          updatedAt,
+        }
+      }
+
+      const movedSnapshot = applyWorkflowEntityMove(fixtureSnapshot, {
+        entityKind: request.entityKind,
+        entityId,
+        targetColumnId: request.targetColumnId,
+      })
+
+      this.testFixtureSnapshot = withFreshTimestamps(movedSnapshot)
+      const scopedSnapshot = this.resolveScope(this.enrichWithSymphonyContext(this.testFixtureSnapshot))
+      this.lastSnapshot = scopedSnapshot
+      this.lastSuccessSnapshot = scopedSnapshot
+
+      return {
+        success: true,
+        entityKind: request.entityKind,
+        entityId,
+        targetColumnId: request.targetColumnId,
+        status: 'success',
+        code: 'COMMITTED',
+        phase: 'committed',
+        message: `${request.entityKind === 'slice' ? 'Slice' : 'Task'} moved to ${toColumnTitle(request.targetColumnId)}.`,
+        refreshBoard: true,
+        updatedAt,
+      }
+    }
+
+    try {
+      await this.linearClient.moveIssueToColumn({
+        issueId: entityId,
+        targetColumnId: request.targetColumnId,
+      })
+
+      return {
+        success: true,
+        entityKind: request.entityKind,
+        entityId,
+        targetColumnId: request.targetColumnId,
+        status: 'success',
+        code: 'COMMITTED',
+        phase: 'committed',
+        message: `${request.entityKind === 'slice' ? 'Slice' : 'Task'} moved to ${toColumnTitle(request.targetColumnId)}.`,
+        refreshBoard: true,
+        updatedAt,
+      }
+    } catch (error) {
+      const workflowError = LinearWorkflowClient.toWorkflowError(error)
+      const code = workflowError.code === 'NOT_FOUND' ? 'NOT_FOUND' : 'FAILED'
+
+      return {
+        success: false,
+        entityKind: request.entityKind,
+        entityId,
+        targetColumnId: request.targetColumnId,
+        status: 'error',
+        code,
+        phase: 'rolled_back',
+        message: workflowError.message,
+        refreshBoard: false,
+        updatedAt,
+      }
     }
   }
 
@@ -416,7 +553,10 @@ export class WorkflowBoardService {
     }
 
     if (process.env.KATA_TEST_WORKFLOW_FIXTURE === '1') {
-      const fixture = this.resolveScope(this.enrichWithSymphonyContext(withFreshTimestamps(this.resolveTestLinearFixture())))
+      const baseFixture = this.testFixtureSnapshot ?? this.resolveTestLinearFixture()
+      this.testFixtureSnapshot = withFreshTimestamps(baseFixture)
+
+      const fixture = this.resolveScope(this.enrichWithSymphonyContext(this.testFixtureSnapshot))
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = fixture
         this.lastSuccessSnapshot = fixture
@@ -498,7 +638,10 @@ export class WorkflowBoardService {
     }
 
     if (isWorkflowFixtureEnabled()) {
-      const fixture = this.resolveScope(this.enrichWithSymphonyContext(withFreshTimestamps(this.fixtureForTracker(tracker))))
+      const baseFixture = this.testFixtureSnapshot ?? this.fixtureForTracker(tracker)
+      this.testFixtureSnapshot = withFreshTimestamps(baseFixture)
+
+      const fixture = this.resolveScope(this.enrichWithSymphonyContext(this.testFixtureSnapshot))
       if (capturedScopeKey === this.scopeKey) {
         this.lastSnapshot = fixture
         this.lastSuccessSnapshot = fixture
@@ -1145,6 +1288,108 @@ function projectActiveScope(snapshot: WorkflowBoardSnapshot): {
     },
     matchIdentifiers,
   }
+}
+
+function findWorkflowEntity(
+  snapshot: WorkflowBoardSnapshot,
+  entityKind: WorkflowMoveEntityRequest['entityKind'],
+  entityId: string,
+): WorkflowBoardSliceCard | WorkflowBoardTask | null {
+  if (entityKind === 'slice') {
+    for (const column of snapshot.columns) {
+      const card = column.cards.find((candidate) => candidate.id === entityId)
+      if (card) {
+        return card
+      }
+    }
+    return null
+  }
+
+  for (const column of snapshot.columns) {
+    for (const card of column.cards) {
+      const task = card.tasks.find((candidate) => candidate.id === entityId)
+      if (task) {
+        return task
+      }
+    }
+  }
+
+  return null
+}
+
+function applyWorkflowEntityMove(
+  snapshot: WorkflowBoardSnapshot,
+  request: Pick<WorkflowMoveEntityRequest, 'entityKind' | 'entityId' | 'targetColumnId'>,
+): WorkflowBoardSnapshot {
+  const next = structuredClone(snapshot)
+  const targetColumn = next.columns.find((column) => column.id === request.targetColumnId)
+  if (!targetColumn) {
+    return next
+  }
+
+  if (request.entityKind === 'slice') {
+    let movingCard: WorkflowBoardSliceCard | null = null
+
+    for (const column of next.columns) {
+      const index = column.cards.findIndex((card) => card.id === request.entityId)
+      if (index >= 0) {
+        movingCard = column.cards.splice(index, 1)[0] ?? null
+        break
+      }
+    }
+
+    if (!movingCard) {
+      return next
+    }
+
+    movingCard.columnId = request.targetColumnId
+    movingCard.stateName = toColumnTitle(request.targetColumnId)
+    movingCard.stateType = toColumnStateType(request.targetColumnId)
+    targetColumn.cards.push(movingCard)
+    targetColumn.cards.sort((left, right) => left.identifier.localeCompare(right.identifier))
+
+    return next
+  }
+
+  for (const column of next.columns) {
+    for (const card of column.cards) {
+      const task = card.tasks.find((candidate) => candidate.id === request.entityId)
+      if (!task) {
+        continue
+      }
+
+      task.columnId = request.targetColumnId
+      task.stateName = toColumnTitle(request.targetColumnId)
+      task.stateType = toColumnStateType(request.targetColumnId)
+      card.taskCounts = {
+        total: card.tasks.length,
+        done: card.tasks.filter((candidate) => candidate.columnId === 'done').length,
+      }
+      return next
+    }
+  }
+
+  return next
+}
+
+function toColumnTitle(columnId: WorkflowColumnId): string {
+  return WORKFLOW_COLUMNS.find((column) => column.id === columnId)?.title ?? columnId
+}
+
+function toColumnStateType(columnId: WorkflowColumnId): string {
+  if (columnId === 'backlog') {
+    return 'backlog'
+  }
+
+  if (columnId === 'todo') {
+    return 'unstarted'
+  }
+
+  if (columnId === 'done') {
+    return 'completed'
+  }
+
+  return 'started'
 }
 
 function isExecutionActive(summary: WorkflowBoardTask['symphony'] | WorkflowBoardSliceCard['symphony'] | undefined): boolean {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { WORKFLOW_COLUMNS } from '../shared/types'
 import { AuthBridge } from './auth-bridge'
-import { LinearWorkflowClient } from './linear-workflow-client'
+import { LinearWorkflowClient, mapLinearStateToColumnId } from './linear-workflow-client'
 import { GithubWorkflowClient } from './github-workflow-client'
 import log from './logger'
 import { WorkflowContextService } from './workflow-context-service'
@@ -21,6 +21,8 @@ import type {
   WorkflowContextSnapshot,
   WorkflowMoveEntityRequest,
   WorkflowMoveEntityResult,
+  WorkflowCreateTaskRequest,
+  WorkflowCreateTaskResult,
   WorkflowTrackerConfig,
   WorkflowColumnId,
   WorkflowSymphonyExecutionFreshness,
@@ -479,6 +481,153 @@ export class WorkflowBoardService {
         status: 'error',
         code,
         phase: 'rolled_back',
+        message: workflowError.message,
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+  }
+
+  async createTask(request: WorkflowCreateTaskRequest): Promise<WorkflowCreateTaskResult> {
+    const parentSliceId = request.parentSliceId.trim()
+    const updatedAt = new Date().toISOString()
+
+    if (!parentSliceId) {
+      return {
+        success: false,
+        parentSliceId,
+        status: 'error',
+        code: 'VALIDATION_ERROR',
+        message: 'Parent slice id is required.',
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+
+    const title = request.title.trim()
+    if (!title) {
+      return {
+        success: false,
+        parentSliceId,
+        status: 'error',
+        code: 'VALIDATION_ERROR',
+        message: 'Task title is required.',
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+
+    const snapshot = this.lastSnapshot ?? (await this.getBoard()).snapshot
+    if (snapshot.backend !== 'linear') {
+      return {
+        success: false,
+        parentSliceId,
+        status: 'error',
+        code: 'UNSUPPORTED',
+        message: 'Workflow board task creation is currently supported only for Linear trackers.',
+        refreshBoard: false,
+        updatedAt,
+      }
+    }
+
+    const parentSlice = findWorkflowEntity(snapshot, 'slice', parentSliceId)
+    if (!parentSlice || !('tasks' in parentSlice)) {
+      return {
+        success: false,
+        parentSliceId,
+        status: 'error',
+        code: 'NOT_FOUND',
+        message: `Parent slice ${parentSliceId} is no longer visible on the board.`,
+        refreshBoard: true,
+        updatedAt,
+      }
+    }
+
+    if (isWorkflowFixtureEnabled()) {
+      if (/fail/i.test(title)) {
+        return {
+          success: false,
+          parentSliceId,
+          status: 'error',
+          code: 'ROLLED_BACK',
+          message: 'Mocked Linear task creation failure for rollback coverage.',
+          refreshBoard: false,
+          updatedAt,
+        }
+      }
+
+      const fixtureSnapshot = this.testFixtureSnapshot ?? this.lastSuccessSnapshot ?? this.resolveTestLinearFixture()
+      const nextTaskNumber = countWorkflowTasks(fixtureSnapshot) + 1
+      const createdTaskId = `task-created-${nextTaskNumber}`
+
+      const createdSnapshot = applyWorkflowTaskCreate(fixtureSnapshot, {
+        parentSliceId,
+        task: {
+          id: createdTaskId,
+          identifier: `KAT-NEW-${nextTaskNumber}`,
+          title,
+          columnId: request.initialColumnId ?? 'todo',
+          stateName: toColumnTitle(request.initialColumnId ?? 'todo'),
+          stateType: toColumnStateType(request.initialColumnId ?? 'todo'),
+          teamId: request.teamId,
+          projectId: request.projectId,
+          parentSliceId,
+        },
+      })
+
+      this.testFixtureSnapshot = withFreshTimestamps(createdSnapshot)
+      const scopedSnapshot = this.resolveScope(this.enrichWithSymphonyContext(this.testFixtureSnapshot))
+      this.lastSnapshot = scopedSnapshot
+      this.lastSuccessSnapshot = scopedSnapshot
+
+      return {
+        success: true,
+        parentSliceId,
+        status: 'success',
+        code: 'CREATED',
+        message: 'Task created successfully.',
+        refreshBoard: true,
+        updatedAt,
+        task: {
+          id: createdTaskId,
+          identifier: `KAT-NEW-${nextTaskNumber}`,
+          title,
+          columnId: request.initialColumnId ?? 'todo',
+        },
+      }
+    }
+
+    try {
+      const created = await this.linearClient.createChildTask({
+        parentIssueId: parentSliceId,
+        title,
+        description: request.description,
+        initialColumnId: request.initialColumnId ?? 'todo',
+      })
+
+      return {
+        success: true,
+        parentSliceId,
+        status: 'success',
+        code: 'CREATED',
+        message: 'Task created successfully.',
+        refreshBoard: true,
+        updatedAt,
+        task: {
+          id: created.id,
+          identifier: created.identifier,
+          title: created.title ?? title,
+          columnId: mapLinearStateToColumnId(created.stateName, created.stateType),
+        },
+      }
+    } catch (error) {
+      const workflowError = LinearWorkflowClient.toWorkflowError(error)
+      const code = workflowError.code === 'NOT_FOUND' ? 'NOT_FOUND' : 'FAILED'
+      return {
+        success: false,
+        parentSliceId,
+        status: 'error',
+        code,
         message: workflowError.message,
         refreshBoard: false,
         updatedAt,
@@ -1370,6 +1519,51 @@ function applyWorkflowEntityMove(
   }
 
   return next
+}
+
+function applyWorkflowTaskCreate(
+  snapshot: WorkflowBoardSnapshot,
+  input: {
+    parentSliceId: string
+    task: {
+      id: string
+      identifier?: string
+      title: string
+      columnId: WorkflowColumnId
+      stateName: string
+      stateType: string
+      teamId?: string
+      projectId?: string
+      parentSliceId?: string
+    }
+  },
+): WorkflowBoardSnapshot {
+  const next = structuredClone(snapshot)
+
+  for (const column of next.columns) {
+    for (const card of column.cards) {
+      if (card.id !== input.parentSliceId) {
+        continue
+      }
+
+      card.tasks.push({
+        ...input.task,
+      })
+      card.taskCounts = {
+        total: card.tasks.length,
+        done: card.tasks.filter((task) => task.columnId === 'done').length,
+      }
+      return next
+    }
+  }
+
+  return next
+}
+
+function countWorkflowTasks(snapshot: WorkflowBoardSnapshot): number {
+  return snapshot.columns.reduce((total, column) => {
+    return total + column.cards.reduce((cardTotal, card) => cardTotal + card.tasks.length, 0)
+  }, 0)
 }
 
 function toColumnTitle(columnId: WorkflowColumnId): string {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -67,6 +67,7 @@ const TEST_LINEAR_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
               id: 'task-1',
               identifier: 'KAT-2251',
               title: '[T01] Define canonical workflow snapshot contract',
+              description: 'Baseline fixture task for completed-state coverage.',
               columnId: 'done',
               stateName: 'Done',
               stateType: 'completed',
@@ -75,6 +76,7 @@ const TEST_LINEAR_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
               id: 'task-2',
               identifier: 'KAT-2252',
               title: '[T02] Wire workflow board service through IPC',
+              description: 'Fixture task used for edit-dialog hydration and mutation coverage.',
               columnId: 'in_progress',
               stateName: 'In Progress',
               stateType: 'started',
@@ -129,6 +131,7 @@ const TEST_LINEAR_ASSEMBLED_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
               id: 'task-s04-2',
               identifier: 'KAT-2356',
               title: '[T02] Prove the healthy assembled operator flow in Electron',
+              description: 'Assembled fixture task for live symphony board correlation.',
               columnId: 'in_progress',
               stateName: 'In Progress',
               stateType: 'started',
@@ -576,6 +579,7 @@ export class WorkflowBoardService {
           teamId: request.teamId,
           projectId: request.projectId,
           parentSliceId,
+          description: request.description ?? '',
         },
       })
 
@@ -683,7 +687,7 @@ export class WorkflowBoardService {
           stateType: task.stateType,
           columnId: task.columnId,
           title: task.title,
-          description: '',
+          description: task.description ?? '',
         },
       }
     }
@@ -792,6 +796,7 @@ export class WorkflowBoardService {
         taskId,
         title,
         columnId: targetColumnId,
+        description: request.description,
       })
 
       this.testFixtureSnapshot = withFreshTimestamps(updatedSnapshot)
@@ -1753,6 +1758,7 @@ function applyWorkflowTaskCreate(
       teamId?: string
       projectId?: string
       parentSliceId?: string
+      description?: string
     }
   },
 ): WorkflowBoardSnapshot {
@@ -1784,6 +1790,7 @@ function applyWorkflowTaskUpdate(
     taskId: string
     title: string
     columnId: WorkflowColumnId
+    description?: string
   },
 ): WorkflowBoardSnapshot {
   const next = structuredClone(snapshot)
@@ -1796,6 +1803,9 @@ function applyWorkflowTaskUpdate(
       }
 
       task.title = input.title
+      if (input.description !== undefined) {
+        task.description = input.description
+      }
       task.columnId = input.columnId
       task.stateName = toColumnTitle(input.columnId)
       task.stateType = toColumnStateType(input.columnId)

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -169,6 +169,12 @@ const api: DesktopApi = {
     createTask: async (request: Parameters<DesktopApi['workflow']['createTask']>[0]) => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowCreateTask, request)
     },
+    getTaskDetail: async (request: Parameters<DesktopApi['workflow']['getTaskDetail']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowGetTaskDetail, request)
+    },
+    updateTask: async (request: Parameters<DesktopApi['workflow']['updateTask']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowUpdateTask, request)
+    },
     respondToEscalation: async (request: Parameters<DesktopApi['workflow']['respondToEscalation']>[0]) => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowRespondEscalation, request)
     },

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -163,6 +163,9 @@ const api: DesktopApi = {
     setScope: async (request: Parameters<DesktopApi['workflow']['setScope']>[0]) => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowSetScope, request)
     },
+    moveEntity: async (request: Parameters<DesktopApi['workflow']['moveEntity']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowMoveEntity, request)
+    },
     respondToEscalation: async (request: Parameters<DesktopApi['workflow']['respondToEscalation']>[0]) => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowRespondEscalation, request)
     },

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -166,6 +166,9 @@ const api: DesktopApi = {
     moveEntity: async (request: Parameters<DesktopApi['workflow']['moveEntity']>[0]) => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowMoveEntity, request)
     },
+    createTask: async (request: Parameters<DesktopApi['workflow']['createTask']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowCreateTask, request)
+    },
     respondToEscalation: async (request: Parameters<DesktopApi['workflow']['respondToEscalation']>[0]) => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowRespondEscalation, request)
     },

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -1,7 +1,14 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import { useEffect, useRef } from 'react'
-import type { WorkflowBoardSnapshot, WorkflowBoardScope, WorkflowColumnId } from '@shared/types'
+import {
+  WORKFLOW_COLUMNS,
+  type WorkflowBoardSnapshot,
+  type WorkflowBoardScope,
+  type WorkflowColumnId,
+  type WorkflowEntityKind,
+  type WorkflowMoveEntityResult,
+} from '@shared/types'
 import { currentSessionIdAtom, workingDirectoryAtom } from './session'
 import { rightPaneModeAtom, setWorkflowContextAtom } from './right-pane'
 
@@ -31,8 +38,17 @@ type IssueActionState = {
   updatedAt: string
 }
 
+type WorkflowEntityMutationState = {
+  action: 'move'
+  phase: 'pending' | 'success' | 'error'
+  targetColumnId: WorkflowColumnId
+  message: string
+  updatedAt: string
+}
+
 export const workflowEscalationActionStateAtom = atom<Record<string, EscalationActionState>>({})
 export const workflowIssueActionStateAtom = atom<Record<string, IssueActionState>>({})
+export const workflowEntityMutationStateAtom = atom<Record<string, WorkflowEntityMutationState>>({})
 
 const workflowBoardScopePreferencesAtom = atomWithStorage<ScopePreferenceMap>(
   WORKFLOW_BOARD_SCOPE_STORAGE_KEY,
@@ -109,6 +125,204 @@ export const workflowBoardHasCardsAtom = atom((get) => {
   const snapshot = get(workflowBoardAtom)
   return snapshot ? snapshot.columns.some((column) => column.cards.length > 0) : false
 })
+
+export function workflowEntityMutationKey(entityKind: WorkflowEntityKind, entityId: string): string {
+  return `${entityKind}:${entityId}`
+}
+
+function toColumnTitle(columnId: WorkflowColumnId): string {
+  return WORKFLOW_COLUMNS.find((column) => column.id === columnId)?.title ?? columnId
+}
+
+function toColumnStateType(columnId: WorkflowColumnId): string {
+  if (columnId === 'backlog') return 'backlog'
+  if (columnId === 'todo') return 'unstarted'
+  if (columnId === 'done') return 'completed'
+  return 'started'
+}
+
+function applyOptimisticMove(
+  snapshot: WorkflowBoardSnapshot,
+  input: { entityKind: WorkflowEntityKind; entityId: string; targetColumnId: WorkflowColumnId },
+): WorkflowBoardSnapshot {
+  const next = structuredClone(snapshot)
+  const targetColumn = next.columns.find((column) => column.id === input.targetColumnId)
+  if (!targetColumn) {
+    return next
+  }
+
+  if (input.entityKind === 'slice') {
+    let movingCard: WorkflowBoardSnapshot['columns'][number]['cards'][number] | null = null
+
+    for (const column of next.columns) {
+      const cardIndex = column.cards.findIndex((card) => card.id === input.entityId)
+      if (cardIndex >= 0) {
+        movingCard = column.cards.splice(cardIndex, 1)[0] ?? null
+        break
+      }
+    }
+
+    if (!movingCard) {
+      return next
+    }
+
+    movingCard.columnId = input.targetColumnId
+    movingCard.stateName = toColumnTitle(input.targetColumnId)
+    movingCard.stateType = toColumnStateType(input.targetColumnId)
+    targetColumn.cards.push(movingCard)
+    targetColumn.cards.sort((left, right) => left.identifier.localeCompare(right.identifier))
+
+    return next
+  }
+
+  for (const column of next.columns) {
+    for (const card of column.cards) {
+      const task = card.tasks.find((candidate) => candidate.id === input.entityId)
+      if (!task) {
+        continue
+      }
+
+      task.columnId = input.targetColumnId
+      task.stateName = toColumnTitle(input.targetColumnId)
+      task.stateType = toColumnStateType(input.targetColumnId)
+      card.taskCounts = {
+        total: card.tasks.length,
+        done: card.tasks.filter((candidate) => candidate.columnId === 'done').length,
+      }
+      return next
+    }
+  }
+
+  return next
+}
+
+export const moveWorkflowEntityAtom = atom(
+  null,
+  async (
+    get,
+    set,
+    input: {
+      entityKind: WorkflowEntityKind
+      entityId: string
+      targetColumnId: WorkflowColumnId
+      currentColumnId?: WorkflowColumnId
+      currentStateId?: string
+      currentStateName?: string
+      currentStateType?: string
+      teamId?: string
+      projectId?: string
+    },
+  ) => {
+    const snapshot = get(workflowBoardAtom)
+    if (!snapshot) {
+      const nowIso = new Date().toISOString()
+      return {
+        success: false,
+        entityKind: input.entityKind,
+        entityId: input.entityId,
+        targetColumnId: input.targetColumnId,
+        status: 'error',
+        code: 'FAILED',
+        phase: 'rolled_back',
+        message: 'Workflow board snapshot unavailable. Please refresh and retry.',
+        refreshBoard: false,
+        updatedAt: nowIso,
+      } satisfies WorkflowMoveEntityResult
+    }
+
+    const previousSnapshot = snapshot
+    const optimisticSnapshot = applyOptimisticMove(snapshot, input)
+    const mutationKey = workflowEntityMutationKey(input.entityKind, input.entityId)
+    const startedAt = new Date().toISOString()
+
+    set(workflowBoardAtom, optimisticSnapshot)
+    set(workflowEntityMutationStateAtom, (previous) => ({
+      ...previous,
+      [mutationKey]: {
+        action: 'move',
+        phase: 'pending',
+        targetColumnId: input.targetColumnId,
+        message: `Moving to ${toColumnTitle(input.targetColumnId)}…`,
+        updatedAt: startedAt,
+      },
+    }))
+
+    try {
+      const result = await window.api.workflow.moveEntity({
+        entityKind: input.entityKind,
+        entityId: input.entityId,
+        targetColumnId: input.targetColumnId,
+        currentColumnId: input.currentColumnId,
+        currentStateId: input.currentStateId,
+        currentStateName: input.currentStateName,
+        currentStateType: input.currentStateType,
+        teamId: input.teamId,
+        projectId: input.projectId,
+      })
+
+      if (!result.success) {
+        set(workflowBoardAtom, previousSnapshot)
+        set(workflowEntityMutationStateAtom, (previous) => ({
+          ...previous,
+          [mutationKey]: {
+            action: 'move',
+            phase: 'error',
+            targetColumnId: input.targetColumnId,
+            message: result.message,
+            updatedAt: result.updatedAt,
+          },
+        }))
+
+        return result
+      }
+
+      set(workflowEntityMutationStateAtom, (previous) => ({
+        ...previous,
+        [mutationKey]: {
+          action: 'move',
+          phase: 'success',
+          targetColumnId: input.targetColumnId,
+          message: result.message,
+          updatedAt: result.updatedAt,
+        },
+      }))
+
+      if (result.refreshBoard) {
+        const refreshed = await window.api.workflow.refreshBoard()
+        set(workflowBoardAtom, refreshed.snapshot)
+        set(workflowBoardErrorAtom, refreshed.snapshot.lastError?.message ?? null)
+      }
+
+      return result
+    } catch (error) {
+      const failedAt = new Date().toISOString()
+      set(workflowBoardAtom, previousSnapshot)
+      set(workflowEntityMutationStateAtom, (previous) => ({
+        ...previous,
+        [mutationKey]: {
+          action: 'move',
+          phase: 'error',
+          targetColumnId: input.targetColumnId,
+          message: error instanceof Error ? error.message : String(error),
+          updatedAt: failedAt,
+        },
+      }))
+
+      return {
+        success: false,
+        entityKind: input.entityKind,
+        entityId: input.entityId,
+        targetColumnId: input.targetColumnId,
+        status: 'error',
+        code: 'FAILED',
+        phase: 'rolled_back',
+        message: error instanceof Error ? error.message : String(error),
+        refreshBoard: false,
+        updatedAt: failedAt,
+      } satisfies WorkflowMoveEntityResult
+    }
+  },
+)
 
 export const refreshWorkflowBoardAtom = atom(null, async (_get, set) => {
   set(workflowBoardRefreshingAtom, true)

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -264,7 +264,14 @@ export const moveWorkflowEntityAtom = atom(
       })
 
       if (!result.success) {
-        set(workflowBoardAtom, previousSnapshot)
+        if (result.refreshBoard) {
+          const refreshed = await window.api.workflow.refreshBoard()
+          set(workflowBoardAtom, refreshed.snapshot)
+          set(workflowBoardErrorAtom, refreshed.snapshot.lastError?.message ?? null)
+        } else {
+          set(workflowBoardAtom, previousSnapshot)
+        }
+
         set(workflowEntityMutationStateAtom, (previous) => ({
           ...previous,
           [mutationKey]: {
@@ -350,7 +357,7 @@ export const createWorkflowTaskAtom = atom(
       projectId: input.projectId,
     })) satisfies WorkflowCreateTaskResult
 
-    if (result.success && result.refreshBoard) {
+    if (result.refreshBoard) {
       const refreshed = await window.api.workflow.refreshBoard()
       set(workflowBoardAtom, refreshed.snapshot)
       set(workflowBoardErrorAtom, refreshed.snapshot.lastError?.message ?? null)
@@ -409,28 +416,51 @@ export const updateWorkflowTaskAtom = atom(
       set(workflowBoardAtom, optimisticSnapshot)
     }
 
-    const result = (await window.api.workflow.updateTask({
-      taskId: input.taskId,
-      title: input.title,
-      description: input.description,
-      targetColumnId: input.targetColumnId,
-      teamId: input.teamId,
-      projectId: input.projectId,
-      currentStateId: input.currentStateId,
-    })) satisfies WorkflowUpdateTaskResult
+    try {
+      const result = (await window.api.workflow.updateTask({
+        taskId: input.taskId,
+        title: input.title,
+        description: input.description,
+        targetColumnId: input.targetColumnId,
+        teamId: input.teamId,
+        projectId: input.projectId,
+        currentStateId: input.currentStateId,
+      })) satisfies WorkflowUpdateTaskResult
 
-    if (!result.success && previousSnapshot) {
-      set(workflowBoardAtom, previousSnapshot)
+      if (!result.success) {
+        if (result.refreshBoard) {
+          const refreshed = await window.api.workflow.refreshBoard()
+          set(workflowBoardAtom, refreshed.snapshot)
+          set(workflowBoardErrorAtom, refreshed.snapshot.lastError?.message ?? null)
+        } else if (previousSnapshot) {
+          set(workflowBoardAtom, previousSnapshot)
+        }
+
+        return result
+      }
+
+      if (result.refreshBoard) {
+        const refreshed = await window.api.workflow.refreshBoard()
+        set(workflowBoardAtom, refreshed.snapshot)
+        set(workflowBoardErrorAtom, refreshed.snapshot.lastError?.message ?? null)
+      }
+
       return result
-    }
+    } catch (error) {
+      if (previousSnapshot) {
+        set(workflowBoardAtom, previousSnapshot)
+      }
 
-    if (result.success && result.refreshBoard) {
-      const refreshed = await window.api.workflow.refreshBoard()
-      set(workflowBoardAtom, refreshed.snapshot)
-      set(workflowBoardErrorAtom, refreshed.snapshot.lastError?.message ?? null)
+      return {
+        success: false,
+        taskId: input.taskId,
+        status: 'error',
+        code: 'FAILED',
+        message: error instanceof Error ? error.message : String(error),
+        refreshBoard: false,
+        updatedAt: new Date().toISOString(),
+      } satisfies WorkflowUpdateTaskResult
     }
-
-    return result
   },
 )
 

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -9,6 +9,8 @@ import {
   type WorkflowCreateTaskResult,
   type WorkflowEntityKind,
   type WorkflowMoveEntityResult,
+  type WorkflowTaskDetailResponse,
+  type WorkflowUpdateTaskResult,
 } from '@shared/types'
 import { currentSessionIdAtom, workingDirectoryAtom } from './session'
 import { rightPaneModeAtom, setWorkflowContextAtom } from './right-pane'
@@ -347,6 +349,80 @@ export const createWorkflowTaskAtom = atom(
       teamId: input.teamId,
       projectId: input.projectId,
     })) satisfies WorkflowCreateTaskResult
+
+    if (result.success && result.refreshBoard) {
+      const refreshed = await window.api.workflow.refreshBoard()
+      set(workflowBoardAtom, refreshed.snapshot)
+      set(workflowBoardErrorAtom, refreshed.snapshot.lastError?.message ?? null)
+    }
+
+    return result
+  },
+)
+
+export const loadWorkflowTaskDetailAtom = atom(
+  null,
+  async (_get, _set, input: { taskId: string }) => {
+    return (await window.api.workflow.getTaskDetail({ taskId: input.taskId })) satisfies WorkflowTaskDetailResponse
+  },
+)
+
+export const updateWorkflowTaskAtom = atom(
+  null,
+  async (
+    get,
+    set,
+    input: {
+      taskId: string
+      title: string
+      description?: string
+      targetColumnId?: WorkflowColumnId
+      teamId?: string
+      projectId?: string
+      currentStateId?: string
+    },
+  ) => {
+    const previousSnapshot = get(workflowBoardAtom)
+
+    if (previousSnapshot) {
+      const optimisticSnapshot = structuredClone(previousSnapshot)
+      for (const column of optimisticSnapshot.columns) {
+        for (const card of column.cards) {
+          const task = card.tasks.find((candidate) => candidate.id === input.taskId)
+          if (!task) {
+            continue
+          }
+
+          task.title = input.title
+          if (input.targetColumnId) {
+            task.columnId = input.targetColumnId
+            task.stateName = toColumnTitle(input.targetColumnId)
+            task.stateType = toColumnStateType(input.targetColumnId)
+            card.taskCounts = {
+              total: card.tasks.length,
+              done: card.tasks.filter((candidate) => candidate.columnId === 'done').length,
+            }
+          }
+        }
+      }
+
+      set(workflowBoardAtom, optimisticSnapshot)
+    }
+
+    const result = (await window.api.workflow.updateTask({
+      taskId: input.taskId,
+      title: input.title,
+      description: input.description,
+      targetColumnId: input.targetColumnId,
+      teamId: input.teamId,
+      projectId: input.projectId,
+      currentStateId: input.currentStateId,
+    })) satisfies WorkflowUpdateTaskResult
+
+    if (!result.success && previousSnapshot) {
+      set(workflowBoardAtom, previousSnapshot)
+      return result
+    }
 
     if (result.success && result.refreshBoard) {
       const refreshed = await window.api.workflow.refreshBoard()

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -6,6 +6,7 @@ import {
   type WorkflowBoardSnapshot,
   type WorkflowBoardScope,
   type WorkflowColumnId,
+  type WorkflowCreateTaskResult,
   type WorkflowEntityKind,
   type WorkflowMoveEntityResult,
 } from '@shared/types'
@@ -321,6 +322,39 @@ export const moveWorkflowEntityAtom = atom(
         updatedAt: failedAt,
       } satisfies WorkflowMoveEntityResult
     }
+  },
+)
+
+export const createWorkflowTaskAtom = atom(
+  null,
+  async (
+    _get,
+    set,
+    input: {
+      parentSliceId: string
+      title: string
+      description?: string
+      initialColumnId?: WorkflowColumnId
+      teamId?: string
+      projectId?: string
+    },
+  ) => {
+    const result = (await window.api.workflow.createTask({
+      parentSliceId: input.parentSliceId,
+      title: input.title,
+      description: input.description,
+      initialColumnId: input.initialColumnId,
+      teamId: input.teamId,
+      projectId: input.projectId,
+    })) satisfies WorkflowCreateTaskResult
+
+    if (result.success && result.refreshBoard) {
+      const refreshed = await window.api.workflow.refreshBoard()
+      set(workflowBoardAtom, refreshed.snapshot)
+      set(workflowBoardErrorAtom, refreshed.snapshot.lastError?.message ?? null)
+    }
+
+    return result
   },
 )
 

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -8,6 +8,7 @@ import {
   type WorkflowBoardTask,
 } from '@shared/types'
 import {
+  createWorkflowTaskAtom,
   moveWorkflowEntityAtom,
   openWorkflowIssueAtom,
   respondToWorkflowEscalationAtom,
@@ -17,6 +18,7 @@ import {
   workflowIssueActionStateAtom,
 } from '@/atoms/workflow-board'
 import { TaskList } from '@/components/kanban/TaskList'
+import { TaskMutationDialog } from '@/components/kanban/TaskMutationDialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -74,6 +76,9 @@ export function getMoveTargetOptions(currentColumnId: WorkflowBoardSliceCard['co
 export function SliceCard({ card }: SliceCardProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [showEscalationComposer, setShowEscalationComposer] = useState(false)
+  const [showCreateTaskDialog, setShowCreateTaskDialog] = useState(false)
+  const [createTaskError, setCreateTaskError] = useState<string | null>(null)
+  const [createTaskSubmitting, setCreateTaskSubmitting] = useState(false)
   const [responseDraftByRequestId, setResponseDraftByRequestId] = useState<Record<string, string>>({})
 
   const symphony = card.symphony
@@ -82,6 +87,7 @@ export function SliceCard({ card }: SliceCardProps) {
   const mutationStates = useAtomValue(workflowEntityMutationStateAtom)
   const openIssue = useSetAtom(openWorkflowIssueAtom)
   const respondToEscalation = useSetAtom(respondToWorkflowEscalationAtom)
+  const createTask = useSetAtom(createWorkflowTaskAtom)
   const moveEntity = useSetAtom(moveWorkflowEntityAtom)
 
   const pendingEscalations = useMemo(
@@ -158,6 +164,30 @@ export function SliceCard({ card }: SliceCardProps) {
     })
   }
 
+  const submitCreateTask = async (input: { title: string; description: string; columnId: WorkflowBoardSliceCard['columnId'] }) => {
+    setCreateTaskSubmitting(true)
+    setCreateTaskError(null)
+
+    const result = await createTask({
+      parentSliceId: card.id,
+      title: input.title,
+      description: input.description,
+      initialColumnId: input.columnId,
+      teamId: card.teamId,
+      projectId: card.projectId,
+    })
+
+    if (!result.success) {
+      setCreateTaskError(result.message)
+      setCreateTaskSubmitting(false)
+      return
+    }
+
+    setCreateTaskSubmitting(false)
+    setCreateTaskError(null)
+    setShowCreateTaskDialog(false)
+  }
+
   return (
     <Card size="sm" className="gap-3 rounded-xl border border-border/70 py-3 shadow-none">
       <CardHeader className="px-3 pb-0">
@@ -213,6 +243,20 @@ export function SliceCard({ card }: SliceCardProps) {
               Open Linear issue
             </Button>
           ) : null}
+
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 px-2 text-[11px]"
+            data-testid={`slice-add-task-${card.identifier}`}
+            onClick={() => {
+              setCreateTaskError(null)
+              setShowCreateTaskDialog(true)
+            }}
+          >
+            Add task
+          </Button>
 
           {pendingEscalations.length > 0 ? (
             <Button
@@ -332,6 +376,30 @@ export function SliceCard({ card }: SliceCardProps) {
             <TaskList tasks={card.tasks} issueActions={issueActions} onOpenIssue={openTaskIssue} />
           </CollapsibleContent>
         </Collapsible>
+
+        <TaskMutationDialog
+          open={showCreateTaskDialog}
+          mode="create"
+          heading={`Add task to ${card.identifier}`}
+          subheading="Create a child task in Linear without leaving the board."
+          confirmLabel="Create task"
+          initialValues={{
+            title: '',
+            description: '',
+            columnId: 'todo',
+          }}
+          submitting={createTaskSubmitting}
+          errorMessage={createTaskError}
+          onOpenChange={(open) => {
+            setShowCreateTaskDialog(open)
+            if (!open) {
+              setCreateTaskError(null)
+            }
+          }}
+          onSubmit={async (values) => {
+            await submitCreateTask(values)
+          }}
+        />
       </CardContent>
     </Card>
   )

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -1,10 +1,18 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { AlertCircle, ChevronDown, MessageSquareText } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import type { WorkflowBoardEscalationRequest, WorkflowBoardSliceCard, WorkflowBoardTask } from '@shared/types'
 import {
+  WORKFLOW_COLUMNS,
+  type WorkflowBoardEscalationRequest,
+  type WorkflowBoardSliceCard,
+  type WorkflowBoardTask,
+} from '@shared/types'
+import {
+  moveWorkflowEntityAtom,
   openWorkflowIssueAtom,
   respondToWorkflowEscalationAtom,
+  workflowEntityMutationKey,
+  workflowEntityMutationStateAtom,
   workflowEscalationActionStateAtom,
   workflowIssueActionStateAtom,
 } from '@/atoms/workflow-board'
@@ -14,6 +22,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
 interface SliceCardProps {
   card: WorkflowBoardSliceCard
@@ -58,6 +67,10 @@ export function isInlineEscalationEnabled(symphony: WorkflowBoardSliceCard['symp
   return symphony.freshness === 'fresh' && symphony.provenance === 'dashboard-derived'
 }
 
+export function getMoveTargetOptions(currentColumnId: WorkflowBoardSliceCard['columnId']) {
+  return WORKFLOW_COLUMNS.filter((column) => column.id !== currentColumnId)
+}
+
 export function SliceCard({ card }: SliceCardProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [showEscalationComposer, setShowEscalationComposer] = useState(false)
@@ -66,13 +79,17 @@ export function SliceCard({ card }: SliceCardProps) {
   const symphony = card.symphony
   const issueActions = useAtomValue(workflowIssueActionStateAtom)
   const escalationActions = useAtomValue(workflowEscalationActionStateAtom)
+  const mutationStates = useAtomValue(workflowEntityMutationStateAtom)
   const openIssue = useSetAtom(openWorkflowIssueAtom)
   const respondToEscalation = useSetAtom(respondToWorkflowEscalationAtom)
+  const moveEntity = useSetAtom(moveWorkflowEntityAtom)
 
   const pendingEscalations = useMemo(
     () => symphony?.pendingEscalationRequests ?? [],
     [symphony?.pendingEscalationRequests],
   )
+  const moveOptions = useMemo(() => getMoveTargetOptions(card.columnId), [card.columnId])
+  const sliceMoveState = mutationStates[workflowEntityMutationKey('slice', card.id)]
 
   const canRespondInline = isInlineEscalationEnabled(symphony) && pendingEscalations.length > 0
 
@@ -120,6 +137,24 @@ export function SliceCard({ card }: SliceCardProps) {
       cardId: task.id,
       url: task.url,
       identifier: task.identifier ?? card.identifier,
+    })
+  }
+
+  const moveSliceToColumn = (targetColumnId: WorkflowBoardSliceCard['columnId']) => {
+    if (targetColumnId === card.columnId) {
+      return
+    }
+
+    void moveEntity({
+      entityKind: 'slice',
+      entityId: card.id,
+      targetColumnId,
+      currentColumnId: card.columnId,
+      currentStateId: card.stateId,
+      currentStateName: card.stateName,
+      currentStateType: card.stateType,
+      teamId: card.teamId,
+      projectId: card.projectId,
     })
   }
 
@@ -192,11 +227,43 @@ export function SliceCard({ card }: SliceCardProps) {
               Respond to escalation
             </Button>
           ) : null}
+
+          {moveOptions.length > 0 ? (
+            <Select
+              value={card.columnId}
+              onValueChange={(value) => {
+                moveSliceToColumn(value as WorkflowBoardSliceCard['columnId'])
+              }}
+              disabled={sliceMoveState?.phase === 'pending'}
+            >
+              <SelectTrigger
+                size="sm"
+                className="h-7 min-w-[8.25rem] rounded-md border border-border/70 bg-background px-2 text-[11px]"
+                data-testid={`slice-move-select-${card.identifier}`}
+              >
+                <SelectValue placeholder="Move slice" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={card.columnId}>Current: {card.stateName}</SelectItem>
+                {moveOptions.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    Move to {option.title}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
         </div>
 
         {issueAction?.message ? (
           <p className="text-[11px] text-muted-foreground" data-testid={`slice-issue-action-${card.identifier}`}>
             {issueAction.message}
+          </p>
+        ) : null}
+
+        {sliceMoveState ? (
+          <p className="text-[11px] text-muted-foreground" data-testid={`slice-move-state-${card.identifier}`}>
+            {sliceMoveState.message}
           </p>
         ) : null}
 

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -168,24 +168,28 @@ export function SliceCard({ card }: SliceCardProps) {
     setCreateTaskSubmitting(true)
     setCreateTaskError(null)
 
-    const result = await createTask({
-      parentSliceId: card.id,
-      title: input.title,
-      description: input.description,
-      initialColumnId: input.columnId,
-      teamId: card.teamId,
-      projectId: card.projectId,
-    })
+    try {
+      const result = await createTask({
+        parentSliceId: card.id,
+        title: input.title,
+        description: input.description,
+        initialColumnId: input.columnId,
+        teamId: card.teamId,
+        projectId: card.projectId,
+      })
 
-    if (!result.success) {
-      setCreateTaskError(result.message)
+      if (!result.success) {
+        setCreateTaskError(result.message)
+        return
+      }
+
+      setCreateTaskError(null)
+      setShowCreateTaskDialog(false)
+    } catch (error) {
+      setCreateTaskError(error instanceof Error ? error.message : 'Unable to create task.')
+    } finally {
       setCreateTaskSubmitting(false)
-      return
     }
-
-    setCreateTaskSubmitting(false)
-    setCreateTaskError(null)
-    setShowCreateTaskDialog(false)
   }
 
   return (
@@ -368,7 +372,10 @@ export function SliceCard({ card }: SliceCardProps) {
         ) : null}
 
         <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-          <CollapsibleTrigger className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
+          <CollapsibleTrigger
+            className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+            data-testid={`slice-task-toggle-${card.identifier}`}
+          >
             <ChevronDown className={`size-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
             {isOpen ? 'Hide tasks' : 'Show tasks'}
           </CollapsibleTrigger>

--- a/apps/desktop/src/renderer/components/kanban/TaskList.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskList.tsx
@@ -1,16 +1,21 @@
 import { useAtomValue, useSetAtom } from 'jotai'
+import { useMemo, useState } from 'react'
 import {
   WORKFLOW_COLUMNS,
   type WorkflowBoardTask,
+  type WorkflowColumnId,
 } from '@shared/types'
 import {
+  loadWorkflowTaskDetailAtom,
   moveWorkflowEntityAtom,
+  updateWorkflowTaskAtom,
   workflowEntityMutationKey,
   workflowEntityMutationStateAtom,
 } from '@/atoms/workflow-board'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { TaskMutationDialog } from '@/components/kanban/TaskMutationDialog'
 import { cn } from '@/lib/utils'
 
 interface TaskListProps {
@@ -35,117 +40,248 @@ export function getTaskMoveTargetOptions(currentColumnId: WorkflowBoardTask['col
   return WORKFLOW_COLUMNS.filter((column) => column.id !== currentColumnId)
 }
 
+interface TaskEditDialogState {
+  taskId: string
+  identifier?: string
+  title: string
+  description: string
+  columnId: WorkflowColumnId
+  teamId?: string
+  projectId?: string
+  stateId?: string
+}
+
 export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProps) {
   const moveEntity = useSetAtom(moveWorkflowEntityAtom)
+  const loadTaskDetail = useSetAtom(loadWorkflowTaskDetailAtom)
+  const updateTask = useSetAtom(updateWorkflowTaskAtom)
   const mutationStates = useAtomValue(workflowEntityMutationStateAtom)
+
+  const [editDialogOpen, setEditDialogOpen] = useState(false)
+  const [editDialogLoading, setEditDialogLoading] = useState(false)
+  const [editDialogSubmitting, setEditDialogSubmitting] = useState(false)
+  const [editDialogError, setEditDialogError] = useState<string | null>(null)
+  const [editDialogState, setEditDialogState] = useState<TaskEditDialogState | null>(null)
+
+  const editStateOptions = useMemo(() => WORKFLOW_COLUMNS, [])
+
+  const openEditDialog = async (task: WorkflowBoardTask) => {
+    setEditDialogOpen(true)
+    setEditDialogLoading(true)
+    setEditDialogSubmitting(false)
+    setEditDialogError(null)
+    setEditDialogState({
+      taskId: task.id,
+      identifier: task.identifier,
+      title: task.title,
+      description: '',
+      columnId: task.columnId,
+      teamId: task.teamId,
+      projectId: task.projectId,
+      stateId: task.stateId,
+    })
+
+    const response = await loadTaskDetail({ taskId: task.id })
+    if (!response.success || !response.task) {
+      setEditDialogError(response.message)
+      setEditDialogLoading(false)
+      return
+    }
+
+    setEditDialogState({
+      taskId: response.task.id,
+      identifier: response.task.identifier,
+      title: response.task.title,
+      description: response.task.description,
+      columnId: response.task.columnId,
+      teamId: response.task.teamId,
+      projectId: response.task.projectId,
+      stateId: response.task.stateId,
+    })
+    setEditDialogLoading(false)
+  }
+
+  const submitTaskEdit = async (values: { title: string; description: string; columnId: WorkflowColumnId }) => {
+    if (!editDialogState) {
+      return
+    }
+
+    setEditDialogSubmitting(true)
+    setEditDialogError(null)
+
+    const result = await updateTask({
+      taskId: editDialogState.taskId,
+      title: values.title,
+      description: values.description,
+      targetColumnId: values.columnId,
+      teamId: editDialogState.teamId,
+      projectId: editDialogState.projectId,
+      currentStateId: editDialogState.stateId,
+    })
+
+    if (!result.success) {
+      setEditDialogError(result.message)
+      setEditDialogSubmitting(false)
+      return
+    }
+
+    setEditDialogSubmitting(false)
+    setEditDialogError(null)
+    setEditDialogOpen(false)
+  }
 
   if (tasks.length === 0) {
     return <p className="text-xs text-muted-foreground">No child tasks</p>
   }
 
   return (
-    <ul className="space-y-2">
-      {tasks.map((task) => {
-        const issueAction = issueActions[task.id]
-        const mutationState = mutationStates[workflowEntityMutationKey('task', task.id)]
-        const moveTargetOptions = getTaskMoveTargetOptions(task.columnId)
+    <>
+      <ul className="space-y-2">
+        {tasks.map((task) => {
+          const issueAction = issueActions[task.id]
+          const mutationState = mutationStates[workflowEntityMutationKey('task', task.id)]
+          const moveTargetOptions = getTaskMoveTargetOptions(task.columnId)
 
-        return (
-          <li key={task.id} className="rounded-md border border-border/60 bg-background/50 px-2 py-1.5">
-            <div className="flex items-center justify-between gap-2">
-              <p className="truncate text-xs font-medium text-foreground">
-                {task.identifier ? `${task.identifier} · ` : ''}
-                {task.title}
-              </p>
-              <Badge
-                variant="outline"
-                className={cn('border-transparent text-[10px]', TASK_STATE_TONE[task.columnId] ?? DEFAULT_TASK_TONE)}
-              >
-                {task.stateName}
-              </Badge>
-            </div>
-            {task.symphony ? (
-              <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
-                <span>
-                  {task.symphony.assignmentState === 'assigned'
-                    ? `Worker ${task.symphony.identifier ?? '(unknown)'}`
-                    : 'Unassigned'}
-                </span>
-                {task.symphony.workerState ? <span>· {task.symphony.workerState}</span> : null}
-                {task.symphony.pendingEscalations > 0 ? (
-                  <Badge variant="destructive" className="text-[10px]">
-                    {task.symphony.pendingEscalations} escalation{task.symphony.pendingEscalations === 1 ? '' : 's'}
-                  </Badge>
-                ) : null}
-              </div>
-            ) : null}
-
-            <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-              <Select
-                value={task.columnId}
-                onValueChange={(value) => {
-                  if (value === task.columnId) {
-                    return
-                  }
-
-                  void moveEntity({
-                    entityKind: 'task',
-                    entityId: task.id,
-                    targetColumnId: value as WorkflowBoardTask['columnId'],
-                    currentColumnId: task.columnId,
-                    currentStateId: task.stateId,
-                    currentStateName: task.stateName,
-                    currentStateType: task.stateType,
-                    teamId: task.teamId,
-                    projectId: task.projectId,
-                  })
-                }}
-                disabled={mutationState?.phase === 'pending'}
-              >
-                <SelectTrigger
-                  size="sm"
-                  className="h-6 min-w-[7.5rem] rounded-md border border-border/70 bg-background px-2 text-[10px]"
-                  data-testid={`task-move-select-${task.identifier ?? task.id}`}
+          return (
+            <li key={task.id} className="rounded-md border border-border/60 bg-background/50 px-2 py-1.5">
+              <div className="flex items-center justify-between gap-2">
+                <p className="truncate text-xs font-medium text-foreground">
+                  {task.identifier ? `${task.identifier} · ` : ''}
+                  {task.title}
+                </p>
+                <Badge
+                  variant="outline"
+                  className={cn('border-transparent text-[10px]', TASK_STATE_TONE[task.columnId] ?? DEFAULT_TASK_TONE)}
                 >
-                  <SelectValue placeholder="Move task" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={task.columnId}>Current: {task.stateName}</SelectItem>
-                  {moveTargetOptions.map((option) => (
-                    <SelectItem key={option.id} value={option.id}>
-                      Move to {option.title}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                  {task.stateName}
+                </Badge>
+              </div>
+              {task.symphony ? (
+                <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
+                  <span>
+                    {task.symphony.assignmentState === 'assigned'
+                      ? `Worker ${task.symphony.identifier ?? '(unknown)'}`
+                      : 'Unassigned'}
+                  </span>
+                  {task.symphony.workerState ? <span>· {task.symphony.workerState}</span> : null}
+                  {task.symphony.pendingEscalations > 0 ? (
+                    <Badge variant="destructive" className="text-[10px]">
+                      {task.symphony.pendingEscalations} escalation{task.symphony.pendingEscalations === 1 ? '' : 's'}
+                    </Badge>
+                  ) : null}
+                </div>
+              ) : null}
 
-              {task.url && onOpenIssue ? (
+              <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                <Select
+                  value={task.columnId}
+                  onValueChange={(value) => {
+                    if (value === task.columnId) {
+                      return
+                    }
+
+                    void moveEntity({
+                      entityKind: 'task',
+                      entityId: task.id,
+                      targetColumnId: value as WorkflowBoardTask['columnId'],
+                      currentColumnId: task.columnId,
+                      currentStateId: task.stateId,
+                      currentStateName: task.stateName,
+                      currentStateType: task.stateType,
+                      teamId: task.teamId,
+                      projectId: task.projectId,
+                    })
+                  }}
+                  disabled={mutationState?.phase === 'pending'}
+                >
+                  <SelectTrigger
+                    size="sm"
+                    className="h-6 min-w-[7.5rem] rounded-md border border-border/70 bg-background px-2 text-[10px]"
+                    data-testid={`task-move-select-${task.identifier ?? task.id}`}
+                  >
+                    <SelectValue placeholder="Move task" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={task.columnId}>Current: {task.stateName}</SelectItem>
+                    {moveTargetOptions.map((option) => (
+                      <SelectItem key={option.id} value={option.id}>
+                        Move to {option.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
                 <Button
                   type="button"
                   size="sm"
                   variant="outline"
                   className="h-6 px-2 text-[10px]"
-                  data-testid={`task-open-issue-${task.identifier ?? task.id}`}
-                  onClick={() => onOpenIssue(task)}
-                  disabled={issueAction?.status === 'opening'}
+                  data-testid={`task-edit-${task.identifier ?? task.id}`}
+                  onClick={() => {
+                    void openEditDialog(task)
+                  }}
+                  disabled={editDialogSubmitting && editDialogState?.taskId === task.id}
                 >
-                  Open issue
+                  Edit task
                 </Button>
+
+                {task.url && onOpenIssue ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="h-6 px-2 text-[10px]"
+                    data-testid={`task-open-issue-${task.identifier ?? task.id}`}
+                    onClick={() => onOpenIssue(task)}
+                    disabled={issueAction?.status === 'opening'}
+                  >
+                    Open issue
+                  </Button>
+                ) : null}
+              </div>
+
+              {mutationState ? (
+                <p className="mt-1 text-[10px] text-muted-foreground" data-testid={`task-move-state-${task.identifier ?? task.id}`}>
+                  {mutationState.message}
+                </p>
               ) : null}
-            </div>
 
-            {mutationState ? (
-              <p className="mt-1 text-[10px] text-muted-foreground" data-testid={`task-move-state-${task.identifier ?? task.id}`}>
-                {mutationState.message}
-              </p>
-            ) : null}
+              {issueAction?.message ? (
+                <p className="mt-1 text-[10px] text-muted-foreground">{issueAction.message}</p>
+              ) : null}
+            </li>
+          )
+        })}
+      </ul>
 
-            {issueAction?.message ? (
-              <p className="mt-1 text-[10px] text-muted-foreground">{issueAction.message}</p>
-            ) : null}
-          </li>
-        )
-      })}
-    </ul>
+      <TaskMutationDialog
+        open={editDialogOpen}
+        mode="edit"
+        heading={editDialogState?.identifier ? `Edit ${editDialogState.identifier}` : 'Edit task'}
+        subheading="Load current task details, then save updates back to Linear."
+        confirmLabel="Save task"
+        initialValues={{
+          title: editDialogState?.title ?? '',
+          description: editDialogState?.description ?? '',
+          columnId: editDialogState?.columnId ?? 'todo',
+        }}
+        includeStateField
+        stateOptions={editStateOptions}
+        loading={editDialogLoading}
+        submitting={editDialogSubmitting}
+        errorMessage={editDialogError}
+        onOpenChange={(open) => {
+          setEditDialogOpen(open)
+          if (!open) {
+            setEditDialogError(null)
+            setEditDialogLoading(false)
+            setEditDialogSubmitting(false)
+          }
+        }}
+        onSubmit={async (values) => {
+          await submitTaskEdit(values)
+        }}
+      />
+    </>
   )
 }

--- a/apps/desktop/src/renderer/components/kanban/TaskList.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskList.tsx
@@ -1,6 +1,16 @@
-import type { WorkflowBoardTask } from '@shared/types'
+import { useAtomValue, useSetAtom } from 'jotai'
+import {
+  WORKFLOW_COLUMNS,
+  type WorkflowBoardTask,
+} from '@shared/types'
+import {
+  moveWorkflowEntityAtom,
+  workflowEntityMutationKey,
+  workflowEntityMutationStateAtom,
+} from '@/atoms/workflow-board'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
 
 interface TaskListProps {
@@ -21,7 +31,14 @@ const TASK_STATE_TONE: Record<WorkflowBoardTask['columnId'], string> = {
   done: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
 }
 
+export function getTaskMoveTargetOptions(currentColumnId: WorkflowBoardTask['columnId']) {
+  return WORKFLOW_COLUMNS.filter((column) => column.id !== currentColumnId)
+}
+
 export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProps) {
+  const moveEntity = useSetAtom(moveWorkflowEntityAtom)
+  const mutationStates = useAtomValue(workflowEntityMutationStateAtom)
+
   if (tasks.length === 0) {
     return <p className="text-xs text-muted-foreground">No child tasks</p>
   }
@@ -30,6 +47,8 @@ export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProp
     <ul className="space-y-2">
       {tasks.map((task) => {
         const issueAction = issueActions[task.id]
+        const mutationState = mutationStates[workflowEntityMutationKey('task', task.id)]
+        const moveTargetOptions = getTaskMoveTargetOptions(task.columnId)
 
         return (
           <li key={task.id} className="rounded-md border border-border/60 bg-background/50 px-2 py-1.5">
@@ -61,8 +80,46 @@ export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProp
               </div>
             ) : null}
 
-            {task.url && onOpenIssue ? (
-              <div className="mt-1.5">
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+              <Select
+                value={task.columnId}
+                onValueChange={(value) => {
+                  if (value === task.columnId) {
+                    return
+                  }
+
+                  void moveEntity({
+                    entityKind: 'task',
+                    entityId: task.id,
+                    targetColumnId: value as WorkflowBoardTask['columnId'],
+                    currentColumnId: task.columnId,
+                    currentStateId: task.stateId,
+                    currentStateName: task.stateName,
+                    currentStateType: task.stateType,
+                    teamId: task.teamId,
+                    projectId: task.projectId,
+                  })
+                }}
+                disabled={mutationState?.phase === 'pending'}
+              >
+                <SelectTrigger
+                  size="sm"
+                  className="h-6 min-w-[7.5rem] rounded-md border border-border/70 bg-background px-2 text-[10px]"
+                  data-testid={`task-move-select-${task.identifier ?? task.id}`}
+                >
+                  <SelectValue placeholder="Move task" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={task.columnId}>Current: {task.stateName}</SelectItem>
+                  {moveTargetOptions.map((option) => (
+                    <SelectItem key={option.id} value={option.id}>
+                      Move to {option.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {task.url && onOpenIssue ? (
                 <Button
                   type="button"
                   size="sm"
@@ -74,10 +131,17 @@ export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProp
                 >
                   Open issue
                 </Button>
-                {issueAction?.message ? (
-                  <p className="mt-1 text-[10px] text-muted-foreground">{issueAction.message}</p>
-                ) : null}
-              </div>
+              ) : null}
+            </div>
+
+            {mutationState ? (
+              <p className="mt-1 text-[10px] text-muted-foreground" data-testid={`task-move-state-${task.identifier ?? task.id}`}>
+                {mutationState.message}
+              </p>
+            ) : null}
+
+            {issueAction?.message ? (
+              <p className="mt-1 text-[10px] text-muted-foreground">{issueAction.message}</p>
             ) : null}
           </li>
         )

--- a/apps/desktop/src/renderer/components/kanban/TaskList.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskList.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from 'jotai'
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import {
   WORKFLOW_COLUMNS,
   type WorkflowBoardTask,
@@ -62,10 +62,13 @@ export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProp
   const [editDialogSubmitting, setEditDialogSubmitting] = useState(false)
   const [editDialogError, setEditDialogError] = useState<string | null>(null)
   const [editDialogState, setEditDialogState] = useState<TaskEditDialogState | null>(null)
+  const editDialogRequestIdRef = useRef(0)
 
   const editStateOptions = useMemo(() => WORKFLOW_COLUMNS, [])
 
   const openEditDialog = async (task: WorkflowBoardTask) => {
+    const requestId = ++editDialogRequestIdRef.current
+
     setEditDialogOpen(true)
     setEditDialogLoading(true)
     setEditDialogSubmitting(false)
@@ -74,31 +77,47 @@ export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProp
       taskId: task.id,
       identifier: task.identifier,
       title: task.title,
-      description: '',
+      description: task.description ?? '',
       columnId: task.columnId,
       teamId: task.teamId,
       projectId: task.projectId,
       stateId: task.stateId,
     })
 
-    const response = await loadTaskDetail({ taskId: task.id })
-    if (!response.success || !response.task) {
-      setEditDialogError(response.message)
-      setEditDialogLoading(false)
-      return
-    }
+    try {
+      const response = await loadTaskDetail({ taskId: task.id })
+      if (requestId !== editDialogRequestIdRef.current) {
+        return
+      }
 
-    setEditDialogState({
-      taskId: response.task.id,
-      identifier: response.task.identifier,
-      title: response.task.title,
-      description: response.task.description,
-      columnId: response.task.columnId,
-      teamId: response.task.teamId,
-      projectId: response.task.projectId,
-      stateId: response.task.stateId,
-    })
-    setEditDialogLoading(false)
+      if (!response.success || !response.task) {
+        setEditDialogError(response.message)
+        setEditDialogState(null)
+        return
+      }
+
+      setEditDialogState({
+        taskId: response.task.id,
+        identifier: response.task.identifier,
+        title: response.task.title,
+        description: response.task.description,
+        columnId: response.task.columnId,
+        teamId: response.task.teamId,
+        projectId: response.task.projectId,
+        stateId: response.task.stateId,
+      })
+    } catch (error) {
+      if (requestId !== editDialogRequestIdRef.current) {
+        return
+      }
+
+      setEditDialogError(error instanceof Error ? error.message : 'Unable to load task details.')
+      setEditDialogState(null)
+    } finally {
+      if (requestId === editDialogRequestIdRef.current) {
+        setEditDialogLoading(false)
+      }
+    }
   }
 
   const submitTaskEdit = async (values: { title: string; description: string; columnId: WorkflowColumnId }) => {
@@ -273,9 +292,11 @@ export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProp
         onOpenChange={(open) => {
           setEditDialogOpen(open)
           if (!open) {
+            editDialogRequestIdRef.current += 1
             setEditDialogError(null)
             setEditDialogLoading(false)
             setEditDialogSubmitting(false)
+            setEditDialogState(null)
           }
         }}
         onSubmit={async (values) => {

--- a/apps/desktop/src/renderer/components/kanban/TaskMutationDialog.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskMutationDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { WORKFLOW_COLUMNS, type WorkflowColumnId } from '@shared/types'
 import { Button } from '@/components/ui/button'
 import {
@@ -69,28 +69,36 @@ export function TaskMutationDialog({
   onOpenChange,
   onSubmit,
 }: TaskMutationDialogProps) {
+  const initialTitle = initialValues?.title ?? DEFAULT_VALUES.title
+  const initialDescription = initialValues?.description ?? DEFAULT_VALUES.description
+  const initialColumnId = initialValues?.columnId ?? DEFAULT_VALUES.columnId
+
   const mergedInitialValues = useMemo(
     () => ({
-      ...DEFAULT_VALUES,
-      ...initialValues,
-      title: initialValues?.title ?? DEFAULT_VALUES.title,
-      description: initialValues?.description ?? DEFAULT_VALUES.description,
-      columnId: initialValues?.columnId ?? DEFAULT_VALUES.columnId,
+      title: initialTitle,
+      description: initialDescription,
+      columnId: initialColumnId,
     }),
-    [initialValues],
+    [initialTitle, initialDescription, initialColumnId],
   )
 
   const [values, setValues] = useState<TaskMutationDialogValues>(mergedInitialValues)
   const [validationError, setValidationError] = useState<string | null>(null)
+  const wasOpenRef = useRef(open)
 
   useEffect(() => {
-    if (!open) {
+    const openedNow = open && !wasOpenRef.current
+
+    if (openedNow) {
+      setValues(mergedInitialValues)
       setValidationError(null)
-      return
     }
 
-    setValues(mergedInitialValues)
-    setValidationError(null)
+    if (!open) {
+      setValidationError(null)
+    }
+
+    wasOpenRef.current = open
   }, [open, mergedInitialValues])
 
   const submit = async () => {

--- a/apps/desktop/src/renderer/components/kanban/TaskMutationDialog.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskMutationDialog.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { WorkflowColumnId } from '@shared/types'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+
+export interface TaskMutationDialogValues {
+  title: string
+  description: string
+  columnId: WorkflowColumnId
+}
+
+export interface TaskMutationDialogProps {
+  open: boolean
+  mode: 'create' | 'edit'
+  heading: string
+  subheading?: string
+  confirmLabel: string
+  initialValues?: Partial<TaskMutationDialogValues>
+  includeStateField?: boolean
+  submitting?: boolean
+  errorMessage?: string | null
+  onOpenChange: (open: boolean) => void
+  onSubmit: (values: TaskMutationDialogValues) => Promise<void> | void
+}
+
+export function validateTaskMutationValues(values: TaskMutationDialogValues): string | null {
+  if (!values.title.trim()) {
+    return 'Task title is required.'
+  }
+
+  if (values.title.trim().length > 240) {
+    return 'Task title must be 240 characters or fewer.'
+  }
+
+  return null
+}
+
+const DEFAULT_VALUES: TaskMutationDialogValues = {
+  title: '',
+  description: '',
+  columnId: 'todo',
+}
+
+export function TaskMutationDialog({
+  open,
+  mode,
+  heading,
+  subheading,
+  confirmLabel,
+  initialValues,
+  includeStateField = false,
+  submitting = false,
+  errorMessage = null,
+  onOpenChange,
+  onSubmit,
+}: TaskMutationDialogProps) {
+  const mergedInitialValues = useMemo(
+    () => ({
+      ...DEFAULT_VALUES,
+      ...initialValues,
+      title: initialValues?.title ?? DEFAULT_VALUES.title,
+      description: initialValues?.description ?? DEFAULT_VALUES.description,
+      columnId: initialValues?.columnId ?? DEFAULT_VALUES.columnId,
+    }),
+    [initialValues],
+  )
+
+  const [values, setValues] = useState<TaskMutationDialogValues>(mergedInitialValues)
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) {
+      setValidationError(null)
+      return
+    }
+
+    setValues(mergedInitialValues)
+    setValidationError(null)
+  }, [open, mergedInitialValues])
+
+  const submit = async () => {
+    const nextValidationError = validateTaskMutationValues(values)
+    if (nextValidationError) {
+      setValidationError(nextValidationError)
+      return
+    }
+
+    setValidationError(null)
+    await onSubmit({
+      title: values.title.trim(),
+      description: values.description,
+      columnId: values.columnId,
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[34rem]" showCloseButton={!submitting}>
+        <DialogHeader>
+          <DialogTitle>{heading}</DialogTitle>
+          {subheading ? <DialogDescription>{subheading}</DialogDescription> : null}
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="task-mutation-title">Title</Label>
+            <Input
+              id="task-mutation-title"
+              value={values.title}
+              placeholder="Describe the task"
+              onChange={(event) => {
+                const title = event.target.value
+                setValues((current) => ({ ...current, title }))
+              }}
+              data-testid="task-mutation-title"
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="task-mutation-description">Description</Label>
+            <Textarea
+              id="task-mutation-description"
+              value={values.description}
+              placeholder={mode === 'create' ? 'Optional task details' : 'Update task details'}
+              onChange={(event) => {
+                const description = event.target.value
+                setValues((current) => ({ ...current, description }))
+              }}
+              data-testid="task-mutation-description"
+              disabled={submitting}
+            />
+          </div>
+
+          {includeStateField ? (
+            <p className="text-xs text-muted-foreground" data-testid="task-mutation-state-placeholder">
+              State editing is enabled in edit mode.
+            </p>
+          ) : null}
+
+          {validationError ? (
+            <p className="text-xs text-destructive" data-testid="task-mutation-validation-error">
+              {validationError}
+            </p>
+          ) : null}
+
+          {errorMessage ? (
+            <p className="text-xs text-destructive" data-testid="task-mutation-submit-error">
+              {errorMessage}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={() => void submit()} data-testid="task-mutation-submit" disabled={submitting}>
+            {submitting ? `${confirmLabel}…` : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/components/kanban/TaskMutationDialog.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskMutationDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import type { WorkflowColumnId } from '@shared/types'
+import { WORKFLOW_COLUMNS, type WorkflowColumnId } from '@shared/types'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 
 export interface TaskMutationDialogValues {
@@ -27,6 +28,8 @@ export interface TaskMutationDialogProps {
   confirmLabel: string
   initialValues?: Partial<TaskMutationDialogValues>
   includeStateField?: boolean
+  stateOptions?: ReadonlyArray<{ id: WorkflowColumnId; title: string }>
+  loading?: boolean
   submitting?: boolean
   errorMessage?: string | null
   onOpenChange: (open: boolean) => void
@@ -59,6 +62,8 @@ export function TaskMutationDialog({
   confirmLabel,
   initialValues,
   includeStateField = false,
+  stateOptions = WORKFLOW_COLUMNS,
+  loading = false,
   submitting = false,
   errorMessage = null,
   onOpenChange,
@@ -89,6 +94,10 @@ export function TaskMutationDialog({
   }, [open, mergedInitialValues])
 
   const submit = async () => {
+    if (loading || submitting) {
+      return
+    }
+
     const nextValidationError = validateTaskMutationValues(values)
     if (nextValidationError) {
       setValidationError(nextValidationError)
@@ -105,7 +114,7 @@ export function TaskMutationDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[34rem]" showCloseButton={!submitting}>
+      <DialogContent className="sm:max-w-[34rem]" showCloseButton={!loading && !submitting}>
         <DialogHeader>
           <DialogTitle>{heading}</DialogTitle>
           {subheading ? <DialogDescription>{subheading}</DialogDescription> : null}
@@ -123,7 +132,7 @@ export function TaskMutationDialog({
                 setValues((current) => ({ ...current, title }))
               }}
               data-testid="task-mutation-title"
-              disabled={submitting}
+              disabled={loading || submitting}
             />
           </div>
 
@@ -138,13 +147,40 @@ export function TaskMutationDialog({
                 setValues((current) => ({ ...current, description }))
               }}
               data-testid="task-mutation-description"
-              disabled={submitting}
+              disabled={loading || submitting}
             />
           </div>
 
           {includeStateField ? (
-            <p className="text-xs text-muted-foreground" data-testid="task-mutation-state-placeholder">
-              State editing is enabled in edit mode.
+            <div className="space-y-1.5">
+              <Label htmlFor="task-mutation-state">State</Label>
+              <Select
+                value={values.columnId}
+                onValueChange={(value) => {
+                  setValues((current) => ({
+                    ...current,
+                    columnId: value as WorkflowColumnId,
+                  }))
+                }}
+                disabled={loading || submitting}
+              >
+                <SelectTrigger id="task-mutation-state" className="w-full rounded-md border border-border/70">
+                  <SelectValue placeholder="Select task state" />
+                </SelectTrigger>
+                <SelectContent>
+                  {stateOptions.map((option) => (
+                    <SelectItem key={option.id} value={option.id}>
+                      {option.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
+
+          {loading ? (
+            <p className="text-xs text-muted-foreground" data-testid="task-mutation-loading">
+              Loading task details…
             </p>
           ) : null}
 
@@ -166,12 +202,17 @@ export function TaskMutationDialog({
             type="button"
             variant="outline"
             onClick={() => onOpenChange(false)}
-            disabled={submitting}
+            disabled={loading || submitting}
           >
             Cancel
           </Button>
-          <Button type="button" onClick={() => void submit()} data-testid="task-mutation-submit" disabled={submitting}>
-            {submitting ? `${confirmLabel}…` : confirmLabel}
+          <Button
+            type="button"
+            onClick={() => void submit()}
+            data-testid="task-mutation-submit"
+            disabled={loading || submitting}
+          >
+            {loading ? 'Loading…' : submitting ? `${confirmLabel}…` : confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { WorkflowBoardSliceCard } from '@shared/types'
-import { formatSliceSymphonyHint, isInlineEscalationEnabled } from '../SliceCard'
+import { formatSliceSymphonyHint, getMoveTargetOptions, isInlineEscalationEnabled } from '../SliceCard'
 
 describe('SliceCard symphony hint formatting', () => {
   test('shows unavailable hint when context is missing', () => {
@@ -99,5 +99,14 @@ describe('SliceCard inline escalation affordance', () => {
         provenance: 'runtime-disconnected',
       }),
     ).toBe(false)
+  })
+})
+
+describe('SliceCard move options', () => {
+  test('excludes the current column from move targets', () => {
+    const options = getMoveTargetOptions('todo')
+    expect(options.some((option) => option.id === 'todo')).toBe(false)
+    expect(options.some((option) => option.id === 'in_progress')).toBe(true)
+    expect(options.some((option) => option.id === 'done')).toBe(true)
   })
 })

--- a/apps/desktop/src/renderer/components/kanban/__tests__/TaskList.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/TaskList.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'vitest'
+import { getTaskMoveTargetOptions } from '../TaskList'
+
+describe('TaskList move options', () => {
+  test('returns all workflow columns except the current task column', () => {
+    const options = getTaskMoveTargetOptions('in_progress')
+
+    expect(options.some((option) => option.id === 'in_progress')).toBe(false)
+    expect(options.some((option) => option.id === 'todo')).toBe(true)
+    expect(options.some((option) => option.id === 'done')).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/components/kanban/__tests__/TaskMutationDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/TaskMutationDialog.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest'
+import { validateTaskMutationValues } from '../TaskMutationDialog'
+
+describe('TaskMutationDialog validation', () => {
+  test('requires a non-empty title', () => {
+    expect(
+      validateTaskMutationValues({
+        title: '   ',
+        description: '',
+        columnId: 'todo',
+      }),
+    ).toBe('Task title is required.')
+  })
+
+  test('rejects titles longer than 240 characters', () => {
+    expect(
+      validateTaskMutationValues({
+        title: 'x'.repeat(241),
+        description: '',
+        columnId: 'todo',
+      }),
+    ).toBe('Task title must be 240 characters or fewer.')
+  })
+
+  test('accepts valid task mutation payloads', () => {
+    expect(
+      validateTaskMutationValues({
+        title: 'Implement mutation dialog',
+        description: 'Optional details',
+        columnId: 'todo',
+      }),
+    ).toBeNull()
+  })
+})

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -33,6 +33,8 @@ export const IPC_CHANNELS = {
   workflowSetScope: 'workflow:set-scope',
   workflowMoveEntity: 'workflow:move-entity',
   workflowCreateTask: 'workflow:create-task',
+  workflowGetTaskDetail: 'workflow:get-task-detail',
+  workflowUpdateTask: 'workflow:update-task',
   workflowRespondEscalation: 'workflow:respond-escalation',
   workflowOpenIssue: 'workflow:open-issue',
   workflowGetContext: 'workflow:get-context',
@@ -847,6 +849,67 @@ export interface WorkflowCreateTaskResult {
   }
 }
 
+export interface WorkflowTaskDetailRequest {
+  taskId: string
+}
+
+export interface WorkflowTaskDetail {
+  id: string
+  identifier?: string
+  parentSliceId?: string
+  teamId?: string
+  projectId?: string
+  stateId?: string
+  stateName: string
+  stateType: string
+  columnId: WorkflowColumnId
+  title: string
+  description: string
+}
+
+export type WorkflowTaskDetailCode = 'LOADED' | 'NOT_FOUND' | 'UNSUPPORTED' | 'FAILED'
+
+export interface WorkflowTaskDetailResponse {
+  success: boolean
+  code: WorkflowTaskDetailCode
+  message: string
+  task?: WorkflowTaskDetail
+}
+
+export interface WorkflowUpdateTaskRequest {
+  taskId: string
+  title: string
+  description?: string
+  targetColumnId?: WorkflowColumnId
+  teamId?: string
+  projectId?: string
+  currentStateId?: string
+}
+
+export type WorkflowUpdateTaskCode =
+  | 'UPDATED'
+  | 'VALIDATION_ERROR'
+  | 'ROLLED_BACK'
+  | 'NOT_FOUND'
+  | 'UNSUPPORTED'
+  | 'FAILED'
+
+export interface WorkflowUpdateTaskResult {
+  success: boolean
+  taskId: string
+  status: 'success' | 'error'
+  code: WorkflowUpdateTaskCode
+  message: string
+  refreshBoard: boolean
+  updatedAt: string
+  task?: {
+    id: string
+    identifier?: string
+    title: string
+    columnId: WorkflowColumnId
+  }
+}
+
 export interface WorkflowBoardEscalationResponseRequest {
   cardId: string
   requestId: string
@@ -1327,6 +1390,8 @@ export interface DesktopApi {
     setScope: (request: WorkflowBoardScopeRequest | string) => Promise<WorkflowBoardScopeResponse>
     moveEntity: (request: WorkflowMoveEntityRequest) => Promise<WorkflowMoveEntityResult>
     createTask: (request: WorkflowCreateTaskRequest) => Promise<WorkflowCreateTaskResult>
+    getTaskDetail: (request: WorkflowTaskDetailRequest) => Promise<WorkflowTaskDetailResponse>
+    updateTask: (request: WorkflowUpdateTaskRequest) => Promise<WorkflowUpdateTaskResult>
     respondToEscalation: (
       request: WorkflowBoardEscalationResponseRequest,
     ) => Promise<WorkflowBoardEscalationResponseResult>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -683,6 +683,7 @@ export interface WorkflowBoardTask {
   id: string
   identifier?: string
   title: string
+  description?: string
   columnId: WorkflowColumnId
   stateId?: string
   stateName: string

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -32,6 +32,7 @@ export const IPC_CHANNELS = {
   workflowSetBoardActive: 'workflow:set-board-active',
   workflowSetScope: 'workflow:set-scope',
   workflowMoveEntity: 'workflow:move-entity',
+  workflowCreateTask: 'workflow:create-task',
   workflowRespondEscalation: 'workflow:respond-escalation',
   workflowOpenIssue: 'workflow:open-issue',
   workflowGetContext: 'workflow:get-context',
@@ -813,6 +814,39 @@ export interface WorkflowMoveEntityResult {
   updatedAt: string
 }
 
+export interface WorkflowCreateTaskRequest {
+  parentSliceId: string
+  title: string
+  description?: string
+  initialColumnId?: WorkflowColumnId
+  teamId?: string
+  projectId?: string
+}
+
+export type WorkflowCreateTaskCode =
+  | 'CREATED'
+  | 'VALIDATION_ERROR'
+  | 'ROLLED_BACK'
+  | 'NOT_FOUND'
+  | 'UNSUPPORTED'
+  | 'FAILED'
+
+export interface WorkflowCreateTaskResult {
+  success: boolean
+  parentSliceId: string
+  status: 'success' | 'error'
+  code: WorkflowCreateTaskCode
+  message: string
+  refreshBoard: boolean
+  updatedAt: string
+  task?: {
+    id: string
+    identifier?: string
+    title: string
+    columnId: WorkflowColumnId
+  }
+}
+
 export interface WorkflowBoardEscalationResponseRequest {
   cardId: string
   requestId: string
@@ -1292,6 +1326,7 @@ export interface DesktopApi {
     setBoardActive: (active: boolean) => Promise<WorkflowBoardLifecycleResponse>
     setScope: (request: WorkflowBoardScopeRequest | string) => Promise<WorkflowBoardScopeResponse>
     moveEntity: (request: WorkflowMoveEntityRequest) => Promise<WorkflowMoveEntityResult>
+    createTask: (request: WorkflowCreateTaskRequest) => Promise<WorkflowCreateTaskResult>
     respondToEscalation: (
       request: WorkflowBoardEscalationResponseRequest,
     ) => Promise<WorkflowBoardEscalationResponseResult>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -31,6 +31,7 @@ export const IPC_CHANNELS = {
   workflowRefreshBoard: 'workflow:refresh-board',
   workflowSetBoardActive: 'workflow:set-board-active',
   workflowSetScope: 'workflow:set-scope',
+  workflowMoveEntity: 'workflow:move-entity',
   workflowRespondEscalation: 'workflow:respond-escalation',
   workflowOpenIssue: 'workflow:open-issue',
   workflowGetContext: 'workflow:get-context',
@@ -680,8 +681,12 @@ export interface WorkflowBoardTask {
   identifier?: string
   title: string
   columnId: WorkflowColumnId
+  stateId?: string
   stateName: string
   stateType: string
+  teamId?: string
+  projectId?: string
+  parentSliceId?: string
   url?: string
   symphony?: WorkflowSymphonyExecutionSummary
 }
@@ -691,8 +696,11 @@ export interface WorkflowBoardSliceCard {
   identifier: string
   title: string
   columnId: WorkflowColumnId
+  stateId?: string
   stateName: string
   stateType: string
+  teamId?: string
+  projectId?: string
   url?: string
   milestoneId: string
   milestoneName: string
@@ -768,6 +776,41 @@ export interface WorkflowBoardScopeResponse {
   requestedScope: WorkflowBoardScope
   resolvedScope: WorkflowBoardScope
   resolutionReason: WorkflowBoardScopeResolutionReason
+}
+
+export type WorkflowEntityKind = 'slice' | 'task'
+
+export interface WorkflowMoveEntityRequest {
+  entityKind: WorkflowEntityKind
+  entityId: string
+  targetColumnId: WorkflowColumnId
+  currentColumnId?: WorkflowColumnId
+  currentStateId?: string
+  currentStateName?: string
+  currentStateType?: string
+  teamId?: string
+  projectId?: string
+}
+
+export type WorkflowMoveEntityCode =
+  | 'COMMITTED'
+  | 'ROLLED_BACK'
+  | 'VALIDATION_ERROR'
+  | 'NOT_FOUND'
+  | 'UNSUPPORTED'
+  | 'FAILED'
+
+export interface WorkflowMoveEntityResult {
+  success: boolean
+  entityKind: WorkflowEntityKind
+  entityId: string
+  targetColumnId: WorkflowColumnId
+  status: 'success' | 'error'
+  code: WorkflowMoveEntityCode
+  phase: 'committed' | 'rolled_back'
+  message: string
+  refreshBoard: boolean
+  updatedAt: string
 }
 
 export interface WorkflowBoardEscalationResponseRequest {
@@ -1248,6 +1291,7 @@ export interface DesktopApi {
     refreshBoard: () => Promise<WorkflowBoardSnapshotResponse>
     setBoardActive: (active: boolean) => Promise<WorkflowBoardLifecycleResponse>
     setScope: (request: WorkflowBoardScopeRequest | string) => Promise<WorkflowBoardScopeResponse>
+    moveEntity: (request: WorkflowMoveEntityRequest) => Promise<WorkflowMoveEntityResult>
     respondToEscalation: (
       request: WorkflowBoardEscalationResponseRequest,
     ) => Promise<WorkflowBoardEscalationResponseResult>


### PR DESCRIPTION
## Summary
- add Linear-backed board mutation paths for moving slices/tasks, creating child tasks, and editing task details through Desktop main-process workflow services
- wire mutation IPC/preload/renderer flows with explicit optimistic pending, success, and rollback/error state on slice cards, task rows, and mutation dialogs
- add mutation-focused Electron e2e coverage (`workflow-board-mutations.e2e.ts`) plus live smoke documentation at `docs/uat/M005/S02-LINEAR-MUTATION-SMOKE.md`
- harden edge and failure coverage in Linear workflow client + workflow board service tests (validation, unsupported backend, missing entities, mapping fallbacks)

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/linear-workflow-client.test.ts src/main/__tests__/workflow-board-service.test.ts src/renderer/components/kanban/__tests__/SliceCard.test.tsx src/renderer/components/kanban/__tests__/TaskList.test.tsx src/renderer/components/kanban/__tests__/TaskMutationDialog.test.tsx`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/workflow-board-mutations.e2e.ts`
- pre-push gate: `turbo run lint typecheck test --affected`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Move cards and individual tasks between workflow columns with optimistic UI updates and visible mutation status.
  * Create tasks directly from a board card via a modal dialog.
  * Edit task title, description, and workflow state from the board with live validation and loading/error feedback.
  * Controls disable during pending operations and automatically refresh or roll back on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires Linear write mutations through the full Desktop stack — slice/task moves, child task creation, and task title/description/state edits — with optimistic UI, mutation-state tracking, rollback visibility, and new e2e coverage. Two data-integrity issues in the edit-task path need to be resolved before merging.

- **Description silently cleared on Linear update:** `linearClient.updateTask` unconditionally includes `description: options.description ?? ''` in the GraphQL mutation input, so callers that omit `description` (or where `undefined` is passed) will overwrite any existing description with an empty string in Linear.
- **Submit enabled after failed task-detail load:** in `TaskList`, if `loadTaskDetail` fails, `editDialogLoading` is set back to `false` but the dialog's submit button is not disabled; the user can click "Save task" with the pre-populated empty description, triggering the data-loss path above.

<h3>Confidence Score: 4/5</h3>

Two P1 data-integrity bugs in the task edit path (description clearing + missing rollback on IPC exception) should be fixed before merging.

The move/create mutations and the overall architecture are solid. The two P1 findings are isolated to the edit-task path and have straightforward fixes, but they can cause silent data loss in Linear on real user flows (failed detail load → submit → description cleared).

apps/desktop/src/main/linear-workflow-client.ts (line 502 description coalescion), apps/desktop/src/renderer/components/kanban/TaskList.tsx (submit after failed load), apps/desktop/src/renderer/atoms/workflow-board.ts (missing try/catch in updateWorkflowTaskAtom)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/linear-workflow-client.ts | Adds moveIssueToColumn, createChildTask, fetchIssueDetail, updateTask; updateTask unconditionally sends description:'' when undefined, silently clearing Linear descriptions. |
| apps/desktop/src/main/workflow-board-service.ts | Adds moveEntity, createTask, getTaskDetail, updateTask with proper validation, backend guard, and fixture-mode support. |
| apps/desktop/src/renderer/atoms/workflow-board.ts | Adds moveWorkflowEntityAtom (with try/catch rollback), createWorkflowTaskAtom, loadWorkflowTaskDetailAtom; updateWorkflowTaskAtom applies an optimistic update but lacks try/catch, leaving the board stuck in optimistic state on IPC exception. |
| apps/desktop/src/renderer/components/kanban/TaskList.tsx | New TaskList component with inline move and edit-task dialog; 'Save task' button remains enabled after a failed detail load, allowing submission with an empty description that clears the existing one in Linear. |
| apps/desktop/src/renderer/components/kanban/SliceCard.tsx | New slice card with move, add-task, and escalation actions; optimistic move state and rollback correctly wired. |
| apps/desktop/src/renderer/components/kanban/TaskMutationDialog.tsx | Generic create/edit dialog with validation; correctly disables submit during loading/submitting. |
| apps/desktop/src/main/ipc.ts | Registers workflowMoveEntity, workflowCreateTask, workflowGetTaskDetail, workflowUpdateTask IPC channels with cleanup handlers. |
| apps/desktop/src/preload/index.ts | Exposes workflow mutation calls (moveEntity, createTask, getTaskDetail, updateTask) via contextBridge. |
| apps/desktop/src/shared/types.ts | Adds WorkflowMoveEntityRequest/Result, WorkflowCreateTaskRequest/Result, WorkflowTaskDetailRequest/Response, WorkflowUpdateTaskRequest/Result types. |
| apps/desktop/e2e/tests/workflow-board-mutations.e2e.ts | New Playwright e2e tests covering move, rollback, create, and edit paths using fixture mode. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer (Jotai atom)
    participant P as Preload (contextBridge)
    participant M as WorkflowBoardService
    participant L as LinearWorkflowClient
    participant G as Linear GraphQL API

    note over R,G: Move slice / task (optimistic)
    R->>R: applyOptimisticMove()<br/>set workflowBoardAtom → optimistic<br/>set mutationState → pending
    R->>P: window.api.workflow.moveEntity(request)
    P->>M: ipcRenderer.invoke(workflowMoveEntity)
    M->>L: moveIssueToColumn(issueId, targetColumnId)
    L->>G: query WorkflowTeamStates
    G-->>L: state list
    L->>G: mutation WorkflowIssueMove
    alt success
        G-->>L: issueUpdate.success = true
        L-->>M: result
        M-->>R: success, refreshBoard: true
        R->>R: set mutationState → success
        R->>P: workflow.refreshBoard()
        P->>M: workflowRefreshBoard
        M->>G: WorkflowIssuesByProject
        G-->>M: fresh snapshot
        M-->>R: authoritative snapshot
        R->>R: set workflowBoardAtom (server)
    else failure
        G-->>L: error
        L-->>M: LinearWorkflowClientError
        M-->>R: success: false, rolled_back
        R->>R: restore previousSnapshot<br/>set mutationState → error
    end

    note over R,G: Create child task
    R->>P: workflow.createTask(request)
    P->>M: workflowCreateTask
    M->>L: createChildTask(parentIssueId, title, description)
    L->>G: mutation WorkflowCreateChildTask
    alt success
        G-->>L: issueCreate.issue
        L-->>M: created task
        M-->>R: success, refreshBoard: true
        R->>P: workflow.refreshBoard()
        P->>M: full board refresh
        M-->>R: snapshot with new task
        R->>R: set workflowBoardAtom
    else failure
        G-->>L: error
        M-->>R: success: false (board unchanged)
    end

    note over R,G: Edit task (load then update)
    R->>P: workflow.getTaskDetail(taskId)
    P->>M: workflowGetTaskDetail
    M->>L: fetchIssueDetail(issueId)
    L->>G: query WorkflowIssueForMutation
    G-->>L: issue detail
    L-->>M: LinearIssueDetailResult
    M-->>R: WorkflowTaskDetailResponse
    R->>R: pre-fill edit form
    R->>R: applyOptimisticEdit()<br/>set workflowBoardAtom (no try/catch)
    R->>P: workflow.updateTask(request)
    P->>M: workflowUpdateTask
    M->>L: updateTask(issueId, title, description)
    note over L: description: options.description ?? '' may clear description!
    L->>G: mutation WorkflowTaskUpdate
    alt success
        G-->>L: issueUpdate.issue
        M-->>R: success, refreshBoard: true
        R->>P: workflow.refreshBoard()
        M-->>R: authoritative snapshot
        R->>R: set workflowBoardAtom (server)
    else failure
        G-->>L: error
        M-->>R: success: false
        R->>R: restore previousSnapshot
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/linear-workflow-client.ts
Line: 502

Comment:
**`description: undefined` silently clears Linear description**

When `options.description` is `undefined`, this line sends `description: ''` as part of the `IssueUpdateInput` payload, which overwrites any existing description in Linear with an empty string. The `??` coalescion only guards against `null`/`undefined` at the JS level, but the Linear API treats an explicitly supplied `''` as "clear the description". Omitting the field entirely would leave the description unchanged.

```suggestion
          description: options.description ?? undefined,
```

Or, to exclude it from the mutation when not explicitly provided:
```ts
input: {
  title,
  ...(options.description !== undefined ? { description: options.description } : {}),
  ...(stateId ? { stateId } : {}),
},
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/kanban/TaskList.tsx
Line: 84-90

Comment:
**Submit button stays enabled after failed detail load**

When `loadTaskDetail` fails, `editDialogLoading` is set to `false` and `editDialogError` is set, but the dialog's submit button is not disabled. The `editDialogState.description` is still `''` (the placeholder set in `openEditDialog` before the fetch). If the user clicks "Save task", the empty description is sent to Linear via `updateTask`, which — combined with the `description ?? ''` coalescion in the client — will clear the existing description in Linear.

A minimal guard: track whether the initial load succeeded and prevent submission if it did not.
```ts
// After the failed load branch:
if (!response.success || !response.task) {
  setEditDialogError(response.message)
  setEditDialogLoading(false)
  setEditDialogState(null) // prevent submission with empty description
  return
}
```
Then in the `onSubmit` handler early-return if `editDialogState` is null (which it already does), and disable the submit button when `editDialogError` is set and `editDialogState?.description` was never populated from the server.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/workflow-board.ts
Line: 412-421

Comment:
**Missing try/catch in `updateWorkflowTaskAtom` leaves board in optimistic state on IPC exception**

The atom applies an optimistic snapshot update at line ~409 (`set(workflowBoardAtom, optimisticSnapshot)`) but wraps the IPC call in no try/catch. If `window.api.workflow.updateTask(...)` rejects (e.g., due to a serialisation or unhandled main-process error), the rejection propagates uncaught and `workflowBoardAtom` is never rolled back to `previousSnapshot`. Compare to `moveWorkflowEntityAtom`, which has an explicit `catch` that restores the previous snapshot.

```ts
try {
  const result = (await window.api.workflow.updateTask({ ... })) satisfies WorkflowUpdateTaskResult
  if (!result.success && previousSnapshot) {
    set(workflowBoardAtom, previousSnapshot)
    return result
  }
  // ... refresh logic
  return result
} catch (error) {
  if (previousSnapshot) {
    set(workflowBoardAtom, previousSnapshot)
  }
  throw error
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): expand workflow mutation ..."](https://github.com/gannonh/kata/commit/ef0f6d1747e391f20525e91dc0f729c472915c2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27499632)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->