### PR TITLE
feat(desktop): deterministic Desktop validation environment (KAT-2476)

### DIFF
--- a/apps/desktop/e2e/fixtures/electron.fixture.ts
+++ b/apps/desktop/e2e/fixtures/electron.fixture.ts
@@ -448,6 +448,10 @@ export const test = base.extend<DesktopFixtures>({
         KATA_DESKTOP_SYMPHONY_MOCK: symphonyMockMode,
         KATA_DESKTOP_SYMPHONY_DASHBOARD_MOCK: symphonyMockMode,
         KATA_SYMPHONY_URL: 'http://127.0.0.1:8080',
+        // R029: prevent host-level binary override from affecting e2e tests.
+        // The app should fall through to mock mode (KATA_DESKTOP_SYMPHONY_MOCK) or
+        // bundled/PATH discovery — never use a developer's local binary.
+        KATA_SYMPHONY_BIN_PATH: '',
         KATA_DESKTOP_MCP_CONFIG_PATH: mcpConfigPath,
         KATA_DESKTOP_AUTH_FILE_PATH: authFilePath,
         KATA_DESKTOP_RELIABILITY_CHAT_FAULT: chatRuntimeFaultMode,

--- a/apps/desktop/src/main/__tests__/symphony-config.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-config.test.ts
@@ -21,6 +21,15 @@ function createExecutable(workspacePath: string, name = 'symphony'): string {
   return executablePath
 }
 
+describe('test environment isolation (R029)', () => {
+  test('KATA_SYMPHONY_BIN_PATH is stripped from process.env by test-setup.ts', () => {
+    // The Vitest setup file (src/test-setup.ts) deletes KATA_SYMPHONY_BIN_PATH
+    // from process.env before any test file runs. This smoke test confirms the
+    // stripping worked, even if the developer's shell had the var exported.
+    expect(process.env.KATA_SYMPHONY_BIN_PATH).toBeUndefined()
+  })
+})
+
 describe('resolveSymphonyLaunch', () => {
   const cleanups: Array<() => void> = []
 

--- a/apps/desktop/src/main/__tests__/symphony-config.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-config.test.ts
@@ -60,6 +60,7 @@ describe('resolveSymphonyLaunch', () => {
       appIsPackaged: false,
       env: {
         ...process.env,
+        // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029)
         KATA_SYMPHONY_URL: 'http://localhost:8080',
       },
     })
@@ -208,6 +209,8 @@ describe('resolveSymphonyLaunch', () => {
     const result = await resolveSymphonyLaunch({
       workspacePath: workspace.workspacePath,
       appIsPackaged: false,
+      // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+      // This test exercises config validation; binary resolution is not reached.
       env: process.env,
     })
 
@@ -234,6 +237,8 @@ describe('resolveSymphonyLaunch', () => {
     const result = await resolveSymphonyLaunch({
       workspacePath: workspace.workspacePath,
       appIsPackaged: false,
+      // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+      // This test exercises workflow path validation; binary resolution is not reached.
       env: process.env,
     })
 
@@ -261,6 +266,8 @@ describe('resolveSymphonyLaunch', () => {
     const result = await resolveSymphonyLaunch({
       workspacePath: workspace.workspacePath,
       appIsPackaged: false,
+      // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+      // This test exercises workflow path validation; binary resolution is not reached.
       env: process.env,
     })
 
@@ -286,6 +293,8 @@ describe('resolveSymphonyLaunch', () => {
     const result = await resolveSymphonyLaunch({
       workspacePath: workspace.workspacePath,
       appIsPackaged: false,
+      // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+      // This test exercises URL validation; binary resolution is not reached.
       env: process.env,
     })
 
@@ -341,6 +350,7 @@ describe('resolveSymphonyLaunch', () => {
       appIsPackaged: false,
       env: {
         ...process.env,
+        // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029)
         KATA_SYMPHONY_URL: 'http://localhost:8080',
       },
     })
@@ -364,6 +374,7 @@ describe('resolveSymphonyLaunch', () => {
       appIsPackaged: false,
       env: {
         ...process.env,
+        // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029)
         KATA_SYMPHONY_URL: '',
         SYMPHONY_URL: '',
       },
@@ -418,6 +429,8 @@ describe('resolveSymphonyLaunch', () => {
       resourcesPath,
       env: {
         ...process.env,
+        // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+        // With no env override, the packaged binary should be discovered via resourcesPath.
         KATA_SYMPHONY_URL: 'http://localhost:8080',
       },
     })
@@ -545,5 +558,72 @@ describe('resolveSymphonyLaunch', () => {
     }
 
     expect(result.error.code).toBe('BINARY_NOT_FOUND')
+  })
+
+  // --- R029 regression tests ---
+
+  test('R029: KATA_SYMPHONY_BIN_PATH takes priority when explicitly set in env', async () => {
+    // Regression guard: when a test explicitly provides KATA_SYMPHONY_BIN_PATH,
+    // it must be used — proving the env var → bundled → PATH priority is preserved.
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+    const explicitBinary = createExecutable(workspace.workspacePath, 'explicit-priority-bin')
+
+    // Also place a binary on PATH to prove the env var wins
+    const binDir = mkdtempSync(path.join(tmpdir(), 'desktop-symphony-r029-path-'))
+    cleanups.push(() => rmSync(binDir, { recursive: true, force: true }))
+    createExecutable(binDir, 'symphony')
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: 'http://localhost:8080',
+        KATA_SYMPHONY_BIN_PATH: explicitBinary,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.launch.command).toBe(explicitBinary)
+    expect(result.launch.source).toBe('env')
+  })
+
+  test('R029: PATH discovery works when KATA_SYMPHONY_BIN_PATH is absent', async () => {
+    // Regression guard: when no KATA_SYMPHONY_BIN_PATH is in the env object
+    // (as guaranteed by test-setup.ts stripping it from process.env), the
+    // binary is discovered via PATH. This proves no host leakage occurs.
+    const workspace = createWorkspace()
+    cleanups.push(workspace.cleanup)
+
+    writeFileSync(path.join(workspace.workspacePath, 'WORKFLOW.md'), '# workflow\n', 'utf8')
+
+    const binDir = mkdtempSync(path.join(tmpdir(), 'desktop-symphony-r029-nodiscovery-'))
+    cleanups.push(() => rmSync(binDir, { recursive: true, force: true }))
+    const pathBinary = createExecutable(binDir, 'symphony')
+
+    // Confirm the var is not in process.env (setup file guarantee)
+    expect(process.env.KATA_SYMPHONY_BIN_PATH).toBeUndefined()
+
+    const result = await resolveSymphonyLaunch({
+      workspacePath: workspace.workspacePath,
+      appIsPackaged: false,
+      env: {
+        ...process.env,
+        KATA_SYMPHONY_URL: 'http://localhost:8080',
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.launch.command).toBe(pathBinary)
+    expect(result.launch.source).toBe('path')
   })
 })

--- a/apps/desktop/src/main/__tests__/symphony-config.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-config.test.ts
@@ -523,7 +523,7 @@ describe('resolveSymphonyLaunch', () => {
         ...process.env,
         KATA_SYMPHONY_URL: 'http://localhost:8080',
         KATA_SYMPHONY_BIN_PATH: '',
-        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
       },
     })
 
@@ -583,7 +583,7 @@ describe('resolveSymphonyLaunch', () => {
         ...process.env,
         KATA_SYMPHONY_URL: 'http://localhost:8080',
         KATA_SYMPHONY_BIN_PATH: explicitBinary,
-        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
       },
     })
 
@@ -616,7 +616,7 @@ describe('resolveSymphonyLaunch', () => {
       env: {
         ...process.env,
         KATA_SYMPHONY_URL: 'http://localhost:8080',
-        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
       },
     })
 

--- a/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-supervisor.test.ts
@@ -170,6 +170,8 @@ describe('SymphonySupervisor', () => {
       appIsPackaged: false,
       env: {
         ...process.env,
+        // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+        // Mock mode bypasses binary resolution entirely.
         KATA_DESKTOP_SYMPHONY_MOCK: 'ready',
         KATA_SYMPHONY_URL: 'http://127.0.0.1:7000',
       },
@@ -194,6 +196,8 @@ describe('SymphonySupervisor', () => {
       appIsPackaged: false,
       env: {
         ...process.env,
+        // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+        // Mock mode bypasses binary resolution entirely.
         KATA_DESKTOP_SYMPHONY_MOCK: 'assembled_healthy',
       },
     })
@@ -213,6 +217,8 @@ describe('SymphonySupervisor', () => {
       appIsPackaged: false,
       env: {
         ...process.env,
+        // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+        // Mock mode bypasses binary resolution entirely.
         KATA_DESKTOP_SYMPHONY_MOCK: 'config_error',
       },
     })
@@ -227,6 +233,8 @@ describe('SymphonySupervisor', () => {
       appIsPackaged: false,
       env: {
         ...process.env,
+        // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+        // Mock mode bypasses binary resolution entirely.
         KATA_DESKTOP_SYMPHONY_MOCK: 'readiness_error',
       },
     })
@@ -457,6 +465,8 @@ describe('SymphonySupervisor', () => {
     const supervisor = new SymphonySupervisor({
       workspacePath: workspace.workspacePath,
       appIsPackaged: false,
+      // KATA_SYMPHONY_BIN_PATH absent — stripped by test-setup.ts (R029).
+      // stop() doesn't need binary resolution; this just confirms idle stop works.
       env: process.env,
     })
 

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -1,0 +1,26 @@
+/**
+ * Vitest global setup file — strips host-level Symphony env vars from process.env
+ * before any test file executes.
+ *
+ * This prevents host-specific values (e.g. a developer's local KATA_SYMPHONY_BIN_PATH)
+ * from leaking into tests via `...process.env` spreads, ensuring deterministic results
+ * regardless of the developer's shell environment.
+ *
+ * Registered in vitest.config.ts → test.setupFiles.
+ *
+ * @see https://linear.app/kata-sh/issue/KAT-2476 (R029)
+ */
+
+const SYMPHONY_ENV_VARS_TO_STRIP = [
+  'KATA_SYMPHONY_BIN_PATH',
+  'KATA_SYMPHONY_URL',
+  'SYMPHONY_URL',
+] as const
+
+for (const key of SYMPHONY_ENV_VARS_TO_STRIP) {
+  if (key in process.env) {
+    // eslint-disable-next-line no-console
+    console.info(`[test-setup] stripping host env var: ${key}`)
+    delete process.env[key]
+  }
+}

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     },
   },
   test: {
+    setupFiles: ['./src/test-setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     passWithNoTests: true,
     testTimeout: 15_000,


### PR DESCRIPTION
## Summary

Closes KAT-2476: [S04] Deterministic Desktop Validation Environment

Makes Desktop's unit, integration, and e2e test suites produce identical results whether the host machine has `KATA_SYMPHONY_BIN_PATH` set, unset, or pointing to a wrong binary — without changing the real runtime discovery rules.

## Changes

### T01: Vitest setup file to strip host Symphony env vars
- **New:** `src/test-setup.ts` — deletes `KATA_SYMPHONY_BIN_PATH`, `KATA_SYMPHONY_URL`, and `SYMPHONY_URL` from `process.env` before any test runs
- **Updated:** `vitest.config.ts` — registered setup file in `test.setupFiles`
- **Updated:** `symphony-config.test.ts` — smoke test proving the stripping works

### T02: Audited and hardened symphony test env objects
- **Updated:** `symphony-config.test.ts` — self-documenting R029 comments on every env object; two regression tests proving env var priority and PATH discovery
- **Updated:** `symphony-supervisor.test.ts` — self-documenting R029 comments on mock-mode and idle-stop env objects

### T03: Cleared Symphony env overrides in e2e fixture
- **Updated:** `electron.fixture.ts` — explicit `KATA_SYMPHONY_BIN_PATH: ''` in the Electron launch env

## Verification

All tests pass identically with and without `KATA_SYMPHONY_BIN_PATH=/tmp/fake`:

```
cd apps/desktop && KATA_SYMPHONY_BIN_PATH=/tmp/fake-binary npx vitest run src/main/__tests__/symphony-config.test.ts src/main/__tests__/symphony-supervisor.test.ts
# 38 tests pass

cd apps/desktop && npx vitest run src/main/__tests__/symphony-config.test.ts src/main/__tests__/symphony-supervisor.test.ts
# 38 tests pass (identical)

cd apps/desktop && bun run typecheck
# Clean
```

## What is NOT changed

- `src/main/symphony-config.ts` — production `resolveBinaryPath` logic is untouched
- No runtime behavior changes — this is purely test infrastructure hardening

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Desktop test suite so unit, integration, and e2e tests produce identical results regardless of whether `KATA_SYMPHONY_BIN_PATH` is set in the host shell environment. It introduces a Vitest global setup file that strips the three Symphony-related env vars before any test runs, adds regression tests that prove both the stripping and the priority rules, and adds an explicit `KATA_SYMPHONY_BIN_PATH: ''` override in the Playwright e2e fixture.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure test infrastructure hardening with no production code changes.

All five changed files are test/fixture infrastructure only. The new setup file is correctly scoped (strips only the targeted vars, guards with `in` check), the vitest.config.ts registration is minimal, env objects in both test files are now explicit and self-documenting, and the e2e fixture override is consistent with how the production code treats an empty string. No P0/P1 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/test-setup.ts | New Vitest global setup file; correctly deletes the three Symphony env vars from process.env with conditional guard and informational logging. |
| apps/desktop/vitest.config.ts | Registers the new setup file via test.setupFiles; all other config settings unchanged. |
| apps/desktop/src/main/__tests__/symphony-config.test.ts | Added smoke test for env-stripping, R029 self-documenting comments on every env object, and two new regression tests verifying env-var priority and PATH-discovery fallback. |
| apps/desktop/src/main/__tests__/symphony-supervisor.test.ts | R029 comments added to mock-mode and idle-stop env objects; no logic changes. |
| apps/desktop/e2e/fixtures/electron.fixture.ts | Adds KATA_SYMPHONY_BIN_PATH: '' to the Electron launch env so host overrides never reach e2e tests; consistent with how the production code treats an empty string as absent. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer runs tests] --> B{Host env has\nKATA_SYMPHONY_BIN_PATH?}
    B -->|Yes| C[test-setup.ts\nstrips var from process.env]
    B -->|No| D[process.env already clean]
    C --> E[Test workers see\nno host binary override]
    D --> E

    E --> F{Test type}
    F -->|Vitest unit/integration| G[symphony-config.test.ts\nsymphony-supervisor.test.ts\nspread ...process.env — clean]
    F -->|Playwright e2e| H[electron.fixture.ts\nexplicit KATA_SYMPHONY_BIN_PATH: '']

    G --> I[Binary resolution uses\nexplicit KATA_SYMPHONY_BIN_PATH\nor PATH discovery\nor mock mode]
    H --> I

    I --> J[Deterministic test result\nregardless of host environment]
```

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): clear KATA\_SYMPHONY\_BIN\_P..."](https://github.com/gannonh/kata/commit/d40995e4e7fffe2315154ce9bc7d591616148109) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28040720)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for Symphony binary resolution priority handling, verifying correct behavior when environment variables and PATH-based discovery are used.
  * Enhanced test environment isolation to prevent host configuration from interfering with test execution.

* **Chores**
  * Configured automatic cleanup of test environment variables during test setup to ensure consistent test conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->