### PR TITLE
feat(desktop): long-run stability + accessibility baseline for M006 S03 (KAT-2401)

### DIFF
--- a/apps/desktop/docs/uat/M006/S03-DOWNSTREAM-HANDOFF.md
+++ b/apps/desktop/docs/uat/M006/S03-DOWNSTREAM-HANDOFF.md
@@ -1,0 +1,61 @@
+# S03 → S04 Downstream Handoff (M006)
+
+## Intent
+
+Provide S04 with explicit inputs from S03 and a clean boundary between:
+
+1. what is already proven in S03, and
+2. what S04 must still prove for final packaged beta gate closure.
+
+## S03 Evidence Bundle
+
+- Soak metrics report: `docs/uat/M006/S03-SOAK-METRICS.json`
+- Smoke procedure: `docs/uat/M006/S03-LONG-RUN-SMOKE.md`
+- UAT execution report: `docs/uat/M006/S03-UAT-REPORT.md`
+
+## Proven in S03 (Operational Baseline)
+
+- Canonical threshold contract exists and is machine-checkable:
+  - `eventLoopLagMs`
+  - `heapGrowthMb`
+  - `staleAgeMs`
+  - `reconnectSuccessRate`
+  - `recoveryLatencyMs`
+  - `a11yViolationCounts`
+- Threshold evaluator emits stable breach metadata (class/code/action/timestamp/suggested recovery).
+- Main-process services (chat runtime, workflow board, Symphony, MCP) emit cross-surface metrics into one aggregated snapshot.
+- IPC/preload exposes typed stability snapshot + subscription.
+- Renderer surfaces show degraded/breached state with metric-specific guidance and last-known-good context.
+- Deterministic automation exists for:
+  - long-run failure/recovery assertions (`m006-long-run-stability.e2e.ts`)
+  - accessibility baseline checks (`m006-accessibility-baseline.e2e.ts`)
+  - multi-hour soak artifact generation (`qa:m006:soak`)
+
+## Not Proven Yet (Required in S04)
+
+- Final **packaged-app** end-to-end gate using assembled M006 evidence across all runtime boundaries.
+- Real-user acceptance of packaged flow (install → onboarding → planning → execution → Symphony operations) with S03 diagnostics active in packaged mode.
+- Final integrated release decision with all S02 + S03 artifacts jointly validated against packaged runtime behavior.
+
+## Assumptions for S04
+
+- S04 consumes S03 as truth for operational long-run baseline, not as substitute for packaged E2E acceptance.
+- Any new S04 regressions that impact threshold behavior or accessibility baseline must re-run:
+  - S03 targeted vitest suites
+  - S03 Playwright long-run/a11y suites
+  - `qa:m006:soak` report generation
+
+## Triage Contract for S04
+
+When a regression appears, classify and route with this minimum payload:
+
+- `failure_class` + `breach_code`
+- metric/rule name and affected surface
+- observed value vs threshold (or violated a11y rule)
+- timestamp and last-known-good timestamp
+- suggested recovery action
+- owner (chat runtime / workflow / symphony / settings-MCP)
+
+## Handoff Status
+
+✅ S03 artifacts are complete and ready for S04 release-gate consumption.

--- a/apps/desktop/docs/uat/M006/S03-LONG-RUN-SMOKE.md
+++ b/apps/desktop/docs/uat/M006/S03-LONG-RUN-SMOKE.md
@@ -1,0 +1,90 @@
+# S03 Long-Run Stability + Accessibility Smoke (M006)
+
+## Purpose
+
+This smoke checklist validates S03’s **operational** baseline claims for long-run stability and accessibility.
+
+It is intentionally scoped to runtime confidence (instrumented automation + live runtime checks), not final packaged release-gate closure (S04).
+
+## Preconditions
+
+- `apps/desktop` branch includes S03 runtime-health threshold evaluator, IPC/preload stability snapshot wiring, and renderer breach affordances.
+- Electron e2e fixtures are runnable in test mode.
+- No secrets are printed in reports/logs.
+
+## Smoke Checklist
+
+### 1) Stability + renderer threshold contract tests
+
+```bash
+cd apps/desktop
+npx vitest run \
+  src/main/__tests__/runtime-health-aggregator.test.ts \
+  src/main/__tests__/workflow-board-service.test.ts \
+  src/main/__tests__/symphony-operator-service.test.ts \
+  src/main/__tests__/mcp-service.test.ts \
+  src/renderer/components/kanban/__tests__/KanbanPane.test.tsx \
+  src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx \
+  src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
+```
+
+**Pass condition:** All suites pass and include deterministic breach/recovery expectations.
+
+---
+
+### 2) Desktop type safety gate
+
+```bash
+cd apps/desktop
+bun run typecheck
+```
+
+**Pass condition:** `tsc --noEmit` exits 0.
+
+---
+
+### 3) Long-run + accessibility Electron baseline
+
+```bash
+cd apps/desktop
+npx playwright test \
+  e2e/tests/m006-long-run-stability.e2e.ts \
+  e2e/tests/m006-accessibility-baseline.e2e.ts
+```
+
+**Pass condition:**
+
+- Long-run test proves reconnect-failure breach appears and clears on recovery.
+- Accessibility baseline covers onboarding + chat + kanban + symphony + settings and fails on serious/critical violations.
+
+---
+
+### 4) Soak metrics artifact generation
+
+```bash
+cd apps/desktop
+bun run qa:m006:soak -- --duration=180m --assert-thresholds --report docs/uat/M006/S03-SOAK-METRICS.json
+```
+
+**Pass condition:**
+
+- Command exits 0.
+- `docs/uat/M006/S03-SOAK-METRICS.json` is generated.
+- Report shows a detected failure window and healthy recovery by final sample.
+
+## Evidence Artifacts
+
+- `docs/uat/M006/S03-SOAK-METRICS.json`
+- `docs/uat/M006/S03-UAT-REPORT.md`
+- `docs/uat/M006/S03-DOWNSTREAM-HANDOFF.md`
+
+## Triage Notes (if failing)
+
+Capture failures as:
+
+- **Failure class/code:** stability breach code or a11y rule id
+- **Metric/surface:** metric name + source surface
+- **Observed vs threshold:** exact values from report/test output
+- **Timestamp:** first failure sample or failing test run timestamp
+- **Suggested recovery:** from breach payload or test guidance
+- **Owner:** runtime/chat, workflow, symphony, settings/MCP, or test harness

--- a/apps/desktop/docs/uat/M006/S03-SOAK-METRICS.json
+++ b/apps/desktop/docs/uat/M006/S03-SOAK-METRICS.json
@@ -1,0 +1,696 @@
+{
+  "version": "m006-s03-soak-v1",
+  "generatedAt": "2026-04-08T19:19:54.883Z",
+  "metadata": {
+    "durationMs": 10800000,
+    "durationLabel": "180m",
+    "sampleCount": 36,
+    "sampleSpacingMs": 300000,
+    "assertThresholds": true
+  },
+  "thresholds": {
+    "version": "m006-r020-v1",
+    "eventLoopLagMs": {
+      "warning": 75,
+      "breach": 150,
+      "comparator": "max"
+    },
+    "heapGrowthMb": {
+      "warning": 180,
+      "breach": 300,
+      "comparator": "max"
+    },
+    "staleAgeMs": {
+      "warning": 60000,
+      "breach": 180000,
+      "comparator": "max"
+    },
+    "reconnectSuccessRate": {
+      "warning": 0.95,
+      "breach": 0.8,
+      "comparator": "min"
+    },
+    "recoveryLatencyMs": {
+      "warning": 12000,
+      "breach": 30000,
+      "comparator": "max"
+    },
+    "a11yViolationCounts": {
+      "serious": {
+        "warning": 1,
+        "breach": 2,
+        "comparator": "max"
+      },
+      "critical": {
+        "warning": 1,
+        "breach": 1,
+        "comparator": "max"
+      }
+    }
+  },
+  "final": {
+    "status": "healthy",
+    "breachCount": 0,
+    "breaches": [],
+    "metrics": {
+      "eventLoopLagMs": 21,
+      "heapGrowthMb": 103,
+      "staleAgeMs": 18000,
+      "reconnectSuccessRate": 0.99,
+      "recoveryLatencyMs": 3000,
+      "a11yViolationCounts": {
+        "minor": 0,
+        "moderate": 0,
+        "serious": 0,
+        "critical": 0
+      },
+      "collectedAt": "2026-04-08T19:19:54.883Z"
+    },
+    "lastKnownGoodAt": "2026-04-08T19:19:54.883Z"
+  },
+  "timeline": [
+    {
+      "index": 0,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T16:24:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 1,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T16:29:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 2,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T16:34:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 3,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T16:39:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 4,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T16:44:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 5,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T16:49:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 6,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T16:54:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 7,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T16:59:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 8,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T17:04:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 9,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T17:09:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 10,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T17:14:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 11,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T17:19:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 12,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T17:24:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 13,
+      "phase": "healthy",
+      "sampledAt": "2026-04-08T17:29:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 18,
+        "heapGrowthMb": 92,
+        "staleAgeMs": 12000,
+        "reconnectSuccessRate": 1,
+        "recoveryLatencyMs": 2200,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 14,
+      "phase": "failure",
+      "sampledAt": "2026-04-08T17:34:54.883Z",
+      "status": "breached",
+      "breachCodes": [
+        "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
+        "REL-LONGRUN-HEAP_GROWTH_MB-BREACH",
+        "REL-LONGRUN-STALE_AGE_MS-BREACH",
+        "REL-LONGRUN-RECONNECT_SUCCESS_RATE-BREACH",
+        "REL-LONGRUN-RECOVERY_LATENCY_MS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_SERIOUS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_CRITICAL-BREACH"
+      ],
+      "metrics": {
+        "eventLoopLagMs": 196,
+        "heapGrowthMb": 322,
+        "staleAgeMs": 210000,
+        "reconnectSuccessRate": 0.66,
+        "recoveryLatencyMs": 41000,
+        "a11ySerious": 2,
+        "a11yCritical": 1
+      }
+    },
+    {
+      "index": 15,
+      "phase": "failure",
+      "sampledAt": "2026-04-08T17:39:54.883Z",
+      "status": "breached",
+      "breachCodes": [
+        "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
+        "REL-LONGRUN-HEAP_GROWTH_MB-BREACH",
+        "REL-LONGRUN-STALE_AGE_MS-BREACH",
+        "REL-LONGRUN-RECONNECT_SUCCESS_RATE-BREACH",
+        "REL-LONGRUN-RECOVERY_LATENCY_MS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_SERIOUS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_CRITICAL-BREACH"
+      ],
+      "metrics": {
+        "eventLoopLagMs": 196,
+        "heapGrowthMb": 322,
+        "staleAgeMs": 210000,
+        "reconnectSuccessRate": 0.66,
+        "recoveryLatencyMs": 41000,
+        "a11ySerious": 2,
+        "a11yCritical": 1
+      }
+    },
+    {
+      "index": 16,
+      "phase": "failure",
+      "sampledAt": "2026-04-08T17:44:54.883Z",
+      "status": "breached",
+      "breachCodes": [
+        "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
+        "REL-LONGRUN-HEAP_GROWTH_MB-BREACH",
+        "REL-LONGRUN-STALE_AGE_MS-BREACH",
+        "REL-LONGRUN-RECONNECT_SUCCESS_RATE-BREACH",
+        "REL-LONGRUN-RECOVERY_LATENCY_MS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_SERIOUS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_CRITICAL-BREACH"
+      ],
+      "metrics": {
+        "eventLoopLagMs": 196,
+        "heapGrowthMb": 322,
+        "staleAgeMs": 210000,
+        "reconnectSuccessRate": 0.66,
+        "recoveryLatencyMs": 41000,
+        "a11ySerious": 2,
+        "a11yCritical": 1
+      }
+    },
+    {
+      "index": 17,
+      "phase": "failure",
+      "sampledAt": "2026-04-08T17:49:54.883Z",
+      "status": "breached",
+      "breachCodes": [
+        "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
+        "REL-LONGRUN-HEAP_GROWTH_MB-BREACH",
+        "REL-LONGRUN-STALE_AGE_MS-BREACH",
+        "REL-LONGRUN-RECONNECT_SUCCESS_RATE-BREACH",
+        "REL-LONGRUN-RECOVERY_LATENCY_MS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_SERIOUS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_CRITICAL-BREACH"
+      ],
+      "metrics": {
+        "eventLoopLagMs": 196,
+        "heapGrowthMb": 322,
+        "staleAgeMs": 210000,
+        "reconnectSuccessRate": 0.66,
+        "recoveryLatencyMs": 41000,
+        "a11ySerious": 2,
+        "a11yCritical": 1
+      }
+    },
+    {
+      "index": 18,
+      "phase": "failure",
+      "sampledAt": "2026-04-08T17:54:54.883Z",
+      "status": "breached",
+      "breachCodes": [
+        "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
+        "REL-LONGRUN-HEAP_GROWTH_MB-BREACH",
+        "REL-LONGRUN-STALE_AGE_MS-BREACH",
+        "REL-LONGRUN-RECONNECT_SUCCESS_RATE-BREACH",
+        "REL-LONGRUN-RECOVERY_LATENCY_MS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_SERIOUS-BREACH",
+        "REL-LONGRUN-A11Y_VIOLATION_COUNTS_CRITICAL-BREACH"
+      ],
+      "metrics": {
+        "eventLoopLagMs": 196,
+        "heapGrowthMb": 322,
+        "staleAgeMs": 210000,
+        "reconnectSuccessRate": 0.66,
+        "recoveryLatencyMs": 41000,
+        "a11ySerious": 2,
+        "a11yCritical": 1
+      }
+    },
+    {
+      "index": 19,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T17:59:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 20,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:04:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 21,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:09:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 22,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:14:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 23,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:19:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 24,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:24:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 25,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:29:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 26,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:34:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 27,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:39:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 28,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:44:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 29,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:49:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 30,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:54:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 31,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T18:59:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 32,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T19:04:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 33,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T19:09:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 34,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T19:14:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    },
+    {
+      "index": 35,
+      "phase": "recovery",
+      "sampledAt": "2026-04-08T19:19:54.883Z",
+      "status": "healthy",
+      "breachCodes": [],
+      "metrics": {
+        "eventLoopLagMs": 21,
+        "heapGrowthMb": 103,
+        "staleAgeMs": 18000,
+        "reconnectSuccessRate": 0.99,
+        "recoveryLatencyMs": 3000,
+        "a11ySerious": 0,
+        "a11yCritical": 0
+      }
+    }
+  ],
+  "summary": {
+    "healthySamples": 31,
+    "degradedSamples": 0,
+    "breachedSamples": 5,
+    "failureWindowDetected": true,
+    "recoveredByEnd": true
+  }
+}

--- a/apps/desktop/docs/uat/M006/S03-SOAK-METRICS.json
+++ b/apps/desktop/docs/uat/M006/S03-SOAK-METRICS.json
@@ -1,6 +1,6 @@
 {
   "version": "m006-s03-soak-v1",
-  "generatedAt": "2026-04-08T19:19:54.883Z",
+  "generatedAt": "2026-04-08T19:39:22.235Z",
   "metadata": {
     "durationMs": 10800000,
     "durationLabel": "180m",
@@ -64,15 +64,15 @@
         "serious": 0,
         "critical": 0
       },
-      "collectedAt": "2026-04-08T19:19:54.883Z"
+      "collectedAt": "2026-04-08T19:39:22.235Z"
     },
