### PR TITLE
fix(desktop-release): pin Ubuntu amd64 sources before adding arm64 ports

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -406,13 +406,29 @@ jobs:
         if: matrix.arch == 'arm64'
         run: |
           sudo dpkg --add-architecture arm64
-          # Pin existing Ubuntu sources to amd64 only, then add arm64 from ports.
-          # Ubuntu 24.04 runners use DEB822 .sources format — only modify that file,
-          # leave third-party .list files (e.g. microsoft-prod.list) untouched.
-          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
-            sudo sed -i 's/^Architectures:.*/Architectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources
-          fi
-          printf 'deb [arch=arm64] http://ports.ubuntu.com/ noble main restricted universe multiverse\ndeb [arch=arm64] http://ports.ubuntu.com/ noble-updates main restricted universe multiverse\n' | sudo tee /etc/apt/sources.list.d/arm64-cross.list
+          # GitHub's amd64 Ubuntu runners use archive/security.ubuntu.com sources.
+          # After adding arm64, apt will incorrectly try to fetch arm64 indexes there
+          # and fail with 404s. Replace the default sources with explicit amd64-only
+          # entries, then add explicit arm64 entries from ubuntu-ports.
+          printf '%s\n' \
+            'Types: deb' \
+            'URIs: http://archive.ubuntu.com/ubuntu/' \
+            'Suites: noble noble-updates noble-backports' \
+            'Components: main universe restricted multiverse' \
+            'Architectures: amd64' \
+            'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
+            '' \
+            'Types: deb' \
+            'URIs: http://security.ubuntu.com/ubuntu/' \
+            'Suites: noble-security' \
+            'Components: main universe restricted multiverse' \
+            'Architectures: amd64' \
+            'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' | sudo tee /etc/apt/sources.list.d/ubuntu.sources >/dev/null
+          printf '%s\n' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-updates main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-backports main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-security main universe restricted multiverse' | sudo tee /etc/apt/sources.list.d/arm64-cross.list >/dev/null
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libssl-dev:arm64 pkg-config
 


### PR DESCRIPTION
Fixes the failing `build-linux (arm64)` job in `.github/workflows/desktop-release.yml` on `main`.

## Root cause

After `dpkg --add-architecture arm64`, `apt-get update` on GitHub's amd64 Ubuntu runner still tried to fetch arm64 package indexes from:

- `archive.ubuntu.com`
- `security.ubuntu.com`

Those arm64 URLs 404 on the runner, so the release job failed before it ever reached Cargo or packaging.

## Fix

Replace the default `ubuntu.sources` with explicit `amd64`-only entries for:

- `archive.ubuntu.com`
- `security.ubuntu.com`

Then add explicit arm64 package sources from `ubuntu-ports` for:

- `noble`
- `noble-updates`
- `noble-backports`
- `noble-security`

This prevents APT from requesting arm64 indexes from the wrong mirrors.

## Verification

- YAML parse check passes
- Reproduced locally in an `ubuntu:24.04` amd64 container
- Verified `apt-get update` succeeds with the new source config
- Verified install succeeds for:
  - `gcc-aarch64-linux-gnu`
  - `g++-aarch64-linux-gnu`
  - `libssl-dev:arm64`
  - `pkg-config`

This is a targeted workflow fix only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the failing `build-linux (arm64)` CI job by pinning the Ubuntu APT sources to the correct mirrors. After `dpkg --add-architecture arm64`, the default `ubuntu.sources` causes `apt-get update` to request arm64 indexes from `archive.ubuntu.com` and `security.ubuntu.com`, which 404 on amd64 runners. The fix overwrites `ubuntu.sources` with explicit `Architectures: amd64` stanzas and adds a separate `arm64-cross.list` pointing to `ports.ubuntu.com` for all four Noble suites.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted CI fix with no application code changes and verified cross-compilation behavior.

The change is a single-step CI fix gated behind `if: matrix.arch == 'arm64'`, so it can't regress the amd64 or macOS/Windows builds. The DEB822 format is correct, the suites (noble, noble-updates, noble-backports, noble-security) are fully covered for both architectures, and ports.ubuntu.com is the canonical mirror for arm64. No blocking issues found.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The fix installs packages from official Ubuntu archive and ports mirrors, uses the Ubuntu archive keyring for verification, and the change is scoped entirely to the CI workflow.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/desktop-release.yml | Adds APT source-pinning fix for the arm64 cross-compilation step: overwrites ubuntu.sources with amd64-only DEB822 stanzas, then appends ports.ubuntu.com entries for arm64, resolving 404s from archive/security.ubuntu.com during apt-get update. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build-linux matrix: arm64] --> B{matrix.arch == arm64?}
    B -- No --> G[apt-get update with default sources]
    B -- Yes --> C[dpkg --add-architecture arm64]
    C --> D[Overwrite /etc/apt/sources.list.d/ubuntu.sources\nArchitectures: amd64 only\narchive.ubuntu.com + security.ubuntu.com]
    D --> E[Write /etc/apt/sources.list.d/arm64-cross.list\nports.ubuntu.com noble / noble-updates\n noble-backports / noble-security]
    E --> F[apt-get update — no more 404s]
    F --> H[apt-get install gcc-aarch64 g++-aarch64\nlibssl-dev:arm64 pkg-config]
    G --> I[cargo build aarch64-unknown-linux-gnu]
    H --> I
```

<sub>Reviews (1): Last reviewed commit: ["fix(desktop-release): pin Ubuntu amd64 s..."](https://github.com/gannonh/kata/commit/eb5e3344e992e5bc40876c4cf21ace8ae7d28ba4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27924533)</sub>

<!-- /greptile_comment -->