### PR TITLE
fix(desktop-release): add Linux package metadata and robust artifact checks

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -497,26 +497,30 @@ jobs:
 
       - name: Verify Linux artifacts
         run: |
-          set -e
+          set -euo pipefail
           echo "Checking for Linux ${{ matrix.arch }} artifacts..."
           ls -la apps/desktop/release/
-          if ! ls apps/desktop/release/Kata-Desktop-${{ matrix.arch }}.AppImage 1>/dev/null 2>&1; then
+          APPIMAGE=$(find apps/desktop/release -maxdepth 1 -type f -name '*.AppImage' | head -1)
+          DEB=$(find apps/desktop/release -maxdepth 1 -type f -name '*.deb' | head -1)
+          if [ -z "$APPIMAGE" ]; then
             echo "::error::AppImage for ${{ matrix.arch }} not found"
             exit 1
           fi
-          if ! ls apps/desktop/release/Kata-Desktop-${{ matrix.arch }}.deb 1>/dev/null 2>&1; then
-            echo "::error::deb package for ${{ matrix.arch }} not found"
+          if [ -z "$DEB" ]; then
+            echo "::error::.deb package for ${{ matrix.arch }} not found"
             exit 1
           fi
-          echo "Found Linux artifacts for ${{ matrix.arch }}"
+          echo "Found Linux artifacts:"
+          echo "  AppImage: $APPIMAGE"
+          echo "  deb: $DEB"
 
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: linux-${{ matrix.arch }}
           path: |
-            apps/desktop/release/Kata-Desktop-${{ matrix.arch }}.AppImage
-            apps/desktop/release/Kata-Desktop-${{ matrix.arch }}.deb
+            apps/desktop/release/*.AppImage
+            apps/desktop/release/*.deb
             apps/desktop/release/latest-linux.yml
 
   release:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -465,13 +465,15 @@ jobs:
       - name: Build Symphony for Linux ${{ matrix.arch }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          PKG_CONFIG_ALLOW_CROSS: '1'
-          PKG_CONFIG_PATH: ${{ matrix.arch == 'arm64' && '/usr/lib/aarch64-linux-gnu/pkgconfig' || '' }}
-          OPENSSL_DIR: ${{ matrix.arch == 'arm64' && '/usr' || '' }}
-          OPENSSL_INCLUDE_DIR: ${{ matrix.arch == 'arm64' && '/usr/include/aarch64-linux-gnu' || '' }}
-          OPENSSL_LIB_DIR: ${{ matrix.arch == 'arm64' && '/usr/lib/aarch64-linux-gnu' || '' }}
         run: |
           TARGET="${{ matrix.arch == 'arm64' && 'aarch64-unknown-linux-gnu' || 'x86_64-unknown-linux-gnu' }}"
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            export PKG_CONFIG_ALLOW_CROSS=1
+            export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+            export OPENSSL_DIR=/usr
+            export OPENSSL_INCLUDE_DIR=/usr/include/aarch64-linux-gnu
+            export OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu
+          fi
           echo "Building Symphony for $TARGET..."
           cd apps/symphony && cargo build --release --target "$TARGET"
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -406,13 +406,29 @@ jobs:
         if: matrix.arch == 'arm64'
         run: |
           sudo dpkg --add-architecture arm64
-          # Pin existing Ubuntu sources to amd64 only, then add arm64 from ports.
-          # Ubuntu 24.04 runners use DEB822 .sources format — only modify that file,
-          # leave third-party .list files (e.g. microsoft-prod.list) untouched.
-          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
-            sudo sed -i 's/^Architectures:.*/Architectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources
-          fi
-          printf 'deb [arch=arm64] http://ports.ubuntu.com/ noble main restricted universe multiverse\ndeb [arch=arm64] http://ports.ubuntu.com/ noble-updates main restricted universe multiverse\n' | sudo tee /etc/apt/sources.list.d/arm64-cross.list
+          # GitHub's amd64 Ubuntu runners use archive/security.ubuntu.com sources.
+          # After adding arm64, apt will incorrectly try to fetch arm64 indexes there
+          # and fail with 404s. Replace the default sources with explicit amd64-only
+          # entries, then add explicit arm64 entries from ubuntu-ports.
+          printf '%s\n' \
+            'Types: deb' \
+            'URIs: http://archive.ubuntu.com/ubuntu/' \
+            'Suites: noble noble-updates noble-backports' \
+            'Components: main universe restricted multiverse' \
+            'Architectures: amd64' \
+            'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
+            '' \
+            'Types: deb' \
+            'URIs: http://security.ubuntu.com/ubuntu/' \
+            'Suites: noble-security' \
+            'Components: main universe restricted multiverse' \
+            'Architectures: amd64' \
+            'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' | sudo tee /etc/apt/sources.list.d/ubuntu.sources >/dev/null
+          printf '%s\n' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-updates main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-backports main universe restricted multiverse' \
+            'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ noble-security main universe restricted multiverse' | sudo tee /etc/apt/sources.list.d/arm64-cross.list >/dev/null
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libssl-dev:arm64 pkg-config
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -80,3 +80,4 @@ appImage:
 
 deb:
   artifactName: "Kata-Desktop-${arch}.${ext}"
