### PR TITLE
feat(desktop): Provider truthfulness across onboarding and settings [KAT-2463]

### DIFF
--- a/.agents/skills/sym-land/SKILL.md
+++ b/.agents/skills/sym-land/SKILL.md
@@ -117,7 +117,6 @@ Exit codes:
 - 2: Review comments detected (address feedback)
 - 3: CI checks failed
 - 4: PR head updated (autofix commit detected)
-- 5: Merge conflict detected (run conflict-resolution flow)
 
 ## Failure Handling
 

--- a/apps/desktop/e2e/tests/onboarding.e2e.ts
+++ b/apps/desktop/e2e/tests/onboarding.e2e.ts
@@ -112,6 +112,7 @@ test.describe('Onboarding provider consistency', () => {
 
     // Should be on step 4 (completion), NOT step 3 (key entry)
     await expect(window.getByText('Step 4 of 4').first()).toBeVisible({ timeout: 5_000 })
+    await expect(window.getByText('Step 3 of 4')).toHaveCount(0)
     await expect(window.getByRole('button', { name: /Start chatting/i })).toBeVisible()
   })
 })

--- a/apps/desktop/e2e/tests/onboarding.e2e.ts
+++ b/apps/desktop/e2e/tests/onboarding.e2e.ts
@@ -94,6 +94,26 @@ test.describe('Onboarding provider consistency', () => {
 
     await expect(openAiCard.getByText(/Configured/i)).toBeVisible()
   })
