### PR TITLE
Desktop v0.2.0 — Windows & Linux platform support

### DIFF
--- a/.agents/skills/releasing-kata/references/desktop-release.md
+++ b/.agents/skills/releasing-kata/references/desktop-release.md
@@ -53,15 +53,19 @@ CI workflow: `desktop-release.yml`
 
 1. Compares `apps/desktop/package.json` version against existing `desktop-v*` tags — skips if tag exists
 2. Builds for macOS (arm64 + x64) — bundles CLI runtime, Symphony binary, and Bun
-3. Code signs and notarizes macOS builds
-4. Creates GitHub Release with macOS artifacts
+3. Builds for Windows (x64 + arm64) — NSIS installer with bundled runtime
+4. Builds for Linux (x64 + arm64) — AppImage and .deb with bundled runtime
+5. Code signs and notarizes macOS builds
+6. Creates GitHub Release with all platform artifacts
 
 Expected artifacts:
 
 - `Kata-Desktop-arm64.dmg` / `Kata-Desktop-arm64.zip` (macOS Apple Silicon)
 - `Kata-Desktop-x64.dmg` / `Kata-Desktop-x64.zip` (macOS Intel)
-
-Linux and Windows builds will be added in a future release.
+- `Kata-Desktop-x64-Setup.exe` (Windows x64)
+- `Kata-Desktop-arm64-Setup.exe` (Windows ARM64)
+- `Kata-Desktop-x64.AppImage` / `Kata-Desktop-x64.deb` (Linux x64)
+- `Kata-Desktop-arm64.AppImage` / `Kata-Desktop-arm64.deb` (Linux ARM64)
 
 ## Bundled runtime
 
@@ -77,4 +81,4 @@ The packaged app is self-contained. The build pipeline bundles:
 - [ ] `apps/desktop/package.json` version bumped
 - [ ] `apps/desktop/CHANGELOG.md` updated
 - [ ] Local `bun run desktop:dist:mac` succeeds and app launches
-- [ ] GitHub Release created with tag `desktop-vX.Y.Z` and macOS artifacts
+- [ ] GitHub Release created with tag `desktop-vX.Y.Z` and macOS/Windows/Linux artifacts

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -315,12 +315,10 @@ jobs:
 
           # Create Windows launcher script (kata.cmd)
           cat > vendor/kata.cmd <<'LAUNCHER'
-          @echo off
-          set "SCRIPT_DIR=%~dp0"
-          "%SCRIPT_DIR%bun\bun.exe" "%SCRIPT_DIR%kata-runtime\dist\loader.js" %*
-          LAUNCHER
-          # Strip leading whitespace from heredoc
-          sed -i 's/^          //' vendor/kata.cmd
+@echo off
+set "SCRIPT_DIR=%~dp0"
+"%SCRIPT_DIR%bun\bun.exe" "%SCRIPT_DIR%kata-runtime\dist\loader.js" %*
+LAUNCHER
 
       - name: Build Symphony for Windows ${{ matrix.arch }}
         shell: bash
@@ -436,7 +434,7 @@ jobs:
           TEMP_DIR=$(mktemp -d)
           curl -fSL "https://github.com/oven-sh/bun/releases/download/${BUN_VERSION}/${BUN_DOWNLOAD}.zip" -o "$TEMP_DIR/${BUN_DOWNLOAD}.zip"
           curl -fSL "https://github.com/oven-sh/bun/releases/download/${BUN_VERSION}/SHASUMS256.txt" -o "$TEMP_DIR/SHASUMS256.txt"
-          cd "$TEMP_DIR" && grep "${BUN_DOWNLOAD}.zip" SHASUMS256.txt | shasum -a 256 -c - && cd -
+          cd "$TEMP_DIR" && grep "${BUN_DOWNLOAD}.zip" SHASUMS256.txt | sha256sum -c - && cd -
           unzip -o "$TEMP_DIR/${BUN_DOWNLOAD}.zip" -d "$TEMP_DIR"
           cp "$TEMP_DIR/${BUN_DOWNLOAD}/bun" vendor/bun/bun
           chmod +x vendor/bun/bun
