### PR TITLE
feat(desktop): first-run and onboarding beta readiness (KAT-2400)

### DIFF
--- a/apps/desktop/docs/uat/M006/S02-DOWNSTREAM-HANDOFF.md
+++ b/apps/desktop/docs/uat/M006/S02-DOWNSTREAM-HANDOFF.md
@@ -1,0 +1,68 @@
+# S02 Downstream Handoff — First-Run Readiness Inputs for S04
+
+## Purpose
+
+This handoff captures what S02 now guarantees for first-run beta readiness, what evidence exists, and what S04 (integrated packaged acceptance gate) must still validate at full assembly level.
+
+## What S02 now guarantees
+
+### 1) Canonical first-run checkpoint contract
+
+S02 standardizes and wires the four checkpoint model:
+
+- `auth`
+- `model`
+- `startup`
+- `first_turn`
+
+Each checkpoint is represented with canonical failure metadata aligned to S01 taxonomy (`class`, `severity`, `code`, `recoveryAction`, `timestamp`) and surfaced consistently across onboarding, settings, model selector, and runtime diagnostics.
+
+### 2) Cross-surface provider/model truth consistency
+
+- Provider status semantics are aligned across onboarding and settings.
+- Model readiness uses provider-auth consistency checks.
+- Contradictory provider/model state now resolves to explicit canonical failure (`MODEL_PROVIDER_NOT_CONFIGURED`) rather than surfacing uncaught invariant exceptions in UI flows.
+
+### 3) Deterministic packaged-like first-run proof coverage
+
+Playwright Electron suites now prove:
+
+- Happy-path first-turn completion (`first_turn: pass`)
+- Clean-profile auth-failure guidance and recovery affordances
+- Startup degradation guidance (`binary_missing` mode)
+- Provider consistency badges for seeded credentials
+
+## Artifacts produced by S02
+
+- `docs/uat/M006/S02-FIRST-RUN-SMOKE.md`
+- `docs/uat/M006/S02-UAT-REPORT.md`
+- `e2e/tests/onboarding.e2e.ts`
+- `e2e/tests/first-run-beta-readiness.e2e.ts`
+- `e2e/fixtures/electron.fixture.ts`
+- `src/shared/first-run-readiness.ts`
+- `src/main/runtime-health-aggregator.ts`
+
+## What S04 can assume from S02
+
+S04 may assume the following are already operational and regression-guarded:
+
+1. First-run checkpoint contract shape and taxonomy semantics are stable.
+2. Onboarding/settings/model selector show consistent readiness status and actionable guidance.
+3. Deterministic first-run automation can catch auth/model/startup/first-turn regressions.
+4. Startup degradation guidance is present and legible in packaged-like runtime modes.
+
+## What S04 must still prove (not closed by S02)
+
+S02 is operational readiness, not final integrated release-gate closure. S04 still needs to prove:
+
+1. Full packaged `.dmg` assembly acceptance (not only packaged-like fixture runs).
+2. End-to-end first-run behavior alongside all integrated M006 surfaces under release-like conditions.
+3. Final gate sign-off with milestone-wide stability/accessibility/performance constraints applied in assembled packaging.
+4. Cross-slice convergence with S03 long-run stability baselines.
+
+## Guardrails for S04
+
+- Do not bypass the canonical first-run checkpoint contract with ad hoc UI-only status logic.
+- Preserve canonical failure codes and recovery actions in release-gate assertions.
+- Keep redaction guarantees intact (no secret-bearing diagnostics in logs/reports).
+- Reuse S02 deterministic suites as pre-gate regression checks before final packaged acceptance walkthrough.

--- a/apps/desktop/docs/uat/M006/S02-FIRST-RUN-SMOKE.md
+++ b/apps/desktop/docs/uat/M006/S02-FIRST-RUN-SMOKE.md
@@ -1,0 +1,68 @@
+# S02 First-Run Beta Readiness Smoke (M006)
+
+## Goal
+
+Prove first-run readiness for packaged Desktop flows with explicit checkpoint semantics:
+
+1. `auth` checkpoint is truthful and recoverable.
+2. `model` checkpoint is consistent with provider auth state.
+3. `startup` checkpoint exposes actionable runtime guidance.
+4. `first_turn` checkpoint flips to pass only after a real productive turn.
+
+## Preconditions
+
+- Branch includes S02 first-run readiness wiring and onboarding/settings parity changes.
+- Desktop build artifacts exist (`dist/main.cjs`, `dist/preload.cjs`, renderer assets).
+- Electron binary is installed (`npx electron --version` succeeds).
+- No secret values are logged in traces, screenshots, or report artifacts.
+
+## Deterministic packaged-like smoke
+
+```bash
+cd apps/desktop
+bun run build:main && bun run build:preload && bun run build:renderer
+npx playwright test e2e/tests/onboarding.e2e.ts e2e/tests/first-run-beta-readiness.e2e.ts
+npx playwright test e2e/tests/first-run-beta-readiness.e2e.ts
+```
+
+> The fixture launches built Desktop bundles (`dist/main.cjs` + `dist/preload.cjs`) with isolated `--user-data-dir` and explicit startup/auth modes (`firstRunProfileMode`, `firstRunStartupMode`). This is the packaged-like validation path used for S02 proof.
+
+## Checkpoint walkthrough
+
+### A. Happy path (seeded auth)
+
+1. Launch on a fresh profile with seeded OpenAI auth state.
+2. Complete onboarding.
+3. Select `openai/gpt-4.1`.
+4. Send first productive turn.
+5. Assert `firstRunReadiness.checkpoints.first_turn.status === "pass"`.
+
+### B. Auth failure + recovery guidance (clean profile)
+
+1. Launch on a clean profile with no provider keys.
+2. Enter onboarding provider step.
+3. Assert onboarding auth guidance banner is visible.
+4. Move to key step and verify actionable controls (`Validate & Save`, `Skip for now`).
+5. Confirm completion summary truthfully reports `Auth: Fail` when skipping.
+
+### C. Startup degradation guidance (binary missing)
+
+1. Launch with `firstRunStartupMode: "binary_missing"`.
+2. Complete onboarding.
+3. Assert model selector readiness notice shows runtime degradation guidance.
+4. Open settings and assert startup guidance is visible and actionable.
+
+### D. Provider consistency (seeded auth)
+
+1. Launch with seeded auth profile.
+2. Enter onboarding provider step.
+3. Confirm OpenAI card renders `Configured` badge (no drift vs settings/runtime state).
+
+## Evidence capture requirements
+
+Record in `S02-UAT-REPORT.md`:
+
+- Exact command list and pass/fail outcomes.
+- Checkpoint-level outcome table for happy path + failure/recovery paths.
+- References to deterministic test sources and fixtures.
+- Explicit confirmation that diagnostics remained redaction-safe.

