### PR TITLE
[S03] Context-Safe MCP Recovery Affordances

### DIFF
--- a/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { IPC_CHANNELS } from '@shared/types'
+import { IPC_CHANNELS, type McpConfigReadResponse } from '@shared/types'
 
 const handlers = new Map<string, (...args: any[]) => any>()
 
@@ -213,6 +213,140 @@ describe('mcp ipc handlers', () => {
     expect(mcpService.reconnectServer).toHaveBeenCalledWith('server-a')
     expect(refreshResult.success).toBe(true)
     expect(reconnectResult.success).toBe(false)
+
+    unregister()
+  })
+
+  test('malformed config error flows through recovery handler with gated action (fix_config succeeds)', async () => {
+    // Simulate: config is malformed on first read → listServers returns error
+    // Then recovery action fix_config re-reads → succeeds the second time
+    let callCount = 0
+    const mcpConfigBridge = {
+      listServers: vi.fn(async (): Promise<McpConfigReadResponse> => {
+        callCount++
+        if (callCount === 1) {
+          // First call: malformed config
+          return {
+            success: false,
+            provenance: {
+              mode: 'global_only',
+              globalConfigPath: '/tmp/mcp.json',
+            },
+            servers: [],
+            error: {
+              code: 'MALFORMED_CONFIG',
+              message: 'Invalid JSON in mcp.json',
+            },
+          }
+        }
+        // Second call (recovery): config is fixed
+        return {
+          success: true,
+          provenance: {
+            mode: 'global_only',
+            globalConfigPath: '/tmp/mcp.json',
+          },
+          servers: [],
+        }
+      }),
+      getServer: vi.fn(),
+      saveServer: vi.fn(),
+      deleteServer: vi.fn(),
+    } as any
+
+    const mcpService = {
+      refreshStatus: vi.fn(),
+      reconnectServer: vi.fn(),
+      getStabilityMetrics: vi.fn(() => ({
+        a11yViolationCounts: { minor: 0, moderate: 0, serious: 0, critical: 0 },
+      })),
+    } as any
+
+    const unregister = registerSessionIpc({
+      bridge: createBridgeStub(),
+      authBridge: {
+        getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+        setProviderKey: vi.fn(),
+        removeProviderKey: vi.fn(),
+        validateKey: vi.fn(),
+      } as any,
+      sessionManager: {
+        listSessions: vi.fn(async () => ({ sessions: [], warnings: [], directory: process.cwd() })),
+        getSessionInfo: vi.fn(),
+        resolveSessionPathById: vi.fn(async () => null),
+      } as any,
+      window: createWindowStub(),
+      mcpConfigBridge,
+      mcpService,
+    })
+
+    // First: trigger the error by listing servers (populates aggregator with config error signal)
+    await handlers.get(IPC_CHANNELS.mcpListServers)?.({})
+
+    // The gated action for a config error should be fix_config, which the handler supports
+    const recoveryResult = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'mcp',
+      action: 'fix_config',
+    })
+
+    // fix_config is a supported action → should succeed (no MCP_RECOVERY_ACTION_UNSUPPORTED)
+    expect(recoveryResult.success).toBe(true)
+    expect(recoveryResult.code).toBe('MCP_CONFIG_REFRESHED')
+    expect(recoveryResult.code).not.toBe('MCP_RECOVERY_ACTION_UNSUPPORTED')
+
+    unregister()
+  })
+
+  test('defense-in-depth: reconnect without server context returns graceful failure, not crash', async () => {
+    const mcpConfigBridge = {
+      listServers: vi.fn(async () => ({
+        success: true,
+        provenance: { mode: 'global_only', globalConfigPath: '/tmp/mcp.json' },
+        servers: [],
+      })),
+      getServer: vi.fn(),
+      saveServer: vi.fn(),
+      deleteServer: vi.fn(),
+    } as any
+
+    const mcpService = {
+      refreshStatus: vi.fn(),
+      reconnectServer: vi.fn(),
+      getStabilityMetrics: vi.fn(() => ({
+        a11yViolationCounts: { minor: 0, moderate: 0, serious: 0, critical: 0 },
+      })),
+    } as any
+
+    const unregister = registerSessionIpc({
+      bridge: createBridgeStub(),
+      authBridge: {
+        getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+        setProviderKey: vi.fn(),
+        removeProviderKey: vi.fn(),
+        validateKey: vi.fn(),
+      } as any,
+      sessionManager: {
+        listSessions: vi.fn(async () => ({ sessions: [], warnings: [], directory: process.cwd() })),
+        getSessionInfo: vi.fn(),
+        resolveSessionPathById: vi.fn(async () => null),
+      } as any,
+      window: createWindowStub(),
+      mcpConfigBridge,
+      mcpService,
+    })
+
+    // Bypass gating: directly send 'reconnect' action without server context
+    // The handler should return a graceful failure (existing MCP_RECOVERY_ACTION_UNSUPPORTED guard)
+    const result = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'mcp',
+      action: 'reconnect',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.outcome).toBe('failed')
+    expect(result.code).toBe('MCP_RECOVERY_ACTION_UNSUPPORTED')
+    // Verify it didn't throw/crash — the result is a structured failure
+    expect(result.message).toBeTruthy()
 
     unregister()
   })

--- a/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-ipc.test.ts
@@ -297,6 +297,68 @@ describe('mcp ipc handlers', () => {
     unregister()
   })
 
