### PR TITLE
feat(desktop): Subagent Chat UX and Assembled QoL Acceptance [KAT-2480]

### DIFF
--- a/apps/desktop/docs/uat/M007/M007-QOL-ACCEPTANCE.md
+++ b/apps/desktop/docs/uat/M007/M007-QOL-ACCEPTANCE.md
@@ -1,0 +1,162 @@
+# M007 QoL Backlog Sweep — Assembled Acceptance Walkthrough
+
+**Milestone:** M007 — QoL Backlog Sweep
+**Scope:** R025 (Provider Truthfulness), R026 (Board PR Context), R027 (Subagent Chat UX), R028 (MCP Recovery), R029 (Deterministic Validation)
+
+## Purpose
+
+This document defines a repeatable acceptance walkthrough that proves the M007 QoL sweep is coherent across all five requirement surfaces in one real Desktop session. It does **not** re-prove M001–M006 capabilities.
+
+## Prerequisites
+
+- Kata Desktop built and launchable (`cd apps/desktop && bun run build`)
+- At least one AI provider configured (e.g. Anthropic API key in `~/.kata-cli/agent/auth.json`)
+- A Linear workspace with PR-linked issues (for board PR badge verification)
+- MCP config file at `~/.kata-cli/agent/mcp.json`
+- Subagent agents available in `~/.kata-cli/agent/agents/` (e.g. `scout.md`, `worker.md`)
+
+## Walkthrough Checkpoints
+
+### CP1: Provider Truthfulness (S01 / R025)
+
+**What to verify:** Onboarding and Settings correctly reflect configured provider state.
+
+**Steps:**
+1. Launch Desktop with a configured API-key provider (e.g. Anthropic).
+2. Observe onboarding: if a valid key is already configured, the onboarding step should indicate the key is present and allow skipping key entry.
+3. Open **Settings → Providers**.
+4. Confirm the configured provider shows as connected/authenticated.
+5. Confirm OAuth-capable providers (if any) show their OAuth status truthfully (connected vs. not connected).
+
+**Expected outcome:**
+- Onboarding does not prompt for a key that is already configured.
+- Settings → Providers panel displays accurate connection state for each provider.
+- No stale or misleading status labels.
+
+**Evidence:** Screenshot of Settings → Providers showing truthful status.
+
+**Pass criteria:** Provider states match actual configuration. No false "connected" or "missing key" labels.
+
+---
+
+### CP2: Board PR Context (S02 / R026)
+
+**What to verify:** Kanban board cards show PR badges for linked issues and columns auto-collapse/expand appropriately.
+
+**Steps:**
+1. Open the kanban board (workflow view) in Desktop.
+2. Navigate to a Linear workspace that has issues with linked GitHub PRs.
+3. Inspect slice cards — look for PR badge indicators on cards that have associated PRs.
+4. Observe column behavior — empty columns should auto-collapse; columns gaining cards should expand.
+
+**Expected outcome:**
+- Cards with linked PRs display a PR badge with PR number and status (open/merged/closed).
+- Cards without PRs do not show a PR badge.
+- Empty kanban columns collapse to save space; columns with cards are expanded.
+
+**Evidence:** Screenshot of kanban board showing at least one card with a PR badge.
+
+**Pass criteria:** PR badges are visible on linked cards. Auto-collapse/expand behaves as described. No phantom badges on unlinked cards.
+
+---
+
+### CP3: MCP Recovery (S03 / R028)
+
+**What to verify:** MCP error states show actionable, truthful recovery CTAs.
+
+**Steps:**
+1. Open **Settings → MCP Servers**.
+2. Trigger an MCP error condition. Options:
+   - Temporarily edit `~/.kata-cli/agent/mcp.json` to contain invalid JSON, then refresh.
+   - Configure a server that points to a non-existent command.
+3. Observe the error state displayed for the affected server.
+4. Confirm the recovery CTA label says **"Refresh config"** (not generic "Reconnect").
+5. Fix the config (revert the invalid JSON), then click the recovery CTA.
+6. Confirm the server recovers and shows a healthy state.
+
+**Expected outcome:**
+- Error state shows a specific, actionable message (not a generic "server error").
+- Recovery CTA uses context-aware language matching the error class.
+- Clicking recovery CTA after fixing the root cause succeeds.
+
+**Evidence:** Screenshot of MCP error state with recovery CTA visible.
+
+**Pass criteria:** Recovery CTA is truthful and actionable. After fixing config and clicking CTA, server recovers without requiring app restart.
+
+---
+
+### CP4: Subagent Chat UX (S05 / R027)
+
+**What to verify:** Subagent tool calls render as dedicated readable cards instead of collapsed JSON.
+
+**Steps:**
+1. Start a chat session in Desktop.
+2. Trigger a subagent tool call. Options:
+   - Ask the agent to "use the scout subagent to find the auth module in this codebase"
+   - Run a `/kata` command that delegates to a subagent
+3. While the subagent is running, observe the chat:
+   - A dedicated card should appear (not a generic JSON card).
+   - The card header shows the agent name (e.g. "scout") as a badge.
+   - A running status indicator (amber badge + spinner) is visible.
+4. When the subagent completes:
+   - Status transitions to "done" (green badge) or "error" (red badge).
+   - For errors, the exit code and error message are visible in the card.
+5. If testing parallel mode, confirm each sub-result appears as a separate row with individual status.
+
+**Expected outcome:**
+- Subagent cards show agent name, task text, and mode badge.
+- Running → done/error transition is visible.
+- Error states show exit code and message, not hidden in collapsed JSON.
+- For parallel/chain, per-result rows are rendered.
+
+**Evidence:** Screenshot of a completed subagent card showing agent name, task, and done status.
+
+**Pass criteria:** Subagent calls never render as raw JSON. Agent name, task, and status are human-readable. Error details are visible without expanding collapsed sections.
+
+---
+
+### CP5: Deterministic Validation (S04 / R029)
+
+**What to verify:** Desktop test suite produces deterministic results regardless of host environment.
+
+**Steps:**
+1. Run the test suite with the host `KATA_SYMPHONY_BIN_PATH` set:
+   ```bash
+   KATA_SYMPHONY_BIN_PATH=/some/path cd apps/desktop && npx vitest run
+   ```
+2. Run the same test suite without the env var:
+   ```bash
+   unset KATA_SYMPHONY_BIN_PATH && cd apps/desktop && npx vitest run
+   ```
+3. Compare results — both runs should produce identical pass/fail outcomes.
+
+**Expected outcome:**
+- `test-setup.ts` strips `KATA_SYMPHONY_BIN_PATH`, `KATA_SYMPHONY_URL`, and `SYMPHONY_URL` from `process.env` before tests execute.
+- No test depends on host-level Symphony configuration.
+- Both runs produce the same number of passing tests with zero failures.
+
+**Evidence:** Terminal output showing matching test counts for both runs.
+
+**Pass criteria:** Test results are identical with and without host Symphony env vars. Zero test failures in both runs.
+
+---
+
+## Summary Checklist
+
+| Checkpoint | Requirement | Slice | Pass/Fail | Evidence |
+|------------|-------------|-------|-----------|----------|
+| CP1 | R025 — Provider Truthfulness | S01 | ☐ | |
+| CP2 | R026 — Board PR Context | S02 | ☐ | |
+| CP3 | R028 — MCP Recovery | S03 | ☐ | |
+| CP4 | R027 — Subagent Chat UX | S05 | ☐ | |
+| CP5 | R029 — Deterministic Validation | S04 | ☐ | |
+
+## Completion Criteria
+
+The M007 milestone acceptance is **PASS** when all five checkpoints pass in one continuous Desktop session (or test run for CP5). Any checkpoint failure blocks milestone completion and requires the owning slice to address the gap.
+
+## Notes
+
+- This walkthrough is bounded to M007 scope. It does not re-test capabilities from M001–M006.
+- Evidence should be captured as screenshots or terminal output and attached to the milestone review.
+- A reviewer should be able to independently repeat this walkthrough from this document alone.

