### PR TITLE
feat(desktop): assemble workflow↔MCP shortcuts and failure recovery proof (KAT-2392)

### DIFF
--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -70,9 +70,29 @@ async function dismissOnboardingIfPresent(window: Page): Promise<void> {
 export async function startMockWorkflowRuntime(page: Page): Promise<void> {
   await page.getByRole('heading', { name: /Workflow Board/i }).waitFor({ state: 'visible' })
 
-  await page.evaluate(async () => {
-    await window.api.symphony.start()
+  const startResult = await page.evaluate(async () => {
+    try {
+      return await window.api.symphony.start()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return {
+        success: false,
+        error: {
+          code: 'UNKNOWN',
+          phase: 'unknown',
+          message,
+        },
+      }
+    }
   })
+
+  if (!startResult?.success) {
+    const details =
+      typeof startResult?.error === 'string'
+        ? startResult.error
+        : startResult?.error?.message ?? 'unknown error'
+    throw new Error(`Failed to start mock workflow runtime: ${details}`)
+  }
 
   await page.getByTestId('kanban-refresh-board').click()
   await page.getByTestId('kanban-column-in_progress').waitFor({ state: 'visible' })

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -67,6 +67,21 @@ async function dismissOnboardingIfPresent(window: Page): Promise<void> {
   }
 }
 
+export async function startMockWorkflowRuntime(page: Page): Promise<void> {
+  await page.getByRole('heading', { name: /Workflow Board/i }).waitFor({ state: 'visible' })
+
+  await page.evaluate(async () => {
+    await window.api.symphony.start()
+  })
+
+  await page.getByTestId('kanban-refresh-board').click()
+}
+
+export async function openMcpSettingsFromWorkflow(page: Page): Promise<void> {
+  await page.getByTestId('kanban-open-mcp-settings').click()
+  await page.getByTestId('mcp-settings-panel').waitFor({ state: 'visible' })
+}
+
 type DesktopFixtures = {
   electronApp: ElectronApplication
   workspaceDir: string

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -75,6 +75,7 @@ export async function startMockWorkflowRuntime(page: Page): Promise<void> {
   })
 
   await page.getByTestId('kanban-refresh-board').click()
+  await page.getByTestId('kanban-column-in_progress').waitFor({ state: 'visible' })
 }
 
 export async function openMcpSettingsFromWorkflow(page: Page): Promise<void> {

--- a/apps/desktop/e2e/tests/m005-interactive-workflow.e2e.ts
+++ b/apps/desktop/e2e/tests/m005-interactive-workflow.e2e.ts
@@ -32,7 +32,7 @@ function writeValidMcpConfig(mcpConfigPath: string): void {
   )
 }
 
-async function selectMoveOption(page: Page, triggerTestId: string, optionText: string) {
+async function selectMoveOption(page: Page, triggerTestId: string, optionText: string): Promise<void> {
   await page.getByTestId(triggerTestId).click()
   await page.getByRole('option', { name: optionText }).click()
 }

--- a/apps/desktop/e2e/tests/m005-interactive-workflow.e2e.ts
+++ b/apps/desktop/e2e/tests/m005-interactive-workflow.e2e.ts
@@ -1,0 +1,134 @@
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Page } from '@playwright/test'
+import {
+  expect,
+  openMcpSettingsFromWorkflow,
+  startMockWorkflowRuntime,
+  test,
+} from '../fixtures/electron.fixture'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const MCP_FIXTURE_SCRIPT = path.resolve(__dirname, '../fixtures/mcp-stdio-server.mjs')
+
+function writeValidMcpConfig(mcpConfigPath: string): void {
+  writeFileSync(
+    mcpConfigPath,
+    `${JSON.stringify(
+      {
+        imports: [],
+        settings: {
+          toolPrefix: 'server',
+          idleTimeout: 10,
+        },
+        mcpServers: {},
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  )
+}
+
+async function selectMoveOption(page: Page, triggerTestId: string, optionText: string) {
+  await page.getByTestId(triggerTestId).click()
+  await page.getByRole('option', { name: optionText }).click()
+}
+
+test.describe('m005 interactive workflow assembly', () => {
+  test.describe('healthy assembled flow', () => {
+    test.use({ symphonyMockMode: 'assembled_healthy' })
+
+    test('healthy assembled flow keeps workflow and MCP surfaces coherent in one session', async ({
+      readyWindow,
+    }) => {
+      await startMockWorkflowRuntime(readyWindow)
+
+      await selectMoveOption(readyWindow, 'slice-move-select-KAT-2337', 'Move to Agent Review')
+      await expect(readyWindow.getByTestId('slice-move-state-KAT-2337')).toContainText('Committed')
+      await expect(readyWindow.getByTestId('kanban-column-agent_review')).toContainText('KAT-2337')
+
+      await openMcpSettingsFromWorkflow(readyWindow)
+
+      await readyWindow.getByTestId('mcp-add-server').click()
+      await readyWindow.getByTestId('mcp-editor-name').fill('assembled-healthy-fixture')
+      await readyWindow.getByTestId('mcp-editor-command').fill(process.execPath)
+      await readyWindow.getByTestId('mcp-editor-args').fill(MCP_FIXTURE_SCRIPT)
+      await readyWindow.getByTestId('mcp-editor-save').click()
+
+      await expect(readyWindow.getByTestId('mcp-server-row-assembled-healthy-fixture')).toBeVisible()
+      await readyWindow.getByTestId('mcp-refresh-assembled-healthy-fixture').click()
+      await expect(readyWindow.getByTestId('mcp-status-badge-assembled-healthy-fixture')).toContainText('Connected')
+
+      await readyWindow.getByTestId('settings-return-to-workflow').click()
+      await expect(readyWindow.getByRole('heading', { name: /Workflow Board/i })).toBeVisible()
+      await expect(readyWindow.getByTestId('kanban-column-agent_review')).toContainText('KAT-2337')
+    })
+  })
+
+  test.describe('failure-path recovery', () => {
+    test.use({ symphonyMockMode: 'assembled_failure_recovery' })
+
+    test('failure-path recovery keeps rollback and MCP errors visible until recovery succeeds', async ({
+      readyWindow,
+      mcpConfigPath,
+    }) => {
+      await startMockWorkflowRuntime(readyWindow)
+
+      await selectMoveOption(readyWindow, 'slice-move-select-KAT-2337', 'Move to Human Review')
+      await expect(readyWindow.getByTestId('slice-move-state-KAT-2337')).toContainText('Rollback:')
+      await expect(readyWindow.getByTestId('slice-move-state-KAT-2337')).toContainText('Mocked Linear move failure')
+      await expect(readyWindow.getByTestId('kanban-column-in_progress')).toContainText('KAT-2337')
+
+      await readyWindow.evaluate(async () => {
+        await window.api.symphony.refreshDashboardSnapshot()
+      })
+      await readyWindow.getByTestId('kanban-refresh-board').click()
+      await expect(readyWindow.getByTestId('board-state-notice-symphony-stale')).toBeVisible()
+
+      await readyWindow.evaluate(async () => {
+        await window.api.symphony.refreshDashboardSnapshot()
+      })
+      await readyWindow.getByTestId('kanban-refresh-board').click()
+      await expect(readyWindow.getByTestId('board-state-notice-symphony-stale')).toHaveCount(0)
+
+      await openMcpSettingsFromWorkflow(readyWindow)
+
+      writeFileSync(mcpConfigPath, '{bad-json', 'utf8')
+      await readyWindow.getByTestId('mcp-refresh-config').click()
+      await expect(readyWindow.getByTestId('mcp-config-error')).toBeVisible()
+      await expect(readyWindow.getByTestId('mcp-recovery-hint')).toBeVisible()
+
+      writeValidMcpConfig(mcpConfigPath)
+      await readyWindow.getByTestId('mcp-refresh-config').click()
+      await expect(readyWindow.getByTestId('mcp-empty-state')).toBeVisible()
+
+      await readyWindow.getByTestId('mcp-add-server').click()
+      await readyWindow.getByTestId('mcp-editor-name').fill('assembled-recovery-fixture')
+      await readyWindow.getByTestId('mcp-editor-command').fill('not-a-real-command-xyz')
+      await readyWindow.getByTestId('mcp-editor-args').fill(MCP_FIXTURE_SCRIPT)
+      await readyWindow.getByTestId('mcp-editor-save').click()
+
+      await readyWindow.getByTestId('mcp-reconnect-assembled-recovery-fixture').click()
+      await expect(readyWindow.getByTestId('mcp-status-badge-assembled-recovery-fixture')).toContainText(
+        'COMMAND_NOT_FOUND',
+      )
+      await expect(readyWindow.getByTestId('mcp-status-error-assembled-recovery-fixture')).toBeVisible()
+      await expect(readyWindow.getByTestId('mcp-row-recovery-hint')).toBeVisible()
+
+      await readyWindow.getByTestId('mcp-edit-assembled-recovery-fixture').click()
+      await readyWindow.getByTestId('mcp-editor-command').fill(process.execPath)
+      await readyWindow.getByTestId('mcp-editor-args').fill(MCP_FIXTURE_SCRIPT)
+      await readyWindow.getByTestId('mcp-editor-save').click()
+
+      await readyWindow.getByTestId('mcp-refresh-assembled-recovery-fixture').click()
+      await expect(readyWindow.getByTestId('mcp-status-badge-assembled-recovery-fixture')).toContainText('Connected')
+
+      await readyWindow.getByTestId('settings-return-to-workflow').click()
+      await expect(readyWindow.getByRole('heading', { name: /Workflow Board/i })).toBeVisible()
+      await expect(readyWindow.getByTestId('kanban-column-in_progress')).toContainText('KAT-2337')
+    })
+  })
+})

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1399,13 +1399,19 @@ export function registerSessionIpc({
         dispatchedAt: new Date().toISOString(),
       }
 
-      if (canSendToRenderer()) {
+      const dispatched = canSendToRenderer()
+      if (dispatched) {
         window.webContents.send(IPC_CHANNELS.workflowShellAction, eventPayload)
       }
 
       return {
-        success: true,
+        success: dispatched,
         dispatchedAt: eventPayload.dispatchedAt,
+        ...(dispatched
+          ? {}
+          : {
+              error: 'Renderer unavailable. Workflow shell action was not dispatched.',
+            }),
       }
     },
   )

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -61,6 +61,9 @@ import {
   type WorkflowBoardOpenIssueRequest,
   type WorkflowBoardOpenIssueResult,
   type WorkflowContextResponse,
+  type WorkflowShellActionDispatchResult,
+  type WorkflowShellActionEvent,
+  type WorkflowShellActionRequest,
   type SymphonyRuntimeStatus,
   type SymphonyRuntimeCommandResult,
   type SymphonyRuntimeStatusResponse,
@@ -601,6 +604,7 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
   ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
   ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
+  ipcMain.removeHandler(IPC_CHANNELS.workflowDispatchShellAction)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyGetStatus)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyStart)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyStop)
@@ -1357,6 +1361,55 @@ export function registerSessionIpc({
     }
   })
 
+  ipcMain.handle(
+    IPC_CHANNELS.workflowDispatchShellAction,
+    async (_event, request: WorkflowShellActionRequest): Promise<WorkflowShellActionDispatchResult> => {
+      if (!request || typeof request !== 'object') {
+        return {
+          success: false,
+          error: 'Workflow shell action request is required.',
+        }
+      }
+
+      if (
+        request.action !== 'open_mcp_settings' &&
+        request.action !== 'return_to_kanban' &&
+        request.action !== 'refresh_board'
+      ) {
+        return {
+          success: false,
+          error: `Unsupported workflow shell action: ${String((request as { action?: unknown }).action)}`,
+        }
+      }
+
+      if (
+        request.source !== 'kanban_header' &&
+        request.source !== 'settings_panel' &&
+        request.source !== 'keyboard_shortcut'
+      ) {
+        return {
+          success: false,
+          error: `Unsupported workflow shell action source: ${String((request as { source?: unknown }).source)}`,
+        }
+      }
+
+      const eventPayload: WorkflowShellActionEvent = {
+        action: request.action,
+        source: request.source,
+        dispatchedAt: new Date().toISOString(),
+      }
+
+      if (canSendToRenderer()) {
+        window.webContents.send(IPC_CHANNELS.workflowShellAction, eventPayload)
+      }
+
+      return {
+        success: true,
+        dispatchedAt: eventPayload.dispatchedAt,
+      }
+    },
+  )
+
   const createSymphonyDisconnectedResult = (): SymphonyRuntimeCommandResult => {
     const status: SymphonyRuntimeStatus = {
       phase: 'disconnected',
@@ -1555,6 +1608,7 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.workflowRespondEscalation)
     ipcMain.removeHandler(IPC_CHANNELS.workflowOpenIssue)
     ipcMain.removeHandler(IPC_CHANNELS.workflowGetContext)
+    ipcMain.removeHandler(IPC_CHANNELS.workflowDispatchShellAction)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyGetStatus)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyStart)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyStop)

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -12,6 +12,7 @@ import {
   type ThinkingLevel,
   type SymphonyRuntimeStatus,
   type SymphonyOperatorSnapshot,
+  type WorkflowShellActionEvent,
 } from '../shared/types'
 
 const api: DesktopApi = {
@@ -183,6 +184,20 @@ const api: DesktopApi = {
     },
     getContext: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.workflowGetContext)
+    },
+    dispatchShellAction: async (request: Parameters<DesktopApi['workflow']['dispatchShellAction']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workflowDispatchShellAction, request)
+    },
+    onShellAction: (listener: (event: WorkflowShellActionEvent) => void) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, shellEvent: WorkflowShellActionEvent) => {
+        listener(shellEvent)
+      }
+
+      ipcRenderer.on(IPC_CHANNELS.workflowShellAction, wrapped)
+
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.workflowShellAction, wrapped)
+      }
     },
   },
   symphony: {

--- a/apps/desktop/src/renderer/atoms/right-pane.ts
+++ b/apps/desktop/src/renderer/atoms/right-pane.ts
@@ -7,6 +7,8 @@ import type {
   WorkflowContextSnapshot,
 } from '@shared/types'
 
+export type SettingsTabId = 'providers' | 'mcp' | 'general' | 'appearance' | 'symphony'
+
 export const RIGHT_PANE_OVERRIDE_STORAGE_KEY = 'kata-desktop:right-pane-override'
 
 const defaultWorkflowContext: WorkflowContextSnapshot = {
@@ -79,3 +81,18 @@ export const setWorkflowContextAtom = atom(
     set(workflowContextAtom, context)
   },
 )
+
+export const settingsPanelOpenAtom = atom(false)
+export const settingsPanelTabAtom = atom<SettingsTabId>('providers')
+
+export const openSettingsPanelAtom = atom(
+  null,
+  (_get, set, targetTab: SettingsTabId = 'providers') => {
+    set(settingsPanelTabAtom, targetTab)
+    set(settingsPanelOpenAtom, true)
+  },
+)
+
+export const closeSettingsPanelAtom = atom(null, (_get, set) => {
+  set(settingsPanelOpenAtom, false)
+})

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -29,6 +29,13 @@ export const workflowBoardRefreshingAtom = atom<boolean>(false)
 export const workflowBoardErrorAtom = atom<string | null>(null)
 export const workflowBoardActiveAtom = atom<boolean>(false)
 
+export interface WorkflowBoardReturnContext {
+  scope: WorkflowBoardScope
+  capturedAt: string
+}
+
+export const workflowBoardReturnContextAtom = atom<WorkflowBoardReturnContext | null>(null)
+
 type EscalationActionState = {
   status: 'idle' | 'submitting' | 'success' | 'error' | 'disabled'
   message?: string
@@ -52,6 +59,10 @@ type WorkflowEntityMutationState = {
 export const workflowEscalationActionStateAtom = atom<Record<string, EscalationActionState>>({})
 export const workflowIssueActionStateAtom = atom<Record<string, IssueActionState>>({})
 export const workflowEntityMutationStateAtom = atom<Record<string, WorkflowEntityMutationState>>({})
+
+export const workflowMutationPendingAtom = atom((get) => {
+  return Object.values(get(workflowEntityMutationStateAtom)).some((mutation) => mutation.phase === 'pending')
+})
 
 const workflowBoardScopePreferencesAtom = atomWithStorage<ScopePreferenceMap>(
   WORKFLOW_BOARD_SCOPE_STORAGE_KEY,
@@ -84,6 +95,17 @@ const workflowBoardCollapseKeyAtom = atom((get) => {
   const workspaceKey = get(workflowBoardWorkspaceKeyAtom)
   const scope = get(workflowBoardScopeAtom)
   return `${workspaceKey}::scope:${scope}`
+})
+
+export const captureWorkflowBoardReturnContextAtom = atom(null, (get, set) => {
+  set(workflowBoardReturnContextAtom, {
+    scope: get(workflowBoardScopeAtom),
+    capturedAt: new Date().toISOString(),
+  })
+})
+
+export const clearWorkflowBoardReturnContextAtom = atom(null, (_get, set) => {
+  set(workflowBoardReturnContextAtom, null)
 })
 
 export const collapsedWorkflowColumnsAtom = atom((get) => {

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -19,6 +19,8 @@ import {
   captureWorkflowBoardReturnContextAtom,
   clearWorkflowBoardReturnContextAtom,
   refreshWorkflowBoardAtom,
+  workflowBoardLoadingAtom,
+  workflowBoardRefreshingAtom,
   workflowBoardReturnContextAtom,
   workflowBoardScopeAtom,
   workflowMutationPendingAtom,
@@ -100,6 +102,8 @@ export function AppShell() {
   const settingsTab = useAtomValue(settingsPanelTabAtom)
   const workflowScope = useAtomValue(workflowBoardScopeAtom)
   const workflowReturnContext = useAtomValue(workflowBoardReturnContextAtom)
+  const workflowLoading = useAtomValue(workflowBoardLoadingAtom)
+  const workflowRefreshing = useAtomValue(workflowBoardRefreshingAtom)
   const workflowMutationPending = useAtomValue(workflowMutationPendingAtom)
 
   const mcpMutationPending = useAtomValue(mcpMutationPendingAtom)
@@ -134,7 +138,7 @@ export function AppShell() {
       }
 
       if (event.action === 'refresh_board') {
-        if (workflowMutationPending) {
+        if (workflowLoading || workflowRefreshing || workflowMutationPending) {
           return
         }
 
@@ -159,6 +163,8 @@ export function AppShell() {
       }
     },
     [
+      workflowLoading,
+      workflowRefreshing,
       workflowMutationPending,
       captureReturnContext,
       openSettingsPanel,

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -1,14 +1,32 @@
-import { useEffect, useMemo } from 'react'
-import { useSetAtom } from 'jotai'
+import { useCallback, useEffect, useMemo } from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
 import {
   Group,
   Panel,
   Separator as PanelSeparator,
   type Layout,
 } from 'react-resizable-panels'
+import type { WorkflowShellActionEvent } from '@shared/types'
 import { initializeSessionsAtom } from '@/atoms/session'
+import {
+  closeSettingsPanelAtom,
+  openSettingsPanelAtom,
+  settingsPanelOpenAtom,
+  settingsPanelTabAtom,
+  setRightPaneOverrideAtom,
+} from '@/atoms/right-pane'
+import {
+  captureWorkflowBoardReturnContextAtom,
+  clearWorkflowBoardReturnContextAtom,
+  refreshWorkflowBoardAtom,
+  workflowBoardReturnContextAtom,
+  workflowBoardScopeAtom,
+  workflowMutationPendingAtom,
+} from '@/atoms/workflow-board'
+import { mcpMutationPendingAtom, mcpStatusPendingByServerAtom } from '@/atoms/mcp'
 import { LeftPane } from './LeftPane'
 import { RightPane } from './RightPane'
+import { SettingsPanel } from '../settings/SettingsPanel'
 
 const LAYOUT_STORAGE_KEY = 'kata-desktop:app-shell-layout'
 const LEFT_PANEL_ID = 'chat-pane'
@@ -53,13 +71,146 @@ function readInitialLayout(): Layout {
   return DEFAULT_LAYOUT
 }
 
+function isKeyboardShortcutEvent(event: KeyboardEvent, key: string): boolean {
+  if (!(event.metaKey || event.ctrlKey) || !event.shiftKey || event.altKey) {
+    return false
+  }
+
+  return event.key.toLowerCase() === key
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  if (target.isContentEditable) {
+    return true
+  }
+
+  const tagName = target.tagName.toLowerCase()
+  return tagName === 'input' || tagName === 'textarea' || tagName === 'select'
+}
+
 export function AppShell() {
   const defaultLayout = useMemo(readInitialLayout, [])
   const initializeSessions = useSetAtom(initializeSessionsAtom)
 
+  const settingsOpen = useAtomValue(settingsPanelOpenAtom)
+  const settingsTab = useAtomValue(settingsPanelTabAtom)
+  const workflowScope = useAtomValue(workflowBoardScopeAtom)
+  const workflowReturnContext = useAtomValue(workflowBoardReturnContextAtom)
+  const workflowMutationPending = useAtomValue(workflowMutationPendingAtom)
+
+  const mcpMutationPending = useAtomValue(mcpMutationPendingAtom)
+  const mcpStatusPendingByServer = useAtomValue(mcpStatusPendingByServerAtom)
+  const mcpBusy =
+    mcpMutationPending ||
+    Object.values(mcpStatusPendingByServer).some((isPending) => Boolean(isPending))
+
+  const openSettingsPanel = useSetAtom(openSettingsPanelAtom)
+  const closeSettingsPanel = useSetAtom(closeSettingsPanelAtom)
+  const setSettingsTab = useSetAtom(settingsPanelTabAtom)
+  const captureReturnContext = useSetAtom(captureWorkflowBoardReturnContextAtom)
+  const clearReturnContext = useSetAtom(clearWorkflowBoardReturnContextAtom)
+  const setWorkflowScope = useSetAtom(workflowBoardScopeAtom)
+  const setRightPaneOverride = useSetAtom(setRightPaneOverrideAtom)
+  const refreshWorkflowBoard = useSetAtom(refreshWorkflowBoardAtom)
+
   useEffect(() => {
     void initializeSessions()
   }, [initializeSessions])
+
+  const handleWorkflowShellAction = useCallback(
+    async (event: WorkflowShellActionEvent) => {
+      if (event.action === 'open_mcp_settings') {
+        if (workflowMutationPending) {
+          return
+        }
+
+        captureReturnContext()
+        openSettingsPanel('mcp')
+        return
+      }
+
+      if (event.action === 'refresh_board') {
+        if (workflowMutationPending) {
+          return
+        }
+
+        await refreshWorkflowBoard()
+        return
+      }
+
+      if (event.action === 'return_to_kanban') {
+        if (mcpBusy) {
+          return
+        }
+
+        closeSettingsPanel()
+        setRightPaneOverride('kanban')
+
+        if (workflowReturnContext?.scope && workflowReturnContext.scope !== workflowScope) {
+          setWorkflowScope(workflowReturnContext.scope)
+        }
+
+        clearReturnContext()
+        await refreshWorkflowBoard()
+      }
+    },
+    [
+      workflowMutationPending,
+      captureReturnContext,
+      openSettingsPanel,
+      refreshWorkflowBoard,
+      mcpBusy,
+      closeSettingsPanel,
+      setRightPaneOverride,
+      workflowReturnContext,
+      workflowScope,
+      setWorkflowScope,
+      clearReturnContext,
+    ],
+  )
+
+  useEffect(() => {
+    return window.api.workflow.onShellAction((event) => {
+      void handleWorkflowShellAction(event)
+    })
+  }, [handleWorkflowShellAction])
+
+  useEffect(() => {
+    const handleKeyboardShortcut = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat || isEditableTarget(event.target)) {
+        return
+      }
+
+      let action: WorkflowShellActionEvent['action'] | null = null
+
+      if (isKeyboardShortcutEvent(event, 'm')) {
+        action = 'open_mcp_settings'
+      } else if (isKeyboardShortcutEvent(event, 'b')) {
+        action = 'return_to_kanban'
+      } else if (isKeyboardShortcutEvent(event, 'r')) {
+        action = 'refresh_board'
+      }
+
+      if (!action) {
+        return
+      }
+
+      event.preventDefault()
+      void window.api.workflow.dispatchShellAction({
+        action,
+        source: 'keyboard_shortcut',
+      })
+    }
+
+    window.addEventListener('keydown', handleKeyboardShortcut)
+    return () => {
+      window.removeEventListener('keydown', handleKeyboardShortcut)
+    }
+  }, [])
 
   return (
     <main className="size-full bg-background text-foreground">
@@ -76,7 +227,12 @@ export function AppShell() {
         }}
       >
         <Panel id={LEFT_PANEL_ID} defaultSize={defaultLayout[LEFT_PANEL_ID]} minSize={45}>
-          <LeftPane />
+          <LeftPane
+            onOpenSettings={() => {
+              clearReturnContext()
+              openSettingsPanel('providers')
+            }}
+          />
         </Panel>
 
         <PanelSeparator className="w-px bg-border transition-colors hover:bg-accent" />
@@ -85,6 +241,31 @@ export function AppShell() {
           <RightPane />
         </Panel>
       </Group>
+
+      <SettingsPanel
+        open={settingsOpen}
+        activeTab={settingsTab}
+        onActiveTabChange={setSettingsTab}
+        onOpenChange={(open) => {
+          if (open) {
+            openSettingsPanel(settingsTab)
+            return
+          }
+
+          closeSettingsPanel()
+          clearReturnContext()
+        }}
+        onReturnToWorkflowBoard={() => {
+          void window.api.workflow.dispatchShellAction({
+            action: 'return_to_kanban',
+            source: 'settings_panel',
+          })
+        }}
+        returnToWorkflowDisabled={mcpBusy}
+        returnToWorkflowDisabledReason={
+          mcpBusy ? 'Finish pending MCP save/reconnect work before returning to the workflow board.' : null
+        }
+      />
     </main>
   )
 }

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -181,7 +181,9 @@ export function AppShell() {
 
   useEffect(() => {
     return window.api.workflow.onShellAction((event) => {
-      void handleWorkflowShellAction(event)
+      handleWorkflowShellAction(event).catch((error) => {
+        console.error('[AppShell] Workflow shell action failed:', error)
+      })
     })
   }, [handleWorkflowShellAction])
 

--- a/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
@@ -1,18 +1,19 @@
-import { useState } from 'react'
 import { Menu, Settings } from 'lucide-react'
 import { useAtom } from 'jotai'
 import { sessionSidebarOpenAtom } from '@/atoms/session'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
-import { SettingsPanel } from '../settings/SettingsPanel'
 import { ChatPanel } from '../chat/ChatPanel'
 import { ModelSelector } from './ModelSelector'
 import { SessionSidebar } from './SessionSidebar'
 import { WorkspaceIndicator } from './WorkspaceIndicator'
 import { SymphonyStatusBadge } from './SymphonyStatusBadge'
 
-export function LeftPane() {
-  const [settingsOpen, setSettingsOpen] = useState(false)
+interface LeftPaneProps {
+  onOpenSettings: () => void
+}
+
+export function LeftPane({ onOpenSettings }: LeftPaneProps) {
   const [sessionSidebarOpen, setSessionSidebarOpen] = useAtom(sessionSidebarOpenAtom)
 
   return (
@@ -37,7 +38,7 @@ export function LeftPane() {
 
         <div className="flex flex-1 items-center justify-end gap-2">
           <ModelSelector />
-          <Button type="button" variant="outline" size="sm" onClick={() => setSettingsOpen(true)}>
+          <Button type="button" variant="outline" size="sm" onClick={onOpenSettings}>
             <Settings data-icon="inline-start" />
             Settings
           </Button>
@@ -54,7 +55,6 @@ export function LeftPane() {
         </div>
       </div>
 
-      <SettingsPanel open={settingsOpen} onOpenChange={setSettingsOpen} />
     </section>
   )
 }

--- a/apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx
+++ b/apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx
@@ -12,7 +12,16 @@ export function BoardStateNotice({ board, error }: BoardStateNoticeProps) {
     notices.push({
       id: 'board-error',
       tone: 'error',
-      message: error,
+      message: `${error} Last known board state is still shown so you can recover without losing context.`,
+    })
+  }
+
+  if (board?.status === 'stale') {
+    notices.push({
+      id: 'board-stale',
+      tone: 'warning',
+      message:
+        'Workflow data is stale. Retry refresh to reconcile rollback or remote changes before continuing board mutations.',
     })
   }
 

--- a/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
@@ -146,9 +146,13 @@ interface KanbanHeaderProps {
   rightPaneOverride: RightPaneOverride
   paneResolution: RightPaneResolution
   workflowContext: WorkflowContextSnapshot
+  mcpShortcutDisabled: boolean
+  refreshDisabled: boolean
+  actionLockReason?: string | null
   onScopeChange: (scope: WorkflowBoardScope) => void
   onExpandAllColumns: () => void
   onOpenPlanningView: () => void
+  onOpenMcpSettings: () => void
   onRefresh: () => void
   onClearOverride: () => void
 }
@@ -163,9 +167,13 @@ export function KanbanHeader({
   rightPaneOverride,
   paneResolution,
   workflowContext,
+  mcpShortcutDisabled,
+  refreshDisabled,
+  actionLockReason,
   onScopeChange,
   onExpandAllColumns,
   onOpenPlanningView,
+  onOpenMcpSettings,
   onRefresh,
   onClearOverride,
 }: KanbanHeaderProps) {
@@ -209,11 +217,34 @@ export function KanbanHeader({
             </Button>
           ) : null}
 
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 px-2 text-[11px]"
+            aria-label="Open MCP tab"
+            onClick={onOpenMcpSettings}
+            disabled={mcpShortcutDisabled}
+            title="Open MCP settings (⌘⇧M / Ctrl+Shift+M)"
+            data-testid="kanban-open-mcp-settings"
+          >
+            MCP
+          </Button>
+
           <Button type="button" size="icon" variant="ghost" aria-label="Open planning view" onClick={onOpenPlanningView}>
             <LayoutGrid className="size-4" />
           </Button>
 
-          <Button type="button" size="icon" variant="ghost" aria-label="Refresh workflow board" onClick={onRefresh}>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Refresh workflow board"
+            onClick={onRefresh}
+            disabled={refreshDisabled}
+            title="Refresh workflow board (⌘⇧R / Ctrl+Shift+R)"
+            data-testid="kanban-refresh-board"
+          >
             <RefreshCcw className="size-4" />
           </Button>
         </div>
@@ -244,6 +275,20 @@ export function KanbanHeader({
         {' · '}
         {formatSymphonyBoardStatus(board)}
       </div>
+
+      <div className="border-b border-border bg-background/80 px-4 py-1 text-[11px] text-muted-foreground">
+        Shortcuts: <span className="font-mono">⌘⇧M</span> open MCP settings ·{' '}
+        <span className="font-mono">⌘⇧R</span> refresh board
+      </div>
+
+      {actionLockReason ? (
+        <div
+          className="border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-900 dark:text-amber-200"
+          data-testid="kanban-action-lock-reason"
+        >
+          {actionLockReason}
+        </div>
+      ) : null}
 
       {board?.scope?.note ? (
         <div className="border-b border-border bg-muted/60 px-4 py-2 text-xs text-muted-foreground" data-testid="workflow-board-scope-note">

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -11,6 +11,7 @@ import {
   workflowBoardLoadingAtom,
   workflowBoardRefreshingAtom,
   workflowBoardScopeAtom,
+  workflowMutationPendingAtom,
 } from '@/atoms/workflow-board'
 import {
   clearRightPaneOverrideAtom,
@@ -19,6 +20,7 @@ import {
   setRightPaneOverrideAtom,
   workflowContextAtom,
 } from '@/atoms/right-pane'
+import { mcpMutationPendingAtom, mcpStatusPendingByServerAtom } from '@/atoms/mcp'
 import { BoardStateNotice } from '@/components/kanban/BoardStateNotice'
 import { KanbanColumn } from '@/components/kanban/KanbanColumn'
 import { KanbanHeader } from '@/components/kanban/KanbanHeader'
@@ -59,7 +61,22 @@ export function KanbanPane() {
   const rightPaneOverride = useAtomValue(rightPaneOverrideAtom)
   const paneResolution = useAtomValue(rightPaneResolutionAtom)
   const workflowContext = useAtomValue(workflowContextAtom)
+  const workflowMutationPending = useAtomValue(workflowMutationPendingAtom)
+  const mcpMutationPending = useAtomValue(mcpMutationPendingAtom)
+  const mcpStatusPendingByServer = useAtomValue(mcpStatusPendingByServerAtom)
   const refreshBoard = useSetAtom(refreshWorkflowBoardAtom)
+
+  const mcpBusy =
+    mcpMutationPending || Object.values(mcpStatusPendingByServer).some((isPending) => Boolean(isPending))
+
+  const actionLockReason = workflowMutationPending
+    ? 'Workflow mutation is in flight. Wait for it to finish before navigating or refreshing.'
+    : mcpBusy
+      ? 'MCP operation is in flight. Wait for save/reconnect to finish before switching surfaces.'
+      : null
+
+  const refreshDisabled = loading || refreshing || workflowMutationPending
+  const mcpShortcutDisabled = workflowMutationPending || mcpBusy
 
   const columns = board ? normalizeWorkflowColumns(board) : []
   const presentation = summarizeColumnPresentation(columns, collapsedColumns)
@@ -76,6 +93,9 @@ export function KanbanPane() {
         rightPaneOverride={rightPaneOverride}
         paneResolution={paneResolution}
         workflowContext={workflowContext}
+        mcpShortcutDisabled={mcpShortcutDisabled}
+        refreshDisabled={refreshDisabled}
+        actionLockReason={actionLockReason}
         onScopeChange={(scope) => {
           setScope(scope)
         }}
@@ -83,7 +103,21 @@ export function KanbanPane() {
           resetCollapsedColumns()
         }}
         onOpenPlanningView={() => setRightPaneOverride('planning')}
+        onOpenMcpSettings={() => {
+          if (mcpShortcutDisabled) {
+            return
+          }
+
+          void window.api.workflow.dispatchShellAction({
+            action: 'open_mcp_settings',
+            source: 'kanban_header',
+          })
+        }}
         onRefresh={() => {
+          if (refreshDisabled) {
+            return
+          }
+
           void refreshBoard()
         }}
         onClearOverride={() => clearOverride()}

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -73,6 +73,30 @@ export function getMoveTargetOptions(currentColumnId: WorkflowBoardSliceCard['co
   return WORKFLOW_COLUMNS.filter((column) => column.id !== currentColumnId)
 }
 
+function formatMoveStateMessage(moveState: { phase: 'pending' | 'success' | 'error'; message: string }): string {
+  if (moveState.phase === 'pending') {
+    return moveState.message
+  }
+
+  if (moveState.phase === 'success') {
+    return `Committed: ${moveState.message}`
+  }
+
+  return `Rollback: ${moveState.message}`
+}
+
+function moveStateTone(phase: 'pending' | 'success' | 'error'): string {
+  if (phase === 'pending') {
+    return 'text-muted-foreground'
+  }
+
+  if (phase === 'success') {
+    return 'text-emerald-700 dark:text-emerald-300'
+  }
+
+  return 'text-destructive'
+}
+
 export function SliceCard({ card }: SliceCardProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [showEscalationComposer, setShowEscalationComposer] = useState(false)
@@ -310,8 +334,11 @@ export function SliceCard({ card }: SliceCardProps) {
         ) : null}
 
         {sliceMoveState ? (
-          <p className="text-[11px] text-muted-foreground" data-testid={`slice-move-state-${card.identifier}`}>
-            {sliceMoveState.message}
+          <p
+            className={`text-[11px] ${moveStateTone(sliceMoveState.phase)}`}
+            data-testid={`slice-move-state-${card.identifier}`}
+          >
+            {formatMoveStateMessage(sliceMoveState)}
           </p>
         ) : null}
 

--- a/apps/desktop/src/renderer/components/settings/McpServerEditorDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerEditorDialog.tsx
@@ -529,8 +529,16 @@ export function McpServerEditorDialog({
             </>
           )}
 
-          {localError ? <p className="text-xs text-destructive">{localError}</p> : null}
-          {errorMessage ? <p className="text-xs text-destructive">{errorMessage}</p> : null}
+          {localError ? (
+            <p className="text-xs text-destructive" data-testid="mcp-editor-local-error">
+              Fix before saving: {localError}
+            </p>
+          ) : null}
+          {errorMessage ? (
+            <p className="text-xs text-destructive" data-testid="mcp-editor-save-error">
+              Save failed: {errorMessage}
+            </p>
+          ) : null}
         </div>
 
         <DialogFooter>

--- a/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
@@ -53,6 +53,9 @@ export function McpServerPanel() {
   const [pendingDeleteName, setPendingDeleteName] = useState<string | null>(null)
 
   const servers = useMemo(() => configState.servers, [configState.servers])
+  const serverErrorCount = useMemo(() => {
+    return Object.values(statuses).filter((status) => status?.phase === 'error').length
+  }, [statuses])
 
   const openCreateDialog = () => {
     setEditingServer(undefined)
@@ -129,6 +132,26 @@ export function McpServerPanel() {
           <Alert data-testid="mcp-mutation-success">
             <AlertTitle>MCP config updated</AlertTitle>
             <AlertDescription>{mutationSuccess}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {configState.error ? (
+          <Alert data-testid="mcp-recovery-hint">
+            <AlertTitle>Recovery tip</AlertTitle>
+            <AlertDescription>
+              Restore a valid <span className="font-mono">mcp.json</span> (or fix malformed entries), then use
+              Refresh to confirm readback before reconnecting servers.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {serverErrorCount > 0 ? (
+          <Alert data-testid="mcp-row-recovery-hint">
+            <AlertTitle>Server connection errors stay row-scoped</AlertTitle>
+            <AlertDescription>
+              {serverErrorCount} server{serverErrorCount === 1 ? '' : 's'} currently failed health checks. Fix each
+              row and retry Refresh/Reconnect without restarting Desktop.
+            </AlertDescription>
           </Alert>
         ) : null}
 

--- a/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
@@ -54,8 +54,10 @@ export function McpServerPanel() {
 
   const servers = useMemo(() => configState.servers, [configState.servers])
   const serverErrorCount = useMemo(() => {
-    return Object.values(statuses).filter((status) => status?.phase === 'error').length
-  }, [statuses])
+    return servers.reduce((count, server) => {
+      return count + (statuses[server.name]?.phase === 'error' ? 1 : 0)
+    }, 0)
+  }, [servers, statuses])
 
   const openCreateDialog = () => {
     setEditingServer(undefined)

--- a/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -11,19 +10,23 @@ import {
 } from '@/components/ui/dialog'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import type { SettingsTabId } from '@/atoms/right-pane'
 import { ProviderAuthPanel } from './ProviderAuthPanel'
 import { SymphonyRuntimePanel } from './SymphonyRuntimePanel'
 import { SymphonyDashboard } from '../symphony/SymphonyDashboard'
 import { McpServerPanel } from './McpServerPanel'
 
-type SettingsTab = 'providers' | 'mcp' | 'general' | 'appearance' | 'symphony'
-
 interface SettingsPanelProps {
   open: boolean
+  activeTab: SettingsTabId
   onOpenChange: (open: boolean) => void
+  onActiveTabChange: (tab: SettingsTabId) => void
+  onReturnToWorkflowBoard?: () => void
+  returnToWorkflowDisabled?: boolean
+  returnToWorkflowDisabledReason?: string | null
 }
 
-const SETTINGS_TABS: Array<{ id: SettingsTab; label: string }> = [
+const SETTINGS_TABS: Array<{ id: SettingsTabId; label: string }> = [
   { id: 'providers', label: 'Providers' },
   { id: 'mcp', label: 'MCP' },
   { id: 'symphony', label: 'Symphony' },
@@ -31,8 +34,23 @@ const SETTINGS_TABS: Array<{ id: SettingsTab; label: string }> = [
   { id: 'appearance', label: 'Appearance' },
 ]
 
-export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
-  const [activeTab, setActiveTab] = useState<SettingsTab>('providers')
+export function shouldShowReturnToWorkflowAction(
+  activeTab: SettingsTabId,
+  onReturnToWorkflowBoard?: () => void,
+): boolean {
+  return Boolean(onReturnToWorkflowBoard) && activeTab === 'mcp'
+}
+
+export function SettingsPanel({
+  open,
+  activeTab,
+  onOpenChange,
+  onActiveTabChange,
+  onReturnToWorkflowBoard,
+  returnToWorkflowDisabled,
+  returnToWorkflowDisabledReason,
+}: SettingsPanelProps) {
+  const showReturnToWorkflow = shouldShowReturnToWorkflowAction(activeTab, onReturnToWorkflowBoard)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -49,13 +67,34 @@ export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
               <DialogDescription className="text-xs text-muted-foreground">
                 Manage providers, preferences, and desktop defaults.
               </DialogDescription>
+              {showReturnToWorkflow && returnToWorkflowDisabledReason ? (
+                <p className="text-xs text-amber-700 dark:text-amber-300" data-testid="settings-return-disabled-reason">
+                  {returnToWorkflowDisabledReason}
+                </p>
+              ) : null}
             </div>
 
-            <DialogClose asChild>
-              <Button type="button" variant="outline" size="sm">
-                Close
-              </Button>
-            </DialogClose>
+            <div className="flex items-center gap-2">
+              {showReturnToWorkflow ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onReturnToWorkflowBoard}
+                  disabled={Boolean(returnToWorkflowDisabled)}
+                  title="Return to workflow board (⌘⇧B / Ctrl+Shift+B)"
+                  data-testid="settings-return-to-workflow"
+                >
+                  Return to workflow board
+                </Button>
+              ) : null}
+
+              <DialogClose asChild>
+                <Button type="button" variant="outline" size="sm">
+                  Close
+                </Button>
+              </DialogClose>
+            </div>
           </div>
         </DialogHeader>
 
@@ -64,7 +103,7 @@ export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
         <Tabs
           orientation="vertical"
           value={activeTab}
-          onValueChange={(value) => setActiveTab(value as SettingsTab)}
+          onValueChange={(value) => onActiveTabChange(value as SettingsTabId)}
           className="flex min-h-0 flex-1 gap-0 overflow-hidden"
         >
           <TabsList className="h-full w-48 shrink-0 items-start rounded-none bg-background/40 p-3" variant="line">

--- a/apps/desktop/src/renderer/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SettingsPanel.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+import { shouldShowReturnToWorkflowAction } from '../SettingsPanel'
+
+describe('SettingsPanel workflow return affordance', () => {
+  const noop = () => {}
+
+  test('shows return-to-workflow action only on the MCP tab', () => {
+    expect(shouldShowReturnToWorkflowAction('mcp', noop)).toBe(true)
+    expect(shouldShowReturnToWorkflowAction('providers', noop)).toBe(false)
+    expect(shouldShowReturnToWorkflowAction('symphony', noop)).toBe(false)
+  })
+
+  test('hides return-to-workflow action when no callback is provided', () => {
+    expect(shouldShowReturnToWorkflowAction('mcp')).toBe(false)
+  })
+})

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -38,6 +38,8 @@ export const IPC_CHANNELS = {
   workflowRespondEscalation: 'workflow:respond-escalation',
   workflowOpenIssue: 'workflow:open-issue',
   workflowGetContext: 'workflow:get-context',
+  workflowDispatchShellAction: 'workflow:dispatch-shell-action',
+  workflowShellAction: 'workflow:shell-action',
   symphonyGetStatus: 'symphony:get-status',
   symphonyStart: 'symphony:start',
   symphonyStop: 'symphony:stop',
@@ -617,6 +619,25 @@ export interface RightPaneResolution {
   mode: RightPaneMode
   source: 'manual' | 'automatic'
   reason: WorkflowContextReason | 'manual_override' | 'default_fallback'
+}
+
+export type WorkflowShellAction = 'open_mcp_settings' | 'return_to_kanban' | 'refresh_board'
+
+export type WorkflowShellActionSource = 'kanban_header' | 'settings_panel' | 'keyboard_shortcut'
+
+export interface WorkflowShellActionRequest {
+  action: WorkflowShellAction
+  source: WorkflowShellActionSource
+}
+
+export interface WorkflowShellActionEvent extends WorkflowShellActionRequest {
+  dispatchedAt: string
+}
+
+export interface WorkflowShellActionDispatchResult {
+  success: boolean
+  dispatchedAt?: string
+  error?: string
 }
 
 export type WorkflowBoardErrorCode =
@@ -1398,6 +1419,10 @@ export interface DesktopApi {
     ) => Promise<WorkflowBoardEscalationResponseResult>
     openIssue: (request: WorkflowBoardOpenIssueRequest) => Promise<WorkflowBoardOpenIssueResult>
     getContext: () => Promise<WorkflowContextResponse>
+    dispatchShellAction: (
+      request: WorkflowShellActionRequest,
+    ) => Promise<WorkflowShellActionDispatchResult>
+    onShellAction: (listener: (event: WorkflowShellActionEvent) => void) => () => void
   }
   symphony: {
     getStatus: () => Promise<SymphonyRuntimeStatusResponse>


### PR DESCRIPTION
## Summary
- add typed workflow shell action wiring (main IPC + preload + renderer) for workflow-adjacent deep links
- add kanban-to-MCP shortcut affordances, keyboard shortcuts, return-to-board flow, and explicit busy/disabled state handling
- strengthen recovery UX copy for board stale/rollback and MCP row/dialog failures
- add assembled Electron proof (`m005-interactive-workflow.e2e.ts`) for both healthy and failure-path recovery flows

## Linear
- Closes KAT-2393
- Closes KAT-2394
- Part of KAT-2392

## Validation
- `cd apps/desktop && npx vitest run src/renderer/components/kanban/__tests__/KanbanPane.test.tsx src/renderer/components/settings/__tests__/SettingsPanel.test.tsx src/renderer/atoms/__tests__/right-pane-mode.test.ts`
- `cd apps/desktop && npx vitest run src/main/__tests__/workflow-board-service.test.ts src/main/__tests__/linear-workflow-client.test.ts src/main/__tests__/mcp-config-bridge.test.ts src/main/__tests__/mcp-service.test.ts src/main/__tests__/mcp-ipc.test.ts src/renderer/components/kanban/__tests__/SliceCard.test.tsx src/renderer/components/kanban/__tests__/TaskMutationDialog.test.tsx src/renderer/components/settings/__tests__/McpServerPanel.test.tsx`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/workflow-board-mutations.e2e.ts e2e/tests/mcp-settings.e2e.ts e2e/tests/m005-interactive-workflow.e2e.ts`
- `cd apps/desktop && npx playwright test e2e/tests/m005-interactive-workflow.e2e.ts --grep "healthy assembled flow"`
- `cd apps/desktop && npx playwright test e2e/tests/m005-interactive-workflow.e2e.ts --grep "failure-path recovery"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP settings accessible from the workflow board (button + Cmd/Ctrl+Shift+M) and return-to-workflow action (Cmd/Ctrl+Shift+B).
  * Keyboard shortcut for refreshing board (Cmd/Ctrl+Shift+R).
  * Stale-board notice with guidance.

* **Improvements**
  * Preserves/returns workflow context when opening settings; return action can be disabled with a reason.
  * Operation-lock indicators that prevent conflicting actions.
  * Clearer MCP error messages and recovery hints for config/server failures.

* **Tests**
  * New interactive end-to-end tests covering healthy and failure/recovery workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires typed workflow shell actions (IPC + preload + renderer), adds kanban↔MCP keyboard shortcuts (⌘⇧M / ⌘⇧B / ⌘⇧R), a "return to board" flow with busy-state guards, and strengthened recovery copy for stale boards and MCP errors. It also promotes `SettingsPanel` ownership from `LeftPane` to `AppShell` to support cross-surface navigation, and adds an assembled Playwright proof (`m005-interactive-workflow.e2e.ts`) for both healthy and failure-recovery paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 findings; all observations are P2 style suggestions

The IPC wiring is well-typed with two-way channel separation, the keyboard shortcut handler correctly guards editable targets, the return-context capture/clear lifecycle is consistent, and the e2e proof covers both healthy and failure paths. The three P2 comments (missing post-refresh wait in fixture helper, silent success when renderer not ready, missing return type) are non-blocking.

apps/desktop/e2e/fixtures/electron.fixture.ts (startMockWorkflowRuntime post-refresh wait) and apps/desktop/src/main/ipc.ts (canSendToRenderer silent success contract)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/e2e/fixtures/electron.fixture.ts | Adds startMockWorkflowRuntime and openMcpSettingsFromWorkflow helpers; the former lacks a post-refresh board-content wait |
| apps/desktop/e2e/tests/m005-interactive-workflow.e2e.ts | New assembled Playwright proof covering healthy and failure-recovery flows for workflow↔MCP navigation |
| apps/desktop/src/main/ipc.ts | Adds workflowDispatchShellAction IPC handler with action/source validation, timestamping, and re-emission to renderer |
| apps/desktop/src/preload/index.ts | Exposes dispatchShellAction and onShellAction (with cleanup unsubscribe) on the preload API |
| apps/desktop/src/renderer/atoms/right-pane.ts | Adds SettingsTabId, settingsPanelOpenAtom, settingsPanelTabAtom, and open/close write atoms |
| apps/desktop/src/renderer/atoms/workflow-board.ts | Adds workflowBoardReturnContextAtom, workflowMutationPendingAtom, and capture/clear return-context atoms |
| apps/desktop/src/renderer/components/app-shell/AppShell.tsx | Lifts SettingsPanel ownership, registers IPC shell-action listener, and adds global keyboard shortcut handler |
| apps/desktop/src/renderer/components/app-shell/LeftPane.tsx | Replaces local panel state with onOpenSettings prop; removes SettingsPanel from LeftPane |
| apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx | Enriches error copy with context-preservation note; adds stale-board notice with recovery guidance |
| apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx | Adds MCP shortcut button, disabled-refresh guard, shortcut hint bar, and action-lock reason banner |
| apps/desktop/src/renderer/components/kanban/KanbanPane.tsx | Derives mcpBusy and actionLockReason; forwards disable flags and MCP handler to KanbanHeader |
| apps/desktop/src/renderer/components/kanban/SliceCard.tsx | Adds formatMoveStateMessage/moveStateTone helpers for coloured Committed/Rollback move feedback |
| apps/desktop/src/renderer/components/settings/McpServerEditorDialog.tsx | Adds data-testid attributes and prefixed error labels to local/save error messages |
| apps/desktop/src/renderer/components/settings/McpServerPanel.tsx | Adds config-parse recovery-hint and per-row error-count alert; computes serverErrorCount from statuses |
| apps/desktop/src/renderer/components/settings/SettingsPanel.tsx | Lifts tab/open state to props; adds return-to-workflow-board button scoped to MCP tab |
| apps/desktop/src/renderer/components/settings/__tests__/SettingsPanel.test.tsx | New unit tests for shouldShowReturnToWorkflowAction helper covering tab gating and missing-callback case |
| apps/desktop/src/shared/types.ts | Adds WorkflowShellAction/Source/Request/Event/DispatchResult types and two new IPC channel constants |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer<br/>(AppShell)
    participant P as Preload API
    participant M as Main Process<br/>(ipc.ts)

    note over R: User presses ⌘⇧M / clicks MCP button
    R->>P: dispatchShellAction({ action, source })
    P->>M: ipcRenderer.invoke(workflowDispatchShellAction)
    M->>M: Validate action + source
    M->>M: Build WorkflowShellActionEvent<br/>with dispatchedAt timestamp
    alt canSendToRenderer() == true
        M-->>R: webContents.send(workflowShellAction, event)
        R->>R: handleWorkflowShellAction(event)
        note over R: open MCP panel / return to kanban / refresh board
    else renderer destroyed
        M-->>P: { success: true } (silent no-op)
    end
    P-->>R: WorkflowShellActionDispatchResult
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/e2e/fixtures/electron.fixture.ts
Line: 70-78

Comment:
**Missing board-content stability wait after refresh click**

`startMockWorkflowRuntime` clicks `kanban-refresh-board` but returns immediately with no assertion that board data has loaded. Downstream steps that interact with specific cards (`slice-move-select-KAT-2337`) rely on Playwright's element retry, which handles this in practice, but under a slow CI agent the missing stability gate increases the risk of intermittent timeouts. A single `waitFor` on a column or the kanban container after the click would make the helper self-contained.

```suggestion
export async function startMockWorkflowRuntime(page: Page): Promise<void> {
  await page.getByRole('heading', { name: /Workflow Board/i }).waitFor({ state: 'visible' })

  await page.evaluate(async () => {
    await window.api.symphony.start()
  })

  await page.getByTestId('kanban-refresh-board').click()
  await page.getByTestId('kanban-column-in_progress').waitFor({ state: 'visible' })
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/ipc.ts
Line: 1401-1408

Comment:
**Silent `success: true` when renderer is unavailable**

When `canSendToRenderer()` returns `false` (window teardown), the handler still returns `{ success: true, dispatchedAt }` even though the event was never delivered. Callers use `void` on the promise and never inspect the result, so they cannot distinguish a real dispatch from a silent no-op. This is consistent with other handlers in this file, but the `success` field is misleading here. Returning `success: false` (or adding a `skipped` field) when the renderer is unavailable would make the contract more accurate and easier to test.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/e2e/tests/m005-interactive-workflow.e2e.ts
Line: 35-38

Comment:
**Missing return type on async helper**

`selectMoveOption` is an async helper without an explicit return type. Annotating it `Promise<void>` keeps the file consistent with the typed fixture helpers.

```suggestion
async function selectMoveOption(page: Page, triggerTestId: string, optionText: string): Promise<void> {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): KAT-2394 add assembled fa..."](https://github.com/gannonh/kata/commit/2c89357e14dcf93748467c85a9be9d97cc602a33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27510816)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->