@@ -520,7 +518,11 @@ jobs:
           # Windows
           cp artifacts/windows-x64/*.exe release-files/
           cp artifacts/windows-arm64/*.exe release-files/
-          cp artifacts/windows-x64/latest.yml release-files/ 2>/dev/null || true
+          # Merge latest.yml from both architectures — electron-builder generates per-arch content.
+          # Copy both and rename to avoid collision; auto-update is currently disabled (publish: null)
+          # but this keeps the metadata correct for when it's enabled.
+          cp artifacts/windows-x64/latest.yml release-files/latest.yml 2>/dev/null || true
+          cp artifacts/windows-arm64/latest.yml release-files/latest-arm64.yml 2>/dev/null || true
           # Linux
           cp artifacts/linux-x64/*.AppImage release-files/
           cp artifacts/linux-x64/*.deb release-files/

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -241,8 +241,260 @@ jobs:
             apps/desktop/release/Kata-Desktop-${{ matrix.arch }}.zip
             apps/desktop/release/latest-mac.yml
 
+  build-windows:
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: windows-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    strategy:
+      matrix:
+        arch: [x64, arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        with:
+          bun-version: '1.3.8'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.arch == 'arm64' && 'aarch64-pc-windows-msvc' || 'x86_64-pc-windows-msvc' }}
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/symphony/target
+          key: ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('apps/symphony/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-cargo-
+
+      - name: Bundle CLI runtime and Bun binary
+        shell: bash
+        run: |
+          cd apps/desktop && bun run bundle:cli
+
+          # Replace host-arch Bun with correct target-arch Bun binary
+          BUN_VERSION="bun-v1.3.8"
+          BUN_ARCH="${{ matrix.arch == 'arm64' && 'aarch64' || 'x64' }}"
+          BUN_DOWNLOAD="bun-windows-${BUN_ARCH}"
+          echo "Downloading Bun ${BUN_VERSION} for windows-${BUN_ARCH}..."
+          TEMP_DIR=$(mktemp -d)
+          curl -fSL "https://github.com/oven-sh/bun/releases/download/${BUN_VERSION}/${BUN_DOWNLOAD}.zip" -o "$TEMP_DIR/${BUN_DOWNLOAD}.zip"
+          curl -fSL "https://github.com/oven-sh/bun/releases/download/${BUN_VERSION}/SHASUMS256.txt" -o "$TEMP_DIR/SHASUMS256.txt"
+          cd "$TEMP_DIR" && grep "${BUN_DOWNLOAD}.zip" SHASUMS256.txt | sha256sum -c - && cd -
+          unzip -o "$TEMP_DIR/${BUN_DOWNLOAD}.zip" -d "$TEMP_DIR"
+          # Windows Bun zip contains bun.exe
+          cp "$TEMP_DIR/${BUN_DOWNLOAD}/bun.exe" vendor/bun/bun.exe
+          rm -f vendor/bun/bun
+          rm -rf "$TEMP_DIR"
+          echo "Bun binary replaced with ${BUN_DOWNLOAD}"
+
+          # Create Windows launcher script (kata.cmd)
+          cat > vendor/kata.cmd <<'LAUNCHER'
+          @echo off
+          set "SCRIPT_DIR=%~dp0"
+          "%SCRIPT_DIR%bun\bun.exe" "%SCRIPT_DIR%kata-runtime\dist\loader.js" %*
+          LAUNCHER
+          # Strip leading whitespace from heredoc
+          sed -i 's/^          //' vendor/kata.cmd
+
+      - name: Build Symphony for Windows ${{ matrix.arch }}
+        shell: bash
+        run: |
+          TARGET="${{ matrix.arch == 'arm64' && 'aarch64-pc-windows-msvc' || 'x86_64-pc-windows-msvc' }}"
+          echo "Building Symphony for $TARGET..."
+          cd apps/symphony && cargo build --release --target "$TARGET"
+
+          BUILT_BIN="target/$TARGET/release/symphony.exe"
+          if [ -f "$BUILT_BIN" ]; then
+            cp "$BUILT_BIN" ../desktop/vendor/symphony.exe
+            echo "Symphony binary staged for $TARGET"
+          else
+            echo "::error::Symphony binary not found at $BUILT_BIN"
+            exit 1
+          fi
+
+      - name: Build Desktop app
+        run: cd apps/desktop && bun run build
+
+      - name: Package for Windows ${{ matrix.arch }}
+        shell: bash
+        run: |
+          cd apps/desktop
+          npx electron-builder --config electron-builder.yml --win nsis --${{ matrix.arch }}
+
+      - name: Verify Windows artifacts
+        shell: bash
+        run: |
+          set -e
+          echo "Checking for Windows ${{ matrix.arch }} artifacts..."
+          ls -la apps/desktop/release/
+          if ! ls apps/desktop/release/Kata-Desktop-${{ matrix.arch }}-Setup.exe 1>/dev/null 2>&1; then
+            echo "::error::NSIS installer for ${{ matrix.arch }} not found"
+            exit 1
+          fi
+          echo "Found Windows artifacts for ${{ matrix.arch }}"
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: windows-${{ matrix.arch }}
+          path: |
+            apps/desktop/release/Kata-Desktop-${{ matrix.arch }}-Setup.exe
+            apps/desktop/release/latest.yml
+
+  build-linux:
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    strategy:
+      matrix:
+        arch: [x64, arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        with:
+          bun-version: '1.3.8'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.arch == 'arm64' && 'aarch64-unknown-linux-gnu' || 'x86_64-unknown-linux-gnu' }}
+
+      - name: Install cross-compilation tools
+        if: matrix.arch == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/symphony/target
+          key: ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('apps/symphony/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-cargo-
+
+      - name: Bundle CLI runtime and Bun binary
+        run: |
+          cd apps/desktop && bun run bundle:cli
+
+          # Replace host-arch Bun with correct target-arch Bun binary
+          BUN_VERSION="bun-v1.3.8"
+          BUN_ARCH="${{ matrix.arch == 'arm64' && 'aarch64' || 'x64' }}"
+          BUN_DOWNLOAD="bun-linux-${BUN_ARCH}"
+          echo "Downloading Bun ${BUN_VERSION} for linux-${BUN_ARCH}..."
+          TEMP_DIR=$(mktemp -d)
+          curl -fSL "https://github.com/oven-sh/bun/releases/download/${BUN_VERSION}/${BUN_DOWNLOAD}.zip" -o "$TEMP_DIR/${BUN_DOWNLOAD}.zip"
+          curl -fSL "https://github.com/oven-sh/bun/releases/download/${BUN_VERSION}/SHASUMS256.txt" -o "$TEMP_DIR/SHASUMS256.txt"
+          cd "$TEMP_DIR" && grep "${BUN_DOWNLOAD}.zip" SHASUMS256.txt | shasum -a 256 -c - && cd -
+          unzip -o "$TEMP_DIR/${BUN_DOWNLOAD}.zip" -d "$TEMP_DIR"
+          cp "$TEMP_DIR/${BUN_DOWNLOAD}/bun" vendor/bun/bun
+          chmod +x vendor/bun/bun
+          rm -rf "$TEMP_DIR"
+          echo "Bun binary replaced with ${BUN_DOWNLOAD}"
+
+      - name: Build Symphony for Linux ${{ matrix.arch }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: |
+          TARGET="${{ matrix.arch == 'arm64' && 'aarch64-unknown-linux-gnu' || 'x86_64-unknown-linux-gnu' }}"
+          echo "Building Symphony for $TARGET..."
+          cd apps/symphony && cargo build --release --target "$TARGET"
+
+          BUILT_BIN="target/$TARGET/release/symphony"
+          if [ -f "$BUILT_BIN" ]; then
+            cp "$BUILT_BIN" ../desktop/vendor/symphony
+            chmod +x ../desktop/vendor/symphony
+            echo "Symphony binary staged for $TARGET"
+          else
+            echo "::error::Symphony binary not found at $BUILT_BIN"
+            exit 1
+          fi
+
+      - name: Build Desktop app
+        run: cd apps/desktop && bun run build
+
+      - name: Package for Linux ${{ matrix.arch }}
+        run: |
+          cd apps/desktop
+          npx electron-builder --config electron-builder.yml --linux AppImage deb --${{ matrix.arch }}
+
+      - name: Verify Linux artifacts
+        run: |
+          set -e
+          echo "Checking for Linux ${{ matrix.arch }} artifacts..."
+          ls -la apps/desktop/release/
+          if ! ls apps/desktop/release/Kata-Desktop-${{ matrix.arch }}.AppImage 1>/dev/null 2>&1; then
+            echo "::error::AppImage for ${{ matrix.arch }} not found"
+            exit 1
+          fi
+          if ! ls apps/desktop/release/Kata-Desktop-${{ matrix.arch }}.deb 1>/dev/null 2>&1; then
+            echo "::error::deb package for ${{ matrix.arch }} not found"
+            exit 1
+          fi
+          echo "Found Linux artifacts for ${{ matrix.arch }}"
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: linux-${{ matrix.arch }}
+          path: |
+            apps/desktop/release/Kata-Desktop-${{ matrix.arch }}.AppImage
+            apps/desktop/release/Kata-Desktop-${{ matrix.arch }}.deb
+            apps/desktop/release/latest-linux.yml
+
   release:
-    needs: [check-version, build-macos]
+    needs: [check-version, build-macos, build-windows, build-linux]
     if: needs.check-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -259,11 +511,22 @@ jobs:
       - name: Prepare release files
         run: |
           mkdir -p release-files
+          # macOS
           cp artifacts/macos-arm64/*.dmg release-files/
           cp artifacts/macos-arm64/*.zip release-files/
           cp artifacts/macos-x64/*.dmg release-files/
           cp artifacts/macos-x64/*.zip release-files/
           cp artifacts/macos-arm64/latest-mac.yml release-files/ 2>/dev/null || true
+          # Windows
+          cp artifacts/windows-x64/*.exe release-files/
+          cp artifacts/windows-arm64/*.exe release-files/
+          cp artifacts/windows-x64/latest.yml release-files/ 2>/dev/null || true
+          # Linux
+          cp artifacts/linux-x64/*.AppImage release-files/
+          cp artifacts/linux-x64/*.deb release-files/
+          cp artifacts/linux-arm64/*.AppImage release-files/
+          cp artifacts/linux-arm64/*.deb release-files/
+          cp artifacts/linux-x64/latest-linux.yml release-files/ 2>/dev/null || true
           echo "Files to be released:"
           ls -la release-files/
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -528,7 +528,8 @@ LAUNCHER
           cp artifacts/linux-x64/*.deb release-files/
           cp artifacts/linux-arm64/*.AppImage release-files/
           cp artifacts/linux-arm64/*.deb release-files/
-          cp artifacts/linux-x64/latest-linux.yml release-files/ 2>/dev/null || true
+          cp artifacts/linux-x64/latest-linux.yml release-files/latest-linux.yml 2>/dev/null || true
+          cp artifacts/linux-arm64/latest-linux.yml release-files/latest-linux-arm64.yml 2>/dev/null || true
           echo "Files to be released:"
           ls -la release-files/
 

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -9,6 +9,10 @@
 - **Cross-platform CI** — Release workflow now builds for macOS, Windows, and Linux in parallel
 - **Cross-platform binary discovery** — Desktop app correctly resolves bundled kata and Symphony binaries on all platforms (.exe/.cmd on Windows, shell scripts on macOS/Linux)
 
+### Fixes
+
+- **False Symphony reliability banner** — Suppressed the yellow "Symphony operator is reconnecting" warning that flashed during normal Symphony startup transitions
+
 ## 0.1.1
 
 ### Features

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.2.0
+
+### Features
+
+- **Windows support** — NSIS installer for x64 and arm64 (Kata-Desktop-x64-Setup.exe, Kata-Desktop-arm64-Setup.exe)
+- **Linux support** — AppImage and .deb packages for x64 and arm64
+- **Cross-platform CI** — Release workflow now builds for macOS, Windows, and Linux in parallel
+- **Cross-platform binary discovery** — Desktop app correctly resolves bundled kata and Symphony binaries on all platforms (.exe/.cmd on Windows, shell scripts on macOS/Linux)
+
 ## 0.1.1
 
 ### Features

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -47,3 +47,37 @@ dmg:
   window:
     width: 540
     height: 380
+
+win:
+  icon: resources/icon.ico
+  target:
+    - target: nsis
+      arch:
+        - x64
+        - arm64
+
+nsis:
+  artifactName: "Kata-Desktop-${arch}-Setup.${ext}"
+  oneClick: true
+  perMachine: false
+  allowToChangeInstallationDirectory: false
+  deleteAppDataOnUninstall: false
+
+linux:
+  icon: resources/icon.png
+  category: Development
+  target:
+    - target: AppImage
+      arch:
+        - x64
+        - arm64
+    - target: deb
+      arch:
+        - x64
+        - arm64
+
+appImage:
+  artifactName: "Kata-Desktop-${arch}.${ext}"
+
+deb:
+  artifactName: "Kata-Desktop-${arch}.${ext}"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata/desktop",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "dist/main.cjs",

--- a/apps/desktop/scripts/afterPack.cjs
+++ b/apps/desktop/scripts/afterPack.cjs
@@ -29,14 +29,15 @@ function stripScriptExecutablePermissions(appBundlePath) {
   }
 }
 
-function copyVendorResources(projectDir, resourcesDir) {
+function copyVendorResources(projectDir, resourcesDir, platform) {
   const vendorDir = path.join(projectDir, 'vendor');
+  const isWindows = platform === 'win32';
 
   const items = [
-    { src: 'kata', type: 'file', executable: true },
+    { src: isWindows ? 'kata.cmd' : 'kata', type: 'file', executable: true },
     { src: 'kata-runtime', type: 'dir' },
-    { src: 'bun', type: 'dir', executableChild: 'bun' },
-    { src: 'symphony', type: 'file', executable: true, optional: true },
+    { src: 'bun', type: 'dir', executableChild: isWindows ? 'bun.exe' : 'bun' },
+    { src: isWindows ? 'symphony.exe' : 'symphony', type: 'file', executable: true, optional: true },
   ];
 
   for (const item of items) {
@@ -72,37 +73,53 @@ function copyVendorResources(projectDir, resourcesDir) {
 }
 
 module.exports = async function afterPack(context) {
-  if (context.electronPlatformName !== 'darwin') {
-    console.log('afterPack: Skipping (not macOS)');
-    return;
-  }
-
+  const platform = context.electronPlatformName;
   const appOutDir = context.appOutDir;
   const productName = context.packager.appInfo.productName;
-  const appBundlePath = path.join(appOutDir, `${productName}.app`);
-  const resourcesDir = path.join(appBundlePath, 'Contents', 'Resources');
   const projectDir = context.packager.projectDir;
 
-  // 1. Copy vendor runtime resources
-  copyVendorResources(projectDir, resourcesDir);
+  let resourcesDir;
 
-  // Remove .bin symlinks from kata-runtime — they point to relative targets
-  // that codesign rejects as "invalid destination for symbolic link in bundle"
-  const binDir = path.join(resourcesDir, 'kata-runtime', 'node_modules', '.bin');
-  if (fs.existsSync(binDir)) {
-    fs.rmSync(binDir, { recursive: true });
-    console.log('afterPack: removed kata-runtime/node_modules/.bin symlinks');
-  }
+  if (platform === 'darwin') {
+    const appBundlePath = path.join(appOutDir, `${productName}.app`);
+    resourcesDir = path.join(appBundlePath, 'Contents', 'Resources');
 
-  // 2. Copy Liquid Glass icon (Assets.car)
-  const precompiledAssets = path.join(projectDir, 'resources', 'liquid-glass', 'Assets.car');
-  if (fs.existsSync(precompiledAssets)) {
-    fs.copyFileSync(precompiledAssets, path.join(resourcesDir, 'Assets.car'));
-    console.log('afterPack: Liquid Glass icon (Assets.car) copied');
+    // 1. Copy vendor runtime resources
+    copyVendorResources(projectDir, resourcesDir, platform);
+
+    // Remove .bin symlinks from kata-runtime — they point to relative targets
+    // that codesign rejects as "invalid destination for symbolic link in bundle"
+    const binDir = path.join(resourcesDir, 'kata-runtime', 'node_modules', '.bin');
+    if (fs.existsSync(binDir)) {
+      fs.rmSync(binDir, { recursive: true });
+      console.log('afterPack: removed kata-runtime/node_modules/.bin symlinks');
+    }
+
+    // 2. Copy Liquid Glass icon (Assets.car)
+    const precompiledAssets = path.join(projectDir, 'resources', 'liquid-glass', 'Assets.car');
+    if (fs.existsSync(precompiledAssets)) {
+      fs.copyFileSync(precompiledAssets, path.join(resourcesDir, 'Assets.car'));
+      console.log('afterPack: Liquid Glass icon (Assets.car) copied');
+    } else {
+      console.log('afterPack: Assets.car not found — app will use fallback icon.icns');
+    }
+
+    // 3. Strip executable permissions for notarization
+    stripScriptExecutablePermissions(path.join(appOutDir, `${productName}.app`));
   } else {
-    console.log('afterPack: Assets.car not found — app will use fallback icon.icns');
-  }
+    // Windows and Linux: resources dir is at <appOutDir>/resources
+    resourcesDir = path.join(appOutDir, 'resources');
 
-  // 3. Strip executable permissions for notarization
-  stripScriptExecutablePermissions(appBundlePath);
+    // Copy vendor runtime resources
+    copyVendorResources(projectDir, resourcesDir, platform);
+
+    // Remove .bin symlinks/shims from kata-runtime
+    const binDir = path.join(resourcesDir, 'kata-runtime', 'node_modules', '.bin');
+    if (fs.existsSync(binDir)) {
+      fs.rmSync(binDir, { recursive: true });
+      console.log(`afterPack: removed kata-runtime/node_modules/.bin (${platform})`);
+    }
+
+    console.log(`afterPack: vendor resources copied for ${platform}`);
+  }
 };

--- a/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
@@ -287,6 +287,69 @@ describe('RuntimeHealthAggregator', () => {
     expect(symphonySurface?.signal?.code).toBe('REL-SYMPHONY-PROCESS-PROCESS_EXITED')
   })
 
+  test('suppresses operator reconnecting signal during symphony startup transition', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    // Supervisor reports starting phase
+    aggregator.ingestSymphonyRuntimeStatus(
+      createSymphonyStatus({
+        phase: 'starting',
+        managedProcessRunning: false,
+        pid: null,
+        url: null,
+      }),
+    )
+
+    // Operator sees reconnecting because Symphony isn't ready yet
+    aggregator.ingestSymphonyOperatorSnapshot(
+      createSymphonySnapshot({
+        connection: {
+          state: 'reconnecting',
+          lastError: 'Symphony operator is reconnecting.',
+          updatedAt: '2026-04-07T20:00:01.000Z',
+        },
+      }),
+    )
+
+    // The runtime 'starting' signal should be the only one surfaced (warning severity),
+    // not the operator reconnecting signal — startup is expected, not a network failure.
+    const symphonySurface = getSurface(aggregator.getSnapshot(), 'symphony')
+    expect(symphonySurface?.status).toBe('degraded')
+    expect(symphonySurface?.signal?.class).toBe('process')
+    expect(symphonySurface?.signal?.code).toBe('REL-SYMPHONY-PROCESS-RESTARTING')
+    expect(symphonySurface?.signal?.severity).toBe('warning')
+    // No network/reconnecting signal should leak through
+    expect(symphonySurface?.signal?.code).not.toContain('RECONNECTING')
+  })
+
+  test('suppresses operator reconnecting signal during symphony restart transition', () => {
+    const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
+
+    aggregator.ingestSymphonyRuntimeStatus(
+      createSymphonyStatus({
+        phase: 'restarting',
+        managedProcessRunning: false,
+        pid: null,
+        url: null,
+      }),
+    )
+
+    aggregator.ingestSymphonyOperatorSnapshot(
+      createSymphonySnapshot({
+        connection: {
+          state: 'reconnecting',
+          lastError: 'Symphony operator is reconnecting.',
+          updatedAt: '2026-04-07T20:00:01.000Z',
+        },
+      }),
+    )
+
+    const symphonySurface = getSurface(aggregator.getSnapshot(), 'symphony')
+    expect(symphonySurface?.status).toBe('degraded')
+    expect(symphonySurface?.signal?.class).toBe('process')
+    expect(symphonySurface?.signal?.code).not.toContain('RECONNECTING')
+  })
+
   test('supports recovery-action execution and records recovery outcome', async () => {
     const requestRecovery = vi.fn(async () => ({
       success: true,

--- a/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
@@ -287,7 +287,7 @@ describe('RuntimeHealthAggregator', () => {
     expect(symphonySurface?.signal?.code).toBe('REL-SYMPHONY-PROCESS-PROCESS_EXITED')
   })
 
-  test('suppresses operator reconnecting signal during symphony startup transition', () => {
+  test('suppresses all reliability signals during normal symphony startup transition', () => {
     const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
 
     // Supervisor reports starting phase
@@ -311,18 +311,14 @@ describe('RuntimeHealthAggregator', () => {
       }),
     )
 
-    // The runtime 'starting' signal should be the only one surfaced (warning severity),
-    // not the operator reconnecting signal — startup is expected, not a network failure.
+    // Normal startup is not a reliability issue — no banner should appear.
+    // The header bar already shows "Symphony: Starting".
     const symphonySurface = getSurface(aggregator.getSnapshot(), 'symphony')
-    expect(symphonySurface?.status).toBe('degraded')
-    expect(symphonySurface?.signal?.class).toBe('process')
-    expect(symphonySurface?.signal?.code).toBe('REL-SYMPHONY-PROCESS-RESTARTING')
-    expect(symphonySurface?.signal?.severity).toBe('warning')
-    // No network/reconnecting signal should leak through
-    expect(symphonySurface?.signal?.code).not.toContain('RECONNECTING')
+    expect(symphonySurface?.status).toBe('healthy')
+    expect(symphonySurface?.signal).toBeNull()
   })
 
-  test('suppresses operator reconnecting signal during symphony restart transition', () => {
+  test('suppresses all reliability signals during symphony restart transition', () => {
     const aggregator = new RuntimeHealthAggregator({ now: () => '2026-04-07T20:00:00.000Z' })
 
     aggregator.ingestSymphonyRuntimeStatus(
@@ -345,9 +341,8 @@ describe('RuntimeHealthAggregator', () => {
     )
 
     const symphonySurface = getSurface(aggregator.getSnapshot(), 'symphony')
-    expect(symphonySurface?.status).toBe('degraded')
-    expect(symphonySurface?.signal?.class).toBe('process')
-    expect(symphonySurface?.signal?.code).not.toContain('RECONNECTING')
+    expect(symphonySurface?.status).toBe('healthy')
+    expect(symphonySurface?.signal).toBeNull()
   })
 
   test('supports recovery-action execution and records recovery outcome', async () => {

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -724,13 +724,20 @@ export class PiAgentBridge extends EventEmitter {
     const checkedPaths: string[] = []
 
     if (isPackaged) {
-      const bundledPath = path.join(process.resourcesPath, 'kata')
-      checkedPaths.push(bundledPath)
-      if (this.isExecutableFile(bundledPath)) {
-        return {
-          source: 'bundled',
-          resolvedPath: bundledPath,
-          checkedPaths,
+      // On Windows, look for kata.cmd; on macOS/Linux, look for kata shell script
+      const bundledCandidates =
+        process.platform === 'win32'
+          ? [path.join(process.resourcesPath, 'kata.cmd'), path.join(process.resourcesPath, 'kata')]
+          : [path.join(process.resourcesPath, 'kata')]
+
+      for (const bundledPath of bundledCandidates) {
+        checkedPaths.push(bundledPath)
+        if (this.isExecutableFile(bundledPath)) {
+          return {
+            source: 'bundled',
+            resolvedPath: bundledPath,
+            checkedPaths,
+          }
         }
       }
     }

--- a/apps/desktop/src/main/pi-agent-bridge.ts
+++ b/apps/desktop/src/main/pi-agent-bridge.ts
@@ -217,10 +217,13 @@ export class PiAgentBridge extends EventEmitter {
       args.push('--model', launchModel)
     }
     this.spawnTimestamp = Date.now()
+    // On Windows, .cmd files require shell: true for child_process.spawn
+    const useShell = process.platform === 'win32' && command.toLowerCase().endsWith('.cmd')
     const child = spawn(command, args, {
       cwd: this.workspacePath,
       env: process.env,
       stdio: 'pipe',
+      ...(useShell ? { shell: true } : {}),
     })
 
     this.child = child

--- a/apps/desktop/src/main/reliability-contract.ts
+++ b/apps/desktop/src/main/reliability-contract.ts
@@ -291,24 +291,10 @@ export function mapSymphonyRuntimeStatusToReliability(
     return null
   }
 
-  if (status.phase === 'starting' || status.phase === 'restarting') {
-    return toSignal({
-      sourceSurface: 'symphony',
-      reliabilityClass: 'process',
-      sourceCode: 'RESTARTING',
-      message: status.lastError?.message ?? 'Symphony runtime is recovering.',
-      timestamp: status.updatedAt,
-      outcome: 'pending',
-      severity: 'warning',
-      recoveryAction: 'restart_process',
-      diagnostics: {
-        code: status.lastError?.code,
-        detail: status.lastError?.details,
-      },
-    })
-  }
-
-  if (status.phase === 'idle' || status.phase === 'stopped') {
+  if (status.phase === 'starting' || status.phase === 'restarting' || status.phase === 'idle' || status.phase === 'stopped') {
+    // Normal transitional and inactive phases are not reliability issues.
+    // The header bar already shows "Symphony: Starting" during transitions.
+    // If startup fails, the phase moves to 'failed' and gets surfaced then.
     return null
   }
 

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -690,14 +690,17 @@ export class RuntimeHealthAggregator extends EventEmitter {
     // Use the operator snapshot's own connection state as the primary signal.
     // An 'inactive' snapshot means the operator was never started or was cleanly
     // shut down — suppress to avoid false alarms from the default empty snapshot.
-    // Also suppress during startup-failure phases (config_error, failed) where
-    // the supervisor itself owns the failure surface and operator signals would
-    // be misleading (e.g. "reconnect" when the real fix is a config change).
+    // Also suppress during transitional phases (starting, restarting) and
+    // terminal-failure phases (config_error, failed) where the supervisor itself
+    // owns the failure surface and operator signals would be misleading (e.g.
+    // "reconnect" when the process is still booting or the real fix is a config change).
     // External Symphony mode (supervisor idle, operator connected via manual
     // Refresh) works because the snapshot transitions out of 'inactive' on
     // successful poll, so operatorSignalAllowed becomes true.
     const operatorSignalAllowed =
       snapshot?.connection.state !== 'inactive' &&
+      this.lastSymphonyRuntimePhase !== 'starting' &&
+      this.lastSymphonyRuntimePhase !== 'restarting' &&
       this.lastSymphonyRuntimePhase !== 'config_error' &&
       this.lastSymphonyRuntimePhase !== 'failed'
     this.symphonyOperatorSignal = operatorSignalAllowed


### PR DESCRIPTION
## Desktop v0.2.0

Adds Windows and Linux builds to the Desktop release pipeline. All three platforms build in parallel in CI.

### Changes

**CI Workflow (`desktop-release.yml`)**
- `build-windows` job: Windows x64 + arm64, NSIS installer, bundled Bun/Symphony/CLI
- `build-linux` job: Linux x64 + arm64, AppImage + .deb, bundled Bun/Symphony/CLI
- `release` job: collects artifacts from all 3 platform builds

**Electron Builder (`electron-builder.yml`)**
- `win`: NSIS installer target (x64 + arm64)
- `linux`: AppImage + deb targets (x64 + arm64)
- Artifact naming: `Kata-Desktop-{arch}-Setup.exe`, `Kata-Desktop-{arch}.AppImage`, `Kata-Desktop-{arch}.deb`

**Packaging (`afterPack.cjs`)**
- Platform-aware vendor resource bundling (kata.cmd/bun.exe/symphony.exe on Windows, shell scripts on macOS/Linux)
- Correct resources directory per platform (Contents/Resources on macOS, resources/ on Windows/Linux)

**Runtime (`pi-agent-bridge.ts`)**
- Binary discovery checks kata.cmd first on Windows, falls back to kata

### Release Artifacts

| Platform | Artifacts |
|----------|-----------|
| macOS | `Kata-Desktop-arm64.dmg`, `Kata-Desktop-arm64.zip`, `Kata-Desktop-x64.dmg`, `Kata-Desktop-x64.zip` |
| Windows | `Kata-Desktop-x64-Setup.exe`, `Kata-Desktop-arm64-Setup.exe` |
| Linux | `Kata-Desktop-x64.AppImage`, `Kata-Desktop-x64.deb`, `Kata-Desktop-arm64.AppImage`, `Kata-Desktop-arm64.deb` |

### Verification

- TypeScript: ✅ clean
- Unit tests: ✅ 429/429 passed
- Coverage: ✅ 91.83% statements, 80.55% branches, 94.55% functions
- ESLint: ✅ clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Windows and Linux desktop builds for x64 and arm64 with platform-specific installers (Windows NSIS, Linux AppImage and deb).

* **Improvements**
  * Reduces false reliability/health alerts by suppressing signals during transient Symphony states (starting, restarting, idle, stopped).
  * Installer/package metadata handling improved for multi-arch releases.

* **Chores**
  * Bumped desktop version to 0.2.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Windows and Linux build support to the Desktop release pipeline, wiring up `build-windows` and `build-linux` CI jobs that cross-compile Symphony, download the correct Bun binary, and produce NSIS/AppImage/deb artifacts alongside the existing macOS job.

- **P1 — `kata.cmd` spawn fails on Windows**: `child_process.spawn(kata.cmd, args)` without `shell: true` calls `CreateProcess` directly, which cannot execute `.cmd`/`.bat` files on Windows. The app will silently fail to start the agent on every Windows install until this is fixed (`pi-agent-bridge.ts` line 220).

<h3>Confidence Score: 4/5</h3>

Do not merge until the kata.cmd spawn issue is fixed — Windows users will get a non-functional agent bridge at runtime.

One P1 defect: spawning a .cmd file without shell:true or cmd.exe will fail on every Windows install, making the agent completely unusable. All other findings are P2 (a no-op sed and a potential auto-updater metadata gap). The CI pipeline, afterPack hook, and electron-builder config are otherwise correct.

apps/desktop/src/main/pi-agent-bridge.ts — the spawn call at line 220 must handle .cmd files explicitly for Windows.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Bun binaries downloaded during the CI build are verified with SHA-256 checksums against the official Bun release SHASUMS256.txt before use. No secrets are exposed, and the `kata.cmd` launcher does not introduce command injection vectors beyond what already exists in the application.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/pi-agent-bridge.ts | Adds Windows-aware binary discovery (kata.cmd first), but spawns .cmd files via spawn() without shell:true, which fails on Windows at runtime. |
| .github/workflows/desktop-release.yml | Adds build-windows and build-linux jobs with correct cross-compilation, checksum verification, and artifact staging; minor issues with a no-op sed and potential arm64 latest.yml loss. |
| apps/desktop/scripts/afterPack.cjs | Correctly extends afterPack hook to handle Windows and Linux resource directories and platform-specific binary names alongside existing macOS logic. |
| apps/desktop/electron-builder.yml | Adds win (NSIS) and linux (AppImage + deb) build targets with correct artifact naming conventions for x64 and arm64. |
| apps/desktop/package.json | Version bump from 0.1.1 to 0.2.0 matching the changelog and PR intent. |
| apps/desktop/CHANGELOG.md | Adds 0.2.0 changelog entry documenting Windows/Linux support, CI changes, and cross-platform binary discovery. |
| .agents/skills/releasing-kata/references/desktop-release.md | Updates release reference doc to reflect the new three-platform build pipeline and expected artifacts. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PiAgentBridge.discoverBinary] --> B{isPackaged?}
    B -- yes --> C{win32?}
    C -- yes --> D["Check resources/kata.cmd\n(isExecutableFile)"]
    D -- found --> E["spawn(kata.cmd, args)\n⚠️ No shell:true → ENOENT on Windows"]
    D -- not found --> F["Check resources/kata"]
    F -- found --> G["spawn(kata, args) ✓"]
    C -- no --> F
    B -- no --> H{KATA_BIN_PATH set?}
    H -- yes --> I["spawn(env path, args) ✓"]
    H -- no --> J["where/which kata → spawn ✓"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/pi-agent-bridge.ts`, line 220-224 ([link](https://github.com/gannonh/kata/blob/38bca820cb18b05f423ef2488773157104db5c48/apps/desktop/src/main/pi-agent-bridge.ts#L220-L224)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`kata.cmd` cannot be spawned without `shell: true` on Windows**

   `child_process.spawn` on Windows calls `CreateProcess` directly, which cannot execute `.bat`/`.cmd` files — they require cmd.exe. Without `shell: true` (or an explicit `cmd.exe /c` invocation), this call will throw `ENOENT` on Windows every time the resolved path ends in `.cmd`. The Node.js docs explicitly state: "`.bat` and `.cmd` files can only be invoked using `child_process.exec()`, with `options.shell` set to `true`."

   The fix requires branching on whether the resolved command is a `.cmd` file:
   ```typescript
   const isCmd = command.toLowerCase().endsWith('.cmd')
   const child = spawn(isCmd ? 'cmd.exe' : command, isCmd ? ['/c', command, ...args] : args, {
     cwd: this.workspacePath,
     env: process.env,
     stdio: 'pipe',
   })
   ```
   Using `shell: true` is an alternative but carries command-injection risk if `workspacePath` ever contains special chars.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/pi-agent-bridge.ts
   Line: 220-224

   Comment:
   **`kata.cmd` cannot be spawned without `shell: true` on Windows**

   `child_process.spawn` on Windows calls `CreateProcess` directly, which cannot execute `.bat`/`.cmd` files — they require cmd.exe. Without `shell: true` (or an explicit `cmd.exe /c` invocation), this call will throw `ENOENT` on Windows every time the resolved path ends in `.cmd`. The Node.js docs explicitly state: "`.bat` and `.cmd` files can only be invoked using `child_process.exec()`, with `options.shell` set to `true`."

   The fix requires branching on whether the resolved command is a `.cmd` file:
   ```typescript
   const isCmd = command.toLowerCase().endsWith('.cmd')
   const child = spawn(isCmd ? 'cmd.exe' : command, isCmd ? ['/c', command, ...args] : args, {
     cwd: this.workspacePath,
     env: process.env,
     stdio: 'pipe',
   })
   ```
   Using `shell: true` is an alternative but carries command-injection risk if `workspacePath` ever contains special chars.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/pi-agent-bridge.ts
Line: 220-224

Comment:
**`kata.cmd` cannot be spawned without `shell: true` on Windows**

`child_process.spawn` on Windows calls `CreateProcess` directly, which cannot execute `.bat`/`.cmd` files — they require cmd.exe. Without `shell: true` (or an explicit `cmd.exe /c` invocation), this call will throw `ENOENT` on Windows every time the resolved path ends in `.cmd`. The Node.js docs explicitly state: "`.bat` and `.cmd` files can only be invoked using `child_process.exec()`, with `options.shell` set to `true`."

The fix requires branching on whether the resolved command is a `.cmd` file:
```typescript
const isCmd = command.toLowerCase().endsWith('.cmd')
const child = spawn(isCmd ? 'cmd.exe' : command, isCmd ? ['/c', command, ...args] : args, {
  cwd: this.workspacePath,
  env: process.env,
  stdio: 'pipe',
})
```
Using `shell: true` is an alternative but carries command-injection risk if `workspacePath` ever contains special chars.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/desktop-release.yml
Line: 316-323

Comment:
**`sed` strip is a no-op — YAML already removes the indentation**

The `run: |` block scalar strips leading whitespace equal to the minimum indentation of its content before the script reaches bash. Every line in this block has 10 spaces of leading indentation, so YAML strips all 10 spaces before bash ever sees the heredoc. By the time bash runs, the heredoc content and the `LAUNCHER` terminator both start at column 0 — the file is written correctly without extra spaces. The `sed -i 's/^          //' vendor/kata.cmd` line is therefore a no-op and the comment above it is misleading. It can be removed.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/desktop-release.yml
Line: 362-368

Comment:
**`latest.yml` from `windows-arm64` is silently discarded**

Both the `windows-x64` and `windows-arm64` matrix jobs upload `apps/desktop/release/latest.yml` into their respective artifact directories. The release job then copies only `artifacts/windows-x64/latest.yml` — the arm64 copy is never used. If electron-builder generates different `latest.yml` content per arch (listing that arch's installer SHA and download URL), the auto-updater metadata for Windows arm64 will be missing from the release, breaking in-app updates for arm64 users. Worth confirming whether electron-builder emits a single combined `latest.yml` or one per arch, and uploading/renaming accordingly if they differ.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(desktop): add reliability banner fi..."](https://github.com/gannonh/kata/commit/38bca820cb18b05f423ef2488773157104db5c48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27896212)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->