### PR TITLE
fix(desktop): fix YAML parse error in desktop-release.yml

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -314,11 +314,7 @@ jobs:
           echo "Bun binary replaced with ${BUN_DOWNLOAD}"
 
           # Create Windows launcher script (kata.cmd)
-          cat > vendor/kata.cmd <<'LAUNCHER'
-@echo off
-set "SCRIPT_DIR=%~dp0"
-"%SCRIPT_DIR%bun\bun.exe" "%SCRIPT_DIR%kata-runtime\dist\loader.js" %*
-LAUNCHER
+          printf '@echo off\r\nset "SCRIPT_DIR=%%~dp0"\r\n"%%SCRIPT_DIR%%bun\\bun.exe" "%%SCRIPT_DIR%%kata-runtime\\dist\\loader.js" %%*\r\n' > vendor/kata.cmd
 
       - name: Build Symphony for Windows ${{ matrix.arch }}
         shell: bash


### PR DESCRIPTION
Hotfix for the desktop release workflow that was broken by the v0.2.0 PR merge.

### Problem

The Windows `kata.cmd` heredoc content starting with `@echo off` at column 0 breaks YAML parsing — the `@` character is invalid at that position in a block scalar. This caused `desktop-release.yml` to fail to parse on every push to main.

### Fix

Replace the heredoc with `printf`, which keeps all content inline within the YAML block scalar and avoids the column-0 `@` issue. The printf produces correct Windows CRLF line endings and proper `%` escaping.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix replaces a heredoc-based `.cmd` file creation with a `printf` call to fix a YAML parse error in `desktop-release.yml`. The `@echo off` line at column 0 in the heredoc body was illegal in a YAML block scalar, breaking the workflow on every push to `main` after the v0.2.0 merge.

The `printf` approach is correct: `%%` → `%`, `\\` → `\`, and `\r\n` → CRLF — producing output identical to (and slightly better than) the original heredoc, since `.cmd` files canonically use CRLF line endings.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted hotfix with correct escaping and no functional regressions.

The single-line change correctly addresses the root cause (YAML reserved `@` at column 0 in a block scalar) and produces byte-for-byte equivalent CMD content with an added CRLF improvement. No other files are touched and there are no P1/P0 findings.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/desktop-release.yml | Replaces a YAML-breaking heredoc with a single-line `printf` that correctly generates the Windows CMD launcher script with CRLF endings and proper `%` escaping. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant YAML as YAML Parser
    participant Bash as bash (Git Bash)
    participant FS as vendor/kata.cmd

    Note over YAML: Before fix — heredoc @echo off at col 0
    YAML-->>YAML: ❌ Parse error (@reserved in block scalar)

    Note over YAML: After fix — printf on single line
    YAML->>Bash: Parses run block cleanly
    Bash->>FS: printf output written to vendor/kata.cmd
    Note over FS: ✅ CRLF line endings, correct % escaping
```

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): fix YAML parse error from ..."](https://github.com/gannonh/kata/commit/927f73fd909b68797c42f38e5b58bc5fac80464a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27917840)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build launcher script generation to ensure consistent line ending handling and proper script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->