+
+  test('configured provider skips key entry and advances to completion', async ({ electronApp }) => {
+    const window = await getOnboardingWindow(electronApp)
+
+    // Step 1 → 2: "Get started"
+    await window.getByRole('button', { name: /Get started/i }).click()
+    await expect(window.getByText('Step 2 of 4').first()).toBeVisible()
+
+    // Select the pre-configured OpenAI provider (seeded with valid key)
+    const openAiCard = window.getByRole('button', { name: /OpenAI/i }).first()
+    await openAiCard.click()
+    await expect(openAiCard.getByText(/Configured/i)).toBeVisible()
+
+    // Click Continue — should skip key entry (step 3) and go to completion (step 4)
+    await window.getByRole('button', { name: /^Continue$/i }).click()
+
+    // Should be on step 4 (completion), NOT step 3 (key entry)
+    await expect(window.getByText('Step 4 of 4').first()).toBeVisible({ timeout: 5_000 })
+    await expect(window.getByRole('button', { name: /Start chatting/i })).toBeVisible()
+  })
 })
 
 test.describe('Onboarding recovery messaging', () => {

--- a/apps/desktop/src/main/__tests__/auth-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/auth-bridge.test.ts
@@ -374,12 +374,13 @@ describe('AuthBridge', () => {
   test('normalizes auth checkpoint as pass when a provider is configured', () => {
     const normalized = normalizeFirstRunAuthReadiness({
       providers: {
-        anthropic: { provider: 'anthropic', status: 'missing' },
-        openai: { provider: 'openai', status: 'valid', maskedKey: '••••1234' },
-        google: { provider: 'google', status: 'missing' },
-        mistral: { provider: 'mistral', status: 'missing' },
-        bedrock: { provider: 'bedrock', status: 'missing' },
-        azure: { provider: 'azure', status: 'missing' },
+        anthropic: { provider: 'anthropic', status: 'missing', authType: 'api_key' },
+        openai: { provider: 'openai', status: 'valid', authType: 'api_key', maskedKey: '••••1234' },
+        google: { provider: 'google', status: 'missing', authType: 'api_key' },
+        mistral: { provider: 'mistral', status: 'missing', authType: 'api_key' },
+        bedrock: { provider: 'bedrock', status: 'missing', authType: 'api_key' },
+        azure: { provider: 'azure', status: 'missing', authType: 'api_key' },
+        'github-copilot': { provider: 'github-copilot', status: 'missing', authType: 'oauth' },
       },
       selectedProvider: 'openai',
       now: '2026-04-08T00:00:00.000Z',
@@ -393,12 +394,13 @@ describe('AuthBridge', () => {
   test('fails auth checkpoint when selected provider requires key', () => {
     const normalized = normalizeFirstRunAuthReadiness({
       providers: {
-        anthropic: { provider: 'anthropic', status: 'valid', maskedKey: '••••1234' },
-        openai: { provider: 'openai', status: 'missing' },
-        google: { provider: 'google', status: 'missing' },
-        mistral: { provider: 'mistral', status: 'missing' },
-        bedrock: { provider: 'bedrock', status: 'missing' },
-        azure: { provider: 'azure', status: 'missing' },
+        anthropic: { provider: 'anthropic', status: 'valid', authType: 'api_key', maskedKey: '••••1234' },
+        openai: { provider: 'openai', status: 'missing', authType: 'api_key' },
+        google: { provider: 'google', status: 'missing', authType: 'api_key' },
+        mistral: { provider: 'mistral', status: 'missing', authType: 'api_key' },
+        bedrock: { provider: 'bedrock', status: 'missing', authType: 'api_key' },
+        azure: { provider: 'azure', status: 'missing', authType: 'api_key' },
+        'github-copilot': { provider: 'github-copilot', status: 'missing', authType: 'oauth' },
       },
       selectedProvider: 'openai',
       now: '2026-04-08T00:00:00.000Z',
@@ -407,5 +409,126 @@ describe('AuthBridge', () => {
     expect(normalized.checkpoint.status).toBe('fail')
     expect(normalized.checkpoint.failure?.code).toBe('AUTH_PROVIDER_KEY_REQUIRED')
     expect(normalized.checkpoint.failure?.recoveryAction).toBe('reauthenticate')
+  })
+
+  test('includes github-copilot in provider list with authType oauth', async () => {
+    const bridge = new AuthBridge(authFilePath)
+    const response = await bridge.getProviders()
+
+    expect(response.success).toBe(true)
+    expect(response.providers['github-copilot']).toBeDefined()
+    expect(response.providers['github-copilot'].authType).toBe('oauth')
+    expect(response.providers['github-copilot'].provider).toBe('github-copilot')
+  })
+
+  test('authType is always populated for all providers', async () => {
+    await fs.writeFile(
+      authFilePath,
+      JSON.stringify({ anthropic: { type: 'api_key', key: 'test-key' } }, null, 2),
+      'utf8',
+    )
+
+    const bridge = new AuthBridge(authFilePath)
+    const response = await bridge.getProviders()
+
+    expect(response.success).toBe(true)
+    for (const provider of Object.values(response.providers)) {
+      expect(provider.authType).toBeDefined()
+      expect(['api_key', 'oauth']).toContain(provider.authType)
+    }
+  })
+
+  test('detects github-copilot as valid when token file exists', async () => {
+    // Create a mock token file for GitHub Copilot
+    const copilotDir = path.join(tempDir, '.config', 'github-copilot')
+    await fs.mkdir(copilotDir, { recursive: true })
+    await fs.writeFile(path.join(copilotDir, 'hosts.json'), '{}', 'utf8')
+
+    // Override HOME so the bridge finds our mock token
+    const originalHome = process.env.HOME
+    process.env.HOME = tempDir
+    try {
+      const bridge = new AuthBridge(authFilePath)
+      const response = await bridge.getProviders()
+
+      expect(response.providers['github-copilot']).toMatchObject({
+        provider: 'github-copilot',
+        status: 'valid',
+        authType: 'oauth',
+      })
+    } finally {
+      process.env.HOME = originalHome
+    }
+  })
+
+  test('detects github-copilot as missing when no token file exists', async () => {
+    const bridge = new AuthBridge(authFilePath)
+    const response = await bridge.getProviders()
+
+    expect(response.providers['github-copilot']).toMatchObject({
+      provider: 'github-copilot',
+      status: 'missing',
+      authType: 'oauth',
+    })
+  })
+
+  test('rejects setProviderKey for OAuth providers', async () => {
+    const bridge = new AuthBridge(authFilePath)
+    const result = await bridge.setProviderKey('github-copilot', 'some-key')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('OAuth authentication')
+    expect(result.error).toContain('cannot be configured with an API key')
+  })
+
+  test('rejects removeProviderKey for OAuth providers', async () => {
+    const bridge = new AuthBridge(authFilePath)
+    const result = await bridge.removeProviderKey('github-copilot')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('OAuth authentication')
+    expect(result.error).toContain('cannot be removed here')
+  })
+
+  test('rejects validateKey for OAuth providers', async () => {
+    const bridge = new AuthBridge(authFilePath)
+    const result = await bridge.validateKey('github-copilot', 'some-key')
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('OAuth authentication')
+  })
+
+  test('mixed provider map returns correct types for API-key and OAuth providers', async () => {
+    await fs.writeFile(
+      authFilePath,
+      JSON.stringify(
+        {
+          anthropic: { type: 'api_key', key: 'anthropic-key' },
+          openai: { type: 'api_key', key: 'openai-key' },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    const bridge = new AuthBridge(authFilePath)
+    const response = await bridge.getProviders()
+
+    expect(response.success).toBe(true)
+
+    // API-key providers
+    expect(response.providers.anthropic.authType).toBe('api_key')
+    expect(response.providers.anthropic.status).toBe('valid')
+    expect(response.providers.openai.authType).toBe('api_key')
+    expect(response.providers.openai.status).toBe('valid')
+
+    // Unconfigured API-key providers
+    expect(response.providers.google.authType).toBe('api_key')
+    expect(response.providers.google.status).toBe('missing')
+
+    // OAuth providers
+    expect(response.providers['github-copilot'].authType).toBe('oauth')
+    expect(['valid', 'missing']).toContain(response.providers['github-copilot'].status)
   })
 })

--- a/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/pi-agent-bridge.test.ts
@@ -1051,12 +1051,13 @@ setTimeout(() => {
 
   test('normalizes first-run model checkpoint and startup checkpoint', () => {
     const providers: ProviderStatusMap = {
-      anthropic: { provider: 'anthropic', status: 'missing' as const },
-      openai: { provider: 'openai', status: 'valid' as const, maskedKey: '••••1234' },
-      google: { provider: 'google', status: 'missing' as const },
-      mistral: { provider: 'mistral', status: 'missing' as const },
-      bedrock: { provider: 'bedrock', status: 'missing' as const },
-      azure: { provider: 'azure', status: 'missing' as const },
+      anthropic: { provider: 'anthropic', status: 'missing' as const, authType: 'api_key' as const },
+      openai: { provider: 'openai', status: 'valid' as const, authType: 'api_key' as const, maskedKey: '••••1234' },
+      google: { provider: 'google', status: 'missing' as const, authType: 'api_key' as const },
+      mistral: { provider: 'mistral', status: 'missing' as const, authType: 'api_key' as const },
+      bedrock: { provider: 'bedrock', status: 'missing' as const, authType: 'api_key' as const },
+      azure: { provider: 'azure', status: 'missing' as const, authType: 'api_key' as const },
+      'github-copilot': { provider: 'github-copilot', status: 'missing' as const, authType: 'oauth' as const },
     }
 
     const modelCheckpoint = normalizeFirstRunModelReadiness({
@@ -1078,12 +1079,13 @@ setTimeout(() => {
 
   test('treats aliased selected models as available when canonical provider model exists', () => {
     const providers: ProviderStatusMap = {
-      anthropic: { provider: 'anthropic', status: 'missing' as const },
-      openai: { provider: 'openai', status: 'valid' as const, maskedKey: '••••1234' },
-      google: { provider: 'google', status: 'missing' as const },
-      mistral: { provider: 'mistral', status: 'missing' as const },
-      bedrock: { provider: 'bedrock', status: 'missing' as const },
-      azure: { provider: 'azure', status: 'missing' as const },
+      anthropic: { provider: 'anthropic', status: 'missing' as const, authType: 'api_key' as const },
+      openai: { provider: 'openai', status: 'valid' as const, authType: 'api_key' as const, maskedKey: '••••1234' },
+      google: { provider: 'google', status: 'missing' as const, authType: 'api_key' as const },
+      mistral: { provider: 'mistral', status: 'missing' as const, authType: 'api_key' as const },
+      bedrock: { provider: 'bedrock', status: 'missing' as const, authType: 'api_key' as const },
+      azure: { provider: 'azure', status: 'missing' as const, authType: 'api_key' as const },
+      'github-copilot': { provider: 'github-copilot', status: 'missing' as const, authType: 'oauth' as const },
     }
 
     const checkpoint = normalizeFirstRunModelReadiness({
@@ -1099,12 +1101,13 @@ setTimeout(() => {
 
   test('fails model checkpoint when selected model provider is not configured', () => {
     const providers: ProviderStatusMap = {
-      anthropic: { provider: 'anthropic', status: 'missing' as const },
-      openai: { provider: 'openai', status: 'missing' as const },
-      google: { provider: 'google', status: 'valid' as const, maskedKey: '••••5678' },
-      mistral: { provider: 'mistral', status: 'missing' as const },
-      bedrock: { provider: 'bedrock', status: 'missing' as const },
-      azure: { provider: 'azure', status: 'missing' as const },
+      anthropic: { provider: 'anthropic', status: 'missing' as const, authType: 'api_key' as const },
+      openai: { provider: 'openai', status: 'missing' as const, authType: 'api_key' as const },
+      google: { provider: 'google', status: 'valid' as const, authType: 'api_key' as const, maskedKey: '••••5678' },
+      mistral: { provider: 'mistral', status: 'missing' as const, authType: 'api_key' as const },
+      bedrock: { provider: 'bedrock', status: 'missing' as const, authType: 'api_key' as const },
+      azure: { provider: 'azure', status: 'missing' as const, authType: 'api_key' as const },
+      'github-copilot': { provider: 'github-copilot', status: 'missing' as const, authType: 'oauth' as const },
     }
 
     const checkpoint = normalizeFirstRunModelReadiness({

--- a/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-health-aggregator.test.ts
@@ -74,12 +74,13 @@ function getSurface(snapshot: ReliabilitySnapshot, sourceSurface: string) {
 
 function createProviderStatuses(statusByProvider: Partial<Record<string, 'valid' | 'missing' | 'invalid' | 'expired'>> = {}) {
   return {
-    anthropic: { provider: 'anthropic' as const, status: statusByProvider.anthropic ?? 'missing' },
-    openai: { provider: 'openai' as const, status: statusByProvider.openai ?? 'missing' },
-    google: { provider: 'google' as const, status: statusByProvider.google ?? 'missing' },
-    mistral: { provider: 'mistral' as const, status: statusByProvider.mistral ?? 'missing' },
-    bedrock: { provider: 'bedrock' as const, status: statusByProvider.bedrock ?? 'missing' },
-    azure: { provider: 'azure' as const, status: statusByProvider.azure ?? 'missing' },
+    anthropic: { provider: 'anthropic' as const, status: statusByProvider.anthropic ?? 'missing', authType: 'api_key' as const },
+    openai: { provider: 'openai' as const, status: statusByProvider.openai ?? 'missing', authType: 'api_key' as const },
+    google: { provider: 'google' as const, status: statusByProvider.google ?? 'missing', authType: 'api_key' as const },
+    mistral: { provider: 'mistral' as const, status: statusByProvider.mistral ?? 'missing', authType: 'api_key' as const },
+    bedrock: { provider: 'bedrock' as const, status: statusByProvider.bedrock ?? 'missing', authType: 'api_key' as const },
+    azure: { provider: 'azure' as const, status: statusByProvider.azure ?? 'missing', authType: 'api_key' as const },
+    'github-copilot': { provider: 'github-copilot' as const, status: statusByProvider['github-copilot'] ?? 'missing', authType: 'oauth' as const },
   }
 }
 

--- a/apps/desktop/src/main/auth-bridge.ts
+++ b/apps/desktop/src/main/auth-bridge.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs'
-import { homedir } from 'node:os'
+import { homedir, platform } from 'node:os'
 import path from 'node:path'
 import log from './logger'
 import {
@@ -96,10 +96,16 @@ const UNSUPPORTED_PROVIDER_MESSAGES: Partial<Record<AuthProvider, string>> = {
  * never read or expose token contents.
  */
 const OAUTH_TOKEN_PATHS: Partial<Record<AuthProvider, string[]>> = {
-  'github-copilot': [
-    path.join('.config', 'github-copilot', 'hosts.json'),
-    path.join('.config', 'github-copilot', 'apps.json'),
-  ],
+  'github-copilot':
+    platform() === 'win32'
+      ? [
+          path.join('AppData', 'Local', 'GitHub Copilot', 'hosts.json'),
+          path.join('AppData', 'Local', 'GitHub Copilot', 'apps.json'),
+        ]
+      : [
+          path.join('.config', 'github-copilot', 'hosts.json'),
+          path.join('.config', 'github-copilot', 'apps.json'),
+        ],
 }
 
 export function normalizeFirstRunAuthReadiness(input: {

--- a/apps/desktop/src/main/auth-bridge.ts
+++ b/apps/desktop/src/main/auth-bridge.ts
@@ -5,6 +5,7 @@ import log from './logger'
 import {
   ALL_AUTH_PROVIDERS,
   AUTH_PROVIDER_ALIASES,
+  OAUTH_PROVIDERS,
   type AuthProvider,
   type AuthProvidersResponse,
   type AuthRecord,
@@ -89,6 +90,18 @@ const UNSUPPORTED_PROVIDER_MESSAGES: Partial<Record<AuthProvider, string>> = {
   azure: 'Azure validation requires both API key and Azure endpoint configuration',
 }
 
+/**
+ * Token file paths probed to detect OAuth provider sessions.
+ * Paths are resolved relative to $HOME. We only check for file existence,
+ * never read or expose token contents.
+ */
+const OAUTH_TOKEN_PATHS: Partial<Record<AuthProvider, string[]>> = {
+  'github-copilot': [
+    path.join('.config', 'github-copilot', 'hosts.json'),
+    path.join('.config', 'github-copilot', 'apps.json'),
+  ],
+}
+
 export function normalizeFirstRunAuthReadiness(input: {
   providers: ProviderStatusMap
   selectedProvider?: AuthProvider | null
@@ -149,7 +162,7 @@ export class AuthBridge {
   public async getProviders(): Promise<AuthProvidersResponse> {
     try {
       const auth = await this.readAuthFile()
-      const providers = this.toProviderStatusMap(auth)
+      const providers = await this.toProviderStatusMap(auth)
 
       log.info('[auth-bridge] auth:read', {
         path: this.authFilePath,
@@ -177,6 +190,13 @@ export class AuthBridge {
   }
 
   public async validateKey(provider: AuthProvider, key: string): Promise<AuthValidationResult> {
+    if (OAUTH_PROVIDERS.has(provider)) {
+      return {
+        valid: false,
+        error: `${provider} uses OAuth authentication and does not accept API keys.`,
+      }
+    }
+
     const trimmedKey = key.trim()
     if (!trimmedKey) {
       return {
@@ -261,6 +281,14 @@ export class AuthBridge {
   }
 
   public async setProviderKey(provider: AuthProvider, key: string): Promise<AuthSetKeyResponse> {
+    if (OAUTH_PROVIDERS.has(provider)) {
+      return {
+        success: false,
+        provider,
+        error: `${provider} uses OAuth authentication and cannot be configured with an API key. Set it up via the Kata CLI.`,
+      }
+    }
+
     const validation = await this.validateKey(provider, key)
     if (!validation.valid) {
       return {
@@ -311,6 +339,14 @@ export class AuthBridge {
   }
 
   public async removeProviderKey(provider: AuthProvider): Promise<AuthRemoveKeyResponse> {
+    if (OAUTH_PROVIDERS.has(provider)) {
+      return {
+        success: false,
+        provider,
+        error: `${provider} uses OAuth authentication and cannot be removed here. Manage it via the Kata CLI.`,
+      }
+    }
+
     try {
       const auth = await this.readAuthFile()
       delete auth[provider]
@@ -379,11 +415,17 @@ export class AuthBridge {
     await fs.rename(tempPath, this.authFilePath)
   }
 
-  private toProviderStatusMap(auth: AuthRecord): ProviderStatusMap {
-    const entries = ALL_AUTH_PROVIDERS.map((provider) => [
-      provider,
-      this.toProviderInfo(provider, this.resolveAuthRecord(auth, provider)),
-    ])
+  private async toProviderStatusMap(auth: AuthRecord): Promise<ProviderStatusMap> {
+    const entries: [AuthProvider, ProviderInfo][] = []
+
+    for (const provider of ALL_AUTH_PROVIDERS) {
+      if (OAUTH_PROVIDERS.has(provider)) {
+        const oauthStatus = await this.detectOAuthProvider(provider)
+        entries.push([provider, oauthStatus])
+      } else {
+        entries.push([provider, this.toProviderInfo(provider, this.resolveAuthRecord(auth, provider))])
+      }
+    }
 
     return Object.fromEntries(entries) as ProviderStatusMap
   }
@@ -413,7 +455,9 @@ export class AuthBridge {
   private emptyProviderStatusMap(): ProviderStatusMap {
     const entries = ALL_AUTH_PROVIDERS.map((provider) => [
       provider,
-      this.toProviderInfo(provider, undefined),
+      OAUTH_PROVIDERS.has(provider)
+        ? { provider, status: 'missing' as const, authType: 'oauth' as const }
+        : this.toProviderInfo(provider, undefined),
     ])
 
     return Object.fromEntries(entries) as ProviderStatusMap
@@ -424,6 +468,7 @@ export class AuthBridge {
       return {
         provider,
         status: 'missing',
+        authType: OAUTH_PROVIDERS.has(provider) ? 'oauth' : 'api_key',
       }
     }
 
@@ -451,7 +496,35 @@ export class AuthBridge {
     return {
       provider,
       status: 'invalid',
+      authType: OAUTH_PROVIDERS.has(provider) ? 'oauth' : 'api_key',
     }
+  }
+
+  /**
+   * Detect whether an OAuth-backed provider has an active session by probing
+   * for token files on disk. Never reads or exposes token contents.
+   */
+  private async detectOAuthProvider(provider: AuthProvider): Promise<ProviderInfo> {
+    const tokenPaths = OAUTH_TOKEN_PATHS[provider]
+    if (!tokenPaths || tokenPaths.length === 0) {
+      log.debug('[auth-bridge] oauth:detect no token paths configured', { provider })
+      return { provider, status: 'missing', authType: 'oauth' }
+    }
+
+    const home = homedir()
+    for (const relativePath of tokenPaths) {
+      const fullPath = path.join(home, relativePath)
+      try {
+        await fs.access(fullPath)
+        log.debug('[auth-bridge] oauth:detect token file found', { provider, authType: 'oauth', status: 'valid' })
+        return { provider, status: 'valid', authType: 'oauth' }
+      } catch {
+        // File not found — continue to next path
+      }
+    }
+
+    log.debug('[auth-bridge] oauth:detect no token files found', { provider, authType: 'oauth', status: 'missing' })
+    return { provider, status: 'missing', authType: 'oauth' }
   }
 
   private maskKey(value: string | undefined): string | undefined {

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -40,7 +40,7 @@ import type {
   ThresholdBreach,
   WorkflowBoardSnapshot,
 } from '../shared/types'
-import { ALL_AUTH_PROVIDERS } from '../shared/types'
+import { ALL_AUTH_PROVIDERS, OAUTH_PROVIDERS } from '../shared/types'
 import { buildFirstRunReadinessSnapshot } from '../shared/first-run-readiness'
 
 type RecoveryAttempt = {
@@ -459,11 +459,13 @@ function hasThresholdStateContradiction(
 
 function createMissingProviderStatusMap(): ProviderStatusMap {
   const entries = ALL_AUTH_PROVIDERS.map((provider) => {
+    const authType = OAUTH_PROVIDERS.has(provider) ? 'oauth' as const : 'api_key' as const
     return [
       provider,
       {
         provider,
         status: 'missing' as const,
+        authType,
       },
     ] as const
   })

--- a/apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/KeyInputStep.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { ArrowLeft, KeyRound } from 'lucide-react'
 import type { AuthProvider, FirstRunReadinessSnapshot } from '@shared/types'
+import { OAUTH_PROVIDERS } from '@shared/types'
 import { buildFirstRunGuidance, getFirstRunCheckpoint } from '@/lib/first-run-readiness'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -23,8 +24,48 @@ export function KeyInputStep({ provider, readiness, onBack, onSaved, onSkip }: K
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
 
   const metadata = PROVIDER_METADATA[provider]
+  const isOAuth = OAUTH_PROVIDERS.has(provider)
   const authGuidance = buildFirstRunGuidance(getFirstRunCheckpoint(readiness, 'auth'))
   const modelGuidance = buildFirstRunGuidance(getFirstRunCheckpoint(readiness, 'model'))
+
+  if (isOAuth) {
+    return (
+      <div className="flex h-full flex-col justify-between">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <h2 className="text-2xl font-semibold text-foreground">{metadata.name}</h2>
+            <p className="text-sm text-muted-foreground">
+              This provider authenticates through an OAuth session, not an API key.
+            </p>
+          </div>
+
+          <div
+            className="rounded-md border border-border bg-muted/50 px-4 py-3 text-sm text-muted-foreground"
+            data-testid="onboarding-oauth-guidance"
+          >
+            <p className="font-medium text-foreground">Set up via Kata CLI</p>
+            <p className="mt-1">
+              Run <code className="rounded bg-accent px-1">kata</code> in your terminal to authenticate with{' '}
+              {metadata.name}. Once connected, return here and the provider will show as configured.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-4">
+          <Separator />
+          <div className="flex items-center justify-between">
+            <Button type="button" variant="outline" onClick={onBack}>
+              <ArrowLeft data-icon="inline-start" />
+              Back
+            </Button>
+            <Button type="button" variant="ghost" onClick={onSkip} className="text-muted-foreground">
+              Skip for now
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   const validateAndSave = async (): Promise<void> => {
     const trimmed = keyValue.trim()

--- a/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSetAtom } from 'jotai'
 import {
   ALL_AUTH_PROVIDERS,
+  OAUTH_PROVIDERS,
   type AuthProvider,
   type ProviderStatusMap,
 } from '@shared/types'
@@ -46,13 +47,17 @@ export function getOnboardingAccessibilityBaseline(): OnboardingAccessibilityChe
 }
 
 function createMissingProviderMap(): ProviderStatusMap {
-  const entries = ALL_AUTH_PROVIDERS.map((provider) => [
-    provider,
-    {
+  const entries = ALL_AUTH_PROVIDERS.map((provider) => {
+    const authType = OAUTH_PROVIDERS.has(provider) ? 'oauth' as const : 'api_key' as const
+    return [
       provider,
-      status: 'missing' as const,
-    },
-  ])
+      {
+        provider,
+        status: 'missing' as const,
+        authType,
+      },
+    ]
+  })
 
   return Object.fromEntries(entries) as ProviderStatusMap
 }

--- a/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -165,7 +165,21 @@ export function OnboardingWizard() {
               onBack={() => setStep('welcome')}
               onSelect={setSelectedProvider}
               onContinue={() => {
-                if (selectedProvider) {
+                if (!selectedProvider) return
+                const info = providers[selectedProvider]
+                if (info?.status === 'valid') {
+                  // Provider already configured — skip key entry, auto-select model, go to completion
+                  void (async () => {
+                    try {
+                      const model = await selectModelForProvider(selectedProvider)
+                      setResolvedModel(model)
+                    } catch {
+                      // Model selection failed — still advance past key entry
+                      setResolvedModel(null)
+                    }
+                    setStep('complete')
+                  })()
+                } else {
                   setStep('key')
                 }
               }}

--- a/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -177,8 +177,9 @@ export function OnboardingWizard() {
                     try {
                       const model = await selectModelForProvider(selectedProvider)
                       setResolvedModel(model)
-                    } catch {
+                    } catch (err) {
                       // Model selection failed — still advance past key entry
+                      console.error('[OnboardingWizard] Model auto-selection failed:', err)
                       setResolvedModel(null)
                     } finally {
                       setSkipping(false)

--- a/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -73,6 +73,7 @@ export function OnboardingWizard() {
   const [providersLoading, setProvidersLoading] = useState(false)
   const [providersError, setProvidersError] = useState<string | null>(null)
   const [resolvedModel, setResolvedModel] = useState<string | null>(null)
+  const [skipping, setSkipping] = useState(false)
 
   const firstRunReadiness = reliabilitySnapshot.firstRunReadiness ?? null
 
@@ -160,7 +161,7 @@ export function OnboardingWizard() {
               providers={providers}
               selectedProvider={selectedProvider}
               loadError={providersError}
-              loading={providersLoading}
+              loading={providersLoading || skipping}
               readiness={firstRunReadiness}
               onBack={() => setStep('welcome')}
               onSelect={setSelectedProvider}
@@ -169,15 +170,19 @@ export function OnboardingWizard() {
                 const info = providers[selectedProvider]
                 if (info?.status === 'valid') {
                   // Provider already configured — skip key entry, auto-select model, go to completion
+                  if (skipping) return
                   void (async () => {
+                    setSkipping(true)
                     try {
                       const model = await selectModelForProvider(selectedProvider)
                       setResolvedModel(model)
                     } catch {
                       // Model selection failed — still advance past key entry
                       setResolvedModel(null)
+                    } finally {
+                      setSkipping(false)
+                      setStep('complete')
                     }
-                    setStep('complete')
                   })()
                 } else {
                   setStep('key')

--- a/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -74,6 +74,7 @@ export function OnboardingWizard() {
   const [providersError, setProvidersError] = useState<string | null>(null)
   const [resolvedModel, setResolvedModel] = useState<string | null>(null)
   const [skipping, setSkipping] = useState(false)
+  const [keyStepVisited, setKeyStepVisited] = useState(false)
 
   const firstRunReadiness = reliabilitySnapshot.firstRunReadiness ?? null
 
@@ -185,6 +186,7 @@ export function OnboardingWizard() {
                     }
                   })()
                 } else {
+                  setKeyStepVisited(true)
                   setStep('key')
                 }
               }}
@@ -195,7 +197,10 @@ export function OnboardingWizard() {
             <KeyInputStep
               provider={selectedProvider}
               readiness={firstRunReadiness}
-              onBack={() => setStep('provider')}
+              onBack={() => {
+                setKeyStepVisited(false)
+                setStep('provider')
+              }}
               onSaved={async (provider) => {
                 await loadProviders()
                 const model = await selectModelForProvider(provider)
@@ -210,7 +215,7 @@ export function OnboardingWizard() {
             <CompletionStep
               selectedModel={resolvedModel}
               readiness={firstRunReadiness}
-              onBack={() => setStep(selectedProvider ? 'key' : 'provider')}
+              onBack={() => setStep(keyStepVisited ? 'key' : 'provider')}
               onFinish={() => setOnboardingComplete(true)}
             />
           )}

--- a/apps/desktop/src/renderer/components/onboarding/ProviderStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/ProviderStep.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Check, ChevronRight, KeyRound } from 'lucide-react'
 import type { AuthProvider, FirstRunReadinessSnapshot, ProviderStatusMap } from '@shared/types'
+import { OAUTH_PROVIDERS } from '@shared/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -64,8 +65,19 @@ export function ProviderStep({
             const readinessInfo = readiness?.providers?.[provider]
             const configured = readinessInfo?.configured ?? info.status === 'valid'
             const needsRecovery = (readinessInfo?.status ?? info.status) === 'expired' || (readinessInfo?.status ?? info.status) === 'invalid'
+            const isOAuth = OAUTH_PROVIDERS.has(provider)
             const selected = selectedProvider === provider
-            const badgeLabel = configured ? 'Configured' : needsRecovery ? 'Fix key' : 'Add key'
+
+            let badgeLabel: string
+            if (configured) {
+              badgeLabel = 'Configured'
+            } else if (isOAuth) {
+              badgeLabel = 'Set up in CLI'
+            } else if (needsRecovery) {
+              badgeLabel = 'Fix key'
+            } else {
+              badgeLabel = 'Add key'
+            }
 
             return (
               <Card

--- a/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
@@ -6,6 +6,7 @@ import type {
   ProviderInfo,
   ProviderStatusMap,
 } from '@shared/types'
+import { OAUTH_PROVIDERS } from '@shared/types'
 import { useReliabilitySnapshot } from '@/atoms/reliability'
 import { Check, KeyRound, Trash2 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
@@ -31,6 +32,7 @@ const PROVIDER_ORDER: AuthProvider[] = [
   'mistral',
   'bedrock',
   'azure',
+  'github-copilot',
 ]
 
 function statusVariant(status: ProviderInfo['status']): 'secondary' | 'destructive' | 'outline' {
@@ -136,6 +138,8 @@ export function ProviderAuthPanel() {
     return row?.info ?? providers?.[activeProvider]
   }, [activeProvider, providerRows, providers])
 
+  const activeIsOAuth = OAUTH_PROVIDERS.has(activeProvider)
+
   const handleSave = async () => {
     const trimmed = apiKeyInput.trim()
     if (!trimmed) {
@@ -226,34 +230,49 @@ export function ProviderAuthPanel() {
               <p className="text-xs text-muted-foreground">No providers available</p>
             )}
 
-            {providerRows.map(({ provider, metadata, info }) => (
-              <Button
-                key={provider}
-                type="button"
-                variant="ghost"
-                onClick={() => {
-                  setActiveProvider(provider)
-                  setActionError(null)
-                  setActionSuccess(null)
-                  setApiKeyInput('')
-                }}
-                className={cn(
-                  'h-auto w-full justify-between rounded-md border border-border bg-background/30 px-2 py-2 text-left',
-                  activeProvider === provider
-                    ? 'border-ring bg-accent text-foreground'
-                    : 'text-muted-foreground hover:bg-accent/70 hover:text-foreground',
-                )}
-              >
-                <span className="flex flex-col gap-0.5">
-                  <span className="font-medium text-foreground">{metadata.name}</span>
-                  <span className="text-xs text-muted-foreground">{info.maskedKey ?? 'Not configured'}</span>
-                </span>
+            {providerRows.map(({ provider, metadata, info }) => {
+              const isOAuth = OAUTH_PROVIDERS.has(provider)
+              let statusLabel: string
+              if (isOAuth && info.status === 'valid') {
+                statusLabel = 'Authenticated'
+              } else if (isOAuth && info.status === 'missing') {
+                statusLabel = 'Not connected'
+              } else {
+                statusLabel = info.status
+              }
+              const subtitleLabel = isOAuth
+                ? (info.status === 'valid' ? 'OAuth session' : 'Set up in CLI')
+                : (info.maskedKey ?? 'Not configured')
 
-                <Badge variant={statusVariant(info.status)} className="capitalize">
-                  {info.status}
-                </Badge>
-              </Button>
-            ))}
+              return (
+                <Button
+                  key={provider}
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    setActiveProvider(provider)
+                    setActionError(null)
+                    setActionSuccess(null)
+                    setApiKeyInput('')
+                  }}
+                  className={cn(
+                    'h-auto w-full justify-between rounded-md border border-border bg-background/30 px-2 py-2 text-left',
+                    activeProvider === provider
+                      ? 'border-ring bg-accent text-foreground'
+                      : 'text-muted-foreground hover:bg-accent/70 hover:text-foreground',
+                  )}
+                >
+                  <span className="flex flex-col gap-0.5">
+                    <span className="font-medium text-foreground">{metadata.name}</span>
+                    <span className="text-xs text-muted-foreground">{subtitleLabel}</span>
+                  </span>
+
+                  <Badge variant={statusVariant(info.status)} className="capitalize">
+                    {statusLabel}
+                  </Badge>
+                </Button>
+              )
+            })}
           </CardContent>
         </Card>
 
@@ -267,67 +286,96 @@ export function ProviderAuthPanel() {
             <div className="flex items-center gap-2 text-xs">
               <span className="text-muted-foreground">Status:</span>
               <Badge variant={statusVariant(activeInfo?.status ?? 'missing')} className="capitalize">
-                {activeInfo?.status ?? 'missing'}
+                {activeIsOAuth
+                  ? (activeInfo?.status === 'valid' ? 'Authenticated' : 'Not connected')
+                  : (activeInfo?.status ?? 'missing')}
               </Badge>
+              {activeIsOAuth && (
+                <span className="text-xs text-muted-foreground">(OAuth)</span>
+              )}
             </div>
 
             <Separator />
 
-            {activeInfo?.maskedKey ? (
-              <div className="rounded-md border border-border bg-accent/60 px-3 py-2 text-xs text-muted-foreground">
-                <p>
-                  Saved key: <span className="font-mono text-foreground">{activeInfo.maskedKey}</span>
-                </p>
+            {activeIsOAuth ? (
+              <div
+                className="rounded-md border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground"
+                data-testid="settings-oauth-provider-info"
+              >
+                {activeInfo?.status === 'valid' ? (
+                  <p>
+                    <span className="font-medium text-foreground">Authenticated</span> — this provider
+                    is connected via an OAuth session managed by the Kata CLI.
+                  </p>
+                ) : (
+                  <>
+                    <p className="font-medium text-foreground">Not connected</p>
+                    <p className="mt-1">
+                      Run <code className="rounded bg-accent px-1">kata</code> in your terminal to
+                      authenticate with {PROVIDER_METADATA[activeProvider].name}.
+                    </p>
+                  </>
+                )}
               </div>
             ) : (
-              <div className="flex flex-col gap-2">
-                <Label
-                  htmlFor="provider-auth-input"
-                  className="text-xs uppercase tracking-wide text-muted-foreground"
-                >
-                  API key
-                </Label>
-                <Input
-                  id="provider-auth-input"
-                  type="password"
-                  value={apiKeyInput}
-                  onChange={(event) => setApiKeyInput(event.target.value)}
-                  placeholder={`Enter ${PROVIDER_METADATA[activeProvider].shortName} key`}
-                  className="h-9 text-xs"
-                />
-              </div>
+              <>
+                {activeInfo?.maskedKey ? (
+                  <div className="rounded-md border border-border bg-accent/60 px-3 py-2 text-xs text-muted-foreground">
+                    <p>
+                      Saved key: <span className="font-mono text-foreground">{activeInfo.maskedKey}</span>
+                    </p>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    <Label
+                      htmlFor="provider-auth-input"
+                      className="text-xs uppercase tracking-wide text-muted-foreground"
+                    >
+                      API key
+                    </Label>
+                    <Input
+                      id="provider-auth-input"
+                      type="password"
+                      value={apiKeyInput}
+                      onChange={(event) => setApiKeyInput(event.target.value)}
+                      placeholder={`Enter ${PROVIDER_METADATA[activeProvider].shortName} key`}
+                      className="h-9 text-xs"
+                    />
+                  </div>
+                )}
+
+                <div className="flex flex-wrap gap-2">
+                  {!activeInfo?.maskedKey && (
+                    <Button
+                      type="button"
+                      disabled={submitting}
+                      onClick={() => {
+                        void handleSave()
+                      }}
+                      size="sm"
+                    >
+                      <KeyRound data-icon="inline-start" />
+                      {submitting ? 'Validating…' : 'Validate & Save'}
+                    </Button>
+                  )}
+
+                  {activeInfo?.maskedKey && (
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      disabled={submitting}
+                      onClick={() => {
+                        void handleRemove()
+                      }}
+                      size="sm"
+                    >
+                      <Trash2 data-icon="inline-start" />
+                      {submitting ? 'Removing…' : 'Remove key'}
+                    </Button>
+                  )}
+                </div>
+              </>
             )}
-
-            <div className="flex flex-wrap gap-2">
-              {!activeInfo?.maskedKey && (
-                <Button
-                  type="button"
-                  disabled={submitting}
-                  onClick={() => {
-                    void handleSave()
-                  }}
-                  size="sm"
-                >
-                  <KeyRound data-icon="inline-start" />
-                  {submitting ? 'Validating…' : 'Validate & Save'}
-                </Button>
-              )}
-
-              {activeInfo?.maskedKey && (
-                <Button
-                  type="button"
-                  variant="destructive"
-                  disabled={submitting}
-                  onClick={() => {
-                    void handleRemove()
-                  }}
-                  size="sm"
-                >
-                  <Trash2 data-icon="inline-start" />
-                  {submitting ? 'Removing…' : 'Remove key'}
-                </Button>
-              )}
-            </div>
 
             {actionError && <p className="text-xs text-destructive">{actionError}</p>}
             {actionSuccess && (

--- a/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx
@@ -235,13 +235,17 @@ export function ProviderAuthPanel() {
               let statusLabel: string
               if (isOAuth && info.status === 'valid') {
                 statusLabel = 'Authenticated'
-              } else if (isOAuth && info.status === 'missing') {
+              } else if (isOAuth && (info.status === 'missing' || info.status === 'expired')) {
                 statusLabel = 'Not connected'
               } else {
                 statusLabel = info.status
               }
               const subtitleLabel = isOAuth
-                ? (info.status === 'valid' ? 'OAuth session' : 'Set up in CLI')
+                ? (info.status === 'valid'
+                    ? 'OAuth session'
+                    : info.status === 'expired'
+                      ? 'OAuth session expired'
+                      : 'Set up in CLI')
                 : (info.maskedKey ?? 'Not configured')
 
               return (

--- a/apps/desktop/src/renderer/components/settings/__tests__/ProviderAuthPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ProviderAuthPanel.test.tsx
@@ -23,6 +23,7 @@ function createReadiness(
       mistral: { provider: 'mistral', status: 'missing', configured: false, requiresKey: true },
       bedrock: { provider: 'bedrock', status: 'missing', configured: false, requiresKey: true },
       azure: { provider: 'azure', status: 'missing', configured: false, requiresKey: true },
+      'github-copilot': { provider: 'github-copilot', status: 'missing', configured: false, requiresKey: false },
     },
     checkpoints: {
       auth: { checkpoint: 'auth', status: 'pass' },

--- a/apps/desktop/src/renderer/components/settings/__tests__/ProviderAuthPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ProviderAuthPanel.test.tsx
@@ -3,7 +3,8 @@ import {
   buildProviderAuthReadinessNotice,
   buildProviderAuthRecoveryAction,
 } from '../ProviderAuthPanel'
-import type { FirstRunReadinessSnapshot } from '@shared/types'
+import type { FirstRunReadinessSnapshot, ProviderInfo } from '@shared/types'
+import { OAUTH_PROVIDERS } from '@shared/types'
 
 function createReadiness(
   overrides: Partial<FirstRunReadinessSnapshot['checkpoints']> = {},
@@ -95,5 +96,65 @@ describe('ProviderAuthPanel first-run readiness helpers', () => {
     const readiness = createReadiness()
     expect(buildProviderAuthReadinessNotice(readiness)).toBeNull()
     expect(buildProviderAuthRecoveryAction(null)).toBeNull()
+  })
+})
+
+describe('OAuth provider rendering logic', () => {
+  test('OAUTH_PROVIDERS contains github-copilot', () => {
+    expect(OAUTH_PROVIDERS.has('github-copilot')).toBe(true)
+  })
+
+  test('OAuth provider with valid status should not show API key input', () => {
+    const oauthValidProvider: ProviderInfo = {
+      provider: 'github-copilot',
+      status: 'valid',
+      authType: 'oauth',
+    }
+
+    // OAuth provider should be rendered as authenticated row — no maskedKey, no API-key input
+    expect(OAUTH_PROVIDERS.has(oauthValidProvider.provider)).toBe(true)
+    expect(oauthValidProvider.authType).toBe('oauth')
+    expect(oauthValidProvider.status).toBe('valid')
+    expect(oauthValidProvider.maskedKey).toBeUndefined()
+  })
+
+  test('OAuth provider with missing status should show CLI guidance', () => {
+    const oauthMissingProvider: ProviderInfo = {
+      provider: 'github-copilot',
+      status: 'missing',
+      authType: 'oauth',
+    }
+
+    expect(OAUTH_PROVIDERS.has(oauthMissingProvider.provider)).toBe(true)
+    expect(oauthMissingProvider.status).toBe('missing')
+    expect(oauthMissingProvider.authType).toBe('oauth')
+  })
+
+  test('API-key provider is not in OAUTH_PROVIDERS', () => {
+    expect(OAUTH_PROVIDERS.has('anthropic')).toBe(false)
+    expect(OAUTH_PROVIDERS.has('openai')).toBe(false)
+  })
+
+  test('mixed provider list has correct auth types', () => {
+    const providers: Record<string, ProviderInfo> = {
+      anthropic: { provider: 'anthropic', status: 'valid', authType: 'api_key', maskedKey: '••••1234' },
+      openai: { provider: 'openai', status: 'missing', authType: 'api_key' },
+      'github-copilot': { provider: 'github-copilot', status: 'valid', authType: 'oauth' },
+    }
+
+    // API-key providers should have api_key authType
+    expect(providers.anthropic!.authType).toBe('api_key')
+    expect(providers.openai!.authType).toBe('api_key')
+    // OAuth providers should have oauth authType
+    expect(providers['github-copilot']!.authType).toBe('oauth')
+
+    // Only github-copilot is OAuth
+    for (const [key, info] of Object.entries(providers)) {
+      if (OAUTH_PROVIDERS.has(key as 'github-copilot')) {
+        expect(info.authType).toBe('oauth')
+      } else {
+        expect(info.authType).toBe('api_key')
+      }
+    }
   })
 })

--- a/apps/desktop/src/renderer/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SettingsPanel.test.tsx
@@ -31,6 +31,7 @@ describe('SettingsPanel workflow return affordance', () => {
           mistral: { provider: 'mistral', status: 'missing', configured: false, requiresKey: true },
           bedrock: { provider: 'bedrock', status: 'missing', configured: false, requiresKey: true },
           azure: { provider: 'azure', status: 'missing', configured: false, requiresKey: true },
+          'github-copilot': { provider: 'github-copilot', status: 'missing', configured: false, requiresKey: false },
         },
         checkpoints: {
           auth: { checkpoint: 'auth', status: 'pass' },

--- a/apps/desktop/src/renderer/constants/providers.test.ts
+++ b/apps/desktop/src/renderer/constants/providers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest'
 import { ONBOARDING_PROVIDER_IDS, PROVIDER_METADATA } from './providers'
 
 describe('PROVIDER_METADATA', () => {
-  test('contains expected metadata for all six providers', () => {
+  test('contains expected metadata for all providers', () => {
     expect(PROVIDER_METADATA).toEqual({
       anthropic: {
         id: 'anthropic',
@@ -39,6 +39,12 @@ describe('PROVIDER_METADATA', () => {
         name: 'Azure OpenAI',
         shortName: 'Azure',
         description: 'Provider currently requires endpoint + key',
+      },
+      'github-copilot': {
+        id: 'github-copilot',
+        name: 'GitHub Copilot',
+        shortName: 'Copilot',
+        description: 'Authenticated via GitHub Copilot CLI session',
       },
     })
   })

--- a/apps/desktop/src/renderer/constants/providers.ts
+++ b/apps/desktop/src/renderer/constants/providers.ts
@@ -44,6 +44,12 @@ export const PROVIDER_METADATA: Record<AuthProvider, ProviderMetadata> = {
     shortName: 'Azure',
     description: 'Provider currently requires endpoint + key',
   },
+  'github-copilot': {
+    id: 'github-copilot',
+    name: 'GitHub Copilot',
+    shortName: 'Copilot',
+    description: 'Authenticated via GitHub Copilot CLI session',
+  },
 }
 
 export const ONBOARDING_PROVIDER_IDS: AuthProvider[] = [

--- a/apps/desktop/src/shared/__tests__/first-run-readiness.test.ts
+++ b/apps/desktop/src/shared/__tests__/first-run-readiness.test.ts
@@ -136,4 +136,20 @@ describe('buildFirstRunReadinessSnapshot', () => {
     expect(snapshot.checkpoints.auth.status).toBe('fail')
     expect(snapshot.checkpoints.auth.failure?.code).toBe('AUTH_PROVIDER_KEY_REQUIRED')
   })
+
+  test('selected missing OAuth provider fails auth with OAuth-specific code', () => {
+    const providers = createProviders()
+    // github-copilot is missing (default), but it is selected
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers,
+      selectedProvider: 'github-copilot',
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(snapshot.checkpoints.auth.status).toBe('fail')
+    expect(snapshot.checkpoints.auth.failure?.code).toBe('AUTH_OAUTH_PROVIDER_NOT_CONNECTED')
+    // requiresKey must remain false — OAuth providers never ask for a key
+    expect(snapshot.providers['github-copilot'].requiresKey).toBe(false)
+  })
 })

--- a/apps/desktop/src/shared/__tests__/first-run-readiness.test.ts
+++ b/apps/desktop/src/shared/__tests__/first-run-readiness.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'vitest'
+import { buildFirstRunReadinessSnapshot } from '../first-run-readiness'
+import type { ProviderStatusMap } from '../types'
+
+function createProviders(overrides: Partial<ProviderStatusMap> = {}): ProviderStatusMap {
+  return {
+    anthropic: { provider: 'anthropic', status: 'missing', authType: 'api_key' },
+    openai: { provider: 'openai', status: 'missing', authType: 'api_key' },
+    google: { provider: 'google', status: 'missing', authType: 'api_key' },
+    mistral: { provider: 'mistral', status: 'missing', authType: 'api_key' },
+    bedrock: { provider: 'bedrock', status: 'missing', authType: 'api_key' },
+    azure: { provider: 'azure', status: 'missing', authType: 'api_key' },
+    'github-copilot': { provider: 'github-copilot', status: 'missing', authType: 'oauth' },
+    ...overrides,
+  }
+}
+
+describe('buildFirstRunReadinessSnapshot', () => {
+  test('configured API-key provider passes auth checkpoint', () => {
+    const providers = createProviders({
+      openai: { provider: 'openai', status: 'valid', authType: 'api_key', maskedKey: '••••1234' },
+    })
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers,
+      selectedProvider: 'openai',
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(snapshot.checkpoints.auth.status).toBe('pass')
+    expect(snapshot.providers.openai.configured).toBe(true)
+    expect(snapshot.providers.openai.requiresKey).toBe(false)
+  })
+
+  test('configured OAuth provider passes auth checkpoint', () => {
+    const providers = createProviders({
+      'github-copilot': { provider: 'github-copilot', status: 'valid', authType: 'oauth' },
+    })
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers,
+      selectedProvider: 'github-copilot',
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(snapshot.checkpoints.auth.status).toBe('pass')
+    expect(snapshot.providers['github-copilot'].configured).toBe(true)
+    expect(snapshot.providers['github-copilot'].requiresKey).toBe(false)
+  })
+
+  test('missing OAuth provider does not require key', () => {
+    const providers = createProviders()
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers,
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(snapshot.providers['github-copilot'].status).toBe('missing')
+    expect(snapshot.providers['github-copilot'].configured).toBe(false)
+    expect(snapshot.providers['github-copilot'].requiresKey).toBe(false)
+  })
+
+  test('unconfigured API-key provider requires key', () => {
+    const providers = createProviders({
+      openai: { provider: 'openai', status: 'valid', authType: 'api_key', maskedKey: '••••1234' },
+    })
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers,
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(snapshot.providers.anthropic.requiresKey).toBe(true)
+    expect(snapshot.providers.google.requiresKey).toBe(true)
+    expect(snapshot.providers['github-copilot'].requiresKey).toBe(false)
+  })
+
+  test('skip-key-entry transition: configured provider makes auth pass', () => {
+    const providers = createProviders({
+      anthropic: { provider: 'anthropic', status: 'valid', authType: 'api_key', maskedKey: '••••5678' },
+    })
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers,
+      selectedProvider: 'anthropic',
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    // Auth passes — onboarding should skip key entry
+    expect(snapshot.checkpoints.auth.status).toBe('pass')
+    expect(snapshot.providers.anthropic.configured).toBe(true)
+  })
+
+  test('mixed providers: API-key configured + OAuth missing = auth passes', () => {
+    const providers = createProviders({
+      openai: { provider: 'openai', status: 'valid', authType: 'api_key', maskedKey: '••••1234' },
+      // github-copilot remains missing (default)
+    })
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers,
+      selectedProvider: 'openai',
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(snapshot.checkpoints.auth.status).toBe('pass')
+    expect(snapshot.providers.openai.configured).toBe(true)
+    expect(snapshot.providers['github-copilot'].configured).toBe(false)
+    expect(snapshot.providers['github-copilot'].requiresKey).toBe(false)
+  })
+
+  test('no configured providers fails auth checkpoint', () => {
+    const providers = createProviders()
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers,
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(snapshot.checkpoints.auth.status).toBe('fail')
+    expect(snapshot.checkpoints.auth.failure?.code).toBe('AUTH_PROVIDER_NOT_CONFIGURED')
+  })
+
+  test('selected provider requiring key fails auth checkpoint', () => {
+    const providers = createProviders({
+      anthropic: { provider: 'anthropic', status: 'valid', authType: 'api_key', maskedKey: '••••5678' },
+    })
+
+    const snapshot = buildFirstRunReadinessSnapshot({
+      providers,
+      selectedProvider: 'openai',
+      now: '2026-04-08T00:00:00.000Z',
+    })
+
+    expect(snapshot.checkpoints.auth.status).toBe('fail')
+    expect(snapshot.checkpoints.auth.failure?.code).toBe('AUTH_PROVIDER_KEY_REQUIRED')
+  })
+})

--- a/apps/desktop/src/shared/first-run-readiness.ts
+++ b/apps/desktop/src/shared/first-run-readiness.ts
@@ -171,6 +171,23 @@ function evaluateAuthCheckpoint(
         }),
       }
     }
+
+    // OAuth provider selected but not connected — show CLI-setup guidance instead of key entry
+    const isSelectedOAuth = OAUTH_PROVIDERS.has(selectedProvider)
+    if (isSelectedOAuth && !selected.configured) {
+      return {
+        checkpoint: 'auth',
+        status: 'fail',
+        failure: toFailure({
+          class: 'auth',
+          severity: 'error',
+          code: 'AUTH_OAUTH_PROVIDER_NOT_CONNECTED',
+          message: `Connect ${selectedProvider} via the Kata CLI to continue onboarding.`,
+          recoveryAction: 'reauthenticate',
+          now,
+        }),
+      }
+    }
   }
 
   if (configuredProviders.length === 0) {
@@ -181,7 +198,8 @@ function evaluateAuthCheckpoint(
         class: 'auth',
         severity: 'error',
         code: 'AUTH_PROVIDER_NOT_CONFIGURED',
-        message: 'No providers are configured. Add an API key to unlock first-run setup.',
+        message:
+          'No providers are configured. Add an API key or connect an OAuth provider via the Kata CLI to unlock first-run setup.',
         recoveryAction: 'reauthenticate',
         now,
       }),

--- a/apps/desktop/src/shared/first-run-readiness.ts
+++ b/apps/desktop/src/shared/first-run-readiness.ts
@@ -1,6 +1,7 @@
 import {
   ALL_AUTH_PROVIDERS,
   AUTH_PROVIDER_ALIASES,
+  OAUTH_PROVIDERS,
   type AuthProvider,
   type AvailableModel,
   type BridgeLifecycleState,
@@ -113,8 +114,12 @@ function toFailure(
 function buildProviderStateMap(providers: ProviderStatusMap): FirstRunProviderStateMap {
   const entries = ALL_AUTH_PROVIDERS.map((provider) => {
     const info = providers[provider]
+    const isOAuth = OAUTH_PROVIDERS.has(provider) || info.authType === 'oauth'
     const configured = info.status === 'valid'
-    const requiresKey = info.status === 'missing' || info.status === 'invalid' || info.status === 'expired'
+    // OAuth providers never "require a key" — they are set up externally via CLI
+    const requiresKey = isOAuth
+      ? false
+      : info.status === 'missing' || info.status === 'invalid' || info.status === 'expired'
 
     if (configured && requiresKey) {
       throw new FirstRunInvariantError(

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -73,6 +73,7 @@ export const ALL_AUTH_PROVIDERS = [
   'mistral',
   'bedrock',
   'azure',
+  'github-copilot',
 ] as const
 
 export type AuthProvider = (typeof ALL_AUTH_PROVIDERS)[number]
@@ -85,6 +86,14 @@ export const AUTH_PROVIDER_ALIASES: Partial<Record<AuthProvider, string[]>> = {
   openai: ['openai-codex'],
 }
 
+/**
+ * Providers that authenticate via OAuth sessions rather than API keys.
+ * These are detected by probing for token files on disk, not by reading auth.json.
+ */
+export const OAUTH_PROVIDERS: ReadonlySet<AuthProvider> = new Set<AuthProvider>([
+  'github-copilot',
+])
+
 export type ProviderStatus = 'valid' | 'missing' | 'expired' | 'invalid'
 
 export type ProviderAuthType = 'api_key' | 'oauth'
@@ -92,7 +101,7 @@ export type ProviderAuthType = 'api_key' | 'oauth'
 export interface ProviderInfo {
   provider: AuthProvider
   status: ProviderStatus
-  authType?: ProviderAuthType
+  authType: ProviderAuthType
   maskedKey?: string
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -3880,7 +3880,7 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
-    "@kata-sh/cli/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+    "@kata-sh/cli/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@kata-sh/cli/typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
@@ -4648,7 +4648,7 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "@kata-sh/cli/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "@kata-sh/cli/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@kata/context/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 


### PR DESCRIPTION
## Summary

Makes provider readiness truthful across onboarding and settings so a provider shown as configured actually advances through the flow, and authenticated OAuth-backed providers like GitHub Copilot are visible in settings without pretending to be API-key rows.

Closes KAT-2463

## Changes

### T01: Extend provider types and auth bridge for OAuth providers (KAT-2465)
- Add `github-copilot` to `ALL_AUTH_PROVIDERS` with OAuth detection semantics
- Add `OAUTH_PROVIDERS` set to distinguish OAuth from API-key providers
- Make `ProviderInfo.authType` required (always populated as `api_key` or `oauth`)
- Add `AuthBridge.detectOAuthProvider()` — probes for GitHub Copilot token files without exposing contents
- Reject `setProviderKey`/`removeProviderKey`/`validateKey` for OAuth providers with clear error messages

### T02: Fix onboarding to skip key entry for configured providers (KAT-2466)
- `OnboardingWizard` skips `KeyInputStep` when selected provider has `status: 'valid'`
- Auto-selects model for configured provider and advances directly to completion step
- `ProviderStep` shows "Set up in CLI" badge for OAuth providers instead of "Add key"
- `KeyInputStep` renders CLI guidance card for OAuth providers instead of API-key input
- `first-run-readiness.ts`: OAuth providers never `requiresKey`

### T03: Surface OAuth providers in settings and add Electron proof (KAT-2464)
- `ProviderAuthPanel` renders OAuth providers as distinct rows with "Authenticated" / "Not connected" badges
- OAuth detail panel shows CLI guidance for missing providers
- Extended onboarding e2e test for skip-key-entry

## Testing

- 42 unit/component tests across 3 suites (auth-bridge, first-run-readiness, ProviderAuthPanel)
- 452 total tests pass in Desktop vitest suite (0 new failures)
- Typecheck clean
- E2e test added: configured provider skip-key-entry assertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub Copilot as a supported authentication provider with OAuth-based authentication
  * Streamlined onboarding for pre-configured providers by bypassing key entry steps
  * Updated provider settings panel to distinguish OAuth providers from API-key providers with appropriate UI and guidance

* **Tests**
  * Added end-to-end testing for OAuth provider onboarding flows
  * Expanded test coverage for mixed provider scenarios across authentication and readiness checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces OAuth provider support for GitHub Copilot across the desktop app: `authType` is now a required field on `ProviderInfo`, a new `OAUTH_PROVIDERS` set drives branching logic throughout the stack, token-file probing detects Copilot sessions without reading credentials, and both onboarding and settings render OAuth providers distinctly (skipping key-entry, showing CLI guidance).

- **Windows token path gap**: `OAUTH_TOKEN_PATHS` only lists Linux/macOS paths (`~/.config/github-copilot/…`). On Windows, the Copilot token lives at `%LOCALAPPDATA%\\GitHub Copilot\\hosts.json`, so Windows users will always see \"Not connected\" even when authenticated.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the Windows token path issue; all other findings are P2 style/UX improvements.

One P1 finding: OAUTH_TOKEN_PATHS only covers Linux/macOS paths for GitHub Copilot. Windows users (a supported CI target) will always see 'Not connected' even when authenticated, making the new 'Authenticated' badge functionally broken on that platform. The two P2 findings are minor UX rough edges that don't break correctness. Test coverage and type safety work is thorough.

apps/desktop/src/main/auth-bridge.ts — OAUTH_TOKEN_PATHS needs Windows-specific paths added.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/auth-bridge.ts | Core auth bridge extended with OAuth detection via token-file probing; Windows path gap means GitHub Copilot always resolves as missing on that platform. |
| apps/desktop/src/shared/types.ts | Adds `github-copilot` to `ALL_AUTH_PROVIDERS`, `OAUTH_PROVIDERS` set, and makes `authType` required on `ProviderInfo` — clean type-safe extension. |
| apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx | Skip-key-entry logic added for configured providers; async model selection has no loading guard and back-navigation from completion returns to key step instead of provider step. |
| apps/desktop/src/renderer/components/settings/ProviderAuthPanel.tsx | OAuth providers now render with distinct "Authenticated"/"Not connected" badges and CLI guidance panel instead of API-key input — well-structured branching. |
| apps/desktop/src/shared/first-run-readiness.ts | OAuth providers correctly set `requiresKey: false`, preventing auth checkpoint failures for Copilot-style providers that have no API key. |
| apps/desktop/e2e/tests/onboarding.e2e.ts | New e2e test verifies configured provider skips key entry and lands on step 4 — good coverage of the primary new flow. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getProviders called] --> B{Provider in OAUTH_PROVIDERS?}
    B -- Yes --> C[detectOAuthProvider]
    B -- No --> D[resolveAuthRecord from auth.json]

    C --> E{Token file exists?}
    E -- Yes --> F[status: valid, authType: oauth]
    E -- No --> G[status: missing, authType: oauth]

    D --> H{Record found?}
    H -- No --> I[status: missing, authType: api_key]
    H -- Yes, api_key --> J[status: valid/missing, authType: api_key]
    H -- Yes, oauth --> K[status: valid/expired, authType: oauth]

    F & G & I & J & K --> M[ProviderStatusMap]

    M --> N[Onboarding: provider selected]
    N --> O{info.status === valid?}
    O -- Yes --> P[Skip key entry, go to complete]
    O -- No --> Q[Go to KeyInputStep]

    Q --> R{isOAuth?}
    R -- Yes --> S[Show CLI guidance card]
    R -- No --> T[Show API key input]

    M --> U[Settings: ProviderAuthPanel]
    U --> V{isOAuth?}
    V -- Yes --> W[Authenticated / Not connected badge]
    V -- No --> X[API key input or saved key row]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx`, line 208 ([link](https://github.com/gannonh/kata/blob/6ade13e47aaf979948daa68c97de83155bffe886/apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx#L208)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Back from completion goes to key step when key entry was skipped**

   `onBack` unconditionally returns to `'key'` whenever `selectedProvider` is set. When a configured provider skips key entry entirely, clicking Back from the completion step drops the user into the key-entry form they never visited rather than back to provider selection. Consider tracking whether key entry was skipped:

   ```tsx
   onBack={() => setStep(keyEntrySkipped || !selectedProvider ? 'provider' : 'key')}
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
   Line: 208

   Comment:
   **Back from completion goes to key step when key entry was skipped**

   `onBack` unconditionally returns to `'key'` whenever `selectedProvider` is set. When a configured provider skips key entry entirely, clicking Back from the completion step drops the user into the key-entry form they never visited rather than back to provider selection. Consider tracking whether key entry was skipped:

   ```tsx
   onBack={() => setStep(keyEntrySkipped || !selectedProvider ? 'provider' : 'key')}
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/auth-bridge.ts
Line: 98-103

Comment:
**GitHub Copilot token path missing Windows location**

`OAUTH_TOKEN_PATHS` only covers the Linux/macOS path (`~/.config/github-copilot/…`). On Windows, GitHub Copilot stores its token at `%LOCALAPPDATA%\GitHub Copilot\hosts.json` (i.e., `os.homedir() + \AppData\Local\GitHub Copilot\hosts.json`). Since `detectOAuthProvider` iterates only these paths, Windows users will always resolve to `status: 'missing'` and see "Not connected" even when they're fully authenticated. The CI builds a Windows target, so this will affect real users.

```ts
import { platform } from 'node:os'

const OAUTH_TOKEN_PATHS: Partial<Record<AuthProvider, string[]>> = {
  'github-copilot': platform() === 'win32'
    ? [
        path.join('AppData', 'Local', 'GitHub Copilot', 'hosts.json'),
        path.join('AppData', 'Local', 'GitHub Copilot', 'apps.json'),
      ]
    : [
        path.join('.config', 'github-copilot', 'hosts.json'),
        path.join('.config', 'github-copilot', 'apps.json'),
      ],
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
Line: 172-181

Comment:
**No loading guard during async model-selection skip**

The IIFE that calls `selectModelForProvider` before advancing to `complete` is fire-and-forget (`void`). If `selectModelForProvider` takes a few hundred milliseconds, the Continue button stays enabled and the step doesn't show a loading state during that window — a second click would launch a second concurrent IIFE, both eventually calling `setStep('complete')`. Consider disabling the button or tracking a local `skipping` state while the async work runs:

```tsx
void (async () => {
  setSkipping(true)
  try {
    const model = await selectModelForProvider(selectedProvider)
    setResolvedModel(model)
  } catch {
    setResolvedModel(null)
  } finally {
    setSkipping(false)
    setStep('complete')
  }
})()
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx
Line: 208

Comment:
**Back from completion goes to key step when key entry was skipped**

`onBack` unconditionally returns to `'key'` whenever `selectedProvider` is set. When a configured provider skips key entry entirely, clicking Back from the completion step drops the user into the key-entry form they never visited rather than back to provider selection. Consider tracking whether key entry was skipped:

```tsx
onBack={() => setStep(keyEntrySkipped || !selectedProvider ? 'provider' : 'key')}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): surface OAuth providers i..."](https://github.com/gannonh/kata/commit/6ade13e47aaf979948daa68c97de83155bffe886) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28026821)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->