### PR TITLE
fix(desktop): fix CI failures for Linux arm64 and Windows arm64 builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -314,11 +314,7 @@ jobs:
           echo "Bun binary replaced with ${BUN_DOWNLOAD}"
 
           # Create Windows launcher script (kata.cmd)
-          cat > vendor/kata.cmd <<'LAUNCHER'
-@echo off
-set "SCRIPT_DIR=%~dp0"
-"%SCRIPT_DIR%bun\bun.exe" "%SCRIPT_DIR%kata-runtime\dist\loader.js" %*
-LAUNCHER
+          printf '@echo off\r\nset "SCRIPT_DIR=%%~dp0"\r\n"%%SCRIPT_DIR%%bun\\bun.exe" "%%SCRIPT_DIR%%kata-runtime\\dist\\loader.js" %%*\r\n' > vendor/kata.cmd
 
       - name: Build Symphony for Windows ${{ matrix.arch }}
         shell: bash

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -250,7 +250,8 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     strategy:
       matrix:
-        arch: [x64, arm64]
+        # Bun does not publish Windows arm64 binaries, so only x64 is supported
+        arch: [x64]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -404,8 +405,13 @@ jobs:
       - name: Install cross-compilation tools
         if: matrix.arch == 'arm64'
         run: |
+          sudo dpkg --add-architecture arm64
+          # Add arm64 package sources for cross-compilation libraries
+          sudo sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list.d/*.list 2>/dev/null || true
+          echo 'deb [arch=arm64] http://ports.ubuntu.com/ noble main restricted universe multiverse' | sudo tee /etc/apt/sources.list.d/arm64.list
+          echo 'deb [arch=arm64] http://ports.ubuntu.com/ noble-updates main restricted universe multiverse' | sudo tee -a /etc/apt/sources.list.d/arm64.list
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libssl-dev:arm64 pkg-config
 
       - name: Cache Cargo registry and build
         uses: actions/cache@v5
@@ -440,6 +446,11 @@ jobs:
       - name: Build Symphony for Linux ${{ matrix.arch }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          PKG_CONFIG_ALLOW_CROSS: '1'
+          PKG_CONFIG_PATH: ${{ matrix.arch == 'arm64' && '/usr/lib/aarch64-linux-gnu/pkgconfig' || '' }}
+          OPENSSL_DIR: ${{ matrix.arch == 'arm64' && '/usr' || '' }}
+          OPENSSL_INCLUDE_DIR: ${{ matrix.arch == 'arm64' && '/usr/include/aarch64-linux-gnu' || '' }}
+          OPENSSL_LIB_DIR: ${{ matrix.arch == 'arm64' && '/usr/lib/aarch64-linux-gnu' || '' }}
         run: |
           TARGET="${{ matrix.arch == 'arm64' && 'aarch64-unknown-linux-gnu' || 'x86_64-unknown-linux-gnu' }}"
           echo "Building Symphony for $TARGET..."
@@ -511,14 +522,9 @@ jobs:
           cp artifacts/macos-x64/*.dmg release-files/
           cp artifacts/macos-x64/*.zip release-files/
           cp artifacts/macos-arm64/latest-mac.yml release-files/ 2>/dev/null || true
-          # Windows
+          # Windows (x64 only — Bun does not publish Windows arm64 binaries)
           cp artifacts/windows-x64/*.exe release-files/
-          cp artifacts/windows-arm64/*.exe release-files/
-          # Merge latest.yml from both architectures — electron-builder generates per-arch content.
-          # Copy both and rename to avoid collision; auto-update is currently disabled (publish: null)
-          # but this keeps the metadata correct for when it's enabled.
           cp artifacts/windows-x64/latest.yml release-files/latest.yml 2>/dev/null || true
-          cp artifacts/windows-arm64/latest.yml release-files/latest-arm64.yml 2>/dev/null || true
           # Linux
           cp artifacts/linux-x64/*.AppImage release-files/
           cp artifacts/linux-x64/*.deb release-files/

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- **Windows support** — NSIS installer for x64 and arm64 (Kata-Desktop-x64-Setup.exe, Kata-Desktop-arm64-Setup.exe)
+- **Windows support** — NSIS installer for x64 (Kata-Desktop-x64-Setup.exe)
 - **Linux support** — AppImage and .deb packages for x64 and arm64
 - **Cross-platform CI** — Release workflow now builds for macOS, Windows, and Linux in parallel
 - **Cross-platform binary discovery** — Desktop app correctly resolves bundled kata and Symphony binaries on all platforms (.exe/.cmd on Windows, shell scripts on macOS/Linux)

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -54,7 +54,6 @@ win:
     - target: nsis
       arch:
         - x64
-        - arm64
 
 nsis:
   artifactName: "Kata-Desktop-${arch}-Setup.${ext}"


### PR DESCRIPTION
Fixes the two CI failures from the Desktop v0.2.0 release run on main.

### Linux arm64: OpenSSL cross-compilation failure

`openssl-sys` couldn't find OpenSSL headers/libs when cross-compiling Symphony to `aarch64-unknown-linux-gnu`.

**Fix:** Add arm64 dpkg architecture, install `libssl-dev:arm64`, and set `PKG_CONFIG_ALLOW_CROSS`, `OPENSSL_DIR`, `OPENSSL_INCLUDE_DIR`, `OPENSSL_LIB_DIR` env vars pointing to the aarch64 sysroot.

### Windows arm64: Bun binary 404

Bun does not publish `bun-windows-aarch64` binaries — the download URL returned 404.

**Fix:** Drop Windows arm64 from the build matrix and electron-builder targets. Windows is x64-only until Bun adds arm64 support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined desktop application build configuration to focus on Windows x64 architecture only.
  * Enhanced Linux arm64 cross-compilation support with expanded dependencies and environment configuration.
  * Updated release artifact preparation to align with supported build architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two CI failures from the v0.2.0 desktop release: Windows arm64 is dropped entirely (Bun has no `bun-windows-aarch64` binary), and Linux arm64 gains proper OpenSSL cross-compilation support via `libssl-dev:arm64` and matching `OPENSSL_*` env vars.

- The OpenSSL env vars (`OPENSSL_DIR`, `OPENSSL_INCLUDE_DIR`, `OPENSSL_LIB_DIR`) fall back to `''` (empty string) for x64 builds. Because openssl-sys reads `OPENSSL_DIR` via `std::env::var` and treats any `Ok` value — including `\"\"` — as a path, an empty string produces relative lookup paths (`include`, `lib`) that won't resolve, likely breaking the existing x64 Linux Symphony build.
- The Windows job retains dead `matrix.arch == 'arm64'` branches in the Rust target and Bun arch expressions; these will never execute but add misleading noise.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge once the empty OPENSSL env var regression for x64 Linux is resolved

The Windows arm64 removal and electron-builder update are clean and correct. The Linux arm64 OpenSSL fix is the right approach, but setting the OPENSSL env vars to empty strings for x64 introduces a likely regression in the x64 Linux build path. That P1 finding warrants holding at 4/5 until addressed.

.github/workflows/desktop-release.yml — specifically the env: block on the Build Symphony for Linux step

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/desktop-release.yml | Drops Windows arm64 from matrix, adds Linux arm64 OpenSSL cross-compilation fix, and fixes Windows kata.cmd CRLF — but sets OpenSSL env vars to empty strings for x64, which may break the x64 Linux Symphony build |
| apps/desktop/electron-builder.yml | Removes arm64 from Windows NSIS targets, correctly matching the updated CI matrix; Linux arm64 targets unchanged |
| apps/desktop/CHANGELOG.md | Updates Windows support entry to reflect x64-only, removing the arm64 artifact mention |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main] --> B{Version changed?}
    B -- No --> Z[Skip release]
    B -- Yes --> C[build-macos arm64+x64]
    B -- Yes --> D[build-windows x64 only]
    B -- Yes --> E[build-linux x64+arm64]
    D --> D1[Download bun-windows-x64]
    D --> D2[Write kata.cmd via printf CRLF]
    D --> D3[Build Symphony x86_64-pc-windows-msvc]
    E --> E1{arch == arm64?}
    E1 -- Yes --> E2[dpkg add arm64 arch\napt install libssl-dev:arm64\nSet OPENSSL env vars]
    E1 -- No --> E3[No extra setup]
    E2 --> E4[cargo build aarch64-unknown-linux-gnu]
    E3 --> E5[cargo build x86_64-unknown-linux-gnu]
    C --> F[release job]
    D --> F
    E --> F
    F --> G[Assemble: macOS arm64+x64, Windows x64, Linux arm64+x64]
    G --> H[GitHub Release]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/desktop-release.yml`, line 283-303 ([link](https://github.com/gannonh/kata/blob/c2e68bdcc5856291be22c56b2e26ba0ca4271a56/.github/workflows/desktop-release.yml#L283-L303)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead arm64 conditions in Windows job**

   The Windows matrix is now `arch: [x64]` only, so `matrix.arch == 'arm64'` in these expressions will always be false. The `'aarch64-pc-windows-msvc'` Rust target and `'aarch64'` Bun arch will never be selected. These dead branches are harmless but could confuse future readers.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/desktop-release.yml
   Line: 283-303

   Comment:
   **Dead arm64 conditions in Windows job**

   The Windows matrix is now `arch: [x64]` only, so `matrix.arch == 'arm64'` in these expressions will always be false. The `'aarch64-pc-windows-msvc'` Rust target and `'aarch64'` Bun arch will never be selected. These dead branches are harmless but could confuse future readers.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/desktop-release.yml
Line: 449-453

Comment:
**Empty OPENSSL env vars may break the x64 Linux build**

When `matrix.arch == 'x64'`, these env vars are set to empty strings (`''`) rather than being omitted. In the Rust openssl-sys crate, `std::env::var("OPENSSL_DIR")` returns `Ok("")` for an empty-string value (not `Err(NotPresent)`), so the build script treats `""` as a valid directory prefix — resulting in paths like `include` and `lib` (relative), which won't resolve to OpenSSL headers and will cause a build failure for the previously-working x64 target.

The safest fix is to only set these vars for arm64, using a separate step that appends to `$GITHUB_ENV`:

```yaml
      - name: Set OpenSSL env for arm64 cross-compilation
        if: matrix.arch == 'arm64'
        run: |
          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
          echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
          echo "OPENSSL_DIR=/usr" >> $GITHUB_ENV
          echo "OPENSSL_INCLUDE_DIR=/usr/include/aarch64-linux-gnu" >> $GITHUB_ENV
          echo "OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu" >> $GITHUB_ENV
```

And then remove these from the `env:` block of the build step entirely (keeping only `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER`, which is already a no-op for x64).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/desktop-release.yml
Line: 283-303

Comment:
**Dead arm64 conditions in Windows job**

The Windows matrix is now `arch: [x64]` only, so `matrix.arch == 'arm64'` in these expressions will always be false. The `'aarch64-pc-windows-msvc'` Rust target and `'aarch64'` Bun arch will never be selected. These dead branches are harmless but could confuse future readers.

```suggestion
        targets: x86_64-pc-windows-msvc
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): fix Linux arm64 OpenSSL cr..."](https://github.com/gannonh/kata/commit/c2e68bdcc5856291be22c56b2e26ba0ca4271a56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27920389)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->