### PR TITLE
fix(desktop-release): fix Linux x64 OpenSSL env regression

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -406,13 +406,29 @@ jobs:
         if: matrix.arch == 'arm64'
         run: |
           sudo dpkg --add-architecture arm64
-          # Pin existing Ubuntu sources to amd64 only, then add arm64 from ports.
-          # Ubuntu 24.04 runners use DEB822 .sources format — only modify that file,
-          # leave third-party .list files (e.g. microsoft-prod.list) untouched.
-          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
-            sudo sed -i 's/^Architectures:.*/Architectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources
-          fi
-          printf 'deb [arch=arm64] http://ports.ubuntu.com/ noble main restricted universe multiverse\ndeb [arch=arm64] http://ports.ubuntu.com/ noble-updates main restricted universe multiverse\n' | sudo tee /etc/apt/sources.list.d/arm64-cross.list
+          # GitHub's amd64 Ubuntu runners use archive/security.ubuntu.com sources.
+          # After adding arm64, apt will incorrectly try to fetch arm64 indexes there
+          # and fail with 404s. Replace the default sources with explicit amd64-only
+          # entries, then add explicit arm64 entries from ubuntu-ports.
+          printf '%s\n' \
+            'Types: deb' \
+            'URIs: http://archive.ubuntu.com/ubuntu/' \
+            'Suites: noble noble-updates noble-backports' \
+            'Components: main universe restricted multiverse' \
+            'Architectures: amd64' \
+            'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
+            '' \
+            'Types: deb' \
+            'URIs: http://security.ubuntu.com/ubuntu/' \
+            'Suites: noble-security' \
+            'Components: main universe restricted multiverse' \
+            'Architectures: amd64' \
+            'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' | sudo tee /etc/apt/sources.list.d/ubuntu.sources >/dev/null
+          printf '%s\n' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-updates main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-backports main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-security main universe restricted multiverse' | sudo tee /etc/apt/sources.list.d/arm64-cross.list >/dev/null
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libssl-dev:arm64 pkg-config
 


### PR DESCRIPTION
Follow-up to the Linux release fixes on `main`.

## Root cause

The `build-linux` Symphony step exported these environment variables for **all** Linux architectures:

- `PKG_CONFIG_PATH`
- `OPENSSL_DIR`
- `OPENSSL_INCLUDE_DIR`
- `OPENSSL_LIB_DIR`

For `x64`, those resolved to empty strings. `openssl-sys` then failed during the normal x64 build with:

```text
OpenSSL library directory does not exist: [""]
```

## Fix

Only export the OpenSSL cross-compilation environment variables when `matrix.arch == 'arm64'`.

This preserves the arm64 cross-compile configuration while allowing the native x64 build to use the runner's default OpenSSL discovery.

## Verification

- Inspected the failing GitHub Actions run on `main`
- Confirmed failure was in `build-linux (x64)` during `Build Symphony for Linux x64`
- YAML parse check passes

This PR is intentionally scoped to the Linux x64 OpenSSL env regression in `.github/workflows/desktop-release.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Linux ARM64 build process with updated package repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the arm64 cross-compilation apt source setup in `build-linux`, replacing a fragile `sed`-based edit of `ubuntu.sources` with an explicit, complete DEB822 rewrite that correctly pins amd64 sources and adds full arm64 ports entries (including `noble-backports` and `noble-security` which the previous approach omitted). The OpenSSL conditional env vars introduced in the companion PR #303 are preserved unchanged here.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the change is narrowly scoped to the arm64-only cross-compile setup step and correctly replaces a fragile sed patch with an explicit, complete DEB822 rewrite.

All findings are P2 or lower. The apt sources rewrite is logically correct (valid DEB822 stanzas, correct keyring, full suite coverage for both amd64 and arm64), the change only runs under `if: matrix.arch == 'arm64'` so x64 builds are completely unaffected, and the approach is strictly more robust than what it replaces. No blocking issues.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The workflow change rewrites apt sources on the CI runner; all URLs reference official Ubuntu mirrors (`archive.ubuntu.com`, `security.ubuntu.com`, `ports.ubuntu.com`), the keyring path (`/usr/share/keyrings/ubuntu-archive-keyring.gpg`) is the standard Ubuntu archive key, and no secrets or credentials are involved.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/desktop-release.yml | Replaces the sed-based ubuntu.sources patch with an explicit DEB822 rewrite and expands arm64 ports entries to cover noble-backports and noble-security; all changes are scoped to the arm64 cross-compile setup step. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build-linux matrix: x64 / arm64] --> B{matrix.arch == arm64?}
    B -- Yes --> C[Install cross-compilation tools]
    C --> C1[dpkg --add-architecture arm64]
    C1 --> C2[Rewrite ubuntu.sources\namd64-only: archive + security stanzas]
    C2 --> C3[Write arm64-cross.list\nnoble / noble-updates / noble-backports / noble-security\nfrom ports.ubuntu.com/ubuntu-ports]
    C3 --> C4[apt-get install gcc-aarch64 libssl-dev:arm64 pkg-config]
    B -- No --> D[Skip cross-compilation setup]
    C4 --> E[Build Symphony for Linux]
    D --> E
    E --> E1{matrix.arch == arm64?}
    E1 -- Yes --> E2[Export OPENSSL_DIR / OPENSSL_INCLUDE_DIR / OPENSSL_LIB_DIR\n/usr/lib/aarch64-linux-gnu paths]
    E1 -- No --> E3[Export empty-string fallback\nuse runner default OpenSSL discovery]
    E2 --> F[cargo build --target aarch64-unknown-linux-gnu]
    E3 --> G[cargo build --target x86_64-unknown-linux-gnu]
```

<sub>Reviews (1): Last reviewed commit: ["fix(desktop-release): pin Ubuntu amd64 s..."](https://github.com/gannonh/kata/commit/b30c229e8c900643be278f7b1db35ab80232b426) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27926349)</sub>

<!-- /greptile_comment -->