--- a/apps/desktop/docs/uat/M006/S02-UAT-REPORT.md
+++ b/apps/desktop/docs/uat/M006/S02-UAT-REPORT.md
@@ -1,0 +1,70 @@
+# S02 UAT Report — First-Run and Onboarding Beta Readiness
+
+- Slice: **KAT-2400 / S02**
+- Child tasks: **KAT-2408 (T01), KAT-2409 (T02), KAT-2410 (T03), KAT-2411 (T04)**
+- Milestone: **M006 Integrated Beta**
+- Date (UTC): **2026-04-08**
+- Tester: **Kata orchestration agent (deterministic packaged-like runtime validation)**
+- Environment: **Electron `_electron` with built Desktop artifacts (`dist/main.cjs`, `dist/preload.cjs`, renderer build), isolated user-data dirs, fixture-driven startup/auth modes**
+
+## Run matrix
+
+| Flow | Mode | Result | Notes |
+| --- | --- | --- | --- |
+| Main-process readiness contract proofs | Vitest | ✅ Pass | `auth-bridge`, `pi-agent-bridge`, `runtime-health-aggregator` |
+| Renderer readiness parity proofs | Vitest | ✅ Pass | settings + model selector consistency checks |
+| Type system gate | TypeScript (`bun run typecheck`) | ✅ Pass | no type errors |
+| Packaged-like build gate | Electron/Vite build | ✅ Pass | `build:main`, `build:preload`, `build:renderer` |
+| First-run + onboarding deterministic smoke | Playwright Electron | ✅ Pass | `onboarding.e2e.ts` + `first-run-beta-readiness.e2e.ts` |
+| Focused first-run replay | Playwright Electron | ✅ Pass | `first-run-beta-readiness.e2e.ts` only |
+
+## Validation command results
+
+```bash
+cd apps/desktop && npx vitest run src/main/__tests__/auth-bridge.test.ts src/main/__tests__/pi-agent-bridge.test.ts src/main/__tests__/runtime-health-aggregator.test.ts
+cd apps/desktop && npx vitest run src/renderer/components/settings/__tests__/SettingsPanel.test.tsx src/renderer/components/settings/__tests__/ProviderAuthPanel.test.tsx src/renderer/components/app-shell/__tests__/ModelSelector.test.tsx
+cd apps/desktop && bun run typecheck
+cd apps/desktop && bun run build:main && bun run build:preload && bun run build:renderer
+cd apps/desktop && npx playwright test e2e/tests/onboarding.e2e.ts e2e/tests/first-run-beta-readiness.e2e.ts
+cd apps/desktop && npx playwright test e2e/tests/first-run-beta-readiness.e2e.ts
+```
+
+- Main Vitest suite: **Pass** (73 tests)
+- Renderer Vitest suite: **Pass** (9 tests)
+- Typecheck: **Pass**
+- Build: **Pass**
+- Playwright combined smoke: **Pass** (10/10)
+- Playwright focused replay: **Pass** (3/3)
+
+## First-run checkpoint outcomes
+
+| Scenario | Auth | Model | Startup | First turn | Result |
+| --- | --- | --- | --- | --- | --- |
+| Seeded-auth happy path | pass | pass | pass | pass | ✅ |
+| Clean profile (no keys) | fail (actionable guidance) | blocked/fail | pass | fail summary truthful | ✅ |
+| Binary-missing startup mode | pass (seeded) | pass | fail (runtime guidance) | blocked by startup | ✅ |
+| Seeded provider consistency | pass (`Configured` badge on provider card) | pass | pass | n/a | ✅ |
+
+## Recovery and truthfulness assertions
+
+- ✅ Onboarding provider step, settings auth panel, and model selector remain consistent on provider/model truth.
+- ✅ Contradictory provider/model pairing now yields canonical failure (`MODEL_PROVIDER_NOT_CONFIGURED`) instead of throwing cross-surface invariant exceptions.
+- ✅ Startup degradation remains legible in both model selector and settings guidance.
+- ✅ `first_turn` only passes after a productive turn completes (`agent_end` path observed via deterministic mock runtime events).
+- ✅ Diagnostics and reports remain redaction-safe (no raw API keys or tokens surfaced).
+
+## Evidence index
+
+| Artifact | Location | Notes |
+| --- | --- | --- |
+| Deterministic first-run suite | `apps/desktop/e2e/tests/first-run-beta-readiness.e2e.ts` | Happy path + auth failure + startup degradation |
+| Onboarding consistency suite | `apps/desktop/e2e/tests/onboarding.e2e.ts` | Provider consistency + recovery messaging coverage |
+| Fixture modes and runtime seams | `apps/desktop/e2e/fixtures/electron.fixture.ts` | clean/seeded auth + healthy/binary-missing startup |
+| Shared readiness contract | `apps/desktop/src/shared/first-run-readiness.ts` | Canonical checkpoint composition |
+| Runtime aggregator integration | `apps/desktop/src/main/runtime-health-aggregator.ts` | Explicit checkpoint projection + blocked checkpoint resolution |
+
+## Final assessment
+
+- S02 first-run operational readiness proof: **✅ Ready for Agent Review**
+- Blocking defects found in this validation run: **None**
+- Follow-up tickets created from this run: **None**

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -54,6 +54,7 @@ rl.on('line', (line) => {
   switch (message.type) {
     case 'prompt':
       respond(message, { ok: true })
+      process.stdout.write(JSON.stringify({ type: 'event', event: { type: 'agent_end' } }) + '\\n')
       break
     case 'abort':
       respond(message, { ok: true })
@@ -65,6 +66,11 @@ rl.on('line', (line) => {
     case 'get_available_models':
       respond(message, {
         models: [
+          {
+            provider: 'openai',
+            id: 'gpt-4.1',
+            reasoning: true,
+          },
           {
             provider: 'anthropic',
             id: 'claude-sonnet-4-6',
@@ -89,6 +95,30 @@ rl.on('line', (line) => {
 
   chmodSync(executablePath, 0o755)
   return executablePath
+}
+
+function seedAuthFixture(authFilePath: string, mode: 'clean' | 'seeded_auth'): void {
+  mkdirSync(path.dirname(authFilePath), { recursive: true })
+
+  if (mode === 'seeded_auth') {
+    writeFileSync(
+      authFilePath,
+      JSON.stringify(
+        {
+          openai: {
+            type: 'api_key',
+            key: 'sk-seeded-openai-key-1234567890',
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+    return
+  }
+
+  writeFileSync(authFilePath, '{}\n', 'utf8')
 }
 
 async function waitForAppReady(window: Page): Promise<void> {
@@ -181,6 +211,7 @@ type DesktopFixtures = {
   electronApp: ElectronApplication
   workspaceDir: string
   mcpConfigPath: string
+  authFilePath: string
   mainWindow: Page
   readyWindow: Page
   symphonyMockMode:
@@ -195,11 +226,15 @@ type DesktopFixtures = {
     | 'assembled_healthy'
     | 'assembled_failure_recovery'
   chatRuntimeFaultMode: 'none' | 'process_crash_once'
+  firstRunProfileMode: 'clean' | 'seeded_auth'
+  firstRunStartupMode: 'healthy' | 'binary_missing'
 }
 
 export const test = base.extend<DesktopFixtures>({
   symphonyMockMode: ['ready', { option: true }],
   chatRuntimeFaultMode: ['none', { option: true }],
+  firstRunProfileMode: ['clean', { option: true }],
+  firstRunStartupMode: ['healthy', { option: true }],
   workspaceDir: async ({}, use) => {
     const dataDir = createIsolatedDataDir()
     const workspaceDir = path.join(dataDir, 'workspace')
@@ -209,11 +244,25 @@ export const test = base.extend<DesktopFixtures>({
       try { rmSync(dataDir, { recursive: true, force: true }) } catch { /* noop */ }
     }
   },
-  electronApp: async ({ workspaceDir, symphonyMockMode, chatRuntimeFaultMode, mcpConfigPath }, use) => {
-    const mockKataBinary = chatRuntimeFaultMode === 'process_crash_once'
-      ? createMockKataRpcBinary(path.dirname(workspaceDir))
-      : null
+  electronApp: async (
+    {
+      workspaceDir,
+      symphonyMockMode,
+      chatRuntimeFaultMode,
+      firstRunProfileMode,
+      firstRunStartupMode,
+      mcpConfigPath,
+      authFilePath,
+    },
+    use,
+  ) => {
     const dataDir = path.dirname(workspaceDir)
+    const mockKataBinary = createMockKataRpcBinary(dataDir)
+    const configuredKataBinary =
+      firstRunStartupMode === 'binary_missing' ? path.join(dataDir, 'missing-kata-binary') : mockKataBinary
+
+    seedAuthFixture(authFilePath, firstRunProfileMode)
+
     const mainEntry = path.join(__dirname, '../../dist/main.cjs')
     const preloadEntry = path.join(__dirname, '../../dist/preload.cjs')
 
@@ -246,8 +295,9 @@ export const test = base.extend<DesktopFixtures>({
         KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: symphonyMockMode,
         KATA_SYMPHONY_URL: 'http://127.0.0.1:8080',
         KATA_DESKTOP_MCP_CONFIG_PATH: mcpConfigPath,
+        KATA_DESKTOP_AUTH_FILE_PATH: authFilePath,
         KATA_DESKTOP_RELIABILITY_CHAT_FAULT: chatRuntimeFaultMode,
-        ...(mockKataBinary ? { KATA_BIN_PATH: mockKataBinary } : {}),
+        KATA_BIN_PATH: configuredKataBinary,
         // Force packaged-file mode for deterministic e2e: if a parent shell exported
         // VITE_DEV_SERVER_URL we would silently bind to an arbitrary dev server.
         VITE_DEV_SERVER_URL: '',
@@ -274,6 +324,11 @@ export const test = base.extend<DesktopFixtures>({
   mcpConfigPath: async ({ workspaceDir }, use) => {
     const configPath = path.join(path.dirname(workspaceDir), '.kata-cli', 'agent', 'mcp.json')
     await use(configPath)
+  },
+
+  authFilePath: async ({ workspaceDir }, use) => {
+    const filePath = path.join(path.dirname(workspaceDir), '.kata-cli', 'agent', 'auth.json')
+    await use(filePath)
   },
 
   mainWindow: async ({ electronApp }, use) => {

--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -261,6 +261,11 @@ export const test = base.extend<DesktopFixtures>({
     const configuredKataBinary =
       firstRunStartupMode === 'binary_missing' ? path.join(dataDir, 'missing-kata-binary') : mockKataBinary
 
+    const binaryMissingPathDir = path.join(dataDir, 'empty-path')
+    if (firstRunStartupMode === 'binary_missing') {
+      mkdirSync(binaryMissingPathDir, { recursive: true })
+    }
+
     seedAuthFixture(authFilePath, firstRunProfileMode)
 
     const mainEntry = path.join(__dirname, '../../dist/main.cjs')
@@ -288,6 +293,7 @@ export const test = base.extend<DesktopFixtures>({
       args,
       env: {
         ...process.env,
+        ...(firstRunStartupMode === 'binary_missing' ? { PATH: binaryMissingPathDir } : {}),
         NODE_ENV: 'test',
         KATA_TEST_MODE: '1',
         KATA_WORKSPACE_PATH: workspaceDir,

--- a/apps/desktop/e2e/tests/first-run-beta-readiness.e2e.ts
+++ b/apps/desktop/e2e/tests/first-run-beta-readiness.e2e.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '../fixtures/electron.fixture'
+import type { ElectronApplication, Page } from '@playwright/test'
+
+async function getOnboardingWindow(electronApp: ElectronApplication): Promise<Page> {
+  const window = await electronApp.firstWindow()
+  await window.waitForLoadState('domcontentloaded')
+  await window.waitForSelector('#root', { timeout: 20_000 })
+  await expect(window.getByText('Onboarding')).toBeVisible()
+  return window
+}
+
+async function completeOnboarding(window: Page): Promise<void> {
+  const getStarted = window.getByRole('button', { name: /Get started/i })
+  if (await getStarted.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await getStarted.click()
+  }
+
+  const openAiCard = window.getByRole('button', { name: /OpenAI/i }).first()
+  if (await openAiCard.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await openAiCard.click()
+  }
+
+  const continueButton = window.getByRole('button', { name: /^Continue$/i })
+  if (await continueButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await continueButton.click()
+  }
+
+  const skipForNow = window.getByRole('button', { name: /Skip for now/i })
+  if (await skipForNow.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await skipForNow.click()
+  }
+
+  const startChatting = window.getByRole('button', { name: /Start chatting/i })
+  if (await startChatting.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await startChatting.click()
+  }
+}
+
+test.describe('first-run beta readiness', () => {
+  test.use({ firstRunProfileMode: 'seeded_auth' })
+
+  test('clean productive turn passes first_turn checkpoint when auth + model + startup are ready', async ({
+    electronApp,
+  }) => {
+    const window = await getOnboardingWindow(electronApp)
+
+    await window.getByRole('button', { name: /Get started/i }).click()
+    const openAiCard = window.getByRole('button', { name: /OpenAI/i }).first()
+    await expect(openAiCard.getByText(/Configured/i)).toBeVisible()
+
+    await completeOnboarding(window)
+
+    await expect(window.getByRole('button', { name: /New Session/i })).toBeVisible()
+
+    await window.evaluate(async () => {
+      await window.api.setModel('openai/gpt-4.1')
+    })
+
+    await window.getByPlaceholder('Ask Kata to help with your code...').fill('Summarize readiness checkpoints')
+    await window.getByRole('button', { name: /^Send$/i }).click()
+
+    await expect
+      .poll(async () => {
+        return await window.evaluate(async () => {
+          const status = await window.api.reliability.getStatus()
+          return status.snapshot.firstRunReadiness?.checkpoints.first_turn.status ?? 'missing'
+        })
+      })
+      .toBe('pass')
+  })
+})
+
+test.describe('first-run failure and recovery guidance', () => {
+  test('clean profile surfaces auth failure with actionable recovery controls', async ({ electronApp }) => {
+    const window = await getOnboardingWindow(electronApp)
+
+    await window.getByRole('button', { name: /Get started/i }).click()
+
+    await expect(window.getByTestId('onboarding-auth-guidance')).toBeVisible()
+    await expect(window.getByTestId('onboarding-auth-guidance')).toContainText(
+      /No providers are configured|Add a valid/i,
+    )
+
+    await window.getByRole('button', { name: /OpenAI/i }).first().click()
+    await window.getByRole('button', { name: /^Continue$/i }).click()
+
+    await expect(window.getByTestId('onboarding-key-auth-guidance')).toBeVisible()
+    await expect(window.getByRole('button', { name: /Validate & Save/i })).toBeVisible()
+    await expect(window.getByRole('button', { name: /Skip for now/i })).toBeVisible()
+
+    await window.getByRole('button', { name: /Skip for now/i }).click()
+    await expect(window.getByTestId('onboarding-checkpoint-summary')).toContainText(/Auth:\s*Fail/i)
+  })
+
+  test.describe('startup degradation', () => {
+    test.use({ firstRunProfileMode: 'seeded_auth', firstRunStartupMode: 'binary_missing' })
+
+    test('startup degradation is legible in model selector and settings guidance', async ({ electronApp }) => {
+      const window = await getOnboardingWindow(electronApp)
+      await completeOnboarding(window)
+
+      await expect(window.getByTestId('model-selector-readiness-notice')).toBeVisible()
+      await expect(window.getByTestId('model-selector-readiness-notice')).toContainText(/runtime/i)
+
+      await window.getByRole('button', { name: /Settings/i }).click()
+      await expect(window.getByTestId('settings-startup-guidance')).toBeVisible()
+    })
+  })
+})

--- a/apps/desktop/e2e/tests/onboarding.e2e.ts
+++ b/apps/desktop/e2e/tests/onboarding.e2e.ts
@@ -82,3 +82,26 @@ test.describe('Onboarding wizard', () => {
     await expect(window.getByText('Onboarding')).toHaveCount(0)
   })
 })
+
+test.describe('Onboarding provider consistency', () => {
+  test.use({ firstRunProfileMode: 'seeded_auth' })
+
+  test('provider consistency keeps seeded providers marked as configured', async ({ electronApp }) => {
+    const window = await getOnboardingWindow(electronApp)
+
+    await window.getByRole('button', { name: /Get started/i }).click()
+    const openAiCard = window.getByRole('button', { name: /OpenAI/i }).first()
+
+    await expect(openAiCard.getByText(/Configured/i)).toBeVisible()
+  })
+})
+
+test.describe('Onboarding recovery messaging', () => {
+  test('recovery guidance appears when no provider key is configured', async ({ electronApp }) => {
+    const window = await getOnboardingWindow(electronApp)
+
+    await window.getByRole('button', { name: /Get started/i }).click()
+    await expect(window.getByTestId('onboarding-auth-guidance')).toBeVisible()
+    await expect(window.getByTestId('onboarding-auth-guidance')).toContainText(/Recovery/i)
+  })
+})

--- a/apps/desktop/e2e/tests/onboarding.e2e.ts
+++ b/apps/desktop/e2e/tests/onboarding.e2e.ts
@@ -97,6 +97,8 @@ test.describe('Onboarding provider consistency', () => {
 })
 
 test.describe('Onboarding recovery messaging', () => {
+  test.use({ firstRunProfileMode: 'clean' })
+
   test('recovery guidance appears when no provider key is configured', async ({ electronApp }) => {
     const window = await getOnboardingWindow(electronApp)
 

--- a/apps/desktop/src/main/__tests__/auth-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/auth-bridge.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { promises as fs } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { AuthBridge } from '../auth-bridge'
+import { AuthBridge, normalizeFirstRunAuthReadiness } from '../auth-bridge'
 
 const originalFetch = globalThis.fetch
 
@@ -369,5 +369,43 @@ describe('AuthBridge', () => {
     await expect(bridge.getApiKey('google')).resolves.toBeNull()
     await expect(bridge.getApiKey('')).resolves.toBeNull()
     await expect(bridge.getApiKey('linear')).resolves.toBeNull()
+  })
+
+  test('normalizes auth checkpoint as pass when a provider is configured', () => {
+    const normalized = normalizeFirstRunAuthReadiness({
+      providers: {
+        anthropic: { provider: 'anthropic', status: 'missing' },
+        openai: { provider: 'openai', status: 'valid', maskedKey: '••••1234' },
+        google: { provider: 'google', status: 'missing' },
+        mistral: { provider: 'mistral', status: 'missing' },
+        bedrock: { provider: 'bedrock', status: 'missing' },
+        azure: { provider: 'azure', status: 'missing' },
+      },
+      selectedProvider: 'openai',
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(normalized.providers.openai.configured).toBe(true)
+    expect(normalized.providers.openai.requiresKey).toBe(false)
+    expect(normalized.checkpoint.status).toBe('pass')
+  })
+
+  test('fails auth checkpoint when selected provider requires key', () => {
+    const normalized = normalizeFirstRunAuthReadiness({
+      providers: {
+        anthropic: { provider: 'anthropic', status: 'valid', maskedKey: '••••1234' },
+        openai: { provider: 'openai', status: 'missing' },
+        google: { provider: 'google', status: 'missing' },
+        mistral: { provider: 'mistral', status: 'missing' },
+        bedrock: { provider: 'bedrock', status: 'missing' },
+        azure: { provider: 'azure', status: 'missing' },
+      },
+      selectedProvider: 'openai',
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(normalized.checkpoint.status).toBe('fail')
+    expect(normalized.checkpoint.failure?.code).toBe('AUTH_PROVIDER_KEY_REQUIRED')
+    expect(normalized.checkpoint.failure?.recoveryAction).toBe('reauthenticate')
   })
 })

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -1038,10 +1038,6 @@ setTimeout(() => {
     })
 
     const startupCheckpoint = normalizeFirstRunStartupReadiness({
-      providers,
-      selectedProvider: 'openai',
-      selectedModel: 'openai/gpt-4.1',
-      availableModels: [{ provider: 'openai', id: 'gpt-4.1' }],
       bridgeStatus: 'running',
       now: '2026-04-08T00:00:00.000Z',
     })

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -1046,6 +1046,27 @@ setTimeout(() => {
     expect(startupCheckpoint.status).toBe('pass')
   })
 
+  test('treats aliased selected models as available when canonical provider model exists', () => {
+    const providers: ProviderStatusMap = {
+      anthropic: { provider: 'anthropic', status: 'missing' as const },
+      openai: { provider: 'openai', status: 'valid' as const, maskedKey: '••••1234' },
+      google: { provider: 'google', status: 'missing' as const },
+      mistral: { provider: 'mistral', status: 'missing' as const },
+      bedrock: { provider: 'bedrock', status: 'missing' as const },
+      azure: { provider: 'azure', status: 'missing' as const },
+    }
+
+    const checkpoint = normalizeFirstRunModelReadiness({
+      providers,
+      selectedProvider: 'openai',
+      selectedModel: 'openai-codex/gpt-4.1',
+      availableModels: [{ provider: 'openai', id: 'gpt-4.1' }],
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(checkpoint.status).toBe('pass')
+  })
+
   test('fails model checkpoint when selected model provider is not configured', () => {
     const providers: ProviderStatusMap = {
       anthropic: { provider: 'anthropic', status: 'missing' as const },

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -3,8 +3,12 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import type { CommandResult } from '@shared/types'
-import { PiAgentBridge } from '../pi-agent-bridge'
+import type { CommandResult, ProviderStatusMap } from '@shared/types'
+import {
+  PiAgentBridge,
+  normalizeFirstRunModelReadiness,
+  normalizeFirstRunStartupReadiness,
+} from '../pi-agent-bridge'
 
 async function waitFor(condition: () => boolean, timeoutMs = 1_500): Promise<void> {
   const startedAt = Date.now()
@@ -1013,5 +1017,59 @@ setTimeout(() => {
 
     expect(debugEvents.some((event) => event.type === 'bridge:error')).toBe(true)
     expect(bridge.getState().status).toBe('crashed')
+  })
+
+  test('normalizes first-run model checkpoint and startup checkpoint', () => {
+    const providers: ProviderStatusMap = {
+      anthropic: { provider: 'anthropic', status: 'missing' as const },
+      openai: { provider: 'openai', status: 'valid' as const, maskedKey: '••••1234' },
+      google: { provider: 'google', status: 'missing' as const },
+      mistral: { provider: 'mistral', status: 'missing' as const },
+      bedrock: { provider: 'bedrock', status: 'missing' as const },
+      azure: { provider: 'azure', status: 'missing' as const },
+    }
+
+    const modelCheckpoint = normalizeFirstRunModelReadiness({
+      providers,
+      selectedProvider: 'openai',
+      selectedModel: 'openai/gpt-4.1',
+      availableModels: [{ provider: 'openai', id: 'gpt-4.1' }],
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    const startupCheckpoint = normalizeFirstRunStartupReadiness({
+      providers,
+      selectedProvider: 'openai',
+      selectedModel: 'openai/gpt-4.1',
+      availableModels: [{ provider: 'openai', id: 'gpt-4.1' }],
+      bridgeStatus: 'running',
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(modelCheckpoint.status).toBe('pass')
+    expect(startupCheckpoint.status).toBe('pass')
+  })
+
+  test('fails model checkpoint when selected model provider is not configured', () => {
+    const providers: ProviderStatusMap = {
+      anthropic: { provider: 'anthropic', status: 'missing' as const },
+      openai: { provider: 'openai', status: 'missing' as const },
+      google: { provider: 'google', status: 'valid' as const, maskedKey: '••••5678' },
+      mistral: { provider: 'mistral', status: 'missing' as const },
+      bedrock: { provider: 'bedrock', status: 'missing' as const },
+      azure: { provider: 'azure', status: 'missing' as const },
+    }
+
+    const checkpoint = normalizeFirstRunModelReadiness({
+      providers,
+      selectedProvider: 'google',
+      selectedModel: 'openai/gpt-4.1',
+      availableModels: [{ provider: 'openai', id: 'gpt-4.1' }],
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(checkpoint.status).toBe('fail')
+    expect(checkpoint.failure?.code).toBe('MODEL_PROVIDER_NOT_CONFIGURED')
+    expect(checkpoint.failure?.recoveryAction).toBe('reauthenticate')
   })
 })

--- a/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
@@ -72,6 +72,17 @@ function getSurface(snapshot: ReliabilitySnapshot, sourceSurface: string) {
   return snapshot.surfaces.find((surface) => surface.sourceSurface === sourceSurface)
 }
 
+function createProviderStatuses(statusByProvider: Partial<Record<string, 'valid' | 'missing' | 'invalid' | 'expired'>> = {}) {
+  return {
+    anthropic: { provider: 'anthropic' as const, status: statusByProvider.anthropic ?? 'missing' },
+    openai: { provider: 'openai' as const, status: statusByProvider.openai ?? 'missing' },
+    google: { provider: 'google' as const, status: statusByProvider.google ?? 'missing' },
+    mistral: { provider: 'mistral' as const, status: statusByProvider.mistral ?? 'missing' },
+    bedrock: { provider: 'bedrock' as const, status: statusByProvider.bedrock ?? 'missing' },
+    azure: { provider: 'azure' as const, status: statusByProvider.azure ?? 'missing' },
+  }
+}
+
 describe('RuntimeHealthAggregator', () => {
   test('starts healthy across all reliability surfaces', () => {
     const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
@@ -83,6 +94,60 @@ describe('RuntimeHealthAggregator', () => {
       expect(surface.status).toBe('healthy')
       expect(surface.signal).toBeNull()
     }
+
+    expect(snapshot.firstRunReadiness?.checkpoints.auth.status).toBe('fail')
+    expect(snapshot.firstRunReadiness?.checkpoints.startup.status).toBe('fail')
+  })
+
+  test('composes first-run readiness checkpoints from auth/model/startup inputs', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    aggregator.ingestFirstRunAuthState({
+      providers: createProviderStatuses({ openai: 'valid' }),
+      selectedProvider: 'openai',
+    })
+
+    aggregator.ingestFirstRunModelState({
+      selectedModel: 'openai/gpt-4.1',
+      availableModels: [{ provider: 'openai', id: 'gpt-4.1' }],
+      selectedProvider: 'openai',
+    })
+
+    aggregator.ingestFirstRunBridgeStatus({
+      state: 'running',
+      pid: 99,
+      updatedAt: Date.parse('2026-04-07T20:00:00.000Z'),
+    })
+
+    const readiness = aggregator.getFirstRunReadinessSnapshot()
+
+    expect(readiness.checkpoints.auth.status).toBe('pass')
+    expect(readiness.checkpoints.model.status).toBe('pass')
+    expect(readiness.checkpoints.startup.status).toBe('pass')
+    expect(readiness.checkpoints.first_turn.status).toBe('fail')
+
+    aggregator.ingestFirstTurnCompletion(true)
+
+    expect(aggregator.getFirstRunReadinessSnapshot().checkpoints.first_turn.status).toBe('pass')
+  })
+
+  test('keeps first-run readiness blocked when selected model provider is not configured', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    aggregator.ingestFirstRunAuthState({
+      providers: createProviderStatuses({ google: 'valid' }),
+      selectedProvider: 'google',
+    })
+
+    aggregator.ingestFirstRunModelState({
+      selectedModel: 'openai/gpt-4.1',
+      availableModels: [{ provider: 'openai', id: 'gpt-4.1' }],
+      selectedProvider: 'google',
+    })
+
+    const readiness = aggregator.getFirstRunReadinessSnapshot()
+    expect(readiness.checkpoints.model.status).toBe('fail')
+    expect(readiness.checkpoints.model.failure?.code).toBe('MODEL_PROVIDER_NOT_CONFIGURED')
   })
 
   test('tracks workflow degradation without dropping last-known-good timestamp', () => {

--- a/apps/desktop/src/main/auth-bridge.ts
+++ b/apps/desktop/src/main/auth-bridge.ts
@@ -11,11 +11,16 @@ import {
   type AuthSetKeyResponse,
   type AuthRemoveKeyResponse,
   type AuthValidationResult,
+  type FirstRunCheckpointState,
+  type FirstRunProviderStateMap,
   type ProviderInfo,
   type ProviderStatusMap,
 } from '../shared/types'
+import { buildFirstRunReadinessSnapshot } from '../shared/first-run-readiness'
 
-const DEFAULT_AUTH_PATH = path.join(homedir(), '.kata-cli', 'agent', 'auth.json')
+const DEFAULT_AUTH_PATH =
+  process.env.KATA_DESKTOP_AUTH_FILE_PATH?.trim() ||
+  path.join(homedir(), '.kata-cli', 'agent', 'auth.json')
 
 /**
  * The CLI stores some providers under variant key names in auth.json.
@@ -89,6 +94,28 @@ const PROVIDER_VALIDATION_CONFIG: Partial<Record<AuthProvider, ValidationConfig>
 const UNSUPPORTED_PROVIDER_MESSAGES: Partial<Record<AuthProvider, string>> = {
   bedrock: 'AWS Bedrock validation requires AWS credentials and region configuration',
   azure: 'Azure validation requires both API key and Azure endpoint configuration',
+}
+
+export function normalizeFirstRunAuthReadiness(input: {
+  providers: ProviderStatusMap
+  selectedProvider?: AuthProvider | null
+  now?: string
+}): {
+  providers: FirstRunProviderStateMap
+  checkpoint: FirstRunCheckpointState
+} {
+  const snapshot = buildFirstRunReadinessSnapshot({
+    providers: input.providers,
+    selectedProvider: input.selectedProvider ?? null,
+    bridgeStatus: 'running',
+    completedFirstTurn: false,
+    now: input.now,
+  })
+
+  return {
+    providers: snapshot.providers,
+    checkpoint: snapshot.checkpoints.auth,
+  }
 }
 
 export class AuthBridge {

--- a/apps/desktop/src/main/auth-bridge.ts
+++ b/apps/desktop/src/main/auth-bridge.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import log from './logger'
 import {
   ALL_AUTH_PROVIDERS,
+  AUTH_PROVIDER_ALIASES,
   type AuthProvider,
   type AuthProvidersResponse,
   type AuthRecord,
@@ -21,14 +22,6 @@ import { buildFirstRunReadinessSnapshot } from '../shared/first-run-readiness'
 const DEFAULT_AUTH_PATH =
   process.env.KATA_DESKTOP_AUTH_FILE_PATH?.trim() ||
   path.join(homedir(), '.kata-cli', 'agent', 'auth.json')
-
-/**
- * The CLI stores some providers under variant key names in auth.json.
- * Map canonical AuthProvider → alternate keys to check.
- */
-const AUTH_PROVIDER_ALIASES: Partial<Record<AuthProvider, string[]>> = {
-  openai: ['openai-codex'],
-}
 
 interface ValidationConfig {
   url: (key: string) => string

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -687,6 +687,10 @@ export function registerSessionIpc({
     for (const chatEvent of adapter.adapt(rpcEvent)) {
       sendEventToRenderer(chatEvent)
       planningToolDetector.handleChatEvent(chatEvent)
+
+      if (chatEvent.type === 'agent_end') {
+        reliabilityAggregator.ingestFirstTurnCompletion(true)
+      }
     }
   }
 
@@ -758,6 +762,22 @@ export function registerSessionIpc({
   }
   sendBridgeStatus(initialBridgeStatus)
   reliabilityAggregator.ingestChatBridgeStatus(initialBridgeStatus)
+  reliabilityAggregator.ingestFirstRunModelState({
+    selectedModel: initialState.selectedModel,
+  })
+
+  void authBridge
+    .getProviders()
+    .then((response) => {
+      reliabilityAggregator.ingestFirstRunAuthState({
+        providers: response.providers,
+      })
+    })
+    .catch((error) => {
+      log.warn('[desktop-ipc] initial auth readiness snapshot failed', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    })
 
   if (symphonySupervisor) {
     const initialSymphonyStatus = symphonySupervisor.getStatus()
@@ -868,6 +888,11 @@ export function registerSessionIpc({
   ipcMain.handle(IPC_CHANNELS.sessionGetAvailableModels, async (): Promise<AvailableModelsResponse> => {
     try {
       const models = await bridge.getAvailableModels()
+      reliabilityAggregator.ingestFirstRunModelState({
+        selectedModel: bridge.getSelectedModel(),
+        availableModels: models,
+      })
+
       return {
         success: true,
         models,
@@ -911,6 +936,10 @@ export function registerSessionIpc({
           })
         }
       }
+
+      reliabilityAggregator.ingestFirstRunModelState({
+        selectedModel: model,
+      })
 
       log.info('[desktop-ipc] model switch', {
         model,
@@ -1236,14 +1265,25 @@ export function registerSessionIpc({
   })
 
   ipcMain.handle(IPC_CHANNELS.authGetProviders, async (): Promise<AuthProvidersResponse> => {
-    return authBridge.getProviders()
+    const response = await authBridge.getProviders()
+    reliabilityAggregator.ingestFirstRunAuthState({
+      providers: response.providers,
+    })
+    return response
   })
 
   ipcMain.handle(
     IPC_CHANNELS.authSetKey,
     async (_event, provider: AuthProvider, key: string): Promise<AuthSetKeyResponse> => {
       try {
-        return await authBridge.setProviderKey(provider, key)
+        const response = await authBridge.setProviderKey(provider, key)
+
+        const providersResponse = await authBridge.getProviders()
+        reliabilityAggregator.ingestFirstRunAuthState({
+          providers: providersResponse.providers,
+        })
+
+        return response
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         return {
@@ -1259,7 +1299,14 @@ export function registerSessionIpc({
     IPC_CHANNELS.authRemoveKey,
     async (_event, provider: AuthProvider): Promise<AuthRemoveKeyResponse> => {
       try {
-        return await authBridge.removeProviderKey(provider)
+        const response = await authBridge.removeProviderKey(provider)
+
+        const providersResponse = await authBridge.getProviders()
+        reliabilityAggregator.ingestFirstRunAuthState({
+          providers: providersResponse.providers,
+        })
+
+        return response
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         return {

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -19,7 +19,10 @@ import {
   type ProviderStatusMap,
   type RpcCommand,
 } from '../shared/types'
-import { buildFirstRunReadinessSnapshot } from '../shared/first-run-readiness'
+import {
+  buildFirstRunReadinessSnapshot,
+  normalizeFirstRunStartupCheckpoint,
+} from '../shared/first-run-readiness'
 
 interface PendingCommand {
   command: string
@@ -76,24 +79,13 @@ export function normalizeFirstRunModelReadiness(input: {
 }
 
 export function normalizeFirstRunStartupReadiness(input: {
-  providers: ProviderStatusMap
-  selectedProvider?: AuthProvider | null
-  selectedModel?: string | null
-  availableModels?: AvailableModel[]
   bridgeStatus: BridgeLifecycleState
   now?: string
 }): FirstRunCheckpointState {
-  const snapshot = buildFirstRunReadinessSnapshot({
-    providers: input.providers,
-    selectedProvider: input.selectedProvider ?? null,
-    selectedModel: input.selectedModel ?? null,
-    availableModels: input.availableModels ?? [],
+  return normalizeFirstRunStartupCheckpoint({
     bridgeStatus: input.bridgeStatus,
-    completedFirstTurn: false,
     now: input.now,
   })
-
-  return snapshot.checkpoints.startup
 }
 
 export class PiAgentBridge extends EventEmitter {

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module'
 import readline from 'node:readline'
 import log from './logger'
 import {
+  type AuthProvider,
   type AvailableModel,
   type BridgeLifecycleState,
   type BridgeState,
@@ -13,9 +14,12 @@ import {
   type CommandResult,
   type ExtensionUIRequest,
   type ExtensionUIResponse,
+  type FirstRunCheckpointState,
   type PermissionMode,
+  type ProviderStatusMap,
   type RpcCommand,
 } from '../shared/types'
+import { buildFirstRunReadinessSnapshot } from '../shared/first-run-readiness'
 
 interface PendingCommand {
   command: string
@@ -49,6 +53,47 @@ interface BinaryDiscoveryResult {
   source: 'bundled' | 'path' | 'not_found'
   resolvedPath: string | null
   checkedPaths: string[]
+}
+
+export function normalizeFirstRunModelReadiness(input: {
+  providers: ProviderStatusMap
+  selectedProvider?: AuthProvider | null
+  selectedModel?: string | null
+  availableModels?: AvailableModel[]
+  now?: string
+}): FirstRunCheckpointState {
+  const snapshot = buildFirstRunReadinessSnapshot({
+    providers: input.providers,
+    selectedProvider: input.selectedProvider ?? null,
+    selectedModel: input.selectedModel ?? null,
+    availableModels: input.availableModels ?? [],
+    bridgeStatus: 'running',
+    completedFirstTurn: false,
+    now: input.now,
+  })
+
+  return snapshot.checkpoints.model
+}
+
+export function normalizeFirstRunStartupReadiness(input: {
+  providers: ProviderStatusMap
+  selectedProvider?: AuthProvider | null
+  selectedModel?: string | null
+  availableModels?: AvailableModel[]
+  bridgeStatus: BridgeLifecycleState
+  now?: string
+}): FirstRunCheckpointState {
+  const snapshot = buildFirstRunReadinessSnapshot({
+    providers: input.providers,
+    selectedProvider: input.selectedProvider ?? null,
+    selectedModel: input.selectedModel ?? null,
+    availableModels: input.availableModels ?? [],
+    bridgeStatus: input.bridgeStatus,
+    completedFirstTurn: false,
+    now: input.now,
+  })
+
+  return snapshot.checkpoints.startup
 }
 
 export class PiAgentBridge extends EventEmitter {

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -33,11 +33,6 @@ import type {
 } from '../shared/types'
 import { ALL_AUTH_PROVIDERS } from '../shared/types'
 import { buildFirstRunReadinessSnapshot } from '../shared/first-run-readiness'
-import { normalizeFirstRunAuthReadiness } from './auth-bridge'
-import {
-  normalizeFirstRunModelReadiness,
-  normalizeFirstRunStartupReadiness,
-} from './pi-agent-bridge'
 
 type RecoveryAttempt = {
   success: boolean
@@ -386,30 +381,7 @@ export class RuntimeHealthAggregator extends EventEmitter {
   private recomputeFirstRunReadiness(nowOverride?: string): void {
     const now = nowOverride ?? this.now()
 
-    const authNormalization = normalizeFirstRunAuthReadiness({
-      providers: this.firstRunProviders,
-      selectedProvider: this.firstRunSelectedProvider,
-      now,
-    })
-
-    const modelCheckpoint = normalizeFirstRunModelReadiness({
-      providers: this.firstRunProviders,
-      selectedProvider: this.firstRunSelectedProvider,
-      selectedModel: this.firstRunSelectedModel,
-      availableModels: this.firstRunAvailableModels,
-      now,
-    })
-
-    const startupCheckpoint = normalizeFirstRunStartupReadiness({
-      providers: this.firstRunProviders,
-      selectedProvider: this.firstRunSelectedProvider,
-      selectedModel: this.firstRunSelectedModel,
-      availableModels: this.firstRunAvailableModels,
-      bridgeStatus: this.firstRunBridgeStatus,
-      now,
-    })
-
-    const snapshot = buildFirstRunReadinessSnapshot({
+    this.firstRunReadiness = buildFirstRunReadinessSnapshot({
       providers: this.firstRunProviders,
       selectedProvider: this.firstRunSelectedProvider,
       selectedModel: this.firstRunSelectedModel,
@@ -418,27 +390,6 @@ export class RuntimeHealthAggregator extends EventEmitter {
       completedFirstTurn: this.firstTurnCompleted,
       now,
     })
-
-    // Keep checkpoint composition explicit: auth/model/startup come from their
-    // dedicated normalizers and first_turn from the composed snapshot.
-    const checkpoints = {
-      ...snapshot.checkpoints,
-      auth: authNormalization.checkpoint,
-      model: modelCheckpoint,
-      startup: startupCheckpoint,
-    }
-
-    const blockedCheckpoint =
-      (['auth', 'model', 'startup', 'first_turn'] as const).find(
-        (checkpoint) => checkpoints[checkpoint].status === 'fail',
-      ) ?? null
-
-    this.firstRunReadiness = {
-      ...snapshot,
-      checkpoints,
-      blockedCheckpoint,
-      overallStatus: blockedCheckpoint ? 'blocked' : 'ready',
-    }
   }
 
   private toSnapshot(): ReliabilitySnapshot {

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -12,9 +12,14 @@ import {
   RELIABILITY_SURFACES,
 } from './reliability-contract'
 import type {
+  AuthProvider,
+  AvailableModel,
+  BridgeLifecycleState,
   BridgeStatusEvent,
+  FirstRunReadinessSnapshot,
   McpConfigReadResponse,
   McpServerStatusResponse,
+  ProviderStatusMap,
   ReliabilityRecoveryAction,
   ReliabilityRecoveryRequest,
   ReliabilityRecoveryResult,
@@ -26,6 +31,13 @@ import type {
   SymphonyRuntimeStatus,
   WorkflowBoardSnapshot,
 } from '../shared/types'
+import { ALL_AUTH_PROVIDERS } from '../shared/types'
+import { buildFirstRunReadinessSnapshot } from '../shared/first-run-readiness'
+import { normalizeFirstRunAuthReadiness } from './auth-bridge'
+import {
+  normalizeFirstRunModelReadiness,
+  normalizeFirstRunStartupReadiness,
+} from './pi-agent-bridge'
 
 type RecoveryAttempt = {
   success: boolean
@@ -46,6 +58,20 @@ interface RuntimeHealthAggregatorEvents {
   snapshot: (snapshot: ReliabilitySnapshot) => void
 }
 
+function createMissingProviderStatusMap(): ProviderStatusMap {
+  const entries = ALL_AUTH_PROVIDERS.map((provider) => {
+    return [
+      provider,
+      {
+        provider,
+        status: 'missing' as const,
+      },
+    ] as const
+  })
+
+  return Object.fromEntries(entries) as ProviderStatusMap
+}
+
 export class RuntimeHealthAggregator extends EventEmitter {
   private readonly now: () => string
   private readonly requestRecovery?: RuntimeHealthAggregatorOptions['requestRecovery']
@@ -58,6 +84,14 @@ export class RuntimeHealthAggregator extends EventEmitter {
   private symphonyOperatorSignal: ReliabilitySignal | null = null
   private mcpConfigSignal: ReliabilitySignal | null = null
   private mcpStatusSignal: ReliabilitySignal | null = null
+
+  private firstRunProviders: ProviderStatusMap = createMissingProviderStatusMap()
+  private firstRunSelectedProvider: AuthProvider | null = null
+  private firstRunSelectedModel: string | null = null
+  private firstRunAvailableModels: AvailableModel[] = []
+  private firstRunBridgeStatus: BridgeLifecycleState = 'shutdown'
+  private firstTurnCompleted = false
+  private firstRunReadiness: FirstRunReadinessSnapshot | null = null
 
   constructor(options: RuntimeHealthAggregatorOptions = {}) {
     super()
@@ -74,6 +108,8 @@ export class RuntimeHealthAggregator extends EventEmitter {
         lastHealthyAt: startedAt,
       })
     }
+
+    this.recomputeFirstRunReadiness(startedAt)
   }
 
   override on<K extends keyof RuntimeHealthAggregatorEvents>(
@@ -101,6 +137,55 @@ export class RuntimeHealthAggregator extends EventEmitter {
     return this.toSnapshot()
   }
 
+  public getFirstRunReadinessSnapshot(): FirstRunReadinessSnapshot {
+    if (!this.firstRunReadiness) {
+      this.recomputeFirstRunReadiness(this.now())
+    }
+
+    return this.firstRunReadiness as FirstRunReadinessSnapshot
+  }
+
+  public ingestFirstRunAuthState(input: {
+    providers: ProviderStatusMap
+    selectedProvider?: AuthProvider | null
+  }): ReliabilitySnapshot {
+    this.firstRunProviders = input.providers
+    this.firstRunSelectedProvider = input.selectedProvider ?? this.firstRunSelectedProvider
+    this.recomputeFirstRunReadiness()
+    this.emit('snapshot', this.toSnapshot())
+    return this.toSnapshot()
+  }
+
+  public ingestFirstRunModelState(input: {
+    selectedModel?: string | null
+    availableModels?: AvailableModel[]
+    selectedProvider?: AuthProvider | null
+  }): ReliabilitySnapshot {
+    this.firstRunSelectedModel = input.selectedModel?.trim() || null
+    this.firstRunAvailableModels = input.availableModels ?? this.firstRunAvailableModels
+    this.firstRunSelectedProvider = input.selectedProvider ?? this.firstRunSelectedProvider
+    this.recomputeFirstRunReadiness()
+    this.emit('snapshot', this.toSnapshot())
+    return this.toSnapshot()
+  }
+
+  public ingestFirstRunBridgeStatus(status: BridgeStatusEvent | null | undefined): ReliabilitySnapshot {
+    if (status) {
+      this.firstRunBridgeStatus = status.state
+    }
+
+    this.recomputeFirstRunReadiness()
+    this.emit('snapshot', this.toSnapshot())
+    return this.toSnapshot()
+  }
+
+  public ingestFirstTurnCompletion(completed = true): ReliabilitySnapshot {
+    this.firstTurnCompleted = completed
+    this.recomputeFirstRunReadiness()
+    this.emit('snapshot', this.toSnapshot())
+    return this.toSnapshot()
+  }
+
   public ingestWorkflowSnapshot(snapshot: WorkflowBoardSnapshot | null | undefined): ReliabilitySnapshot {
     this.updateSurface('workflow_board', mapWorkflowBoardSnapshotToReliability(snapshot))
     return this.toSnapshot()
@@ -112,6 +197,11 @@ export class RuntimeHealthAggregator extends EventEmitter {
     // A recovered bridge status supersedes any prior crash-only signal.
     if (status && status.state !== 'crashed') {
       this.chatCrashSignal = null
+    }
+
+    if (status) {
+      this.firstRunBridgeStatus = status.state
+      this.recomputeFirstRunReadiness()
     }
 
     this.syncChatSurface()
@@ -126,6 +216,8 @@ export class RuntimeHealthAggregator extends EventEmitter {
     timestamp?: string
   }): ReliabilitySnapshot {
     this.chatCrashSignal = mapChatSubprocessCrashToReliability(input)
+    this.firstRunBridgeStatus = 'crashed'
+    this.recomputeFirstRunReadiness(input.timestamp)
     this.syncChatSurface()
     return this.toSnapshot()
   }
@@ -291,6 +383,64 @@ export class RuntimeHealthAggregator extends EventEmitter {
     this.emit('snapshot', this.toSnapshot())
   }
 
+  private recomputeFirstRunReadiness(nowOverride?: string): void {
+    const now = nowOverride ?? this.now()
+
+    const authNormalization = normalizeFirstRunAuthReadiness({
+      providers: this.firstRunProviders,
+      selectedProvider: this.firstRunSelectedProvider,
+      now,
+    })
+
+    const modelCheckpoint = normalizeFirstRunModelReadiness({
+      providers: this.firstRunProviders,
+      selectedProvider: this.firstRunSelectedProvider,
+      selectedModel: this.firstRunSelectedModel,
+      availableModels: this.firstRunAvailableModels,
+      now,
+    })
+
+    const startupCheckpoint = normalizeFirstRunStartupReadiness({
+      providers: this.firstRunProviders,
+      selectedProvider: this.firstRunSelectedProvider,
+      selectedModel: this.firstRunSelectedModel,
+      availableModels: this.firstRunAvailableModels,
+      bridgeStatus: this.firstRunBridgeStatus,
+      now,
+    })
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers: this.firstRunProviders,
+      selectedProvider: this.firstRunSelectedProvider,
+      selectedModel: this.firstRunSelectedModel,
+      availableModels: this.firstRunAvailableModels,
+      bridgeStatus: this.firstRunBridgeStatus,
+      completedFirstTurn: this.firstTurnCompleted,
+      now,
+    })
+
+    // Keep checkpoint composition explicit: auth/model/startup come from their
+    // dedicated normalizers and first_turn from the composed snapshot.
+    const checkpoints = {
+      ...snapshot.checkpoints,
+      auth: authNormalization.checkpoint,
+      model: modelCheckpoint,
+      startup: startupCheckpoint,
+    }
+
+    const blockedCheckpoint =
+      (['auth', 'model', 'startup', 'first_turn'] as const).find(
+        (checkpoint) => checkpoints[checkpoint].status === 'fail',
+      ) ?? null
+
+    this.firstRunReadiness = {
+      ...snapshot,
+      checkpoints,
+      blockedCheckpoint,
+      overallStatus: blockedCheckpoint ? 'blocked' : 'ready',
+    }
+  }
+
   private toSnapshot(): ReliabilitySnapshot {
     const surfaces = RELIABILITY_SURFACES.map((surface) => {
       const state = this.surfaces.get(surface)
@@ -315,6 +465,7 @@ export class RuntimeHealthAggregator extends EventEmitter {
       generatedAt: this.now(),
       overallStatus: surfaces.some((surface) => surface.status === 'degraded') ? 'degraded' : 'healthy',
       surfaces,
+      ...(this.firstRunReadiness ? { firstRunReadiness: this.firstRunReadiness } : {}),
     }
   }
 }

--- a/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
@@ -6,6 +6,7 @@ import {
   modelLoadingAtom,
   selectedModelAtom,
 } from '@/atoms/model'
+import { useReliabilitySnapshot } from '@/atoms/reliability'
 import {
   Select,
   SelectContent,
@@ -15,7 +16,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import type { FirstRunReadinessSnapshot } from '@shared/types'
 import { MODELS_REFRESH_EVENT, PROVIDER_METADATA } from '@/constants/providers'
+import { buildFirstRunGuidance, getFirstRunCheckpoint } from '@/lib/first-run-readiness'
 
 function toModelIdentifier(provider: string, id: string): string {
   return `${provider}/${id}`
@@ -27,11 +31,24 @@ function formatProviderLabel(provider: string): string {
   return metadata?.name ?? provider
 }
 
+export function buildModelSelectorReadinessNotice(
+  readiness: FirstRunReadinessSnapshot | null | undefined,
+): string | null {
+  const startupGuidance = buildFirstRunGuidance(getFirstRunCheckpoint(readiness, 'startup'))
+  if (startupGuidance) {
+    return startupGuidance
+  }
+
+  return buildFirstRunGuidance(getFirstRunCheckpoint(readiness, 'model'))
+}
+
 export function ModelSelector() {
   const [selectedModel, setSelectedModel] = useAtom(selectedModelAtom)
   const [availableModels, setAvailableModels] = useAtom(availableModelsAtom)
   const [loading, setLoading] = useAtom(modelLoadingAtom)
   const [error, setError] = useAtom(modelErrorAtom)
+  const reliabilitySnapshot = useReliabilitySnapshot()
+  const readinessNotice = buildModelSelectorReadinessNotice(reliabilitySnapshot.firstRunReadiness)
 
   const refreshModels = useCallback(async () => {
     setLoading(true)
@@ -167,6 +184,23 @@ export function ModelSelector() {
       </Select>
 
       {error && <p className="text-[11px] text-destructive">{error}</p>}
+
+      {readinessNotice && (
+        <div className="space-y-1" data-testid="model-selector-readiness-notice">
+          <p className="text-[11px] text-muted-foreground">{readinessNotice}</p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-auto px-0 py-0 text-[11px]"
+            onClick={() => {
+              void refreshModels()
+            }}
+          >
+            Retry model check
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/components/app-shell/__tests__/ModelSelector.test.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/__tests__/ModelSelector.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'vitest'
+import { buildModelSelectorReadinessNotice } from '../ModelSelector'
+import type { FirstRunReadinessSnapshot } from '@shared/types'
+
+function createReadiness(
+  overrides: Partial<FirstRunReadinessSnapshot['checkpoints']> = {},
+): FirstRunReadinessSnapshot {
+  return {
+    generatedAt: '2026-04-08T00:00:00.000Z',
+    selectedProvider: 'openai',
+    selectedModel: 'openai/gpt-4.1',
+    availableModelCount: 1,
+    completedFirstTurn: false,
+    blockedCheckpoint: 'startup',
+    overallStatus: 'blocked',
+    providers: {
+      anthropic: { provider: 'anthropic', status: 'missing', configured: false, requiresKey: true },
+      openai: { provider: 'openai', status: 'valid', configured: true, requiresKey: false },
+      google: { provider: 'google', status: 'missing', configured: false, requiresKey: true },
+      mistral: { provider: 'mistral', status: 'missing', configured: false, requiresKey: true },
+      bedrock: { provider: 'bedrock', status: 'missing', configured: false, requiresKey: true },
+      azure: { provider: 'azure', status: 'missing', configured: false, requiresKey: true },
+    },
+    checkpoints: {
+      auth: { checkpoint: 'auth', status: 'pass' },
+      model: { checkpoint: 'model', status: 'pass' },
+      startup: {
+        checkpoint: 'startup',
+        status: 'fail',
+        failure: {
+          class: 'process',
+          severity: 'critical',
+          code: 'STARTUP_RUNTIME_CRASHED',
+          message: 'Kata runtime failed to start. Restart the runtime from the chat banner.',
+          recoveryAction: 'restart_process',
+          recoverable: true,
+          timestamp: '2026-04-08T00:00:00.000Z',
+        },
+      },
+      first_turn: {
+        checkpoint: 'first_turn',
+        status: 'fail',
+        blockedBy: 'startup',
+        failure: {
+          class: 'process',
+          severity: 'warning',
+          code: 'FIRST_TURN_BLOCKED_BY_STARTUP',
+          message: 'First turn is blocked until runtime startup completes.',
+          recoveryAction: 'restart_process',
+          recoverable: true,
+          timestamp: '2026-04-08T00:00:00.000Z',
+        },
+      },
+      ...overrides,
+    },
+  }
+}
+
+describe('ModelSelector readiness notice helper', () => {
+  test('prefers startup guidance when startup checkpoint is failing', () => {
+    const readiness = createReadiness()
+    const notice = buildModelSelectorReadinessNotice(readiness)
+
+    expect(notice).toContain('Kata runtime failed to start')
+    expect(notice).toContain('Restart runtime')
+  })
+
+  test('falls back to model checkpoint guidance when startup is healthy', () => {
+    const readiness = createReadiness({
+      startup: { checkpoint: 'startup', status: 'pass' },
+      model: {
+        checkpoint: 'model',
+        status: 'fail',
+        failure: {
+          class: 'config',
+          severity: 'warning',
+          code: 'MODEL_NOT_AVAILABLE',
+          message: 'Selected model is unavailable. Refresh models or choose another model.',
+          recoveryAction: 'retry_request',
+          recoverable: true,
+          timestamp: '2026-04-08T00:00:00.000Z',
+        },
+      },
+    })
+
+    const notice = buildModelSelectorReadinessNotice(readiness)
+    expect(notice).toContain('Selected model is unavailable')
+    expect(notice).toContain('Retry request')
+  })
+
+  test('returns null when no startup/model checkpoint is blocked', () => {
+    const readiness = createReadiness({
+      startup: { checkpoint: 'startup', status: 'pass' },
+      model: { checkpoint: 'model', status: 'pass' },
+    })
+
+    expect(buildModelSelectorReadinessNotice(readiness)).toBeNull()
+    expect(buildModelSelectorReadinessNotice(null)).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/components/onboarding/CompletionStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/CompletionStep.tsx
@@ -1,15 +1,33 @@
 import { ArrowLeft, Check } from 'lucide-react'
+import type { FirstRunCheckpointId, FirstRunReadinessSnapshot } from '@shared/types'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
+import {
+  FIRST_RUN_CHECKPOINT_LABELS,
+  buildFirstRunGuidance,
+  getFirstRunCheckpoint,
+} from '@/lib/first-run-readiness'
 
 interface CompletionStepProps {
   selectedModel: string | null
+  readiness?: FirstRunReadinessSnapshot | null
   onBack: () => void
   onFinish: () => void
 }
 
-export function CompletionStep({ selectedModel, onBack, onFinish }: CompletionStepProps) {
+const CHECKPOINT_ORDER: FirstRunCheckpointId[] = ['auth', 'model', 'startup', 'first_turn']
+
+export function CompletionStep({ selectedModel, readiness, onBack, onFinish }: CompletionStepProps) {
+  const checkpointRows = CHECKPOINT_ORDER.map((checkpoint) => {
+    const value = getFirstRunCheckpoint(readiness, checkpoint)
+    return {
+      checkpoint,
+      status: value?.status ?? 'fail',
+      guidance: buildFirstRunGuidance(value),
+    }
+  })
+
   return (
     <div className="flex h-full flex-col justify-between">
       <div className="flex flex-col gap-5">
@@ -31,6 +49,25 @@ export function CompletionStep({ selectedModel, onBack, onFinish }: CompletionSt
                 You can choose a model anytime from the toolbar model picker.
               </p>
             )}
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border bg-card/80 py-0" data-testid="onboarding-checkpoint-summary">
+          <CardContent className="space-y-2 p-4">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">First-run checkpoints</p>
+            <ul className="space-y-2 text-xs">
+              {checkpointRows.map((checkpoint) => (
+                <li key={checkpoint.checkpoint} className="space-y-1">
+                  <p className="text-foreground">
+                    <span className="font-semibold">{FIRST_RUN_CHECKPOINT_LABELS[checkpoint.checkpoint]}:</span>{' '}
+                    {checkpoint.status === 'pass' ? 'Pass' : 'Fail'}
+                  </p>
+                  {checkpoint.guidance && (
+                    <p className="text-muted-foreground">{checkpoint.guidance}</p>
+                  )}
+                </li>
+              ))}
+            </ul>
           </CardContent>
         </Card>
       </div>

--- a/apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { ArrowLeft, KeyRound } from 'lucide-react'
-import type { AuthProvider } from '@shared/types'
+import type { AuthProvider, FirstRunReadinessSnapshot } from '@shared/types'
+import { buildFirstRunGuidance, getFirstRunCheckpoint } from '@/lib/first-run-readiness'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -9,18 +10,21 @@ import { PROVIDER_METADATA } from '@/constants/providers'
 
 interface KeyInputStepProps {
   provider: AuthProvider
+  readiness?: FirstRunReadinessSnapshot | null
   onBack: () => void
   onSaved: (provider: AuthProvider) => Promise<void>
   onSkip: () => void
 }
 
-export function KeyInputStep({ provider, onBack, onSaved, onSkip }: KeyInputStepProps) {
+export function KeyInputStep({ provider, readiness, onBack, onSaved, onSkip }: KeyInputStepProps) {
   const [keyValue, setKeyValue] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
 
   const metadata = PROVIDER_METADATA[provider]
+  const authGuidance = buildFirstRunGuidance(getFirstRunCheckpoint(readiness, 'auth'))
+  const modelGuidance = buildFirstRunGuidance(getFirstRunCheckpoint(readiness, 'model'))
 
   const validateAndSave = async (): Promise<void> => {
     const trimmed = keyValue.trim()
@@ -64,6 +68,21 @@ export function KeyInputStep({ provider, onBack, onSaved, onSkip }: KeyInputStep
             shared with Kata CLI.
           </p>
         </div>
+
+        {authGuidance && (
+          <div
+            className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-200"
+            data-testid="onboarding-key-auth-guidance"
+          >
+            {authGuidance}
+          </div>
+        )}
+
+        {modelGuidance && (
+          <div className="rounded-md border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+            {modelGuidance}
+          </div>
+        )}
 
         <div className="flex flex-col gap-2">
           <Label htmlFor="provider-api-key" className="text-xs uppercase tracking-wide text-muted-foreground">

--- a/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -7,6 +7,7 @@ import {
 } from '@shared/types'
 import { onboardingCompleteAtom } from '@/atoms/onboarding'
 import { selectedModelAtom } from '@/atoms/model'
+import { useReliabilitySnapshot } from '@/atoms/reliability'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { MODELS_REFRESH_EVENT } from '@/constants/providers'
@@ -33,6 +34,7 @@ function createMissingProviderMap(): ProviderStatusMap {
 export function OnboardingWizard() {
   const setOnboardingComplete = useSetAtom(onboardingCompleteAtom)
   const setSelectedModel = useSetAtom(selectedModelAtom)
+  const reliabilitySnapshot = useReliabilitySnapshot()
 
   const [step, setStep] = useState<OnboardingStep>('welcome')
   const [providers, setProviders] = useState<ProviderStatusMap>(createMissingProviderMap)
@@ -40,6 +42,8 @@ export function OnboardingWizard() {
   const [providersLoading, setProvidersLoading] = useState(false)
   const [providersError, setProvidersError] = useState<string | null>(null)
   const [resolvedModel, setResolvedModel] = useState<string | null>(null)
+
+  const firstRunReadiness = reliabilitySnapshot.firstRunReadiness ?? null
 
   const loadProviders = useCallback(async () => {
     setProvidersLoading(true)
@@ -126,6 +130,7 @@ export function OnboardingWizard() {
               selectedProvider={selectedProvider}
               loadError={providersError}
               loading={providersLoading}
+              readiness={firstRunReadiness}
               onBack={() => setStep('welcome')}
               onSelect={setSelectedProvider}
               onContinue={() => {
@@ -139,6 +144,7 @@ export function OnboardingWizard() {
           {step === 'key' && selectedProvider && (
             <KeyInputStep
               provider={selectedProvider}
+              readiness={firstRunReadiness}
               onBack={() => setStep('provider')}
               onSaved={async (provider) => {
                 await loadProviders()
@@ -153,6 +159,7 @@ export function OnboardingWizard() {
           {step === 'complete' && (
             <CompletionStep
               selectedModel={resolvedModel}
+              readiness={firstRunReadiness}
               onBack={() => setStep(selectedProvider ? 'key' : 'provider')}
               onFinish={() => setOnboardingComplete(true)}
             />

--- a/apps/desktop/src/renderer/components/onboarding/ProviderStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/ProviderStep.tsx
@@ -1,17 +1,19 @@
 import { ArrowLeft, Check, ChevronRight, KeyRound } from 'lucide-react'
-import type { AuthProvider, ProviderStatusMap } from '@shared/types'
+import type { AuthProvider, FirstRunReadinessSnapshot, ProviderStatusMap } from '@shared/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { cn } from '@/lib/utils'
 import { ONBOARDING_PROVIDER_IDS, PROVIDER_METADATA } from '@/constants/providers'
+import { buildFirstRunGuidance, getFirstRunCheckpoint } from '@/lib/first-run-readiness'
 
 interface ProviderStepProps {
   providers: ProviderStatusMap
   selectedProvider: AuthProvider | null
   loadError: string | null
   loading: boolean
+  readiness?: FirstRunReadinessSnapshot | null
   onBack: () => void
   onSelect: (provider: AuthProvider) => void
   onContinue: () => void
@@ -22,10 +24,14 @@ export function ProviderStep({
   selectedProvider,
   loadError,
   loading,
+  readiness,
   onBack,
   onSelect,
   onContinue,
 }: ProviderStepProps) {
+  const authCheckpoint = getFirstRunCheckpoint(readiness, 'auth')
+  const authGuidance = buildFirstRunGuidance(authCheckpoint)
+
   return (
     <div className="flex h-full flex-col justify-between">
       <div className="flex flex-col gap-4">
@@ -42,12 +48,24 @@ export function ProviderStep({
           </div>
         )}
 
+        {authGuidance && (
+          <div
+            className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-200"
+            data-testid="onboarding-auth-guidance"
+          >
+            {authGuidance}
+          </div>
+        )}
+
         <div className="grid gap-3 md:grid-cols-2">
           {ONBOARDING_PROVIDER_IDS.map((provider) => {
             const metadata = PROVIDER_METADATA[provider]
             const info = providers[provider]
-            const configured = info.status === 'valid'
+            const readinessInfo = readiness?.providers?.[provider]
+            const configured = readinessInfo?.configured ?? info.status === 'valid'
+            const needsRecovery = (readinessInfo?.status ?? info.status) === 'expired' || (readinessInfo?.status ?? info.status) === 'invalid'
             const selected = selectedProvider === provider
+            const badgeLabel = configured ? 'Configured' : needsRecovery ? 'Fix key' : 'Add key'
 
             return (
               <Card
@@ -74,7 +92,7 @@ export function ProviderStep({
 
                   <Badge variant={configured ? 'secondary' : 'outline'} className="shrink-0">
                     {configured ? <Check data-icon="inline-start" /> : <KeyRound data-icon="inline-start" />}
-                    {configured ? 'Configured' : 'Add key'}
+                    {badgeLabel}
                   </Badge>
                 </CardContent>
               </Card>

--- a/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { AuthProvider, ProviderInfo, ProviderStatusMap } from '@shared/types'
+import type {
+  AuthProvider,
+  FirstRunCheckpointState,
+  FirstRunReadinessSnapshot,
+  ProviderInfo,
+  ProviderStatusMap,
+} from '@shared/types'
+import { useReliabilitySnapshot } from '@/atoms/reliability'
 import { Check, KeyRound, Trash2 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -8,6 +15,11 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
 import { MODELS_REFRESH_EVENT, PROVIDER_METADATA } from '@/constants/providers'
+import {
+  buildFirstRunGuidance,
+  formatFirstRunRecoveryAction,
+  getFirstRunCheckpoint,
+} from '@/lib/first-run-readiness'
 import { cn } from '@/lib/utils'
 
 const AUTH_FILE_DISPLAY_PATH = '~/.kata-cli/agent/auth.json'
@@ -33,6 +45,33 @@ function statusVariant(status: ProviderInfo['status']): 'secondary' | 'destructi
   return 'outline'
 }
 
+export function buildProviderAuthReadinessNotice(
+  readiness: FirstRunReadinessSnapshot | null | undefined,
+): string | null {
+  const authCheckpoint = getFirstRunCheckpoint(readiness, 'auth')
+  const modelCheckpoint = getFirstRunCheckpoint(readiness, 'model')
+
+  if (authCheckpoint?.status === 'fail' && authCheckpoint.failure) {
+    return authCheckpoint.failure.message
+  }
+
+  if (modelCheckpoint?.status === 'fail' && modelCheckpoint.failure) {
+    return modelCheckpoint.failure.message
+  }
+
+  return null
+}
+
+export function buildProviderAuthRecoveryAction(
+  checkpoint: FirstRunCheckpointState | null | undefined,
+): string | null {
+  if (!checkpoint || checkpoint.status === 'pass' || !checkpoint.failure) {
+    return null
+  }
+
+  return formatFirstRunRecoveryAction(checkpoint.failure.recoveryAction)
+}
+
 export function ProviderAuthPanel() {
   const [providers, setProviders] = useState<ProviderStatusMap | null>(null)
   const [loading, setLoading] = useState<boolean>(false)
@@ -42,6 +81,15 @@ export function ProviderAuthPanel() {
   const [actionError, setActionError] = useState<string | null>(null)
   const [actionSuccess, setActionSuccess] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+
+  const reliabilitySnapshot = useReliabilitySnapshot()
+  const firstRunReadiness = reliabilitySnapshot.firstRunReadiness ?? null
+  const authCheckpoint = getFirstRunCheckpoint(firstRunReadiness, 'auth')
+  const modelCheckpoint = getFirstRunCheckpoint(firstRunReadiness, 'model')
+  const startupCheckpoint = getFirstRunCheckpoint(firstRunReadiness, 'startup')
+  const readinessNotice = buildProviderAuthReadinessNotice(firstRunReadiness)
+  const readinessAction =
+    buildProviderAuthRecoveryAction(authCheckpoint?.status === 'fail' ? authCheckpoint : modelCheckpoint)
 
   const loadProviders = useCallback(async () => {
     setLoading(true)
@@ -61,8 +109,6 @@ export function ProviderAuthPanel() {
     void loadProviders()
   }, [loadProviders])
 
-  const activeInfo = providers?.[activeProvider]
-
   const providerRows = useMemo(() => {
     if (!providers) {
       return []
@@ -71,13 +117,24 @@ export function ProviderAuthPanel() {
     return PROVIDER_ORDER.map((provider) => {
       const metadata = PROVIDER_METADATA[provider]
       const info = providers[provider]
+      const readinessInfo = firstRunReadiness?.providers?.[provider]
+
       return {
         provider,
         metadata,
-        info,
+        info: {
+          ...info,
+          status: readinessInfo?.status ?? info.status,
+          maskedKey: readinessInfo?.maskedKey ?? info.maskedKey,
+        },
       }
     })
-  }, [providers])
+  }, [firstRunReadiness, providers])
+
+  const activeInfo = useMemo(() => {
+    const row = providerRows.find((providerRow) => providerRow.provider === activeProvider)
+    return row?.info ?? providers?.[activeProvider]
+  }, [activeProvider, providerRows, providers])
 
   const handleSave = async () => {
     const trimmed = apiKeyInput.trim()
@@ -137,6 +194,22 @@ export function ProviderAuthPanel() {
           <p className="mt-1">
             Check file: <span className="font-mono">{AUTH_FILE_DISPLAY_PATH}</span>
           </p>
+        </div>
+      )}
+
+      {readinessNotice && (
+        <div
+          className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-200"
+          data-testid="provider-auth-readiness-notice"
+        >
+          <p>{readinessNotice}</p>
+          {readinessAction && <p className="mt-1 font-medium">Suggested recovery: {readinessAction}</p>}
+        </div>
+      )}
+
+      {startupCheckpoint?.status === 'fail' && startupCheckpoint.failure && (
+        <div className="rounded-md border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+          {buildFirstRunGuidance(startupCheckpoint)}
         </div>
       )}
 

--- a/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
@@ -10,7 +10,10 @@ import {
 } from '@/components/ui/dialog'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import type { FirstRunReadinessSnapshot } from '@shared/types'
 import type { SettingsTabId } from '@/atoms/right-pane'
+import { useReliabilitySnapshot } from '@/atoms/reliability'
+import { buildFirstRunGuidance, getFirstRunCheckpoint } from '@/lib/first-run-readiness'
 import { ProviderAuthPanel } from './ProviderAuthPanel'
 import { SymphonyRuntimePanel } from './SymphonyRuntimePanel'
 import { SymphonyDashboard } from '../symphony/SymphonyDashboard'
@@ -41,6 +44,12 @@ export function shouldShowReturnToWorkflowAction(
   return Boolean(onReturnToWorkflowBoard) && activeTab === 'mcp'
 }
 
+export function formatFirstRunStartupGuidance(
+  readiness: FirstRunReadinessSnapshot | null | undefined,
+): string | null {
+  return buildFirstRunGuidance(getFirstRunCheckpoint(readiness, 'startup'))
+}
+
 export function SettingsPanel({
   open,
   activeTab,
@@ -51,6 +60,8 @@ export function SettingsPanel({
   returnToWorkflowDisabledReason,
 }: SettingsPanelProps) {
   const showReturnToWorkflow = shouldShowReturnToWorkflowAction(activeTab, onReturnToWorkflowBoard)
+  const reliabilitySnapshot = useReliabilitySnapshot()
+  const startupGuidance = formatFirstRunStartupGuidance(reliabilitySnapshot.firstRunReadiness)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -70,6 +81,11 @@ export function SettingsPanel({
               {showReturnToWorkflow && returnToWorkflowDisabledReason ? (
                 <p className="text-xs text-amber-700 dark:text-amber-300" data-testid="settings-return-disabled-reason">
                   {returnToWorkflowDisabledReason}
+                </p>
+              ) : null}
+              {startupGuidance ? (
+                <p className="text-xs text-muted-foreground" data-testid="settings-startup-guidance">
+                  {startupGuidance}
                 </p>
               ) : null}
             </div>

--- a/apps/desktop/src/renderer/components/settings/__tests__/ProviderAuthPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ProviderAuthPanel.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest'
+import {
+  buildProviderAuthReadinessNotice,
+  buildProviderAuthRecoveryAction,
+} from '../ProviderAuthPanel'
+import type { FirstRunReadinessSnapshot } from '@shared/types'
+
+function createReadiness(
+  overrides: Partial<FirstRunReadinessSnapshot['checkpoints']> = {},
+): FirstRunReadinessSnapshot {
+  return {
+    generatedAt: '2026-04-08T00:00:00.000Z',
+    selectedProvider: 'openai',
+    selectedModel: 'openai/gpt-4.1',
+    availableModelCount: 1,
+    completedFirstTurn: false,
+    blockedCheckpoint: 'first_turn',
+    overallStatus: 'blocked',
+    providers: {
+      anthropic: { provider: 'anthropic', status: 'missing', configured: false, requiresKey: true },
+      openai: { provider: 'openai', status: 'valid', configured: true, requiresKey: false },
+      google: { provider: 'google', status: 'missing', configured: false, requiresKey: true },
+      mistral: { provider: 'mistral', status: 'missing', configured: false, requiresKey: true },
+      bedrock: { provider: 'bedrock', status: 'missing', configured: false, requiresKey: true },
+      azure: { provider: 'azure', status: 'missing', configured: false, requiresKey: true },
+    },
+    checkpoints: {
+      auth: { checkpoint: 'auth', status: 'pass' },
+      model: { checkpoint: 'model', status: 'pass' },
+      startup: { checkpoint: 'startup', status: 'pass' },
+      first_turn: {
+        checkpoint: 'first_turn',
+        status: 'fail',
+        failure: {
+          class: 'stale',
+          severity: 'info',
+          code: 'FIRST_TURN_PENDING',
+          message: 'Send your first message to verify end-to-end readiness.',
+          recoveryAction: 'inspect',
+          recoverable: true,
+          timestamp: '2026-04-08T00:00:00.000Z',
+        },
+      },
+      ...overrides,
+    },
+  }
+}
+
+describe('ProviderAuthPanel first-run readiness helpers', () => {
+  test('prefers auth checkpoint message when auth is blocked', () => {
+    const readiness = createReadiness({
+      auth: {
+        checkpoint: 'auth',
+        status: 'fail',
+        failure: {
+          class: 'auth',
+          severity: 'error',
+          code: 'AUTH_PROVIDER_KEY_REQUIRED',
+          message: 'Add a valid OpenAI key.',
+          recoveryAction: 'reauthenticate',
+          recoverable: true,
+          timestamp: '2026-04-08T00:00:00.000Z',
+        },
+      },
+    })
+
+    expect(buildProviderAuthReadinessNotice(readiness)).toBe('Add a valid OpenAI key.')
+    expect(buildProviderAuthRecoveryAction(readiness.checkpoints.auth)).toBe('Update credentials')
+  })
+
+  test('falls back to model checkpoint message when auth passes', () => {
+    const readiness = createReadiness({
+      model: {
+        checkpoint: 'model',
+        status: 'fail',
+        failure: {
+          class: 'config',
+          severity: 'warning',
+          code: 'MODEL_SELECTION_REQUIRED',
+          message: 'Select a model before starting your first productive turn.',
+          recoveryAction: 'inspect',
+          recoverable: true,
+          timestamp: '2026-04-08T00:00:00.000Z',
+        },
+      },
+    })
+
+    expect(buildProviderAuthReadinessNotice(readiness)).toBe(
+      'Select a model before starting your first productive turn.',
+    )
+  })
+
+  test('returns null when no blocked auth/model checkpoints exist', () => {
+    const readiness = createReadiness()
+    expect(buildProviderAuthReadinessNotice(readiness)).toBeNull()
+    expect(buildProviderAuthRecoveryAction(null)).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SettingsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { shouldShowReturnToWorkflowAction } from '../SettingsPanel'
+import { formatFirstRunStartupGuidance, shouldShowReturnToWorkflowAction } from '../SettingsPanel'
 
 describe('SettingsPanel workflow return affordance', () => {
   const noop = () => {}
@@ -12,5 +12,60 @@ describe('SettingsPanel workflow return affordance', () => {
 
   test('hides return-to-workflow action when no callback is provided', () => {
     expect(shouldShowReturnToWorkflowAction('mcp')).toBe(false)
+  })
+
+  test('formats startup guidance from first-run readiness checkpoint', () => {
+    expect(
+      formatFirstRunStartupGuidance({
+        generatedAt: '2026-04-08T00:00:00.000Z',
+        selectedProvider: 'openai',
+        selectedModel: 'openai/gpt-4.1',
+        availableModelCount: 1,
+        completedFirstTurn: false,
+        blockedCheckpoint: 'startup',
+        overallStatus: 'blocked',
+        providers: {
+          anthropic: { provider: 'anthropic', status: 'missing', configured: false, requiresKey: true },
+          openai: { provider: 'openai', status: 'valid', configured: true, requiresKey: false },
+          google: { provider: 'google', status: 'missing', configured: false, requiresKey: true },
+          mistral: { provider: 'mistral', status: 'missing', configured: false, requiresKey: true },
+          bedrock: { provider: 'bedrock', status: 'missing', configured: false, requiresKey: true },
+          azure: { provider: 'azure', status: 'missing', configured: false, requiresKey: true },
+        },
+        checkpoints: {
+          auth: { checkpoint: 'auth', status: 'pass' },
+          model: { checkpoint: 'model', status: 'pass' },
+          startup: {
+            checkpoint: 'startup',
+            status: 'fail',
+            failure: {
+              class: 'process',
+              severity: 'critical',
+              code: 'STARTUP_RUNTIME_CRASHED',
+              message: 'Kata runtime failed to start.',
+              recoveryAction: 'restart_process',
+              recoverable: true,
+              timestamp: '2026-04-08T00:00:00.000Z',
+            },
+          },
+          first_turn: {
+            checkpoint: 'first_turn',
+            status: 'fail',
+            blockedBy: 'startup',
+            failure: {
+              class: 'process',
+              severity: 'warning',
+              code: 'FIRST_TURN_BLOCKED_BY_STARTUP',
+              message: 'First turn blocked by startup.',
+              recoveryAction: 'restart_process',
+              recoverable: true,
+              timestamp: '2026-04-08T00:00:00.000Z',
+            },
+          },
+        },
+      }),
+    ).toContain('Kata runtime failed to start.')
+
+    expect(formatFirstRunStartupGuidance(null)).toBeNull()
   })
 })

--- a/apps/desktop/src/renderer/lib/first-run-readiness.ts
+++ b/apps/desktop/src/renderer/lib/first-run-readiness.ts
@@ -1,0 +1,52 @@
+import type {
+  FirstRunCheckpointId,
+  FirstRunCheckpointState,
+  FirstRunReadinessSnapshot,
+  ReliabilityRecoveryAction,
+} from '@shared/types'
+
+export const FIRST_RUN_CHECKPOINT_LABELS: Record<FirstRunCheckpointId, string> = {
+  auth: 'Auth',
+  model: 'Model',
+  startup: 'Startup',
+  first_turn: 'First turn',
+}
+
+export function formatFirstRunRecoveryAction(action: ReliabilityRecoveryAction): string {
+  switch (action) {
+    case 'fix_config':
+      return 'Fix configuration'
+    case 'reauthenticate':
+      return 'Update credentials'
+    case 'retry_request':
+      return 'Retry request'
+    case 'restart_process':
+      return 'Restart runtime'
+    case 'reconnect':
+      return 'Reconnect service'
+    case 'refresh_state':
+      return 'Refresh state'
+    case 'inspect':
+    default:
+      return 'Inspect diagnostics'
+  }
+}
+
+export function getFirstRunCheckpoint(
+  readiness: FirstRunReadinessSnapshot | null | undefined,
+  checkpoint: FirstRunCheckpointId,
+): FirstRunCheckpointState | null {
+  return readiness?.checkpoints?.[checkpoint] ?? null
+}
+
+export function buildFirstRunGuidance(
+  checkpoint: FirstRunCheckpointState | null | undefined,
+): string | null {
+  if (!checkpoint || checkpoint.status === 'pass' || !checkpoint.failure) {
+    return null
+  }
+
+  return `${checkpoint.failure.message} Recovery: ${formatFirstRunRecoveryAction(
+    checkpoint.failure.recoveryAction,
+  )}.`
+}

--- a/apps/desktop/src/shared/first-run-readiness.ts
+++ b/apps/desktop/src/shared/first-run-readiness.ts
@@ -1,0 +1,445 @@
+import {
+  ALL_AUTH_PROVIDERS,
+  type AuthProvider,
+  type AvailableModel,
+  type BridgeLifecycleState,
+  type FirstRunCheckpointFailure,
+  type FirstRunCheckpointId,
+  type FirstRunCheckpointState,
+  type FirstRunProviderState,
+  type FirstRunProviderStateMap,
+  type FirstRunReadinessSnapshot,
+  type ProviderStatusMap,
+} from './types'
+
+export const FIRST_RUN_CHECKPOINT_ORDER: readonly FirstRunCheckpointId[] = [
+  'auth',
+  'model',
+  'startup',
+  'first_turn',
+]
+
+const PROVIDER_ALIASES: Partial<Record<AuthProvider, string[]>> = {
+  openai: ['openai-codex'],
+}
+
+export class FirstRunInvariantError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FirstRunInvariantError'
+  }
+}
+
+export interface BuildFirstRunReadinessInput {
+  providers: ProviderStatusMap
+  selectedProvider?: AuthProvider | null
+  selectedModel?: string | null
+  availableModels?: AvailableModel[]
+  bridgeStatus?: BridgeLifecycleState
+  completedFirstTurn?: boolean
+  now?: string
+}
+
+function isoNow(value?: string): string {
+  return value?.trim() || new Date().toISOString()
+}
+
+function normalizeProvider(provider: string | null | undefined): AuthProvider | null {
+  const normalized = provider?.trim().toLowerCase()
+  if (!normalized) {
+    return null
+  }
+
+  if (ALL_AUTH_PROVIDERS.includes(normalized as AuthProvider)) {
+    return normalized as AuthProvider
+  }
+
+  for (const canonical of ALL_AUTH_PROVIDERS) {
+    const aliases = PROVIDER_ALIASES[canonical] ?? []
+    if (aliases.includes(normalized)) {
+      return canonical
+    }
+  }
+
+  return null
+}
+
+function normalizeModelProvider(selectedModel: string | null | undefined): AuthProvider | null {
+  const value = selectedModel?.trim()
+  if (!value) {
+    return null
+  }
+
+  const providerSegment = value.split('/')[0]?.trim().toLowerCase()
+  return normalizeProvider(providerSegment)
+}
+
+function toFailure(
+  input: Omit<FirstRunCheckpointFailure, 'recoverable' | 'timestamp'> & {
+    now: string
+    recoverable?: boolean
+  },
+): FirstRunCheckpointFailure {
+  return {
+    class: input.class,
+    severity: input.severity,
+    code: input.code,
+    message: input.message,
+    recoveryAction: input.recoveryAction,
+    recoverable: input.recoverable ?? true,
+    timestamp: input.now,
+    ...(input.detail ? { detail: input.detail } : {}),
+  }
+}
+
+function buildProviderStateMap(providers: ProviderStatusMap): FirstRunProviderStateMap {
+  const entries = ALL_AUTH_PROVIDERS.map((provider) => {
+    const info = providers[provider]
+    const configured = info.status === 'valid'
+    const requiresKey = info.status === 'missing' || info.status === 'invalid' || info.status === 'expired'
+
+    if (configured && requiresKey) {
+      throw new FirstRunInvariantError(
+        `Contradictory provider state for ${provider}: configured cannot require key`,
+      )
+    }
+
+    if (!configured && info.status === 'valid') {
+      throw new FirstRunInvariantError(
+        `Contradictory provider state for ${provider}: valid status requires configured=true`,
+      )
+    }
+
+    const state: FirstRunProviderState = {
+      provider,
+      status: info.status,
+      configured,
+      requiresKey,
+      ...(info.maskedKey ? { maskedKey: info.maskedKey } : {}),
+    }
+
+    return [provider, state] as const
+  })
+
+  return Object.fromEntries(entries) as FirstRunProviderStateMap
+}
+
+function evaluateAuthCheckpoint(
+  providerStates: FirstRunProviderStateMap,
+  selectedProvider: AuthProvider | null,
+  now: string,
+): FirstRunCheckpointState {
+  const configuredProviders = Object.values(providerStates).filter((provider) => provider.configured)
+
+  if (selectedProvider) {
+    const selected = providerStates[selectedProvider]
+    if (selected.requiresKey) {
+      const code =
+        selected.status === 'expired'
+          ? 'AUTH_PROVIDER_EXPIRED'
+          : selected.status === 'invalid'
+            ? 'AUTH_PROVIDER_INVALID'
+            : 'AUTH_PROVIDER_KEY_REQUIRED'
+
+      return {
+        checkpoint: 'auth',
+        status: 'fail',
+        failure: toFailure({
+          class: 'auth',
+          severity: 'error',
+          code,
+          message: `Add a valid ${selectedProvider} key in Settings to continue onboarding.`,
+          recoveryAction: 'reauthenticate',
+          now,
+        }),
+      }
+    }
+  }
+
+  if (configuredProviders.length === 0) {
+    return {
+      checkpoint: 'auth',
+      status: 'fail',
+      failure: toFailure({
+        class: 'auth',
+        severity: 'error',
+        code: 'AUTH_PROVIDER_NOT_CONFIGURED',
+        message: 'No providers are configured. Add an API key to unlock first-run setup.',
+        recoveryAction: 'reauthenticate',
+        now,
+      }),
+    }
+  }
+
+  return {
+    checkpoint: 'auth',
+    status: 'pass',
+  }
+}
+
+function evaluateModelCheckpoint(input: {
+  selectedModel: string | null
+  selectedProvider: AuthProvider | null
+  providerStates: FirstRunProviderStateMap
+  availableModels: AvailableModel[]
+  authCheckpoint: FirstRunCheckpointState
+  now: string
+}): FirstRunCheckpointState {
+  if (input.authCheckpoint.status === 'fail') {
+    return {
+      checkpoint: 'model',
+      status: 'fail',
+      blockedBy: 'auth',
+      failure: toFailure({
+        class: 'auth',
+        severity: 'warning',
+        code: 'MODEL_BLOCKED_BY_AUTH',
+        message: 'Model selection is blocked until provider authentication succeeds.',
+        recoveryAction: 'reauthenticate',
+        now: input.now,
+      }),
+    }
+  }
+
+  const modelProvider = normalizeModelProvider(input.selectedModel)
+  if (modelProvider) {
+    const providerState = input.providerStates[modelProvider]
+    if (!providerState?.configured) {
+      return {
+        checkpoint: 'model',
+        status: 'fail',
+        failure: toFailure({
+          class: 'auth',
+          severity: 'error',
+          code: 'MODEL_PROVIDER_NOT_CONFIGURED',
+          message: `Selected model provider ${modelProvider} is not configured. Add credentials or choose a different model.`,
+          recoveryAction: 'reauthenticate',
+          now: input.now,
+        }),
+      }
+    }
+  }
+
+  if (!input.selectedModel) {
+    return {
+      checkpoint: 'model',
+      status: 'fail',
+      failure: toFailure({
+        class: 'config',
+        severity: 'warning',
+        code: 'MODEL_SELECTION_REQUIRED',
+        message: 'Select a model before starting your first productive turn.',
+        recoveryAction: 'inspect',
+        now: input.now,
+      }),
+    }
+  }
+
+  const selectedModelExists = input.availableModels.some(
+    (model) => `${model.provider}/${model.id}` === input.selectedModel,
+  )
+
+  if (!selectedModelExists) {
+    return {
+      checkpoint: 'model',
+      status: 'fail',
+      failure: toFailure({
+        class: 'config',
+        severity: 'warning',
+        code: 'MODEL_NOT_AVAILABLE',
+        message: 'Selected model is unavailable. Refresh models or choose another model.',
+        recoveryAction: 'retry_request',
+        now: input.now,
+      }),
+    }
+  }
+
+  return {
+    checkpoint: 'model',
+    status: 'pass',
+  }
+}
+
+function evaluateStartupCheckpoint(
+  bridgeStatus: BridgeLifecycleState,
+  now: string,
+): FirstRunCheckpointState {
+  if (bridgeStatus === 'running') {
+    return {
+      checkpoint: 'startup',
+      status: 'pass',
+    }
+  }
+
+  if (bridgeStatus === 'spawning') {
+    return {
+      checkpoint: 'startup',
+      status: 'fail',
+      failure: toFailure({
+        class: 'process',
+        severity: 'warning',
+        code: 'STARTUP_IN_PROGRESS',
+        message: 'Kata runtime is starting. Wait a moment, then retry.',
+        recoveryAction: 'restart_process',
+        now,
+      }),
+    }
+  }
+
+  if (bridgeStatus === 'crashed') {
+    return {
+      checkpoint: 'startup',
+      status: 'fail',
+      failure: toFailure({
+        class: 'process',
+        severity: 'critical',
+        code: 'STARTUP_RUNTIME_CRASHED',
+        message: 'Kata runtime failed to start. Restart the runtime from the chat banner.',
+        recoveryAction: 'restart_process',
+        now,
+      }),
+    }
+  }
+
+  return {
+    checkpoint: 'startup',
+    status: 'fail',
+    failure: toFailure({
+      class: 'process',
+      severity: 'error',
+      code: 'STARTUP_RUNTIME_NOT_READY',
+      message: 'Kata runtime is not ready. Start or restart the runtime to continue.',
+      recoveryAction: 'restart_process',
+      now,
+    }),
+  }
+}
+
+function evaluateFirstTurnCheckpoint(input: {
+  completedFirstTurn: boolean
+  authCheckpoint: FirstRunCheckpointState
+  modelCheckpoint: FirstRunCheckpointState
+  startupCheckpoint: FirstRunCheckpointState
+  now: string
+}): FirstRunCheckpointState {
+  if (input.authCheckpoint.status === 'fail') {
+    return {
+      checkpoint: 'first_turn',
+      status: 'fail',
+      blockedBy: 'auth',
+      failure: toFailure({
+        class: 'auth',
+        severity: 'warning',
+        code: 'FIRST_TURN_BLOCKED_BY_AUTH',
+        message: 'First turn is blocked until provider authentication succeeds.',
+        recoveryAction: 'reauthenticate',
+        now: input.now,
+      }),
+    }
+  }
+
+  if (input.modelCheckpoint.status === 'fail') {
+    return {
+      checkpoint: 'first_turn',
+      status: 'fail',
+      blockedBy: 'model',
+      failure: toFailure({
+        class: 'config',
+        severity: 'warning',
+        code: 'FIRST_TURN_BLOCKED_BY_MODEL',
+        message: 'First turn is blocked until a valid model is selected.',
+        recoveryAction: 'inspect',
+        now: input.now,
+      }),
+    }
+  }
+
+  if (input.startupCheckpoint.status === 'fail') {
+    return {
+      checkpoint: 'first_turn',
+      status: 'fail',
+      blockedBy: 'startup',
+      failure: toFailure({
+        class: 'process',
+        severity: 'warning',
+        code: 'FIRST_TURN_BLOCKED_BY_STARTUP',
+        message: 'First turn is blocked until runtime startup completes.',
+        recoveryAction: 'restart_process',
+        now: input.now,
+      }),
+    }
+  }
+
+  if (input.completedFirstTurn) {
+    return {
+      checkpoint: 'first_turn',
+      status: 'pass',
+    }
+  }
+
+  return {
+    checkpoint: 'first_turn',
+    status: 'fail',
+    failure: toFailure({
+      class: 'stale',
+      severity: 'info',
+      code: 'FIRST_TURN_PENDING',
+      message: 'Send your first message to verify end-to-end readiness.',
+      recoveryAction: 'inspect',
+      now: input.now,
+    }),
+  }
+}
+
+export function buildFirstRunReadinessSnapshot(
+  input: BuildFirstRunReadinessInput,
+): FirstRunReadinessSnapshot {
+  const now = isoNow(input.now)
+  const selectedProvider = input.selectedProvider ?? null
+  const selectedModel = input.selectedModel?.trim() || null
+  const availableModels = input.availableModels ?? []
+  const bridgeStatus = input.bridgeStatus ?? 'shutdown'
+  const completedFirstTurn = input.completedFirstTurn ?? false
+
+  const providers = buildProviderStateMap(input.providers)
+
+  const authCheckpoint = evaluateAuthCheckpoint(providers, selectedProvider, now)
+  const modelCheckpoint = evaluateModelCheckpoint({
+    selectedModel,
+    selectedProvider,
+    providerStates: providers,
+    availableModels,
+    authCheckpoint,
+    now,
+  })
+  const startupCheckpoint = evaluateStartupCheckpoint(bridgeStatus, now)
+  const firstTurnCheckpoint = evaluateFirstTurnCheckpoint({
+    completedFirstTurn,
+    authCheckpoint,
+    modelCheckpoint,
+    startupCheckpoint,
+    now,
+  })
+
+  const checkpoints: Record<FirstRunCheckpointId, FirstRunCheckpointState> = {
+    auth: authCheckpoint,
+    model: modelCheckpoint,
+    startup: startupCheckpoint,
+    first_turn: firstTurnCheckpoint,
+  }
+
+  const blockedCheckpoint =
+    FIRST_RUN_CHECKPOINT_ORDER.find((checkpoint) => checkpoints[checkpoint].status === 'fail') ?? null
+
+  return {
+    generatedAt: now,
+    providers,
+    selectedProvider,
+    selectedModel,
+    availableModelCount: availableModels.length,
+    completedFirstTurn,
+    checkpoints,
+    blockedCheckpoint,
+    overallStatus: blockedCheckpoint ? 'blocked' : 'ready',
+  }
+}

--- a/apps/desktop/src/shared/first-run-readiness.ts
+++ b/apps/desktop/src/shared/first-run-readiness.ts
@@ -104,12 +104,6 @@ function buildProviderStateMap(providers: ProviderStatusMap): FirstRunProviderSt
       )
     }
 
-    if (!configured && info.status === 'valid') {
-      throw new FirstRunInvariantError(
-        `Contradictory provider state for ${provider}: valid status requires configured=true`,
-      )
-    }
-
     const state: FirstRunProviderState = {
       provider,
       status: info.status,
@@ -313,6 +307,14 @@ function evaluateStartupCheckpoint(
       now,
     }),
   }
+}
+
+export function normalizeFirstRunStartupCheckpoint(input: {
+  bridgeStatus: BridgeLifecycleState
+  now?: string
+}): FirstRunCheckpointState {
+  const now = isoNow(input.now)
+  return evaluateStartupCheckpoint(input.bridgeStatus, now)
 }
 
 function evaluateFirstTurnCheckpoint(input: {

--- a/apps/desktop/src/shared/first-run-readiness.ts
+++ b/apps/desktop/src/shared/first-run-readiness.ts
@@ -71,6 +71,27 @@ function normalizeModelProvider(selectedModel: string | null | undefined): AuthP
   return normalizeProvider(providerSegment)
 }
 
+function normalizeModelKey(modelRef: string | null | undefined): string | null {
+  const value = modelRef?.trim()
+  if (!value) {
+    return null
+  }
+
+  const separatorIndex = value.indexOf('/')
+  if (separatorIndex < 0) {
+    return value.toLowerCase()
+  }
+
+  const providerSegment = value.slice(0, separatorIndex).trim()
+  const modelId = value.slice(separatorIndex + 1).trim()
+  if (!providerSegment || !modelId) {
+    return null
+  }
+
+  const canonicalProvider = normalizeProvider(providerSegment) ?? providerSegment.toLowerCase()
+  return `${canonicalProvider}/${modelId}`
+}
+
 function toFailure(
   input: Omit<FirstRunCheckpointFailure, 'recoverable' | 'timestamp'> & {
     now: string
@@ -226,8 +247,13 @@ function evaluateModelCheckpoint(input: {
     }
   }
 
-  const selectedModelExists = input.availableModels.some(
-    (model) => `${model.provider}/${model.id}` === input.selectedModel,
+  const normalizedSelectedModel = normalizeModelKey(input.selectedModel)
+  const selectedModelExists = Boolean(
+    normalizedSelectedModel &&
+      input.availableModels.some((model) => {
+        const availableModelKey = normalizeModelKey(`${model.provider}/${model.id}`)
+        return availableModelKey === normalizedSelectedModel
+      }),
   )
 
   if (!selectedModelExists) {

--- a/apps/desktop/src/shared/first-run-readiness.ts
+++ b/apps/desktop/src/shared/first-run-readiness.ts
@@ -1,5 +1,6 @@
 import {
   ALL_AUTH_PROVIDERS,
+  AUTH_PROVIDER_ALIASES,
   type AuthProvider,
   type AvailableModel,
   type BridgeLifecycleState,
@@ -18,10 +19,6 @@ export const FIRST_RUN_CHECKPOINT_ORDER: readonly FirstRunCheckpointId[] = [
   'startup',
   'first_turn',
 ]
-
-const PROVIDER_ALIASES: Partial<Record<AuthProvider, string[]>> = {
-  openai: ['openai-codex'],
-}
 
 export class FirstRunInvariantError extends Error {
   constructor(message: string) {
@@ -55,7 +52,7 @@ function normalizeProvider(provider: string | null | undefined): AuthProvider | 
   }
 
   for (const canonical of ALL_AUTH_PROVIDERS) {
-    const aliases = PROVIDER_ALIASES[canonical] ?? []
+    const aliases = AUTH_PROVIDER_ALIASES[canonical] ?? []
     if (aliases.includes(normalized)) {
       return canonical
     }

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -75,6 +75,14 @@ export const ALL_AUTH_PROVIDERS = [
 
 export type AuthProvider = (typeof ALL_AUTH_PROVIDERS)[number]
 
+/**
+ * Auth.json can contain provider entries under alias keys.
+ * Canonical provider -> accepted alias keys.
+ */
+export const AUTH_PROVIDER_ALIASES: Partial<Record<AuthProvider, string[]>> = {
+  openai: ['openai-codex'],
+}
+
 export type ProviderStatus = 'valid' | 'missing' | 'expired' | 'invalid'
 
 export type ProviderAuthType = 'api_key' | 'oauth'

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1350,6 +1350,7 @@ export interface ReliabilitySnapshot {
   generatedAt: string
   overallStatus: 'healthy' | 'degraded'
   surfaces: ReliabilitySurfaceState[]
+  firstRunReadiness?: FirstRunReadinessSnapshot
 }
 
 export interface ReliabilityStatusResponse {
@@ -1370,6 +1371,50 @@ export interface ReliabilityRecoveryResult {
   code: string
   message: string
   timestamp: string
+}
+
+export type FirstRunCheckpointId = 'auth' | 'model' | 'startup' | 'first_turn'
+
+export type FirstRunCheckpointStatus = 'pass' | 'fail'
+
+export interface FirstRunCheckpointFailure {
+  class: ReliabilityClass
+  severity: ReliabilitySeverity
+  code: string
+  message: string
+  recoveryAction: ReliabilityRecoveryAction
+  recoverable: boolean
+  timestamp: string
+  detail?: string
+}
+
+export interface FirstRunCheckpointState {
+  checkpoint: FirstRunCheckpointId
+  status: FirstRunCheckpointStatus
+  blockedBy?: FirstRunCheckpointId
+  failure?: FirstRunCheckpointFailure
+}
+
+export interface FirstRunProviderState {
+  provider: AuthProvider
+  status: ProviderStatus
+  configured: boolean
+  requiresKey: boolean
+  maskedKey?: string
+}
+
+export type FirstRunProviderStateMap = Record<AuthProvider, FirstRunProviderState>
+
+export interface FirstRunReadinessSnapshot {
+  generatedAt: string
+  providers: FirstRunProviderStateMap
+  selectedProvider: AuthProvider | null
+  selectedModel: string | null
+  availableModelCount: number
+  completedFirstTurn: boolean
+  checkpoints: Record<FirstRunCheckpointId, FirstRunCheckpointState>
+  blockedCheckpoint: FirstRunCheckpointId | null
+  overallStatus: 'ready' | 'blocked'
 }
 
 export type ArtifactType = 'roadmap' | 'requirements' | 'decisions' | 'context' | 'slice'


### PR DESCRIPTION
## Summary
- establish a canonical first-run readiness contract (auth, model, startup, first_turn) shared across main-process bridges and renderer surfaces
- align onboarding, settings, and model selector state + recovery UX so provider/model/setup truth does not diverge by surface
- add deterministic first-run packaged-like coverage for happy path and representative failure/recovery paths
- capture S02 first-run smoke, UAT report, and downstream handoff artifacts for M006

## Task coverage
- [x] KAT-2408 T01
- [x] KAT-2409 T02
- [x] KAT-2410 T03
- [x] KAT-2411 T04

## Validation
- cd apps/desktop && npx vitest run src/main/__tests__/auth-bridge.test.ts src/main/__tests__/pi-agent-bridge.test.ts src/main/__tests__/runtime-health-aggregator.test.ts src/renderer/components/settings/__tests__/SettingsPanel.test.tsx src/renderer/components/settings/__tests__/ProviderAuthPanel.test.tsx src/renderer/components/app-shell/__tests__/ModelSelector.test.tsx
- cd apps/desktop && bun run typecheck
- cd apps/desktop && npx playwright test e2e/tests/onboarding.e2e.ts e2e/tests/first-run-beta-readiness.e2e.ts
- cd apps/desktop && npx playwright test e2e/tests/first-run-beta-readiness.e2e.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added first-run readiness tracking with real-time status monitoring for authentication, model selection, runtime startup, and chat session initiation.
  * Enhanced onboarding wizard with contextual guidance for authentication and model configuration failures, plus a completion checkpoint summary.
  * Added readiness notices in the model selector and settings panel to alert users of runtime or configuration issues with recovery suggestions.

* **Improvements**
  * Improved error messaging and recovery actions during initial setup to guide users through auth, model, and startup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes a canonical first-run readiness contract (`FirstRunReadinessSnapshot`) shared across the main-process aggregator and renderer surfaces, aligning onboarding, settings, and model selector UX around a single source of truth for auth/model/startup/first_turn checkpoints.

The core architecture — shared `buildFirstRunReadinessSnapshot`, three dedicated normalizers, `RuntimeHealthAggregator` ingestion methods — is solid and the test coverage is thorough. All remaining findings are P2 style/maintainability concerns with no current behavioral impact.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/maintainability concerns with no current behavioral impact

The three P2 findings (dead invariant guard, redundant 4× snapshot computation, fragile first_turn override pattern) are all correctness-neutral under current inputs and do not affect the primary user path. The architecture is sound, the test coverage is thorough, and the renderer integration is clean.

apps/desktop/src/shared/first-run-readiness.ts (dead invariant) and apps/desktop/src/main/runtime-health-aggregator.ts (redundant computation + first_turn coupling)

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The new `KATA_DESKTOP_AUTH_FILE_PATH` env-var override is trimmed before use and is only set by the test harness, not exposed to user input.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/shared/first-run-readiness.ts | New shared module implementing `buildFirstRunReadinessSnapshot`; contains a dead invariant guard that can never throw (second `if` in `buildProviderStateMap` is logically always false) |
| apps/desktop/src/shared/types.ts | Adds FirstRun* types and extends `ReliabilitySnapshot` with optional `firstRunReadiness`; clean additions with no issues |
| apps/desktop/src/main/runtime-health-aggregator.ts | Adds first-run ingestion methods and `recomputeFirstRunReadiness`; calls `buildFirstRunReadinessSnapshot` 4× per recompute, and `first_turn` is evaluated against pre-override checkpoints — both are P2 style concerns |
| apps/desktop/src/main/auth-bridge.ts | Adds `normalizeFirstRunAuthReadiness` helper and `KATA_DESKTOP_AUTH_FILE_PATH` env-var override for the auth file path; correct and well-tested |
| apps/desktop/src/main/pi-agent-bridge.ts | Adds `normalizeFirstRunModelReadiness` and `normalizeFirstRunStartupReadiness`; startup normalizer accepts unnecessary parameters that have no effect on the returned checkpoint |
| apps/desktop/src/main/ipc.ts | Wires auth/model/bridge/first-turn state changes to the aggregator; `agent_end` detection correctly triggers first-turn completion; clean integration |
| apps/desktop/src/renderer/lib/first-run-readiness.ts | Renderer-side helpers for checkpoint extraction and guidance formatting; straightforward and well-structured |
| apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx | Adds readiness notice banner with retry action driven by startup/model checkpoints; clean integration with reliability snapshot atom |
| apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx | Merges first-run readiness provider state with live provider data for display; recovery notice and action correctly prioritize auth checkpoint over model checkpoint |
| apps/desktop/e2e/fixtures/electron.fixture.ts | Adds `firstRunProfileMode` and `firstRunStartupMode` fixtures; mock binary is now always created (previously only on `process_crash_once`), making tests more deterministic |
| apps/desktop/e2e/tests/first-run-beta-readiness.e2e.ts | New E2E tests covering happy-path first-turn completion, auth failure guidance, and startup degradation legibility; well-structured with clear fixture usage |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant IPC as ipc.ts (main)
    participant RHA as RuntimeHealthAggregator
    participant BFR as buildFirstRunReadinessSnapshot
    participant Renderer as Renderer (reliability atom)

    IPC->>RHA: ingestFirstRunAuthState(providers)
    RHA->>BFR: normalizeFirstRunAuthReadiness → auth checkpoint
    RHA->>BFR: normalizeFirstRunModelReadiness → model checkpoint
    RHA->>BFR: normalizeFirstRunStartupReadiness → startup checkpoint
    RHA->>BFR: buildFirstRunReadinessSnapshot (all inputs) → full snapshot
    RHA->>RHA: compose checkpoints (override auth/model/startup, keep first_turn)
    RHA-->>IPC: emit snapshot

    IPC->>RHA: ingestFirstRunModelState(selectedModel, availableModels)
    RHA->>BFR: (same 4-call recompute)
    RHA-->>Renderer: snapshot via reliability:status IPC push

    IPC->>RHA: ingestChatBridgeStatus(running)
    RHA->>BFR: (same 4-call recompute)
    RHA-->>Renderer: snapshot updated

    IPC->>RHA: ingestFirstTurnCompletion(true) [on agent_end]
    RHA->>BFR: (same 4-call recompute)
    RHA-->>Renderer: firstRunReadiness.overallStatus = ready

    Renderer->>Renderer: ModelSelector shows/hides readiness notice
    Renderer->>Renderer: ProviderAuthPanel merges readiness provider state
    Renderer->>Renderer: CompletionStep renders checkpoint summary
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/shared/first-run-readiness.ts
Line: 107-111

Comment:
**Dead invariant guard — can never throw**

`configured` is defined as `info.status === 'valid'`, so `!configured` is `info.status !== 'valid'`. The condition `!configured && info.status === 'valid'` therefore reduces to `false` at all times and this branch is unreachable dead code. The intended guard (catching a state where the upstream status is `'valid'` but `configured` was set incorrectly) can never fire because `configured` is derived directly from `info.status`.

If this was meant to guard against a case where `configured` could be `false` while `info.status === 'valid'` (e.g. if `configured` were calculated separately), the condition should be removed — the first check (`configured && requiresKey`) already covers contradictory states, and `configured` is always the truth-bearer of `info.status === 'valid'`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/runtime-health-aggregator.ts
Line: 386-421

Comment:
**`buildFirstRunReadinessSnapshot` called 4× per recompute**

Each of the three normalizer functions (`normalizeFirstRunAuthReadiness`, `normalizeFirstRunModelReadiness`, `normalizeFirstRunStartupReadiness`) internally calls `buildFirstRunReadinessSnapshot` — evaluating all four checkpoints — and returns only one. Then there is a fourth direct call. Since all four invocations receive the same inputs, the auth/model/startup checkpoints from the normalizers are identical to those already inside `snapshot.checkpoints`.

`recomputeFirstRunReadiness` is called on every auth, model, bridge, and turn state change. Each call builds four full snapshots where one would suffice. The `first_turn` checkpoint and the non-checkpoint metadata fields could simply be taken from the single direct call, making the three normalizer calls inside this method redundant (the exported normalizers remain useful for tests and individual IPC handlers).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/runtime-health-aggregator.ts
Line: 422-441

Comment:
**`first_turn` evaluated against pre-override checkpoints**

`snapshot.checkpoints.first_turn` (from the direct call to `buildFirstRunReadinessSnapshot`) is computed against the auth/model/startup checkpoints produced *inside* that same call. The final `checkpoints` object then overrides auth/model/startup with the normalizer values. In practice these produce identical values because `bridgeStatus` does not affect auth or model, so the normalizers' outputs match the direct-call outputs — but the coupling is implicit and fragile.

If a future normalizer diverges (e.g. overrides the auth checkpoint based on additional signals), the `first_turn` status could disagree with the auth/model/startup values in the same `checkpoints` map. A safer pattern is to compute `first_turn` after the overrides are applied, so it is always evaluated against the canonical final checkpoint states.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/pi-agent-bridge.ts
Line: 78-97

Comment:
**`normalizeFirstRunStartupReadiness` accepts unnecessary parameters**

`evaluateStartupCheckpoint` (called inside `buildFirstRunReadinessSnapshot`) depends solely on `bridgeStatus`. The `providers`, `selectedProvider`, `selectedModel`, and `availableModels` parameters passed here have no effect on the returned startup checkpoint. Accepting them makes the function signature misleading and encourages callers to pass all state when only the bridge lifecycle matters.

Consider narrowing the signature to just `{ bridgeStatus, now? }` and calling `evaluateStartupCheckpoint` directly (or exposing it), which also avoids the four-snapshot overhead noted above.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(desktop): capture S02 first-run smo..."](https://github.com/gannonh/kata/commit/98b348d4d8d10195e9e5de657774e349012f44d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27744740)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->