--- a/apps/desktop/docs/uat/M007/README.md
+++ b/apps/desktop/docs/uat/M007/README.md
@@ -1,0 +1,21 @@
+# M007: QoL Backlog Sweep — UAT Artifacts
+
+This directory contains User Acceptance Testing artifacts for M007.
+
+## Documents
+
+| File | Purpose |
+|------|---------|
+| [M007-QOL-ACCEPTANCE.md](./M007-QOL-ACCEPTANCE.md) | Assembled acceptance walkthrough covering all five M007 requirement surfaces (R025–R029) in one coherent Desktop session |
+
+## Scope
+
+M007 is a QoL backlog sweep milestone covering five requirements:
+
+- **R025** (S01): Provider truthfulness in onboarding and settings
+- **R026** (S02): Workflow board card PR context and auto-collapse/expand
+- **R028** (S03): Context-safe MCP recovery affordances
+- **R027** (S05): Subagent chat UX with dedicated cards
+- **R029** (S04): Deterministic Desktop validation environment
+
+The acceptance walkthrough proves these surfaces work together in one real Desktop session.

--- a/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
@@ -1030,4 +1030,305 @@ describe('Real RPC event shapes', () => {
       expect(events, `expected [] for ame type ${ameType}`).toEqual([])
     }
   })
+
+  // ── Subagent extraction tests ───────────────────────────────────────────────
+
+  describe('subagent arg extraction', () => {
+    test('single-mode args → SubagentArgs with agent + task + mode', () => {
+      const [event] = adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-1',
+        toolName: 'subagent',
+        args: {
+          agent: 'scout',
+          task: 'Find the auth module',
+        },
+      })
+
+      expect(event).toMatchObject({
+        type: 'tool_start',
+        toolCallId: 'tool-sub-1',
+        toolName: 'subagent',
+        args: {
+          agent: 'scout',
+          task: 'Find the auth module',
+          mode: 'single',
+        },
+      })
+      // Should not have tasks/chain fields
+      const args = (event as unknown as { args: Record<string, unknown> }).args
+      expect(args).not.toHaveProperty('tasks')
+      expect(args).not.toHaveProperty('chain')
+    })
+
+    test('parallel-mode args with tasks[] → correct extraction', () => {
+      const [event] = adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-2',
+        toolName: 'subagent',
+        args: {
+          tasks: [
+            { agent: 'scout', task: 'Find auth module' },
+            { agent: 'worker', task: 'Fix the bug in login.ts' },
+          ],
+        },
+      })
+
+      expect(event).toMatchObject({
+        type: 'tool_start',
+        toolName: 'subagent',
+        args: {
+          mode: 'parallel',
+          tasks: [
+            { agent: 'scout', task: 'Find auth module' },
+            { agent: 'worker', task: 'Fix the bug in login.ts' },
+          ],
+        },
+      })
+    })
+
+    test('chain-mode args → correct extraction with mode chain', () => {
+      const [event] = adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-3',
+        toolName: 'subagent',
+        args: {
+          chain: [
+            { agent: 'scout', task: 'Find context for auth' },
+            { agent: 'worker', task: 'Implement the fix based on {previous}' },
+          ],
+        },
+      })
+
+      expect(event).toMatchObject({
+        type: 'tool_start',
+        toolName: 'subagent',
+        args: {
+          mode: 'chain',
+          chain: [
+            { agent: 'scout', task: 'Find context for auth' },
+            { agent: 'worker', task: 'Implement the fix based on {previous}' },
+          ],
+        },
+      })
+    })
+
+    test('chain takes priority over tasks when both present', () => {
+      const [event] = adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-4',
+        toolName: 'subagent',
+        args: {
+          tasks: [{ agent: 'scout', task: 'parallel task' }],
+          chain: [{ agent: 'worker', task: 'chain task' }],
+        },
+      })
+
+      const args = (event as unknown as { args: Record<string, unknown> }).args
+      expect(args).toMatchObject({ mode: 'chain' })
+    })
+
+    test('missing/null args → single mode with no agent or task', () => {
+      const [event] = adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-5',
+        toolName: 'subagent',
+        args: null,
+      })
+
+      expect(event).toMatchObject({
+        type: 'tool_start',
+        toolName: 'subagent',
+        args: { mode: 'single' },
+      })
+    })
+  })
+
+  describe('subagent result extraction', () => {
+    test('result with exitCode 0 → done SubagentResult', () => {
+      // Start event to populate cache
+      adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-res-1',
+        toolName: 'subagent',
+        args: { agent: 'scout', task: 'Find files' },
+      })
+
+      const [event] = adapter.adapt({
+        type: 'tool_execution_end',
+        toolCallId: 'tool-sub-res-1',
+        toolName: 'subagent',
+        result: {
+          details: {
+            mode: 'single',
+            results: [
+              { agent: 'scout', task: 'Find files', exitCode: 0, model: 'claude-sonnet-4-5' },
+            ],
+          },
+        },
+        isError: false,
+      })
+
+      expect(event).toMatchObject({
+        type: 'tool_end',
+        toolName: 'subagent',
+        isError: false,
+        result: {
+          mode: 'single',
+          results: [
+            { agent: 'scout', task: 'Find files', exitCode: 0, model: 'claude-sonnet-4-5' },
+          ],
+        },
+      })
+    })
+
+    test('result with exitCode non-zero → error with message', () => {
+      adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-res-2',
+        toolName: 'subagent',
+        args: { agent: 'worker', task: 'Deploy the app' },
+      })
+
+      const [event] = adapter.adapt({
+        type: 'tool_execution_end',
+        toolCallId: 'tool-sub-res-2',
+        toolName: 'subagent',
+        result: {
+          details: {
+            mode: 'single',
+            results: [
+              {
+                agent: 'worker',
+                task: 'Deploy the app',
+                exitCode: 1,
+                errorMessage: 'Permission denied',
+              },
+            ],
+          },
+        },
+        isError: true,
+      })
+
+      expect(event).toMatchObject({
+        type: 'tool_end',
+        toolName: 'subagent',
+        isError: true,
+        result: {
+          mode: 'single',
+          results: [
+            {
+              agent: 'worker',
+              task: 'Deploy the app',
+              exitCode: 1,
+              errorMessage: 'Permission denied',
+            },
+          ],
+        },
+      })
+    })
+
+    test('parallel result with mixed exit codes', () => {
+      adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-res-3',
+        toolName: 'subagent',
+        args: {
+          tasks: [
+            { agent: 'scout', task: 'Find files' },
+            { agent: 'worker', task: 'Fix bug' },
+          ],
+        },
+      })
+
+      const [event] = adapter.adapt({
+        type: 'tool_execution_end',
+        toolCallId: 'tool-sub-res-3',
+        toolName: 'subagent',
+        result: {
+          details: {
+            mode: 'parallel',
+            results: [
+              { agent: 'scout', task: 'Find files', exitCode: 0 },
+              { agent: 'worker', task: 'Fix bug', exitCode: 1, errorMessage: 'Build failed' },
+            ],
+          },
+        },
+        isError: false,
+      })
+
+      const result = (event as unknown as { result: { mode: string; results: Array<Record<string, unknown>> } }).result
+      expect(result.mode).toBe('parallel')
+      expect(result.results).toHaveLength(2)
+      expect(result.results[0]).toMatchObject({ agent: 'scout', exitCode: 0 })
+      expect(result.results[1]).toMatchObject({ agent: 'worker', exitCode: 1, errorMessage: 'Build failed' })
+    })
+
+    test('update event → partial SubagentResult extracted', () => {
+      adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-upd-1',
+        toolName: 'subagent',
+        args: {
+          tasks: [
+            { agent: 'scout', task: 'Find files' },
+            { agent: 'worker', task: 'Fix bug' },
+          ],
+        },
+      })
+
+      const [event] = adapter.adapt({
+        type: 'tool_execution_update',
+        toolCallId: 'tool-sub-upd-1',
+        toolName: 'subagent',
+        result: {
+          mode: 'parallel',
+          results: [
+            { agent: 'scout', task: 'Find files', exitCode: 0 },
+          ],
+        },
+      })
+
+      expect(event).toMatchObject({
+        type: 'tool_update',
+        toolName: 'subagent',
+        partialResult: {
+          mode: 'parallel',
+          results: [
+            { agent: 'scout', task: 'Find files', exitCode: 0 },
+          ],
+        },
+      })
+    })
+
+    test('result without details wrapper → extracts from top level', () => {
+      adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-res-4',
+        toolName: 'subagent',
+        args: { agent: 'scout', task: 'Find files' },
+      })
+
+      const [event] = adapter.adapt({
+        type: 'tool_execution_end',
+        toolCallId: 'tool-sub-res-4',
+        toolName: 'subagent',
+        result: {
+          mode: 'single',
+          results: [
+            { agent: 'scout', task: 'Find files', exitCode: 0 },
+          ],
+        },
+        isError: false,
+      })
+
+      expect(event).toMatchObject({
+        type: 'tool_end',
+        result: {
+          mode: 'single',
+          results: [{ agent: 'scout', exitCode: 0 }],
+        },
+      })
+    })
+  })
 })