+  maintainer: "Kata Contributors <hello@kata.sh>"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,9 +1,16 @@
 {
   "name": "@kata/desktop",
   "version": "0.2.0",
+  "description": "Kata Desktop — native desktop app for the Kata coding agent",
   "private": true,
   "type": "module",
   "main": "dist/main.cjs",
+  "author": {
+    "name": "Kata Contributors",
+    "email": "hello@kata.sh"
+  },
+  "homepage": "https://github.com/gannonh/kata",
+  "license": "MIT",
   "scripts": {
     "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload.cjs --external:electron",


### PR DESCRIPTION
Addresses the next Linux release blockers before rerunning `desktop-release.yml`.

## Failures addressed

### 1. Debian packaging metadata
The Linux x64 packaging step failed with:

- missing project homepage
- missing author email
- missing Debian maintainer metadata

Fixes:
- add `description`, `homepage`, `license`, and `author.email` to `apps/desktop/package.json`
- add `deb.maintainer` to `apps/desktop/electron-builder.yml`

### 2. Linux artifact filename assumptions
The workflow currently verifies/uploads Linux artifacts using `${{ matrix.arch }}` in filenames, but electron-builder emits Linux names like:

- `Kata-Desktop-x86_64.AppImage`
- `Kata-Desktop-amd64.deb`

So even after packaging succeeds, the workflow would fail in verify/upload.

Fix:
- verify the actual generated `*.AppImage` / `*.deb` files
- upload via globs instead of hardcoded `${{ matrix.arch }}` filenames

## Scope

Only touches:
- `.github/workflows/desktop-release.yml`
- `apps/desktop/package.json`
- `apps/desktop/electron-builder.yml`

No version bump, no app code changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses Linux release blockers by fixing missing Debian packaging metadata (`description`, `author.email`, `homepage`, `license`, `deb.maintainer`) and replacing hardcoded `${{ matrix.arch }}` artifact filenames with glob-based discovery. It also rewrites the arm64 cross-compilation apt sources setup to correctly scope architectures and adds `noble-backports` and `noble-security` to the arm64 ports list, and moves cross-build env vars into a conditional shell block.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are targeted fixes for known Linux release blockers with no app code touched.

No P0 or P1 findings. The apt sources rewrite is correct DEB822 format, the conditional env-var approach is functionally equivalent to the old env: block, glob-based artifact discovery correctly handles electron-builder's divergent arch naming (x86_64 vs amd64), and the package.json/electron-builder.yml metadata additions are well-formed.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/desktop-release.yml | Rewrites arm64 apt sources to explicit DEB822 stanzas scoped to amd64/arm64, moves cross-build env vars into a conditional shell block, and replaces hardcoded arch filenames with glob-based artifact verify/upload — all changes are correct and well-reasoned. |
| apps/desktop/electron-builder.yml | Adds deb.maintainer field required by Debian packaging — correct format and no other changes. |
| apps/desktop/package.json | Adds description, author (with email), homepage, and license fields needed by electron-builder for Linux packaging metadata — all values are appropriate. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build-linux matrix
x64 / arm64] --> B{matrix.arch == arm64?}
    B -- Yes --> C[dpkg --add-architecture arm64
Rewrite ubuntu.sources amd64 only
Add arm64-cross.list from ubuntu-ports]
    C --> D[apt install gcc-aarch64-linux-gnu
libssl-dev:arm64 pkg-config]
    D --> E[Set PKG_CONFIG / OPENSSL
env vars in shell]
    B -- No --> F[No extra setup needed]
    E --> G[cargo build --target aarch64-unknown-linux-gnu]
    F --> H[cargo build --target x86_64-unknown-linux-gnu]
    G --> I[electron-builder --linux AppImage deb --arm64
Outputs: Kata-Desktop-arm64.AppImage
         Kata-Desktop-arm64.deb]
    H --> J[electron-builder --linux AppImage deb --x64
Outputs: Kata-Desktop-x86_64.AppImage
         Kata-Desktop-amd64.deb]
    I --> K[Verify: find *.AppImage + *.deb
Upload: glob *.AppImage *.deb latest-linux.yml]
    J --> K
    K --> L[release job
Download + cp artifacts/linux-x64/* + linux-arm64/*
Create GitHub Release]
```

<sub>Reviews (1): Last reviewed commit: ["fix(desktop-release): add linux package ..."](https://github.com/gannonh/kata/commit/c5ffbec4a4388e22765495c9f013893c63c38dab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27930551)</sub>

<!-- /greptile_comment -->