### PR TITLE
fix(desktop-release): only set OpenSSL cross env for Linux arm64

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -465,13 +465,15 @@ jobs:
       - name: Build Symphony for Linux ${{ matrix.arch }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          PKG_CONFIG_ALLOW_CROSS: '1'
-          PKG_CONFIG_PATH: ${{ matrix.arch == 'arm64' && '/usr/lib/aarch64-linux-gnu/pkgconfig' || '' }}
-          OPENSSL_DIR: ${{ matrix.arch == 'arm64' && '/usr' || '' }}
-          OPENSSL_INCLUDE_DIR: ${{ matrix.arch == 'arm64' && '/usr/include/aarch64-linux-gnu' || '' }}
-          OPENSSL_LIB_DIR: ${{ matrix.arch == 'arm64' && '/usr/lib/aarch64-linux-gnu' || '' }}
         run: |
           TARGET="${{ matrix.arch == 'arm64' && 'aarch64-unknown-linux-gnu' || 'x86_64-unknown-linux-gnu' }}"
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            export PKG_CONFIG_ALLOW_CROSS=1
+            export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+            export OPENSSL_DIR=/usr
+            export OPENSSL_INCLUDE_DIR=/usr/include/aarch64-linux-gnu
+            export OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu
+          fi
           echo "Building Symphony for $TARGET..."
           cd apps/symphony && cargo build --release --target "$TARGET"
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -406,13 +406,29 @@ jobs:
         if: matrix.arch == 'arm64'
         run: |
           sudo dpkg --add-architecture arm64
-          # Pin existing Ubuntu sources to amd64 only, then add arm64 from ports.
-          # Ubuntu 24.04 runners use DEB822 .sources format — only modify that file,
-          # leave third-party .list files (e.g. microsoft-prod.list) untouched.
-          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
-            sudo sed -i 's/^Architectures:.*/Architectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources
-          fi
-          printf 'deb [arch=arm64] http://ports.ubuntu.com/ noble main restricted universe multiverse\ndeb [arch=arm64] http://ports.ubuntu.com/ noble-updates main restricted universe multiverse\n' | sudo tee /etc/apt/sources.list.d/arm64-cross.list
+          # GitHub's amd64 Ubuntu runners use archive/security.ubuntu.com sources.
+          # After adding arm64, apt will incorrectly try to fetch arm64 indexes there
+          # and fail with 404s. Replace the default sources with explicit amd64-only
+          # entries, then add explicit arm64 entries from ubuntu-ports.
+          printf '%s\n' \
+            'Types: deb' \
+            'URIs: http://archive.ubuntu.com/ubuntu/' \
+            'Suites: noble noble-updates noble-backports' \
+            'Components: main universe restricted multiverse' \
+            'Architectures: amd64' \
+            'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
+            '' \
+            'Types: deb' \
+            'URIs: http://security.ubuntu.com/ubuntu/' \
+            'Suites: noble-security' \
+            'Components: main universe restricted multiverse' \
+            'Architectures: amd64' \
+            'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' | sudo tee /etc/apt/sources.list.d/ubuntu.sources >/dev/null
+          printf '%s\n' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-updates main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-backports main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-security main universe restricted multiverse' | sudo tee /etc/apt/sources.list.d/arm64-cross.list >/dev/null
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libssl-dev:arm64 pkg-config
 


### PR DESCRIPTION
Fixes the current `desktop-release.yml` failure on `main`.

## Actual failure

Run `24215049202` failed in:
- `build-linux (x64)`
- step: `Build Symphony for Linux x64`

With:

```text
OpenSSL library directory does not exist: [""]
```

## Root cause

The workflow exports OpenSSL-related environment variables for **all** Linux architectures:

- `PKG_CONFIG_ALLOW_CROSS`
- `PKG_CONFIG_PATH`
- `OPENSSL_DIR`
- `OPENSSL_INCLUDE_DIR`
- `OPENSSL_LIB_DIR`

For `x64`, those resolve to empty strings, which breaks `openssl-sys` discovery.

## Fix

Only export the OpenSSL cross-compilation environment variables when `matrix.arch == 'arm64'`.

That keeps the arm64 cross-compile configuration while allowing native Linux x64 builds to use the runner's normal OpenSSL discovery.

## Scope

This PR is intentionally limited to `.github/workflows/desktop-release.yml`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Linux x64 build failure by moving the OpenSSL cross-compilation environment variables (`PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_PATH`, `OPENSSL_DIR`, `OPENSSL_INCLUDE_DIR`, `OPENSSL_LIB_DIR`) inside an `if [ "${{ matrix.arch }}" = "arm64" ]` shell block, so they are only exported during arm64 cross-compilation builds and never set to empty strings for native x64 builds.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted, minimal fix with no side effects on other build jobs.

The change is a single-file, single-step fix that correctly scopes the OpenSSL env vars to arm64 using an in-script conditional. The CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER env var remains at the step level but is harmless for x64 (Cargo ignores target-specific linker vars for other targets). No P0/P1 issues found.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/desktop-release.yml | Scopes OpenSSL cross-compilation env vars to the arm64 branch inside the shell script, fixing the x64 build failure where those vars resolved to empty strings. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build-linux matrix: x64 / arm64] --> B{matrix.arch == 'arm64'?}
    B -- Yes --> C[Install cross-compilation tools\ngcc-aarch64, libssl-dev:arm64]
    B -- No --> D[Skip cross-compilation tools]
    C --> E[Build Symphony step]
    D --> E
    E --> F{matrix.arch == 'arm64'?}
    F -- Yes --> G[export PKG_CONFIG_ALLOW_CROSS=1\nexport PKG_CONFIG_PATH=...\nexport OPENSSL_DIR=/usr\nexport OPENSSL_INCLUDE_DIR=...\nexport OPENSSL_LIB_DIR=...]
    F -- No --> H[No OpenSSL env vars set\nnative discovery used]
    G --> I[cargo build --target aarch64-unknown-linux-gnu]
    H --> J[cargo build --target x86_64-unknown-linux-gnu]
```

<sub>Reviews (1): Last reviewed commit: ["fix(desktop-release): only set OpenSSL c..."](https://github.com/gannonh/kata/commit/4f4cf81c2c3a14ccb9c08ecff116586ec8f98cb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27928887)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized Linux ARM64 cross-compilation infrastructure in the CI/CD pipeline, improving the reliability and configuration of architecture-specific build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->