### PR TITLE
feat(desktop): cross-boundary reliability and recovery envelope (KAT-2399)

### DIFF
--- a/apps/desktop/docs/uat/M006/S01-DOWNSTREAM-HANDOFF.md
+++ b/apps/desktop/docs/uat/M006/S01-DOWNSTREAM-HANDOFF.md
@@ -1,0 +1,116 @@
+# S01 Downstream Handoff — Reliability Envelope Outputs
+
+## Purpose
+
+This handoff captures what S01 produced for downstream M006 slices (S02/S03/S04), including contract surfaces, deterministic proofs, and reuse checkpoints.
+
+## Produced contract (authoritative)
+
+### Canonical taxonomy
+
+- Classes: `config`, `auth`, `network`, `process`, `stale`, `unknown`
+- Severity scale: `info`, `warning`, `error`, `critical`
+- Recovery actions: `fix_config`, `reauthenticate`, `retry_request`, `restart_process`, `reconnect`, `refresh_state`, `inspect`
+- Outcomes: `pending`, `succeeded`, `failed`, `none`
+
+### Canonical signal envelope
+
+`ReliabilitySignal` includes:
+
+- `code` (stable format: `REL-<SOURCE>-<CLASS>-<CODE_FRAGMENT>`)
+- `class`, `severity`, `sourceSurface`
+- `recoveryAction`, `outcome`
+- `message`, `timestamp`
+- optional `staleSince`, `lastKnownGoodAt`, `diagnostics`
+
+### Redaction guarantees
+
+Reliability mapping and bridge stderr handling redact secrets/tokens (`sk-*`, `api_key`, bearer tokens) before surfacing diagnostics.
+
+## Runtime wiring delivered
+
+- Main-process mapper contract: `src/main/reliability-contract.ts`
+- Cross-surface aggregator: `src/main/runtime-health-aggregator.ts`
+- IPC/preload/public API surface: `window.api.reliability` (`getStatus`, `onStatus`, `requestRecoveryAction`)
+- Renderer parity surfaces:
+  - App-level reliability banner
+  - Kanban board state notice
+  - Symphony dashboard recovery notice
+  - MCP settings recovery notice
+
+## Deterministic failure-path proofs delivered
+
+### Unit / integration proof set
+
+- `src/main/__tests__/reliability-contract.test.ts`
+- `src/main/__tests__/runtime-health-aggregator.test.ts`
+- `src/main/__tests__/workflow-board-service.test.ts`
+- `src/main/__tests__/symphony-operator-service.test.ts`
+- `src/main/__tests__/mcp-service.test.ts`
+- `src/main/__tests__/pi-agent-bridge.test.ts` (chat crash fault seam)
+
+### Electron recovery proof
+
+- `e2e/tests/recovery-envelope.e2e.ts`
+- Fault classes covered:
+  1. workflow transient backend stale/error
+  2. Symphony disconnect/restart
+  3. malformed MCP config
+  4. chat subprocess crash
+
+## Downstream consumption map
+
+### S02 — First-run/onboarding beta readiness
+
+Consume:
+
+- Shared reliability taxonomy + message/action vocabulary for onboarding validation/fail states.
+- `window.api.reliability` snapshot/subscription to keep onboarding recovery hints consistent with runtime surfaces.
+
+Required checkpoint:
+
+- Onboarding failure states must map to canonical classes/actions (no onboarding-specific error dialect).
+
+### S03 — Long-run stability/performance/accessibility baseline
+
+Consume:
+
+- Aggregated reliability surface snapshots for long-run degradation tracking.
+- Recovery outcome transitions (`pending`→`succeeded|failed`) as measurable stability signals.
+
+Required checkpoint:
+
+- Soak metrics must include per-surface failure/recovery counts by canonical class.
+
+### S04 — Packaged integrated acceptance + release gate
+
+Consume:
+
+- `S01-RECOVERY-SMOKE.md` scenario matrix.
+- `recovery-envelope.e2e.ts` deterministic assertions as release-gate regression check.
+
+Required checkpoint:
+
+- Packaged acceptance must replay the same four representative fault classes and preserve truthful LKG/stale behavior.
+
+## Open risks / guardrails for downstream slices
+
+- If new surfaces are added, they must map through the same contract before exposing UI diagnostics.
+- Do not introduce raw backend error payloads into renderer state; always pass through redaction + canonical mapper.
+- Recovery controls must remain action-labeled by canonical recovery action strings to prevent UX drift.
+
+## Artifact index
+
+- `src/shared/types.ts`
+- `src/main/reliability-contract.ts`
+- `src/main/runtime-health-aggregator.ts`
+- `src/main/ipc.ts`
+- `src/preload/index.ts`
+- `src/renderer/atoms/reliability.ts`
+- `src/renderer/components/app-shell/AppShell.tsx`
+- `src/renderer/components/kanban/BoardStateNotice.tsx`
+- `src/renderer/components/symphony/SymphonyDashboard.tsx`
+- `src/renderer/components/settings/McpServerPanel.tsx`
+- `e2e/tests/recovery-envelope.e2e.ts`
+- `docs/uat/M006/S01-RECOVERY-SMOKE.md`
+- `docs/uat/M006/S01-UAT-REPORT.md`

--- a/apps/desktop/docs/uat/M006/S01-RECOVERY-SMOKE.md
+++ b/apps/desktop/docs/uat/M006/S01-RECOVERY-SMOKE.md
@@ -1,0 +1,80 @@
+# S01 Recovery Envelope Smoke (M006)
+
+## Goal
+
+Prove one cross-boundary reliability envelope across Desktop runtime boundaries by injecting representative faults and validating:
+
+1. Fault class and severity are normalized (`config`, `auth`, `network`, `process`, `stale`, `unknown`).
+2. Last-known-good/stale state is preserved truthfully (no silent empty-state replacement).
+3. Recovery action semantics are consistent and actionable.
+4. Recovery outcomes are explicit (`pending` → `succeeded|failed`) with stable codes/timestamps.
+
+## Preconditions
+
+- Branch includes S01 reliability contract + runtime aggregator wiring.
+- Desktop build artifacts exist (`dist/main.cjs`, `dist/preload.cjs`, renderer build).
+- Electron binary is installed and runnable for Playwright `_electron` tests.
+- No secret values are written in logs/screenshots/reports.
+
+## Deterministic automated smoke
+
+```bash
+cd apps/desktop
+bun run build:main && bun run build:preload && bun run build:renderer
+npx playwright test e2e/tests/recovery-envelope.e2e.ts
+```
+
+Focused invocation used by T04 verification:
+
+```bash
+cd apps/desktop
+npx playwright test e2e/tests/recovery-envelope.e2e.ts --grep "recovery envelope"
+```
+
+## Live recovery walkthrough checkpoints
+
+> The `recovery-envelope.e2e.ts` scenario executes this sequence in a real Electron runtime (main/preload/renderer + IPC + services), with deterministic fault controls.
+
+### A. Workflow transient backend failure (stale state)
+
+1. Set workflow scenario to `scenario:stale` and refresh board.
+2. Confirm reliability surface `workflow_board` is `degraded` with class `network`.
+3. Confirm `lastKnownGoodAt` is present and retained.
+4. Switch to `scenario:recovery` and request workflow recovery.
+5. Confirm outcome `succeeded` and surface returns `healthy`.
+
+### B. Symphony disconnect/restart recovery
+
+1. Trigger mock dashboard refresh causing disconnect phase.
+2. Confirm reliability surface `symphony` is `degraded` with class `network`.
+3. Request recovery action for Symphony.
+4. Confirm outcome `succeeded` and surface returns `healthy`.
+
+### C. Malformed MCP config recovery
+
+1. Corrupt MCP JSON config (`{bad-json`).
+2. Confirm `window.api.mcp.listServers()` fails.
+3. Confirm reliability surface `mcp` is `degraded` with class `config`.
+4. Restore valid config and request MCP recovery.
+5. Confirm outcome `succeeded` and surface returns `healthy`.
+
+### D. Chat subprocess crash + restart recovery
+
+1. Inject one-time chat crash fault via prompt path.
+2. Confirm reliability surface `chat_runtime` is `degraded` with class `process` and stable `REL-CHAT-PROCESS-*` code.
+3. Request chat recovery action.
+4. Confirm outcome `succeeded` and surface returns `healthy`.
+
+### E. Envelope convergence
+
+1. Confirm final reliability snapshot `overallStatus = healthy`.
+2. Confirm all surfaces are `healthy`.
+
+## Evidence requirements
+
+Capture in `S01-UAT-REPORT.md`:
+
+- Command outputs + pass/fail for deterministic smoke.
+- Per-fault checkpoint results (class, action, outcome).
+- Any deviation details with stable error codes and timestamps.
+- Explicit confirmation that no secrets/tokens were exposed.

--- a/apps/desktop/docs/uat/M006/S01-UAT-REPORT.md
+++ b/apps/desktop/docs/uat/M006/S01-UAT-REPORT.md
@@ -1,0 +1,63 @@
+# S01 UAT Report — Cross-Boundary Reliability and Recovery Envelope
+
+- Slice: **KAT-2399 / S01**
+- Child tasks: **KAT-2406 (T01), KAT-2404 (T02), KAT-2405 (T03), KAT-2403 (T04)**
+- Milestone: **M006 Integrated Beta**
+- Commit SHA: `sym/KAT-2399` (working tree during run)
+- Date (UTC): **2026-04-07**
+- Tester: **Kata orchestration agent (automated runtime + e2e evidence capture)**
+- Environment: **Electron main/preload/renderer via Playwright `_electron`; `KATA_TEST_MODE=1`; deterministic fault mocks enabled**
+
+## Run matrix
+
+| Flow | Mode | Result | Notes |
+| --- | --- | --- | --- |
+| Reliability contract + aggregator/service unit proofs | Vitest | ✅ Pass | Canonical mapping, stale/LKG invariants, recovery outcome coverage passed |
+| Type system gate | TypeScript (`bun run typecheck`) | ✅ Pass | No type errors |
+| Cross-boundary recovery envelope | Playwright Electron | ✅ Pass | `recovery-envelope.e2e.ts` passed end-to-end |
+| Focused smoke replay (`--grep "recovery envelope"`) | Playwright Electron | ✅ Pass | Replay validated deterministic recovery sequence |
+
+## Validation command results
+
+```bash
+cd apps/desktop && npx vitest run src/main/__tests__/reliability-contract.test.ts src/main/__tests__/runtime-health-aggregator.test.ts src/main/__tests__/workflow-board-service.test.ts src/main/__tests__/symphony-operator-service.test.ts src/main/__tests__/mcp-service.test.ts
+cd apps/desktop && bun run typecheck
+cd apps/desktop && npx playwright test e2e/tests/recovery-envelope.e2e.ts
+cd apps/desktop && npx playwright test e2e/tests/recovery-envelope.e2e.ts --grep "recovery envelope"
+```
+
+- Vitest suite: **Pass** (104 tests)
+- Typecheck: **Pass**
+- Playwright full file run: **Pass** (1/1)
+- Playwright grep replay: **Pass** (1/1)
+
+## Recovery checkpoint outcomes
+
+| Fault injection class | Surface | Expected canonical class | Recovery action path | Outcome |
+| --- | --- | --- | --- | --- |
+| Workflow transient backend failure (`scenario:stale`) | `workflow_board` | `network` | `window.api.reliability.requestRecoveryAction({sourceSurface:"workflow_board"})` after `scenario:recovery` | ✅ Succeeded; returned to healthy |
+| Symphony disconnect/restart | `symphony` | `network` | `window.api.reliability.requestRecoveryAction({sourceSurface:"symphony"})` | ✅ Succeeded; returned to healthy |
+| Malformed MCP JSON config | `mcp` | `config` | restore valid config + `requestRecoveryAction({sourceSurface:"mcp"})` | ✅ Succeeded; returned to healthy |
+| Chat subprocess crash (one-shot injected) | `chat_runtime` | `process` | `requestRecoveryAction({sourceSurface:"chat_runtime"})` | ✅ Succeeded; returned to healthy |
+
+## Truthfulness / invariants validated
+
+- ✅ `lastKnownGoodAt` remained present for stale workflow failure state.
+- ✅ Recovery never silently replaced good state with contradictory empty state.
+- ✅ Final reliability snapshot converged to `overallStatus: healthy` with all surfaces healthy.
+- ✅ Reliability diagnostics remained redaction-safe (no secret/token body exposure in assertions or report).
+
+## Evidence index
+
+| Artifact | Location | Notes |
+| --- | --- | --- |
+| Deterministic recovery test source | `apps/desktop/e2e/tests/recovery-envelope.e2e.ts` | Encodes full 4-class failure/recovery matrix |
+| Electron fixture with chat crash seam + deterministic runtime env | `apps/desktop/e2e/fixtures/electron.fixture.ts` | Adds test-mode bridge binary + reliability fault controls |
+| Aggregator crash-clear invariant proof | `apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts` | Verifies chat surface returns healthy after runtime recovery |
+| Chat crash fault seam proof | `apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts` | Verifies one-time injected crash and post-fault prompt behavior |
+
+## Final assessment
+
+- S01 recovery envelope operational proof: **✅ Ready for Agent Review**
+- Blocking defects found during S01 UAT: **None**
+- Follow-up issues created from this run: **None**

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -1,6 +1,6 @@
 import { test as base, _electron as electron } from '@playwright/test'
 import type { ElectronApplication, Page } from '@playwright/test'