+  test('server-scoped reconnect with serverName routes through mcpService.reconnectServer', async () => {
+    const mcpConfigBridge = {
+      listServers: vi.fn(async () => ({
+        success: true,
+        provenance: { mode: 'global_only', globalConfigPath: '/tmp/mcp.json' },
+        servers: [],
+      })),
+      getServer: vi.fn(),
+      saveServer: vi.fn(),
+      deleteServer: vi.fn(),
+    } as any
+
+    const mcpService = {
+      refreshStatus: vi.fn(),
+      reconnectServer: vi.fn(async () => ({
+        success: true,
+        status: {
+          serverName: 'my-server',
+          phase: 'connected',
+          checkedAt: new Date().toISOString(),
+          toolNames: ['read'],
+          toolCount: 1,
+        },
+      })),
+      getStabilityMetrics: vi.fn(() => ({
+        a11yViolationCounts: { minor: 0, moderate: 0, serious: 0, critical: 0 },
+      })),
+    } as any
+
+    const unregister = registerSessionIpc({
+      bridge: createBridgeStub(),
+      authBridge: {
+        getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+        setProviderKey: vi.fn(),
+        removeProviderKey: vi.fn(),
+        validateKey: vi.fn(),
+      } as any,
+      sessionManager: {
+        listSessions: vi.fn(async () => ({ sessions: [], warnings: [], directory: process.cwd() })),
+        getSessionInfo: vi.fn(),
+        resolveSessionPathById: vi.fn(async () => null),
+      } as any,
+      window: createWindowStub(),
+      mcpConfigBridge,
+      mcpService,
+    })
+
+    const result = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'mcp',
+      action: 'reconnect',
+      serverName: 'my-server',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.code).toBe('MCP_SERVER_RECONNECTED')
+    expect(mcpService.reconnectServer).toHaveBeenCalledWith('my-server')
+    // Must NOT return MCP_RECOVERY_ACTION_UNSUPPORTED when serverName is provided
+    expect(result.code).not.toBe('MCP_RECOVERY_ACTION_UNSUPPORTED')
+
+    unregister()
+  })
+
   test('defense-in-depth: reconnect without server context returns graceful failure, not crash', async () => {
     const mcpConfigBridge = {
       listServers: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/reliability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-contract.test.ts
@@ -11,6 +11,7 @@ import {
   mapChatBridgeStatusToReliability,
   mapChatSubprocessCrashToReliability,
   mapMcpConfigReadResponseToReliability,
+  mapMcpServerStatusToReliability,
   mapMcpStatusResponseToReliability,
   mapSymphonyOperatorSnapshotToReliability,
   mapSymphonyRuntimeStatusToReliability,
@@ -287,5 +288,151 @@ describe('reliability-contract', () => {
     expect(code).toMatch(/^REL-SYMPHONY-UNKNOWN-/)
     const suffix = code.split('-').slice(3).join('-')
     expect(suffix.length).toBeLessThanOrEqual(32)
+  })
+
+  describe('MCP recovery action gating (R028)', () => {
+    test('config-read error always maps to fix_config, never reconnect or reauthenticate', () => {
+      const signal = mapMcpConfigReadResponseToReliability({
+        success: false,
+        provenance: {
+          mode: 'global_only',
+          globalConfigPath: '/tmp/mcp.json',
+        },
+        servers: [],
+        error: {
+          code: 'MALFORMED_CONFIG',
+          message: 'Invalid JSON in mcp.json',
+        },
+      })
+
+      expect(signal).toBeTruthy()
+      expect(signal?.recoveryAction).toBe('fix_config')
+      expect(signal?.recoveryAction).not.toBe('reconnect')
+      expect(signal?.recoveryAction).not.toBe('reauthenticate')
+      expect(signal?.diagnostics?.serverName).toBeUndefined()
+    })
+
+    test('config-read network error still maps to fix_config (not reconnect)', () => {
+      const signal = mapMcpConfigReadResponseToReliability({
+        success: false,
+        provenance: {
+          mode: 'global_only',
+          globalConfigPath: '/tmp/mcp.json',
+        },
+        servers: [],
+        error: {
+          code: 'CONNECTION_FAILED',
+          message: 'Unable to read config due to network issue',
+        },
+      })
+
+      expect(signal).toBeTruthy()
+      // Even though CONNECTION_FAILED is classified as network (default: reconnect),
+      // config-read errors are always clamped to fix_config
+      expect(signal?.recoveryAction).toBe('fix_config')
+    })
+
+    test('server-status error with server name allows reconnect and populates serverName', () => {
+      const signal = mapMcpServerStatusToReliability({
+        serverName: 'my-server',
+        phase: 'error',
+        checkedAt: '2026-04-10T12:00:00.000Z',
+        toolNames: [],
+        toolCount: 0,
+        error: {
+          code: 'CONNECTION_FAILED',
+          message: 'Unable to connect to my-server',
+        },
+      })
+
+      expect(signal).toBeTruthy()
+      expect(signal?.recoveryAction).toBe('reconnect')
+      expect(signal?.diagnostics?.serverName).toBe('my-server')
+    })
+
+    test('server-status error without server name clamps to refresh_state', () => {
+      const signal = mapMcpServerStatusToReliability({
+        serverName: '',
+        phase: 'error',
+        checkedAt: '2026-04-10T12:00:00.000Z',
+        toolNames: [],
+        toolCount: 0,
+        error: {
+          code: 'CONNECTION_FAILED',
+          message: 'Unable to connect',
+        },
+      })
+
+      expect(signal).toBeTruthy()
+      expect(signal?.recoveryAction).toBe('refresh_state')
+      expect(signal?.diagnostics?.serverName).toBeUndefined()
+    })
+
+    test('server-status auth error with server name allows reauthenticate', () => {
+      const signal = mapMcpServerStatusToReliability({
+        serverName: 'linear',
+        phase: 'error',
+        checkedAt: '2026-04-10T12:00:00.000Z',
+        toolNames: [],
+        toolCount: 0,
+        error: {
+          code: 'MISSING_BEARER_TOKEN',
+          message: 'Bearer token missing for linear',
+        },
+      })
+
+      expect(signal).toBeTruthy()
+      expect(signal?.recoveryAction).toBe('reauthenticate')
+      expect(signal?.diagnostics?.serverName).toBe('linear')
+    })
+
+    test('status-response error without embedded status has no server context, clamps to refresh_state', () => {
+      const signal = mapMcpStatusResponseToReliability({
+        success: false,
+        error: {
+          code: 'CONNECTION_FAILED',
+          message: 'Network error checking server status',
+        },
+      })
+
+      expect(signal).toBeTruthy()
+      // CONNECTION_FAILED would default to reconnect, but no server context → refresh_state
+      expect(signal?.recoveryAction).toBe('refresh_state')
+      expect(signal?.diagnostics?.serverName).toBeUndefined()
+    })
+
+    test('status-response with embedded server status delegates to server gating', () => {
+      const signal = mapMcpStatusResponseToReliability({
+        success: false,
+        status: {
+          serverName: 'remote-api',
+          phase: 'error',
+          checkedAt: '2026-04-10T12:00:00.000Z',
+          toolNames: [],
+          toolCount: 0,
+          error: {
+            code: 'UNREACHABLE',
+            message: 'Server unreachable',
+          },
+        },
+      })
+
+      expect(signal).toBeTruthy()
+      expect(signal?.recoveryAction).toBe('reconnect')
+      expect(signal?.diagnostics?.serverName).toBe('remote-api')
+    })
+
+    test('unknown MCP error maps to inspect action', () => {
+      const signal = mapMcpStatusResponseToReliability({
+        success: false,
+        error: {
+          code: 'UNKNOWN',
+          message: 'Something unexpected happened',
+        },
+      })
+
+      expect(signal).toBeTruthy()
+      expect(signal?.recoveryAction).toBe('inspect')
+    })
   })
 })

--- a/apps/desktop/src/main/__tests__/reliability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-contract.test.ts
@@ -312,7 +312,7 @@ describe('reliability-contract', () => {
       expect(signal?.diagnostics?.serverName).toBeUndefined()
     })
 
-    test('config-read network error still maps to fix_config (not reconnect)', () => {
+    test('config-read unknown error still maps to fix_config (not reconnect)', () => {
       const signal = mapMcpConfigReadResponseToReliability({
         success: false,
         provenance: {
@@ -321,13 +321,13 @@ describe('reliability-contract', () => {
         },
         servers: [],
         error: {
-          code: 'CONNECTION_FAILED',
-          message: 'Unable to read config due to network issue',
+          code: 'UNKNOWN',
+          message: 'Unable to read config due to unknown issue',
         },
       })
 
       expect(signal).toBeTruthy()
-      // Even though CONNECTION_FAILED is classified as network (default: reconnect),
+      // Even though UNKNOWN is classified as unknown (default: inspect),
       // config-read errors are always clamped to fix_config
       expect(signal?.recoveryAction).toBe('fix_config')
     })

--- a/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
@@ -291,6 +291,42 @@ describe('reliability recovery IPC handler', () => {
     unregister()
   })
 
+  test('server-scoped reconnect with serverName succeeds via mcpService.reconnectServer', async () => {
+    const mcpService = {
+      refreshStatus: vi.fn(),
+      reconnectServer: vi.fn(async () => ({
+        success: true,
+        status: {
+          serverName: 'my-server',
+          phase: 'connected' as const,
+          checkedAt: new Date().toISOString(),
+          toolNames: ['read'],
+          toolCount: 1,
+        },
+      })),
+      getStabilityMetrics: vi.fn(() => ({
+        a11yViolationCounts: { minor: 0, moderate: 0, serious: 0, critical: 0 },
+      })),
+    } as any
+
+    const unregister = registerSessionIpc({
+      ...createCommonOptions(),
+      mcpService,
+    })
+
+    const result = await handlers.get(IPC_CHANNELS.reliabilityRequestRecoveryAction)?.({}, {
+      sourceSurface: 'mcp',
+      action: 'reconnect',
+      serverName: 'my-server',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.code).toBe('MCP_SERVER_RECONNECTED')
+    expect(mcpService.reconnectServer).toHaveBeenCalledWith('my-server')
+
+    unregister()
+  })
+
   test('server-scoped MCP error propagates serverName through aggregator to reliability snapshot', async () => {
     const mcpService = {
       refreshStatus: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/reliability-ipc.test.ts
@@ -291,6 +291,105 @@ describe('reliability recovery IPC handler', () => {
     unregister()
   })
 
+  test('server-scoped MCP error propagates serverName through aggregator to reliability snapshot', async () => {
+    const mcpService = {
+      refreshStatus: vi.fn(async () => ({
+        success: false,
+        status: {
+          serverName: 'my-failing-server',
+          phase: 'error' as const,
+          checkedAt: '2026-04-10T12:00:00.000Z',
+          toolNames: [],
+          toolCount: 0,
+          error: {
+            code: 'CONNECTION_FAILED' as const,
+            message: 'Unable to connect to my-failing-server',
+          },
+        },
+        error: {
+          code: 'CONNECTION_FAILED' as const,
+          message: 'Unable to connect to my-failing-server',
+        },
+      })),
+      reconnectServer: vi.fn(),
+      getStabilityMetrics: vi.fn(() => ({
+        a11yViolationCounts: { minor: 0, moderate: 0, serious: 0, critical: 0 },
+      })),
+    } as any
+
+    const unregister = registerSessionIpc({
+      ...createCommonOptions(),
+      mcpService,
+    })
+
+    // Trigger a server-scoped error through the refresh status handler
+    await handlers.get(IPC_CHANNELS.mcpRefreshStatus)?.({}, 'my-failing-server')
+
+    // Verify the reliability snapshot propagates serverName
+    const statusResult = await handlers.get(IPC_CHANNELS.reliabilityGetStatus)?.({})
+    expect(statusResult.success).toBe(true)
+
+    const mcpSurface = statusResult.snapshot.surfaces.find(
+      (s: any) => s.sourceSurface === 'mcp',
+    )
+    expect(mcpSurface).toBeTruthy()
+    expect(mcpSurface?.status).toBe('degraded')
+    expect(mcpSurface?.signal).toBeTruthy()
+    expect(mcpSurface?.signal?.diagnostics?.serverName).toBe('my-failing-server')
+    expect(mcpSurface?.signal?.recoveryAction).toBe('reconnect')
+
+    unregister()
+  })
+
+  test('config-read error produces gated fix_config action in reliability snapshot, not reconnect', async () => {
+    const mcpConfigBridge = {
+      listServers: vi.fn(async () => ({
+        success: false,
+        provenance: {
+          mode: 'global_only' as const,
+          globalConfigPath: '/tmp/mcp.json',
+        },
+        servers: [],
+        error: {
+          code: 'MALFORMED_CONFIG' as const,
+          message: 'Invalid JSON in mcp.json',
+        },
+      })),
+      getServer: vi.fn(),
+      saveServer: vi.fn(),
+      deleteServer: vi.fn(),
+    } as any
+
+    const mcpService = {
+      refreshStatus: vi.fn(),
+      reconnectServer: vi.fn(),
+      getStabilityMetrics: vi.fn(() => ({
+        a11yViolationCounts: { minor: 0, moderate: 0, serious: 0, critical: 0 },
+      })),
+    } as any
+
+    const unregister = registerSessionIpc({
+      ...createCommonOptions(),
+      mcpConfigBridge,
+      mcpService,
+    })
+
+    // Trigger config read error
+    await handlers.get(IPC_CHANNELS.mcpListServers)?.({})
+
+    // Verify the reliability snapshot has a gated action
+    const statusResult = await handlers.get(IPC_CHANNELS.reliabilityGetStatus)?.({})
+    const mcpSurface = statusResult.snapshot.surfaces.find(
+      (s: any) => s.sourceSurface === 'mcp',
+    )
+    expect(mcpSurface?.signal).toBeTruthy()
+    expect(mcpSurface?.signal?.recoveryAction).toBe('fix_config')
+    expect(mcpSurface?.signal?.recoveryAction).not.toBe('reconnect')
+    expect(mcpSurface?.signal?.diagnostics?.serverName).toBeUndefined()
+
+    unregister()
+  })
+
   test('redacts thrown recovery errors before returning them over reliability IPC', async () => {
     const mcpConfigBridge = {
       listServers: vi.fn(async () => {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -134,7 +134,7 @@ export function registerSessionIpc({
   const resolvedMcpService = mcpService ?? new McpService({ configBridge: resolvedMcpConfigBridge })
 
   const reliabilityAggregator = new RuntimeHealthAggregator({
-    requestRecovery: async ({ sourceSurface, action }) => {
+    requestRecovery: async ({ sourceSurface, action, serverName }) => {
       try {
         if (sourceSurface === 'chat_runtime') {
           await bridge.restart()
@@ -252,6 +252,29 @@ export function registerSessionIpc({
         }
 
         if (sourceSurface === 'mcp') {
+          // Server-scoped reconnect: route through mcpService when serverName is present.
+          if ((action === 'reconnect' || action === 'reauthenticate') && serverName) {
+            const response = await resolvedMcpService.reconnectServer(serverName)
+            syncStabilityMetricsFromServices()
+            reliabilityAggregator.ingestMcpStatusResponse(response)
+
+            if (!response.success) {
+              return {
+                success: false,
+                outcome: 'failed' as const,
+                code: response.error?.code ?? 'MCP_RECONNECT_FAILED',
+                message: response.error?.message ?? `MCP server reconnect failed for ${serverName}.`,
+              }
+            }
+
+            return {
+              success: true,
+              outcome: 'succeeded' as const,
+              code: 'MCP_SERVER_RECONNECTED',
+              message: `MCP server ${serverName} reconnected successfully.`,
+            }
+          }
+
           const supportsConfigRefresh =
             action === 'refresh_state' || action === 'inspect' || action === 'fix_config'
 

--- a/apps/desktop/src/main/reliability-contract.ts
+++ b/apps/desktop/src/main/reliability-contract.ts
@@ -177,6 +177,7 @@ function toSignal(input: {
     code?: string
     detail?: string
     occurredAt?: string
+    serverName?: string
   }
   severity?: ReliabilitySeverity
   recoveryAction?: ReliabilityRecoveryAction
@@ -203,6 +204,7 @@ function toSignal(input: {
                 }
               : {}),
             ...(input.diagnostics.occurredAt ? { occurredAt: input.diagnostics.occurredAt } : {}),
+            ...(input.diagnostics.serverName ? { serverName: input.diagnostics.serverName } : {}),
           },
         }
       : {}),
@@ -395,6 +397,36 @@ function classifyMcpCode(code: string | undefined, message: string | undefined):
   return classifyMessageFallback(message)
 }
 
+/**
+ * Actions the MCP recovery handler in ipc.ts can execute at the panel level
+ * (i.e. without server-specific context).
+ */
+const MCP_PANEL_EXECUTABLE_ACTIONS: ReadonlySet<ReliabilityRecoveryAction> = new Set([
+  'refresh_state',
+  'fix_config',
+  'inspect',
+])
+
+/**
+ * Gate an MCP recovery action: if the action requires server-scoped context
+ * (e.g. `reconnect`, `reauthenticate`) but no server name is available,
+ * downgrade to a panel-executable fallback.
+ */
+function gateMcpRecoveryAction(
+  defaultAction: ReliabilityRecoveryAction,
+  serverName: string | undefined,
+): ReliabilityRecoveryAction {
+  if (MCP_PANEL_EXECUTABLE_ACTIONS.has(defaultAction)) {
+    return defaultAction
+  }
+  // Server-scoped actions are only allowed when server identity is known
+  if (serverName) {
+    return defaultAction
+  }
+  // Downgrade to a safe panel-level action
+  return 'refresh_state'
+}
+
 export function mapMcpConfigReadResponseToReliability(
   response: McpConfigReadResponse | null | undefined,
 ): ReliabilitySignal | null {
@@ -403,11 +435,14 @@ export function mapMcpConfigReadResponseToReliability(
   }
 
   const reliabilityClass = classifyMcpCode(response.error.code, response.error.message)
+  // Config-read errors are never server-scoped — always use fix_config
+  const recoveryAction: ReliabilityRecoveryAction = 'fix_config'
   return toSignal({
     sourceSurface: 'mcp',
     reliabilityClass,
     sourceCode: response.error.code,
     message: response.error.message,
+    recoveryAction,
     diagnostics: {
       code: response.error.code,
     },
@@ -423,14 +458,19 @@ export function mapMcpServerStatusToReliability(
   }
 
   const reliabilityClass = classifyMcpCode(status.error.code, status.error.message)
+  const defaults = RELIABILITY_CLASS_DEFAULTS[reliabilityClass]
+  const serverName = status.serverName || undefined
+  const recoveryAction = gateMcpRecoveryAction(defaults.recoveryAction, serverName)
   return toSignal({
     sourceSurface: 'mcp',
     reliabilityClass,
     sourceCode: status.error.code,
     message: status.error.message,
     timestamp: status.checkedAt,
+    recoveryAction,
     diagnostics: {
       code: status.error.code,
+      ...(serverName ? { serverName } : {}),
     },
     outcome: 'failed',
   })
@@ -449,11 +489,15 @@ export function mapMcpStatusResponseToReliability(
 
   if (response.error) {
     const reliabilityClass = classifyMcpCode(response.error.code, response.error.message)
+    const defaults = RELIABILITY_CLASS_DEFAULTS[reliabilityClass]
+    // Response-level errors without embedded status have no server context
+    const recoveryAction = gateMcpRecoveryAction(defaults.recoveryAction, undefined)
     return toSignal({
       sourceSurface: 'mcp',
       reliabilityClass,
       sourceCode: response.error.code,
       message: response.error.message,
+      recoveryAction,
       diagnostics: {
         code: response.error.code,
       },

--- a/apps/desktop/src/main/runtime-health-aggregator.ts
+++ b/apps/desktop/src/main/runtime-health-aggregator.ts
@@ -55,6 +55,7 @@ interface RuntimeHealthAggregatorOptions {
   requestRecovery?: (request: {
     sourceSurface: ReliabilitySourceSurface
     action: ReliabilityRecoveryAction
+    serverName?: string
   }) => Promise<RecoveryAttempt>
   stabilityThresholds?: StabilityThresholdSet
 }
@@ -751,6 +752,7 @@ export class RuntimeHealthAggregator extends EventEmitter {
         attempt = await this.requestRecovery({
           sourceSurface: request.sourceSurface,
           action,
+          serverName: request.serverName,
         })
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)

--- a/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import type { McpServerSummary, ReliabilitySignal, ThresholdBreach } from '@shared/types'
+import type { McpServerSummary, ReliabilityRecoveryAction, ReliabilitySignal, ThresholdBreach } from '@shared/types'
 import {
   deleteMcpServerAtom,
   loadMcpConfigAtom,
@@ -40,6 +40,28 @@ export function formatMcpProvenanceLabel(mode: 'global_only' | 'overlay_present'
 
 export function formatMcpReliabilityNotice(signal: ReliabilitySignal): string {
   return `${signal.message} Recommended recovery: ${formatReliabilityActionLabel(signal.recoveryAction)}.`
+}
+
+/**
+ * Map gated recovery actions to concise button labels.
+ * These labels are intentionally shorter than the generic `formatReliabilityActionLabel`
+ * to fit in the panel header action buttons.
+ */
+export function formatMcpRecoveryButtonLabel(action: ReliabilityRecoveryAction): string {
+  switch (action) {
+    case 'fix_config':
+      return 'Refresh config'
+    case 'refresh_state':
+      return 'Refresh config'
+    case 'reconnect':
+      return 'Reconnect'
+    case 'reauthenticate':
+      return 'Re-authenticate'
+    case 'inspect':
+      return 'Inspect'
+    default:
+      return formatReliabilityActionLabel(action)
+  }
 }
 
 export function formatMcpStabilityNotice(breach: ThresholdBreach): string {
@@ -128,7 +150,7 @@ export function McpServerPanel() {
               >
                 {reliabilityPendingBySurface.mcp
                   ? 'Recovering…'
-                  : formatReliabilityActionLabel(mcpReliability.signal.recoveryAction)}
+                  : formatMcpRecoveryButtonLabel(mcpReliability.signal.recoveryAction)}
               </Button>
             ) : null}
             <Button type="button" size="sm" onClick={openCreateDialog} data-testid="mcp-add-server">
@@ -205,7 +227,16 @@ export function McpServerPanel() {
           </Alert>
         ) : null}
 
-        {serverErrorCount > 0 ? (
+        {mcpReliability.signal && !mcpReliability.signal.diagnostics?.serverName && !configState.error ? (
+          <Alert data-testid="mcp-server-identity-fallback">
+            <AlertTitle>Server identity unavailable</AlertTitle>
+            <AlertDescription>
+              Refresh config to identify the affected server. Once identified, a targeted recovery action will appear on the server row.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {serverErrorCount > 0 && !mcpReliability.signal?.diagnostics?.serverName ? (
           <Alert data-testid="mcp-row-recovery-hint">
             <AlertTitle>Server connection errors stay row-scoped</AlertTitle>
             <AlertDescription>
@@ -221,21 +252,34 @@ export function McpServerPanel() {
           </div>
         ) : (
           <div className="space-y-2">
-            {servers.map((server) => (
-              <McpServerRow
-                key={server.name}
-                server={server}
-                pendingDelete={pendingDeleteName === server.name}
-                mutationPending={mutationPending}
-                onEdit={openEditDialog}
-                onRequestDelete={setPendingDeleteName}
-                onConfirmDelete={(name) => {
-                  void deleteServer(name)
-                  setPendingDeleteName(null)
-                }}
-                onCancelDelete={() => setPendingDeleteName(null)}
-              />
-            ))}
+            {servers.map((server) => {
+              const affectedServerName = mcpReliability.signal?.diagnostics?.serverName
+              const isAffected = Boolean(affectedServerName && affectedServerName === server.name)
+              return (
+                <McpServerRow
+                  key={server.name}
+                  server={server}
+                  pendingDelete={pendingDeleteName === server.name}
+                  mutationPending={mutationPending}
+                  onEdit={openEditDialog}
+                  onRequestDelete={setPendingDeleteName}
+                  onConfirmDelete={(name) => {
+                    void deleteServer(name)
+                    setPendingDeleteName(null)
+                  }}
+                  onCancelDelete={() => setPendingDeleteName(null)}
+                  isAffectedByReliabilitySignal={isAffected}
+                  reliabilityRecoveryAction={isAffected ? mcpReliability.signal?.recoveryAction : undefined}
+                  onRecoveryAction={isAffected ? () => {
+                    void requestRecoveryAction({
+                      sourceSurface: 'mcp',
+                      action: mcpReliability.signal!.recoveryAction,
+                    })
+                  } : undefined}
+                  recoveryPending={isAffected ? reliabilityPendingBySurface.mcp : false}
+                />
+              )
+            })}
           </div>
         )}
       </CardContent>

--- a/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
@@ -140,9 +140,13 @@ export function McpServerPanel() {
                 size="sm"
                 variant="outline"
                 onClick={() => {
+                  const signal = mcpReliability.signal!
                   void requestRecoveryAction({
                     sourceSurface: 'mcp',
-                    action: mcpReliability.signal!.recoveryAction,
+                    action: signal.recoveryAction,
+                    ...(signal.diagnostics?.serverName
+                      ? { serverName: signal.diagnostics.serverName }
+                      : {}),
                   })
                 }}
                 disabled={reliabilityPendingBySurface.mcp}
@@ -274,6 +278,7 @@ export function McpServerPanel() {
                     void requestRecoveryAction({
                       sourceSurface: 'mcp',
                       action: mcpReliability.signal!.recoveryAction,
+                      serverName: mcpReliability.signal!.diagnostics?.serverName,
                     })
                   } : undefined}
                   recoveryPending={isAffected ? reliabilityPendingBySurface.mcp : false}

--- a/apps/desktop/src/renderer/components/settings/McpServerRow.tsx
+++ b/apps/desktop/src/renderer/components/settings/McpServerRow.tsx
@@ -1,4 +1,4 @@
-import type { McpServerStatus, McpServerSummary } from '@shared/types'
+import type { McpServerStatus, McpServerSummary, ReliabilityRecoveryAction } from '@shared/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 
@@ -49,6 +49,17 @@ export function summarizeMcpServer(server: McpServerSummary): string {
   return server.summary.url
 }
 
+function formatRowRecoveryLabel(action: ReliabilityRecoveryAction, serverName: string): string {
+  switch (action) {
+    case 'reconnect':
+      return `Reconnect ${serverName}`
+    case 'reauthenticate':
+      return `Re-authenticate ${serverName}`
+    default:
+      return `Recover ${serverName}`
+  }
+}
+
 interface McpServerRowProps {
   server: McpServerSummary
   pendingDelete?: boolean
@@ -57,6 +68,10 @@ interface McpServerRowProps {
   onConfirmDelete: (name: string) => void
   onCancelDelete: () => void
   mutationPending?: boolean
+  isAffectedByReliabilitySignal?: boolean
+  reliabilityRecoveryAction?: ReliabilityRecoveryAction
+  onRecoveryAction?: () => void
+  recoveryPending?: boolean
 }
 
 export function McpServerRow({
@@ -67,11 +82,20 @@ export function McpServerRow({
   onConfirmDelete,
   onCancelDelete,
   mutationPending,
+  isAffectedByReliabilitySignal,
+  reliabilityRecoveryAction,
+  onRecoveryAction,
+  recoveryPending,
 }: McpServerRowProps) {
   return (
     <article
-      className="rounded-lg border border-border bg-background/40 p-3"
+      className={`rounded-lg border p-3 ${
+        isAffectedByReliabilitySignal
+          ? 'border-destructive bg-destructive/5'
+          : 'border-border bg-background/40'
+      }`}
       data-testid={`mcp-server-row-${server.name}`}
+      data-affected={isAffectedByReliabilitySignal ? 'true' : undefined}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-1">
@@ -153,6 +177,20 @@ export function McpServerRow({
         </div>
       </div>
 
+      {isAffectedByReliabilitySignal && reliabilityRecoveryAction && onRecoveryAction ? (
+        <div className="mt-2 flex items-center gap-2" data-testid={`mcp-row-recovery-${server.name}`}>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={onRecoveryAction}
+            disabled={recoveryPending}
+            data-testid={`mcp-row-recovery-action-${server.name}`}
+          >
+            {recoveryPending ? 'Recovering…' : formatRowRecoveryLabel(reliabilityRecoveryAction, server.name)}
+          </Button>
+        </div>
+      ) : null}
     </article>
   )
 }

--- a/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
@@ -303,5 +303,44 @@ describe('MCP settings helpers', () => {
       // Panel button should say "Refresh config" (the gated fallback)
       expect(formatMcpRecoveryButtonLabel(signal.recoveryAction)).toBe('Refresh config')
     })
+
+    test('recovery request for server-scoped reconnect includes serverName in the payload', () => {
+      // Verify the shape of the payload that McpServerPanel passes to requestRecoveryAction
+      // when a signal with serverName triggers a row-level reconnect.
+      const signal = {
+        code: 'REL-MCP-NETWORK-CONNECTION_FAILED',
+        class: 'network' as const,
+        severity: 'error' as const,
+        sourceSurface: 'mcp' as const,
+        recoveryAction: 'reconnect' as const,
+        outcome: 'failed' as const,
+        message: 'Connection failed for my-server',
+        timestamp: '2026-04-10T12:00:00.000Z',
+        diagnostics: {
+          code: 'CONNECTION_FAILED',
+          serverName: 'my-server',
+        },
+      }
+
+      // The payload built in McpServerPanel onRecoveryAction (row path):
+      const rowPayload = {
+        sourceSurface: signal.sourceSurface,
+        action: signal.recoveryAction,
+        serverName: signal.diagnostics?.serverName,
+      }
+
+      expect(rowPayload.serverName).toBe('my-server')
+      expect(rowPayload.action).toBe('reconnect')
+
+      // The payload built in McpServerPanel onClick (panel-header path) when serverName present:
+      const headerPayload = {
+        sourceSurface: signal.sourceSurface,
+        action: signal.recoveryAction,
+        ...(signal.diagnostics?.serverName ? { serverName: signal.diagnostics.serverName } : {}),
+      }
+
+      expect(headerPayload.serverName).toBe('my-server')
+      expect(headerPayload.action).toBe('reconnect')
+    })
   })
 })

--- a/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import { createMcpServerEditorDraft, parseArgs, validateMcpServerDraft } from '../McpServerEditorDialog'
 import {
   formatMcpProvenanceLabel,
+  formatMcpRecoveryButtonLabel,
   formatMcpReliabilityNotice,
   formatMcpStabilityNotice,
 } from '../McpServerPanel'
@@ -218,5 +219,89 @@ describe('MCP settings helpers', () => {
         hasStoredInlineBearerToken: true,
       }),
     ).toEqual([])
+  })
+
+  describe('MCP recovery CTA truthfulness (R028)', () => {
+    test('formatMcpRecoveryButtonLabel maps fix_config to "Refresh config"', () => {
+      expect(formatMcpRecoveryButtonLabel('fix_config')).toBe('Refresh config')
+    })
+
+    test('formatMcpRecoveryButtonLabel maps refresh_state to "Refresh config"', () => {
+      expect(formatMcpRecoveryButtonLabel('refresh_state')).toBe('Refresh config')
+    })
+
+    test('formatMcpRecoveryButtonLabel maps reconnect to "Reconnect"', () => {
+      expect(formatMcpRecoveryButtonLabel('reconnect')).toBe('Reconnect')
+    })
+
+    test('formatMcpRecoveryButtonLabel maps reauthenticate to "Re-authenticate"', () => {
+      expect(formatMcpRecoveryButtonLabel('reauthenticate')).toBe('Re-authenticate')
+    })
+
+    test('formatMcpRecoveryButtonLabel maps inspect to "Inspect"', () => {
+      expect(formatMcpRecoveryButtonLabel('inspect')).toBe('Inspect')
+    })
+
+    test('formatMcpReliabilityNotice includes gated action label', () => {
+      const notice = formatMcpReliabilityNotice({
+        code: 'REL-MCP-NETWORK-CONNECTION_FAILED',
+        class: 'network',
+        severity: 'error',
+        sourceSurface: 'mcp',
+        recoveryAction: 'refresh_state',
+        outcome: 'failed',
+        message: 'Connection failed',
+        timestamp: '2026-04-10T12:00:00.000Z',
+      })
+
+      expect(notice).toContain('Recommended recovery: Refresh state.')
+      expect(notice).not.toContain('Reconnect')
+    })
+
+    test('signal with serverName should produce row-scoped recovery label', () => {
+      // This tests the pure function in McpServerRow, not the component render
+      // The component uses formatRowRecoveryLabel internally
+      // We validate the behavior indirectly through the exported helpers
+      const signal = {
+        code: 'REL-MCP-NETWORK-CONNECTION_FAILED',
+        class: 'network' as const,
+        severity: 'error' as const,
+        sourceSurface: 'mcp' as const,
+        recoveryAction: 'reconnect' as const,
+        outcome: 'failed' as const,
+        message: 'Connection failed for my-server',
+        timestamp: '2026-04-10T12:00:00.000Z',
+        diagnostics: {
+          code: 'CONNECTION_FAILED',
+          serverName: 'my-server',
+        },
+      }
+
+      // Panel button label should be "Reconnect" (the gated action)
+      expect(formatMcpRecoveryButtonLabel(signal.recoveryAction)).toBe('Reconnect')
+      // serverName is present for row targeting
+      expect(signal.diagnostics.serverName).toBe('my-server')
+    })
+
+    test('signal without serverName should show fallback guidance instead of row action', () => {
+      const signal = {
+        code: 'REL-MCP-NETWORK-CONNECTION_FAILED',
+        class: 'network' as const,
+        severity: 'error' as const,
+        sourceSurface: 'mcp' as const,
+        recoveryAction: 'refresh_state' as const,
+        outcome: 'failed' as const,
+        message: 'Connection failed',
+        timestamp: '2026-04-10T12:00:00.000Z',
+        diagnostics: {
+          code: 'CONNECTION_FAILED',
+        } as { code: string; serverName?: string },
+      }
+
+      // No serverName means no row-scoped action
+      expect(signal.diagnostics.serverName).toBeUndefined()
+      // Panel button should say "Refresh config" (the gated fallback)
+      expect(formatMcpRecoveryButtonLabel(signal.recoveryAction)).toBe('Refresh config')
+    })
   })
 })

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1467,6 +1467,8 @@ export interface StabilitySnapshotResponse {
 export interface ReliabilityRecoveryRequest {
   sourceSurface: ReliabilitySourceSurface
   action?: ReliabilityRecoveryAction
+  /** Server identity for server-scoped MCP recovery actions (e.g. reconnect). */
+  serverName?: string
 }
 
 export interface ReliabilityRecoveryResult {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1341,6 +1341,7 @@ export interface ReliabilityDiagnostics {
   code?: string
   detail?: string
   occurredAt?: string
+  serverName?: string
 }
 
 export interface ReliabilitySignal {


### PR DESCRIPTION
## Summary

Implements context-safe MCP recovery affordances (R028) so the Desktop UI never shows a recovery CTA that will immediately fail with `MCP_RECOVERY_ACTION_UNSUPPORTED`.

### Changes

**T01: Gate MCP reliability signals to executable recovery actions** (KAT-2473)
- Added `serverName?: string` to `ReliabilityDiagnostics` for server-scoped error attribution
- `mapMcpConfigReadResponseToReliability` always returns `fix_config` (config errors are never server-scoped)
- `mapMcpServerStatusToReliability` and `mapMcpStatusResponseToReliability` allow `reconnect` only when server name is available; otherwise clamp to `refresh_state`
- 8 unit tests covering all gating rules

**T02: Truthful recovery CTAs with fallback copy** (KAT-2475)
- Panel-level recovery button uses `formatMcpRecoveryButtonLabel` for concise, truthful labels
- Server-scoped signals highlight the affected row with a targeted "Reconnect [server-name]" action
- Missing server identity shows fallback notice: "Refresh config to identify the affected server"
- `mcp-row-recovery-hint` guarded to avoid conflicting guidance when server-scoped signal is active
- 7 component tests for CTA truthfulness

**T03: Integration proof of recovery-action truthfulness** (KAT-2474)
- Malformed config error flows through full IPC path with gated `fix_config` → succeeds
- Server-scoped error propagates `serverName` through aggregator to reliability snapshot
- Defense-in-depth: `reconnect` without server context returns graceful `MCP_RECOVERY_ACTION_UNSUPPORTED`
- Config-read error in reliability snapshot shows gated `fix_config`, never `reconnect`

### Verification

- `npx vitest run src/main/__tests__/reliability-contract.test.ts` — 18 pass
- `npx vitest run src/renderer/components/settings/__tests__/McpServerPanel.test.tsx` — 16 pass
- `npx vitest run src/main/__tests__/mcp-ipc.test.ts` — 4 pass
- `npx vitest run src/main/__tests__/reliability-ipc.test.ts` — 8 pass
- `npx vitest run src/main/__tests__/mcp-service.test.ts` — 9 pass
- `bun run typecheck` — clean
- Full desktop test suite: 473 pass

### Files Changed

- `src/shared/types.ts` — `serverName` on `ReliabilityDiagnostics`
- `src/main/reliability-contract.ts` — MCP signal gating layer
- `src/renderer/components/settings/McpServerPanel.tsx` — truthful CTA rendering
- `src/renderer/components/settings/McpServerRow.tsx` — row-scoped recovery UI
- `src/main/__tests__/reliability-contract.test.ts` — gating unit tests
- `src/renderer/components/settings/__tests__/McpServerPanel.test.tsx` — CTA tests
- `src/main/__tests__/mcp-ipc.test.ts` — integration tests
- `src/main/__tests__/reliability-ipc.test.ts` — integration tests

Closes KAT-2472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP Server Panel now displays targeted recovery actions with server identity context, showing which server is affected and suggesting specific actions (e.g., "Reconnect," "Re-authenticate").
  * Added contextual recovery button labels based on error type instead of generic labels.
  * Enhanced diagnostic information in reliability signals to include affected server details.

* **Bug Fixes**
  * Improved recovery action gating to prevent unsupported actions and gracefully downgrade to refresh state when server context is unavailable.

* **Tests**
  * Added comprehensive test coverage for MCP recovery action logic and reliability contract validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements context-safe MCP recovery affordances (R028) by gating server-scoped recovery actions (`reconnect`, `reauthenticate`) behind server identity presence in `ReliabilityDiagnostics.serverName`, preventing the UI from displaying recovery CTAs that would fail with `MCP_RECOVERY_ACTION_UNSUPPORTED`. It adds truthful button labels in `McpServerPanel` and row-level highlighting with targeted recovery buttons in `McpServerRow`.

- **Row-level `reconnect` and `reauthenticate` actions are wired to the reliability recovery IPC handler**, which explicitly rejects them with `MCP_RECOVERY_ACTION_UNSUPPORTED` at `ipc.ts:258–264` — the button renders correctly but always fails when clicked.

<h3>Confidence Score: 4/5</h3>

Safe to merge after resolving the row-level reconnect/reauthenticate wiring — gating logic and panel-level CTAs are correct, but server row recovery buttons always fail with MCP_RECOVERY_ACTION_UNSUPPORTED.

One P1 finding: the 'Reconnect [server-name]' and 'Re-authenticate [server-name]' row buttons send `reconnect`/`reauthenticate` to the reliability IPC handler, which explicitly rejects these actions for MCP surface. All other logic — gating rules, panel-level labels, fallback notices, and type changes — is correct and well-tested.

apps/desktop/src/renderer/components/settings/McpServerPanel.tsx (onRecoveryAction wiring) and apps/desktop/src/main/ipc.ts (MCP recovery handler missing `reconnect` case).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/reliability-contract.ts | Adds `gateMcpRecoveryAction` and `MCP_PANEL_EXECUTABLE_ACTIONS` to correctly clamp server-scoped actions when no server identity is present; `mapMcpConfigReadResponseToReliability` hardcodes `fix_config`; `mapMcpServerStatusToReliability` now populates `diagnostics.serverName`. Logic is correct and well-tested. |
| apps/desktop/src/renderer/components/settings/McpServerPanel.tsx | Adds truthful button label formatting and row-level recovery CTA wiring; however the `onRecoveryAction` callback for server-scoped signals passes `reconnect`/`reauthenticate` to the reliability IPC handler, which rejects these actions — buttons render but always fail. |
| apps/desktop/src/renderer/components/settings/McpServerRow.tsx | Adds `isAffectedByReliabilitySignal` highlighting, row-level recovery button with `formatRowRecoveryLabel`; UI rendering logic is correct and defensive. |
| apps/desktop/src/shared/types.ts | Adds optional `serverName` field to `ReliabilityDiagnostics` interface — clean, backward-compatible addition. |
| apps/desktop/src/main/__tests__/reliability-contract.test.ts | Adds 8 unit tests covering all gating rules for all three mapper functions; comprehensive and correct. |
| apps/desktop/src/main/__tests__/reliability-ipc.test.ts | Adds integration tests verifying serverName propagation and config-error gating; missing a test that verifies a server-scoped `reconnect` action succeeds end-to-end through the IPC handler. |
| apps/desktop/src/main/__tests__/mcp-ipc.test.ts | Defense-in-depth test covers `reconnect` without server context returning `MCP_RECOVERY_ACTION_UNSUPPORTED` and `fix_config` succeeding; does not test that `reconnect` with a valid server name succeeds. |
| apps/desktop/src/renderer/components/settings/__tests__/McpServerPanel.test.tsx | 7 CTA-truthfulness tests validate `formatMcpRecoveryButtonLabel` mappings and signal-to-label correctness; all pure-function tests are correct. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Error Signal] --> B{serverName in diagnostics?}
    B -- No --> C[gateMcpRecoveryAction: clamp to refresh_state]
    B -- Yes --> D[Allow reconnect / reauthenticate]

    C --> E[Panel button: Refresh config]
    C --> F[Alert: Refresh config to identify server]

    D --> G[Panel button: Reconnect]
    D --> H[McpServerRow highlighted]
    H --> I[Row button: Reconnect server-name]

    E --> J[IPC: reliabilityRequestRecoveryAction
action=refresh_state ✅ Handled]
    I --> K[IPC: reliabilityRequestRecoveryAction
action=reconnect ❌ MCP_RECOVERY_ACTION_UNSUPPORTED]

    style K fill:#f44,color:#fff
    style J fill:#4a4,color:#fff
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/settings/McpServerPanel.tsx
Line: 272-278

Comment:
**Row-level `reconnect`/`reauthenticate` always fails with `MCP_RECOVERY_ACTION_UNSUPPORTED`**

`onRecoveryAction` passes `mcpReliability.signal!.recoveryAction` (which is `reconnect` or `reauthenticate` for server-scoped signals) into `requestRecoveryAction`. That call routes through `IPC_CHANNELS.reliabilityRequestRecoveryAction`, whose MCP handler at `ipc.ts:255–265` only handles `refresh_state | inspect | fix_config`:

```ts
// ipc.ts (unchanged, lines 255-264)
const supportsConfigRefresh =
  action === 'refresh_state' || action === 'inspect' || action === 'fix_config'
if (!supportsConfigRefresh) {
  return {
    success: false, outcome: 'failed', code: 'MCP_RECOVERY_ACTION_UNSUPPORTED', …
  }
}
```

The "Reconnect [server-name]" (and "Re-authenticate [server-name]") buttons now appear on affected rows but will always return `MCP_RECOVERY_ACTION_UNSUPPORTED` — the exact problem this PR set out to fix. The defense-in-depth test only covers the no-server-context path; neither test verifies that a server-scoped `reconnect` actually succeeds.

Fix options:
1. Update the `reliabilityRequestRecoveryAction` MCP branch to call `mcpService.reconnectServer(serverName)` when `action === 'reconnect'` and a `serverName` is available from the signal diagnostics.
2. Alternatively, exclude `reconnect`/`reauthenticate` from the row-level CTA (keep them gated at `refresh_state`) and add an out-of-band button that uses `IPC_CHANNELS.mcpReconnectServer` directly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): prove MCP recovery-action..."](https://github.com/gannonh/kata/commit/bb807d1714624b2ce4bc8e988b5ed51983aa62e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28035598)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->