--- a/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts
@@ -1301,6 +1301,42 @@ describe('Real RPC event shapes', () => {
       })
     })
 
+    test('update event with partialResult field → prefers event.partialResult over event.result', () => {
+      adapter.adapt({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-sub-upd-partial',
+        toolName: 'subagent',
+        args: {
+          tasks: [
+            { agent: 'scout', task: 'Find files' },
+            { agent: 'worker', task: 'Fix bug' },
+          ],
+        },
+      })
+
+      const [event] = adapter.adapt({
+        type: 'tool_execution_update',
+        toolCallId: 'tool-sub-upd-partial',
+        toolName: 'subagent',
+        partialResult: {
+          mode: 'parallel',
+          results: [
+            { agent: 'scout', task: 'Find files', exitCode: 0 },
+          ],
+        },
+        // result is absent (as during streaming) — partialResult must be used
+      })
+
+      expect(event).toMatchObject({
+        type: 'tool_update',
+        toolName: 'subagent',
+        partialResult: {
+          mode: 'parallel',
+          results: [{ agent: 'scout', task: 'Find files', exitCode: 0 }],
+        },
+      })
+    })
+
     test('result without details wrapper → extracts from top level', () => {
       adapter.adapt({
         type: 'tool_execution_start',

--- a/apps/desktop/src/main/rpc-event-adapter.ts
+++ b/apps/desktop/src/main/rpc-event-adapter.ts
@@ -220,7 +220,7 @@ export class RpcEventAdapter {
             toolName,
             status: typeof event.status === 'string' ? event.status : undefined,
             partialStdout: toolName === 'bash' ? this.extractPartialStdout(event) : undefined,
-            partialResult: toolName === 'subagent' ? this.extractSubagentResult(event.result ?? event.message) : undefined,
+            partialResult: toolName === 'subagent' ? this.extractSubagentResult(event.partialResult ?? event.result ?? event.message) : undefined,
           },
         ]
       }

--- a/apps/desktop/src/main/rpc-event-adapter.ts
+++ b/apps/desktop/src/main/rpc-event-adapter.ts
@@ -6,6 +6,10 @@ import {
   type EditResult,
   type ReadArgs,
   type ReadResult,
+  type SubagentArgs,
+  type SubagentResult,
+  type SubagentResultItem,
+  type SubagentTaskItem,
   type ToolArgs,
   type ToolResult,
   type WriteArgs,
@@ -216,6 +220,7 @@ export class RpcEventAdapter {
             toolName,
             status: typeof event.status === 'string' ? event.status : undefined,
             partialStdout: toolName === 'bash' ? this.extractPartialStdout(event) : undefined,
+            partialResult: toolName === 'subagent' ? this.extractSubagentResult(event.result ?? event.message) : undefined,
           },
         ]
       }
@@ -300,6 +305,9 @@ export class RpcEventAdapter {
           content: asString(argRecord?.content) ?? '',
         } satisfies WriteArgs
 
+      case 'subagent':
+        return this.extractSubagentArgs(argRecord)
+
       default:
         return {
           raw: args,
@@ -317,6 +325,8 @@ export class RpcEventAdapter {
         return this.extractReadResult(args, result)
       case 'write':
         return this.extractWriteResult(args, result)
+      case 'subagent':
+        return this.extractSubagentResult(result)
       default:
         return {
           raw: result,
@@ -419,6 +429,70 @@ export class RpcEventAdapter {
       bytesWritten: asNumber(resultRecord?.bytesWritten) ?? byteLength(content),
       raw: result,
     }
+  }
+
+  private extractSubagentArgs(argRecord: Record<string, unknown> | null): SubagentArgs {
+    const agent = asString(argRecord?.agent)
+    const task = asString(argRecord?.task)
+    const tasks = this.extractSubagentTaskItems(argRecord?.tasks)
+    const chain = this.extractSubagentTaskItems(argRecord?.chain)
+
+    // Derive mode: chain > tasks (parallel) > single
+    const mode = chain.length > 0 ? 'chain' : tasks.length > 0 ? 'parallel' : 'single'
+
+    const result: SubagentArgs = { mode }
+    if (agent) result.agent = agent
+    if (task) result.task = task
+    if (tasks.length > 0) result.tasks = tasks
+    if (chain.length > 0) result.chain = chain
+
+    return result
+  }
+
+  private extractSubagentTaskItems(items: unknown): SubagentTaskItem[] {
+    if (!Array.isArray(items)) return []
+    const result: SubagentTaskItem[] = []
+    for (const item of items) {
+      const rec = asRecord(item)
+      if (!rec) continue
+      const agent = asString(rec.agent)
+      const task = asString(rec.task)
+      if (agent && task) {
+        const entry: SubagentTaskItem = { agent, task }
+        const cwd = asString(rec.cwd)
+        if (cwd) entry.cwd = cwd
+        result.push(entry)
+      }
+    }
+    return result
+  }
+
+  private extractSubagentResult(result: unknown): SubagentResult {
+    const resultRecord = asRecord(result)
+
+    // The subagent tool returns { details: { mode, results: [...] } } or directly { mode, results }
+    const detailsRecord = asRecord(resultRecord?.details) ?? resultRecord
+    const mode = asString(detailsRecord?.mode) ?? 'single'
+
+    const rawResults = Array.isArray(detailsRecord?.results) ? detailsRecord.results : []
+    const results: SubagentResultItem[] = []
+    for (const item of rawResults) {
+      const rec = asRecord(item)
+      if (!rec) continue
+      const agent = asString(rec.agent) ?? 'unknown'
+      const task = asString(rec.task) ?? ''
+      const exitCode = asNumber(rec.exitCode) ?? -1
+      const entry: SubagentResultItem = { agent, task, exitCode }
+      const errorMessage = asString(rec.errorMessage)
+      if (errorMessage) entry.errorMessage = errorMessage
+      const model = asString(rec.model)
+      if (model) entry.model = model
+      const step = asNumber(rec.step)
+      if (step !== undefined) entry.step = step
+      results.push(entry)
+    }
+
+    return { mode, results, raw: result }
   }
 
   private extractPartialStdout(event: RpcEvent): string | undefined {

--- a/apps/desktop/src/renderer/atoms/chat.ts
+++ b/apps/desktop/src/renderer/atoms/chat.ts
@@ -237,6 +237,7 @@ export const applyChatEventAtom = atom(null, (get, set, event: ChatEvent) => {
             partialStdout: event.partialStdout
               ? `${tool.partialStdout ?? ''}${event.partialStdout}`
               : tool.partialStdout,
+            result: event.partialResult ?? tool.result,
           }
         }),
       )

--- a/apps/desktop/src/renderer/components/chat/SubagentCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/SubagentCard.tsx
@@ -1,0 +1,298 @@
+import { useMemo, useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Spinner } from '@/components/ui/spinner'
+import { cn } from '@/lib/utils'
+import type { ToolCallView } from '@/atoms/chat'
+import type { SubagentArgs, SubagentResult, SubagentResultItem } from '@shared/types'
+import { asRecord, asString } from './toolCardUtils'
+
+interface SubagentCardProps {
+  tool: ToolCallView
+}
+
+// ── View model ────────────────────────────────────────────────────────────────
+
+export interface SubagentViewModel {
+  agentName: string
+  task: string
+  mode: 'single' | 'parallel' | 'chain'
+  status: ToolCallView['status']
+  results: SubagentResultItemView[]
+}
+
+export interface SubagentResultItemView {
+  agent: string
+  task: string
+  taskExcerpt: string
+  exitCode: number
+  errorMessage?: string
+  model?: string
+  step?: number
+  status: 'running' | 'done' | 'error'
+}
+
+/** Truncate task text to maxLen characters, adding ellipsis if needed */
+export function truncateTask(task: string, maxLen = 60): string {
+  if (task.length <= maxLen) return task
+  return `${task.slice(0, maxLen)}…`
+}
+
+/** Determine the display mode from args/result */
+function deriveMode(args: SubagentArgs | null, result: SubagentResult | null): 'single' | 'parallel' | 'chain' {
+  const resultMode = result?.mode
+  if (resultMode === 'parallel' || resultMode === 'chain' || resultMode === 'single') {
+    return resultMode
+  }
+  return args?.mode ?? 'single'
+}
+
+/** Determine the agent name to show in the header */
+function deriveAgentName(args: SubagentArgs | null, results: SubagentResultItem[]): string {
+  if (args?.agent) return args.agent
+  const first = results[0]
+  if (results.length === 1 && first) return first.agent
+  return 'subagent'
+}
+
+/** Determine the task text to show */
+function deriveTask(args: SubagentArgs | null, results: SubagentResultItem[]): string {
+  if (args?.task) return args.task
+  const first = results[0]
+  if (results.length === 1 && first?.task) return first.task
+  return ''
+}
+
+/** Map a result item to a view-model item with status derived from exitCode */
+function mapResultItem(item: SubagentResultItem, toolStatus: ToolCallView['status']): SubagentResultItemView {
+  // If the tool is still running and this result has no exit code info yet, it's running
+  // exitCode -1 means "not yet available" (set by adapter when absent)
+  const status: 'running' | 'done' | 'error' =
+    item.exitCode === -1 && toolStatus === 'running'
+      ? 'running'
+      : item.exitCode !== 0
+        ? 'error'
+        : 'done'
+
+  return {
+    agent: item.agent,
+    task: item.task,
+    taskExcerpt: truncateTask(item.task),
+    exitCode: item.exitCode,
+    errorMessage: item.errorMessage,
+    model: item.model,
+    step: item.step,
+    status,
+  }
+}
+
+/** Check if an object looks like SubagentArgs (has mode field with known value) */
+function isSubagentArgs(args: unknown): args is SubagentArgs {
+  const rec = asRecord(args)
+  if (!rec) return false
+  const mode = asString(rec.mode)
+  return mode === 'single' || mode === 'parallel' || mode === 'chain'
+}
+
+/** Check if an object looks like SubagentResult (has mode + results array) */
+function isSubagentResult(result: unknown): result is SubagentResult {
+  const rec = asRecord(result)
+  if (!rec) return false
+  return typeof rec.mode === 'string' && Array.isArray(rec.results)
+}
+
+export function buildSubagentViewModel(tool: ToolCallView): SubagentViewModel {
+  const args = isSubagentArgs(tool.args) ? tool.args : null
+  const result = isSubagentResult(tool.result) ? tool.result : null
+
+  const resultItems: SubagentResultItem[] = result?.results ?? []
+  const mode = deriveMode(args, result)
+  const agentName = deriveAgentName(args, resultItems)
+  const task = deriveTask(args, resultItems)
+
+  const results = resultItems.map((item) => mapResultItem(item, tool.status))
+
+  return {
+    agentName,
+    task,
+    mode,
+    status: tool.status,
+    results,
+  }
+}
+
+// ── Style helpers ─────────────────────────────────────────────────────────────
+
+export function getStatusBadgeClass(status: ToolCallView['status']): string {
+  return cn(
+    'border uppercase tracking-wide text-[10px]',
+    status === 'error' && 'border-red-500/40 bg-red-500/15 text-red-700 dark:text-red-300',
+    status === 'done' && 'border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+    status === 'running' && 'border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300',
+  )
+}
+
+export function getModeBadgeClass(): string {
+  return 'border-border bg-muted text-muted-foreground'
+}
+
+export function formatStatusLabel(status: ToolCallView['status'], agentName: string): string {
+  switch (status) {
+    case 'running':
+      return `Running ${agentName}…`
+    case 'done':
+      return 'Done'
+    case 'error':
+      return 'Error'
+  }
+}
+
+export function formatResultStatusIcon(status: SubagentResultItemView['status']): string {
+  switch (status) {
+    case 'running':
+      return '⏳'
+    case 'done':
+      return '✓'
+    case 'error':
+      return '✗'
+  }
+}
+
+export function formatResultStatusLabel(item: SubagentResultItemView): string {
+  if (item.status === 'error' && item.errorMessage) {
+    return `exit ${item.exitCode}: ${item.errorMessage}`
+  }
+  if (item.status === 'error') {
+    return `exit ${item.exitCode}`
+  }
+  if (item.status === 'running') {
+    return 'running…'
+  }
+  return 'done'
+}
+
+// ── React component ───────────────────────────────────────────────────────────
+
+export function SubagentCard({ tool }: SubagentCardProps) {
+  const [isOpen, setIsOpen] = useState(tool.status !== 'done')
+  const view = useMemo(() => buildSubagentViewModel(tool), [tool])
+
+  const showResultList = (view.mode === 'parallel' || view.mode === 'chain') && view.results.length > 0
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <Card className="gap-0 py-0">
+        <CardHeader className="px-0 py-0">
+          <CollapsibleTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-auto w-full justify-between rounded-none px-3 py-2 hover:bg-accent"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                {/* Agent name badge */}
+                <Badge variant="outline" className="border-blue-500/40 bg-blue-500/15 text-blue-700 dark:text-blue-300 text-[10px]">
+                  {view.agentName}
+                </Badge>
+
+                {/* Mode badge (only for non-single) */}
+                {view.mode !== 'single' && (
+                  <Badge variant="outline" className={getModeBadgeClass()}>
+                    {view.mode}
+                  </Badge>
+                )}
+
+                {/* Running spinner */}
+                {view.status === 'running' && (
+                  <Spinner className="size-3" aria-label="Running" />
+                )}
+              </div>
+
+              <Badge variant="outline" className={getStatusBadgeClass(view.status)}>
+                {view.status}
+              </Badge>
+            </Button>
+          </CollapsibleTrigger>
+        </CardHeader>
+
+        <CollapsibleContent>
+          <CardContent className="flex flex-col gap-2 border-t border-border px-3 py-2">
+            {/* Task summary */}
+            {view.task && (
+              <p className="text-xs text-foreground leading-relaxed">{view.task}</p>
+            )}
+
+            {/* Per-result list for parallel/chain */}
+            {showResultList && (
+              <div className="flex flex-col gap-1">
+                {view.results.map((item, index) => (
+                  <div
+                    key={`${item.agent}-${index}`}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md border px-2 py-1 text-xs',
+                      item.status === 'error'
+                        ? 'border-red-500/30 bg-red-500/5'
+                        : item.status === 'done'
+                          ? 'border-emerald-500/30 bg-emerald-500/5'
+                          : 'border-amber-500/30 bg-amber-500/5',
+                    )}
+                  >
+                    {/* Step number for chain mode */}
+                    {view.mode === 'chain' && (
+                      <span className="text-[10px] font-mono text-muted-foreground">
+                        {item.step ?? index + 1}.
+                      </span>
+                    )}
+
+                    {/* Status icon */}
+                    <span className={cn(
+                      'text-xs font-medium',
+                      item.status === 'error' && 'text-red-600 dark:text-red-400',
+                      item.status === 'done' && 'text-emerald-600 dark:text-emerald-400',
+                      item.status === 'running' && 'text-amber-600 dark:text-amber-400',
+                    )}>
+                      {item.status === 'running' ? '⏳' : item.status === 'done' ? '✓' : '✗'}
+                    </span>
+
+                    {/* Agent name */}
+                    <span className="font-medium text-foreground">{item.agent}</span>
+
+                    {/* Task excerpt */}
+                    <span className="truncate text-muted-foreground">{item.taskExcerpt}</span>
+
+                    {/* Error info */}
+                    {item.status === 'error' && item.errorMessage && (
+                      <span className="ml-auto text-red-600 dark:text-red-400 shrink-0">
+                        exit {item.exitCode}: {truncateTask(item.errorMessage, 40)}
+                      </span>
+                    )}
+                    {item.status === 'error' && !item.errorMessage && (
+                      <span className="ml-auto text-red-600 dark:text-red-400 shrink-0">
+                        exit {item.exitCode}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Single-mode error details */}
+            {view.mode === 'single' && view.results.length === 1 && (() => {
+              const singleResult = view.results[0]!
+              return singleResult.status === 'error' ? (
+                <div className="rounded-md border border-red-500/30 bg-red-500/5 px-2 py-1 text-xs text-red-700 dark:text-red-300">
+                  <span className="font-medium">exit {singleResult.exitCode}</span>
+                  {singleResult.errorMessage && (
+                    <span>: {singleResult.errorMessage}</span>
+                  )}
+                </div>
+              ) : null
+            })()}
+          </CardContent>
+        </CollapsibleContent>
+      </Card>
+    </Collapsible>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/SubagentCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/SubagentCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
@@ -72,9 +72,11 @@ function mapResultItem(item: SubagentResultItem, toolStatus: ToolCallView['statu
   const status: 'running' | 'done' | 'error' =
     item.exitCode === -1 && toolStatus === 'running'
       ? 'running'
-      : item.exitCode !== 0
-        ? 'error'
-        : 'done'
+      : item.exitCode === -1
+        ? 'done'
+        : item.exitCode !== 0
+          ? 'error'
+          : 'done'
 
   return {
     agent: item.agent,
@@ -177,6 +179,10 @@ export function formatResultStatusLabel(item: SubagentResultItemView): string {
 
 export function SubagentCard({ tool }: SubagentCardProps) {
   const [isOpen, setIsOpen] = useState(tool.status !== 'done')
+  // Auto-collapse when the tool finishes
+  useEffect(() => {
+    if (tool.status === 'done') setIsOpen(false)
+  }, [tool.status])
   const view = useMemo(() => buildSubagentViewModel(tool), [tool])
 
   const showResultList = (view.mode === 'parallel' || view.mode === 'chain') && view.results.length > 0

--- a/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
@@ -7,6 +7,7 @@ import type { ToolCallView } from '@/atoms/chat'
 import { BashOutputCard } from './BashOutputCard'
 import { FileEditCard } from './FileEditCard'
 import { FileReadCard } from './FileReadCard'
+import { SubagentCard } from './SubagentCard'
 import { WriteCard } from './WriteCard'
 
 interface ToolCallCardProps {
@@ -94,6 +95,8 @@ export function ToolCallCard({ tool }: ToolCallCardProps) {
       return <FileReadCard tool={tool} />
     case 'write':
       return <WriteCard tool={tool} />
+    case 'subagent':
+      return <SubagentCard tool={tool} />
     default:
       return <GenericToolCallCard tool={tool} />
   }

--- a/apps/desktop/src/renderer/components/chat/__tests__/SubagentCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/SubagentCard.test.tsx
@@ -285,6 +285,40 @@ describe('buildSubagentViewModel', () => {
     expect(view.results[0]).toMatchObject({ agent: 'scout', status: 'done' })
   })
 
+  test('exitCode -1 when toolStatus done → maps to done (not error)', () => {
+    // Regression guard: exitCode -1 is the "not yet available" sentinel.
+    // When the outer tool is done, an unresolved exit code should be 'done', not 'error'.
+    const tool = makeToolCallView({
+      status: 'done',
+      result: makeSubagentResult({
+        mode: 'parallel',
+        results: [
+          { agent: 'scout', task: 'Find files', exitCode: -1 },
+        ],
+      }),
+    })
+    const view = buildSubagentViewModel(tool)
+
+    expect(view.results).toHaveLength(1)
+    expect(view.results[0]!.status).toBe('done')
+  })
+
+  test('exitCode -1 when toolStatus running → maps to running', () => {
+    const tool = makeToolCallView({
+      status: 'running',
+      result: makeSubagentResult({
+        mode: 'parallel',
+        results: [
+          { agent: 'worker', task: 'Running task', exitCode: -1 },
+        ],
+      }),
+    })
+    const view = buildSubagentViewModel(tool)
+
+    expect(view.results).toHaveLength(1)
+    expect(view.results[0]!.status).toBe('running')
+  })
+
   test('result mode takes priority over args mode', () => {
     const tool = makeToolCallView({
       status: 'done',

--- a/apps/desktop/src/renderer/components/chat/__tests__/SubagentCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/SubagentCard.test.tsx
@@ -1,0 +1,305 @@
+import { describe, expect, test } from 'vitest'
+import type { ToolCallView } from '@/atoms/chat'
+import type { SubagentArgs, SubagentResult } from '@shared/types'
+import {
+  buildSubagentViewModel,
+  formatResultStatusLabel,
+  formatStatusLabel,
+  getModeBadgeClass,
+  getStatusBadgeClass,
+  truncateTask,
+} from '../SubagentCard'
+
+// ── Helper factories ──────────────────────────────────────────────────────────
+
+function makeToolCallView(overrides: Partial<ToolCallView> = {}): ToolCallView {
+  return {
+    id: 'tool-1',
+    name: 'subagent',
+    args: { mode: 'single', agent: 'scout', task: 'Find the auth module' } satisfies SubagentArgs,
+    status: 'running',
+    ...overrides,
+  }
+}
+
+function makeSubagentResult(overrides: Partial<SubagentResult> = {}): SubagentResult {
+  return {
+    mode: 'single',
+    results: [{ agent: 'scout', task: 'Find the auth module', exitCode: 0 }],
+    ...overrides,
+  }
+}
+
+// ── truncateTask ──────────────────────────────────────────────────────────────
+
+describe('truncateTask', () => {
+  test('returns short text unchanged', () => {
+    expect(truncateTask('hello')).toBe('hello')
+  })
+
+  test('truncates long text with ellipsis', () => {
+    const long = 'a'.repeat(100)
+    const result = truncateTask(long, 60)
+    expect(result.length).toBe(61) // 60 chars + ellipsis
+    expect(result).toMatch(/…$/)
+  })
+
+  test('returns text of exactly maxLen unchanged', () => {
+    const exact = 'x'.repeat(60)
+    expect(truncateTask(exact, 60)).toBe(exact)
+  })
+})
+
+// ── getStatusBadgeClass ───────────────────────────────────────────────────────
+
+describe('getStatusBadgeClass', () => {
+  test('returns amber classes for running', () => {
+    expect(getStatusBadgeClass('running')).toContain('amber')
+  })
+
+  test('returns emerald classes for done', () => {
+    expect(getStatusBadgeClass('done')).toContain('emerald')
+  })
+
+  test('returns red classes for error', () => {
+    expect(getStatusBadgeClass('error')).toContain('red')
+  })
+})
+
+// ── getModeBadgeClass ─────────────────────────────────────────────────────────
+
+describe('getModeBadgeClass', () => {
+  test('returns muted styling', () => {
+    expect(getModeBadgeClass()).toContain('muted')
+  })
+})
+
+// ── formatStatusLabel ─────────────────────────────────────────────────────────
+
+describe('formatStatusLabel', () => {
+  test('running shows agent name', () => {
+    expect(formatStatusLabel('running', 'scout')).toBe('Running scout…')
+  })
+
+  test('done shows Done', () => {
+    expect(formatStatusLabel('done', 'scout')).toBe('Done')
+  })
+
+  test('error shows Error', () => {
+    expect(formatStatusLabel('error', 'worker')).toBe('Error')
+  })
+})
+
+// ── formatResultStatusLabel ───────────────────────────────────────────────────
+
+describe('formatResultStatusLabel', () => {
+  test('error with message shows exit code and message', () => {
+    const label = formatResultStatusLabel({
+      agent: 'worker',
+      task: 'Deploy',
+      taskExcerpt: 'Deploy',
+      exitCode: 1,
+      errorMessage: 'Permission denied',
+      status: 'error',
+    })
+    expect(label).toBe('exit 1: Permission denied')
+  })
+
+  test('error without message shows just exit code', () => {
+    const label = formatResultStatusLabel({
+      agent: 'worker',
+      task: 'Deploy',
+      taskExcerpt: 'Deploy',
+      exitCode: 1,
+      status: 'error',
+    })
+    expect(label).toBe('exit 1')
+  })
+
+  test('running shows running label', () => {
+    const label = formatResultStatusLabel({
+      agent: 'scout',
+      task: 'Find files',
+      taskExcerpt: 'Find files',
+      exitCode: -1,
+      status: 'running',
+    })
+    expect(label).toBe('running…')
+  })
+
+  test('done shows done label', () => {
+    const label = formatResultStatusLabel({
+      agent: 'scout',
+      task: 'Find files',
+      taskExcerpt: 'Find files',
+      exitCode: 0,
+      status: 'done',
+    })
+    expect(label).toBe('done')
+  })
+})
+
+// ── buildSubagentViewModel ────────────────────────────────────────────────────
+
+describe('buildSubagentViewModel', () => {
+  test('single-mode running → shows agent name, task, running status', () => {
+    const tool = makeToolCallView({ status: 'running' })
+    const view = buildSubagentViewModel(tool)
+
+    expect(view.agentName).toBe('scout')
+    expect(view.task).toBe('Find the auth module')
+    expect(view.mode).toBe('single')
+    expect(view.status).toBe('running')
+    expect(view.results).toHaveLength(0)
+  })
+
+  test('single-mode done → shows green status with result', () => {
+    const tool = makeToolCallView({
+      status: 'done',
+      result: makeSubagentResult(),
+    })
+    const view = buildSubagentViewModel(tool)
+
+    expect(view.agentName).toBe('scout')
+    expect(view.task).toBe('Find the auth module')
+    expect(view.mode).toBe('single')
+    expect(view.status).toBe('done')
+    expect(view.results).toHaveLength(1)
+    expect(view.results[0]!.status).toBe('done')
+    expect(view.results[0]!.exitCode).toBe(0)
+  })
+
+  test('single-mode error → shows red status with error details', () => {
+    const tool = makeToolCallView({
+      status: 'error',
+      result: makeSubagentResult({
+        results: [
+          {
+            agent: 'worker',
+            task: 'Deploy the app',
+            exitCode: 1,
+            errorMessage: 'Permission denied',
+          },
+        ],
+      }),
+    })
+    const view = buildSubagentViewModel(tool)
+
+    expect(view.status).toBe('error')
+    expect(view.results).toHaveLength(1)
+    expect(view.results[0]!.status).toBe('error')
+    expect(view.results[0]!.exitCode).toBe(1)
+    expect(view.results[0]!.errorMessage).toBe('Permission denied')
+  })
+
+  test('parallel-mode with mixed results → both rows visible', () => {
+    const tool = makeToolCallView({
+      status: 'done',
+      args: {
+        mode: 'parallel',
+        tasks: [
+          { agent: 'scout', task: 'Find files' },
+          { agent: 'worker', task: 'Fix bug' },
+        ],
+      } satisfies SubagentArgs,
+      result: makeSubagentResult({
+        mode: 'parallel',
+        results: [
+          { agent: 'scout', task: 'Find files', exitCode: 0 },
+          { agent: 'worker', task: 'Fix bug', exitCode: 1, errorMessage: 'Build failed' },
+        ],
+      }),
+    })
+    const view = buildSubagentViewModel(tool)
+
+    expect(view.mode).toBe('parallel')
+    expect(view.results).toHaveLength(2)
+    expect(view.results[0]).toMatchObject({ agent: 'scout', status: 'done' })
+    expect(view.results[1]).toMatchObject({ agent: 'worker', status: 'error', errorMessage: 'Build failed' })
+  })
+
+  test('chain-mode with step indicators', () => {
+    const tool = makeToolCallView({
+      status: 'done',
+      args: {
+        mode: 'chain',
+        chain: [
+          { agent: 'scout', task: 'Find context' },
+          { agent: 'worker', task: 'Implement fix' },
+        ],
+      } satisfies SubagentArgs,
+      result: makeSubagentResult({
+        mode: 'chain',
+        results: [
+          { agent: 'scout', task: 'Find context', exitCode: 0, step: 1 },
+          { agent: 'worker', task: 'Implement fix', exitCode: 0, step: 2 },
+        ],
+      }),
+    })
+    const view = buildSubagentViewModel(tool)
+
+    expect(view.mode).toBe('chain')
+    expect(view.results).toHaveLength(2)
+    expect(view.results[0]!.step).toBe(1)
+    expect(view.results[1]!.step).toBe(2)
+  })
+
+  test('no subagent args → graceful fallback to defaults', () => {
+    const tool: ToolCallView = {
+      id: 'tool-x',
+      name: 'subagent',
+      args: { raw: { some: 'unknown data' } },
+      status: 'running',
+    }
+    const view = buildSubagentViewModel(tool)
+
+    expect(view.agentName).toBe('subagent')
+    expect(view.task).toBe('')
+    expect(view.mode).toBe('single')
+    expect(view.status).toBe('running')
+    expect(view.results).toHaveLength(0)
+  })
+
+  test('running parallel with partial results → in-progress items visible', () => {
+    const tool = makeToolCallView({
+      status: 'running',
+      args: {
+        mode: 'parallel',
+        tasks: [
+          { agent: 'scout', task: 'Task A' },
+          { agent: 'worker', task: 'Task B' },
+        ],
+      } satisfies SubagentArgs,
+      result: makeSubagentResult({
+        mode: 'parallel',
+        results: [
+          { agent: 'scout', task: 'Task A', exitCode: 0 },
+        ],
+      }),
+    })
+    const view = buildSubagentViewModel(tool)
+
+    expect(view.status).toBe('running')
+    expect(view.mode).toBe('parallel')
+    expect(view.results).toHaveLength(1)
+    expect(view.results[0]).toMatchObject({ agent: 'scout', status: 'done' })
+  })
+
+  test('result mode takes priority over args mode', () => {
+    const tool = makeToolCallView({
+      status: 'done',
+      args: { mode: 'single', agent: 'scout', task: 'test' } satisfies SubagentArgs,
+      result: makeSubagentResult({
+        mode: 'parallel',
+        results: [
+          { agent: 'scout', task: 'test', exitCode: 0 },
+          { agent: 'worker', task: 'test2', exitCode: 0 },
+        ],
+      }),
+    })
+    const view = buildSubagentViewModel(tool)
+
+    // Result mode takes priority
+    expect(view.mode).toBe('parallel')
+  })
+})

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -291,11 +291,25 @@ export interface WriteArgs {
   content: string
 }
 
+export interface SubagentTaskItem {
+  agent: string
+  task: string
+  cwd?: string
+}
+
+export interface SubagentArgs {
+  agent?: string
+  task?: string
+  tasks?: SubagentTaskItem[]
+  chain?: SubagentTaskItem[]
+  mode: 'single' | 'parallel' | 'chain'
+}
+
 export interface UnknownToolArgs {
   raw: unknown
 }
 
-export type ToolArgs = EditArgs | BashArgs | ReadArgs | WriteArgs | UnknownToolArgs
+export type ToolArgs = EditArgs | BashArgs | ReadArgs | WriteArgs | SubagentArgs | UnknownToolArgs
 
 export interface EditResult {
   path?: string
@@ -333,12 +347,27 @@ export interface WriteResult {
   raw?: unknown
 }
 
+export interface SubagentResultItem {
+  agent: string
+  task: string
+  exitCode: number
+  errorMessage?: string
+  model?: string
+  step?: number
+}
+
+export interface SubagentResult {
+  mode: string
+  results: SubagentResultItem[]
+  raw?: unknown
+}
+
 export interface UnknownToolResult {
   raw: unknown
   parseError?: string
 }
 
-export type ToolResult = EditResult | BashResult | ReadResult | WriteResult | UnknownToolResult
+export type ToolResult = EditResult | BashResult | ReadResult | WriteResult | SubagentResult | UnknownToolResult
 
 export interface ExtensionUIRequestBase {
   id: string
@@ -411,6 +440,7 @@ export type ChatEvent =
       toolName: string
       status?: string
       partialStdout?: string
+      partialResult?: ToolResult
     }
   | {
       type: 'tool_end'


### PR DESCRIPTION
## Summary

Implements S05: Subagent Chat UX and Assembled QoL Acceptance — the final assembly slice for M007 QoL Backlog Sweep.

### Changes

**T01: Structured subagent extraction in RPC adapter** (KAT-2481)
- Added `SubagentArgs` and `SubagentResult` types to `src/shared/types.ts`
- Added `case 'subagent'` in `extractToolArgs` and `extractToolResult` in the RPC event adapter
- Wired `partialResult` into `tool_update` events for running-state feedback
- 10 new unit tests covering single/parallel/chain modes, success/error results, partial updates

**T02: SubagentCard component and ToolCallCard dispatch** (KAT-2482)
- New `SubagentCard.tsx` component with agent name badge, mode badge, status indicator
- Parallel/chain modes render per-result rows with individual status
- Running state shows spinner + amber badge; done shows green; error shows red + exit code
- Wired `ToolCallCard` dispatch: `case 'subagent'` → `SubagentCard`
- 22 component tests covering all states and graceful fallback

**T03: M007 assembled acceptance walkthrough** (KAT-2483)
- `docs/uat/M007/M007-QOL-ACCEPTANCE.md` — repeatable acceptance checklist
- Covers all 5 M007 requirements (R025–R029) in one coherent Desktop session
- Each checkpoint has concrete steps, expected outcomes, and evidence guidance

### Verification

- `cd apps/desktop && npx vitest run` — 538 tests pass (41 files)
- `cd apps/desktop && bun run typecheck` — clean
- Full Turborepo pipeline passes (lint + typecheck + test)

### Linear

Closes KAT-2480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subagent tool support: normalized execution modes (single/parallel/chain), prioritized mode selection, and consistent result formatting including exit codes and error messages.
  * UI: new Subagent card shows agent, task, mode, status, per-result items, auto-collapses when done, and surfaces single-mode error details.
  * Incremental tool output now shown during execution (partial results).

* **Tests**
  * Added extensive tests for subagent event handling, result normalization, and Subagent card helpers and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the Subagent Chat UX slice (M007 QoL Sweep): new `SubagentArgs`/`SubagentResult` types, RPC adapter extraction for the `subagent` tool, a `SubagentCard` component with mode/status rendering, and dispatch wiring in `ToolCallCard`. The bulk of the logic is well-structured with strong test coverage (32 new tests), but there is one functional gap in the partial-result path and two minor behavioural issues in the card component.

- **Partial results never populate during running state** (`rpc-event-adapter.ts` line 223): the update handler reads `event.result ?? event.message` instead of `event.partialResult`, so the in-flight per-result rows streamed from the CLI are silently discarded until `tool_execution_end`.
- **`exitCode -1` sentinel shown as error when tool is `done`**: a result item with no exit code info (adapter fills `-1`) that arrives after the tool finishes is mis-classified as `'error'`.
- **`isOpen` not reactive**: the collapsible open state initialises from `tool.status` but never syncs when the prop updates, so a running card won't auto-collapse on completion.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the partial-result lookup fix applied; the running-state UX won't work as intended until then.

One P1 logic gap (partialResult not consulted during updates) means the advertised running-state feedback is a no-op until fixed. The two P2 issues (exitCode sentinel and isOpen reactivity) are minor UX gaps that don't break core functionality. All other changes are clean and well-tested.

apps/desktop/src/main/rpc-event-adapter.ts (line 223) and apps/desktop/src/renderer/components/chat/SubagentCard.tsx (lines 70–78, 179)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/rpc-event-adapter.ts | Adds subagent tool arg/result extraction and wires partialResult into tool_update; however the update handler reads event.result instead of event.partialResult for the subagent case, so running-state partial rows are never populated |
| apps/desktop/src/renderer/components/chat/SubagentCard.tsx | New component rendering subagent tool cards with mode/status badges; isOpen state doesn't react to prop changes and exitCode -1 may be shown as error when the tool is done |
| apps/desktop/src/renderer/components/chat/ToolCallCard.tsx | Adds case 'subagent' dispatch to SubagentCard — minimal, correct change |
| apps/desktop/src/shared/types.ts | Adds SubagentArgs, SubagentTaskItem, SubagentResult, SubagentResultItem types and wires them into ToolArgs/ToolResult unions — clean and well-structured |
| apps/desktop/src/renderer/atoms/chat.ts | tool_update handler wires partialResult into result field for running-state preview — correct and non-breaking |
| apps/desktop/src/main/__tests__/rpc-event-adapter.test.ts | 10 new unit tests for subagent single/parallel/chain modes, success/error/partial paths — thorough coverage |
| apps/desktop/src/renderer/components/chat/__tests__/SubagentCard.test.tsx | 22 component unit tests covering all view-model states; pure logic tests, no DOM rendering |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as CLI (subprocess)
    participant RPC as RpcEventAdapter
    participant Atom as chat.ts atom
    participant Card as SubagentCard

    CLI->>RPC: tool_execution_start {toolName: subagent, args}
    RPC->>Atom: tool_start {toolCallId, args: SubagentArgs}
    Atom->>Card: ToolCallView {status: running}

    loop streaming updates
        CLI->>RPC: tool_execution_update {partialResult: {...}}
        Note over RPC: extracts SubagentResult from<br/>partialResult (P1: currently reads event.result)
        RPC->>Atom: tool_update {partialResult: SubagentResult}
        Atom->>Card: ToolCallView {result: SubagentResult (partial)}
    end

    CLI->>RPC: tool_execution_end {result: SubagentResult}
    RPC->>Atom: tool_end {result: SubagentResult, isError}
    Atom->>Card: ToolCallView {status: done or error, result}
    Note over Card: renders per-result rows<br/>with exit codes and error messages
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/rpc-event-adapter.ts
Line: 223

Comment:
**`event.partialResult` not consulted for subagent updates**

During a `tool_execution_update` the streaming data arrives in `event.partialResult`, not `event.result`. The code falls back to `event.result ?? event.message`, both of which are absent during a running update, so `extractSubagentResult` will always receive `null`/`undefined` and return an empty-results payload — making the in-flight per-result rows never populate until `tool_execution_end`.

```suggestion
            partialResult: toolName === 'subagent' ? this.extractSubagentResult(event.partialResult ?? event.result ?? event.message) : undefined,
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/SubagentCard.tsx
Line: 70-78

Comment:
**`exitCode -1` shown as error when tool is `done`**

If a subagent result item arrives with `exitCode: -1` (the adapter's "not yet available" sentinel) but the outer `toolStatus` is `'done'`, the second branch `item.exitCode !== 0` fires, marking the row as `'error'`. This can happen when a result record is present in the payload but the CLI omitted the exit code field. A finished tool with an unresolved exit code should more defensively default to `'done'` rather than `'error'`.

```suggestion
  const status: 'running' | 'done' | 'error' =
    item.exitCode === -1 && toolStatus === 'running'
      ? 'running'
      : item.exitCode === -1
        ? 'done'
        : item.exitCode !== 0
          ? 'error'
          : 'done'
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/SubagentCard.tsx
Line: 179

Comment:
**`isOpen` not reactive to status changes**

`useState(tool.status !== 'done')` initialises the open state once on mount. When `tool` transitions from `running` → `done`, the card won't auto-collapse because `useState` ignores subsequent changes to its initial argument. If auto-close-on-done is the intended UX (matching how the initial value is derived), a `useEffect` is needed to sync when the tool completes.

```suggestion
  const [isOpen, setIsOpen] = useState(tool.status !== 'done')
  // Auto-collapse when the tool finishes
  useEffect(() => {
    if (tool.status === 'done') setIsOpen(false)
  }, [tool.status])
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(desktop): M007 assembled QoL accept..."](https://github.com/gannonh/kata/commit/dd98dd0bac270140a63038eb72976d2e0867f128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28051186)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->