-import { existsSync, mkdtempSync, rmSync, mkdirSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -15,6 +15,80 @@ function createIsolatedDataDir(): string {
   mkdirSync(path.join(dataDir, 'workspace'), { recursive: true })
   mkdirSync(path.join(dataDir, '.kata-cli', 'agent'), { recursive: true })
   return dataDir
+}
+
+function createMockKataRpcBinary(dataDir: string): string {
+  const executablePath = path.join(dataDir, 'kata-rpc-mock')
+
+  writeFileSync(
+    executablePath,
+    `#!/usr/bin/env node
+const readline = require('node:readline')
+
+const rl = readline.createInterface({ input: process.stdin })
+
+function respond(message, data = {}, success = true, error) {
+  const payload = {
+    type: 'response',
+    id: message.id,
+    command: message.type,
+    success,
+    data,
+  }
+
+  if (error) payload.error = error
+
+  process.stdout.write(JSON.stringify(payload) + '\\n')
+}
+
+process.stdout.write(JSON.stringify({ type: 'event', event: { type: 'agent_ready' } }) + '\\n')
+
+rl.on('line', (line) => {
+  let message
+  try {
+    message = JSON.parse(line)
+  } catch {
+    return
+  }
+
+  switch (message.type) {
+    case 'prompt':
+      respond(message, { ok: true })
+      break
+    case 'abort':
+      respond(message, { ok: true })
+      break
+    case 'shutdown':
+      respond(message, { ok: true })
+      setTimeout(() => process.exit(0), 10)
+      break
+    case 'get_available_models':
+      respond(message, {
+        models: [
+          {
+            provider: 'anthropic',
+            id: 'claude-sonnet-4-6',
+            reasoning: true,
+          },
+        ],
+      })
+      break
+    case 'set_model':
+    case 'set_thinking_level':
+    case 'switch_session':
+      respond(message, { cancelled: false })
+      break
+    default:
+      respond(message, { ok: true })
+      break
+  }
+})
+`,
+    'utf8',
+  )
+
+  chmodSync(executablePath, 0o755)
+  return executablePath
 }
 
 async function waitForAppReady(window: Page): Promise<void> {
@@ -68,7 +142,7 @@ async function dismissOnboardingIfPresent(window: Page): Promise<void> {
 }
 
 export async function startMockWorkflowRuntime(page: Page): Promise<void> {
-  await page.getByRole('heading', { name: /Workflow Board/i }).waitFor({ state: 'visible' })
+  await page.getByTestId('kanban-refresh-board').waitFor({ state: 'visible' })
 
   const startResult = await page.evaluate(async () => {
     try {
@@ -120,10 +194,12 @@ type DesktopFixtures = {
     | 'kanban_disconnected'
     | 'assembled_healthy'
     | 'assembled_failure_recovery'
+  chatRuntimeFaultMode: 'none' | 'process_crash_once'
 }
 
 export const test = base.extend<DesktopFixtures>({
   symphonyMockMode: ['ready', { option: true }],
+  chatRuntimeFaultMode: ['none', { option: true }],
   workspaceDir: async ({}, use) => {
     const dataDir = createIsolatedDataDir()
     const workspaceDir = path.join(dataDir, 'workspace')
@@ -133,7 +209,10 @@ export const test = base.extend<DesktopFixtures>({
       try { rmSync(dataDir, { recursive: true, force: true }) } catch { /* noop */ }
     }
   },
-  electronApp: async ({ workspaceDir, symphonyMockMode, mcpConfigPath }, use) => {
+  electronApp: async ({ workspaceDir, symphonyMockMode, chatRuntimeFaultMode, mcpConfigPath }, use) => {
+    const mockKataBinary = chatRuntimeFaultMode === 'process_crash_once'
+      ? createMockKataRpcBinary(path.dirname(workspaceDir))
+      : null
     const dataDir = path.dirname(workspaceDir)
     const mainEntry = path.join(__dirname, '../../dist/main.cjs')
     const preloadEntry = path.join(__dirname, '../../dist/preload.cjs')
@@ -167,6 +246,8 @@ export const test = base.extend<DesktopFixtures>({
         KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: symphonyMockMode,
         KATA_SYMPHONY_URL: 'http://127.0.0.1:8080',
         KATA_DESKTOP_MCP_CONFIG_PATH: mcpConfigPath,
+        KATA_DESKTOP_RELIABILITY_CHAT_FAULT: chatRuntimeFaultMode,
+        ...(mockKataBinary ? { KATA_BIN_PATH: mockKataBinary } : {}),
         // Force packaged-file mode for deterministic e2e: if a parent shell exported
         // VITE_DEV_SERVER_URL we would silently bind to an arbitrary dev server.
         VITE_DEV_SERVER_URL: '',

--- a/apps/desktop/e2e/tests/recovery-envelope.e2e.ts
+++ b/apps/desktop/e2e/tests/recovery-envelope.e2e.ts
@@ -1,0 +1,172 @@
+import { writeFileSync } from 'node:fs'
+import type { Page } from '@playwright/test'
+import type {
+  ReliabilityRecoveryResult,
+  ReliabilitySignal,
+  ReliabilitySourceSurface,
+  ReliabilitySurfaceState,
+} from '@shared/types'
+import {
+  expect,
+  startMockWorkflowRuntime,
+  test,
+} from '../fixtures/electron.fixture'
+
+function writeValidMcpConfig(mcpConfigPath: string): void {
+  writeFileSync(
+    mcpConfigPath,
+    `${JSON.stringify(
+      {
+        imports: [],
+        settings: {
+          toolPrefix: 'server',
+          idleTimeout: 10,
+        },
+        mcpServers: {},
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  )
+}
+
+interface SurfaceSnapshotView {
+  status: ReliabilitySurfaceState['status']
+  signal: ReliabilitySignal | null
+}
+
+async function readReliabilitySurface(
+  page: Page,
+  sourceSurface: ReliabilitySourceSurface,
+): Promise<SurfaceSnapshotView | null> {
+  return page.evaluate(async (surface: ReliabilitySourceSurface) => {
+    const response = await window.api.reliability.getStatus()
+    const match = response.snapshot.surfaces.find((candidate) => candidate.sourceSurface === surface)
+
+    if (!match) {
+      return null
+    }
+
+    return {
+      status: match.status,
+      signal: match.signal,
+    }
+  }, sourceSurface)
+}
+
+async function requestRecovery(
+  page: Page,
+  sourceSurface: ReliabilitySourceSurface,
+): Promise<ReliabilityRecoveryResult> {
+  return page.evaluate(async (surface: ReliabilitySourceSurface) => {
+    return window.api.reliability.requestRecoveryAction({ sourceSurface: surface })
+  }, sourceSurface)
+}
+
+test.describe('recovery envelope', () => {
+  test.use({
+    symphonyMockMode: 'assembled_failure_recovery',
+    chatRuntimeFaultMode: 'process_crash_once',
+  })
+
+  test('injects cross-boundary failures and preserves truthful recovery state', async ({
+    readyWindow,
+    mcpConfigPath,
+  }) => {
+    await startMockWorkflowRuntime(readyWindow)
+
+    // Baseline: ensure workflow is healthy before injecting faults.
+    await readyWindow.evaluate(async () => {
+      await window.api.workflow.setScope('workspace:e2e::session:recovery::scenario:recovery')
+      await window.api.workflow.refreshBoard()
+    })
+
+    // 1) Workflow backend transient fault (stale + last-known-good retention).
+    await readyWindow.evaluate(async () => {
+      await window.api.workflow.setScope('workspace:e2e::session:recovery::scenario:stale')
+      await window.api.workflow.refreshBoard()
+    })
+
+    const workflowFault = await readReliabilitySurface(readyWindow, 'workflow_board')
+    expect(workflowFault?.status).toBe('degraded')
+    expect(workflowFault?.signal?.class).toBe('network')
+    expect(workflowFault?.signal?.lastKnownGoodAt).toBeTruthy()
+
+    await readyWindow.evaluate(async () => {
+      await window.api.workflow.setScope('workspace:e2e::session:recovery::scenario:recovery')
+    })
+
+    const workflowRecovery = await requestRecovery(readyWindow, 'workflow_board')
+    expect(workflowRecovery.success).toBe(true)
+    expect(workflowRecovery.outcome).toBe('succeeded')
+
+    await expect.poll(async () => (await readReliabilitySurface(readyWindow, 'workflow_board'))?.status).toBe(
+      'healthy',
+    )
+
+    // 2) Symphony disconnect/restart fault.
+    await readyWindow.evaluate(async () => {
+      await window.api.symphony.refreshDashboardSnapshot()
+    })
+
+    const symphonyFault = await readReliabilitySurface(readyWindow, 'symphony')
+    expect(symphonyFault?.status).toBe('degraded')
+    expect(symphonyFault?.signal?.class).toBe('network')
+
+    const symphonyRecovery = await requestRecovery(readyWindow, 'symphony')
+    expect(symphonyRecovery.success).toBe(true)
+    expect(symphonyRecovery.outcome).toBe('succeeded')
+
+    await expect.poll(async () => (await readReliabilitySurface(readyWindow, 'symphony'))?.status).toBe('healthy')
+
+    // 3) Malformed MCP config fault.
+    writeFileSync(mcpConfigPath, '{bad-json', 'utf8')
+
+    const mcpFaultResponse = await readyWindow.evaluate(async () => {
+      return window.api.mcp.listServers()
+    })
+
+    expect(mcpFaultResponse.success).toBe(false)
+
+    const mcpFault = await readReliabilitySurface(readyWindow, 'mcp')
+    expect(mcpFault?.status).toBe('degraded')
+    expect(mcpFault?.signal?.class).toBe('config')
+
+    writeValidMcpConfig(mcpConfigPath)
+
+    const mcpRecovery = await requestRecovery(readyWindow, 'mcp')
+    expect(mcpRecovery.success).toBe(true)
+    expect(mcpRecovery.outcome).toBe('succeeded')
+
+    await expect.poll(async () => (await readReliabilitySurface(readyWindow, 'mcp'))?.status).toBe('healthy')
+
+    // 4) Chat subprocess crash fault + recovery.
+    await readyWindow.evaluate(async () => {
+      await window.api.sendMessage('trigger reliability crash fault')
+    })
+
+    await expect.poll(async () => (await readReliabilitySurface(readyWindow, 'chat_runtime'))?.status).toBe(
+      'degraded',
+    )
+
+    const chatFault = await readReliabilitySurface(readyWindow, 'chat_runtime')
+    expect(chatFault?.signal?.class).toBe('process')
+    expect(chatFault?.signal?.code).toContain('REL-CHAT-PROCESS')
+
+    const chatRecovery = await requestRecovery(readyWindow, 'chat_runtime')
+    expect(chatRecovery.success).toBe(true)
+    expect(chatRecovery.outcome).toBe('succeeded')
+
+    await expect.poll(async () => (await readReliabilitySurface(readyWindow, 'chat_runtime'))?.status).toBe(
+      'healthy',
+    )
+
+    const finalReliability = await readyWindow.evaluate(async () => {
+      return window.api.reliability.getStatus()
+    })
+
+    expect(finalReliability.snapshot.overallStatus).toBe('healthy')
+    expect(finalReliability.snapshot.surfaces.every((surface) => surface.status === 'healthy')).toBe(true)
+  })
+})

--- a/apps/desktop/src/main/__tests__/mcp-service.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-service.test.ts
@@ -128,4 +128,17 @@ describe('McpService', () => {
     expect(response.success).toBe(false)
     expect(response.status?.error?.code).toBe('SERVER_NOT_FOUND')
   })
+
+  test('exposes canonical MCP reliability signal for config/status failures', async () => {
+    await fs.writeFile(configPath, '{bad-json', 'utf8')
+
+    const service = createService()
+    await service.refreshStatus('local')
+
+    const reliability = service.getReliabilitySignal()
+    expect(reliability?.sourceSurface).toBe('mcp')
+    expect(reliability?.class).toBe('config')
+    expect(reliability?.recoveryAction).toBe('fix_config')
+    expect(reliability?.code).toBe('REL-MCP-CONFIG-MALFORMED_CONFIG')
+  })
 })

--- a/apps/desktop/src/main/__tests__/mcp-service.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-service.test.ts
@@ -141,4 +141,44 @@ describe('McpService', () => {
     expect(reliability?.recoveryAction).toBe('fix_config')
     expect(reliability?.code).toBe('REL-MCP-CONFIG-MALFORMED_CONFIG')
   })
+
+  test('aggregates reliability across servers instead of last-write wins', async () => {
+    const serverState = {
+      broken: true,
+    }
+
+    const configBridge = {
+      getRuntimeServer: vi.fn(async (serverName: string) => {
+        if (serverName === 'broken' && serverState.broken) {
+          return {
+            success: false,
+            error: {
+              code: 'MALFORMED_CONFIG',
+              message: 'Invalid config',
+            },
+          }
+        }
+
+        return {
+          success: true,
+          server: {
+            name: serverName,
+            enabled: true,
+          },
+        }
+      }),
+    } as any
+
+    const service = new McpService({ configBridge })
+
+    await service.refreshStatus('broken')
+    expect(service.getReliabilitySignal()?.code).toBe('REL-MCP-CONFIG-MALFORMED_CONFIG')
+
+    await service.refreshStatus('healthy')
+    expect(service.getReliabilitySignal()?.code).toBe('REL-MCP-CONFIG-MALFORMED_CONFIG')
+
+    serverState.broken = false
+    await service.refreshStatus('broken')
+    expect(service.getReliabilitySignal()).toBeNull()
+  })
 })

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -267,6 +267,52 @@ describe('PiAgentBridge additional coverage', () => {
     expect(sendSpy).toHaveBeenNthCalledWith(2, { type: 'abort' })
   })
 
+  test('injects one-time reliability crash fault for prompt in test mode', async () => {
+    const previousTestMode = process.env.KATA_TEST_MODE
+    const previousFaultMode = process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT
+
+    process.env.KATA_TEST_MODE = '1'
+    process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT = 'process_crash_once'
+
+    try {
+      const bridge = new PiAgentBridge(process.cwd())
+      const sendSpy = vi
+        .spyOn(bridge, 'send')
+        .mockResolvedValue({ command: 'prompt', success: true } as CommandResult)
+      const crashes: Array<{ exitCode: number | null; signal: NodeJS.Signals | null; stderrLines: string[] }> = []
+      const statuses: string[] = []
+
+      bridge.on('crash', (payload) => {
+        crashes.push(payload)
+      })
+
+      bridge.on('status', (status) => {
+        statuses.push(status.state)
+      })
+
+      await expect(bridge.prompt('trigger injected crash')).rejects.toThrow('Injected test subprocess crash fault.')
+      expect(crashes).toHaveLength(1)
+      expect(crashes[0]?.exitCode).toBe(137)
+      expect(statuses.at(-1)).toBe('crashed')
+      expect(sendSpy).not.toHaveBeenCalled()
+
+      await bridge.prompt('second prompt should proceed')
+      expect(sendSpy).toHaveBeenCalledWith({ type: 'prompt', message: 'second prompt should proceed' })
+    } finally {
+      if (previousTestMode === undefined) {
+        delete process.env.KATA_TEST_MODE
+      } else {
+        process.env.KATA_TEST_MODE = previousTestMode
+      }
+
+      if (previousFaultMode === undefined) {
+        delete process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT
+      } else {
+        process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT = previousFaultMode
+      }
+    }
+  })
+
   test('getAvailableModels returns only valid model entries', async () => {
     const bridge = new PiAgentBridge(process.cwd())
 

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -125,16 +125,18 @@ function createMockChild(options: MockChildOptions = {}) {
     return true
   })
 
-  return {
-    killed: false,
-    pid: 4242,
-    exitCode: null,
-    stdin: {
-      writable: options.writable ?? true,
-      write,
-    },
-    kill: vi.fn(),
-  } as any
+  const child = new EventEmitter() as any
+  child.killed = false
+  child.pid = 4242
+  child.exitCode = null
+  child.stdin = {
+    writable: options.writable ?? true,
+    write,
+  }
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn(() => true)
+
+  return child
 }
 
 function createTempExecutable(scriptContents: string): { executablePath: string; cleanup: () => void } {
@@ -298,6 +300,63 @@ describe('PiAgentBridge additional coverage', () => {
 
       await bridge.prompt('second prompt should proceed')
       expect(sendSpy).toHaveBeenCalledWith({ type: 'prompt', message: 'second prompt should proceed' })
+    } finally {
+      if (previousTestMode === undefined) {
+        delete process.env.KATA_TEST_MODE
+      } else {
+        process.env.KATA_TEST_MODE = previousTestMode
+      }
+
+      if (previousFaultMode === undefined) {
+        delete process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT
+      } else {
+        process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT = previousFaultMode
+      }
+    }
+  })
+
+  test('injectPromptCrashFault tears down active subprocess state before reporting crash', () => {
+    const previousTestMode = process.env.KATA_TEST_MODE
+    const previousFaultMode = process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT
+
+    process.env.KATA_TEST_MODE = '1'
+    process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT = 'process_crash_once'
+
+    try {
+      const bridge = new PiAgentBridge(process.cwd()) as any
+      const child = createMockChild()
+      const closeReader = vi.fn()
+      bridge.child = child
+      bridge.status = 'running'
+      bridge.stdoutReader = {
+        removeAllListeners: vi.fn(),
+        close: closeReader,
+      }
+
+      let rejectedMessage: string | undefined
+      bridge.pending.set('cmd-1', {
+        command: 'prompt',
+        resolve: () => {},
+        reject: (error: Error) => {
+          rejectedMessage = error.message
+        },
+      })
+
+      const crashes: Array<{ exitCode: number | null; signal: NodeJS.Signals | null; stderrLines: string[] }> = []
+      bridge.on('crash', (payload: { exitCode: number | null; signal: NodeJS.Signals | null; stderrLines: string[] }) => {
+        crashes.push(payload)
+      })
+
+      const error = bridge.injectPromptCrashFault()
+
+      expect(error.message).toBe('Injected test subprocess crash fault.')
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+      expect(closeReader).toHaveBeenCalledTimes(1)
+      expect(bridge.child).toBeNull()
+      expect(bridge.pending.size).toBe(0)
+      expect(rejectedMessage).toBe('Injected test subprocess crash fault.')
+      expect(crashes).toHaveLength(1)
+      expect(crashes[0]?.stderrLines[0]).toBe('Injected test subprocess crash fault.')
     } finally {
       if (previousTestMode === undefined) {
         delete process.env.KATA_TEST_MODE

--- a/apps/desktop/src/main/__tests__/reliability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-contract.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'vitest'
+import type {
+  BridgeStatusEvent,
+  McpServerStatusResponse,
+  SymphonyOperatorSnapshot,
+  SymphonyRuntimeStatus,
+  WorkflowBoardSnapshot,
+} from '@shared/types'
+import {
+  buildReliabilityCode,
+  mapChatBridgeStatusToReliability,
+  mapChatSubprocessCrashToReliability,
+  mapMcpStatusResponseToReliability,
+  mapSymphonyOperatorSnapshotToReliability,
+  mapSymphonyRuntimeStatusToReliability,
+  mapWorkflowBoardSnapshotToReliability,
+  redactReliabilityText,
+} from '../reliability-contract'
+
+describe('reliability-contract', () => {
+  test('buildReliabilityCode normalizes deterministic fragments', () => {
+    expect(buildReliabilityCode('workflow_board', 'network', 'network timeout')).toBe(
+      'REL-WORKFLOW-NETWORK-NETWORK_TIMEOUT',
+    )
+    expect(buildReliabilityCode('workflow_board', 'network', 'network timeout')).toBe(
+      'REL-WORKFLOW-NETWORK-NETWORK_TIMEOUT',
+    )
+    expect(buildReliabilityCode('mcp', 'config')).toBe('REL-MCP-CONFIG-GENERAL')
+  })
+
+  test('redactReliabilityText removes secrets and tokens', () => {
+    const raw =
+      'Authorization: bearer abcdef12345 api_key=super-secret sk-abc1234567890 token=tok-1234567890'
+
+    expect(redactReliabilityText(raw)).toContain('Authorization: bearer ***')
+    expect(redactReliabilityText(raw)).toContain('api_key=***')
+    expect(redactReliabilityText(raw)).toContain('sk-abc123***')
+    expect(redactReliabilityText(raw)).toContain('token=***')
+  })
+
+  test('maps workflow snapshot errors into canonical reliability signals', () => {
+    const snapshot: WorkflowBoardSnapshot = {
+      backend: 'linear',
+      fetchedAt: '2026-04-07T20:00:00.000Z',
+      status: 'stale',
+      source: {
+        projectId: 'proj-1',
+      },
+      activeMilestone: null,
+      columns: [],
+      poll: {
+        status: 'error',
+        backend: 'linear',
+        lastAttemptAt: '2026-04-07T20:00:00.000Z',
+        lastSuccessAt: '2026-04-07T19:58:00.000Z',
+      },
+      lastError: {
+        code: 'NETWORK',
+        message: 'Network timeout while loading workflow board',
+      },
+    }
+
+    const signal = mapWorkflowBoardSnapshotToReliability(snapshot)
+    expect(signal).toBeTruthy()
+    expect(signal?.sourceSurface).toBe('workflow_board')
+    expect(signal?.class).toBe('network')
+    expect(signal?.recoveryAction).toBe('reconnect')
+    expect(signal?.code).toBe('REL-WORKFLOW-NETWORK-NETWORK')
+    expect(signal?.lastKnownGoodAt).toBe('2026-04-07T19:58:00.000Z')
+  })
+
+  test('maps symphony runtime status into canonical reliability signals', () => {
+    const status: SymphonyRuntimeStatus = {
+      phase: 'config_error',
+      managedProcessRunning: false,
+      pid: null,
+      url: null,
+      diagnostics: {
+        stdout: [],
+        stderr: [],
+      },
+      updatedAt: '2026-04-07T20:01:00.000Z',
+      restartCount: 0,
+      lastError: {
+        code: 'WORKFLOW_PATH_MISSING',
+        phase: 'config',
+        message: 'WORKFLOW.md not found at /tmp/workflow',
+      },
+    }
+
+    const signal = mapSymphonyRuntimeStatusToReliability(status)
+    expect(signal).toBeTruthy()
+    expect(signal?.sourceSurface).toBe('symphony')
+    expect(signal?.class).toBe('config')
+    expect(signal?.recoveryAction).toBe('fix_config')
+    expect(signal?.code).toBe('REL-SYMPHONY-CONFIG-WORKFLOW_PATH_MISSING')
+  })
+
+  test('maps symphony operator staleness into canonical stale signal', () => {
+    const snapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: '2026-04-07T20:02:00.000Z',
+      queueCount: 0,
+      completedCount: 0,
+      workers: [],
+      escalations: [],
+      connection: {
+        state: 'connected',
+        updatedAt: '2026-04-07T20:02:00.000Z',
+        lastBaselineRefreshAt: '2026-04-07T19:59:00.000Z',
+      },
+      freshness: {
+        status: 'stale',
+        staleReason: 'No baseline refresh in 180s',
+      },
+      response: {},
+    }
+
+    const signal = mapSymphonyOperatorSnapshotToReliability(snapshot)
+    expect(signal).toBeTruthy()
+    expect(signal?.class).toBe('stale')
+    expect(signal?.recoveryAction).toBe('refresh_state')
+    expect(signal?.code).toBe('REL-SYMPHONY-STALE-STALE')
+    expect(signal?.staleSince).toBe('2026-04-07T19:59:00.000Z')
+  })
+
+  test('maps MCP server status failures to canonical classes', () => {
+    const response: McpServerStatusResponse = {
+      success: false,
+      status: {
+        serverName: 'linear',
+        phase: 'error',
+        checkedAt: '2026-04-07T20:03:00.000Z',
+        toolNames: [],
+        toolCount: 0,
+        error: {
+          code: 'MISSING_BEARER_TOKEN',
+          message: 'Bearer token missing for linear mcp server',
+        },
+      },
+      error: {
+        code: 'MISSING_BEARER_TOKEN',
+        message: 'Bearer token missing for linear mcp server',
+      },
+    }
+
+    const signal = mapMcpStatusResponseToReliability(response)
+    expect(signal).toBeTruthy()
+    expect(signal?.sourceSurface).toBe('mcp')
+    expect(signal?.class).toBe('auth')
+    expect(signal?.recoveryAction).toBe('reauthenticate')
+    expect(signal?.code).toBe('REL-MCP-AUTH-MISSING_BEARER_TOKEN')
+  })
+
+  test('maps chat bridge failures with secret-safe diagnostics', () => {
+    const bridgeStatus: BridgeStatusEvent = {
+      state: 'crashed',
+      pid: 123,
+      message: 'Subprocess crashed: api_key=top-secret',
+      exitCode: 1,
+      signal: null,
+      updatedAt: Date.parse('2026-04-07T20:04:00.000Z'),
+    }
+
+    const bridgeSignal = mapChatBridgeStatusToReliability(bridgeStatus)
+    expect(bridgeSignal).toBeTruthy()
+    expect(bridgeSignal?.sourceSurface).toBe('chat_runtime')
+    expect(bridgeSignal?.code).toBe('REL-CHAT-PROCESS-EXIT_1')
+    expect(bridgeSignal?.message).toContain('api_key=***')
+
+    const crashSignal = mapChatSubprocessCrashToReliability({
+      message: 'fatal crash',
+      exitCode: null,
+      signal: 'SIGKILL',
+      stderrLines: [
+        'Authorization: bearer super-secret-token',
+        'Process exited unexpectedly',
+      ],
+      timestamp: '2026-04-07T20:05:00.000Z',
+    })
+
+    expect(crashSignal.code).toBe('REL-CHAT-PROCESS-SIGNAL_SIGKILL')
+    expect(crashSignal.diagnostics?.detail).toContain('bearer ***')
+    expect(crashSignal.message).toBe('Process exited unexpectedly')
+  })
+})

--- a/apps/desktop/src/main/__tests__/reliability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-contract.test.ts
@@ -38,6 +38,7 @@ describe('reliability-contract', () => {
     expect(redactReliabilityText(raw)).toContain('api_key=***')
     expect(redactReliabilityText(raw)).toContain('sk-abc123***')
     expect(redactReliabilityText(raw)).toContain('token=***')
+    expect(redactReliabilityText('sk-abc123')).toBe('sk-abc123***')
   })
 
   test('maps workflow snapshot errors into canonical reliability signals', () => {

--- a/apps/desktop/src/main/__tests__/reliability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-contract.test.ts
@@ -42,6 +42,9 @@ describe('reliability-contract', () => {
     const shortKeyRedaction = redactReliabilityText('sk-abc123')
     expect(shortKeyRedaction).toContain('***')
     expect(shortKeyRedaction).not.toContain('abc123')
+
+    expect(redactReliabilityText('sk-a')).toBe('sk-a***')
+    expect(redactReliabilityText('sk-ab')).toBe('sk-ab***')
   })
 
   test('maps workflow snapshot errors into canonical reliability signals', () => {

--- a/apps/desktop/src/main/__tests__/reliability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-contract.test.ts
@@ -10,10 +10,12 @@ import {
   buildReliabilityCode,
   mapChatBridgeStatusToReliability,
   mapChatSubprocessCrashToReliability,
+  mapMcpConfigReadResponseToReliability,
   mapMcpStatusResponseToReliability,
   mapSymphonyOperatorSnapshotToReliability,
   mapSymphonyRuntimeStatusToReliability,
   mapWorkflowBoardSnapshotToReliability,
+  pickPrimaryReliabilitySignal,
   redactReliabilityText,
 } from '../reliability-contract'
 
@@ -181,5 +183,102 @@ describe('reliability-contract', () => {
     expect(crashSignal.code).toBe('REL-CHAT-PROCESS-SIGNAL_SIGKILL')
     expect(crashSignal.diagnostics?.detail).toContain('bearer ***')
     expect(crashSignal.message).toBe('Process exited unexpectedly')
+  })
+
+  test('covers fallback reliability branches for mcp/chat code paths', () => {
+    const mcpConfigSignal = mapMcpConfigReadResponseToReliability({
+      success: false,
+      provenance: {
+        mode: 'global_only',
+        globalConfigPath: '/tmp/mcp.json',
+      },
+      servers: [],
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'mcp.json config failed schema validation',
+      },
+    })
+    expect(mcpConfigSignal?.class).toBe('config')
+
+    const mcpResponseSignal = mapMcpStatusResponseToReliability({
+      success: false,
+      error: {
+        code: 'UNKNOWN',
+        message: 'generic MCP status failure',
+      },
+    })
+    expect(mcpResponseSignal?.code).toBe('REL-MCP-UNKNOWN-UNKNOWN')
+
+    const crashedWithoutExit = mapChatBridgeStatusToReliability({
+      state: 'crashed',
+      pid: null,
+      message: 'network timeout while contacting runtime bridge',
+      exitCode: null,
+      signal: null,
+      updatedAt: Date.parse('2026-04-07T20:06:00.000Z'),
+    })
+    expect(crashedWithoutExit?.class).toBe('network')
+    expect(crashedWithoutExit?.code).toBe('REL-CHAT-NETWORK-CRASHED')
+
+    const crashFallback = mapChatSubprocessCrashToReliability({
+      message: 'configuration missing for subprocess runtime',
+      exitCode: null,
+      signal: null,
+      stderrLines: [],
+      timestamp: '2026-04-07T20:07:00.000Z',
+    })
+    expect(crashFallback.class).toBe('config')
+  })
+
+  test('pickPrimaryReliabilitySignal selects highest severity then newest timestamp', () => {
+    const selected = pickPrimaryReliabilitySignal([
+      {
+        code: 'REL-MCP-CONFIG-GENERAL',
+        class: 'config',
+        severity: 'warning',
+        sourceSurface: 'mcp',
+        recoveryAction: 'fix_config',
+        outcome: 'pending',
+        message: 'Needs config fix',
+        timestamp: '2026-04-07T20:00:00.000Z',
+      },
+      {
+        code: 'REL-CHAT-PROCESS-EXIT_1',
+        class: 'process',
+        severity: 'critical',
+        sourceSurface: 'chat_runtime',
+        recoveryAction: 'restart_process',
+        outcome: 'failed',
+        message: 'Runtime crashed',
+        timestamp: '2026-04-07T19:59:00.000Z',
+      },
+      {
+        code: 'REL-WORKFLOW-NETWORK-TIMEOUT',
+        class: 'network',
+        severity: 'critical',
+        sourceSurface: 'workflow_board',
+        recoveryAction: 'reconnect',
+        outcome: 'failed',
+        message: 'Timeout',
+        timestamp: '2026-04-07T20:01:00.000Z',
+      },
+      null,
+      undefined,
+    ])
+
+    expect(selected?.code).toBe('REL-WORKFLOW-NETWORK-TIMEOUT')
+    expect(pickPrimaryReliabilitySignal([null, undefined])).toBeNull()
+  })
+
+  test('buildReliabilityCode truncates long source fragments to stable length', () => {
+    const code = buildReliabilityCode(
+      'symphony',
+      'unknown',
+      'This message has a lot of punctuation !!! and details that should truncate',
+    )
+
+    expect(code).toMatch(/^REL-SYMPHONY-UNKNOWN-/)
+    const suffix = code.split('-').slice(3).join('-')
+    expect(suffix.length).toBeLessThanOrEqual(32)
   })
 })

--- a/apps/desktop/src/main/__tests__/reliability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-contract.test.ts
@@ -36,9 +36,12 @@ describe('reliability-contract', () => {
 
     expect(redactReliabilityText(raw)).toContain('Authorization: bearer ***')
     expect(redactReliabilityText(raw)).toContain('api_key=***')
-    expect(redactReliabilityText(raw)).toContain('sk-abc123***')
+    expect(redactReliabilityText(raw)).toContain('sk-abc***')
     expect(redactReliabilityText(raw)).toContain('token=***')
-    expect(redactReliabilityText('sk-abc123')).toBe('sk-abc123***')
+
+    const shortKeyRedaction = redactReliabilityText('sk-abc123')
+    expect(shortKeyRedaction).toContain('***')
+    expect(shortKeyRedaction).not.toContain('abc123')
   })
 
   test('maps workflow snapshot errors into canonical reliability signals', () => {

--- a/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
@@ -233,4 +233,51 @@ describe('reliability recovery IPC handler', () => {
 
     unregister()
   })
+
+  test('returns unsupported outcome for mcp reconnect action without server-specific context', async () => {
+    const unregister = registerSessionIpc(createCommonOptions())
+
+    const result = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'mcp',
+      action: 'reconnect',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.outcome).toBe('failed')
+    expect(result.code).toBe('MCP_RECOVERY_ACTION_UNSUPPORTED')
+
+    unregister()
+  })
+
+  test('redacts thrown recovery errors before returning them over reliability IPC', async () => {
+    const mcpConfigBridge = {
+      listServers: vi.fn(async () => {
+        throw new Error('Authorization: bearer secret-token api_key=secret sk-abc123')
+      }),
+      getServer: vi.fn(),
+      saveServer: vi.fn(),
+      deleteServer: vi.fn(),
+      getRuntimeServer: vi.fn(),
+    } as any
+
+    const unregister = registerSessionIpc({
+      ...createCommonOptions(),
+      mcpConfigBridge,
+    })
+
+    const result = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'mcp',
+      action: 'refresh_state',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('RECOVERY_ACTION_THROW')
+    expect(result.message).toContain('bearer ***')
+    expect(result.message).toContain('api_key=***')
+    expect(result.message).toContain('sk-abc***')
+    expect(result.message).not.toContain('secret-token')
+    expect(result.message).not.toContain('abc123')
+
+    unregister()
+  })
 })

--- a/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
@@ -1,0 +1,236 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { IPC_CHANNELS, type SymphonyOperatorSnapshot } from '@shared/types'
+
+const handlers = new Map<string, (...args: any[]) => any>()
+const originalTestMode = process.env.KATA_TEST_MODE
+
+vi.mock('electron', () => {
+  return {
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+        handlers.set(channel, handler)
+      }),
+      removeHandler: vi.fn((channel: string) => {
+        handlers.delete(channel)
+      }),
+    },
+    dialog: {
+      showOpenDialog: vi.fn(async () => ({ canceled: true, filePaths: [] })),
+    },
+    shell: {
+      openExternal: vi.fn(async () => undefined),
+    },
+  }
+})
+
+import { registerSessionIpc } from '../ipc'
+
+function createBridgeStub() {
+  const emitter = new EventEmitter()
+
+  return Object.assign(emitter, {
+    getState: vi.fn(() => ({ status: 'running', pid: 1, running: true })),
+    getWorkspacePath: vi.fn(() => process.cwd()),
+    prompt: vi.fn(),
+    abort: vi.fn(),
+    restart: vi.fn(),
+    sendExtensionUIResponse: vi.fn(),
+    setPermissionMode: vi.fn(),
+    getAvailableModels: vi.fn(async () => []),
+    setModel: vi.fn(),
+    setThinkingLevel: vi.fn(),
+    send: vi.fn(async () => ({ data: {} })),
+    switchSession: vi.fn(async () => true),
+    switchWorkspace: vi.fn(async () => undefined),
+  }) as any
+}
+
+function createWindowStub() {
+  return {
+    isDestroyed: () => false,
+    webContents: {
+      isDestroyed: () => false,
+      send: vi.fn(),
+    },
+  } as any
+}
+
+function createSymphonySnapshot(
+  partial: Partial<SymphonyOperatorSnapshot> = {},
+): SymphonyOperatorSnapshot {
+  return {
+    fetchedAt: '2026-04-07T21:00:00.000Z',
+    queueCount: 0,
+    completedCount: 0,
+    workers: [],
+    escalations: [],
+    connection: {
+      state: 'connected',
+      updatedAt: '2026-04-07T21:00:00.000Z',
+    },
+    freshness: {
+      status: 'fresh',
+    },
+    response: {},
+    ...partial,
+  }
+}
+
+function createCommonOptions() {
+  return {
+    bridge: createBridgeStub(),
+    authBridge: {
+      getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+      setProviderKey: vi.fn(),
+      removeProviderKey: vi.fn(),
+      validateKey: vi.fn(),
+    } as any,
+    sessionManager: {
+      listSessions: vi.fn(async () => ({ sessions: [], warnings: [], directory: process.cwd() })),
+      getSessionInfo: vi.fn(),
+      resolveSessionPathById: vi.fn(async () => null),
+    } as any,
+    window: createWindowStub(),
+  }
+}
+
+describe('reliability recovery IPC handler', () => {
+  beforeEach(() => {
+    handlers.clear()
+    process.env.KATA_TEST_MODE = '1'
+  })
+
+  afterEach(() => {
+    process.env.KATA_TEST_MODE = originalTestMode
+  })
+
+  test('returns failed workflow recovery when board remains stale after refresh', async () => {
+    const unregister = registerSessionIpc(createCommonOptions())
+
+    await handlers.get(IPC_CHANNELS.workflowSetScope)?.({}, {
+      scopeKey: 'workspace:none::session:none::scenario:stale',
+      requestedScope: 'project',
+    })
+
+    const result = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'workflow_board',
+      action: 'refresh_state',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.outcome).toBe('failed')
+    expect(result.code).toBe('WORKFLOW_REFRESH_UNHEALTHY')
+    expect(result.message).toContain('Network error while refreshing workflow board')
+
+    unregister()
+  })
+
+  test('uses symphony dashboard reconnect recovery before process restart when reconnect is requested', async () => {
+    const supervisor = {
+      on: vi.fn(),
+      off: vi.fn(),
+      getStatus: vi.fn(() => ({
+        phase: 'ready',
+        managedProcessRunning: true,
+        pid: 123,
+        url: 'http://127.0.0.1:8080',
+        diagnostics: { stdout: [], stderr: [] },
+        updatedAt: '2026-04-07T21:00:00.000Z',
+        restartCount: 0,
+      })),
+      restart: vi.fn(async () => ({ success: true })),
+      start: vi.fn(async () => ({ success: true })),
+      stop: vi.fn(async () => ({ success: true })),
+      setWorkspacePath: vi.fn(async () => undefined),
+    } as any
+
+    const refreshBaseline = vi.fn(async () =>
+      createSymphonySnapshot({
+        connection: {
+          state: 'connected',
+          updatedAt: '2026-04-07T21:02:00.000Z',
+        },
+        freshness: {
+          status: 'fresh',
+        },
+      }),
+    )
+
+    const operatorService = {
+      on: vi.fn(),
+      off: vi.fn(),
+      syncRuntimeStatus: vi.fn(async () => undefined),
+      getSnapshot: vi.fn(() => createSymphonySnapshot()),
+      refreshBaseline,
+      respondToEscalation: vi.fn(),
+    } as any
+
+    const unregister = registerSessionIpc({
+      ...createCommonOptions(),
+      symphonySupervisor: supervisor,
+      symphonyOperatorService: operatorService,
+    })
+
+    const result = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'symphony',
+      action: 'reconnect',
+    })
+
+    expect(refreshBaseline).toHaveBeenCalledTimes(1)
+    expect(supervisor.restart).not.toHaveBeenCalled()
+    expect(result.success).toBe(true)
+    expect(result.code).toBe('SYMPHONY_DASHBOARD_REFRESHED')
+
+    unregister()
+  })
+
+  test('uses supervisor restart for explicit symphony restart_process recovery actions', async () => {
+    const supervisor = {
+      on: vi.fn(),
+      off: vi.fn(),
+      getStatus: vi.fn(() => ({
+        phase: 'ready',
+        managedProcessRunning: true,
+        pid: 123,
+        url: 'http://127.0.0.1:8080',
+        diagnostics: { stdout: [], stderr: [] },
+        updatedAt: '2026-04-07T21:00:00.000Z',
+        restartCount: 0,
+      })),
+      restart: vi.fn(async () => ({ success: true, error: null })),
+      start: vi.fn(async () => ({ success: true })),
+      stop: vi.fn(async () => ({ success: true })),
+      setWorkspacePath: vi.fn(async () => undefined),
+    } as any
+
+    const refreshBaseline = vi.fn(async () => createSymphonySnapshot())
+
+    const operatorService = {
+      on: vi.fn(),
+      off: vi.fn(),
+      syncRuntimeStatus: vi.fn(async () => undefined),
+      getSnapshot: vi.fn(() => createSymphonySnapshot()),
+      refreshBaseline,
+      respondToEscalation: vi.fn(),
+    } as any
+
+    const unregister = registerSessionIpc({
+      ...createCommonOptions(),
+      symphonySupervisor: supervisor,
+      symphonyOperatorService: operatorService,
+    })
+
+    const result = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'symphony',
+      action: 'restart_process',
+    })
+
+    expect(supervisor.restart).toHaveBeenCalledTimes(1)
+    expect(refreshBaseline).not.toHaveBeenCalled()
+    expect(result.success).toBe(true)
+    expect(result.code).toBe('SYMPHONY_RESTARTED')
+
+    unregister()
+  })
+})

--- a/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
@@ -126,6 +126,36 @@ describe('reliability recovery IPC handler', () => {
     unregister()
   })
 
+  test('returns failed chat runtime recovery when restart does not restore running bridge state', async () => {
+    const options = createCommonOptions()
+    const bridge = options.bridge
+
+    bridge.restart = vi.fn(async () => undefined)
+    bridge.getState = vi.fn(() => ({
+      status: 'crashed',
+      pid: null,
+      running: false,
+      message: 'spawn failed',
+    }))
+
+    const unregister = registerSessionIpc({
+      ...options,
+      bridge,
+    })
+
+    const result = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'chat_runtime',
+      action: 'restart_process',
+    })
+
+    expect(bridge.restart).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(false)
+    expect(result.outcome).toBe('failed')
+    expect(result.code).toBe('CHAT_RUNTIME_NOT_RUNNING')
+
+    unregister()
+  })
+
   test('uses symphony dashboard reconnect recovery before process restart when reconnect is requested', async () => {
     const supervisor = {
       on: vi.fn(),

--- a/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
@@ -266,4 +266,22 @@ describe('RuntimeHealthAggregator', () => {
     expect(mcpSurface?.status).toBe('healthy')
     expect(mcpSurface?.signal).toBeNull()
   })
+
+  test('handles listener lifecycle and unknown/internal surface fallbacks safely', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' }) as any
+    const listener = vi.fn()
+
+    aggregator.on('snapshot', listener)
+    aggregator.off('snapshot', listener)
+
+    aggregator.updateSurface('not_a_surface', null)
+    expect(listener).not.toHaveBeenCalled()
+
+    aggregator.surfaces.delete('mcp')
+    const snapshot = aggregator.getSnapshot()
+    const mcpSurface = snapshot.surfaces.find((surface: { sourceSurface: string }) => surface.sourceSurface === 'mcp')
+
+    expect(mcpSurface?.status).toBe('healthy')
+    expect(mcpSurface?.signal).toBeNull()
+  })
 })

--- a/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test, vi } from 'vitest'
+import type {
+  BridgeStatusEvent,
+  McpConfigReadResponse,
+  ReliabilitySnapshot,
+  SymphonyOperatorSnapshot,
+  SymphonyRuntimeStatus,
+  WorkflowBoardSnapshot,
+} from '@shared/types'
+import { RuntimeHealthAggregator } from '../runtime-health-aggregator'
+
+function createWorkflowSnapshot(
+  partial: Partial<WorkflowBoardSnapshot> = {},
+): WorkflowBoardSnapshot {
+  return {
+    backend: 'linear',
+    fetchedAt: '2026-04-07T20:00:00.000Z',
+    status: 'fresh',
+    source: {
+      projectId: 'proj-1',
+    },
+    activeMilestone: null,
+    columns: [],
+    poll: {
+      status: 'success',
+      backend: 'linear',
+      lastAttemptAt: '2026-04-07T20:00:00.000Z',
+      lastSuccessAt: '2026-04-07T20:00:00.000Z',
+    },
+    ...partial,
+  }
+}
+
+function createSymphonyStatus(partial: Partial<SymphonyRuntimeStatus> = {}): SymphonyRuntimeStatus {
+  return {
+    phase: 'ready',
+    managedProcessRunning: true,
+    pid: 42,
+    url: 'http://127.0.0.1:8080',
+    diagnostics: {
+      stdout: [],
+      stderr: [],
+    },
+    updatedAt: '2026-04-07T20:01:00.000Z',
+    restartCount: 0,
+    ...partial,
+  }
+}
+
+function createSymphonySnapshot(
+  partial: Partial<SymphonyOperatorSnapshot> = {},
+): SymphonyOperatorSnapshot {
+  return {
+    fetchedAt: '2026-04-07T20:01:00.000Z',
+    queueCount: 0,
+    completedCount: 0,
+    workers: [],
+    escalations: [],
+    connection: {
+      state: 'connected',
+      updatedAt: '2026-04-07T20:01:00.000Z',
+    },
+    freshness: {
+      status: 'fresh',
+    },
+    response: {},
+    ...partial,
+  }
+}
+
+function getSurface(snapshot: ReliabilitySnapshot, sourceSurface: string) {
+  return snapshot.surfaces.find((surface) => surface.sourceSurface === sourceSurface)
+}
+
+describe('RuntimeHealthAggregator', () => {
+  test('starts healthy across all reliability surfaces', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+    const snapshot = aggregator.getSnapshot()
+
+    expect(snapshot.overallStatus).toBe('healthy')
+    expect(snapshot.surfaces).toHaveLength(4)
+    for (const surface of snapshot.surfaces) {
+      expect(surface.status).toBe('healthy')
+      expect(surface.signal).toBeNull()
+    }
+  })
+
+  test('tracks workflow degradation without dropping last-known-good timestamp', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    aggregator.ingestWorkflowSnapshot(createWorkflowSnapshot())
+
+    aggregator.ingestWorkflowSnapshot(
+      createWorkflowSnapshot({
+        status: 'stale',
+        poll: {
+          status: 'error',
+          backend: 'linear',
+          lastAttemptAt: '2026-04-07T20:03:00.000Z',
+          lastSuccessAt: '2026-04-07T19:58:00.000Z',
+        },
+        lastError: {
+          code: 'NETWORK',
+          message: 'Network timeout while refreshing workflow board',
+        },
+      }),
+    )
+
+    const workflowSurface = getSurface(aggregator.getSnapshot(), 'workflow_board')
+    expect(workflowSurface?.status).toBe('degraded')
+    expect(workflowSurface?.signal?.class).toBe('network')
+    expect(workflowSurface?.signal?.lastKnownGoodAt).toBe('2026-04-07T19:58:00.000Z')
+    expect(workflowSurface?.signal?.recoveryAction).toBe('reconnect')
+  })
+
+  test('prioritizes critical symphony runtime failures over stale operator signals', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    aggregator.ingestSymphonyOperatorSnapshot(
+      createSymphonySnapshot({
+        freshness: {
+          status: 'stale',
+          staleReason: 'No baseline refresh in 120s',
+        },
+      }),
+    )
+
+    aggregator.ingestSymphonyRuntimeStatus(
+      createSymphonyStatus({
+        phase: 'failed',
+        managedProcessRunning: false,
+        pid: null,
+        url: null,
+        lastError: {
+          code: 'PROCESS_EXITED',
+          phase: 'process',
+          message: 'Symphony subprocess exited unexpectedly.',
+        },
+      }),
+    )
+
+    const symphonySurface = getSurface(aggregator.getSnapshot(), 'symphony')
+    expect(symphonySurface?.status).toBe('degraded')
+    expect(symphonySurface?.signal?.class).toBe('process')
+    expect(symphonySurface?.signal?.code).toBe('REL-SYMPHONY-PROCESS-PROCESS_EXITED')
+  })
+
+  test('supports recovery-action execution and records recovery outcome', async () => {
+    const requestRecovery = vi.fn(async () => ({
+      success: true,
+      outcome: 'succeeded' as const,
+      code: 'WORKFLOW_REFRESHED',
+      message: 'Workflow board refreshed.',
+    }))
+
+    const aggregator = new RuntimeHealthAggregator({
+      now: () => '2026-04-07T20:00:00.000Z',
+      requestRecovery,
+    })
+
+    aggregator.ingestWorkflowSnapshot(
+      createWorkflowSnapshot({
+        status: 'error',
+        lastError: {
+          code: 'NOT_CONFIGURED',
+          message: 'Workflow board tracker is not configured.',
+        },
+      }),
+    )
+
+    const result = await aggregator.requestRecoveryAction({
+      sourceSurface: 'workflow_board',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.code).toBe('WORKFLOW_REFRESHED')
+    expect(requestRecovery).toHaveBeenCalledWith({
+      sourceSurface: 'workflow_board',
+      action: 'fix_config',
+    })
+
+    const workflowSurface = getSurface(aggregator.getSnapshot(), 'workflow_board')
+    expect(workflowSurface?.signal?.outcome).toBe('succeeded')
+  })
+
+  test('maps chat crashes into process reliability signals with redacted diagnostics', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    const status: BridgeStatusEvent = {
+      state: 'crashed',
+      pid: 7,
+      message: 'Subprocess crashed: api_key=secret',
+      exitCode: 1,
+      signal: null,
+      updatedAt: Date.parse('2026-04-07T20:00:00.000Z'),
+    }
+
+    aggregator.ingestChatBridgeStatus(status)
+    aggregator.ingestChatSubprocessCrash({
+      message: 'fatal',
+      exitCode: 1,
+      signal: null,
+      stderrLines: ['Authorization: bearer secret-token', 'Process exited unexpectedly'],
+      timestamp: '2026-04-07T20:00:00.000Z',
+    })
+
+    const chatSurface = getSurface(aggregator.getSnapshot(), 'chat_runtime')
+    expect(chatSurface?.signal?.class).toBe('process')
+    expect(chatSurface?.signal?.message).toContain('Process exited unexpectedly')
+    expect(chatSurface?.signal?.diagnostics?.detail).toContain('bearer ***')
+  })
+
+  test('tracks MCP config failures and returns to healthy after successful refresh', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    const failedResponse: McpConfigReadResponse = {
+      success: false,
+      provenance: {
+        mode: 'global_only',
+        globalConfigPath: '/tmp/mcp.json',
+      },
+      servers: [],
+      error: {
+        code: 'MALFORMED_CONFIG',
+        message: 'Invalid JSON in mcp.json',
+      },
+    }
+
+    aggregator.ingestMcpConfigResponse(failedResponse)
+    expect(getSurface(aggregator.getSnapshot(), 'mcp')?.status).toBe('degraded')
+
+    aggregator.ingestMcpConfigResponse({
+      success: true,
+      provenance: {
+        mode: 'global_only',
+        globalConfigPath: '/tmp/mcp.json',
+      },
+      servers: [],
+    })
+
+    const mcpSurface = getSurface(aggregator.getSnapshot(), 'mcp')
+    expect(mcpSurface?.status).toBe('healthy')
+    expect(mcpSurface?.signal).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
@@ -210,6 +210,30 @@ describe('RuntimeHealthAggregator', () => {
     expect(chatSurface?.signal?.diagnostics?.detail).toContain('bearer ***')
   })
 
+  test('clears chat crash reliability state once bridge reports running again', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    aggregator.ingestChatSubprocessCrash({
+      message: 'fatal',
+      exitCode: 137,
+      signal: 'SIGKILL',
+      stderrLines: ['Process exited unexpectedly'],
+      timestamp: '2026-04-07T20:00:00.000Z',
+    })
+
+    expect(getSurface(aggregator.getSnapshot(), 'chat_runtime')?.status).toBe('degraded')
+
+    aggregator.ingestChatBridgeStatus({
+      state: 'running',
+      pid: 42,
+      updatedAt: Date.parse('2026-04-07T20:00:02.000Z'),
+    })
+
+    const recoveredSurface = getSurface(aggregator.getSnapshot(), 'chat_runtime')
+    expect(recoveredSurface?.status).toBe('healthy')
+    expect(recoveredSurface?.signal).toBeNull()
+  })
+
   test('tracks MCP config failures and returns to healthy after successful refresh', () => {
     const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
 

--- a/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
@@ -183,6 +183,48 @@ describe('RuntimeHealthAggregator', () => {
     expect(workflowSurface?.signal?.outcome).toBe('succeeded')
   })
 
+  test('preserves failed recovery outcome when callback clears the surface signal', async () => {
+    let aggregator!: RuntimeHealthAggregator
+
+    const requestRecovery = vi.fn(async () => {
+      aggregator.ingestWorkflowSnapshot(createWorkflowSnapshot())
+      return {
+        success: false,
+        outcome: 'failed' as const,
+        code: 'WORKFLOW_REFRESH_FAILED',
+        message: 'Workflow board is still degraded.',
+      }
+    })
+
+    aggregator = new RuntimeHealthAggregator({
+      now: () => '2026-04-07T20:00:00.000Z',
+      requestRecovery,
+    })
+
+    aggregator.ingestWorkflowSnapshot(
+      createWorkflowSnapshot({
+        status: 'error',
+        lastError: {
+          code: 'NETWORK',
+          message: 'Network timeout while refreshing workflow board',
+        },
+      }),
+    )
+
+    const result = await aggregator.requestRecoveryAction({
+      sourceSurface: 'workflow_board',
+      action: 'reconnect',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.outcome).toBe('failed')
+
+    const workflowSurface = getSurface(aggregator.getSnapshot(), 'workflow_board')
+    expect(workflowSurface?.status).toBe('degraded')
+    expect(workflowSurface?.signal?.outcome).toBe('failed')
+    expect(workflowSurface?.signal?.recoveryAction).toBe('reconnect')
+  })
+
   test('maps chat crashes into process reliability signals with redacted diagnostics', () => {
     const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
 

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -288,6 +288,34 @@ describe('SymphonyOperatorService', () => {
     expect(signal?.code).toBe('REL-SYMPHONY-PROCESS-PROCESS_EXITED')
   })
 
+  test('refreshes freshness before computing operator reliability signal', () => {
+    const service = new SymphonyOperatorService({
+      fetchImpl: vi.fn(async () => ({ ok: true, json: async () => ({}) }) as Response),
+      createWebSocket: () => fakeSocket,
+    }) as any
+
+    service.snapshot = {
+      fetchedAt: new Date(Date.now() - 60_000).toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [],
+      escalations: [],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date(Date.now() - 60_000).toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const signal = service.getReliabilitySignal()
+    expect(signal?.sourceSurface).toBe('symphony')
+    expect(signal?.class).toBe('stale')
+    expect(signal?.recoveryAction).toBe('refresh_state')
+  })
+
   test('preserves legacy kanban mock identifiers for board correlation', async () => {
     const service = new SymphonyOperatorService({
       env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'kanban_assigned' },

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -273,6 +273,21 @@ describe('SymphonyOperatorService', () => {
     expect(response.result?.message).toContain('URL is unavailable')
   })
 
+  test('exposes canonical reliability signal when symphony runtime fails', async () => {
+    const service = new SymphonyOperatorService({
+      fetchImpl: vi.fn(async () => ({ ok: true, json: async () => ({}) }) as Response),
+      createWebSocket: () => fakeSocket,
+    })
+
+    await service.syncRuntimeStatus(DISCONNECTED_STATUS)
+    const signal = service.getReliabilitySignal()
+
+    expect(signal?.sourceSurface).toBe('symphony')
+    expect(signal?.class).toBe('process')
+    expect(signal?.recoveryAction).toBe('restart_process')
+    expect(signal?.code).toBe('REL-SYMPHONY-PROCESS-PROCESS_EXITED')
+  })
+
   test('preserves legacy kanban mock identifiers for board correlation', async () => {
     const service = new SymphonyOperatorService({
       env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'kanban_assigned' },

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -1243,6 +1243,25 @@ describe('WorkflowBoardService', () => {
     expect(second.snapshot.status).toBe('empty')
   })
 
+  test('exposes canonical workflow reliability signal for the latest board failure', async () => {
+    process.env.KATA_TEST_MODE = '1'
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    service.setActive(true)
+    service.setScope('workspace:a::session:b::scenario:auth-failure')
+    await service.refreshBoard()
+
+    const reliability = service.getReliabilitySignal()
+    expect(reliability?.sourceSurface).toBe('workflow_board')
+    expect(reliability?.class).toBe('auth')
+    expect(reliability?.recoveryAction).toBe('reauthenticate')
+    expect(reliability?.code).toBe('REL-WORKFLOW-AUTH-UNAUTHORIZED')
+  })
+
   test('filters active scope to cards with live symphony assignments', async () => {
     const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-active-scope-'))
     mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -12,6 +12,7 @@ import { SessionHistoryLoader } from './session-history-loader'
 import { WorkflowBoardService } from './workflow-board-service'
 import { McpConfigBridge } from './mcp-config-bridge'
 import { McpService } from './mcp-service'
+import { RuntimeHealthAggregator } from './runtime-health-aggregator'
 import type { SymphonySupervisor } from './symphony-supervisor'
 import type { SymphonyOperatorService } from './symphony-operator-service'
 import {
@@ -76,6 +77,10 @@ import {
   type McpServerMutationResponse,
   type McpServerResponse,
   type McpServerStatusResponse,
+  type ReliabilityRecoveryRequest,
+  type ReliabilityRecoveryResult,
+  type ReliabilitySnapshot,
+  type ReliabilityStatusResponse,
 } from '../shared/types'
 
 interface RegisterIpcOptions {
@@ -119,6 +124,111 @@ export function registerSessionIpc({
       getWorkspacePath: () => bridge.getWorkspacePath(),
     })
   const resolvedMcpService = mcpService ?? new McpService({ configBridge: resolvedMcpConfigBridge })
+
+  const reliabilityAggregator = new RuntimeHealthAggregator({
+    requestRecovery: async ({ sourceSurface, action }) => {
+      try {
+        if (sourceSurface === 'chat_runtime') {
+          await bridge.restart()
+          return {
+            success: true,
+            outcome: 'succeeded' as const,
+            code: 'CHAT_RUNTIME_RESTARTED',
+            message: 'Chat runtime restarted successfully.',
+          }
+        }
+
+        if (sourceSurface === 'workflow_board') {
+          const response = await workflowBoardService.refreshBoard()
+          reliabilityAggregator.ingestWorkflowSnapshot(response.snapshot)
+          return {
+            success: true,
+            outcome: 'succeeded' as const,
+            code: 'WORKFLOW_REFRESHED',
+            message: `Workflow board recovery action applied: ${action}.`,
+          }
+        }
+
+        if (sourceSurface === 'symphony') {
+          if (symphonySupervisor) {
+            const commandResult = await symphonySupervisor.restart()
+            return {
+              success: commandResult.success,
+              outcome: commandResult.success ? ('succeeded' as const) : ('failed' as const),
+              code: commandResult.success ? 'SYMPHONY_RESTARTED' : 'SYMPHONY_RESTART_FAILED',
+              message:
+                commandResult.error?.message ??
+                (commandResult.success
+                  ? 'Symphony runtime restart requested.'
+                  : 'Symphony runtime restart failed.'),
+            }
+          }
+
+          if (symphonyOperatorService) {
+            const snapshot = await symphonyOperatorService.refreshBaseline()
+            reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
+            return {
+              success: snapshot.connection.state !== 'disconnected',
+              outcome:
+                snapshot.connection.state !== 'disconnected'
+                  ? ('succeeded' as const)
+                  : ('failed' as const),
+              code:
+                snapshot.connection.state !== 'disconnected'
+                  ? 'SYMPHONY_DASHBOARD_REFRESHED'
+                  : 'SYMPHONY_DASHBOARD_REFRESH_FAILED',
+              message:
+                snapshot.connection.state !== 'disconnected'
+                  ? 'Symphony operator snapshot refreshed.'
+                  : snapshot.connection.lastError ?? 'Symphony operator refresh failed.',
+            }
+          }
+
+          return {
+            success: false,
+            outcome: 'failed' as const,
+            code: 'SYMPHONY_UNAVAILABLE',
+            message: 'Symphony services are unavailable.',
+          }
+        }
+
+        if (sourceSurface === 'mcp') {
+          const response = await resolvedMcpConfigBridge.listServers()
+          reliabilityAggregator.ingestMcpConfigResponse(response)
+
+          if (!response.success) {
+            return {
+              success: false,
+              outcome: 'failed' as const,
+              code: response.error?.code ?? 'MCP_REFRESH_FAILED',
+              message: response.error?.message ?? 'MCP config refresh failed.',
+            }
+          }
+
+          return {
+            success: true,
+            outcome: 'succeeded' as const,
+            code: 'MCP_CONFIG_REFRESHED',
+            message: 'MCP config refreshed successfully.',
+          }
+        }
+
+        return {
+          success: false,
+          outcome: 'failed' as const,
+          code: 'RECOVERY_UNSUPPORTED_SURFACE',
+          message: `Unsupported reliability surface: ${sourceSurface}`,
+        }
+      } catch (error) {
+        return {
+          success: false,
+          outcome: 'failed' as const,
+          code: 'RECOVERY_ACTION_THROW',
+          message: error instanceof Error ? error.message : String(error),
+        }
+      }
+    },
+  })
 
   const planningArtifactsByKey = new Map<string, PlanningArtifact>()
   const planningMetadataByKey = new Map<string, PlanningArtifactEvent>()
@@ -198,6 +308,19 @@ export function registerSessionIpc({
       escalations: snapshot.escalations.length,
       queueCount: snapshot.queueCount,
       completedCount: snapshot.completedCount,
+    })
+  }
+
+  const sendReliabilitySnapshot = (snapshot: ReliabilitySnapshot): void => {
+    if (!safeSend(IPC_CHANNELS.reliabilityStatus, snapshot)) {
+      return
+    }
+
+    log.debug('[desktop-ipc] reliability snapshot', {
+      overallStatus: snapshot.overallStatus,
+      degradedSurfaces: snapshot.surfaces
+        .filter((surface) => surface.status === 'degraded')
+        .map((surface) => surface.sourceSurface),
     })
   }
 
@@ -511,6 +634,7 @@ export function registerSessionIpc({
 
   const onStatus = (status: BridgeStatusEvent): void => {
     sendBridgeStatus(status)
+    reliabilityAggregator.ingestChatBridgeStatus(status)
   }
 
   const onDebug = (payload: Record<string, unknown>): void => {
@@ -526,6 +650,12 @@ export function registerSessionIpc({
       signal,
       stderrLines,
     })
+    reliabilityAggregator.ingestChatSubprocessCrash({
+      message: lastLine,
+      exitCode,
+      signal,
+      stderrLines,
+    })
   }
 
   bridge.on('rpc-event', onRpcEvent)
@@ -536,32 +666,46 @@ export function registerSessionIpc({
 
   const onSymphonyStatus = (status: SymphonyRuntimeStatus): void => {
     sendSymphonyStatusToRenderer(status)
+    reliabilityAggregator.ingestSymphonyRuntimeStatus(status)
     void symphonyOperatorService?.syncRuntimeStatus(status)
   }
 
   const onSymphonyDashboardSnapshot = (snapshot: SymphonyOperatorSnapshot): void => {
     sendSymphonyDashboardSnapshot(snapshot)
+    reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
+  }
+
+  const onReliabilitySnapshot = (snapshot: ReliabilitySnapshot): void => {
+    sendReliabilitySnapshot(snapshot)
   }
 
   symphonySupervisor?.on('status', onSymphonyStatus)
   symphonyOperatorService?.on('snapshot', onSymphonyDashboardSnapshot)
+  reliabilityAggregator.on('snapshot', onReliabilitySnapshot)
 
   const initialState = bridge.getState()
-  sendBridgeStatus({
+  const initialBridgeStatus: BridgeStatusEvent = {
     state: initialState.status,
     pid: initialState.pid,
     updatedAt: Date.now(),
-  })
+  }
+  sendBridgeStatus(initialBridgeStatus)
+  reliabilityAggregator.ingestChatBridgeStatus(initialBridgeStatus)
 
   if (symphonySupervisor) {
     const initialSymphonyStatus = symphonySupervisor.getStatus()
     sendSymphonyStatusToRenderer(initialSymphonyStatus)
+    reliabilityAggregator.ingestSymphonyRuntimeStatus(initialSymphonyStatus)
     void symphonyOperatorService?.syncRuntimeStatus(initialSymphonyStatus)
   }
 
   if (symphonyOperatorService) {
-    sendSymphonyDashboardSnapshot(symphonyOperatorService.getSnapshot())
+    const initialDashboardSnapshot = symphonyOperatorService.getSnapshot()
+    sendSymphonyDashboardSnapshot(initialDashboardSnapshot)
+    reliabilityAggregator.ingestSymphonyOperatorSnapshot(initialDashboardSnapshot)
   }
+
+  sendReliabilitySnapshot(reliabilityAggregator.getSnapshot())
 
   ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
   ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
@@ -611,6 +755,8 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.mcpDeleteServer)
   ipcMain.removeHandler(IPC_CHANNELS.mcpRefreshStatus)
   ipcMain.removeHandler(IPC_CHANNELS.mcpReconnectServer)
+  ipcMain.removeHandler(IPC_CHANNELS.reliabilityGetStatus)
+  ipcMain.removeHandler(IPC_CHANNELS.reliabilityRequestRecoveryAction)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
     if (!message?.trim()) {
@@ -1194,11 +1340,15 @@ export function registerSessionIpc({
   })
 
   ipcMain.handle(IPC_CHANNELS.workflowGetBoard, async (): Promise<WorkflowBoardSnapshotResponse> => {
-    return workflowBoardService.getBoard()
+    const response = await workflowBoardService.getBoard()
+    reliabilityAggregator.ingestWorkflowSnapshot(response.snapshot)
+    return response
   })
 
   ipcMain.handle(IPC_CHANNELS.workflowRefreshBoard, async (): Promise<WorkflowBoardSnapshotResponse> => {
-    return workflowBoardService.refreshBoard()
+    const response = await workflowBoardService.refreshBoard()
+    reliabilityAggregator.ingestWorkflowSnapshot(response.snapshot)
+    return response
   })
 
   ipcMain.handle(
@@ -1454,15 +1604,18 @@ export function registerSessionIpc({
   ipcMain.handle(IPC_CHANNELS.symphonyGetStatus, async (): Promise<SymphonyRuntimeStatusResponse> => {
     if (!symphonySupervisor) {
       const fallback = createSymphonyDisconnectedResult()
+      reliabilityAggregator.ingestSymphonyRuntimeStatus(fallback.status)
       return {
         success: true,
         status: fallback.status,
       }
     }
 
+    const status = symphonySupervisor.getStatus()
+    reliabilityAggregator.ingestSymphonyRuntimeStatus(status)
     return {
       success: true,
-      status: symphonySupervisor.getStatus(),
+      status,
     }
   })
 
@@ -1489,21 +1642,26 @@ export function registerSessionIpc({
   })
 
   ipcMain.handle(IPC_CHANNELS.symphonyGetDashboard, async (): Promise<SymphonyOperatorSnapshotResponse> => {
+    const snapshot = symphonyOperatorService?.getSnapshot() ?? createUnavailableDashboardSnapshot()
+    reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
     return {
       success: true,
-      snapshot: symphonyOperatorService?.getSnapshot() ?? createUnavailableDashboardSnapshot(),
+      snapshot,
     }
   })
 
   ipcMain.handle(IPC_CHANNELS.symphonyRefreshDashboard, async (): Promise<SymphonyOperatorSnapshotResponse> => {
     if (!symphonyOperatorService) {
+      const snapshot = createUnavailableDashboardSnapshot()
+      reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
       return {
         success: false,
-        snapshot: createUnavailableDashboardSnapshot(),
+        snapshot,
       }
     }
 
     const snapshot = await symphonyOperatorService.refreshBaseline()
+    reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
     return {
       success: true,
       snapshot,
@@ -1514,18 +1672,24 @@ export function registerSessionIpc({
     IPC_CHANNELS.symphonyRespondEscalation,
     async (_event, requestId: string, responseText: string): Promise<SymphonyEscalationResponseCommandResult> => {
       if (!symphonyOperatorService) {
+        const snapshot = createUnavailableDashboardSnapshot()
+        reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
         return {
           success: false,
-          snapshot: createUnavailableDashboardSnapshot(),
+          snapshot,
         }
       }
 
-      return symphonyOperatorService.respondToEscalation(requestId, responseText)
+      const response = await symphonyOperatorService.respondToEscalation(requestId, responseText)
+      reliabilityAggregator.ingestSymphonyOperatorSnapshot(response.snapshot)
+      return response
     },
   )
 
   ipcMain.handle(IPC_CHANNELS.mcpListServers, async (): Promise<McpConfigReadResponse> => {
-    return resolvedMcpConfigBridge.listServers()
+    const response = await resolvedMcpConfigBridge.listServers()
+    reliabilityAggregator.ingestMcpConfigResponse(response)
+    return response
   })
 
   ipcMain.handle(IPC_CHANNELS.mcpGetServer, async (_event, name: string): Promise<McpServerResponse> => {
@@ -1549,14 +1713,52 @@ export function registerSessionIpc({
   ipcMain.handle(
     IPC_CHANNELS.mcpRefreshStatus,
     async (_event, name: string): Promise<McpServerStatusResponse> => {
-      return resolvedMcpService.refreshStatus(name)
+      const response = await resolvedMcpService.refreshStatus(name)
+      reliabilityAggregator.ingestMcpStatusResponse(response)
+      return response
     },
   )
 
   ipcMain.handle(
     IPC_CHANNELS.mcpReconnectServer,
     async (_event, name: string): Promise<McpServerStatusResponse> => {
-      return resolvedMcpService.reconnectServer(name)
+      const response = await resolvedMcpService.reconnectServer(name)
+      reliabilityAggregator.ingestMcpStatusResponse(response)
+      return response
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.reliabilityGetStatus,
+    async (): Promise<ReliabilityStatusResponse> => {
+      return {
+        success: true,
+        snapshot: reliabilityAggregator.getSnapshot(),
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.reliabilityRequestRecoveryAction,
+    async (_event, request: ReliabilityRecoveryRequest): Promise<ReliabilityRecoveryResult> => {
+      if (
+        request?.sourceSurface !== 'chat_runtime' &&
+        request?.sourceSurface !== 'workflow_board' &&
+        request?.sourceSurface !== 'symphony' &&
+        request?.sourceSurface !== 'mcp'
+      ) {
+        return {
+          success: false,
+          sourceSurface: request?.sourceSurface ?? 'chat_runtime',
+          action: request?.action ?? 'inspect',
+          outcome: 'failed',
+          code: 'INVALID_RECOVERY_SURFACE',
+          message: `Unsupported reliability source surface: ${String(request?.sourceSurface)}`,
+          timestamp: new Date().toISOString(),
+        }
+      }
+
+      return reliabilityAggregator.requestRecoveryAction(request)
     },
   )
 
@@ -1568,6 +1770,7 @@ export function registerSessionIpc({
     bridge.off('crash', onCrash)
     symphonySupervisor?.off('status', onSymphonyStatus)
     symphonyOperatorService?.off('snapshot', onSymphonyDashboardSnapshot)
+    reliabilityAggregator.off('snapshot', onReliabilitySnapshot)
     planningToolDetector.off('artifact', onPlanningArtifactEvent)
 
     ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
@@ -1618,6 +1821,8 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.mcpDeleteServer)
     ipcMain.removeHandler(IPC_CHANNELS.mcpRefreshStatus)
     ipcMain.removeHandler(IPC_CHANNELS.mcpReconnectServer)
+    ipcMain.removeHandler(IPC_CHANNELS.reliabilityGetStatus)
+    ipcMain.removeHandler(IPC_CHANNELS.reliabilityRequestRecoveryAction)
   }
 }
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -14,8 +14,10 @@ import { McpConfigBridge } from './mcp-config-bridge'
 import { McpService } from './mcp-service'
 import { RuntimeHealthAggregator } from './runtime-health-aggregator'
 import {
+  isReliabilitySourceSurface,
   mapSymphonyOperatorSnapshotToReliability,
   mapWorkflowBoardSnapshotToReliability,
+  redactReliabilityText,
 } from './reliability-contract'
 import type { SymphonySupervisor } from './symphony-supervisor'
 import type { SymphonyOperatorService } from './symphony-operator-service'
@@ -235,6 +237,18 @@ export function registerSessionIpc({
         }
 
         if (sourceSurface === 'mcp') {
+          const supportsConfigRefresh =
+            action === 'refresh_state' || action === 'inspect' || action === 'fix_config'
+
+          if (!supportsConfigRefresh) {
+            return {
+              success: false,
+              outcome: 'failed' as const,
+              code: 'MCP_RECOVERY_ACTION_UNSUPPORTED',
+              message: `MCP recovery action ${action} requires server-specific reconnect or reauthentication.`,
+            }
+          }
+
           const response = await resolvedMcpConfigBridge.listServers()
           reliabilityAggregator.ingestMcpConfigResponse(response)
 
@@ -266,7 +280,7 @@ export function registerSessionIpc({
           success: false,
           outcome: 'failed' as const,
           code: 'RECOVERY_ACTION_THROW',
-          message: error instanceof Error ? error.message : String(error),
+          message: redactReliabilityText(error instanceof Error ? error.message : String(error)),
         }
       }
     },
@@ -1783,15 +1797,10 @@ export function registerSessionIpc({
   ipcMain.handle(
     IPC_CHANNELS.reliabilityRequestRecoveryAction,
     async (_event, request: ReliabilityRecoveryRequest): Promise<ReliabilityRecoveryResult> => {
-      if (
-        request?.sourceSurface !== 'chat_runtime' &&
-        request?.sourceSurface !== 'workflow_board' &&
-        request?.sourceSurface !== 'symphony' &&
-        request?.sourceSurface !== 'mcp'
-      ) {
+      if (!isReliabilitySourceSurface(request?.sourceSurface)) {
         return {
           success: false,
-          sourceSurface: request?.sourceSurface ?? 'chat_runtime',
+          sourceSurface: 'chat_runtime',
           action: request?.action ?? 'inspect',
           outcome: 'failed',
           code: 'INVALID_RECOVERY_SURFACE',

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -136,6 +136,17 @@ export function registerSessionIpc({
       try {
         if (sourceSurface === 'chat_runtime') {
           await bridge.restart()
+          const bridgeState = bridge.getState()
+
+          if (!bridgeState.running || bridgeState.status !== 'running') {
+            return {
+              success: false,
+              outcome: 'failed' as const,
+              code: 'CHAT_RUNTIME_NOT_RUNNING',
+              message: 'Chat runtime failed to reach a healthy running state after restart.',
+            }
+          }
+
           return {
             success: true,
             outcome: 'succeeded' as const,

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -13,6 +13,10 @@ import { WorkflowBoardService } from './workflow-board-service'
 import { McpConfigBridge } from './mcp-config-bridge'
 import { McpService } from './mcp-service'
 import { RuntimeHealthAggregator } from './runtime-health-aggregator'
+import {
+  mapSymphonyOperatorSnapshotToReliability,
+  mapWorkflowBoardSnapshotToReliability,
+} from './reliability-contract'
 import type { SymphonySupervisor } from './symphony-supervisor'
 import type { SymphonyOperatorService } from './symphony-operator-service'
 import {
@@ -141,6 +145,17 @@ export function registerSessionIpc({
         if (sourceSurface === 'workflow_board') {
           const response = await workflowBoardService.refreshBoard()
           reliabilityAggregator.ingestWorkflowSnapshot(response.snapshot)
+
+          const reliabilitySignal = mapWorkflowBoardSnapshotToReliability(response.snapshot)
+          if (reliabilitySignal) {
+            return {
+              success: false,
+              outcome: 'failed' as const,
+              code: 'WORKFLOW_REFRESH_UNHEALTHY',
+              message: reliabilitySignal.message,
+            }
+          }
+
           return {
             success: true,
             outcome: 'succeeded' as const,
@@ -150,7 +165,36 @@ export function registerSessionIpc({
         }
 
         if (sourceSurface === 'symphony') {
-          if (symphonySupervisor) {
+          const refreshOperatorSnapshot = async () => {
+            const snapshot = await symphonyOperatorService!.refreshBaseline()
+            reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
+
+            const reliabilitySignal = mapSymphonyOperatorSnapshotToReliability(snapshot)
+            if (reliabilitySignal) {
+              return {
+                success: false,
+                outcome: 'failed' as const,
+                code: 'SYMPHONY_DASHBOARD_REFRESH_UNHEALTHY',
+                message: reliabilitySignal.message,
+              }
+            }
+
+            return {
+              success: true,
+              outcome: 'succeeded' as const,
+              code: 'SYMPHONY_DASHBOARD_REFRESHED',
+              message: 'Symphony operator snapshot refreshed.',
+            }
+          }
+
+          const shouldRefreshOperatorSnapshot =
+            action === 'reconnect' || action === 'refresh_state' || action === 'inspect'
+
+          if (shouldRefreshOperatorSnapshot && symphonyOperatorService) {
+            return refreshOperatorSnapshot()
+          }
+
+          if (action === 'restart_process' && symphonySupervisor) {
             const commandResult = await symphonySupervisor.restart()
             return {
               success: commandResult.success,
@@ -165,22 +209,20 @@ export function registerSessionIpc({
           }
 
           if (symphonyOperatorService) {
-            const snapshot = await symphonyOperatorService.refreshBaseline()
-            reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
+            return refreshOperatorSnapshot()
+          }
+
+          if (symphonySupervisor) {
+            const commandResult = await symphonySupervisor.restart()
             return {
-              success: snapshot.connection.state !== 'disconnected',
-              outcome:
-                snapshot.connection.state !== 'disconnected'
-                  ? ('succeeded' as const)
-                  : ('failed' as const),
-              code:
-                snapshot.connection.state !== 'disconnected'
-                  ? 'SYMPHONY_DASHBOARD_REFRESHED'
-                  : 'SYMPHONY_DASHBOARD_REFRESH_FAILED',
+              success: commandResult.success,
+              outcome: commandResult.success ? ('succeeded' as const) : ('failed' as const),
+              code: commandResult.success ? 'SYMPHONY_RESTARTED' : 'SYMPHONY_RESTART_FAILED',
               message:
-                snapshot.connection.state !== 'disconnected'
-                  ? 'Symphony operator snapshot refreshed.'
-                  : snapshot.connection.lastError ?? 'Symphony operator refresh failed.',
+                commandResult.error?.message ??
+                (commandResult.success
+                  ? 'Symphony runtime restart requested.'
+                  : 'Symphony runtime restart failed.'),
             }
           }
 

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -1,6 +1,9 @@
 import { McpConfigBridge } from './mcp-config-bridge'
 import type { McpServerStatus, McpServerStatusResponse, ReliabilitySignal } from '../shared/types'
-import { mapMcpStatusResponseToReliability } from './reliability-contract'
+import {
+  mapMcpStatusResponseToReliability,
+  pickPrimaryReliabilitySignal,
+} from './reliability-contract'
 
 interface McpServiceOptions {
   configBridge: McpConfigBridge
@@ -12,7 +15,7 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 10_000
 export class McpService {
   private readonly configBridge: McpConfigBridge
   private readonly requestTimeoutMs: number
-  private lastReliabilitySignal: ReliabilitySignal | null = null
+  private readonly reliabilityByServer = new Map<string, ReliabilitySignal | null>()
 
   constructor(options: McpServiceOptions) {
     this.configBridge = options.configBridge
@@ -20,7 +23,7 @@ export class McpService {
   }
 
   public getReliabilitySignal(): ReliabilitySignal | null {
-    return this.lastReliabilitySignal
+    return pickPrimaryReliabilitySignal([...this.reliabilityByServer.values()])
   }
 
   public async refreshStatus(serverName: string): Promise<McpServerStatusResponse> {
@@ -38,7 +41,7 @@ export class McpService {
         runtimeServerResponse.error.message,
       )
       const response: McpServerStatusResponse = { success: false, status, error: status.error }
-      this.lastReliabilitySignal = mapMcpStatusResponseToReliability(response)
+      this.updateServerReliabilitySignal(serverName, response)
       return response
     }
 
@@ -56,7 +59,7 @@ export class McpService {
           toolCount: 0,
         },
       }
-      this.lastReliabilitySignal = mapMcpStatusResponseToReliability(response)
+      this.updateServerReliabilitySignal(serverName, response)
       return response
     }
 
@@ -70,7 +73,7 @@ export class McpService {
         toolCount: 0,
       },
     }
-    this.lastReliabilitySignal = mapMcpStatusResponseToReliability(response)
+    this.updateServerReliabilitySignal(serverName, response)
     return response
   }
 
@@ -81,6 +84,19 @@ export class McpService {
     // the connections. Spawning servers from the Electron main process
     // is unsafe (e.g. chrome-devtools-mcp hijacks Electron DevTools).
     return this.refreshStatus(serverName)
+  }
+
+  private updateServerReliabilitySignal(
+    serverName: string,
+    response: McpServerStatusResponse,
+  ): void {
+    const signal = mapMcpStatusResponseToReliability(response)
+    if (signal) {
+      this.reliabilityByServer.set(serverName, signal)
+      return
+    }
+
+    this.reliabilityByServer.delete(serverName)
   }
 
   private createErrorStatus(
@@ -114,5 +130,3 @@ function mapBridgeErrorCode(code: string): NonNullable<McpServerStatus['error']>
 
   return 'UNKNOWN'
 }
-
-

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -1,5 +1,6 @@
 import { McpConfigBridge } from './mcp-config-bridge'
-import type { McpServerStatus, McpServerStatusResponse } from '../shared/types'
+import type { McpServerStatus, McpServerStatusResponse, ReliabilitySignal } from '../shared/types'
+import { mapMcpStatusResponseToReliability } from './reliability-contract'
 
 interface McpServiceOptions {
   configBridge: McpConfigBridge
@@ -11,10 +12,15 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 10_000
 export class McpService {
   private readonly configBridge: McpConfigBridge
   private readonly requestTimeoutMs: number
+  private lastReliabilitySignal: ReliabilitySignal | null = null
 
   constructor(options: McpServiceOptions) {
     this.configBridge = options.configBridge
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+  }
+
+  public getReliabilitySignal(): ReliabilitySignal | null {
+    return this.lastReliabilitySignal
   }
 
   public async refreshStatus(serverName: string): Promise<McpServerStatusResponse> {
@@ -31,14 +37,16 @@ export class McpService {
         mapBridgeErrorCode(runtimeServerResponse.error.code),
         runtimeServerResponse.error.message,
       )
-      return { success: false, status, error: status.error }
+      const response: McpServerStatusResponse = { success: false, status, error: status.error }
+      this.lastReliabilitySignal = mapMcpStatusResponseToReliability(response)
+      return response
     }
 
     const server = runtimeServerResponse.server
     const checkedAt = new Date().toISOString()
 
     if (!server.enabled) {
-      return {
+      const response: McpServerStatusResponse = {
         success: true,
         status: {
           serverName: server.name,
@@ -48,9 +56,11 @@ export class McpService {
           toolCount: 0,
         },
       }
+      this.lastReliabilitySignal = mapMcpStatusResponseToReliability(response)
+      return response
     }
 
-    return {
+    const response: McpServerStatusResponse = {
       success: true,
       status: {
         serverName: server.name,
@@ -60,6 +70,8 @@ export class McpService {
         toolCount: 0,
       },
     }
+    this.lastReliabilitySignal = mapMcpStatusResponseToReliability(response)
+    return response
   }
 
   public async reconnectServer(serverName: string): Promise<McpServerStatusResponse> {

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -63,6 +63,8 @@ export class PiAgentBridge extends EventEmitter {
   private startPromise: Promise<void> | null = null
   private permissionMode: PermissionMode = 'ask'
   private selectedModel: string | null
+  private readonly reliabilityFaultMode = process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT?.trim() ?? null
+  private reliabilityFaultInjected = false
 
   constructor(
     private workspacePath: string,
@@ -356,6 +358,11 @@ export class PiAgentBridge extends EventEmitter {
   }
 
   public prompt(message: string): Promise<CommandResult> {
+    if (this.shouldInjectPromptCrashFault()) {
+      const error = this.injectPromptCrashFault()
+      return Promise.reject(error)
+    }
+
     return this.send({ type: 'prompt', message })
   }
 
@@ -503,6 +510,42 @@ export class PiAgentBridge extends EventEmitter {
         }
       }
     }
+  }
+
+  private shouldInjectPromptCrashFault(): boolean {
+    return (
+      process.env.KATA_TEST_MODE === '1' &&
+      this.reliabilityFaultMode === 'process_crash_once' &&
+      !this.reliabilityFaultInjected
+    )
+  }
+
+  private injectPromptCrashFault(): Error {
+    this.reliabilityFaultInjected = true
+
+    const stderrLines = ['Injected test subprocess crash fault.']
+    this.status = 'crashed'
+
+    this.emit('debug', {
+      type: 'bridge:test-fault',
+      fault: 'process_crash_once',
+    })
+
+    this.emit('crash', {
+      exitCode: 137,
+      signal: 'SIGKILL',
+      stderrLines,
+    })
+
+    this.emitStatus({
+      state: 'crashed',
+      pid: this.child?.pid ?? null,
+      message: stderrLines[0],
+      exitCode: 137,
+      signal: 'SIGKILL',
+    })
+
+    return new Error(stderrLines[0])
   }
 
   private writeJsonLine(payload: Record<string, unknown>): Promise<void> {

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -524,6 +524,25 @@ export class PiAgentBridge extends EventEmitter {
     this.reliabilityFaultInjected = true
 
     const stderrLines = ['Injected test subprocess crash fault.']
+    const crashError = new Error(stderrLines[0])
+    const activeChild = this.child
+    const activePid = activeChild?.pid ?? null
+
+    if (activeChild) {
+      activeChild.removeAllListeners('exit')
+      activeChild.removeAllListeners('close')
+      activeChild.removeAllListeners('error')
+      activeChild.stderr.removeAllListeners('data')
+
+      if (!activeChild.killed && activeChild.exitCode === null) {
+        activeChild.kill('SIGKILL')
+      }
+
+      this.cleanupStreams()
+      this.child = null
+      this.rejectPending(crashError)
+    }
+
     this.status = 'crashed'
 
     this.emit('debug', {
@@ -539,13 +558,13 @@ export class PiAgentBridge extends EventEmitter {
 
     this.emitStatus({
       state: 'crashed',
-      pid: this.child?.pid ?? null,
+      pid: activePid,
       message: stderrLines[0],
       exitCode: 137,
       signal: 'SIGKILL',
     })
 
-    return new Error(stderrLines[0])
+    return crashError
   }
 
   private writeJsonLine(payload: Record<string, unknown>): Promise<void> {

--- a/apps/desktop/src/main/reliability-contract.ts
+++ b/apps/desktop/src/main/reliability-contract.ts
@@ -32,6 +32,22 @@ const CLASS_CODE: Record<ReliabilityClass, string> = {
   unknown: 'UNKNOWN',
 }
 
+export const RELIABILITY_SURFACES: ReadonlyArray<ReliabilitySourceSurface> = [
+  'chat_runtime',
+  'workflow_board',
+  'symphony',
+  'mcp',
+]
+
+export function isReliabilitySourceSurface(
+  source: string | null | undefined,
+): source is ReliabilitySourceSurface {
+  return (
+    typeof source === 'string' &&
+    RELIABILITY_SURFACES.includes(source as ReliabilitySourceSurface)
+  )
+}
+
 export const RELIABILITY_CLASS_DEFAULTS: Record<
   ReliabilityClass,
   { severity: ReliabilitySeverity; recoveryAction: ReliabilityRecoveryAction }
@@ -104,7 +120,7 @@ const MCP_ERROR_CLASS: Record<string, ReliabilityClass> = {
 }
 
 const RELIABILITY_SECRET_PATTERNS: Array<[RegExp, string]> = [
-  [/(sk-[A-Za-z0-9_-]{6})[A-Za-z0-9_-]*/g, '$1***'],
+  [/(sk-[A-Za-z0-9_-]{3})[A-Za-z0-9_-]*/g, '$1***'],
   [/(api[_-]?key\s*[=:]\s*)([^\s]+)/gi, '$1***'],
   [/(token\s*[=:]\s*)([^\s]+)/gi, '$1***'],
   [/(authorization\s*[=:]\s*bearer\s+)([^\s]+)/gi, '$1***'],

--- a/apps/desktop/src/main/reliability-contract.ts
+++ b/apps/desktop/src/main/reliability-contract.ts
@@ -538,6 +538,6 @@ export function pickPrimaryReliabilitySignal(
       return selected
     }
 
-    return candidate.timestamp > selected.timestamp ? candidate : selected
+    return candidate.timestamp >= selected.timestamp ? candidate : selected
   })
 }

--- a/apps/desktop/src/main/reliability-contract.ts
+++ b/apps/desktop/src/main/reliability-contract.ts
@@ -1,0 +1,543 @@
+import type {
+  BridgeStatusEvent,
+  McpConfigReadResponse,
+  McpServerStatus,
+  McpServerStatusResponse,
+  ReliabilityClass,
+  ReliabilityRecoveryAction,
+  ReliabilityRecoveryOutcome,
+  ReliabilitySeverity,
+  ReliabilitySignal,
+  ReliabilitySourceSurface,
+  SymphonyOperatorSnapshot,
+  SymphonyRuntimeErrorCode,
+  SymphonyRuntimeStatus,
+  WorkflowBoardErrorCode,
+  WorkflowBoardSnapshot,
+} from '../shared/types'
+
+const SOURCE_CODE: Record<ReliabilitySourceSurface, string> = {
+  chat_runtime: 'CHAT',
+  workflow_board: 'WORKFLOW',
+  symphony: 'SYMPHONY',
+  mcp: 'MCP',
+}
+
+const CLASS_CODE: Record<ReliabilityClass, string> = {
+  config: 'CONFIG',
+  auth: 'AUTH',
+  network: 'NETWORK',
+  process: 'PROCESS',
+  stale: 'STALE',
+  unknown: 'UNKNOWN',
+}
+
+export const RELIABILITY_CLASS_DEFAULTS: Record<
+  ReliabilityClass,
+  { severity: ReliabilitySeverity; recoveryAction: ReliabilityRecoveryAction }
+> = {
+  config: {
+    severity: 'warning',
+    recoveryAction: 'fix_config',
+  },
+  auth: {
+    severity: 'error',
+    recoveryAction: 'reauthenticate',
+  },
+  network: {
+    severity: 'error',
+    recoveryAction: 'reconnect',
+  },
+  process: {
+    severity: 'critical',
+    recoveryAction: 'restart_process',
+  },
+  stale: {
+    severity: 'warning',
+    recoveryAction: 'refresh_state',
+  },
+  unknown: {
+    severity: 'error',
+    recoveryAction: 'inspect',
+  },
+}
+
+const WORKFLOW_ERROR_CLASS: Record<WorkflowBoardErrorCode, ReliabilityClass> = {
+  NOT_CONFIGURED: 'config',
+  INVALID_CONFIG: 'config',
+  MISSING_API_KEY: 'auth',
+  UNAUTHORIZED: 'auth',
+  NOT_FOUND: 'unknown',
+  RATE_LIMITED: 'network',
+  NETWORK: 'network',
+  GRAPHQL: 'network',
+  UNKNOWN: 'unknown',
+}
+
+const SYMPHONY_RUNTIME_ERROR_CLASS: Record<SymphonyRuntimeErrorCode, ReliabilityClass> = {
+  CONFIG_MISSING: 'config',
+  CONFIG_INVALID: 'config',
+  WORKFLOW_PATH_MISSING: 'config',
+  BINARY_NOT_FOUND: 'config',
+  SPAWN_FAILED: 'process',
+  PROCESS_EXITED: 'process',
+  READINESS_FAILED: 'network',
+  STOP_TIMEOUT: 'process',
+  UNKNOWN: 'unknown',
+}
+
+const MCP_ERROR_CLASS: Record<string, ReliabilityClass> = {
+  CONFIG_UNREADABLE: 'config',
+  MALFORMED_CONFIG: 'config',
+  INVALID_CONFIG_SHAPE: 'config',
+  SERVER_NOT_FOUND: 'config',
+  WRITE_FAILED: 'config',
+  READBACK_FAILED: 'config',
+  VALIDATION_FAILED: 'config',
+  MISSING_BEARER_TOKEN: 'auth',
+  COMMAND_NOT_FOUND: 'process',
+  PROTOCOL_ERROR: 'process',
+  CONNECTION_FAILED: 'network',
+  UNREACHABLE: 'network',
+  TIMEOUT: 'network',
+  UNKNOWN: 'unknown',
+}
+
+const RELIABILITY_SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/(sk-[A-Za-z0-9_-]{6})[A-Za-z0-9_-]+/g, '$1***'],
+  [/(api[_-]?key\s*[=:]\s*)([^\s]+)/gi, '$1***'],
+  [/(token\s*[=:]\s*)([^\s]+)/gi, '$1***'],
+  [/(authorization\s*[=:]\s*bearer\s+)([^\s]+)/gi, '$1***'],
+  [/(bearer\s+)([A-Za-z0-9._-]+)/gi, '$1***'],
+]
+
+export function redactReliabilityText(value: string | undefined | null): string {
+  const input = value?.trim()
+  if (!input) {
+    return ''
+  }
+
+  return RELIABILITY_SECRET_PATTERNS.reduce((sanitized, [pattern, replacement]) => {
+    return sanitized.replace(pattern, replacement)
+  }, input)
+}
+
+function normalizeCodeFragment(value: string | undefined, fallback = 'GENERAL'): string {
+  const normalized =
+    value
+      ?.trim()
+      .replace(/[^A-Za-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .toUpperCase() ?? ''
+
+  if (!normalized) {
+    return fallback
+  }
+
+  return normalized.slice(0, 32)
+}
+
+export function buildReliabilityCode(
+  sourceSurface: ReliabilitySourceSurface,
+  reliabilityClass: ReliabilityClass,
+  sourceCode?: string,
+): string {
+  const source = SOURCE_CODE[sourceSurface]
+  const category = CLASS_CODE[reliabilityClass]
+  const suffix = normalizeCodeFragment(sourceCode, 'GENERAL')
+  return `REL-${source}-${category}-${suffix}`
+}
+
+function toSignal(input: {
+  sourceSurface: ReliabilitySourceSurface
+  reliabilityClass: ReliabilityClass
+  sourceCode?: string
+  message: string
+  timestamp?: string
+  outcome?: ReliabilityRecoveryOutcome
+  staleSince?: string
+  lastKnownGoodAt?: string
+  diagnostics?: {
+    code?: string
+    detail?: string
+    occurredAt?: string
+  }
+  severity?: ReliabilitySeverity
+  recoveryAction?: ReliabilityRecoveryAction
+}): ReliabilitySignal {
+  const defaults = RELIABILITY_CLASS_DEFAULTS[input.reliabilityClass]
+  return {
+    code: buildReliabilityCode(input.sourceSurface, input.reliabilityClass, input.sourceCode),
+    class: input.reliabilityClass,
+    severity: input.severity ?? defaults.severity,
+    sourceSurface: input.sourceSurface,
+    recoveryAction: input.recoveryAction ?? defaults.recoveryAction,
+    outcome: input.outcome ?? 'pending',
+    message: redactReliabilityText(input.message) || 'Reliability issue detected.',
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    ...(input.staleSince ? { staleSince: input.staleSince } : {}),
+    ...(input.lastKnownGoodAt ? { lastKnownGoodAt: input.lastKnownGoodAt } : {}),
+    ...(input.diagnostics
+      ? {
+          diagnostics: {
+            ...(input.diagnostics.code ? { code: normalizeCodeFragment(input.diagnostics.code) } : {}),
+            ...(input.diagnostics.detail
+              ? {
+                  detail: redactReliabilityText(input.diagnostics.detail),
+                }
+              : {}),
+            ...(input.diagnostics.occurredAt ? { occurredAt: input.diagnostics.occurredAt } : {}),
+          },
+        }
+      : {}),
+  }
+}
+
+function classifyMessageFallback(message: string | undefined): ReliabilityClass {
+  const normalized = (message ?? '').toLowerCase()
+
+  if (/api[ _-]?key|unauthori[sz]ed|forbidden|token|auth/.test(normalized)) {
+    return 'auth'
+  }
+
+  if (/network|timed? out|econn|enotfound|fetch|socket/.test(normalized)) {
+    return 'network'
+  }
+
+  if (/config|preferences|\.kata|mcp\.json|workflow\.md|missing/.test(normalized)) {
+    return 'config'
+  }
+
+  if (/crash|exit|spawn|subprocess|killed|sig(term|kill|int)/.test(normalized)) {
+    return 'process'
+  }
+
+  if (/stale/.test(normalized)) {
+    return 'stale'
+  }
+
+  return 'unknown'
+}
+
+export function mapWorkflowBoardSnapshotToReliability(
+  snapshot: WorkflowBoardSnapshot | null | undefined,
+): ReliabilitySignal | null {
+  if (!snapshot) {
+    return null
+  }
+
+  if (snapshot.status === 'stale') {
+    const errorCode = snapshot.lastError?.code
+    const reliabilityClass = errorCode ? WORKFLOW_ERROR_CLASS[errorCode] ?? 'stale' : 'stale'
+
+    return toSignal({
+      sourceSurface: 'workflow_board',
+      reliabilityClass,
+      sourceCode: errorCode ?? 'STALE',
+      message: snapshot.lastError?.message ?? 'Workflow board snapshot is stale.',
+      timestamp: snapshot.fetchedAt,
+      staleSince: snapshot.poll.lastSuccessAt,
+      lastKnownGoodAt: snapshot.poll.lastSuccessAt,
+      outcome: 'pending',
+      ...(snapshot.lastError ? { diagnostics: { code: snapshot.lastError.code } } : {}),
+    })
+  }
+
+  if (snapshot.status === 'error' || snapshot.lastError) {
+    const errorCode = snapshot.lastError?.code ?? 'UNKNOWN'
+    const reliabilityClass = WORKFLOW_ERROR_CLASS[errorCode] ?? classifyMessageFallback(snapshot.lastError?.message)
+
+    return toSignal({
+      sourceSurface: 'workflow_board',
+      reliabilityClass,
+      sourceCode: errorCode,
+      message: snapshot.lastError?.message ?? 'Workflow board failed to refresh.',
+      timestamp: snapshot.fetchedAt,
+      lastKnownGoodAt: snapshot.poll.lastSuccessAt,
+      outcome: snapshot.status === 'error' ? 'failed' : 'pending',
+      diagnostics: {
+        code: errorCode,
+      },
+    })
+  }
+
+  return null
+}
+
+export function mapSymphonyRuntimeStatusToReliability(
+  status: SymphonyRuntimeStatus | null | undefined,
+): ReliabilitySignal | null {
+  if (!status) {
+    return null
+  }
+
+  if (status.phase === 'ready') {
+    return null
+  }
+
+  if (status.phase === 'starting' || status.phase === 'restarting') {
+    return toSignal({
+      sourceSurface: 'symphony',
+      reliabilityClass: 'process',
+      sourceCode: 'RESTARTING',
+      message: status.lastError?.message ?? 'Symphony runtime is recovering.',
+      timestamp: status.updatedAt,
+      outcome: 'pending',
+      severity: 'warning',
+      recoveryAction: 'restart_process',
+      diagnostics: {
+        code: status.lastError?.code,
+        detail: status.lastError?.details,
+      },
+    })
+  }
+
+  if (status.phase === 'idle' || status.phase === 'stopped') {
+    return null
+  }
+
+  const runtimeCode = status.lastError?.code ?? (status.phase === 'disconnected' ? 'READINESS_FAILED' : 'UNKNOWN')
+  const reliabilityClass = SYMPHONY_RUNTIME_ERROR_CLASS[runtimeCode] ?? classifyMessageFallback(status.lastError?.message)
+
+  return toSignal({
+    sourceSurface: 'symphony',
+    reliabilityClass,
+    sourceCode: runtimeCode,
+    message: status.lastError?.message ?? `Symphony runtime is ${status.phase}.`,
+    timestamp: status.updatedAt,
+    outcome: status.phase === 'failed' || status.phase === 'config_error' ? 'failed' : 'pending',
+    diagnostics: {
+      code: runtimeCode,
+      detail: status.lastError?.details,
+    },
+  })
+}
+
+export function mapSymphonyOperatorSnapshotToReliability(
+  snapshot: SymphonyOperatorSnapshot | null | undefined,
+): ReliabilitySignal | null {
+  if (!snapshot) {
+    return null
+  }
+
+  if (snapshot.response.lastResult && !snapshot.response.lastResult.ok) {
+    const statusCode = snapshot.response.lastResult.status
+    const reliabilityClass =
+      statusCode === 401 || statusCode === 403
+        ? 'auth'
+        : statusCode >= 500 || statusCode === 0
+          ? 'network'
+          : 'unknown'
+
+    return toSignal({
+      sourceSurface: 'symphony',
+      reliabilityClass,
+      sourceCode: `RESPOND_${statusCode || 'FAILED'}`,
+      message: snapshot.response.lastResult.message,
+      timestamp: snapshot.response.lastResult.completedAt,
+      outcome: 'failed',
+      diagnostics: {
+        occurredAt: snapshot.response.lastResult.submittedAt,
+      },
+    })
+  }
+
+  if (snapshot.connection.state === 'disconnected') {
+    return toSignal({
+      sourceSurface: 'symphony',
+      reliabilityClass: 'network',
+      sourceCode: 'DISCONNECTED',
+      message: snapshot.connection.lastError ?? 'Symphony operator is disconnected.',
+      timestamp: snapshot.connection.updatedAt,
+      outcome: 'pending',
+    })
+  }
+
+  if (snapshot.connection.state === 'reconnecting') {
+    return toSignal({
+      sourceSurface: 'symphony',
+      reliabilityClass: 'network',
+      sourceCode: 'RECONNECTING',
+      message: snapshot.connection.lastError ?? 'Symphony operator is reconnecting.',
+      timestamp: snapshot.connection.updatedAt,
+      outcome: 'pending',
+      severity: 'warning',
+      recoveryAction: 'reconnect',
+    })
+  }
+
+  if (snapshot.freshness.status === 'stale') {
+    return toSignal({
+      sourceSurface: 'symphony',
+      reliabilityClass: 'stale',
+      sourceCode: 'STALE',
+      message: snapshot.freshness.staleReason ?? 'Symphony operator snapshot is stale.',
+      timestamp: snapshot.connection.updatedAt,
+      staleSince: snapshot.connection.lastBaselineRefreshAt,
+      lastKnownGoodAt: snapshot.connection.lastBaselineRefreshAt,
+      outcome: 'pending',
+    })
+  }
+
+  return null
+}
+
+function classifyMcpCode(code: string | undefined, message: string | undefined): ReliabilityClass {
+  if (code) {
+    return MCP_ERROR_CLASS[code] ?? 'unknown'
+  }
+  return classifyMessageFallback(message)
+}
+
+export function mapMcpConfigReadResponseToReliability(
+  response: McpConfigReadResponse | null | undefined,
+): ReliabilitySignal | null {
+  if (!response || response.success || !response.error) {
+    return null
+  }
+
+  const reliabilityClass = classifyMcpCode(response.error.code, response.error.message)
+  return toSignal({
+    sourceSurface: 'mcp',
+    reliabilityClass,
+    sourceCode: response.error.code,
+    message: response.error.message,
+    diagnostics: {
+      code: response.error.code,
+    },
+    outcome: 'failed',
+  })
+}
+
+export function mapMcpServerStatusToReliability(
+  status: McpServerStatus | null | undefined,
+): ReliabilitySignal | null {
+  if (!status || status.phase !== 'error' || !status.error) {
+    return null
+  }
+
+  const reliabilityClass = classifyMcpCode(status.error.code, status.error.message)
+  return toSignal({
+    sourceSurface: 'mcp',
+    reliabilityClass,
+    sourceCode: status.error.code,
+    message: status.error.message,
+    timestamp: status.checkedAt,
+    diagnostics: {
+      code: status.error.code,
+    },
+    outcome: 'failed',
+  })
+}
+
+export function mapMcpStatusResponseToReliability(
+  response: McpServerStatusResponse | null | undefined,
+): ReliabilitySignal | null {
+  if (!response) {
+    return null
+  }
+
+  if (response.status) {
+    return mapMcpServerStatusToReliability(response.status)
+  }
+
+  if (response.error) {
+    const reliabilityClass = classifyMcpCode(response.error.code, response.error.message)
+    return toSignal({
+      sourceSurface: 'mcp',
+      reliabilityClass,
+      sourceCode: response.error.code,
+      message: response.error.message,
+      diagnostics: {
+        code: response.error.code,
+      },
+      outcome: 'failed',
+    })
+  }
+
+  return null
+}
+
+export function mapChatBridgeStatusToReliability(
+  status: BridgeStatusEvent | null | undefined,
+): ReliabilitySignal | null {
+  if (!status || status.state !== 'crashed') {
+    return null
+  }
+
+  const sourceCode =
+    status.exitCode !== null && status.exitCode !== undefined
+      ? `EXIT_${status.exitCode}`
+      : status.signal
+        ? `SIGNAL_${status.signal}`
+        : 'CRASHED'
+  const reliabilityClass = sourceCode === 'CRASHED' ? classifyMessageFallback(status.message) : 'process'
+
+  return toSignal({
+    sourceSurface: 'chat_runtime',
+    reliabilityClass,
+    sourceCode,
+    message: status.message ?? 'Chat runtime crashed.',
+    timestamp: new Date(status.updatedAt).toISOString(),
+    outcome: 'failed',
+  })
+}
+
+export function mapChatSubprocessCrashToReliability(input: {
+  message: string
+  exitCode: number | null
+  signal: NodeJS.Signals | null
+  stderrLines: string[]
+  timestamp?: string
+}): ReliabilitySignal {
+  const sourceCode =
+    input.exitCode !== null && input.exitCode !== undefined
+      ? `EXIT_${input.exitCode}`
+      : input.signal
+        ? `SIGNAL_${input.signal}`
+        : 'CRASHED'
+
+  const message = input.stderrLines.at(-1) ?? input.message
+  const reliabilityClass =
+    input.exitCode !== null || input.signal !== null ? 'process' : classifyMessageFallback(message)
+
+  return toSignal({
+    sourceSurface: 'chat_runtime',
+    reliabilityClass,
+    sourceCode,
+    message,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    diagnostics: {
+      detail: input.stderrLines.join(' | '),
+    },
+    outcome: 'failed',
+  })
+}
+
+export function pickPrimaryReliabilitySignal(
+  signals: Array<ReliabilitySignal | null | undefined>,
+): ReliabilitySignal | null {
+  const candidates = signals.filter((signal): signal is ReliabilitySignal => Boolean(signal))
+  if (candidates.length === 0) {
+    return null
+  }
+
+  const severityRank: Record<ReliabilitySeverity, number> = {
+    info: 0,
+    warning: 1,
+    error: 2,
+    critical: 3,
+  }
+
+  return candidates.reduce((selected, candidate) => {
+    if (severityRank[candidate.severity] > severityRank[selected.severity]) {
+      return candidate
+    }
+
+    if (severityRank[candidate.severity] < severityRank[selected.severity]) {
+      return selected
+    }
+
+    return candidate.timestamp > selected.timestamp ? candidate : selected
+  })
+}

--- a/apps/desktop/src/main/reliability-contract.ts
+++ b/apps/desktop/src/main/reliability-contract.ts
@@ -120,7 +120,7 @@ const MCP_ERROR_CLASS: Record<string, ReliabilityClass> = {
 }
 
 const RELIABILITY_SECRET_PATTERNS: Array<[RegExp, string]> = [
-  [/(sk-[A-Za-z0-9_-]{3})[A-Za-z0-9_-]*/g, '$1***'],
+  [/(sk-[A-Za-z0-9_-]{1,3})[A-Za-z0-9_-]*/g, '$1***'],
   [/(api[_-]?key\s*[=:]\s*)([^\s]+)/gi, '$1***'],
   [/(token\s*[=:]\s*)([^\s]+)/gi, '$1***'],
   [/(authorization\s*[=:]\s*bearer\s+)([^\s]+)/gi, '$1***'],

--- a/apps/desktop/src/main/reliability-contract.ts
+++ b/apps/desktop/src/main/reliability-contract.ts
@@ -104,7 +104,7 @@ const MCP_ERROR_CLASS: Record<string, ReliabilityClass> = {
 }
 
 const RELIABILITY_SECRET_PATTERNS: Array<[RegExp, string]> = [
-  [/(sk-[A-Za-z0-9_-]{6})[A-Za-z0-9_-]+/g, '$1***'],
+  [/(sk-[A-Za-z0-9_-]{6})[A-Za-z0-9_-]*/g, '$1***'],
   [/(api[_-]?key\s*[=:]\s*)([^\s]+)/gi, '$1***'],
   [/(token\s*[=:]\s*)([^\s]+)/gi, '$1***'],
   [/(authorization\s*[=:]\s*bearer\s+)([^\s]+)/gi, '$1***'],

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -1,0 +1,295 @@
+import { EventEmitter } from 'node:events'
+import {
+  mapChatBridgeStatusToReliability,
+  mapChatSubprocessCrashToReliability,
+  mapMcpConfigReadResponseToReliability,
+  mapMcpStatusResponseToReliability,
+  mapSymphonyOperatorSnapshotToReliability,
+  mapSymphonyRuntimeStatusToReliability,
+  mapWorkflowBoardSnapshotToReliability,
+  pickPrimaryReliabilitySignal,
+} from './reliability-contract'
+import type {
+  BridgeStatusEvent,
+  McpConfigReadResponse,
+  McpServerStatusResponse,
+  ReliabilityRecoveryAction,
+  ReliabilityRecoveryRequest,
+  ReliabilityRecoveryResult,
+  ReliabilitySignal,
+  ReliabilitySnapshot,
+  ReliabilitySourceSurface,
+  ReliabilitySurfaceState,
+  SymphonyOperatorSnapshot,
+  SymphonyRuntimeStatus,
+  WorkflowBoardSnapshot,
+} from '../shared/types'
+
+type RecoveryAttempt = {
+  success: boolean
+  outcome: 'succeeded' | 'failed'
+  code: string
+  message: string
+}
+
+interface RuntimeHealthAggregatorOptions {
+  now?: () => string
+  requestRecovery?: (request: {
+    sourceSurface: ReliabilitySourceSurface
+    action: ReliabilityRecoveryAction
+  }) => Promise<RecoveryAttempt>
+}
+
+interface RuntimeHealthAggregatorEvents {
+  snapshot: (snapshot: ReliabilitySnapshot) => void
+}
+
+const RELIABILITY_SURFACES: ReadonlyArray<ReliabilitySourceSurface> = [
+  'chat_runtime',
+  'workflow_board',
+  'symphony',
+  'mcp',
+]
+
+export class RuntimeHealthAggregator extends EventEmitter {
+  private readonly now: () => string
+  private readonly requestRecovery?: RuntimeHealthAggregatorOptions['requestRecovery']
+
+  private readonly surfaces = new Map<ReliabilitySourceSurface, ReliabilitySurfaceState>()
+
+  private chatBridgeSignal: ReliabilitySignal | null = null
+  private chatCrashSignal: ReliabilitySignal | null = null
+  private symphonyRuntimeSignal: ReliabilitySignal | null = null
+  private symphonyOperatorSignal: ReliabilitySignal | null = null
+  private mcpConfigSignal: ReliabilitySignal | null = null
+  private mcpStatusSignal: ReliabilitySignal | null = null
+
+  constructor(options: RuntimeHealthAggregatorOptions = {}) {
+    super()
+    this.now = options.now ?? (() => new Date().toISOString())
+    this.requestRecovery = options.requestRecovery
+
+    const startedAt = this.now()
+    for (const sourceSurface of RELIABILITY_SURFACES) {
+      this.surfaces.set(sourceSurface, {
+        sourceSurface,
+        status: 'healthy',
+        signal: null,
+        updatedAt: startedAt,
+        lastHealthyAt: startedAt,
+      })
+    }
+  }
+
+  override on<K extends keyof RuntimeHealthAggregatorEvents>(
+    event: K,
+    listener: RuntimeHealthAggregatorEvents[K],
+  ): this {
+    return super.on(event, listener)
+  }
+
+  override off<K extends keyof RuntimeHealthAggregatorEvents>(
+    event: K,
+    listener: RuntimeHealthAggregatorEvents[K],
+  ): this {
+    return super.off(event, listener)
+  }
+
+  override emit<K extends keyof RuntimeHealthAggregatorEvents>(
+    event: K,
+    ...args: Parameters<RuntimeHealthAggregatorEvents[K]>
+  ): boolean {
+    return super.emit(event, ...args)
+  }
+
+  public getSnapshot(): ReliabilitySnapshot {
+    return this.toSnapshot()
+  }
+
+  public ingestWorkflowSnapshot(snapshot: WorkflowBoardSnapshot | null | undefined): ReliabilitySnapshot {
+    this.updateSurface('workflow_board', mapWorkflowBoardSnapshotToReliability(snapshot))
+    return this.toSnapshot()
+  }
+
+  public ingestChatBridgeStatus(status: BridgeStatusEvent | null | undefined): ReliabilitySnapshot {
+    this.chatBridgeSignal = mapChatBridgeStatusToReliability(status)
+    this.syncChatSurface()
+    return this.toSnapshot()
+  }
+
+  public ingestChatSubprocessCrash(input: {
+    message: string
+    exitCode: number | null
+    signal: NodeJS.Signals | null
+    stderrLines: string[]
+    timestamp?: string
+  }): ReliabilitySnapshot {
+    this.chatCrashSignal = mapChatSubprocessCrashToReliability(input)
+    this.syncChatSurface()
+    return this.toSnapshot()
+  }
+
+  public ingestSymphonyRuntimeStatus(status: SymphonyRuntimeStatus | null | undefined): ReliabilitySnapshot {
+    this.symphonyRuntimeSignal = mapSymphonyRuntimeStatusToReliability(status)
+    this.syncSymphonySurface()
+    return this.toSnapshot()
+  }
+
+  public ingestSymphonyOperatorSnapshot(
+    snapshot: SymphonyOperatorSnapshot | null | undefined,
+  ): ReliabilitySnapshot {
+    this.symphonyOperatorSignal = mapSymphonyOperatorSnapshotToReliability(snapshot)
+    this.syncSymphonySurface()
+    return this.toSnapshot()
+  }
+
+  public ingestMcpConfigResponse(response: McpConfigReadResponse | null | undefined): ReliabilitySnapshot {
+    this.mcpConfigSignal = mapMcpConfigReadResponseToReliability(response)
+    this.syncMcpSurface()
+    return this.toSnapshot()
+  }
+
+  public ingestMcpStatusResponse(response: McpServerStatusResponse | null | undefined): ReliabilitySnapshot {
+    this.mcpStatusSignal = mapMcpStatusResponseToReliability(response)
+    this.syncMcpSurface()
+    return this.toSnapshot()
+  }
+
+  public async requestRecoveryAction(
+    request: ReliabilityRecoveryRequest,
+  ): Promise<ReliabilityRecoveryResult> {
+    const surface = this.surfaces.get(request.sourceSurface)
+    const action = request.action ?? surface?.signal?.recoveryAction ?? 'inspect'
+    const timestamp = this.now()
+
+    let attempt: RecoveryAttempt
+
+    if (!this.requestRecovery) {
+      attempt = {
+        success: false,
+        outcome: 'failed',
+        code: 'RECOVERY_HANDLER_UNAVAILABLE',
+        message: 'Recovery handler is unavailable.',
+      }
+    } else {
+      try {
+        attempt = await this.requestRecovery({
+          sourceSurface: request.sourceSurface,
+          action,
+        })
+      } catch (error) {
+        attempt = {
+          success: false,
+          outcome: 'failed',
+          code: 'RECOVERY_THROW',
+          message: error instanceof Error ? error.message : String(error),
+        }
+      }
+    }
+
+    const currentSurface = this.surfaces.get(request.sourceSurface)
+    if (currentSurface?.signal) {
+      this.updateSurface(request.sourceSurface, {
+        ...currentSurface.signal,
+        recoveryAction: action,
+        outcome: attempt.outcome,
+        timestamp,
+      })
+    }
+
+    return {
+      success: attempt.success,
+      sourceSurface: request.sourceSurface,
+      action,
+      outcome: attempt.outcome,
+      code: attempt.code,
+      message: attempt.message,
+      timestamp,
+    }
+  }
+
+  private syncChatSurface(): void {
+    this.updateSurface(
+      'chat_runtime',
+      pickPrimaryReliabilitySignal([this.chatBridgeSignal, this.chatCrashSignal]),
+    )
+  }
+
+  private syncSymphonySurface(): void {
+    this.updateSurface(
+      'symphony',
+      pickPrimaryReliabilitySignal([this.symphonyRuntimeSignal, this.symphonyOperatorSignal]),
+    )
+  }
+
+  private syncMcpSurface(): void {
+    this.updateSurface('mcp', pickPrimaryReliabilitySignal([this.mcpConfigSignal, this.mcpStatusSignal]))
+  }
+
+  private updateSurface(
+    sourceSurface: ReliabilitySourceSurface,
+    signal: ReliabilitySignal | null,
+  ): void {
+    const existing = this.surfaces.get(sourceSurface)
+    if (!existing) {
+      return
+    }
+
+    const updatedAt = this.now()
+
+    if (!signal) {
+      this.surfaces.set(sourceSurface, {
+        sourceSurface,
+        status: 'healthy',
+        signal: null,
+        updatedAt,
+        lastHealthyAt: updatedAt,
+      })
+      this.emit('snapshot', this.toSnapshot())
+      return
+    }
+
+    const inferredLastKnownGoodAt =
+      signal.lastKnownGoodAt ?? existing.signal?.lastKnownGoodAt ?? existing.lastHealthyAt
+
+    this.surfaces.set(sourceSurface, {
+      sourceSurface,
+      status: 'degraded',
+      signal: {
+        ...signal,
+        ...(inferredLastKnownGoodAt ? { lastKnownGoodAt: inferredLastKnownGoodAt } : {}),
+      },
+      updatedAt,
+      lastHealthyAt: existing.lastHealthyAt,
+    })
+
+    this.emit('snapshot', this.toSnapshot())
+  }
+
+  private toSnapshot(): ReliabilitySnapshot {
+    const surfaces = RELIABILITY_SURFACES.map((surface) => {
+      const state = this.surfaces.get(surface)
+      if (state) {
+        return {
+          ...state,
+          ...(state.signal ? { signal: { ...state.signal } } : { signal: null }),
+        }
+      }
+
+      const now = this.now()
+      return {
+        sourceSurface: surface,
+        status: 'healthy' as const,
+        signal: null,
+        updatedAt: now,
+        lastHealthyAt: now,
+      }
+    })
+
+    return {
+      generatedAt: this.now(),
+      overallStatus: surfaces.some((surface) => surface.status === 'degraded') ? 'degraded' : 'healthy',
+      surfaces,
+    }
+  }
+}

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -113,6 +113,12 @@ export class RuntimeHealthAggregator extends EventEmitter {
 
   public ingestChatBridgeStatus(status: BridgeStatusEvent | null | undefined): ReliabilitySnapshot {
     this.chatBridgeSignal = mapChatBridgeStatusToReliability(status)
+
+    // A recovered bridge status supersedes any prior crash-only signal.
+    if (status && status.state !== 'crashed') {
+      this.chatCrashSignal = null
+    }
+
     this.syncChatSurface()
     return this.toSnapshot()
   }

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -9,6 +9,7 @@ import {
   mapSymphonyRuntimeStatusToReliability,
   mapWorkflowBoardSnapshotToReliability,
   pickPrimaryReliabilitySignal,
+  RELIABILITY_SURFACES,
 } from './reliability-contract'
 import type {
   BridgeStatusEvent,
@@ -44,13 +45,6 @@ interface RuntimeHealthAggregatorOptions {
 interface RuntimeHealthAggregatorEvents {
   snapshot: (snapshot: ReliabilitySnapshot) => void
 }
-
-const RELIABILITY_SURFACES: ReadonlyArray<ReliabilitySourceSurface> = [
-  'chat_runtime',
-  'workflow_board',
-  'symphony',
-  'mcp',
-]
 
 export class RuntimeHealthAggregator extends EventEmitter {
   private readonly now: () => string

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import log from './logger'
 import {
   mapChatBridgeStatusToReliability,
   mapChatSubprocessCrashToReliability,
@@ -167,6 +168,12 @@ export class RuntimeHealthAggregator extends EventEmitter {
     const surface = this.surfaces.get(request.sourceSurface)
     const action = request.action ?? surface?.signal?.recoveryAction ?? 'inspect'
     const timestamp = this.now()
+    const preRecoverySignal = surface?.signal ? { ...surface.signal } : null
+
+    log.info('[runtime-health-aggregator] recovery requested', {
+      sourceSurface: request.sourceSurface,
+      action,
+    })
 
     let attempt: RecoveryAttempt
 
@@ -184,19 +191,37 @@ export class RuntimeHealthAggregator extends EventEmitter {
           action,
         })
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.error('[runtime-health-aggregator] recovery threw', {
+          sourceSurface: request.sourceSurface,
+          action,
+          error: message,
+        })
         attempt = {
           success: false,
           outcome: 'failed',
           code: 'RECOVERY_THROW',
-          message: error instanceof Error ? error.message : String(error),
+          message,
         }
       }
     }
 
-    const currentSurface = this.surfaces.get(request.sourceSurface)
-    if (currentSurface?.signal) {
+    log.info('[runtime-health-aggregator] recovery completed', {
+      sourceSurface: request.sourceSurface,
+      action,
+      success: attempt.success,
+      outcome: attempt.outcome,
+      code: attempt.code,
+      message: attempt.message,
+    })
+
+    const currentSurfaceSignal = this.surfaces.get(request.sourceSurface)?.signal
+    const signalForOutcome =
+      currentSurfaceSignal ?? (attempt.outcome === 'failed' ? preRecoverySignal : null)
+
+    if (signalForOutcome) {
       this.updateSurface(request.sourceSurface, {
-        ...currentSurface.signal,
+        ...signalForOutcome,
         recoveryAction: action,
         outcome: attempt.outcome,
         timestamp,

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -98,6 +98,7 @@ export class SymphonyOperatorService extends EventEmitter {
   }
 
   public getReliabilitySignal(): ReliabilitySignal | null {
+    this.refreshFreshness()
     return pickPrimaryReliabilitySignal([
       mapSymphonyRuntimeStatusToReliability(this.runtimeStatus),
       mapSymphonyOperatorSnapshotToReliability(this.snapshot),

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import type { SymphonyRuntimeStatus } from '../shared/types'
+import type { SymphonyRuntimeStatus, ReliabilitySignal } from '../shared/types'
 import type {
   SymphonyEscalationResponseCommandResult,
   SymphonyEscalationResponseResult,
@@ -7,6 +7,11 @@ import type {
   SymphonyOperatorSnapshot,
   SymphonyOperatorWorkerRow,
 } from '../shared/types'
+import {
+  mapSymphonyOperatorSnapshotToReliability,
+  mapSymphonyRuntimeStatusToReliability,
+  pickPrimaryReliabilitySignal,
+} from './reliability-contract'
 
 const STALE_AFTER_MS = 30_000
 
@@ -90,6 +95,13 @@ export class SymphonyOperatorService extends EventEmitter {
   public getSnapshot(): SymphonyOperatorSnapshot {
     this.refreshFreshness()
     return this.snapshot
+  }
+
+  public getReliabilitySignal(): ReliabilitySignal | null {
+    return pickPrimaryReliabilitySignal([
+      mapSymphonyRuntimeStatusToReliability(this.runtimeStatus),
+      mapSymphonyOperatorSnapshotToReliability(this.snapshot),
+    ])
   }
 
   public async refreshBaseline(options: { advanceMockScenario?: boolean } = {}): Promise<SymphonyOperatorSnapshot> {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -7,6 +7,7 @@ import { GithubWorkflowClient } from './github-workflow-client'
 import log from './logger'
 import { WorkflowContextService } from './workflow-context-service'
 import { readWorkspaceWorkflowTrackerConfig } from './workflow-config-reader'
+import { mapWorkflowBoardSnapshotToReliability } from './reliability-contract'
 import type {
   SymphonyOperatorSnapshot,
   WorkflowBoardScope,
@@ -31,6 +32,7 @@ import type {
   WorkflowColumnId,
   WorkflowSymphonyExecutionFreshness,
   WorkflowSymphonyExecutionProvenance,
+  ReliabilitySignal,
 } from '../shared/types'
 
 const TEST_LINEAR_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
@@ -877,6 +879,10 @@ export class WorkflowBoardService {
       boardAvailable: Boolean(this.lastSnapshot),
       updatedAt: new Date().toISOString(),
     }
+  }
+
+  getReliabilitySignal(): ReliabilitySignal | null {
+    return mapWorkflowBoardSnapshotToReliability(this.lastSnapshot)
   }
 
   async getBoard(): Promise<WorkflowBoardSnapshotResponse> {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -265,6 +265,25 @@ const api: DesktopApi = {
       return ipcRenderer.invoke(IPC_CHANNELS.mcpReconnectServer, name)
     },
   },
+  reliability: {
+    getStatus: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.reliabilityGetStatus)
+    },
+    requestRecoveryAction: async (request: Parameters<DesktopApi['reliability']['requestRecoveryAction']>[0]) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.reliabilityRequestRecoveryAction, request)
+    },
+    onStatus: (listener: Parameters<DesktopApi['reliability']['onStatus']>[0]) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, snapshot: Parameters<Parameters<DesktopApi['reliability']['onStatus']>[0]>[0]) => {
+        listener(snapshot)
+      }
+
+      ipcRenderer.on(IPC_CHANNELS.reliabilityStatus, wrapped)
+
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.reliabilityStatus, wrapped)
+      }
+    },
+  },
 }
 
 contextBridge.exposeInMainWorld('api', api)

--- a/apps/desktop/src/renderer/atoms/reliability.ts
+++ b/apps/desktop/src/renderer/atoms/reliability.ts
@@ -1,0 +1,242 @@
+import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { useEffect } from 'react'
+import type {
+  ReliabilityRecoveryAction,
+  ReliabilityRecoveryRequest,
+  ReliabilityRecoveryResult,
+  ReliabilitySnapshot,
+  ReliabilitySourceSurface,
+  ReliabilitySurfaceState,
+} from '@shared/types'
+
+const RELIABILITY_SURFACES: ReadonlyArray<ReliabilitySourceSurface> = [
+  'chat_runtime',
+  'workflow_board',
+  'symphony',
+  'mcp',
+]
+
+function buildEmptySnapshot(): ReliabilitySnapshot {
+  const now = new Date(0).toISOString()
+  return {
+    generatedAt: now,
+    overallStatus: 'healthy',
+    surfaces: RELIABILITY_SURFACES.map((surface) => ({
+      sourceSurface: surface,
+      status: 'healthy',
+      signal: null,
+      updatedAt: now,
+      lastHealthyAt: now,
+    })),
+  }
+}
+
+export function formatReliabilityClassLabel(value: string): string {
+  if (!value) {
+    return 'Unknown'
+  }
+
+  return value
+    .split('_')
+    .join(' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+export function formatReliabilityActionLabel(action: ReliabilityRecoveryAction): string {
+  switch (action) {
+    case 'fix_config':
+      return 'Fix configuration'
+    case 'reauthenticate':
+      return 'Re-authenticate'
+    case 'retry_request':
+      return 'Retry request'
+    case 'restart_process':
+      return 'Restart process'
+    case 'reconnect':
+      return 'Reconnect service'
+    case 'refresh_state':
+      return 'Refresh state'
+    case 'inspect':
+    default:
+      return 'Inspect diagnostics'
+  }
+}
+
+export function formatReliabilitySurfaceLabel(surface: ReliabilitySourceSurface): string {
+  switch (surface) {
+    case 'chat_runtime':
+      return 'Chat runtime'
+    case 'workflow_board':
+      return 'Workflow board'
+    case 'symphony':
+      return 'Symphony'
+    case 'mcp':
+      return 'MCP'
+    default:
+      return surface
+  }
+}
+
+export function reliabilitySeverityTone(
+  severity: string | undefined,
+): 'error' | 'warning' | 'info' {
+  if (severity === 'critical' || severity === 'error') {
+    return 'error'
+  }
+
+  if (severity === 'warning') {
+    return 'warning'
+  }
+
+  return 'info'
+}
+
+function mergeReliabilitySnapshot(
+  previous: ReliabilitySnapshot,
+  next: ReliabilitySnapshot,
+): ReliabilitySnapshot {
+  const previousBySurface = new Map(previous.surfaces.map((surface) => [surface.sourceSurface, surface]))
+
+  const mergedSurfaces = next.surfaces.map((surface) => {
+    const previousSurface = previousBySurface.get(surface.sourceSurface)
+    if (!previousSurface) {
+      return surface
+    }
+
+    if (!surface.signal) {
+      return {
+        ...surface,
+        lastHealthyAt: surface.lastHealthyAt ?? previousSurface.lastHealthyAt,
+      }
+    }
+
+    return {
+      ...surface,
+      signal: {
+        ...surface.signal,
+        lastKnownGoodAt:
+          surface.signal.lastKnownGoodAt ??
+          previousSurface.signal?.lastKnownGoodAt ??
+          previousSurface.lastHealthyAt,
+      },
+    }
+  })
+
+  return {
+    ...next,
+    surfaces: mergedSurfaces,
+  }
+}
+
+export const reliabilitySnapshotAtom = atom<ReliabilitySnapshot>(buildEmptySnapshot())
+export const reliabilityLoadingAtom = atom<boolean>(false)
+export const reliabilityRecoveryPendingAtom = atom<Record<ReliabilitySourceSurface, boolean>>({
+  chat_runtime: false,
+  workflow_board: false,
+  symphony: false,
+  mcp: false,
+})
+export const reliabilityRecoveryResultAtom = atom<
+  Record<ReliabilitySourceSurface, ReliabilityRecoveryResult | null>
+>({
+  chat_runtime: null,
+  workflow_board: null,
+  symphony: null,
+  mcp: null,
+})
+
+const setReliabilitySnapshotAtom = atom(
+  null,
+  (get, set, snapshot: ReliabilitySnapshot) => {
+    const previous = get(reliabilitySnapshotAtom)
+    set(reliabilitySnapshotAtom, mergeReliabilitySnapshot(previous, snapshot))
+  },
+)
+
+export const refreshReliabilityStatusAtom = atom(null, async (_get, set) => {
+  set(reliabilityLoadingAtom, true)
+
+  try {
+    const response = await window.api.reliability.getStatus()
+    if (response.success) {
+      set(setReliabilitySnapshotAtom, response.snapshot)
+    }
+  } finally {
+    set(reliabilityLoadingAtom, false)
+  }
+})
+
+export const requestReliabilityRecoveryActionAtom = atom(
+  null,
+  async (_get, set, request: ReliabilityRecoveryRequest) => {
+    set(reliabilityRecoveryPendingAtom, (previous) => ({
+      ...previous,
+      [request.sourceSurface]: true,
+    }))
+
+    try {
+      const result = await window.api.reliability.requestRecoveryAction(request)
+      set(reliabilityRecoveryResultAtom, (previous) => ({
+        ...previous,
+        [request.sourceSurface]: result,
+      }))
+
+      const response = await window.api.reliability.getStatus()
+      if (response.success) {
+        set(setReliabilitySnapshotAtom, response.snapshot)
+      }
+
+      return result
+    } finally {
+      set(reliabilityRecoveryPendingAtom, (previous) => ({
+        ...previous,
+        [request.sourceSurface]: false,
+      }))
+    }
+  },
+)
+
+export function useReliabilityBridge(): void {
+  const setSnapshot = useSetAtom(setReliabilitySnapshotAtom)
+  const refresh = useSetAtom(refreshReliabilityStatusAtom)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const unsubscribe = window.api.reliability.onStatus((snapshot) => {
+      if (cancelled) {
+        return
+      }
+      setSnapshot(snapshot)
+    })
+
+    void refresh()
+
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [refresh, setSnapshot])
+}
+
+export function useReliabilitySnapshot(): ReliabilitySnapshot {
+  return useAtomValue(reliabilitySnapshotAtom)
+}
+
+const FALLBACK_SURFACE_STATE = (surface: ReliabilitySourceSurface): ReliabilitySurfaceState => ({
+  sourceSurface: surface,
+  status: 'healthy',
+  signal: null,
+  updatedAt: new Date(0).toISOString(),
+  lastHealthyAt: new Date(0).toISOString(),
+})
+
+export function useReliabilitySurfaceState(
+  sourceSurface: ReliabilitySourceSurface,
+): ReliabilitySurfaceState {
+  const snapshot = useReliabilitySnapshot()
+  return (
+    snapshot.surfaces.find((surface) => surface.sourceSurface === sourceSurface) ??
+    FALLBACK_SURFACE_STATE(sourceSurface)
+  )
+}

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -283,7 +283,7 @@ export function AppShell() {
   const reliabilityTone = reliabilitySeverityTone(primarySignal?.severity)
 
   return (
-    <main className="size-full bg-background text-foreground">
+    <main className="flex size-full min-h-0 flex-col bg-background text-foreground">
       {primaryReliabilitySurface && primarySignal ? (
         <div
           className={
@@ -329,7 +329,7 @@ export function AppShell() {
 
       <Group
         orientation="horizontal"
-        className="size-full"
+        className="min-h-0 flex-1"
         defaultLayout={defaultLayout}
         onLayoutChanged={(layout) => {
           try {

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -26,6 +26,17 @@ import {
   workflowMutationPendingAtom,
 } from '@/atoms/workflow-board'
 import { mcpMutationPendingAtom, mcpStatusPendingByServerAtom } from '@/atoms/mcp'
+import {
+  formatReliabilityActionLabel,
+  formatReliabilityClassLabel,
+  formatReliabilitySurfaceLabel,
+  reliabilityRecoveryPendingAtom,
+  reliabilitySeverityTone,
+  requestReliabilityRecoveryActionAtom,
+  useReliabilityBridge,
+  useReliabilitySnapshot,
+} from '@/atoms/reliability'
+import { Button } from '@/components/ui/button'
 import { LeftPane } from './LeftPane'
 import { RightPane } from './RightPane'
 import { SettingsPanel } from '../settings/SettingsPanel'
@@ -94,7 +105,17 @@ function isEditableTarget(target: EventTarget | null): boolean {
   return tagName === 'input' || tagName === 'textarea' || tagName === 'select'
 }
 
+function reliabilitySeverityRank(severity: string | undefined): number {
+  if (severity === 'critical') return 4
+  if (severity === 'error') return 3
+  if (severity === 'warning') return 2
+  if (severity === 'info') return 1
+  return 0
+}
+
 export function AppShell() {
+  useReliabilityBridge()
+
   const defaultLayout = useMemo(readInitialLayout, [])
   const initializeSessions = useSetAtom(initializeSessionsAtom)
   const initializedSessionsRef = useRef(false)
@@ -113,6 +134,10 @@ export function AppShell() {
     mcpMutationPending ||
     Object.values(mcpStatusPendingByServer).some((isPending) => Boolean(isPending))
 
+  const reliabilitySnapshot = useReliabilitySnapshot()
+  const reliabilityPendingBySurface = useAtomValue(reliabilityRecoveryPendingAtom)
+  const requestReliabilityRecovery = useSetAtom(requestReliabilityRecoveryActionAtom)
+
   const openSettingsPanel = useSetAtom(openSettingsPanelAtom)
   const closeSettingsPanel = useSetAtom(closeSettingsPanelAtom)
   const setSettingsTab = useSetAtom(settingsPanelTabAtom)
@@ -130,6 +155,33 @@ export function AppShell() {
     initializedSessionsRef.current = true
     void initializeSessions()
   }, [initializeSessions])
+
+  const primaryReliabilitySurface = useMemo(() => {
+    const degraded = reliabilitySnapshot.surfaces.filter((surface) => surface.status === 'degraded' && surface.signal)
+    if (degraded.length === 0) {
+      return null
+    }
+
+    return degraded.reduce((selected, candidate) => {
+      const selectedSignal = selected.signal
+      const candidateSignal = candidate.signal
+      if (!selectedSignal || !candidateSignal) {
+        return selected
+      }
+
+      const selectedRank = reliabilitySeverityRank(selectedSignal.severity)
+      const candidateRank = reliabilitySeverityRank(candidateSignal.severity)
+      if (candidateRank > selectedRank) {
+        return candidate
+      }
+
+      if (candidateRank < selectedRank) {
+        return selected
+      }
+
+      return candidateSignal.timestamp > selectedSignal.timestamp ? candidate : selected
+    })
+  }, [reliabilitySnapshot])
 
   const handleWorkflowShellAction = useCallback(
     async (event: WorkflowShellActionEvent) => {
@@ -226,8 +278,55 @@ export function AppShell() {
     }
   }, [])
 
+  const primarySignal = primaryReliabilitySurface?.signal ?? null
+
+  const reliabilityTone = reliabilitySeverityTone(primarySignal?.severity)
+
   return (
     <main className="size-full bg-background text-foreground">
+      {primaryReliabilitySurface && primarySignal ? (
+        <div
+          className={
+            reliabilityTone === 'error'
+              ? 'border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive'
+              : reliabilityTone === 'warning'
+                ? 'border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-900 dark:text-amber-200'
+                : 'border-b border-border bg-muted/50 px-4 py-2 text-xs text-muted-foreground'
+          }
+          data-testid="reliability-banner"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="space-y-0.5">
+              <p className="font-medium">
+                {formatReliabilitySurfaceLabel(primaryReliabilitySurface.sourceSurface)} ·{' '}
+                {formatReliabilityClassLabel(primarySignal.class)}
+              </p>
+              <p>
+                {primarySignal.message} · Recommended: {formatReliabilityActionLabel(primarySignal.recoveryAction)} ·{' '}
+                {primarySignal.code}
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                void requestReliabilityRecovery({
+                  sourceSurface: primaryReliabilitySurface.sourceSurface,
+                  action: primarySignal.recoveryAction,
+                })
+              }}
+              disabled={reliabilityPendingBySurface[primaryReliabilitySurface.sourceSurface]}
+              data-testid="reliability-banner-recover"
+            >
+              {reliabilityPendingBySurface[primaryReliabilitySurface.sourceSurface]
+                ? 'Recovering…'
+                : formatReliabilityActionLabel(primarySignal.recoveryAction)}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
       <Group
         orientation="horizontal"
         className="size-full"

--- a/apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx
+++ b/apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx
@@ -1,28 +1,56 @@
-import type { WorkflowBoardSnapshot } from '@shared/types'
+import type { ReliabilitySignal, WorkflowBoardSnapshot } from '@shared/types'
+import {
+  formatReliabilityActionLabel,
+  formatReliabilityClassLabel,
+  reliabilitySeverityTone,
+  useReliabilitySurfaceState,
+} from '@/atoms/reliability'
 
 interface BoardStateNoticeProps {
   board: WorkflowBoardSnapshot | null
   error: string | null
 }
 
+export function formatWorkflowReliabilityNotice(signal: ReliabilitySignal): string {
+  return (
+    `${formatReliabilityClassLabel(signal.class)} issue (${signal.code}). ` +
+    `${signal.message} ` +
+    `Recommended recovery: ${formatReliabilityActionLabel(signal.recoveryAction)}.` +
+    (signal.lastKnownGoodAt
+      ? ` Last known good: ${new Date(signal.lastKnownGoodAt).toLocaleTimeString()}.`
+      : '')
+  )
+}
+
 export function BoardStateNotice({ board, error }: BoardStateNoticeProps) {
+  const workflowReliability = useReliabilitySurfaceState('workflow_board')
   const notices: Array<{ id: string; tone: 'error' | 'warning'; message: string }> = []
 
-  if (error) {
-    notices.push({
-      id: 'board-error',
-      tone: 'error',
-      message: `${error} Last known board state is still shown so you can recover without losing context.`,
-    })
-  }
+  if (workflowReliability.signal) {
+    const tone = reliabilitySeverityTone(workflowReliability.signal.severity) === 'error' ? 'error' : 'warning'
 
-  if (board?.status === 'stale') {
     notices.push({
-      id: 'board-stale',
-      tone: 'warning',
-      message:
-        'Workflow data is stale. Retry refresh to reconcile rollback or remote changes before continuing board mutations.',
+      id: 'workflow-reliability',
+      tone,
+      message: formatWorkflowReliabilityNotice(workflowReliability.signal),
     })
+  } else {
+    if (error) {
+      notices.push({
+        id: 'board-error',
+        tone: 'error',
+        message: `${error} Last known board state is still shown so you can recover without losing context.`,
+      })
+    }
+
+    if (board?.status === 'stale') {
+      notices.push({
+        id: 'board-stale',
+        tone: 'warning',
+        message:
+          'Workflow data is stale. Retry refresh to reconcile rollback or remote changes before continuing board mutations.',
+      })
+    }
   }
 
   const activeUnavailable =

--- a/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { formatScopeStatus, formatSymphonyBoardStatus, formatWorkflowBoardStatus } from '../KanbanHeader'
 import { summarizeColumnPresentation } from '../KanbanPane'
+import { formatWorkflowReliabilityNotice } from '../BoardStateNotice'
 
 describe('KanbanPane status formatting', () => {
   test('renders loading state', () => {
@@ -156,6 +157,26 @@ describe('KanbanPane status formatting', () => {
         },
       }),
     ).toContain('Symphony: live · 1 worker · 3 escalations · 2 correlation misses')
+  })
+})
+
+describe('KanbanPane reliability messaging', () => {
+  test('formats workflow reliability notice with canonical recovery language', () => {
+    const message = formatWorkflowReliabilityNotice({
+      code: 'REL-WORKFLOW-NETWORK-NETWORK',
+      class: 'network',
+      severity: 'error',
+      sourceSurface: 'workflow_board',
+      recoveryAction: 'reconnect',
+      outcome: 'pending',
+      message: 'Workflow board refresh failed.',
+      timestamp: '2026-04-07T20:00:00.000Z',
+      lastKnownGoodAt: '2026-04-07T19:58:00.000Z',
+    })
+
+    expect(message).toContain('Network issue (REL-WORKFLOW-NETWORK-NETWORK)')
+    expect(message).toContain('Recommended recovery: Reconnect service.')
+    expect(message).toContain('Last known good:')
   })
 })
 

--- a/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import type { McpServerSummary } from '@shared/types'
+import type { McpServerSummary, ReliabilitySignal } from '@shared/types'
 import {
   deleteMcpServerAtom,
   loadMcpConfigAtom,
@@ -13,6 +13,14 @@ import {
   saveMcpServerAtom,
   useMcpConfigBridge,
 } from '@/atoms/mcp'
+import {
+  formatReliabilityActionLabel,
+  formatReliabilityClassLabel,
+  reliabilityRecoveryPendingAtom,
+  reliabilitySeverityTone,
+  requestReliabilityRecoveryActionAtom,
+  useReliabilitySurfaceState,
+} from '@/atoms/reliability'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -28,6 +36,10 @@ export function formatMcpProvenanceLabel(mode: 'global_only' | 'overlay_present'
   return 'Global shared config'
 }
 
+export function formatMcpReliabilityNotice(signal: ReliabilitySignal): string {
+  return `${signal.message} Recommended recovery: ${formatReliabilityActionLabel(signal.recoveryAction)}.`
+}
+
 export function McpServerPanel() {
   useMcpConfigBridge()
 
@@ -37,10 +49,13 @@ export function McpServerPanel() {
   const mutationError = useAtomValue(mcpMutationErrorAtom)
   const mutationSuccess = useAtomValue(mcpMutationSuccessAtom)
   const statuses = useAtomValue(mcpServerStatusesAtom)
+  const reliabilityPendingBySurface = useAtomValue(reliabilityRecoveryPendingAtom)
+  const mcpReliability = useReliabilitySurfaceState('mcp')
 
   const refreshConfig = useSetAtom(loadMcpConfigAtom)
   const saveServer = useSetAtom(saveMcpServerAtom)
   const deleteServer = useSetAtom(deleteMcpServerAtom)
+  const requestRecoveryAction = useSetAtom(requestReliabilityRecoveryActionAtom)
 
   const [editorOpen, setEditorOpen] = useState(false)
   const [editingServer, setEditingServer] = useState<McpServerSummary | undefined>(undefined)
@@ -90,6 +105,25 @@ export function McpServerPanel() {
             >
               {loading ? 'Refreshing…' : 'Refresh'}
             </Button>
+            {mcpReliability.signal ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  void requestRecoveryAction({
+                    sourceSurface: 'mcp',
+                    action: mcpReliability.signal!.recoveryAction,
+                  })
+                }}
+                disabled={reliabilityPendingBySurface.mcp}
+                data-testid="mcp-reliability-recovery"
+              >
+                {reliabilityPendingBySurface.mcp
+                  ? 'Recovering…'
+                  : formatReliabilityActionLabel(mcpReliability.signal.recoveryAction)}
+              </Button>
+            ) : null}
             <Button type="button" size="sm" onClick={openCreateDialog} data-testid="mcp-add-server">
               Add server
             </Button>
@@ -98,6 +132,18 @@ export function McpServerPanel() {
       </CardHeader>
 
       <CardContent className="space-y-3 p-4 pt-2 text-xs">
+        {mcpReliability.signal ? (
+          <Alert
+            variant={reliabilitySeverityTone(mcpReliability.signal.severity) === 'error' ? 'destructive' : 'default'}
+            data-testid="mcp-reliability"
+          >
+            <AlertTitle>
+              {formatReliabilityClassLabel(mcpReliability.signal.class)} · {mcpReliability.signal.code}
+            </AlertTitle>
+            <AlertDescription>{formatMcpReliabilityNotice(mcpReliability.signal)}</AlertDescription>
+          </Alert>
+        ) : null}
+
         {configState.provenance?.warning ? (
           <Alert data-testid="mcp-overlay-warning">
             <AlertTitle>Project overlay detected</AlertTitle>

--- a/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { createMcpServerEditorDraft, parseArgs, validateMcpServerDraft } from '../McpServerEditorDialog'
-import { formatMcpProvenanceLabel } from '../McpServerPanel'
+import { formatMcpProvenanceLabel, formatMcpReliabilityNotice } from '../McpServerPanel'
 import {
   formatMcpStatusLabel,
   mcpStatusBadgeVariant,
@@ -12,6 +12,22 @@ describe('MCP settings helpers', () => {
     expect(formatMcpProvenanceLabel('global_only')).toBe('Global shared config')
     expect(formatMcpProvenanceLabel('overlay_present')).toBe('Global config (overlay detected)')
     expect(formatMcpProvenanceLabel(undefined)).toBe('Global shared config')
+  })
+
+  test('formats MCP reliability notices with shared recovery language', () => {
+    const notice = formatMcpReliabilityNotice({
+      code: 'REL-MCP-CONFIG-MALFORMED_CONFIG',
+      class: 'config',
+      severity: 'warning',
+      sourceSurface: 'mcp',
+      recoveryAction: 'fix_config',
+      outcome: 'pending',
+      message: 'Invalid JSON in mcp.json',
+      timestamp: '2026-04-07T20:00:00.000Z',
+    })
+
+    expect(notice).toContain('Invalid JSON in mcp.json')
+    expect(notice).toContain('Recommended recovery: Fix configuration.')
   })
 
   test('summarizes stdio and http server rows for compact display', () => {

--- a/apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
+++ b/apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
@@ -1,5 +1,6 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { RefreshCcw } from 'lucide-react'
+import type { ReliabilitySignal } from '@shared/types'
 import { Spinner } from '@/components/ui/spinner'
 import {
   refreshSymphonyDashboardAtom,
@@ -9,6 +10,14 @@ import {
   symphonyEscalationDraftsAtom,
   useSymphonyDashboardSnapshot,
 } from '@/atoms/symphony-dashboard'
+import {
+  formatReliabilityActionLabel,
+  formatReliabilityClassLabel,
+  reliabilityRecoveryPendingAtom,
+  reliabilitySeverityTone,
+  requestReliabilityRecoveryActionAtom,
+  useReliabilitySurfaceState,
+} from '@/atoms/reliability'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -24,13 +33,20 @@ export function connectionBadgeVariant(
   return 'destructive'
 }
 
+export function formatSymphonyReliabilityNotice(signal: ReliabilitySignal): string {
+  return `${signal.message} Recommended recovery: ${formatReliabilityActionLabel(signal.recoveryAction)}.`
+}
+
 export function SymphonyDashboard() {
   const snapshot = useSymphonyDashboardSnapshot()
   const loading = useAtomValue(symphonyDashboardLoadingAtom)
   const drafts = useAtomValue(symphonyEscalationDraftsAtom)
+  const reliabilityPendingBySurface = useAtomValue(reliabilityRecoveryPendingAtom)
+  const symphonyReliability = useReliabilitySurfaceState('symphony')
   const refresh = useSetAtom(refreshSymphonyDashboardAtom)
   const setDraft = useSetAtom(setSymphonyEscalationDraftAtom)
   const respond = useSetAtom(respondToEscalationAtom)
+  const requestRecoveryAction = useSetAtom(requestReliabilityRecoveryActionAtom)
 
   return (
     <Card className="border border-border bg-card/60 py-0" data-testid="symphony-dashboard-panel">
@@ -52,6 +68,25 @@ export function SymphonyDashboard() {
               {loading ? <Spinner className="size-3.5" /> : <RefreshCcw className="size-3.5" />}
               Refresh
             </Button>
+            {symphonyReliability.signal ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  void requestRecoveryAction({
+                    sourceSurface: 'symphony',
+                    action: symphonyReliability.signal!.recoveryAction,
+                  })
+                }}
+                disabled={reliabilityPendingBySurface.symphony}
+                data-testid="symphony-dashboard-recovery"
+              >
+                {reliabilityPendingBySurface.symphony
+                  ? 'Recovering…'
+                  : formatReliabilityActionLabel(symphonyReliability.signal.recoveryAction)}
+              </Button>
+            ) : null}
           </div>
         </div>
       </CardHeader>
@@ -64,14 +99,24 @@ export function SymphonyDashboard() {
           <SummaryStat label="Escalations" value={snapshot.escalations.length} />
         </div>
 
-        {snapshot.freshness.status === 'stale' && !snapshot.connection.lastError ? (
+        {symphonyReliability.signal ? (
+          <Alert
+            variant={reliabilitySeverityTone(symphonyReliability.signal.severity) === 'error' ? 'destructive' : 'default'}
+            data-testid="symphony-dashboard-reliability"
+          >
+            <AlertTitle>
+              {formatReliabilityClassLabel(symphonyReliability.signal.class)} · {symphonyReliability.signal.code}
+            </AlertTitle>
+            <AlertDescription>{formatSymphonyReliabilityNotice(symphonyReliability.signal)}</AlertDescription>
+          </Alert>
+        ) : snapshot.freshness.status === 'stale' && !snapshot.connection.lastError ? (
           <Alert variant="destructive" data-testid="symphony-dashboard-stale">
             <AlertTitle>Dashboard is stale</AlertTitle>
             <AlertDescription>{snapshot.freshness.staleReason ?? 'No recent updates from Symphony.'}</AlertDescription>
           </Alert>
         ) : null}
 
-        {snapshot.connection.lastError ? (
+        {snapshot.connection.lastError && !symphonyReliability.signal ? (
           <Alert variant="destructive" data-testid="symphony-dashboard-error">
             <AlertTitle>Connection issue</AlertTitle>
             <AlertDescription>{snapshot.connection.lastError}</AlertDescription>

--- a/apps/desktop/src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx
+++ b/apps/desktop/src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { connectionBadgeVariant } from '../SymphonyDashboard'
+import { connectionBadgeVariant, formatSymphonyReliabilityNotice } from '../SymphonyDashboard'
 import { formatLastActivity } from '../WorkerTable'
 
 describe('SymphonyDashboard helpers', () => {
@@ -13,5 +13,21 @@ describe('SymphonyDashboard helpers', () => {
     expect(formatLastActivity(undefined)).toBe('—')
     expect(formatLastActivity('not-a-date')).toBe('—')
     expect(formatLastActivity('2026-04-04T19:00:00.000Z')).not.toBe('—')
+  })
+
+  test('formats reliability notice with shared recovery semantics', () => {
+    const notice = formatSymphonyReliabilityNotice({
+      code: 'REL-SYMPHONY-NETWORK-DISCONNECTED',
+      class: 'network',
+      severity: 'error',
+      sourceSurface: 'symphony',
+      recoveryAction: 'reconnect',
+      outcome: 'pending',
+      message: 'Symphony operator is disconnected.',
+      timestamp: '2026-04-07T20:00:00.000Z',
+    })
+
+    expect(notice).toContain('Symphony operator is disconnected.')
+    expect(notice).toContain('Recommended recovery: Reconnect service.')
   })
 })

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -55,6 +55,9 @@ export const IPC_CHANNELS = {
   mcpDeleteServer: 'mcp:delete-server',
   mcpRefreshStatus: 'mcp:refresh-status',
   mcpReconnectServer: 'mcp:reconnect-server',
+  reliabilityGetStatus: 'reliability:get-status',
+  reliabilityStatus: 'reliability:status',
+  reliabilityRequestRecoveryAction: 'reliability:request-recovery-action',
 } as const
 
 export type PermissionMode = 'explore' | 'ask' | 'auto'
@@ -1349,6 +1352,26 @@ export interface ReliabilitySnapshot {
   surfaces: ReliabilitySurfaceState[]
 }
 
+export interface ReliabilityStatusResponse {
+  success: boolean
+  snapshot: ReliabilitySnapshot
+}
+
+export interface ReliabilityRecoveryRequest {
+  sourceSurface: ReliabilitySourceSurface
+  action?: ReliabilityRecoveryAction
+}
+
+export interface ReliabilityRecoveryResult {
+  success: boolean
+  sourceSurface: ReliabilitySourceSurface
+  action: ReliabilityRecoveryAction
+  outcome: 'succeeded' | 'failed'
+  code: string
+  message: string
+  timestamp: string
+}
+
 export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context' | 'slice'
 
 export type RoadmapRisk = 'high' | 'medium' | 'low'
@@ -1496,6 +1519,13 @@ export interface DesktopApi {
     deleteServer: (name: string) => Promise<McpServerDeleteResponse>
     refreshStatus: (name: string) => Promise<McpServerStatusResponse>
     reconnectServer: (name: string) => Promise<McpServerStatusResponse>
+  }
+  reliability: {
+    getStatus: () => Promise<ReliabilityStatusResponse>
+    requestRecoveryAction: (
+      request: ReliabilityRecoveryRequest,
+    ) => Promise<ReliabilityRecoveryResult>
+    onStatus: (listener: (snapshot: ReliabilitySnapshot) => void) => () => void
   }
 }
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1298,6 +1298,57 @@ export interface McpServerStatusResponse {
   }
 }
 
+export type ReliabilityClass = 'config' | 'auth' | 'network' | 'process' | 'stale' | 'unknown'
+
+export type ReliabilitySeverity = 'info' | 'warning' | 'error' | 'critical'
+
+export type ReliabilityRecoveryAction =
+  | 'fix_config'
+  | 'reauthenticate'
+  | 'retry_request'
+  | 'restart_process'
+  | 'reconnect'
+  | 'refresh_state'
+  | 'inspect'
+
+export type ReliabilityRecoveryOutcome = 'pending' | 'succeeded' | 'failed' | 'none'
+
+export type ReliabilitySourceSurface = 'chat_runtime' | 'workflow_board' | 'symphony' | 'mcp'
+
+export interface ReliabilityDiagnostics {
+  code?: string
+  detail?: string
+  occurredAt?: string
+}
+
+export interface ReliabilitySignal {
+  code: string
+  class: ReliabilityClass
+  severity: ReliabilitySeverity
+  sourceSurface: ReliabilitySourceSurface
+  recoveryAction: ReliabilityRecoveryAction
+  outcome: ReliabilityRecoveryOutcome
+  message: string
+  timestamp: string
+  staleSince?: string
+  lastKnownGoodAt?: string
+  diagnostics?: ReliabilityDiagnostics
+}
+
+export interface ReliabilitySurfaceState {
+  sourceSurface: ReliabilitySourceSurface
+  status: 'healthy' | 'degraded'
+  signal: ReliabilitySignal | null
+  updatedAt: string
+  lastHealthyAt?: string
+}
+
+export interface ReliabilitySnapshot {
+  generatedAt: string
+  overallStatus: 'healthy' | 'degraded'
+  surfaces: ReliabilitySurfaceState[]
+}
+
 export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context' | 'slice'
 
 export type RoadmapRisk = 'high' | 'medium' | 'low'


### PR DESCRIPTION
## Summary
- implement canonical reliability taxonomy and mapper contract across chat runtime, workflow board, Symphony, and MCP surfaces
- wire main-process reliability aggregation through IPC/preload and renderer notices for consistent failure/recovery semantics
- add deterministic fault-injection and recovery invariants in unit + Electron e2e coverage
- publish S01 live-smoke, UAT report, and downstream handoff artifacts for M006 consumers
- raise reliability contract branch coverage to satisfy desktop coverage gate during pre-push validation

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/reliability-contract.test.ts src/main/__tests__/runtime-health-aggregator.test.ts src/main/__tests__/workflow-board-service.test.ts src/main/__tests__/symphony-operator-service.test.ts src/main/__tests__/mcp-service.test.ts`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/recovery-envelope.e2e.ts`
- `bun run validate:affected`

## Evidence
- `apps/desktop/docs/uat/M006/S01-RECOVERY-SMOKE.md`
- `apps/desktop/docs/uat/M006/S01-UAT-REPORT.md`
- `apps/desktop/docs/uat/M006/S01-DOWNSTREAM-HANDOFF.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-service reliability system: normalized reliability signals, aggregator with realtime snapshots, recovery actions, IPC + preload bridge, renderer atoms/hooks, and UI banner/surface alerts with “Recover” controls.
  * Chat fault-injection support for one-time subprocess crash simulation (test mode).

* **Tests**
  * Extensive unit and E2E coverage: contract mapping, aggregator behavior, IPC recovery flows, UI formatting, MCP/workflow/symphony/chat recovery scenarios and fault-injection validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a cross-boundary reliability and recovery envelope for Kata Desktop: a `reliability-contract.ts` mapper layer, a `RuntimeHealthAggregator` that aggregates surface states from all four subsystems, IPC handlers for status polling and recovery dispatch, a preload bridge, renderer Jotai atoms, an `AppShell` reliability banner, and targeted unit + Playwright E2E coverage. The architecture is clean and well-layered.

One data-integrity inconsistency worth addressing: the `workflow_board` recovery handler in `ipc.ts` unconditionally returns `outcome: 'succeeded'`, causing `requestRecoveryAction` to stamp the still-degraded signal with `outcome: 'succeeded'` when a post-recovery board refresh still fails. No current UI component renders `signal.outcome`, so there is no user-visible impact today, but downstream consumers of the reliability API would receive misleading data.

<h3>Confidence Score: 5/5</h3>

Safe to merge; both findings are P2 and neither affects current user-visible behavior.

All remaining findings are P2: the workflow recovery outcome inconsistency has zero user-facing impact (no UI renders signal.outcome), and the sk- regex edge case only applies to artificially short keys that don't exist in practice. The core reliability contract, aggregator, IPC wiring, renderer atoms, cleanup paths, and test coverage are all correct.

apps/desktop/src/main/ipc.ts (workflow_board recovery branch, lines 141-149)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/reliability-contract.ts | New mapper module: cleanly translates snapshot/status types from all four surfaces into canonical ReliabilitySignal objects, with secret redaction and deterministic code generation. Minor: the sk- redaction regex may miss very short keys. |
| apps/desktop/src/main/runtime-health-aggregator.ts | New aggregator class: correctly initializes all surfaces as healthy, routes ingestion calls per surface, merges bridge/crash signals for chat_runtime and runtime/operator signals for symphony, and emits snapshot events on each state change. |
| apps/desktop/src/main/ipc.ts | Wires RuntimeHealthAggregator into all IPC event paths and exposes reliability:get-status and reliability:request-recovery-action handlers. The workflow_board recovery path always returns outcome: succeeded regardless of post-refresh board health. |
| apps/desktop/src/renderer/atoms/reliability.ts | Renderer-side Jotai atoms for snapshot, loading, pending, and result state; correctly uses try-finally for pending flags; IPC subscription and merge logic look correct. |
| apps/desktop/src/renderer/components/app-shell/AppShell.tsx | Mounts the reliability bridge and renders a severity-toned banner with a recovery action button for the highest-priority degraded surface. Logic for picking the primary surface and dispatching recovery looks correct. |
| apps/desktop/src/shared/types.ts | Adds complete Reliability type taxonomy (signals, surfaces, snapshots, recovery request/result) plus three new IPC channel entries; types are clean and well-scoped. |
| apps/desktop/src/main/pi-agent-bridge.ts | Adds test-only fault injection (process_crash_once) gated behind KATA_TEST_MODE === '1'; consistent with existing fixture patterns in the codebase. |
| apps/desktop/e2e/tests/recovery-envelope.e2e.ts | Covers all four surfaces (workflow, symphony, mcp, chat_runtime) with fault injection and recovery assertions. Tests only cover the success path; the failure-path outcome inconsistency is not exercised. |
| apps/desktop/src/main/__tests__/reliability-contract.test.ts | Deterministic unit tests for mapper contract covering all surfaces, code normalization, secret redaction, and pickPrimaryReliabilitySignal. Good branch coverage. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer
    participant P as Preload
    participant IPC as IPC (main)
    participant AGG as RuntimeHealthAggregator
    participant SVC as Surface Services

    Note over IPC,AGG: Registration / initial hydration
    IPC->>AGG: new RuntimeHealthAggregator({ requestRecovery })
    IPC->>AGG: ingestChatBridgeStatus(initialState)
    IPC->>AGG: ingestSymphonyRuntimeStatus(initialStatus)
    IPC->>IPC: sendReliabilitySnapshot(aggregator.getSnapshot())
    IPC->>R: IPC push reliability:status

    Note over R,IPC: Ongoing ingestion
    SVC-->>IPC: bridge crash event
    IPC->>AGG: ingestChatSubprocessCrash(...)
    AGG-->>IPC: emit snapshot
    IPC->>R: IPC push reliability:status

    Note over R,IPC: Recovery flow
    R->>P: reliability.requestRecoveryAction
    P->>IPC: ipcRenderer.invoke(reliabilityRequestRecoveryAction)
    IPC->>AGG: requestRecoveryAction(request)
    AGG->>IPC: requestRecovery callback
    IPC->>SVC: workflowBoardService.refreshBoard()
    SVC-->>IPC: response.snapshot
    IPC->>AGG: ingestWorkflowSnapshot(snapshot)
    AGG-->>IPC: emit snapshot (interim)
    IPC->>R: IPC push reliability:status (interim)
    IPC-->>AGG: return RecoveryAttempt
    AGG->>AGG: updateSurface(outcome)
    AGG-->>IPC: emit snapshot (final)
    IPC->>R: IPC push reliability:status (final)
    AGG-->>IPC: return ReliabilityRecoveryResult
    IPC-->>P: ReliabilityRecoveryResult
    P-->>R: result
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/ipc.ts
Line: 141-149

Comment:
**Workflow recovery always reports `succeeded` regardless of board health**

`workflowBoardService.refreshBoard()` always returns `{ success: true, snapshot }` — even when the board snapshot is `stale` or `error` — so this branch unconditionally returns `outcome: 'succeeded'`. When the board is still degraded post-refresh, `ingestWorkflowSnapshot` (called just above) updates the surface with a new failure signal, but `requestRecoveryAction` then overwrites that signal's `outcome` field with `'succeeded'`. The surface correctly stays `'degraded'`, but `signal.outcome === 'succeeded'` on a still-failing surface is semantically wrong and will mislead future consumers of the reliability API.

```suggestion
        if (sourceSurface === 'workflow_board') {
          const response = await workflowBoardService.refreshBoard()
          reliabilityAggregator.ingestWorkflowSnapshot(response.snapshot)
          const boardHealthy =
            response.snapshot.status === 'fresh' || response.snapshot.status === 'empty'
          return {
            success: boardHealthy,
            outcome: boardHealthy ? ('succeeded' as const) : ('failed' as const),
            code: boardHealthy ? 'WORKFLOW_REFRESHED' : 'WORKFLOW_REFRESH_FAILED',
            message: boardHealthy
              ? `Workflow board recovery action applied: ${action}.`
              : response.snapshot.lastError?.message ?? 'Workflow board refresh did not resolve the issue.',
          }
        }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/reliability-contract.ts
Line: 107

Comment:
**Short `sk-` values are not redacted**

The pattern `(sk-[A-Za-z0-9_-]{6})[A-Za-z0-9_-]+` requires at least 7 characters after `sk-` (6 captured + 1 more). A value like `sk-abc123` (exactly 6 suffix chars) would not match and would be logged in plain text. Real Anthropic keys are far longer, so this is low risk in practice, but the intent is full redaction.

```suggestion
  [/(sk-[A-Za-z0-9_-]{6,}?)[A-Za-z0-9_-]*/g, '$1***'],
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): expand reliability contra..."](https://github.com/gannonh/kata/commit/35b26d224ffc35fa1e38c30d6921cffdbbfbd9da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27648642)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->