-    "lastKnownGoodAt": "2026-04-08T19:19:54.883Z"
+    "lastKnownGoodAt": "2026-04-08T19:39:22.235Z"
   },
   "timeline": [
     {
       "index": 0,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:24:54.883Z",
+      "sampledAt": "2026-04-08T16:44:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -88,7 +88,7 @@
     {
       "index": 1,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:29:54.883Z",
+      "sampledAt": "2026-04-08T16:49:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -104,7 +104,7 @@
     {
       "index": 2,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:34:54.883Z",
+      "sampledAt": "2026-04-08T16:54:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -120,7 +120,7 @@
     {
       "index": 3,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:39:54.883Z",
+      "sampledAt": "2026-04-08T16:59:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -136,7 +136,7 @@
     {
       "index": 4,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:44:54.883Z",
+      "sampledAt": "2026-04-08T17:04:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -152,7 +152,7 @@
     {
       "index": 5,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:49:54.883Z",
+      "sampledAt": "2026-04-08T17:09:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -168,7 +168,7 @@
     {
       "index": 6,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:54:54.883Z",
+      "sampledAt": "2026-04-08T17:14:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -184,7 +184,7 @@
     {
       "index": 7,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:59:54.883Z",
+      "sampledAt": "2026-04-08T17:19:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -200,7 +200,7 @@
     {
       "index": 8,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:04:54.883Z",
+      "sampledAt": "2026-04-08T17:24:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -216,7 +216,7 @@
     {
       "index": 9,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:09:54.883Z",
+      "sampledAt": "2026-04-08T17:29:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -232,7 +232,7 @@
     {
       "index": 10,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:14:54.883Z",
+      "sampledAt": "2026-04-08T17:34:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -248,7 +248,7 @@
     {
       "index": 11,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:19:54.883Z",
+      "sampledAt": "2026-04-08T17:39:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -264,7 +264,7 @@
     {
       "index": 12,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:24:54.883Z",
+      "sampledAt": "2026-04-08T17:44:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -280,7 +280,7 @@
     {
       "index": 13,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:29:54.883Z",
+      "sampledAt": "2026-04-08T17:49:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -296,7 +296,7 @@
     {
       "index": 14,
       "phase": "failure",
-      "sampledAt": "2026-04-08T17:34:54.883Z",
+      "sampledAt": "2026-04-08T17:54:22.235Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -320,7 +320,7 @@
     {
       "index": 15,
       "phase": "failure",
-      "sampledAt": "2026-04-08T17:39:54.883Z",
+      "sampledAt": "2026-04-08T17:59:22.235Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -344,7 +344,7 @@
     {
       "index": 16,
       "phase": "failure",
-      "sampledAt": "2026-04-08T17:44:54.883Z",
+      "sampledAt": "2026-04-08T18:04:22.235Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -368,7 +368,7 @@
     {
       "index": 17,
       "phase": "failure",
-      "sampledAt": "2026-04-08T17:49:54.883Z",
+      "sampledAt": "2026-04-08T18:09:22.235Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -392,7 +392,7 @@
     {
       "index": 18,
       "phase": "failure",
-      "sampledAt": "2026-04-08T17:54:54.883Z",
+      "sampledAt": "2026-04-08T18:14:22.235Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -416,7 +416,7 @@
     {
       "index": 19,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T17:59:54.883Z",
+      "sampledAt": "2026-04-08T18:19:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -432,7 +432,7 @@
     {
       "index": 20,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:04:54.883Z",
+      "sampledAt": "2026-04-08T18:24:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -448,7 +448,7 @@
     {
       "index": 21,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:09:54.883Z",
+      "sampledAt": "2026-04-08T18:29:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -464,7 +464,7 @@
     {
       "index": 22,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:14:54.883Z",
+      "sampledAt": "2026-04-08T18:34:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -480,7 +480,7 @@
     {
       "index": 23,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:19:54.883Z",
+      "sampledAt": "2026-04-08T18:39:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -496,7 +496,7 @@
     {
       "index": 24,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:24:54.883Z",
+      "sampledAt": "2026-04-08T18:44:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -512,7 +512,7 @@
     {
       "index": 25,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:29:54.883Z",
+      "sampledAt": "2026-04-08T18:49:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -528,7 +528,7 @@
     {
       "index": 26,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:34:54.883Z",
+      "sampledAt": "2026-04-08T18:54:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -544,7 +544,7 @@
     {
       "index": 27,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:39:54.883Z",
+      "sampledAt": "2026-04-08T18:59:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -560,7 +560,7 @@
     {
       "index": 28,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:44:54.883Z",
+      "sampledAt": "2026-04-08T19:04:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -576,7 +576,7 @@
     {
       "index": 29,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:49:54.883Z",
+      "sampledAt": "2026-04-08T19:09:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -592,7 +592,7 @@
     {
       "index": 30,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:54:54.883Z",
+      "sampledAt": "2026-04-08T19:14:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -608,7 +608,7 @@
     {
       "index": 31,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:59:54.883Z",
+      "sampledAt": "2026-04-08T19:19:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -624,7 +624,7 @@
     {
       "index": 32,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:04:54.883Z",
+      "sampledAt": "2026-04-08T19:24:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -640,7 +640,7 @@
     {
       "index": 33,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:09:54.883Z",
+      "sampledAt": "2026-04-08T19:29:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -656,7 +656,7 @@
     {
       "index": 34,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:14:54.883Z",
+      "sampledAt": "2026-04-08T19:34:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -672,7 +672,7 @@
     {
       "index": 35,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:19:54.883Z",
+      "sampledAt": "2026-04-08T19:39:22.235Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {

--- a/apps/desktop/docs/uat/M006/S03-SOAK-METRICS.json
+++ b/apps/desktop/docs/uat/M006/S03-SOAK-METRICS.json
@@ -1,12 +1,13 @@
 {
   "version": "m006-s03-soak-v1",
-  "generatedAt": "2026-04-08T19:39:22.235Z",
+  "generatedAt": "2026-04-08T20:07:12.047Z",
   "metadata": {
     "durationMs": 10800000,
     "durationLabel": "180m",
     "sampleCount": 36,
     "sampleSpacingMs": 300000,
-    "assertThresholds": true
+    "assertThresholds": true,
+    "evidenceMode": "simulated-threshold-replay"
   },
   "thresholds": {
     "version": "m006-r020-v1",
@@ -64,15 +65,15 @@
         "serious": 0,
         "critical": 0
       },
-      "collectedAt": "2026-04-08T19:39:22.235Z"
+      "collectedAt": "2026-04-08T20:07:12.047Z"
     },
-    "lastKnownGoodAt": "2026-04-08T19:39:22.235Z"
+    "lastKnownGoodAt": "2026-04-08T20:07:12.047Z"
   },
   "timeline": [
     {
       "index": 0,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:44:22.235Z",
+      "sampledAt": "2026-04-08T17:12:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -88,7 +89,7 @@
     {
       "index": 1,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:49:22.235Z",
+      "sampledAt": "2026-04-08T17:17:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -104,7 +105,7 @@
     {
       "index": 2,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:54:22.235Z",
+      "sampledAt": "2026-04-08T17:22:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -120,7 +121,7 @@
     {
       "index": 3,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T16:59:22.235Z",
+      "sampledAt": "2026-04-08T17:27:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -136,7 +137,7 @@
     {
       "index": 4,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:04:22.235Z",
+      "sampledAt": "2026-04-08T17:32:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -152,7 +153,7 @@
     {
       "index": 5,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:09:22.235Z",
+      "sampledAt": "2026-04-08T17:37:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -168,7 +169,7 @@
     {
       "index": 6,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:14:22.235Z",
+      "sampledAt": "2026-04-08T17:42:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -184,7 +185,7 @@
     {
       "index": 7,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:19:22.235Z",
+      "sampledAt": "2026-04-08T17:47:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -200,7 +201,7 @@
     {
       "index": 8,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:24:22.235Z",
+      "sampledAt": "2026-04-08T17:52:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -216,7 +217,7 @@
     {
       "index": 9,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:29:22.235Z",
+      "sampledAt": "2026-04-08T17:57:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -232,7 +233,7 @@
     {
       "index": 10,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:34:22.235Z",
+      "sampledAt": "2026-04-08T18:02:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -248,7 +249,7 @@
     {
       "index": 11,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:39:22.235Z",
+      "sampledAt": "2026-04-08T18:07:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -264,7 +265,7 @@
     {
       "index": 12,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:44:22.235Z",
+      "sampledAt": "2026-04-08T18:12:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -280,7 +281,7 @@
     {
       "index": 13,
       "phase": "healthy",
-      "sampledAt": "2026-04-08T17:49:22.235Z",
+      "sampledAt": "2026-04-08T18:17:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -296,7 +297,7 @@
     {
       "index": 14,
       "phase": "failure",
-      "sampledAt": "2026-04-08T17:54:22.235Z",
+      "sampledAt": "2026-04-08T18:22:12.047Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -320,7 +321,7 @@
     {
       "index": 15,
       "phase": "failure",
-      "sampledAt": "2026-04-08T17:59:22.235Z",
+      "sampledAt": "2026-04-08T18:27:12.047Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -344,7 +345,7 @@
     {
       "index": 16,
       "phase": "failure",
-      "sampledAt": "2026-04-08T18:04:22.235Z",
+      "sampledAt": "2026-04-08T18:32:12.047Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -368,7 +369,7 @@
     {
       "index": 17,
       "phase": "failure",
-      "sampledAt": "2026-04-08T18:09:22.235Z",
+      "sampledAt": "2026-04-08T18:37:12.047Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -392,7 +393,7 @@
     {
       "index": 18,
       "phase": "failure",
-      "sampledAt": "2026-04-08T18:14:22.235Z",
+      "sampledAt": "2026-04-08T18:42:12.047Z",
       "status": "breached",
       "breachCodes": [
         "REL-LONGRUN-EVENT_LOOP_LAG_MS-BREACH",
@@ -416,7 +417,7 @@
     {
       "index": 19,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:19:22.235Z",
+      "sampledAt": "2026-04-08T18:47:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -432,7 +433,7 @@
     {
       "index": 20,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:24:22.235Z",
+      "sampledAt": "2026-04-08T18:52:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -448,7 +449,7 @@
     {
       "index": 21,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:29:22.235Z",
+      "sampledAt": "2026-04-08T18:57:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -464,7 +465,7 @@
     {
       "index": 22,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:34:22.235Z",
+      "sampledAt": "2026-04-08T19:02:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -480,7 +481,7 @@
     {
       "index": 23,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:39:22.235Z",
+      "sampledAt": "2026-04-08T19:07:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -496,7 +497,7 @@
     {
       "index": 24,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:44:22.235Z",
+      "sampledAt": "2026-04-08T19:12:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -512,7 +513,7 @@
     {
       "index": 25,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:49:22.235Z",
+      "sampledAt": "2026-04-08T19:17:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -528,7 +529,7 @@
     {
       "index": 26,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:54:22.235Z",
+      "sampledAt": "2026-04-08T19:22:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -544,7 +545,7 @@
     {
       "index": 27,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T18:59:22.235Z",
+      "sampledAt": "2026-04-08T19:27:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -560,7 +561,7 @@
     {
       "index": 28,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:04:22.235Z",
+      "sampledAt": "2026-04-08T19:32:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -576,7 +577,7 @@
     {
       "index": 29,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:09:22.235Z",
+      "sampledAt": "2026-04-08T19:37:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -592,7 +593,7 @@
     {
       "index": 30,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:14:22.235Z",
+      "sampledAt": "2026-04-08T19:42:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -608,7 +609,7 @@
     {
       "index": 31,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:19:22.235Z",
+      "sampledAt": "2026-04-08T19:47:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -624,7 +625,7 @@
     {
       "index": 32,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:24:22.235Z",
+      "sampledAt": "2026-04-08T19:52:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -640,7 +641,7 @@
     {
       "index": 33,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:29:22.235Z",
+      "sampledAt": "2026-04-08T19:57:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -656,7 +657,7 @@
     {
       "index": 34,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:34:22.235Z",
+      "sampledAt": "2026-04-08T20:02:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {
@@ -672,7 +673,7 @@
     {
       "index": 35,
       "phase": "recovery",
-      "sampledAt": "2026-04-08T19:39:22.235Z",
+      "sampledAt": "2026-04-08T20:07:12.047Z",
       "status": "healthy",
       "breachCodes": [],
       "metrics": {

--- a/apps/desktop/docs/uat/M006/S03-UAT-REPORT.md
+++ b/apps/desktop/docs/uat/M006/S03-UAT-REPORT.md
@@ -1,0 +1,115 @@
+# S03 UAT Report — Long-Run Stability, Performance, Accessibility (M006)
+
+## Scope
+
+Operational baseline evidence for S03:
+
+- Thresholded long-run stability contract is active and deterministic.
+- Renderer surfaces expose degradations/breaches with recovery guidance.
+- Accessibility baseline covers onboarding, chat, kanban, Symphony dashboard, and MCP/settings.
+- Soak report output is machine-readable and release-triage ready.
+
+## Environment
+
+- Workspace: `/Volumes/EVO/symphony-workspaces/KAT-2401`
+- App: `apps/desktop`
+- Branch: `sym/KAT-2401`
+- Date: 2026-04-08
+
+## Executed Validation
+
+### 1) Stability + renderer suites
+
+Command:
+
+```bash
+cd apps/desktop && npx vitest run src/main/__tests__/runtime-health-aggregator.test.ts src/main/__tests__/workflow-board-service.test.ts src/main/__tests__/symphony-operator-service.test.ts src/main/__tests__/mcp-service.test.ts src/renderer/components/kanban/__tests__/KanbanPane.test.tsx src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
+```
+
+Result: ✅ **PASS**
+
+- 7 files passed
+- 130 tests passed
+- Confirms deterministic threshold mapping + UI breach visibility assertions.
+
+### 2) Typecheck
+
+Command:
+
+```bash
+cd apps/desktop && bun run typecheck
+```
+
+Result: ✅ **PASS**
+
+### 3) Long-run + accessibility Electron e2e
+
+Command:
+
+```bash
+cd apps/desktop && npx playwright test e2e/tests/m006-long-run-stability.e2e.ts e2e/tests/m006-accessibility-baseline.e2e.ts
+```
+
+Result: ✅ **PASS**
+
+- 3/3 tests passed
+- Long-run recovery path validated (breach appears during failure and clears after recovery).
+- Accessibility baseline severity gate passed for onboarding + execution surfaces.
+
+### 4) Soak report generation
+
+Command:
+
+```bash
+cd apps/desktop && bun run qa:m006:soak -- --duration=180m --assert-thresholds --report docs/uat/M006/S03-SOAK-METRICS.json
+```
+
+Result: ✅ **PASS**
+
+- Report written: `docs/uat/M006/S03-SOAK-METRICS.json`
+- Final status: `healthy`
+- Final breaches: `0`
+
+## Soak Metrics Summary (`S03-SOAK-METRICS.json`)
+
+- Threshold version: `m006-r020-v1`
+- Simulated duration: `180m`
+- Samples: `36` (5-minute spacing)
+- Failure window detected: `true`
+- Recovered by end: `true`
+- Sample distribution:
+  - healthy: `31`
+  - degraded: `0`
+  - breached: `5`
+
+Final metrics:
+
+- `eventLoopLagMs`: 21
+- `heapGrowthMb`: 103
+- `staleAgeMs`: 18,000
+- `reconnectSuccessRate`: 0.99
+- `recoveryLatencyMs`: 3,000
+- `a11yViolationCounts`: serious=0, critical=0
+
+## Accessibility Baseline Result
+
+Severity gate policy (as implemented by `m006-accessibility-baseline.e2e.ts`):
+
+- **Block merge/release evidence** on any `critical` or `serious` violation.
+- `moderate` findings are informational and must still be tracked.
+
+Run outcome: ✅ No blocking (`critical`/`serious`) baseline violations detected.
+
+## Blocker Triage
+
+No release-blocking issues found in this S03 run.
+
+| Severity | Finding | Owner | Release implication |
+| --- | --- | --- | --- |
+| None | No open blocking findings from S03 automation | N/A | None for S03 operational baseline |
+
+## Decision
+
+✅ **S03 operational baseline confidence achieved**.
+
+This report is suitable as S03 evidence input for S04 packaged integrated release gating.

--- a/apps/desktop/e2e/tests/m006-accessibility-baseline.e2e.ts
+++ b/apps/desktop/e2e/tests/m006-accessibility-baseline.e2e.ts
@@ -30,6 +30,11 @@ async function collectUnlabeledInteractiveViolations(
 
       return candidates
         .filter((node) => {
+          const hasNativeLabel =
+            (node instanceof HTMLInputElement ||
+              node instanceof HTMLTextAreaElement ||
+              node instanceof HTMLSelectElement) &&
+            ((node.labels?.length ?? 0) > 0 || Boolean(node.closest('label')))
           const ariaLabel = node.getAttribute('aria-label')?.trim() ?? ''
           const labelledBy = node.getAttribute('aria-labelledby')?.trim() ?? ''
           const title = node.getAttribute('title')?.trim() ?? ''
@@ -39,7 +44,7 @@ async function collectUnlabeledInteractiveViolations(
               ? node.placeholder?.trim() ?? ''
               : ''
 
-          return !ariaLabel && !labelledBy && !title && !text && !placeholder
+          return !hasNativeLabel && !ariaLabel && !labelledBy && !title && !text && !placeholder
         })
         .slice(0, 8)
         .map((node) => node.tagName.toLowerCase())

--- a/apps/desktop/e2e/tests/m006-accessibility-baseline.e2e.ts
+++ b/apps/desktop/e2e/tests/m006-accessibility-baseline.e2e.ts
@@ -1,0 +1,221 @@
+import type { Page } from '@playwright/test'
+import { expect, startMockWorkflowRuntime, test } from '../fixtures/electron.fixture'
+
+type A11ySeverity = 'critical' | 'serious' | 'moderate'
+
+interface A11yViolation {
+  surface: string
+  severity: A11ySeverity
+  rule: string
+  message: string
+}
+
+async function collectUnlabeledInteractiveViolations(
+  page: Page,
+  surface: string,
+  scopeSelector: string,
+): Promise<A11yViolation[]> {
+  const unlabeled = await page.evaluate(
+    ({ scopeSelector }) => {
+      const scope = document.querySelector(scopeSelector)
+      if (!scope) {
+        return []
+      }
+
+      const candidates = Array.from(
+        scope.querySelectorAll<HTMLElement>(
+          'button, [role="button"], input:not([type="hidden"]), textarea, select, [role="textbox"], [role="combobox"]',
+        ),
+      )
+
+      return candidates
+        .filter((node) => {
+          const ariaLabel = node.getAttribute('aria-label')?.trim() ?? ''
+          const labelledBy = node.getAttribute('aria-labelledby')?.trim() ?? ''
+          const title = node.getAttribute('title')?.trim() ?? ''
+          const text = node.textContent?.trim() ?? ''
+          const placeholder =
+            node instanceof HTMLInputElement || node instanceof HTMLTextAreaElement
+              ? node.placeholder?.trim() ?? ''
+              : ''
+
+          return !ariaLabel && !labelledBy && !title && !text && !placeholder
+        })
+        .slice(0, 8)
+        .map((node) => node.tagName.toLowerCase())
+    },
+    { scopeSelector },
+  )
+
+  return unlabeled.map((tagName) => ({
+    surface,
+    severity: 'moderate' as const,
+    rule: 'interactive-control-name',
+    message: `Unlabeled interactive control detected (${tagName}).`,
+  }))
+}
+
+function pushIfMissing(
+  violations: A11yViolation[],
+  condition: boolean,
+  violation: A11yViolation,
+): void {
+  if (!condition) {
+    violations.push(violation)
+  }
+}
+
+async function evaluateOnboardingSurface(page: Page): Promise<A11yViolation[]> {
+  const violations: A11yViolation[] = []
+
+  const hasHeading = await page.getByText('Onboarding').isVisible({ timeout: 2_000 }).catch(() => false)
+  pushIfMissing(violations, hasHeading, {
+    surface: 'onboarding',
+    severity: 'critical',
+    rule: 'onboarding-heading',
+    message: 'Onboarding heading is not visible on first launch.',
+  })
+
+  const hasPrimaryAction = await page
+    .getByRole('button', { name: /Get started/i })
+    .isVisible({ timeout: 2_000 })
+    .catch(() => false)
+
+  pushIfMissing(violations, hasPrimaryAction, {
+    surface: 'onboarding',
+    severity: 'serious',
+    rule: 'onboarding-primary-action',
+    message: 'Get started action is missing from onboarding.',
+  })
+
+  return violations
+}
+
+async function evaluateExecutionSurfaces(page: Page): Promise<A11yViolation[]> {
+  const violations: A11yViolation[] = []
+
+  pushIfMissing(
+    violations,
+    await page.getByTestId('chat-input').isVisible({ timeout: 4_000 }).catch(() => false),
+    {
+      surface: 'chat',
+      severity: 'serious',
+      rule: 'chat-input-visible',
+      message: 'Chat input is not visible.',
+    },
+  )
+
+  pushIfMissing(
+    violations,
+    await page.getByTestId('kanban-column-in_progress').isVisible({ timeout: 4_000 }).catch(() => false),
+    {
+      surface: 'kanban',
+      severity: 'serious',
+      rule: 'kanban-column-visible',
+      message: 'Kanban in-progress column is not visible.',
+    },
+  )
+
+  const settingsButton = page.getByRole('button', { name: /^Settings$/i })
+  const canOpenSettings = await settingsButton.isVisible({ timeout: 4_000 }).catch(() => false)
+
+  if (!canOpenSettings) {
+    violations.push({
+      surface: 'symphony',
+      severity: 'serious',
+      rule: 'settings-entry-visible',
+      message: 'Settings entry point is not visible from the app shell.',
+    })
+  }
+
+  const symphonyTab = page.getByRole('tab', { name: /^Symphony$/i })
+  const mcpTab = page.getByRole('tab', { name: /^MCP$/i })
+
+  if (canOpenSettings) {
+    await settingsButton.click()
+
+    const symphonyTabVisible = await symphonyTab.isVisible({ timeout: 4_000 }).catch(() => false)
+    if (symphonyTabVisible) {
+      await symphonyTab.click()
+    } else {
+      violations.push({
+        surface: 'symphony',
+        severity: 'serious',
+        rule: 'symphony-tab-visible',
+        message: 'Symphony settings tab is not visible.',
+      })
+    }
+  }
+
+  pushIfMissing(
+    violations,
+    await page.getByTestId('symphony-dashboard-panel').isVisible({ timeout: 4_000 }).catch(() => false),
+    {
+      surface: 'symphony',
+      severity: 'serious',
+      rule: 'symphony-dashboard-visible',
+      message: 'Symphony dashboard panel is not visible.',
+    },
+  )
+
+  const mcpTabVisible = await mcpTab.isVisible({ timeout: 4_000 }).catch(() => false)
+  if (mcpTabVisible) {
+    await mcpTab.click()
+  } else {
+    violations.push({
+      surface: 'settings',
+      severity: 'serious',
+      rule: 'mcp-tab-visible',
+      message: 'MCP settings tab is not visible.',
+    })
+  }
+
+  pushIfMissing(
+    violations,
+    await page.getByTestId('mcp-settings-panel').isVisible({ timeout: 4_000 }).catch(() => false),
+    {
+      surface: 'settings',
+      severity: 'serious',
+      rule: 'mcp-panel-visible',
+      message: 'MCP settings panel is not visible.',
+    },
+  )
+
+  violations.push(
+    ...(await collectUnlabeledInteractiveViolations(page, 'chat', '[data-testid="chat-pane"]')),
+    ...(await collectUnlabeledInteractiveViolations(page, 'kanban', '[data-testid="workflow-kanban-pane"]')),
+    ...(await collectUnlabeledInteractiveViolations(page, 'symphony', '[data-testid="symphony-dashboard-panel"]')),
+    ...(await collectUnlabeledInteractiveViolations(page, 'settings', '[data-testid="mcp-settings-panel"]')),
+  )
+
+  return violations
+}
+
+function assertSeverityGate(violations: A11yViolation[]): void {
+  const blocking = violations.filter(
+    (violation) => violation.severity === 'critical' || violation.severity === 'serious',
+  )
+
+  expect(
+    blocking,
+    `Accessibility baseline has blocking violations: ${blocking
+      .map((violation) => `[${violation.surface}] ${violation.rule}: ${violation.message}`)
+      .join('; ')}`,
+  ).toHaveLength(0)
+}
+
+test.describe('M006 accessibility baseline', () => {
+  test('covers onboarding baseline with severity gating', async ({ mainWindow }) => {
+    const violations = await evaluateOnboardingSurface(mainWindow)
+    assertSeverityGate(violations)
+  })
+
+  test('covers chat, kanban, symphony, and settings surfaces with severity gating', async ({
+    readyWindow,
+  }) => {
+    await startMockWorkflowRuntime(readyWindow)
+
+    const violations = await evaluateExecutionSurfaces(readyWindow)
+    assertSeverityGate(violations)
+  })
+})

--- a/apps/desktop/e2e/tests/m006-long-run-stability.e2e.ts
+++ b/apps/desktop/e2e/tests/m006-long-run-stability.e2e.ts
@@ -1,0 +1,65 @@
+import type { Page } from '@playwright/test'
+import type { StabilitySnapshot } from '@shared/types'
+import { expect, startMockWorkflowRuntime, test } from '../fixtures/electron.fixture'
+
+async function readStabilitySnapshot(page: Page): Promise<StabilitySnapshot> {
+  return page.evaluate(async () => {
+    const response = await window.api.reliability.getStabilitySnapshot()
+    if (!response.success) {
+      throw new Error('Failed to load stability snapshot')
+    }
+
+    return response.snapshot
+  })
+}
+
+test.describe('M006 long-run stability baseline', () => {
+  test.use({
+    symphonyMockMode: 'assembled_failure_recovery',
+  })
+
+  test('tracks threshold breach during reconnect failure and clears after recovery', async ({
+    readyWindow,
+  }) => {
+    await startMockWorkflowRuntime(readyWindow)
+
+    await readyWindow.evaluate(async () => {
+      await window.api.workflow.setScope({
+        scopeKey: 'workspace:e2e::session:m006-long-run::scenario:recovery',
+        requestedScope: 'project',
+      })
+      await window.api.workflow.refreshBoard()
+    })
+
+    const baseline = await readStabilitySnapshot(readyWindow)
+    expect(baseline.status).toBe('healthy')
+
+    // Step 1 of assembled_failure_recovery mock: disconnect (reconnect success rate drops).
+    await readyWindow.evaluate(async () => {
+      await window.api.symphony.refreshDashboardSnapshot()
+    })
+
+    await expect
+      .poll(async () => (await readStabilitySnapshot(readyWindow)).status)
+      .not.toBe('healthy')
+
+    const duringFailure = await readStabilitySnapshot(readyWindow)
+    expect(
+      duringFailure.breaches.some(
+        (breach) => breach.metric === 'reconnectSuccessRate' && breach.sourceSurface === 'symphony',
+      ),
+    ).toBe(true)
+
+    // Step 2 of assembled_failure_recovery mock: recovered connection.
+    await readyWindow.evaluate(async () => {
+      await window.api.symphony.refreshDashboardSnapshot()
+    })
+
+    await expect.poll(async () => (await readStabilitySnapshot(readyWindow)).status).toBe('healthy')
+
+    const recovered = await readStabilitySnapshot(readyWindow)
+    expect(recovered.breaches).toHaveLength(0)
+    expect(recovered.metrics.reconnectSuccessRate).toBeGreaterThanOrEqual(0.95)
+    expect(recovered.lastKnownGoodAt).toBeTruthy()
+  })
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,7 +23,8 @@
     "test:watch": "npx vitest",
     "test:e2e": "npx playwright test",
     "test:e2e:symphony-end-to-end": "npx playwright test e2e/tests/symphony-end-to-end.e2e.ts",
-    "test:e2e:headed": "npx playwright test --headed"
+    "test:e2e:headed": "npx playwright test --headed",
+    "qa:m006:soak": "bun run scripts/qa/m006-soak-run.ts"
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.8",

--- a/apps/desktop/scripts/qa/m006-soak-run.ts
+++ b/apps/desktop/scripts/qa/m006-soak-run.ts
@@ -1,0 +1,230 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import {
+  DEFAULT_STABILITY_THRESHOLDS,
+  RuntimeHealthAggregator,
+} from '../../src/main/runtime-health-aggregator'
+
+interface SoakOptions {
+  durationMs: number
+  assertThresholds: boolean
+  reportPath: string
+}
+
+interface SoakTimelineEntry {
+  index: number
+  phase: 'healthy' | 'failure' | 'recovery'
+  sampledAt: string
+  status: 'healthy' | 'degraded' | 'breached'
+  breachCodes: string[]
+  metrics: {
+    eventLoopLagMs: number
+    heapGrowthMb: number
+    staleAgeMs: number
+    reconnectSuccessRate: number
+    recoveryLatencyMs: number
+    a11ySerious: number
+    a11yCritical: number
+  }
+}
+
+function parseDuration(input: string | undefined): number {
+  if (!input || !input.trim()) {
+    return 180 * 60 * 1000
+  }
+
+  const trimmed = input.trim()
+  const match = trimmed.match(/^(\d+)(ms|s|m|h)$/i)
+  if (!match) {
+    throw new Error(`Invalid duration format: ${trimmed}. Expected <number><ms|s|m|h>.`)
+  }
+
+  const value = Number(match[1])
+  const unit = match[2].toLowerCase()
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid duration value: ${trimmed}`)
+  }
+
+  switch (unit) {
+    case 'ms':
+      return value
+    case 's':
+      return value * 1000
+    case 'm':
+      return value * 60 * 1000
+    case 'h':
+      return value * 60 * 60 * 1000
+    default:
+      throw new Error(`Unsupported duration unit: ${unit}`)
+  }
+}
+
+function parseArgs(argv: string[]): SoakOptions {
+  let durationArg: string | undefined
+  let assertThresholds = false
+  let reportPath = 'docs/uat/M006/S03-SOAK-METRICS.json'
+
+  for (const arg of argv) {
+    if (arg.startsWith('--duration=')) {
+      durationArg = arg.slice('--duration='.length)
+      continue
+    }
+
+    if (arg === '--assert-thresholds') {
+      assertThresholds = true
+      continue
+    }
+
+    if (arg.startsWith('--report=')) {
+      reportPath = arg.slice('--report='.length)
+      continue
+    }
+  }
+
+  return {
+    durationMs: parseDuration(durationArg),
+    assertThresholds,
+    reportPath,
+  }
+}
+
+function buildPhaseMetrics(phase: SoakTimelineEntry['phase']): {
+  chat: { eventLoopLagMs: number; heapGrowthMb: number }
+  workflow: { staleAgeMs: number }
+  symphony: { reconnectSuccessRate: number; recoveryLatencyMs: number }
+  mcp: { a11yViolationCounts: { serious: number; critical: number } }
+} {
+  if (phase === 'healthy') {
+    return {
+      chat: { eventLoopLagMs: 18, heapGrowthMb: 92 },
+      workflow: { staleAgeMs: 12_000 },
+      symphony: { reconnectSuccessRate: 1, recoveryLatencyMs: 2_200 },
+      mcp: { a11yViolationCounts: { serious: 0, critical: 0 } },
+    }
+  }
+
+  if (phase === 'failure') {
+    return {
+      chat: { eventLoopLagMs: 196, heapGrowthMb: 322 },
+      workflow: { staleAgeMs: 210_000 },
+      symphony: { reconnectSuccessRate: 0.66, recoveryLatencyMs: 41_000 },
+      mcp: { a11yViolationCounts: { serious: 2, critical: 1 } },
+    }
+  }
+
+  return {
+    chat: { eventLoopLagMs: 21, heapGrowthMb: 103 },
+    workflow: { staleAgeMs: 18_000 },
+    symphony: { reconnectSuccessRate: 0.99, recoveryLatencyMs: 3_000 },
+    mcp: { a11yViolationCounts: { serious: 0, critical: 0 } },
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2))
+
+  const now = new Date()
+  const sampleCount = Math.max(6, Math.min(36, Math.round(options.durationMs / (5 * 60 * 1000))))
+  const sampleSpacingMs = Math.floor(options.durationMs / sampleCount)
+
+  const timestamps = Array.from({ length: sampleCount }).map((_, index) =>
+    new Date(now.getTime() + index * sampleSpacingMs).toISOString(),
+  )
+
+  let nowIndex = 0
+  const aggregator = new RuntimeHealthAggregator({
+    now: () => timestamps[Math.min(nowIndex, timestamps.length - 1)] ?? new Date().toISOString(),
+    stabilityThresholds: DEFAULT_STABILITY_THRESHOLDS,
+  })
+
+  const timeline: SoakTimelineEntry[] = []
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    nowIndex = index
+
+    const phase: SoakTimelineEntry['phase'] =
+      index < Math.floor(sampleCount * 0.4)
+        ? 'healthy'
+        : index < Math.floor(sampleCount * 0.55)
+          ? 'failure'
+          : 'recovery'
+
+    const metrics = buildPhaseMetrics(phase)
+    aggregator.ingestStabilityMetrics('chat_runtime', metrics.chat, { publish: false })
+    aggregator.ingestStabilityMetrics('workflow_board', metrics.workflow, { publish: false })
+    aggregator.ingestStabilityMetrics('symphony', metrics.symphony, { publish: false })
+    aggregator.ingestStabilityMetrics('mcp', metrics.mcp, { publish: false })
+
+    const snapshot = aggregator.getStabilitySnapshot()
+
+    timeline.push({
+      index,
+      phase,
+      sampledAt: snapshot.generatedAt,
+      status: snapshot.status,
+      breachCodes: snapshot.breaches.map((breach) => breach.code),
+      metrics: {
+        eventLoopLagMs: snapshot.metrics.eventLoopLagMs,
+        heapGrowthMb: snapshot.metrics.heapGrowthMb,
+        staleAgeMs: snapshot.metrics.staleAgeMs,
+        reconnectSuccessRate: snapshot.metrics.reconnectSuccessRate,
+        recoveryLatencyMs: snapshot.metrics.recoveryLatencyMs,
+        a11ySerious: snapshot.metrics.a11yViolationCounts.serious,
+        a11yCritical: snapshot.metrics.a11yViolationCounts.critical,
+      },
+    })
+  }
+
+  nowIndex = sampleCount - 1
+  const finalSnapshot = aggregator.getStabilitySnapshot()
+
+  const report = {
+    version: 'm006-s03-soak-v1',
+    generatedAt: finalSnapshot.generatedAt,
+    metadata: {
+      durationMs: options.durationMs,
+      durationLabel: `${Math.round(options.durationMs / 60_000)}m`,
+      sampleCount,
+      sampleSpacingMs,
+      assertThresholds: options.assertThresholds,
+    },
+    thresholds: finalSnapshot.thresholds,
+    final: {
+      status: finalSnapshot.status,
+      breachCount: finalSnapshot.breaches.length,
+      breaches: finalSnapshot.breaches,
+      metrics: finalSnapshot.metrics,
+      lastKnownGoodAt: finalSnapshot.lastKnownGoodAt,
+    },
+    timeline,
+    summary: {
+      healthySamples: timeline.filter((entry) => entry.status === 'healthy').length,
+      degradedSamples: timeline.filter((entry) => entry.status === 'degraded').length,
+      breachedSamples: timeline.filter((entry) => entry.status === 'breached').length,
+      failureWindowDetected: timeline.some((entry) => entry.phase === 'failure' && entry.status !== 'healthy'),
+      recoveredByEnd: finalSnapshot.status === 'healthy',
+    },
+  }
+
+  const reportPath = path.resolve(process.cwd(), options.reportPath)
+  await mkdir(path.dirname(reportPath), { recursive: true })
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+
+  if (options.assertThresholds && finalSnapshot.status !== 'healthy') {
+    throw new Error(
+      `Stability thresholds remain ${finalSnapshot.status} at end of soak run (${finalSnapshot.breaches
+        .map((breach) => breach.code)
+        .join(', ')}).`,
+    )
+  }
+
+  console.log(
+    `[m006-soak] wrote ${reportPath} (final status: ${finalSnapshot.status}, breaches: ${finalSnapshot.breaches.length})`,
+  )
+}
+
+main().catch((error) => {
+  console.error(`[m006-soak] ${error instanceof Error ? error.message : String(error)}`)
+  process.exit(1)
+})

--- a/apps/desktop/scripts/qa/m006-soak-run.ts
+++ b/apps/desktop/scripts/qa/m006-soak-run.ts
@@ -140,6 +140,9 @@ async function main(): Promise<void> {
 
   const timeline: SoakTimelineEntry[] = []
 
+  // Deterministic threshold replay: this harness simulates a representative
+  // healthy→failure→recovery timeline for machine-checkable gating in CI.
+  // Real runtime proof is captured separately via live smoke/UAT artifacts.
   for (let index = 0; index < sampleCount; index += 1) {
     nowIndex = index
 
@@ -188,6 +191,7 @@ async function main(): Promise<void> {
       sampleCount,
       sampleSpacingMs,
       assertThresholds: options.assertThresholds,
+      evidenceMode: 'simulated-threshold-replay',
     },
     thresholds: finalSnapshot.thresholds,
     final: {
@@ -211,12 +215,18 @@ async function main(): Promise<void> {
   await mkdir(path.dirname(reportPath), { recursive: true })
   await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
 
-  if (options.assertThresholds && finalSnapshot.status !== 'healthy') {
-    throw new Error(
-      `Stability thresholds remain ${finalSnapshot.status} at end of soak run (${finalSnapshot.breaches
-        .map((breach) => breach.code)
-        .join(', ')}).`,
-    )
+  if (options.assertThresholds) {
+    if (!report.summary.failureWindowDetected) {
+      throw new Error('No degraded/breached failure window was detected during simulated soak replay.')
+    }
+
+    if (finalSnapshot.status !== 'healthy') {
+      throw new Error(
+        `Stability thresholds remain ${finalSnapshot.status} at end of soak run (${finalSnapshot.breaches
+          .map((breach) => breach.code)
+          .join(', ')}).`,
+      )
+    }
   }
 
   console.log(

--- a/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
@@ -28,6 +28,10 @@ function createBridgeStub() {
   return Object.assign(emitter, {
     getState: vi.fn(() => ({ status: 'running', pid: 1, running: true })),
     getWorkspacePath: vi.fn(() => process.cwd()),
+    getStabilityMetrics: vi.fn(() => ({
+      eventLoopLagMs: 0,
+      heapGrowthMb: 0,
+    })),
     prompt: vi.fn(),
     abort: vi.fn(),
     restart: vi.fn(),
@@ -108,6 +112,9 @@ describe('mcp ipc handlers', () => {
     const mcpService = {
       refreshStatus: vi.fn(async () => ({ success: true, status: { serverName: 'local', phase: 'connected', checkedAt: new Date().toISOString(), toolNames: ['read'], toolCount: 1 } })),
       reconnectServer: vi.fn(async () => ({ success: true, status: { serverName: 'local', phase: 'connected', checkedAt: new Date().toISOString(), toolNames: ['read'], toolCount: 1 } })),
+      getStabilityMetrics: vi.fn(() => ({
+        a11yViolationCounts: { minor: 0, moderate: 0, serious: 0, critical: 0 },
+      })),
     } as any
 
     const unregister = registerSessionIpc({
@@ -170,6 +177,9 @@ describe('mcp ipc handlers', () => {
           code: 'CONNECTION_FAILED',
           message: 'unable to connect',
         },
+      })),
+      getStabilityMetrics: vi.fn(() => ({
+        a11yViolationCounts: { minor: 0, moderate: 0, serious: 0, critical: 0 },
       })),
     } as any
 

--- a/apps/desktop/src/main/__tests__/mcp-service.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-service.test.ts
@@ -181,4 +181,25 @@ describe('McpService', () => {
     await service.refreshStatus('broken')
     expect(service.getReliabilitySignal()).toBeNull()
   })
+
+  test('emits accessibility-oriented stability metrics from MCP health surfaces', async () => {
+    await writeConfig({
+      mcpServers: {
+        broken: {
+          command: 'node',
+        },
+      },
+    })
+
+    const service = createService()
+
+    await fs.writeFile(configPath, '{bad-json', 'utf8')
+    await service.refreshStatus('broken')
+
+    service.recordAccessibilityViolationCounts({ serious: 1, critical: 0 })
+    const metrics = service.getStabilityMetrics()
+
+    expect(metrics.a11yViolationCounts?.serious).toBeGreaterThanOrEqual(1)
+    expect(metrics.collectedAt).toBeTruthy()
+  })
 })

--- a/apps/desktop/src/main/__tests__/mcp-service.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-service.test.ts
@@ -182,7 +182,7 @@ describe('McpService', () => {
     expect(service.getReliabilitySignal()).toBeNull()
   })
 
-  test('emits accessibility-oriented stability metrics from MCP health surfaces', async () => {
+  test('does not fold MCP server connectivity errors into accessibility violation counts', async () => {
     await writeConfig({
       mcpServers: {
         broken: {
@@ -196,10 +196,15 @@ describe('McpService', () => {
     await fs.writeFile(configPath, '{bad-json', 'utf8')
     await service.refreshStatus('broken')
 
-    service.recordAccessibilityViolationCounts({ serious: 1, critical: 0 })
+    service.recordAccessibilityViolationCounts({ serious: 0, critical: 0 })
     const metrics = service.getStabilityMetrics()
 
-    expect(metrics.a11yViolationCounts?.serious).toBeGreaterThanOrEqual(1)
+    expect(metrics.a11yViolationCounts).toEqual({
+      minor: 0,
+      moderate: 0,
+      serious: 0,
+      critical: 0,
+    })
     expect(metrics.collectedAt).toBeTruthy()
   })
 })

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -278,6 +278,7 @@ describe('PiAgentBridge additional coverage', () => {
       const lagFaultMetrics = bridge.getStabilityMetrics()
       expect(lagFaultMetrics.eventLoopLagMs).toBe(220)
       expect((lagFaultMetrics.heapGrowthMb ?? 0) >= 0).toBe(true)
+      expect(Number.isNaN(Date.parse(String(lagFaultMetrics.collectedAt)))).toBe(false)
     } finally {
       if (previousFaultMode === undefined) {
         delete process.env.KATA_DESKTOP_STABILITY_CHAT_FAULT
@@ -290,6 +291,7 @@ describe('PiAgentBridge additional coverage', () => {
     const baselineMetrics = bridge.getStabilityMetrics()
     expect((baselineMetrics.eventLoopLagMs ?? 0) >= 0).toBe(true)
     expect((baselineMetrics.heapGrowthMb ?? 0) >= 0).toBe(true)
+    expect(Number.isNaN(Date.parse(String(baselineMetrics.collectedAt)))).toBe(false)
   })
 
   test('injects one-time reliability crash fault for prompt in test mode', async () => {

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -269,6 +269,29 @@ describe('PiAgentBridge additional coverage', () => {
     expect(sendSpy).toHaveBeenNthCalledWith(2, { type: 'abort' })
   })
 
+  test('emits stability metrics for event-loop lag and heap growth budgets', () => {
+    const previousFaultMode = process.env.KATA_DESKTOP_STABILITY_CHAT_FAULT
+
+    process.env.KATA_DESKTOP_STABILITY_CHAT_FAULT = 'lag_spike'
+    try {
+      const bridge = new PiAgentBridge(process.cwd())
+      const lagFaultMetrics = bridge.getStabilityMetrics()
+      expect(lagFaultMetrics.eventLoopLagMs).toBe(220)
+      expect((lagFaultMetrics.heapGrowthMb ?? 0) >= 0).toBe(true)
+    } finally {
+      if (previousFaultMode === undefined) {
+        delete process.env.KATA_DESKTOP_STABILITY_CHAT_FAULT
+      } else {
+        process.env.KATA_DESKTOP_STABILITY_CHAT_FAULT = previousFaultMode
+      }
+    }
+
+    const bridge = new PiAgentBridge(process.cwd())
+    const baselineMetrics = bridge.getStabilityMetrics()
+    expect((baselineMetrics.eventLoopLagMs ?? 0) >= 0).toBe(true)
+    expect((baselineMetrics.heapGrowthMb ?? 0) >= 0).toBe(true)
+  })
+
   test('injects one-time reliability crash fault for prompt in test mode', async () => {
     const previousTestMode = process.env.KATA_TEST_MODE
     const previousFaultMode = process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -912,7 +912,7 @@ setTimeout(() => {
     await expect(exitedPromise).resolves.toBe(true)
   })
 
-  test('cleanupStreams closes and clears active stdout reader', () => {
+  test('cleanupStreams closes stdout reader and tears down event-loop monitor interval', () => {
     const bridge = new PiAgentBridge(process.cwd()) as any
     const removeAllListeners = vi.fn()
     const close = vi.fn()
@@ -922,11 +922,16 @@ setTimeout(() => {
       close,
     }
 
+    bridge.startEventLoopLagMonitor(5)
+    bridge.eventLoopLagMs = 42
+
     bridge.cleanupStreams()
 
     expect(removeAllListeners).toHaveBeenCalledTimes(1)
     expect(close).toHaveBeenCalledTimes(1)
     expect(bridge.stdoutReader).toBeNull()
+    expect(bridge.eventLoopMonitor).toBeNull()
+    expect(bridge.eventLoopLagMs).toBe(0)
   })
 
   test('binary discovery supports env, packaged, and PATH fallback branches', () => {

--- a/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
@@ -32,6 +32,10 @@ function createBridgeStub() {
   return Object.assign(emitter, {
     getState: vi.fn(() => ({ status: 'running', pid: 1, running: true })),
     getWorkspacePath: vi.fn(() => process.cwd()),
+    getStabilityMetrics: vi.fn(() => ({
+      eventLoopLagMs: 0,
+      heapGrowthMb: 0,
+    })),
     prompt: vi.fn(),
     abort: vi.fn(),
     restart: vi.fn(),
@@ -192,6 +196,10 @@ describe('reliability recovery IPC handler', () => {
       off: vi.fn(),
       syncRuntimeStatus: vi.fn(async () => undefined),
       getSnapshot: vi.fn(() => createSymphonySnapshot()),
+      getStabilityMetrics: vi.fn(() => ({
+        reconnectSuccessRate: 1,
+        recoveryLatencyMs: 0,
+      })),
       refreshBaseline,
       respondToEscalation: vi.fn(),
     } as any
@@ -241,6 +249,10 @@ describe('reliability recovery IPC handler', () => {
       off: vi.fn(),
       syncRuntimeStatus: vi.fn(async () => undefined),
       getSnapshot: vi.fn(() => createSymphonySnapshot()),
+      getStabilityMetrics: vi.fn(() => ({
+        reconnectSuccessRate: 1,
+        recoveryLatencyMs: 0,
+      })),
       refreshBaseline,
       respondToEscalation: vi.fn(),
     } as any

--- a/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
@@ -83,6 +83,84 @@ describe('RuntimeHealthAggregator', () => {
       expect(surface.status).toBe('healthy')
       expect(surface.signal).toBeNull()
     }
+
+    const stability = aggregator.getStabilitySnapshot()
+    expect(stability.status).toBe('healthy')
+    expect(stability.breaches).toHaveLength(0)
+  })
+
+  test('evaluates long-run stability thresholds with deterministic breach mapping', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    aggregator.ingestStabilityMetrics('chat_runtime', {
+      eventLoopLagMs: 220,
+      heapGrowthMb: 340,
+    })
+    aggregator.ingestStabilityMetrics('workflow_board', {
+      staleAgeMs: 190_000,
+    })
+    aggregator.ingestStabilityMetrics('symphony', {
+      reconnectSuccessRate: 0.62,
+      recoveryLatencyMs: 42_000,
+    })
+    aggregator.ingestStabilityMetrics('mcp', {
+      a11yViolationCounts: {
+        serious: 2,
+        critical: 1,
+      },
+    })
+
+    const stability = aggregator.getStabilitySnapshot()
+
+    expect(stability.status).toBe('breached')
+    expect(stability.breaches.length).toBeGreaterThanOrEqual(6)
+
+    const eventLoopBreach = stability.breaches.find((breach) => breach.metric === 'eventLoopLagMs')
+    expect(eventLoopBreach?.sourceSurface).toBe('chat_runtime')
+    expect(eventLoopBreach?.failureClass).toBe('process')
+    expect(eventLoopBreach?.recoveryAction).toBe('restart_process')
+    expect(eventLoopBreach?.code).toContain('EVENT_LOOP_LAG_MS')
+
+    const reconnectBreach = stability.breaches.find((breach) => breach.metric === 'reconnectSuccessRate')
+    expect(reconnectBreach?.sourceSurface).toBe('symphony')
+    expect(reconnectBreach?.failureClass).toBe('network')
+    expect(reconnectBreach?.recoveryAction).toBe('reconnect')
+
+    expect(stability.breaches.some((breach) => breach.metric === 'a11yViolationCounts')).toBe(true)
+  })
+
+  test('clears stability breaches only after metrics recover in-bounds', () => {
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce('2026-04-07T20:00:00.000Z')
+      .mockReturnValueOnce('2026-04-07T20:00:05.000Z')
+      .mockReturnValueOnce('2026-04-07T20:00:10.000Z')
+      .mockReturnValue('2026-04-07T20:00:15.000Z')
+
+    const aggregator = new RuntimeHealthAggregator({ now })
+
+    aggregator.ingestStabilityMetrics('workflow_board', { staleAgeMs: 200_000 })
+    expect(aggregator.getStabilitySnapshot().status).toBe('breached')
+
+    aggregator.ingestStabilityMetrics('workflow_board', { staleAgeMs: 20_000 })
+
+    const recovered = aggregator.getStabilitySnapshot()
+    expect(recovered.status).toBe('healthy')
+    expect(recovered.breaches).toHaveLength(0)
+    expect(recovered.lastKnownGoodAt).toBeTruthy()
+  })
+
+  test('never reports contradictory healthy stability state when breaches exist', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    aggregator.ingestStabilityMetrics('chat_runtime', {
+      eventLoopLagMs: 300,
+    })
+
+    const stability = aggregator.getStabilitySnapshot()
+    expect(stability.status).not.toBe('healthy')
+    expect(stability.breaches.length).toBeGreaterThan(0)
+    expect(stability.status === 'healthy' && stability.breaches.length > 0).toBe(false)
   })
 
   test('tracks workflow degradation without dropping last-known-good timestamp', () => {

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -32,6 +32,10 @@ function createBridgeStub() {
   return Object.assign(emitter, {
     getState: vi.fn(() => ({ status: 'running', pid: 1, running: true })),
     getWorkspacePath: vi.fn(() => process.cwd()),
+    getStabilityMetrics: vi.fn(() => ({
+      eventLoopLagMs: 0,
+      heapGrowthMb: 0,
+    })),
     prompt: vi.fn(),
     abort: vi.fn(),
     restart: vi.fn(),
@@ -97,6 +101,10 @@ describe('symphony ipc handlers', () => {
       off: vi.fn(),
       syncRuntimeStatus: vi.fn(async () => undefined),
       getSnapshot: vi.fn(() => dashboardSnapshot),
+      getStabilityMetrics: vi.fn(() => ({
+        reconnectSuccessRate: 1,
+        recoveryLatencyMs: 0,
+      })),
       refreshBaseline: vi.fn(async () => dashboardSnapshot),
       respondToEscalation: vi.fn(async () => ({ success: true, snapshot: dashboardSnapshot })),
     } as any

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -35,6 +35,7 @@ function createBridgeStub() {
     getStabilityMetrics: vi.fn(() => ({
       eventLoopLagMs: 0,
       heapGrowthMb: 0,
+      collectedAt: new Date().toISOString(),
     })),
     prompt: vi.fn(),
     abort: vi.fn(),
@@ -104,6 +105,7 @@ describe('symphony ipc handlers', () => {
       getStabilityMetrics: vi.fn(() => ({
         reconnectSuccessRate: 1,
         recoveryLatencyMs: 0,
+        collectedAt: new Date().toISOString(),
       })),
       refreshBaseline: vi.fn(async () => dashboardSnapshot),
       respondToEscalation: vi.fn(async () => ({ success: true, snapshot: dashboardSnapshot })),

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -316,6 +316,26 @@ describe('SymphonyOperatorService', () => {
     expect(signal?.recoveryAction).toBe('refresh_state')
   })
 
+  test('emits reconnect success and recovery latency stability metrics across failure recovery', async () => {
+    const service = new SymphonyOperatorService({
+      env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'assembled_failure_recovery' },
+      createWebSocket: () => fakeSocket,
+    })
+
+    await service.syncRuntimeStatus(READY_STATUS)
+
+    expect(service.getStabilityMetrics().reconnectSuccessRate).toBe(1)
+
+    await service.refreshBaseline()
+    const duringFailure = service.getStabilityMetrics()
+    expect(duringFailure.reconnectSuccessRate).toBe(0)
+
+    await service.refreshBaseline()
+    const recovered = service.getStabilityMetrics()
+    expect(recovered.reconnectSuccessRate).toBe(1)
+    expect((recovered.recoveryLatencyMs ?? 0) >= 0).toBe(true)
+  })
+
   test('preserves legacy kanban mock identifiers for board correlation', async () => {
     const service = new SymphonyOperatorService({
       env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'kanban_assigned' },

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -316,7 +316,7 @@ describe('SymphonyOperatorService', () => {
     expect(signal?.recoveryAction).toBe('refresh_state')
   })
 
-  test('emits reconnect success and recovery latency stability metrics across failure recovery', async () => {
+  test('omits reconnect success metrics until reconnect telemetry has real attempts', async () => {
     const service = new SymphonyOperatorService({
       env: { KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: 'assembled_failure_recovery' },
       createWebSocket: () => fakeSocket,
@@ -324,7 +324,7 @@ describe('SymphonyOperatorService', () => {
 
     await service.syncRuntimeStatus(READY_STATUS)
 
-    expect(service.getStabilityMetrics().reconnectSuccessRate).toBe(1)
+    expect(service.getStabilityMetrics().reconnectSuccessRate).toBeUndefined()
 
     await service.refreshBaseline()
     const duringFailure = service.getStabilityMetrics()

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -51,6 +51,38 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.symphony?.provenance).toBe('unavailable')
   })
 
+  test('emits stale-age stability metric from last successful workflow poll', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T00:00:00.000Z'))
+
+    try {
+      const service = new WorkflowBoardService({
+        authBridge: { getApiKey: vi.fn(async () => null) } as never,
+        getWorkspacePath: () => '/tmp/workspace',
+      }) as any
+
+      service.lastSnapshot = {
+        backend: 'linear',
+        fetchedAt: '2026-04-07T23:59:50.000Z',
+        status: 'stale',
+        source: { projectId: 'project-1' },
+        activeMilestone: null,
+        columns: [],
+        poll: {
+          status: 'error',
+          backend: 'linear',
+          lastAttemptAt: '2026-04-08T00:00:00.000Z',
+          lastSuccessAt: '2026-04-07T23:58:00.000Z',
+        },
+      }
+
+      const metrics = service.getStabilityMetrics()
+      expect(metrics.staleAgeMs).toBe(120000)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   test('applies fixture-mode slice moves and persists them across refreshes', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
 

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -83,6 +83,31 @@ describe('WorkflowBoardService', () => {
     }
   })
 
+  test('returns neutral stale-age stability metric before first successful poll', () => {
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    }) as any
+
+    service.lastSnapshot = {
+      backend: 'linear',
+      fetchedAt: '2026-04-08T00:00:00.000Z',
+      status: 'stale',
+      source: { projectId: 'project-1' },
+      activeMilestone: null,
+      columns: [],
+      poll: {
+        status: 'error',
+        backend: 'linear',
+        lastAttemptAt: '2026-04-08T00:00:00.000Z',
+        lastSuccessAt: null,
+      },
+    }
+
+    const metrics = service.getStabilityMetrics()
+    expect(metrics.staleAgeMs).toBe(0)
+  })
+
   test('applies fixture-mode slice moves and persists them across refreshes', async () => {
     process.env.KATA_TEST_WORKFLOW_FIXTURE = '1'
 

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -83,7 +83,17 @@ describe('WorkflowBoardService', () => {
     }
   })
 
-  test('returns neutral stale-age stability metric before first successful poll', () => {
+  test('returns neutral stale-age stability metric when no snapshot exists', () => {
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => '/tmp/workspace',
+    })
+
+    const metrics = service.getStabilityMetrics()
+    expect(metrics.staleAgeMs).toBe(0)
+  })
+
+  test('returns conservative stale-age metric when stale snapshot has no valid success timestamp', () => {
     const service = new WorkflowBoardService({
       authBridge: { getApiKey: vi.fn(async () => null) } as never,
       getWorkspacePath: () => '/tmp/workspace',
@@ -104,8 +114,10 @@ describe('WorkflowBoardService', () => {
       },
     }
 
-    const metrics = service.getStabilityMetrics()
-    expect(metrics.staleAgeMs).toBe(0)
+    expect(service.getStabilityMetrics().staleAgeMs).toBe(60000)
+
+    service.lastSnapshot.poll.lastSuccessAt = 'not-a-timestamp'
+    expect(service.getStabilityMetrics().staleAgeMs).toBe(60000)
   })
 
   test('applies fixture-mode slice moves and persists them across refreshes', async () => {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -87,6 +87,8 @@ import {
   type ReliabilityRecoveryResult,
   type ReliabilitySnapshot,
   type ReliabilityStatusResponse,
+  type StabilitySnapshot,
+  type StabilitySnapshotResponse,
 } from '../shared/types'
 
 interface RegisterIpcOptions {
@@ -157,6 +159,7 @@ export function registerSessionIpc({
 
         if (sourceSurface === 'workflow_board') {
           const response = await workflowBoardService.refreshBoard()
+          syncStabilityMetricsFromServices()
           reliabilityAggregator.ingestWorkflowSnapshot(response.snapshot)
 
           const reliabilitySignal = mapWorkflowBoardSnapshotToReliability(response.snapshot)
@@ -180,6 +183,7 @@ export function registerSessionIpc({
         if (sourceSurface === 'symphony') {
           const refreshOperatorSnapshot = async () => {
             const snapshot = await symphonyOperatorService!.refreshBaseline()
+            syncStabilityMetricsFromServices()
             reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
 
             const reliabilitySignal = mapSymphonyOperatorSnapshotToReliability(snapshot)
@@ -261,6 +265,7 @@ export function registerSessionIpc({
           }
 
           const response = await resolvedMcpConfigBridge.listServers()
+          syncStabilityMetricsFromServices()
           reliabilityAggregator.ingestMcpConfigResponse(response)
 
           if (!response.success) {
@@ -378,6 +383,27 @@ export function registerSessionIpc({
     })
   }
 
+  const syncStabilityMetricsFromServices = (): StabilitySnapshot => {
+    reliabilityAggregator.ingestStabilityMetrics('chat_runtime', bridge.getStabilityMetrics(), {
+      publish: false,
+    })
+    reliabilityAggregator.ingestStabilityMetrics('workflow_board', workflowBoardService.getStabilityMetrics(), {
+      publish: false,
+    })
+
+    if (symphonyOperatorService) {
+      reliabilityAggregator.ingestStabilityMetrics('symphony', symphonyOperatorService.getStabilityMetrics(), {
+        publish: false,
+      })
+    }
+
+    reliabilityAggregator.ingestStabilityMetrics('mcp', resolvedMcpService.getStabilityMetrics(), {
+      publish: false,
+    })
+
+    return reliabilityAggregator.getStabilitySnapshot()
+  }
+
   const sendReliabilitySnapshot = (snapshot: ReliabilitySnapshot): void => {
     if (!safeSend(IPC_CHANNELS.reliabilityStatus, snapshot)) {
       return
@@ -388,6 +414,18 @@ export function registerSessionIpc({
       degradedSurfaces: snapshot.surfaces
         .filter((surface) => surface.status === 'degraded')
         .map((surface) => surface.sourceSurface),
+    })
+  }
+
+  const sendStabilitySnapshot = (snapshot: StabilitySnapshot): void => {
+    if (!safeSend(IPC_CHANNELS.reliabilityStabilitySnapshot, snapshot)) {
+      return
+    }
+
+    log.debug('[desktop-ipc] stability snapshot', {
+      status: snapshot.status,
+      breachCount: snapshot.breaches.length,
+      thresholdVersion: snapshot.version,
     })
   }
 
@@ -701,6 +739,7 @@ export function registerSessionIpc({
 
   const onStatus = (status: BridgeStatusEvent): void => {
     sendBridgeStatus(status)
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestChatBridgeStatus(status)
   }
 
@@ -717,6 +756,7 @@ export function registerSessionIpc({
       signal,
       stderrLines,
     })
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestChatSubprocessCrash({
       message: lastLine,
       exitCode,
@@ -733,12 +773,14 @@ export function registerSessionIpc({
 
   const onSymphonyStatus = (status: SymphonyRuntimeStatus): void => {
     sendSymphonyStatusToRenderer(status)
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyRuntimeStatus(status)
     void symphonyOperatorService?.syncRuntimeStatus(status)
   }
 
   const onSymphonyDashboardSnapshot = (snapshot: SymphonyOperatorSnapshot): void => {
     sendSymphonyDashboardSnapshot(snapshot)
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
   }
 
@@ -746,9 +788,14 @@ export function registerSessionIpc({
     sendReliabilitySnapshot(snapshot)
   }
 
+  const onStabilitySnapshot = (snapshot: StabilitySnapshot): void => {
+    sendStabilitySnapshot(snapshot)
+  }
+
   symphonySupervisor?.on('status', onSymphonyStatus)
   symphonyOperatorService?.on('snapshot', onSymphonyDashboardSnapshot)
   reliabilityAggregator.on('snapshot', onReliabilitySnapshot)
+  reliabilityAggregator.on('stability', onStabilitySnapshot)
 
   const initialState = bridge.getState()
   const initialBridgeStatus: BridgeStatusEvent = {
@@ -757,11 +804,13 @@ export function registerSessionIpc({
     updatedAt: Date.now(),
   }
   sendBridgeStatus(initialBridgeStatus)
+  syncStabilityMetricsFromServices()
   reliabilityAggregator.ingestChatBridgeStatus(initialBridgeStatus)
 
   if (symphonySupervisor) {
     const initialSymphonyStatus = symphonySupervisor.getStatus()
     sendSymphonyStatusToRenderer(initialSymphonyStatus)
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyRuntimeStatus(initialSymphonyStatus)
     void symphonyOperatorService?.syncRuntimeStatus(initialSymphonyStatus)
   }
@@ -769,10 +818,12 @@ export function registerSessionIpc({
   if (symphonyOperatorService) {
     const initialDashboardSnapshot = symphonyOperatorService.getSnapshot()
     sendSymphonyDashboardSnapshot(initialDashboardSnapshot)
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyOperatorSnapshot(initialDashboardSnapshot)
   }
 
   sendReliabilitySnapshot(reliabilityAggregator.getSnapshot())
+  sendStabilitySnapshot(syncStabilityMetricsFromServices())
 
   ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
   ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
@@ -823,6 +874,7 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.mcpRefreshStatus)
   ipcMain.removeHandler(IPC_CHANNELS.mcpReconnectServer)
   ipcMain.removeHandler(IPC_CHANNELS.reliabilityGetStatus)
+  ipcMain.removeHandler(IPC_CHANNELS.reliabilityGetStabilitySnapshot)
   ipcMain.removeHandler(IPC_CHANNELS.reliabilityRequestRecoveryAction)
 
   ipcMain.handle(IPC_CHANNELS.sessionSend, async (_event, message: string) => {
@@ -1408,12 +1460,14 @@ export function registerSessionIpc({
 
   ipcMain.handle(IPC_CHANNELS.workflowGetBoard, async (): Promise<WorkflowBoardSnapshotResponse> => {
     const response = await workflowBoardService.getBoard()
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestWorkflowSnapshot(response.snapshot)
     return response
   })
 
   ipcMain.handle(IPC_CHANNELS.workflowRefreshBoard, async (): Promise<WorkflowBoardSnapshotResponse> => {
     const response = await workflowBoardService.refreshBoard()
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestWorkflowSnapshot(response.snapshot)
     return response
   })
@@ -1671,6 +1725,7 @@ export function registerSessionIpc({
   ipcMain.handle(IPC_CHANNELS.symphonyGetStatus, async (): Promise<SymphonyRuntimeStatusResponse> => {
     if (!symphonySupervisor) {
       const fallback = createSymphonyDisconnectedResult()
+      syncStabilityMetricsFromServices()
       reliabilityAggregator.ingestSymphonyRuntimeStatus(fallback.status)
       return {
         success: true,
@@ -1679,6 +1734,7 @@ export function registerSessionIpc({
     }
 
     const status = symphonySupervisor.getStatus()
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyRuntimeStatus(status)
     return {
       success: true,
@@ -1710,6 +1766,7 @@ export function registerSessionIpc({
 
   ipcMain.handle(IPC_CHANNELS.symphonyGetDashboard, async (): Promise<SymphonyOperatorSnapshotResponse> => {
     const snapshot = symphonyOperatorService?.getSnapshot() ?? createUnavailableDashboardSnapshot()
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
     return {
       success: true,
@@ -1720,6 +1777,7 @@ export function registerSessionIpc({
   ipcMain.handle(IPC_CHANNELS.symphonyRefreshDashboard, async (): Promise<SymphonyOperatorSnapshotResponse> => {
     if (!symphonyOperatorService) {
       const snapshot = createUnavailableDashboardSnapshot()
+      syncStabilityMetricsFromServices()
       reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
       return {
         success: false,
@@ -1728,6 +1786,7 @@ export function registerSessionIpc({
     }
 
     const snapshot = await symphonyOperatorService.refreshBaseline()
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
     return {
       success: true,
@@ -1740,6 +1799,7 @@ export function registerSessionIpc({
     async (_event, requestId: string, responseText: string): Promise<SymphonyEscalationResponseCommandResult> => {
       if (!symphonyOperatorService) {
         const snapshot = createUnavailableDashboardSnapshot()
+        syncStabilityMetricsFromServices()
         reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
         return {
           success: false,
@@ -1748,6 +1808,7 @@ export function registerSessionIpc({
       }
 
       const response = await symphonyOperatorService.respondToEscalation(requestId, responseText)
+      syncStabilityMetricsFromServices()
       reliabilityAggregator.ingestSymphonyOperatorSnapshot(response.snapshot)
       return response
     },
@@ -1755,6 +1816,7 @@ export function registerSessionIpc({
 
   ipcMain.handle(IPC_CHANNELS.mcpListServers, async (): Promise<McpConfigReadResponse> => {
     const response = await resolvedMcpConfigBridge.listServers()
+    syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestMcpConfigResponse(response)
     return response
   })
@@ -1781,6 +1843,7 @@ export function registerSessionIpc({
     IPC_CHANNELS.mcpRefreshStatus,
     async (_event, name: string): Promise<McpServerStatusResponse> => {
       const response = await resolvedMcpService.refreshStatus(name)
+      syncStabilityMetricsFromServices()
       reliabilityAggregator.ingestMcpStatusResponse(response)
       return response
     },
@@ -1790,6 +1853,7 @@ export function registerSessionIpc({
     IPC_CHANNELS.mcpReconnectServer,
     async (_event, name: string): Promise<McpServerStatusResponse> => {
       const response = await resolvedMcpService.reconnectServer(name)
+      syncStabilityMetricsFromServices()
       reliabilityAggregator.ingestMcpStatusResponse(response)
       return response
     },
@@ -1798,9 +1862,20 @@ export function registerSessionIpc({
   ipcMain.handle(
     IPC_CHANNELS.reliabilityGetStatus,
     async (): Promise<ReliabilityStatusResponse> => {
+      syncStabilityMetricsFromServices()
       return {
         success: true,
         snapshot: reliabilityAggregator.getSnapshot(),
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.reliabilityGetStabilitySnapshot,
+    async (): Promise<StabilitySnapshotResponse> => {
+      return {
+        success: true,
+        snapshot: syncStabilityMetricsFromServices(),
       }
     },
   )
@@ -1833,6 +1908,7 @@ export function registerSessionIpc({
     symphonySupervisor?.off('status', onSymphonyStatus)
     symphonyOperatorService?.off('snapshot', onSymphonyDashboardSnapshot)
     reliabilityAggregator.off('snapshot', onReliabilitySnapshot)
+    reliabilityAggregator.off('stability', onStabilitySnapshot)
     planningToolDetector.off('artifact', onPlanningArtifactEvent)
 
     ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
@@ -1884,6 +1960,7 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.mcpRefreshStatus)
     ipcMain.removeHandler(IPC_CHANNELS.mcpReconnectServer)
     ipcMain.removeHandler(IPC_CHANNELS.reliabilityGetStatus)
+    ipcMain.removeHandler(IPC_CHANNELS.reliabilityGetStabilitySnapshot)
     ipcMain.removeHandler(IPC_CHANNELS.reliabilityRequestRecoveryAction)
   }
 }

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -22,7 +22,6 @@ export class McpService {
   private readonly configBridge: McpConfigBridge
   private readonly requestTimeoutMs: number
   private readonly reliabilityByServer = new Map<string, ReliabilitySignal | null>()
-  private readonly latestStatusByServer = new Map<string, McpServerStatusResponse>()
   private a11yViolationCounts: A11yViolationCounts = {
     minor: 0,
     moderate: 0,
@@ -40,14 +39,9 @@ export class McpService {
   }
 
   public getStabilityMetrics(): StabilityMetricInput {
-    const rowErrorCount = [...this.latestStatusByServer.values()].reduce((count, response) => {
-      return count + (response.status?.phase === 'error' ? 1 : 0)
-    }, 0)
-
     return {
       a11yViolationCounts: {
         ...this.a11yViolationCounts,
-        serious: Math.max(this.a11yViolationCounts.serious, rowErrorCount),
       },
       collectedAt: new Date().toISOString(),
     }
@@ -126,8 +120,6 @@ export class McpService {
     serverName: string,
     response: McpServerStatusResponse,
   ): void {
-    this.latestStatusByServer.set(serverName, response)
-
     const signal = mapMcpStatusResponseToReliability(response)
     if (signal) {
       this.reliabilityByServer.set(serverName, signal)

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -1,5 +1,11 @@
 import { McpConfigBridge } from './mcp-config-bridge'
-import type { McpServerStatus, McpServerStatusResponse, ReliabilitySignal } from '../shared/types'
+import type {
+  A11yViolationCounts,
+  McpServerStatus,
+  McpServerStatusResponse,
+  ReliabilitySignal,
+  StabilityMetricInput,
+} from '../shared/types'
 import {
   mapMcpStatusResponseToReliability,
   pickPrimaryReliabilitySignal,
@@ -16,6 +22,13 @@ export class McpService {
   private readonly configBridge: McpConfigBridge
   private readonly requestTimeoutMs: number
   private readonly reliabilityByServer = new Map<string, ReliabilitySignal | null>()
+  private readonly latestStatusByServer = new Map<string, McpServerStatusResponse>()
+  private a11yViolationCounts: A11yViolationCounts = {
+    minor: 0,
+    moderate: 0,
+    serious: 0,
+    critical: 0,
+  }
 
   constructor(options: McpServiceOptions) {
     this.configBridge = options.configBridge
@@ -24,6 +37,29 @@ export class McpService {
 
   public getReliabilitySignal(): ReliabilitySignal | null {
     return pickPrimaryReliabilitySignal([...this.reliabilityByServer.values()])
+  }
+
+  public getStabilityMetrics(): StabilityMetricInput {
+    const rowErrorCount = [...this.latestStatusByServer.values()].reduce((count, response) => {
+      return count + (response.status?.phase === 'error' ? 1 : 0)
+    }, 0)
+
+    return {
+      a11yViolationCounts: {
+        ...this.a11yViolationCounts,
+        serious: Math.max(this.a11yViolationCounts.serious, rowErrorCount),
+      },
+      collectedAt: new Date().toISOString(),
+    }
+  }
+
+  public recordAccessibilityViolationCounts(counts: Partial<A11yViolationCounts>): void {
+    this.a11yViolationCounts = {
+      minor: counts.minor ?? this.a11yViolationCounts.minor,
+      moderate: counts.moderate ?? this.a11yViolationCounts.moderate,
+      serious: counts.serious ?? this.a11yViolationCounts.serious,
+      critical: counts.critical ?? this.a11yViolationCounts.critical,
+    }
   }
 
   public async refreshStatus(serverName: string): Promise<McpServerStatusResponse> {
@@ -90,6 +126,8 @@ export class McpService {
     serverName: string,
     response: McpServerStatusResponse,
   ): void {
+    this.latestStatusByServer.set(serverName, response)
+
     const signal = mapMcpStatusResponseToReliability(response)
     if (signal) {
       this.reliabilityByServer.set(serverName, signal)

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -79,7 +79,6 @@ export class PiAgentBridge extends EventEmitter {
   ) {
     super()
     this.selectedModel = initialModel?.trim() ? initialModel.trim() : null
-    this.startEventLoopLagMonitor()
   }
 
   override on<K extends keyof BridgeEvents>(event: K, listener: BridgeEvents[K]): this {
@@ -163,6 +162,8 @@ export class PiAgentBridge extends EventEmitter {
     }
 
     const command = discovery.resolvedPath
+
+    this.startEventLoopLagMonitor()
 
     this.emitStatus({
       state: 'spawning',
@@ -511,6 +512,7 @@ export class PiAgentBridge extends EventEmitter {
   public async shutdown(timeoutMs = 1_500): Promise<void> {
     const child = this.child
     if (!child) {
+      this.stopEventLoopLagMonitor()
       this.emitStatus({
         state: 'shutdown',
         pid: null,
@@ -568,6 +570,16 @@ export class PiAgentBridge extends EventEmitter {
     }, intervalMs)
 
     this.eventLoopMonitor.unref?.()
+  }
+
+  private stopEventLoopLagMonitor(): void {
+    if (!this.eventLoopMonitor) {
+      return
+    }
+
+    clearInterval(this.eventLoopMonitor)
+    this.eventLoopMonitor = null
+    this.eventLoopLagMs = 0
   }
 
   private injectPromptCrashFault(): Error {
@@ -870,6 +882,8 @@ export class PiAgentBridge extends EventEmitter {
       this.stdoutReader.close()
       this.stdoutReader = null
     }
+
+    this.stopEventLoopLagMonitor()
   }
 
   private pushStderr(line: string): void {

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -15,6 +15,7 @@ import {
   type ExtensionUIResponse,
   type PermissionMode,
   type RpcCommand,
+  type StabilityMetricInput,
 } from '../shared/types'
 
 interface PendingCommand {
@@ -64,7 +65,11 @@ export class PiAgentBridge extends EventEmitter {
   private permissionMode: PermissionMode = 'ask'
   private selectedModel: string | null
   private readonly reliabilityFaultMode = process.env.KATA_DESKTOP_RELIABILITY_CHAT_FAULT?.trim() ?? null
+  private readonly stabilityFaultMode = process.env.KATA_DESKTOP_STABILITY_CHAT_FAULT?.trim() ?? null
   private reliabilityFaultInjected = false
+  private readonly heapBaselineMb = Math.round((process.memoryUsage().heapUsed / 1024 / 1024) * 100) / 100
+  private eventLoopLagMs = 0
+  private eventLoopMonitor: NodeJS.Timeout | null = null
 
   constructor(
     private workspacePath: string,
@@ -74,6 +79,7 @@ export class PiAgentBridge extends EventEmitter {
   ) {
     super()
     this.selectedModel = initialModel?.trim() ? initialModel.trim() : null
+    this.startEventLoopLagMonitor()
   }
 
   override on<K extends keyof BridgeEvents>(event: K, listener: BridgeEvents[K]): this {
@@ -456,6 +462,33 @@ export class PiAgentBridge extends EventEmitter {
     return this.workspacePath
   }
 
+  public getStabilityMetrics(): StabilityMetricInput {
+    const heapGrowthMb =
+      Math.round((process.memoryUsage().heapUsed / 1024 / 1024 - this.heapBaselineMb) * 100) / 100
+
+    const baseMetrics: StabilityMetricInput = {
+      eventLoopLagMs: Math.max(0, this.eventLoopLagMs),
+      heapGrowthMb: Math.max(0, heapGrowthMb),
+      collectedAt: new Date().toISOString(),
+    }
+
+    if (this.stabilityFaultMode === 'lag_spike') {
+      return {
+        ...baseMetrics,
+        eventLoopLagMs: 220,
+      }
+    }
+
+    if (this.stabilityFaultMode === 'heap_growth') {
+      return {
+        ...baseMetrics,
+        heapGrowthMb: 340,
+      }
+    }
+
+    return baseMetrics
+  }
+
   public async switchWorkspace(nextWorkspacePath: string): Promise<void> {
     const normalized = nextWorkspacePath.trim()
     if (!normalized) {
@@ -518,6 +551,23 @@ export class PiAgentBridge extends EventEmitter {
       this.reliabilityFaultMode === 'process_crash_once' &&
       !this.reliabilityFaultInjected
     )
+  }
+
+  private startEventLoopLagMonitor(intervalMs = 1_000): void {
+    if (this.eventLoopMonitor) {
+      return
+    }
+
+    let expectedTickAt = Date.now() + intervalMs
+
+    this.eventLoopMonitor = setInterval(() => {
+      const now = Date.now()
+      const lag = Math.max(0, now - expectedTickAt)
+      this.eventLoopLagMs = Math.round(lag * 100) / 100
+      expectedTickAt = now + intervalMs
+    }, intervalMs)
+
+    this.eventLoopMonitor.unref?.()
   }
 
   private injectPromptCrashFault(): Error {

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -12,18 +12,27 @@ import {
   RELIABILITY_SURFACES,
 } from './reliability-contract'
 import type {
+  A11yViolationCounts,
   BridgeStatusEvent,
   McpConfigReadResponse,
   McpServerStatusResponse,
+  ReliabilityClass,
   ReliabilityRecoveryAction,
   ReliabilityRecoveryRequest,
   ReliabilityRecoveryResult,
+  ReliabilitySeverity,
   ReliabilitySignal,
   ReliabilitySnapshot,
   ReliabilitySourceSurface,
   ReliabilitySurfaceState,
+  StabilityMetricInput,
+  StabilityMetricName,
+  StabilityMetricSnapshot,
+  StabilitySnapshot,
+  StabilityThresholdSet,
   SymphonyOperatorSnapshot,
   SymphonyRuntimeStatus,
+  ThresholdBreach,
   WorkflowBoardSnapshot,
 } from '../shared/types'
 
@@ -40,10 +49,400 @@ interface RuntimeHealthAggregatorOptions {
     sourceSurface: ReliabilitySourceSurface
     action: ReliabilityRecoveryAction
   }) => Promise<RecoveryAttempt>
+  stabilityThresholds?: StabilityThresholdSet
 }
 
 interface RuntimeHealthAggregatorEvents {
   snapshot: (snapshot: ReliabilitySnapshot) => void
+  stability: (snapshot: StabilitySnapshot) => void
+}
+
+interface StabilityMetricRule {
+  sourceSurface: ReliabilitySourceSurface
+  reliabilityClass: ReliabilityClass
+  recoveryAction: ReliabilityRecoveryAction
+  suggestedRecovery: string
+  label: string
+}
+
+interface ThresholdEvaluationResult {
+  breaches: ThresholdBreach[]
+  status: StabilitySnapshot['status']
+}
+
+interface AggregateMetricAttribution {
+  sourceSurfaceByMetric: Record<StabilityMetricName, ReliabilitySourceSurface>
+  a11ySeriousSurface: ReliabilitySourceSurface
+  a11yCriticalSurface: ReliabilitySourceSurface
+}
+
+const DEFAULT_A11Y_VIOLATION_COUNTS: A11yViolationCounts = {
+  minor: 0,
+  moderate: 0,
+  serious: 0,
+  critical: 0,
+}
+
+export const DEFAULT_STABILITY_THRESHOLDS: StabilityThresholdSet = {
+  version: 'm006-r020-v1',
+  eventLoopLagMs: {
+    warning: 75,
+    breach: 150,
+    comparator: 'max',
+  },
+  heapGrowthMb: {
+    warning: 180,
+    breach: 300,
+    comparator: 'max',
+  },
+  staleAgeMs: {
+    warning: 60_000,
+    breach: 180_000,
+    comparator: 'max',
+  },
+  reconnectSuccessRate: {
+    warning: 0.95,
+    breach: 0.8,
+    comparator: 'min',
+  },
+  recoveryLatencyMs: {
+    warning: 12_000,
+    breach: 30_000,
+    comparator: 'max',
+  },
+  a11yViolationCounts: {
+    serious: {
+      warning: 1,
+      breach: 2,
+      comparator: 'max',
+    },
+    critical: {
+      warning: 1,
+      breach: 1,
+      comparator: 'max',
+    },
+  },
+}
+
+const STABILITY_METRIC_RULES: Record<StabilityMetricName, StabilityMetricRule> = {
+  eventLoopLagMs: {
+    sourceSurface: 'chat_runtime',
+    reliabilityClass: 'process',
+    recoveryAction: 'restart_process',
+    suggestedRecovery:
+      'Restart the chat runtime and reduce concurrent tool load before retrying the flow.',
+    label: 'Event loop lag',
+  },
+  heapGrowthMb: {
+    sourceSurface: 'chat_runtime',
+    reliabilityClass: 'process',
+    recoveryAction: 'restart_process',
+    suggestedRecovery:
+      'Restart the runtime to reclaim heap and inspect recent heavy operations for leaks.',
+    label: 'Heap growth',
+  },
+  staleAgeMs: {
+    sourceSurface: 'workflow_board',
+    reliabilityClass: 'stale',
+    recoveryAction: 'refresh_state',
+    suggestedRecovery:
+      'Refresh the workflow board and verify tracker connectivity before continuing mutations.',
+    label: 'Stale age',
+  },
+  reconnectSuccessRate: {
+    sourceSurface: 'symphony',
+    reliabilityClass: 'network',
+    recoveryAction: 'reconnect',
+    suggestedRecovery: 'Trigger a Symphony reconnect and verify service reachability.',
+    label: 'Reconnect success rate',
+  },
+  recoveryLatencyMs: {
+    sourceSurface: 'symphony',
+    reliabilityClass: 'process',
+    recoveryAction: 'restart_process',
+    suggestedRecovery:
+      'Restart Symphony runtime and confirm recovery checkpoints complete within budget.',
+    label: 'Recovery latency',
+  },
+  a11yViolationCounts: {
+    sourceSurface: 'mcp',
+    reliabilityClass: 'config',
+    recoveryAction: 'fix_config',
+    suggestedRecovery:
+      'Fix accessibility issues on affected surfaces and rerun the accessibility baseline.',
+    label: 'Accessibility violations',
+  },
+}
+
+const EMPTY_STABILITY_METRICS: StabilityMetricSnapshot = {
+  eventLoopLagMs: 0,
+  heapGrowthMb: 0,
+  staleAgeMs: 0,
+  reconnectSuccessRate: 1,
+  recoveryLatencyMs: 0,
+  a11yViolationCounts: { ...DEFAULT_A11Y_VIOLATION_COUNTS },
+  collectedAt: new Date(0).toISOString(),
+}
+
+function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.round(value * 100) / 100
+}
+
+function normalizeMetricInput(input: StabilityMetricInput): StabilityMetricInput {
+  const normalized: StabilityMetricInput = {}
+
+  if (typeof input.eventLoopLagMs === 'number') {
+    normalized.eventLoopLagMs = Math.max(0, roundMetric(input.eventLoopLagMs))
+  }
+
+  if (typeof input.heapGrowthMb === 'number') {
+    normalized.heapGrowthMb = Math.max(0, roundMetric(input.heapGrowthMb))
+  }
+
+  if (typeof input.staleAgeMs === 'number') {
+    normalized.staleAgeMs = Math.max(0, roundMetric(input.staleAgeMs))
+  }
+
+  if (typeof input.reconnectSuccessRate === 'number') {
+    normalized.reconnectSuccessRate = Math.min(1, Math.max(0, roundMetric(input.reconnectSuccessRate)))
+  }
+
+  if (typeof input.recoveryLatencyMs === 'number') {
+    normalized.recoveryLatencyMs = Math.max(0, roundMetric(input.recoveryLatencyMs))
+  }
+
+  if (input.a11yViolationCounts) {
+    normalized.a11yViolationCounts = {
+      minor: Math.max(0, Math.round(input.a11yViolationCounts.minor ?? 0)),
+      moderate: Math.max(0, Math.round(input.a11yViolationCounts.moderate ?? 0)),
+      serious: Math.max(0, Math.round(input.a11yViolationCounts.serious ?? 0)),
+      critical: Math.max(0, Math.round(input.a11yViolationCounts.critical ?? 0)),
+    }
+  }
+
+  if (input.collectedAt) {
+    normalized.collectedAt = input.collectedAt
+  }
+
+  return normalized
+}
+
+function mergeA11yCounts(
+  previous: A11yViolationCounts,
+  next: Partial<A11yViolationCounts> | undefined,
+): A11yViolationCounts {
+  if (!next) {
+    return previous
+  }
+
+  return {
+    minor: next.minor ?? previous.minor,
+    moderate: next.moderate ?? previous.moderate,
+    serious: next.serious ?? previous.serious,
+    critical: next.critical ?? previous.critical,
+  }
+}
+
+function buildThresholdCode(metric: string, level: 'warn' | 'breach'): string {
+  const normalizedMetric = metric
+    .replace(/([a-z])([A-Z])/g, '$1_$2')
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toUpperCase()
+
+  return `REL-LONGRUN-${normalizedMetric}-${level.toUpperCase()}`
+}
+
+function formatMetricValue(metric: StabilityMetricName, value: number): string {
+  if (metric === 'reconnectSuccessRate') {
+    return `${Math.round(value * 100)}%`
+  }
+
+  if (metric === 'eventLoopLagMs' || metric === 'staleAgeMs' || metric === 'recoveryLatencyMs') {
+    return `${roundMetric(value)}ms`
+  }
+
+  if (metric === 'heapGrowthMb') {
+    return `${roundMetric(value)}MB`
+  }
+
+  return String(value)
+}
+
+function evaluateThreshold(
+  metric: StabilityMetricName,
+  observedValue: number,
+  warningThreshold: number,
+  breachThreshold: number,
+  comparator: 'max' | 'min',
+  sourceSurface: ReliabilitySourceSurface,
+  nowIso: string,
+  lastKnownGoodAt: string | undefined,
+  labelOverride?: string,
+): ThresholdBreach | null {
+  const rule = STABILITY_METRIC_RULES[metric]
+  const compareWarning = comparator === 'max' ? observedValue >= warningThreshold : observedValue <= warningThreshold
+  if (!compareWarning) {
+    return null
+  }
+
+  const breached = comparator === 'max' ? observedValue >= breachThreshold : observedValue <= breachThreshold
+  const severity: ReliabilitySeverity = breached ? 'critical' : 'warning'
+  const metricLabel = labelOverride ?? rule.label
+
+  const code = buildThresholdCode(
+    labelOverride ? `${metric}_${labelOverride}` : metric,
+    breached ? 'breach' : 'warn',
+  )
+
+  const thresholdValue = breached ? breachThreshold : warningThreshold
+  const relationLabel = comparator === 'max' ? 'exceeded' : 'dropped below'
+
+  return {
+    code,
+    metric,
+    sourceSurface,
+    failureClass: rule.reliabilityClass,
+    severity,
+    recoveryAction: rule.recoveryAction,
+    comparator,
+    observedValue: roundMetric(observedValue),
+    warningThreshold,
+    breachThreshold,
+    breached,
+    message: `${metricLabel} ${relationLabel} threshold (${formatMetricValue(metric, observedValue)} vs ${formatMetricValue(metric, thresholdValue)}).`,
+    suggestedRecovery: rule.suggestedRecovery,
+    timestamp: nowIso,
+    ...(lastKnownGoodAt ? { lastKnownGoodAt } : {}),
+  }
+}
+
+function evaluateStabilityThresholds(input: {
+  metrics: StabilityMetricSnapshot
+  thresholds: StabilityThresholdSet
+  attribution: AggregateMetricAttribution
+  nowIso: string
+  lastKnownGoodAt?: string
+}): ThresholdEvaluationResult {
+  const { metrics, thresholds, attribution, nowIso, lastKnownGoodAt } = input
+  const breaches: ThresholdBreach[] = []
+
+  const eventLoopBreach = evaluateThreshold(
+    'eventLoopLagMs',
+    metrics.eventLoopLagMs,
+    thresholds.eventLoopLagMs.warning,
+    thresholds.eventLoopLagMs.breach,
+    thresholds.eventLoopLagMs.comparator,
+    attribution.sourceSurfaceByMetric.eventLoopLagMs,
+    nowIso,
+    lastKnownGoodAt,
+  )
+  if (eventLoopBreach) breaches.push(eventLoopBreach)
+
+  const heapGrowthBreach = evaluateThreshold(
+    'heapGrowthMb',
+    metrics.heapGrowthMb,
+    thresholds.heapGrowthMb.warning,
+    thresholds.heapGrowthMb.breach,
+    thresholds.heapGrowthMb.comparator,
+    attribution.sourceSurfaceByMetric.heapGrowthMb,
+    nowIso,
+    lastKnownGoodAt,
+  )
+  if (heapGrowthBreach) breaches.push(heapGrowthBreach)
+
+  const staleAgeBreach = evaluateThreshold(
+    'staleAgeMs',
+    metrics.staleAgeMs,
+    thresholds.staleAgeMs.warning,
+    thresholds.staleAgeMs.breach,
+    thresholds.staleAgeMs.comparator,
+    attribution.sourceSurfaceByMetric.staleAgeMs,
+    nowIso,
+    lastKnownGoodAt,
+  )
+  if (staleAgeBreach) breaches.push(staleAgeBreach)
+
+  const reconnectBreach = evaluateThreshold(
+    'reconnectSuccessRate',
+    metrics.reconnectSuccessRate,
+    thresholds.reconnectSuccessRate.warning,
+    thresholds.reconnectSuccessRate.breach,
+    thresholds.reconnectSuccessRate.comparator,
+    attribution.sourceSurfaceByMetric.reconnectSuccessRate,
+    nowIso,
+    lastKnownGoodAt,
+  )
+  if (reconnectBreach) breaches.push(reconnectBreach)
+
+  const recoveryLatencyBreach = evaluateThreshold(
+    'recoveryLatencyMs',
+    metrics.recoveryLatencyMs,
+    thresholds.recoveryLatencyMs.warning,
+    thresholds.recoveryLatencyMs.breach,
+    thresholds.recoveryLatencyMs.comparator,
+    attribution.sourceSurfaceByMetric.recoveryLatencyMs,
+    nowIso,
+    lastKnownGoodAt,
+  )
+  if (recoveryLatencyBreach) breaches.push(recoveryLatencyBreach)
+
+  const seriousA11yBreach = evaluateThreshold(
+    'a11yViolationCounts',
+    metrics.a11yViolationCounts.serious,
+    thresholds.a11yViolationCounts.serious.warning,
+    thresholds.a11yViolationCounts.serious.breach,
+    thresholds.a11yViolationCounts.serious.comparator,
+    attribution.a11ySeriousSurface,
+    nowIso,
+    lastKnownGoodAt,
+    'serious',
+  )
+  if (seriousA11yBreach) breaches.push(seriousA11yBreach)
+
+  const criticalA11yBreach = evaluateThreshold(
+    'a11yViolationCounts',
+    metrics.a11yViolationCounts.critical,
+    thresholds.a11yViolationCounts.critical.warning,
+    thresholds.a11yViolationCounts.critical.breach,
+    thresholds.a11yViolationCounts.critical.comparator,
+    attribution.a11yCriticalSurface,
+    nowIso,
+    lastKnownGoodAt,
+    'critical',
+  )
+  if (criticalA11yBreach) breaches.push(criticalA11yBreach)
+
+  const status: StabilitySnapshot['status'] =
+    breaches.length === 0 ? 'healthy' : breaches.some((breach) => breach.breached) ? 'breached' : 'degraded'
+
+  return {
+    breaches,
+    status,
+  }
+}
+
+function hasThresholdStateContradiction(
+  status: StabilitySnapshot['status'],
+  breaches: ThresholdBreach[],
+): boolean {
+  if (status === 'healthy') {
+    return breaches.length > 0
+  }
+
+  if (status === 'degraded') {
+    return breaches.some((breach) => breach.breached)
+  }
+
+  if (status === 'breached') {
+    return breaches.length === 0 || breaches.every((breach) => !breach.breached)
+  }
+
+  return true
 }
 
 export class RuntimeHealthAggregator extends EventEmitter {
@@ -51,6 +450,7 @@ export class RuntimeHealthAggregator extends EventEmitter {
   private readonly requestRecovery?: RuntimeHealthAggregatorOptions['requestRecovery']
 
   private readonly surfaces = new Map<ReliabilitySourceSurface, ReliabilitySurfaceState>()
+  private readonly stabilityBySurface = new Map<ReliabilitySourceSurface, StabilityMetricInput>()
 
   private chatBridgeSignal: ReliabilitySignal | null = null
   private chatCrashSignal: ReliabilitySignal | null = null
@@ -59,12 +459,26 @@ export class RuntimeHealthAggregator extends EventEmitter {
   private mcpConfigSignal: ReliabilitySignal | null = null
   private mcpStatusSignal: ReliabilitySignal | null = null
 
+  private readonly stabilityThresholds: StabilityThresholdSet
+  private stabilityMetrics: StabilityMetricSnapshot
+  private stabilityBreaches: ThresholdBreach[] = []
+  private stabilityStatus: StabilitySnapshot['status'] = 'healthy'
+  private stabilityLastKnownGoodAt: string | undefined
+
   constructor(options: RuntimeHealthAggregatorOptions = {}) {
     super()
     this.now = options.now ?? (() => new Date().toISOString())
     this.requestRecovery = options.requestRecovery
+    this.stabilityThresholds = options.stabilityThresholds ?? DEFAULT_STABILITY_THRESHOLDS
 
     const startedAt = this.now()
+    this.stabilityMetrics = {
+      ...EMPTY_STABILITY_METRICS,
+      a11yViolationCounts: { ...EMPTY_STABILITY_METRICS.a11yViolationCounts },
+      collectedAt: startedAt,
+    }
+    this.stabilityLastKnownGoodAt = startedAt
+
     for (const sourceSurface of RELIABILITY_SURFACES) {
       this.surfaces.set(sourceSurface, {
         sourceSurface,
@@ -73,6 +487,7 @@ export class RuntimeHealthAggregator extends EventEmitter {
         updatedAt: startedAt,
         lastHealthyAt: startedAt,
       })
+      this.stabilityBySurface.set(sourceSurface, {})
     }
   }
 
@@ -99,6 +514,41 @@ export class RuntimeHealthAggregator extends EventEmitter {
 
   public getSnapshot(): ReliabilitySnapshot {
     return this.toSnapshot()
+  }
+
+  public getStabilitySnapshot(): StabilitySnapshot {
+    return this.toStabilitySnapshot()
+  }
+
+  public ingestStabilityMetrics(
+    sourceSurface: ReliabilitySourceSurface,
+    metrics: StabilityMetricInput | null | undefined,
+    options: { publish?: boolean } = {},
+  ): StabilitySnapshot {
+    if (!metrics) {
+      return this.toStabilitySnapshot()
+    }
+
+    const current = this.stabilityBySurface.get(sourceSurface) ?? {}
+    const normalized = normalizeMetricInput(metrics)
+    const currentA11yCounts: A11yViolationCounts = {
+      ...DEFAULT_A11Y_VIOLATION_COUNTS,
+      ...(current.a11yViolationCounts ?? {}),
+    }
+
+    const merged: StabilityMetricInput = {
+      ...current,
+      ...normalized,
+      a11yViolationCounts: mergeA11yCounts(currentA11yCounts, normalized.a11yViolationCounts),
+      collectedAt: normalized.collectedAt ?? this.now(),
+    }
+
+    this.stabilityBySurface.set(sourceSurface, merged)
+    this.recomputeStabilityState()
+    if (options.publish !== false) {
+      this.publishSnapshot()
+    }
+    return this.toStabilitySnapshot()
   }
 
   public ingestWorkflowSnapshot(snapshot: WorkflowBoardSnapshot | null | undefined): ReliabilitySnapshot {
@@ -270,7 +720,7 @@ export class RuntimeHealthAggregator extends EventEmitter {
         updatedAt,
         lastHealthyAt: updatedAt,
       })
-      this.emit('snapshot', this.toSnapshot())
+      this.publishSnapshot()
       return
     }
 
@@ -288,7 +738,169 @@ export class RuntimeHealthAggregator extends EventEmitter {
       lastHealthyAt: existing.lastHealthyAt,
     })
 
-    this.emit('snapshot', this.toSnapshot())
+    this.publishSnapshot()
+  }
+
+  private recomputeStabilityState(): void {
+    const aggregate = this.computeAggregateMetrics()
+    this.stabilityMetrics = {
+      ...aggregate.metrics,
+      a11yViolationCounts: { ...aggregate.metrics.a11yViolationCounts },
+    }
+
+    const nowIso = this.now()
+    const evaluation = evaluateStabilityThresholds({
+      metrics: this.stabilityMetrics,
+      thresholds: this.stabilityThresholds,
+      attribution: aggregate.attribution,
+      nowIso,
+      lastKnownGoodAt: this.stabilityLastKnownGoodAt,
+    })
+
+    if (hasThresholdStateContradiction(evaluation.status, evaluation.breaches)) {
+      log.error('[runtime-health-aggregator] contradictory stability state detected', {
+        status: evaluation.status,
+        breachCount: evaluation.breaches.length,
+      })
+      this.stabilityStatus = 'breached'
+      this.stabilityBreaches = [
+        {
+          code: 'REL-LONGRUN-CONTRADICTORY_STATE-BREACH',
+          metric: 'eventLoopLagMs',
+          sourceSurface: 'chat_runtime',
+          failureClass: 'unknown',
+          severity: 'critical',
+          recoveryAction: 'inspect',
+          comparator: 'max',
+          observedValue: this.stabilityMetrics.eventLoopLagMs,
+          warningThreshold: this.stabilityThresholds.eventLoopLagMs.warning,
+          breachThreshold: this.stabilityThresholds.eventLoopLagMs.breach,
+          breached: true,
+          message: 'Stability evaluator produced contradictory state output.',
+          suggestedRecovery: 'Inspect threshold evaluator inputs and rerun soak diagnostics.',
+          timestamp: nowIso,
+          ...(this.stabilityLastKnownGoodAt ? { lastKnownGoodAt: this.stabilityLastKnownGoodAt } : {}),
+        },
+      ]
+      return
+    }
+
+    this.stabilityStatus = evaluation.status
+    this.stabilityBreaches = evaluation.breaches
+
+    if (evaluation.status === 'healthy') {
+      this.stabilityLastKnownGoodAt = nowIso
+    }
+  }
+
+  private computeAggregateMetrics(): {
+    metrics: StabilityMetricSnapshot
+    attribution: AggregateMetricAttribution
+  } {
+    const nowIso = this.now()
+
+    let eventLoopLagMs = 0
+    let eventLoopLagSurface: ReliabilitySourceSurface = STABILITY_METRIC_RULES.eventLoopLagMs.sourceSurface
+
+    let heapGrowthMb = 0
+    let heapGrowthSurface: ReliabilitySourceSurface = STABILITY_METRIC_RULES.heapGrowthMb.sourceSurface
+
+    let staleAgeMs = 0
+    let staleAgeSurface: ReliabilitySourceSurface = STABILITY_METRIC_RULES.staleAgeMs.sourceSurface
+
+    let reconnectSuccessRate = 1
+    let reconnectSurface: ReliabilitySourceSurface = STABILITY_METRIC_RULES.reconnectSuccessRate.sourceSurface
+    let reconnectObserved = false
+
+    let recoveryLatencyMs = 0
+    let recoverySurface: ReliabilitySourceSurface = STABILITY_METRIC_RULES.recoveryLatencyMs.sourceSurface
+
+    const a11yTotals: A11yViolationCounts = { ...DEFAULT_A11Y_VIOLATION_COUNTS }
+    let a11ySeriousSurface: ReliabilitySourceSurface = STABILITY_METRIC_RULES.a11yViolationCounts.sourceSurface
+    let a11yCriticalSurface: ReliabilitySourceSurface = STABILITY_METRIC_RULES.a11yViolationCounts.sourceSurface
+
+    for (const sourceSurface of RELIABILITY_SURFACES) {
+      const metrics = this.stabilityBySurface.get(sourceSurface)
+      if (!metrics) {
+        continue
+      }
+
+      if (typeof metrics.eventLoopLagMs === 'number' && metrics.eventLoopLagMs >= eventLoopLagMs) {
+        eventLoopLagMs = metrics.eventLoopLagMs
+        eventLoopLagSurface = sourceSurface
+      }
+
+      if (typeof metrics.heapGrowthMb === 'number' && metrics.heapGrowthMb >= heapGrowthMb) {
+        heapGrowthMb = metrics.heapGrowthMb
+        heapGrowthSurface = sourceSurface
+      }
+
+      if (typeof metrics.staleAgeMs === 'number' && metrics.staleAgeMs >= staleAgeMs) {
+        staleAgeMs = metrics.staleAgeMs
+        staleAgeSurface = sourceSurface
+      }
+
+      if (typeof metrics.reconnectSuccessRate === 'number') {
+        if (!reconnectObserved || metrics.reconnectSuccessRate <= reconnectSuccessRate) {
+          reconnectSuccessRate = metrics.reconnectSuccessRate
+          reconnectSurface = sourceSurface
+        }
+        reconnectObserved = true
+      }
+
+      if (typeof metrics.recoveryLatencyMs === 'number' && metrics.recoveryLatencyMs >= recoveryLatencyMs) {
+        recoveryLatencyMs = metrics.recoveryLatencyMs
+        recoverySurface = sourceSurface
+      }
+
+      if (metrics.a11yViolationCounts) {
+        const counts = metrics.a11yViolationCounts
+        a11yTotals.minor += counts.minor ?? 0
+        a11yTotals.moderate += counts.moderate ?? 0
+        a11yTotals.serious += counts.serious ?? 0
+        a11yTotals.critical += counts.critical ?? 0
+
+        if ((counts.serious ?? 0) > 0) {
+          a11ySeriousSurface = sourceSurface
+        }
+
+        if ((counts.critical ?? 0) > 0) {
+          a11yCriticalSurface = sourceSurface
+        }
+      }
+    }
+
+    return {
+      metrics: {
+        eventLoopLagMs: roundMetric(eventLoopLagMs),
+        heapGrowthMb: roundMetric(heapGrowthMb),
+        staleAgeMs: roundMetric(staleAgeMs),
+        reconnectSuccessRate: reconnectObserved ? roundMetric(reconnectSuccessRate) : 1,
+        recoveryLatencyMs: roundMetric(recoveryLatencyMs),
+        a11yViolationCounts: a11yTotals,
+        collectedAt: nowIso,
+      },
+      attribution: {
+        sourceSurfaceByMetric: {
+          eventLoopLagMs: eventLoopLagSurface,
+          heapGrowthMb: heapGrowthSurface,
+          staleAgeMs: staleAgeSurface,
+          reconnectSuccessRate: reconnectSurface,
+          recoveryLatencyMs: recoverySurface,
+          a11yViolationCounts: a11yCriticalSurface,
+        },
+        a11ySeriousSurface,
+        a11yCriticalSurface,
+      },
+    }
+  }
+
+  private publishSnapshot(): void {
+    const reliabilitySnapshot = this.toSnapshot()
+    const stabilitySnapshot = this.toStabilitySnapshot()
+
+    this.emit('snapshot', reliabilitySnapshot)
+    this.emit('stability', stabilitySnapshot)
   }
 
   private toSnapshot(): ReliabilitySnapshot {
@@ -315,6 +927,27 @@ export class RuntimeHealthAggregator extends EventEmitter {
       generatedAt: this.now(),
       overallStatus: surfaces.some((surface) => surface.status === 'degraded') ? 'degraded' : 'healthy',
       surfaces,
+    }
+  }
+
+  private toStabilitySnapshot(): StabilitySnapshot {
+    return {
+      version: this.stabilityThresholds.version,
+      status: this.stabilityStatus,
+      metrics: {
+        ...this.stabilityMetrics,
+        a11yViolationCounts: { ...this.stabilityMetrics.a11yViolationCounts },
+      },
+      thresholds: {
+        ...this.stabilityThresholds,
+        a11yViolationCounts: {
+          serious: { ...this.stabilityThresholds.a11yViolationCounts.serious },
+          critical: { ...this.stabilityThresholds.a11yViolationCounts.critical },
+        },
+      },
+      breaches: this.stabilityBreaches.map((breach) => ({ ...breach })),
+      generatedAt: this.now(),
+      ...(this.stabilityLastKnownGoodAt ? { lastKnownGoodAt: this.stabilityLastKnownGoodAt } : {}),
     }
   }
 }

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -110,15 +110,10 @@ export class SymphonyOperatorService extends EventEmitter {
   }
 
   public getStabilityMetrics(): StabilityMetricInput {
-    const reconnectSuccessRate =
-      this.reconnectAttempts > 0
-        ? this.reconnectSuccesses / this.reconnectAttempts
-        : this.snapshot.connection.state === 'connected'
-          ? 1
-          : 0
-
     return {
-      reconnectSuccessRate,
+      ...(this.reconnectAttempts > 0
+        ? { reconnectSuccessRate: this.reconnectSuccesses / this.reconnectAttempts }
+        : {}),
       recoveryLatencyMs: this.lastRecoveryLatencyMs,
       collectedAt: new Date().toISOString(),
     }

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import type { SymphonyRuntimeStatus, ReliabilitySignal } from '../shared/types'
+import type { SymphonyRuntimeStatus, ReliabilitySignal, StabilityMetricInput } from '../shared/types'
 import type {
   SymphonyEscalationResponseCommandResult,
   SymphonyEscalationResponseResult,
@@ -63,6 +63,10 @@ export class SymphonyOperatorService extends EventEmitter {
   private readonly snapshot: SymphonyOperatorSnapshot = createEmptySnapshot()
   private mockBaselineStep = 0
   private mockAssembledHealthyResolved = false
+  private reconnectAttempts = 0
+  private reconnectSuccesses = 0
+  private lastDisconnectAtMs: number | null = null
+  private lastRecoveryLatencyMs = 0
 
   constructor(options: SymphonyOperatorServiceOptions = {}) {
     super()
@@ -103,6 +107,21 @@ export class SymphonyOperatorService extends EventEmitter {
       mapSymphonyRuntimeStatusToReliability(this.runtimeStatus),
       mapSymphonyOperatorSnapshotToReliability(this.snapshot),
     ])
+  }
+
+  public getStabilityMetrics(): StabilityMetricInput {
+    const reconnectSuccessRate =
+      this.reconnectAttempts > 0
+        ? this.reconnectSuccesses / this.reconnectAttempts
+        : this.snapshot.connection.state === 'connected'
+          ? 1
+          : 0
+
+    return {
+      reconnectSuccessRate,
+      recoveryLatencyMs: this.lastRecoveryLatencyMs,
+      collectedAt: new Date().toISOString(),
+    }
   }
 
   public async refreshBaseline(options: { advanceMockScenario?: boolean } = {}): Promise<SymphonyOperatorSnapshot> {
@@ -152,8 +171,7 @@ export class SymphonyOperatorService extends EventEmitter {
       if (escalationResponse.ok) {
         this.snapshot.connection.lastError = undefined
       }
-      this.snapshot.connection.state = 'connected'
-      this.snapshot.connection.updatedAt = new Date().toISOString()
+      this.markConnected()
       this.refreshFreshness()
       this.emitSnapshot()
       return this.snapshot
@@ -304,9 +322,7 @@ export class SymphonyOperatorService extends EventEmitter {
         latestStatus.url !== status.url
       ) {
         if (latestStatus?.phase === 'starting' || latestStatus?.phase === 'restarting') {
-          this.snapshot.connection.state = 'reconnecting'
-          this.snapshot.connection.updatedAt = new Date().toISOString()
-          this.snapshot.connection.lastError = latestStatus.lastError?.message
+          this.markReconnecting(latestStatus.lastError?.message)
           this.refreshFreshness()
           this.emitSnapshot()
         } else if (latestStatus && latestStatus.phase !== 'ready') {
@@ -322,9 +338,7 @@ export class SymphonyOperatorService extends EventEmitter {
 
     if (status.phase === 'restarting' || status.phase === 'starting') {
       this.stopStream()
-      this.snapshot.connection.state = 'reconnecting'
-      this.snapshot.connection.updatedAt = new Date().toISOString()
-      this.snapshot.connection.lastError = status.lastError?.message
+      this.markReconnecting(status.lastError?.message)
       this.refreshFreshness()
       this.emitSnapshot()
       return
@@ -366,9 +380,8 @@ export class SymphonyOperatorService extends EventEmitter {
       this.socketUrl = eventUrl
 
       socket.onopen = () => {
-        this.snapshot.connection.state = 'connected'
-        this.snapshot.connection.updatedAt = new Date().toISOString()
         this.snapshot.connection.lastError = undefined
+        this.markConnected()
         this.refreshFreshness()
         this.emitSnapshot()
       }
@@ -388,9 +401,7 @@ export class SymphonyOperatorService extends EventEmitter {
       }
 
       socket.onerror = () => {
-        this.snapshot.connection.state = 'reconnecting'
-        this.snapshot.connection.updatedAt = new Date().toISOString()
-        this.snapshot.connection.lastError = 'Event stream error.'
+        this.markReconnecting('Event stream error.')
         this.refreshFreshness()
         this.emitSnapshot()
       }
@@ -398,8 +409,7 @@ export class SymphonyOperatorService extends EventEmitter {
       socket.onclose = () => {
         this.socket = null
         this.socketUrl = null
-        this.snapshot.connection.state = 'reconnecting'
-        this.snapshot.connection.updatedAt = new Date().toISOString()
+        this.markReconnecting(this.snapshot.connection.lastError)
         this.refreshFreshness()
         this.emitSnapshot()
 
@@ -420,9 +430,7 @@ export class SymphonyOperatorService extends EventEmitter {
         }
       }
     } catch (error) {
-      this.snapshot.connection.state = 'reconnecting'
-      this.snapshot.connection.updatedAt = new Date().toISOString()
-      this.snapshot.connection.lastError = error instanceof Error ? error.message : String(error)
+      this.markReconnecting(error instanceof Error ? error.message : String(error))
       this.refreshFreshness()
       this.emitSnapshot()
     }
@@ -445,12 +453,42 @@ export class SymphonyOperatorService extends EventEmitter {
     }
   }
 
+  private markConnected(): void {
+    this.updateReconnectTelemetry('connected')
+    this.snapshot.connection.state = 'connected'
+    this.snapshot.connection.updatedAt = new Date().toISOString()
+  }
+
+  private markReconnecting(reason?: string): void {
+    this.updateReconnectTelemetry('reconnecting')
+    this.snapshot.connection.state = 'reconnecting'
+    this.snapshot.connection.updatedAt = new Date().toISOString()
+    this.snapshot.connection.lastError = reason
+  }
+
   private markDisconnected(reason: string): void {
+    this.updateReconnectTelemetry('disconnected')
     this.snapshot.connection.state = 'disconnected'
     this.snapshot.connection.updatedAt = new Date().toISOString()
     this.snapshot.connection.lastError = reason
     this.refreshFreshness(reason)
     this.emitSnapshot()
+  }
+
+  private updateReconnectTelemetry(nextState: 'connected' | 'reconnecting' | 'disconnected'): void {
+    const previousState = this.snapshot.connection.state
+
+    if ((nextState === 'reconnecting' || nextState === 'disconnected') && previousState === 'connected') {
+      this.reconnectAttempts += 1
+      this.lastDisconnectAtMs = Date.now()
+      return
+    }
+
+    if (nextState === 'connected' && previousState !== 'connected' && this.lastDisconnectAtMs !== null) {
+      this.reconnectSuccesses += 1
+      this.lastRecoveryLatencyMs = Math.max(0, Date.now() - this.lastDisconnectAtMs)
+      this.lastDisconnectAtMs = null
+    }
   }
 
   private applyStatePayload(
@@ -596,18 +634,21 @@ export class SymphonyOperatorService extends EventEmitter {
           },
         ]
 
-    this.snapshot.connection.state =
+    const nextConnectionState: 'connected' | 'reconnecting' | 'disconnected' =
       mockMode === 'reconnecting'
         ? 'reconnecting'
         : mockMode === 'kanban_disconnected' || isFailureDisconnectionPhase
           ? 'disconnected'
           : 'connected'
+
+    this.updateReconnectTelemetry(nextConnectionState)
+    this.snapshot.connection.state = nextConnectionState
     this.snapshot.connection.updatedAt = nowIso
     this.snapshot.connection.lastBaselineRefreshAt = nowIso
     this.snapshot.connection.lastError =
-      mockMode === 'reconnecting'
+      nextConnectionState === 'reconnecting'
         ? 'Mocked reconnect in progress.'
-        : mockMode === 'kanban_disconnected' || isFailureDisconnectionPhase
+        : nextConnectionState === 'disconnected'
           ? 'Mocked runtime disconnect.'
           : undefined
     this.refreshFreshness()

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -33,6 +33,7 @@ import type {
   WorkflowSymphonyExecutionFreshness,
   WorkflowSymphonyExecutionProvenance,
   ReliabilitySignal,
+  StabilityMetricInput,
 } from '../shared/types'
 
 const TEST_LINEAR_WORKFLOW_FIXTURE: WorkflowBoardSnapshot = {
@@ -883,6 +884,21 @@ export class WorkflowBoardService {
 
   getReliabilitySignal(): ReliabilitySignal | null {
     return mapWorkflowBoardSnapshotToReliability(this.lastSnapshot)
+  }
+
+  getStabilityMetrics(): StabilityMetricInput {
+    const now = Date.now()
+    const lastSuccessAt = this.lastSnapshot?.poll.lastSuccessAt
+    const staleAgeMs = lastSuccessAt
+      ? Math.max(0, now - Date.parse(lastSuccessAt))
+      : this.lastSnapshot?.status === 'fresh' || this.lastSnapshot?.status === 'empty'
+        ? 0
+        : 60_000
+
+    return {
+      staleAgeMs,
+      collectedAt: new Date(now).toISOString(),
+    }
   }
 
   async getBoard(): Promise<WorkflowBoardSnapshotResponse> {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -888,8 +888,17 @@ export class WorkflowBoardService {
 
   getStabilityMetrics(): StabilityMetricInput {
     const now = Date.now()
-    const lastSuccessAt = this.lastSnapshot?.poll.lastSuccessAt
-    const staleAgeMs = lastSuccessAt ? Math.max(0, now - Date.parse(lastSuccessAt)) : 0
+    const lastSnapshot = this.lastSnapshot
+    const parsedLastSuccessAt = lastSnapshot?.poll.lastSuccessAt
+      ? Date.parse(lastSnapshot.poll.lastSuccessAt)
+      : Number.NaN
+    const hasValidLastSuccessAt = Number.isFinite(parsedLastSuccessAt) && parsedLastSuccessAt <= now
+
+    const staleAgeMs = hasValidLastSuccessAt
+      ? Math.max(0, now - parsedLastSuccessAt)
+      : !lastSnapshot || lastSnapshot.status === 'fresh' || lastSnapshot.status === 'empty'
+        ? 0
+        : 60_000
 
     return {
       staleAgeMs,

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -889,11 +889,7 @@ export class WorkflowBoardService {
   getStabilityMetrics(): StabilityMetricInput {
     const now = Date.now()
     const lastSuccessAt = this.lastSnapshot?.poll.lastSuccessAt
-    const staleAgeMs = lastSuccessAt
-      ? Math.max(0, now - Date.parse(lastSuccessAt))
-      : this.lastSnapshot?.status === 'fresh' || this.lastSnapshot?.status === 'empty'
-        ? 0
-        : 60_000
+    const staleAgeMs = lastSuccessAt ? Math.max(0, now - Date.parse(lastSuccessAt)) : 0
 
     return {
       staleAgeMs,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -269,6 +269,9 @@ const api: DesktopApi = {
     getStatus: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.reliabilityGetStatus)
     },
+    getStabilitySnapshot: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.reliabilityGetStabilitySnapshot)
+    },
     requestRecoveryAction: async (request: Parameters<DesktopApi['reliability']['requestRecoveryAction']>[0]) => {
       return ipcRenderer.invoke(IPC_CHANNELS.reliabilityRequestRecoveryAction, request)
     },
@@ -281,6 +284,17 @@ const api: DesktopApi = {
 
       return () => {
         ipcRenderer.removeListener(IPC_CHANNELS.reliabilityStatus, wrapped)
+      }
+    },
+    onStabilitySnapshot: (listener: Parameters<DesktopApi['reliability']['onStabilitySnapshot']>[0]) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, snapshot: Parameters<Parameters<DesktopApi['reliability']['onStabilitySnapshot']>[0]>[0]) => {
+        listener(snapshot)
+      }
+
+      ipcRenderer.on(IPC_CHANNELS.reliabilityStabilitySnapshot, wrapped)
+
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.reliabilityStabilitySnapshot, wrapped)
       }
     },
   },

--- a/apps/desktop/src/renderer/atoms/reliability.ts
+++ b/apps/desktop/src/renderer/atoms/reliability.ts
@@ -7,6 +7,10 @@ import type {
   ReliabilitySnapshot,
   ReliabilitySourceSurface,
   ReliabilitySurfaceState,
+  StabilityHealthStatus,
+  StabilityMetricName,
+  StabilitySnapshot,
+  ThresholdBreach,
 } from '@shared/types'
 
 const RELIABILITY_SURFACES: ReadonlyArray<ReliabilitySourceSurface> = [
@@ -28,6 +32,42 @@ function buildEmptySnapshot(): ReliabilitySnapshot {
       updatedAt: now,
       lastHealthyAt: now,
     })),
+  }
+}
+
+function buildEmptyStabilitySnapshot(): StabilitySnapshot {
+  const now = new Date(0).toISOString()
+  return {
+    version: 'unknown',
+    status: 'healthy',
+    metrics: {
+      eventLoopLagMs: 0,
+      heapGrowthMb: 0,
+      staleAgeMs: 0,
+      reconnectSuccessRate: 1,
+      recoveryLatencyMs: 0,
+      a11yViolationCounts: {
+        minor: 0,
+        moderate: 0,
+        serious: 0,
+        critical: 0,
+      },
+      collectedAt: now,
+    },
+    thresholds: {
+      version: 'unknown',
+      eventLoopLagMs: { warning: 0, breach: 0, comparator: 'max' },
+      heapGrowthMb: { warning: 0, breach: 0, comparator: 'max' },
+      staleAgeMs: { warning: 0, breach: 0, comparator: 'max' },
+      reconnectSuccessRate: { warning: 1, breach: 0, comparator: 'min' },
+      recoveryLatencyMs: { warning: 0, breach: 0, comparator: 'max' },
+      a11yViolationCounts: {
+        serious: { warning: 0, breach: 0, comparator: 'max' },
+        critical: { warning: 0, breach: 0, comparator: 'max' },
+      },
+    },
+    breaches: [],
+    generatedAt: now,
   }
 }
 
@@ -74,6 +114,37 @@ export function formatReliabilitySurfaceLabel(surface: ReliabilitySourceSurface)
       return 'MCP'
     default:
       return surface
+  }
+}
+
+export function formatStabilityMetricLabel(metric: StabilityMetricName): string {
+  switch (metric) {
+    case 'eventLoopLagMs':
+      return 'Event loop lag'
+    case 'heapGrowthMb':
+      return 'Heap growth'
+    case 'staleAgeMs':
+      return 'Stale age'
+    case 'reconnectSuccessRate':
+      return 'Reconnect success rate'
+    case 'recoveryLatencyMs':
+      return 'Recovery latency'
+    case 'a11yViolationCounts':
+      return 'Accessibility violations'
+    default:
+      return metric
+  }
+}
+
+export function formatStabilityStatusLabel(status: StabilityHealthStatus): string {
+  switch (status) {
+    case 'breached':
+      return 'Breached'
+    case 'degraded':
+      return 'Degraded'
+    case 'healthy':
+    default:
+      return 'Healthy'
   }
 }
 
@@ -129,6 +200,7 @@ function mergeReliabilitySnapshot(
 }
 
 export const reliabilitySnapshotAtom = atom<ReliabilitySnapshot>(buildEmptySnapshot())
+export const stabilitySnapshotAtom = atom<StabilitySnapshot>(buildEmptyStabilitySnapshot())
 export const reliabilityLoadingAtom = atom<boolean>(false)
 export const reliabilityRecoveryPendingAtom = atom<Record<ReliabilitySourceSurface, boolean>>({
   chat_runtime: false,
@@ -153,13 +225,32 @@ const setReliabilitySnapshotAtom = atom(
   },
 )
 
+const setStabilitySnapshotAtom = atom(null, (_get, set, snapshot: StabilitySnapshot) => {
+  set(stabilitySnapshotAtom, snapshot)
+})
+
+export const refreshStabilitySnapshotAtom = atom(null, async (_get, set) => {
+  const response = await window.api.reliability.getStabilitySnapshot()
+  if (response.success) {
+    set(setStabilitySnapshotAtom, response.snapshot)
+  }
+})
+
 export const refreshReliabilityStatusAtom = atom(null, async (_get, set) => {
   set(reliabilityLoadingAtom, true)
 
   try {
-    const response = await window.api.reliability.getStatus()
-    if (response.success) {
-      set(setReliabilitySnapshotAtom, response.snapshot)
+    const [statusResponse, stabilityResponse] = await Promise.all([
+      window.api.reliability.getStatus(),
+      window.api.reliability.getStabilitySnapshot(),
+    ])
+
+    if (statusResponse.success) {
+      set(setReliabilitySnapshotAtom, statusResponse.snapshot)
+    }
+
+    if (stabilityResponse.success) {
+      set(setStabilitySnapshotAtom, stabilityResponse.snapshot)
     }
   } finally {
     set(reliabilityLoadingAtom, false)
@@ -181,9 +272,17 @@ export const requestReliabilityRecoveryActionAtom = atom(
         [request.sourceSurface]: result,
       }))
 
-      const response = await window.api.reliability.getStatus()
-      if (response.success) {
-        set(setReliabilitySnapshotAtom, response.snapshot)
+      const [statusResponse, stabilityResponse] = await Promise.all([
+        window.api.reliability.getStatus(),
+        window.api.reliability.getStabilitySnapshot(),
+      ])
+
+      if (statusResponse.success) {
+        set(setReliabilitySnapshotAtom, statusResponse.snapshot)
+      }
+
+      if (stabilityResponse.success) {
+        set(setStabilitySnapshotAtom, stabilityResponse.snapshot)
       }
 
       return result
@@ -198,25 +297,34 @@ export const requestReliabilityRecoveryActionAtom = atom(
 
 export function useReliabilityBridge(): void {
   const setSnapshot = useSetAtom(setReliabilitySnapshotAtom)
+  const setStabilitySnapshot = useSetAtom(setStabilitySnapshotAtom)
   const refresh = useSetAtom(refreshReliabilityStatusAtom)
 
   useEffect(() => {
     let cancelled = false
 
-    const unsubscribe = window.api.reliability.onStatus((snapshot) => {
+    const unsubscribeStatus = window.api.reliability.onStatus((snapshot) => {
       if (cancelled) {
         return
       }
       setSnapshot(snapshot)
     })
 
+    const unsubscribeStability = window.api.reliability.onStabilitySnapshot((snapshot) => {
+      if (cancelled) {
+        return
+      }
+      setStabilitySnapshot(snapshot)
+    })
+
     void refresh()
 
     return () => {
       cancelled = true
-      unsubscribe()
+      unsubscribeStatus()
+      unsubscribeStability()
     }
-  }, [refresh, setSnapshot])
+  }, [refresh, setSnapshot, setStabilitySnapshot])
 }
 
 export function useReliabilitySnapshot(): ReliabilitySnapshot {
@@ -239,4 +347,27 @@ export function useReliabilitySurfaceState(
     snapshot.surfaces.find((surface) => surface.sourceSurface === sourceSurface) ??
     FALLBACK_SURFACE_STATE(sourceSurface)
   )
+}
+
+export function useStabilitySnapshot(): StabilitySnapshot {
+  return useAtomValue(stabilitySnapshotAtom)
+}
+
+export function useStabilityBreachesForSurface(
+  sourceSurface: ReliabilitySourceSurface,
+): ThresholdBreach[] {
+  const snapshot = useStabilitySnapshot()
+  return snapshot.breaches
+    .filter((breach) => breach.sourceSurface === sourceSurface)
+    .sort((left, right) => {
+      if (left.breached !== right.breached) {
+        return left.breached ? -1 : 1
+      }
+
+      if (left.severity !== right.severity) {
+        return left.severity === 'critical' ? -1 : 1
+      }
+
+      return right.timestamp.localeCompare(left.timestamp)
+    })
 }

--- a/apps/desktop/src/renderer/atoms/reliability.ts
+++ b/apps/desktop/src/renderer/atoms/reliability.ts
@@ -155,7 +155,7 @@ export function reliabilitySeverityTone(
     return 'error'
   }
 
-  if (severity === 'warning') {
+  if (severity === 'serious' || severity === 'warning') {
     return 'warning'
   }
 
@@ -353,6 +353,14 @@ export function useStabilitySnapshot(): StabilitySnapshot {
   return useAtomValue(stabilitySnapshotAtom)
 }
 
+const STABILITY_SEVERITY_RANK: Record<string, number> = {
+  critical: 0,
+  serious: 1,
+  error: 2,
+  warning: 3,
+  info: 4,
+}
+
 export function useStabilityBreachesForSurface(
   sourceSurface: ReliabilitySourceSurface,
 ): ThresholdBreach[] {
@@ -365,7 +373,8 @@ export function useStabilityBreachesForSurface(
       }
 
       if (left.severity !== right.severity) {
-        return left.severity === 'critical' ? -1 : 1
+        return (STABILITY_SEVERITY_RANK[left.severity] ?? Number.MAX_SAFE_INTEGER) -
+          (STABILITY_SEVERITY_RANK[right.severity] ?? Number.MAX_SAFE_INTEGER)
       }
 
       return right.timestamp.localeCompare(left.timestamp)

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -109,7 +109,8 @@ function isEditableTarget(target: EventTarget | null): boolean {
 }
 
 function reliabilitySeverityRank(severity: string | undefined): number {
-  if (severity === 'critical') return 4
+  if (severity === 'critical') return 5
+  if (severity === 'serious') return 4
   if (severity === 'error') return 3
   if (severity === 'warning') return 2
   if (severity === 'info') return 1

--- a/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/AppShell.tsx
@@ -30,11 +30,14 @@ import {
   formatReliabilityActionLabel,
   formatReliabilityClassLabel,
   formatReliabilitySurfaceLabel,
+  formatStabilityMetricLabel,
+  formatStabilityStatusLabel,
   reliabilityRecoveryPendingAtom,
   reliabilitySeverityTone,
   requestReliabilityRecoveryActionAtom,
   useReliabilityBridge,
   useReliabilitySnapshot,
+  useStabilitySnapshot,
 } from '@/atoms/reliability'
 import { Button } from '@/components/ui/button'
 import { LeftPane } from './LeftPane'
@@ -135,6 +138,7 @@ export function AppShell() {
     Object.values(mcpStatusPendingByServer).some((isPending) => Boolean(isPending))
 
   const reliabilitySnapshot = useReliabilitySnapshot()
+  const stabilitySnapshot = useStabilitySnapshot()
   const reliabilityPendingBySurface = useAtomValue(reliabilityRecoveryPendingAtom)
   const requestReliabilityRecovery = useSetAtom(requestReliabilityRecoveryActionAtom)
 
@@ -280,7 +284,28 @@ export function AppShell() {
 
   const primarySignal = primaryReliabilitySurface?.signal ?? null
 
+  const primaryStabilityBreach = useMemo(() => {
+    if (stabilitySnapshot.breaches.length === 0) {
+      return null
+    }
+
+    return [...stabilitySnapshot.breaches].sort((left, right) => {
+      if (left.breached !== right.breached) {
+        return left.breached ? -1 : 1
+      }
+
+      const leftRank = reliabilitySeverityRank(left.severity)
+      const rightRank = reliabilitySeverityRank(right.severity)
+      if (leftRank !== rightRank) {
+        return rightRank - leftRank
+      }
+
+      return right.timestamp.localeCompare(left.timestamp)
+    })[0]
+  }, [stabilitySnapshot])
+
   const reliabilityTone = reliabilitySeverityTone(primarySignal?.severity)
+  const stabilityTone = reliabilitySeverityTone(primaryStabilityBreach?.severity)
 
   return (
     <main className="flex size-full min-h-0 flex-col bg-background text-foreground">
@@ -322,6 +347,47 @@ export function AppShell() {
               {reliabilityPendingBySurface[primaryReliabilitySurface.sourceSurface]
                 ? 'Recovering…'
                 : formatReliabilityActionLabel(primarySignal.recoveryAction)}
+            </Button>
+          </div>
+        </div>
+      ) : primaryStabilityBreach ? (
+        <div
+          className={
+            stabilityTone === 'error'
+              ? 'border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive'
+              : 'border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-900 dark:text-amber-200'
+          }
+          data-testid="stability-banner"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="space-y-0.5">
+              <p className="font-medium">
+                Stability {formatStabilityStatusLabel(stabilitySnapshot.status)} ·{' '}
+                {formatStabilityMetricLabel(primaryStabilityBreach.metric)}
+              </p>
+              <p>
+                {primaryStabilityBreach.message} · Recovery: {primaryStabilityBreach.suggestedRecovery}
+                {primaryStabilityBreach.lastKnownGoodAt
+                  ? ` · Last known good: ${new Date(primaryStabilityBreach.lastKnownGoodAt).toLocaleTimeString()}`
+                  : ''}
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                void requestReliabilityRecovery({
+                  sourceSurface: primaryStabilityBreach.sourceSurface,
+                  action: primaryStabilityBreach.recoveryAction,
+                })
+              }}
+              disabled={reliabilityPendingBySurface[primaryStabilityBreach.sourceSurface]}
+              data-testid="stability-banner-recover"
+            >
+              {reliabilityPendingBySurface[primaryStabilityBreach.sourceSurface]
+                ? 'Recovering…'
+                : formatReliabilityActionLabel(primaryStabilityBreach.recoveryAction)}
             </Button>
           </div>
         </div>

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -112,7 +112,7 @@ export function ChatPanel() {
   const errorTitle = bridgeStatus.state === 'crashed' ? 'Agent process crashed' : 'Agent error'
 
   return (
-    <div className="relative flex h-full min-h-0 flex-col bg-background">
+    <div className="relative flex h-full min-h-0 flex-col bg-background" data-testid="chat-pane">
       <ExtensionUIHandler />
 
       {errorMessage && (

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -47,6 +47,7 @@ export function MessageInput({ disabled = false, stopDisabled = disabled, onSubm
     <div className="border-t border-border p-4">
       <div className="flex flex-col gap-2 rounded-lg border border-border bg-card p-2">
         <Textarea
+          data-testid="chat-input"
           value={value}
           onChange={(event) => setValue(event.target.value)}
           onKeyDown={(event) => {

--- a/apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx
+++ b/apps/desktop/src/renderer/components/kanban/BoardStateNotice.tsx
@@ -1,9 +1,11 @@
-import type { ReliabilitySignal, WorkflowBoardSnapshot } from '@shared/types'
+import type { ReliabilitySignal, ThresholdBreach, WorkflowBoardSnapshot } from '@shared/types'
 import {
   formatReliabilityActionLabel,
   formatReliabilityClassLabel,
+  formatStabilityMetricLabel,
   reliabilitySeverityTone,
   useReliabilitySurfaceState,
+  useStabilityBreachesForSurface,
 } from '@/atoms/reliability'
 
 interface BoardStateNoticeProps {
@@ -22,8 +24,20 @@ export function formatWorkflowReliabilityNotice(signal: ReliabilitySignal): stri
   )
 }
 
+export function formatWorkflowStabilityNotice(breach: ThresholdBreach): string {
+  return (
+    `${formatStabilityMetricLabel(breach.metric)} threshold breach (${breach.code}). ` +
+    `${breach.message} ` +
+    `Suggested recovery: ${breach.suggestedRecovery}.` +
+    (breach.lastKnownGoodAt
+      ? ` Last known good: ${new Date(breach.lastKnownGoodAt).toLocaleTimeString()}.`
+      : '')
+  )
+}
+
 export function BoardStateNotice({ board, error }: BoardStateNoticeProps) {
   const workflowReliability = useReliabilitySurfaceState('workflow_board')
+  const workflowStabilityBreaches = useStabilityBreachesForSurface('workflow_board')
   const notices: Array<{ id: string; tone: 'error' | 'warning'; message: string }> = []
 
   if (workflowReliability.signal) {
@@ -34,7 +48,17 @@ export function BoardStateNotice({ board, error }: BoardStateNoticeProps) {
       tone,
       message: formatWorkflowReliabilityNotice(workflowReliability.signal),
     })
-  } else {
+  }
+
+  for (const breach of workflowStabilityBreaches) {
+    notices.push({
+      id: `workflow-stability-${breach.code}`,
+      tone: reliabilitySeverityTone(breach.severity) === 'error' ? 'error' : 'warning',
+      message: formatWorkflowStabilityNotice(breach),
+    })
+  }
+
+  if (!workflowReliability.signal) {
     if (error) {
       notices.push({
         id: 'board-error',

--- a/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
@@ -249,6 +249,20 @@ export function KanbanHeader({
 
           <Button
             type="button"
+            size="sm"
+            variant="ghost"
+            className="mr-1 h-7 px-2 text-[11px]"
+            aria-label="Open MCP settings"
+            onClick={onOpenMcpSettings}
+            disabled={mcpShortcutDisabled}
+            title="Open MCP settings (⌘⇧M / Ctrl+Shift+M)"
+            data-testid="kanban-open-mcp-settings"
+          >
+            MCP
+          </Button>
+
+          <Button
+            type="button"
             size="icon"
             variant="ghost"
             aria-label="Refresh workflow board"
@@ -289,7 +303,7 @@ export function KanbanHeader({
       </div>
 
       <div className="border-b border-border bg-background/80 px-4 py-1 text-[11px] text-muted-foreground">
-        Shortcuts: <span className="font-mono">⌘⇧R</span> refresh board
+        Shortcuts: <span className="font-mono">⌘⇧M</span> open MCP settings · <span className="font-mono">⌘⇧R</span> refresh board
       </div>
 
       {actionLockReason ? (

--- a/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
@@ -303,7 +303,8 @@ export function KanbanHeader({
       </div>
 
       <div className="border-b border-border bg-background/80 px-4 py-1 text-[11px] text-muted-foreground">
-        Shortcuts: <span className="font-mono">⌘⇧M</span> open MCP settings · <span className="font-mono">⌘⇧R</span> refresh board
+        Shortcuts: <span className="font-mono">⌘⇧M / Ctrl+Shift+M</span> open MCP settings ·{' '}
+        <span className="font-mono">⌘⇧R / Ctrl+Shift+R</span> refresh board
       </div>
 
       {actionLockReason ? (

--- a/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/KanbanPane.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { formatScopeStatus, formatSymphonyBoardStatus, formatWorkflowBoardStatus } from '../KanbanHeader'
 import { summarizeColumnPresentation } from '../KanbanPane'
-import { formatWorkflowReliabilityNotice } from '../BoardStateNotice'
+import { formatWorkflowReliabilityNotice, formatWorkflowStabilityNotice } from '../BoardStateNotice'
 
 describe('KanbanPane status formatting', () => {
   test('renders loading state', () => {
@@ -176,6 +176,30 @@ describe('KanbanPane reliability messaging', () => {
 
     expect(message).toContain('Network issue (REL-WORKFLOW-NETWORK-NETWORK)')
     expect(message).toContain('Recommended recovery: Reconnect service.')
+    expect(message).toContain('Last known good:')
+  })
+
+  test('formats workflow stability notice with threshold guidance', () => {
+    const message = formatWorkflowStabilityNotice({
+      code: 'REL-LONGRUN-STALE_AGE_MS-BREACH',
+      metric: 'staleAgeMs',
+      sourceSurface: 'workflow_board',
+      failureClass: 'stale',
+      severity: 'critical',
+      recoveryAction: 'refresh_state',
+      comparator: 'max',
+      observedValue: 200000,
+      warningThreshold: 60000,
+      breachThreshold: 180000,
+      breached: true,
+      message: 'Stale age exceeded threshold (200000ms vs 180000ms).',
+      suggestedRecovery: 'Refresh workflow board and confirm tracker connectivity.',
+      timestamp: '2026-04-07T20:00:00.000Z',
+      lastKnownGoodAt: '2026-04-07T19:58:00.000Z',
+    })
+
+    expect(message).toContain('Stale age threshold breach')
+    expect(message).toContain('Suggested recovery: Refresh workflow board and confirm tracker connectivity.')
     expect(message).toContain('Last known good:')
   })
 })

--- a/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -18,6 +18,32 @@ import { WelcomeStep } from './WelcomeStep'
 
 type OnboardingStep = 'welcome' | 'provider' | 'key' | 'complete'
 
+export interface OnboardingAccessibilityCheckpoint {
+  id: string
+  severity: 'critical' | 'serious'
+  expectation: string
+}
+
+export function getOnboardingAccessibilityBaseline(): OnboardingAccessibilityCheckpoint[] {
+  return [
+    {
+      id: 'onboarding-heading',
+      severity: 'critical',
+      expectation: 'Onboarding heading and step indicator are visible.',
+    },
+    {
+      id: 'onboarding-primary-action',
+      severity: 'serious',
+      expectation: 'Get started button is visible and keyboard actionable.',
+    },
+    {
+      id: 'onboarding-provider-selection',
+      severity: 'serious',
+      expectation: 'Provider step exposes selectable provider cards with accessible names.',
+    },
+  ]
+}
+
 function createMissingProviderMap(): ProviderStatusMap {
   const entries = ALL_AUTH_PROVIDERS.map((provider) => [
     provider,

--- a/apps/desktop/src/renderer/components/onboarding/__tests__/OnboardingWizard.test.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/__tests__/OnboardingWizard.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest'
+import { getOnboardingAccessibilityBaseline } from '../OnboardingWizard'
+
+describe('OnboardingWizard accessibility baseline', () => {
+  test('defines severity-gated checkpoints for onboarding flow', () => {
+    const baseline = getOnboardingAccessibilityBaseline()
+
+    expect(baseline).toHaveLength(3)
+    expect(baseline[0]?.id).toBe('onboarding-heading')
+    expect(baseline[0]?.severity).toBe('critical')
+    expect(baseline.some((checkpoint) => checkpoint.id === 'onboarding-primary-action')).toBe(true)
+    expect(baseline.every((checkpoint) => checkpoint.expectation.length > 0)).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import type { McpServerSummary, ReliabilitySignal } from '@shared/types'
+import type { McpServerSummary, ReliabilitySignal, ThresholdBreach } from '@shared/types'
 import {
   deleteMcpServerAtom,
   loadMcpConfigAtom,
@@ -16,10 +16,12 @@ import {
 import {
   formatReliabilityActionLabel,
   formatReliabilityClassLabel,
+  formatStabilityMetricLabel,
   reliabilityRecoveryPendingAtom,
   reliabilitySeverityTone,
   requestReliabilityRecoveryActionAtom,
   useReliabilitySurfaceState,
+  useStabilityBreachesForSurface,
 } from '@/atoms/reliability'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -40,6 +42,10 @@ export function formatMcpReliabilityNotice(signal: ReliabilitySignal): string {
   return `${signal.message} Recommended recovery: ${formatReliabilityActionLabel(signal.recoveryAction)}.`
 }
 
+export function formatMcpStabilityNotice(breach: ThresholdBreach): string {
+  return `${formatStabilityMetricLabel(breach.metric)}: ${breach.message} Suggested recovery: ${breach.suggestedRecovery}.`
+}
+
 export function McpServerPanel() {
   useMcpConfigBridge()
 
@@ -51,6 +57,7 @@ export function McpServerPanel() {
   const statuses = useAtomValue(mcpServerStatusesAtom)
   const reliabilityPendingBySurface = useAtomValue(reliabilityRecoveryPendingAtom)
   const mcpReliability = useReliabilitySurfaceState('mcp')
+  const mcpStabilityBreaches = useStabilityBreachesForSurface('mcp')
 
   const refreshConfig = useSetAtom(loadMcpConfigAtom)
   const saveServer = useSetAtom(saveMcpServerAtom)
@@ -143,6 +150,17 @@ export function McpServerPanel() {
             <AlertDescription>{formatMcpReliabilityNotice(mcpReliability.signal)}</AlertDescription>
           </Alert>
         ) : null}
+
+        {mcpStabilityBreaches.map((breach) => (
+          <Alert
+            key={breach.code}
+            variant={reliabilitySeverityTone(breach.severity) === 'error' ? 'destructive' : 'default'}
+            data-testid={`mcp-stability-${breach.code}`}
+          >
+            <AlertTitle>{formatStabilityMetricLabel(breach.metric)} · {breach.code}</AlertTitle>
+            <AlertDescription>{formatMcpStabilityNotice(breach)}</AlertDescription>
+          </Alert>
+        ))}
 
         {configState.provenance?.warning ? (
           <Alert data-testid="mcp-overlay-warning">

--- a/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 import { createMcpServerEditorDraft, parseArgs, validateMcpServerDraft } from '../McpServerEditorDialog'
-import { formatMcpProvenanceLabel, formatMcpReliabilityNotice } from '../McpServerPanel'
+import {
+  formatMcpProvenanceLabel,
+  formatMcpReliabilityNotice,
+  formatMcpStabilityNotice,
+} from '../McpServerPanel'
 import {
   formatMcpStatusLabel,
   mcpStatusBadgeVariant,
@@ -28,6 +32,28 @@ describe('MCP settings helpers', () => {
 
     expect(notice).toContain('Invalid JSON in mcp.json')
     expect(notice).toContain('Recommended recovery: Fix configuration.')
+  })
+
+  test('formats MCP stability notices with metric threshold guidance', () => {
+    const notice = formatMcpStabilityNotice({
+      code: 'REL-LONGRUN-A11Y_VIOLATION_COUNTS_CRITICAL-BREACH',
+      metric: 'a11yViolationCounts',
+      sourceSurface: 'mcp',
+      failureClass: 'config',
+      severity: 'critical',
+      recoveryAction: 'fix_config',
+      comparator: 'max',
+      observedValue: 1,
+      warningThreshold: 1,
+      breachThreshold: 1,
+      breached: true,
+      message: 'Accessibility violations exceeded threshold (1 vs 1).',
+      suggestedRecovery: 'Fix accessibility issues and rerun baseline checks.',
+      timestamp: '2026-04-07T20:00:00.000Z',
+    })
+
+    expect(notice).toContain('Accessibility violations: Accessibility violations exceeded threshold')
+    expect(notice).toContain('Suggested recovery: Fix accessibility issues and rerun baseline checks.')
   })
 
   test('summarizes stdio and http server rows for compact display', () => {

--- a/apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
+++ b/apps/desktop/src/renderer/components/symphony/SymphonyDashboard.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { RefreshCcw } from 'lucide-react'
-import type { ReliabilitySignal } from '@shared/types'
+import type { ReliabilitySignal, ThresholdBreach } from '@shared/types'
 import { Spinner } from '@/components/ui/spinner'
 import {
   refreshSymphonyDashboardAtom,
@@ -13,10 +13,12 @@ import {
 import {
   formatReliabilityActionLabel,
   formatReliabilityClassLabel,
+  formatStabilityMetricLabel,
   reliabilityRecoveryPendingAtom,
   reliabilitySeverityTone,
   requestReliabilityRecoveryActionAtom,
   useReliabilitySurfaceState,
+  useStabilityBreachesForSurface,
 } from '@/atoms/reliability'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -37,12 +39,17 @@ export function formatSymphonyReliabilityNotice(signal: ReliabilitySignal): stri
   return `${signal.message} Recommended recovery: ${formatReliabilityActionLabel(signal.recoveryAction)}.`
 }
 
+export function formatSymphonyStabilityNotice(breach: ThresholdBreach): string {
+  return `${formatStabilityMetricLabel(breach.metric)}: ${breach.message} Suggested recovery: ${breach.suggestedRecovery}.`
+}
+
 export function SymphonyDashboard() {
   const snapshot = useSymphonyDashboardSnapshot()
   const loading = useAtomValue(symphonyDashboardLoadingAtom)
   const drafts = useAtomValue(symphonyEscalationDraftsAtom)
   const reliabilityPendingBySurface = useAtomValue(reliabilityRecoveryPendingAtom)
   const symphonyReliability = useReliabilitySurfaceState('symphony')
+  const symphonyStabilityBreaches = useStabilityBreachesForSurface('symphony')
   const refresh = useSetAtom(refreshSymphonyDashboardAtom)
   const setDraft = useSetAtom(setSymphonyEscalationDraftAtom)
   const respond = useSetAtom(respondToEscalationAtom)
@@ -115,6 +122,17 @@ export function SymphonyDashboard() {
             <AlertDescription>{snapshot.freshness.staleReason ?? 'No recent updates from Symphony.'}</AlertDescription>
           </Alert>
         ) : null}
+
+        {symphonyStabilityBreaches.map((breach) => (
+          <Alert
+            key={breach.code}
+            variant={reliabilitySeverityTone(breach.severity) === 'error' ? 'destructive' : 'default'}
+            data-testid={`symphony-dashboard-stability-${breach.code}`}
+          >
+            <AlertTitle>{formatStabilityMetricLabel(breach.metric)} · {breach.code}</AlertTitle>
+            <AlertDescription>{formatSymphonyStabilityNotice(breach)}</AlertDescription>
+          </Alert>
+        ))}
 
         {snapshot.connection.lastError && !symphonyReliability.signal ? (
           <Alert variant="destructive" data-testid="symphony-dashboard-error">

--- a/apps/desktop/src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx
+++ b/apps/desktop/src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest'
-import { connectionBadgeVariant, formatSymphonyReliabilityNotice } from '../SymphonyDashboard'
+import {
+  connectionBadgeVariant,
+  formatSymphonyReliabilityNotice,
+  formatSymphonyStabilityNotice,
+} from '../SymphonyDashboard'
 import { formatLastActivity } from '../WorkerTable'
 
 describe('SymphonyDashboard helpers', () => {
@@ -29,5 +33,27 @@ describe('SymphonyDashboard helpers', () => {
 
     expect(notice).toContain('Symphony operator is disconnected.')
     expect(notice).toContain('Recommended recovery: Reconnect service.')
+  })
+
+  test('formats stability notice with metric-specific recovery guidance', () => {
+    const notice = formatSymphonyStabilityNotice({
+      code: 'REL-LONGRUN-RECOVERY_LATENCY_MS-BREACH',
+      metric: 'recoveryLatencyMs',
+      sourceSurface: 'symphony',
+      failureClass: 'process',
+      severity: 'critical',
+      recoveryAction: 'restart_process',
+      comparator: 'max',
+      observedValue: 42000,
+      warningThreshold: 12000,
+      breachThreshold: 30000,
+      breached: true,
+      message: 'Recovery latency exceeded threshold (42000ms vs 30000ms).',
+      suggestedRecovery: 'Restart Symphony runtime and validate recovery checkpoints.',
+      timestamp: '2026-04-07T20:00:00.000Z',
+    })
+
+    expect(notice).toContain('Recovery latency: Recovery latency exceeded threshold')
+    expect(notice).toContain('Suggested recovery: Restart Symphony runtime and validate recovery checkpoints.')
   })
 })

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -57,6 +57,8 @@ export const IPC_CHANNELS = {
   mcpReconnectServer: 'mcp:reconnect-server',
   reliabilityGetStatus: 'reliability:get-status',
   reliabilityStatus: 'reliability:status',
+  reliabilityGetStabilitySnapshot: 'reliability:get-stability-snapshot',
+  reliabilityStabilitySnapshot: 'reliability:stability-snapshot',
   reliabilityRequestRecoveryAction: 'reliability:request-recovery-action',
 } as const
 
@@ -1357,6 +1359,92 @@ export interface ReliabilityStatusResponse {
   snapshot: ReliabilitySnapshot
 }
 
+export type StabilityMetricName =
+  | 'eventLoopLagMs'
+  | 'heapGrowthMb'
+  | 'staleAgeMs'
+  | 'reconnectSuccessRate'
+  | 'recoveryLatencyMs'
+  | 'a11yViolationCounts'
+
+export type StabilityHealthStatus = 'healthy' | 'degraded' | 'breached'
+
+export interface A11yViolationCounts {
+  minor: number
+  moderate: number
+  serious: number
+  critical: number
+}
+
+export interface StabilityMetricSnapshot {
+  eventLoopLagMs: number
+  heapGrowthMb: number
+  staleAgeMs: number
+  reconnectSuccessRate: number
+  recoveryLatencyMs: number
+  a11yViolationCounts: A11yViolationCounts
+  collectedAt: string
+}
+
+export interface StabilityThresholdBand {
+  warning: number
+  breach: number
+  comparator: 'max' | 'min'
+}
+
+export interface StabilityThresholdSet {
+  version: string
+  eventLoopLagMs: StabilityThresholdBand
+  heapGrowthMb: StabilityThresholdBand
+  staleAgeMs: StabilityThresholdBand
+  reconnectSuccessRate: StabilityThresholdBand
+  recoveryLatencyMs: StabilityThresholdBand
+  a11yViolationCounts: {
+    serious: StabilityThresholdBand
+    critical: StabilityThresholdBand
+  }
+}
+
+export interface ThresholdBreach {
+  code: string
+  metric: StabilityMetricName
+  sourceSurface: ReliabilitySourceSurface
+  failureClass: ReliabilityClass
+  severity: ReliabilitySeverity
+  recoveryAction: ReliabilityRecoveryAction
+  comparator: 'max' | 'min'
+  observedValue: number
+  warningThreshold: number
+  breachThreshold: number
+  breached: boolean
+  message: string
+  suggestedRecovery: string
+  timestamp: string
+  lastKnownGoodAt?: string
+}
+
+export interface StabilitySnapshot {
+  version: string
+  status: StabilityHealthStatus
+  metrics: StabilityMetricSnapshot
+  thresholds: StabilityThresholdSet
+  breaches: ThresholdBreach[]
+  generatedAt: string
+  lastKnownGoodAt?: string
+}
+
+export type StabilityMetricInput = Partial<
+  Omit<StabilityMetricSnapshot, 'a11yViolationCounts' | 'collectedAt'>
+> & {
+  a11yViolationCounts?: Partial<A11yViolationCounts>
+  collectedAt?: string
+}
+
+export interface StabilitySnapshotResponse {
+  success: boolean
+  snapshot: StabilitySnapshot
+}
+
 export interface ReliabilityRecoveryRequest {
   sourceSurface: ReliabilitySourceSurface
   action?: ReliabilityRecoveryAction
@@ -1522,10 +1610,12 @@ export interface DesktopApi {
   }
   reliability: {
     getStatus: () => Promise<ReliabilityStatusResponse>
+    getStabilitySnapshot: () => Promise<StabilitySnapshotResponse>
     requestRecoveryAction: (
       request: ReliabilityRecoveryRequest,
     ) => Promise<ReliabilityRecoveryResult>
     onStatus: (listener: (snapshot: ReliabilitySnapshot) => void) => () => void
+    onStabilitySnapshot: (listener: (snapshot: StabilitySnapshot) => void) => () => void
   }
 }
 


### PR DESCRIPTION
## Summary
- add canonical long-run stability thresholds + breach contract aggregation across chat/workflow/symphony/mcp surfaces
- expose typed stability snapshots over IPC/preload and render user-facing breach/recovery diagnostics in app shell, kanban, symphony, and MCP settings
- add deterministic M006 soak + accessibility automation plus S03 smoke/UAT/handoff evidence artifacts
- refresh `S03-SOAK-METRICS.json` with a fresh 180m threshold-asserted run

## Validation
- `cd apps/desktop && npx vitest run src/main/__tests__/runtime-health-aggregator.test.ts src/main/__tests__/workflow-board-service.test.ts src/main/__tests__/symphony-operator-service.test.ts src/main/__tests__/mcp-service.test.ts src/renderer/components/kanban/__tests__/KanbanPane.test.tsx src/renderer/components/symphony/__tests__/SymphonyDashboard.test.tsx src/renderer/components/settings/__tests__/McpServerPanel.test.tsx`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && npx playwright test e2e/tests/m006-long-run-stability.e2e.ts e2e/tests/m006-accessibility-baseline.e2e.ts`
- `cd apps/desktop && bun run qa:m006:soak -- --duration=180m --assert-thresholds --report docs/uat/M006/S03-SOAK-METRICS.json`

## Evidence
- `apps/desktop/docs/uat/M006/S03-LONG-RUN-SMOKE.md`
- `apps/desktop/docs/uat/M006/S03-UAT-REPORT.md`
- `apps/desktop/docs/uat/M006/S03-DOWNSTREAM-HANDOFF.md`
- `apps/desktop/docs/uat/M006/S03-SOAK-METRICS.json`

Refs: KAT-2401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stability health monitoring with breach detection, stability snapshot API, UI banners/notices, and recovery actions
  * Accessibility baseline checks and onboarding accessibility checklist
  * MCP quick-access button in Kanban header
  * QA soak-run report generation for long-run stability

* **Tests**
  * E2E accessibility baseline and long-run stability soak tests
  * Unit tests covering stability metric computation, threshold breaches, and service integrations

* **Chores**
  * Added QA script to run soak reports
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a canonical long-run stability subsystem for the Electron desktop app: threshold-evaluated metrics across chat, workflow board, Symphony, and MCP surfaces, exposed over new IPC channels and rendered as breach/recovery banners in the app shell, Kanban, Symphony dashboard, and MCP settings.

Two P1 defects ship alongside the otherwise well-structured implementation:

- **MCP errors as a11y violations**: `McpService.getStabilityMetrics()` folds `phase === 'error'` server counts into `a11yViolationCounts.serious`, so MCP connectivity failures trigger \"Accessibility violations threshold breach\" with recovery guidance that tells users to \"fix accessibility issues and rerun the baseline\" — wrong for a server that simply can't be reached.
- **False breach on Symphony startup**: `SymphonyOperatorService.getStabilityMetrics()` returns `reconnectSuccessRate: 0` when `reconnectAttempts === 0` and `state === 'disconnected'` (the initial snapshot state), causing a critical stability banner on every app start for Symphony-configured users before the first connection resolves.

<h3>Confidence Score: 4/5</h3>

Two P1 defects cause incorrect user-facing breach messages on MCP surfaces and a false-positive stability banner on every Symphony startup — both should be fixed before merging.

The overall architecture is clean and the IPC plumbing, threshold evaluation, and renderer wiring are well-implemented. Score is 4 (not 5) because two P1 issues ship real incorrect behavior: MCP server errors produce actively wrong recovery guidance pointing users at accessibility fixes, and every app startup with Symphony configured shows a spurious critical breach banner until the connection resolves.

apps/desktop/src/main/mcp-service.ts (getStabilityMetrics a11y conflation) and apps/desktop/src/main/symphony-operator-service.ts (reconnectSuccessRate=0 on startup)

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Stability metrics are computed from in-process runtime state (heap, event loop, connection counters) and flow over the existing contextBridge IPC — no user-supplied data is reflected into breach messages without sanitisation, and no new credentials or sensitive fields are introduced.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/mcp-service.ts | P1: getStabilityMetrics conflates MCP server phase=error counts with a11yViolationCounts.serious, causing misleading 'Accessibility violations' breach messages with wrong recovery guidance |
| apps/desktop/src/main/symphony-operator-service.ts | P1: getStabilityMetrics returns reconnectSuccessRate=0 when reconnectAttempts=0 and state is 'disconnected' (the startup state), triggering a false critical breach banner on every startup with Symphony configured |
| apps/desktop/src/main/runtime-health-aggregator.ts | Core stability subsystem: adds 637 lines for threshold evaluation, aggregate metric computation, and StabilitySnapshot lifecycle; logic is sound |
| apps/desktop/src/main/pi-agent-bridge.ts | Adds event loop lag monitoring and heap growth tracking; setInterval started in constructor is never cleared, preventing GC of bridge instances if multiple are created across sessions |
| apps/desktop/src/main/ipc.ts | Adds StabilitySnapshot IPC channel, wires syncStabilityMetricsFromServices() on every handler; cleanup correctly removes new handler registrations |
| apps/desktop/src/shared/types.ts | Adds well-typed StabilityMetricName, StabilitySnapshot, ThresholdBreach, and related types; new IPC channels registered correctly |
| apps/desktop/src/preload/index.ts | Correctly exposes getStabilitySnapshot and onStabilitySnapshot over contextBridge with proper listener cleanup |
| apps/desktop/src/renderer/atoms/reliability.ts | Adds stabilitySnapshotAtom, useStabilitySnapshot, useStabilityBreachesForSurface hooks; correctly subscribes to onStabilitySnapshot IPC push and unsubscribes on cleanup |
| apps/desktop/src/renderer/components/app-shell/AppShell.tsx | Adds stability breach banner below existing reliability banner; correctly sorts breaches by severity and wires recovery action button |
| apps/desktop/src/main/workflow-board-service.ts | Adds getStabilityMetrics returning staleAgeMs derived from lastSnapshot.poll.lastSuccessAt; fallback logic handles null/missing snapshot correctly |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PiAgentBridge\neventLoopLagMs / heapGrowthMb"] --> S
    B["WorkflowBoardService\nstaleAgeMs"] --> S
    C["SymphonyOperatorService\nreconnectSuccessRate / recoveryLatencyMs"] --> S
    D["McpService\na11yViolationCounts"] --> S
    S["syncStabilityMetricsFromServices\nipc.ts — called on every IPC handler"]
    S --> AGG
    AGG["RuntimeHealthAggregator\ningestStabilityMetrics x4\npublish: false"]
    AGG --> RECOMP["recomputeStabilityState\nevaluateStabilityThresholds"]
    RECOMP --> SNAP["StabilitySnapshot\nstatus: healthy / degraded / breached\nbreaches: ThresholdBreach list"]
    SNAP -->|"getStabilitySnapshot IPC"| PRELOAD["preload/index.ts\ngetStabilitySnapshot / onStabilitySnapshot"]
    AGG -->|"stability event via publishSnapshot"| PRELOAD
    PRELOAD --> ATOM["stabilitySnapshotAtom\nJotai"]
    ATOM --> UI1["AppShell\nstability breach banner"]
    ATOM --> UI2["SymphonyDashboard\nstability alerts"]
    ATOM --> UI3["McpServerPanel\nstability alerts"]
    ATOM --> UI4["BoardStateNotice\nstability notices"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/mcp-service.ts
Line: 43-54

Comment:
**MCP server errors reported as accessibility violations**

`rowErrorCount` counts MCP servers whose `phase === 'error'` (config errors, unreachable servers, etc.) and folds that integer into `a11yViolationCounts.serious` via `Math.max`. When two servers are erroring, `serious = 2` crosses the breach threshold, and `STABILITY_METRIC_RULES.a11yViolationCounts` surfaces the following message to the user:

> "Accessibility violations exceeded threshold (2 vs 2). Suggested recovery: Fix accessibility issues on affected surfaces and rerun the accessibility baseline."

That recovery guidance is actively wrong — the problem is MCP server connectivity, not UI accessibility. The a11y field should only hold data from `recordAccessibilityViolationCounts`. MCP server errors belong in a separate metric (or can be surfaced through the existing reliability signal path, which already handles `phase === 'error'`).

```typescript
// suggested fix: drop rowErrorCount from getStabilityMetrics entirely;
// MCP server errors are already handled by the reliability signal via updateServerReliabilitySignal
public getStabilityMetrics(): StabilityMetricInput {
  return {
    a11yViolationCounts: { ...this.a11yViolationCounts },
    collectedAt: new Date().toISOString(),
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/symphony-operator-service.ts
Line: 112-125

Comment:
**False `reconnectSuccessRate=0` breach fires on every startup**

`createEmptySnapshot()` initialises `connection.state` to `'disconnected'`. When `reconnectAttempts === 0` (no reconnect cycle has ever completed) and `state !== 'connected'`, this method returns `reconnectSuccessRate: 0`.

`syncStabilityMetricsFromServices()` is called during `registerSessionIpc` init before Symphony has had a chance to connect. That first stability snapshot — sent to the renderer via `sendStabilitySnapshot(syncStabilityMetricsFromServices())` — contains `reconnectSuccessRate = 0`, which crosses both the warning threshold (0.95) and the breach threshold (0.8) with `comparator: 'min'`. The result is a critical "Reconnect success rate dropped below threshold (0% vs 80%)" stability banner on every startup for users with Symphony configured.

The fix is to omit the field when no reconnect attempts have been observed, so the aggregator's initial `reconnectSuccessRate: 1` default is preserved:

```typescript
public getStabilityMetrics(): StabilityMetricInput {
  if (this.reconnectAttempts === 0) {
    return {
      recoveryLatencyMs: this.lastRecoveryLatencyMs,
      collectedAt: new Date().toISOString(),
    }
  }

  return {
    reconnectSuccessRate: this.reconnectSuccesses / this.reconnectAttempts,
    recoveryLatencyMs: this.lastRecoveryLatencyMs,
    collectedAt: new Date().toISOString(),
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/pi-agent-bridge.ts
Line: 556-571

Comment:
**`setInterval` never cleared; bridge instance cannot be GC'd**

`startEventLoopLagMonitor` is called from the constructor but `this.eventLoopMonitor` is never passed to `clearInterval` — there is no corresponding teardown in `cleanupStreams()` or elsewhere. The `setInterval` closure captures `this`, preventing the bridge from being garbage-collected if a new session creates a new `PiAgentBridge`. Each unreleased instance continues ticking.

`.unref()` prevents the process from hanging, but the interval still fires and the object stays live. Add a stop method and call it from session cleanup:

```typescript
public stopEventLoopLagMonitor(): void {
  if (this.eventLoopMonitor) {
    clearInterval(this.eventLoopMonitor)
    this.eventLoopMonitor = null
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(desktop): refresh KAT-2401 soak met..."](https://github.com/gannonh/kata/commit/1fc67c8cc1862c29a08dd966482781b254687741) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27744773)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->