### PR TITLE
KAT-2516: migrate remaining pre-archive tests to Vitest

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/ --max-warnings=20",
-    "test": "bun test src/"
+    "test": "vitest run"
   },
   "dependencies": {
     "@craft-agent/core": "workspace:*",
@@ -33,6 +33,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.3",
-    "vite": "^8.0.2"
+    "vite": "^8.0.2",
+    "vitest": "^4.1.2"
   }
 }

--- a/apps/viewer/src/__tests__/smoke.test.ts
+++ b/apps/viewer/src/__tests__/smoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect } from "vitest";
 
 describe("viewer", () => {
   test("package.json is valid", async () => {

--- a/apps/viewer/vitest.config.ts
+++ b/apps/viewer/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const viewerSrcDir = fileURLToPath(new URL('./src/', import.meta.url))
+const coreSrcDir = fileURLToPath(new URL('../../packages/core/src/', import.meta.url))
+const uiSrcDir = fileURLToPath(new URL('../../packages/ui/src/', import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: '@', replacement: viewerSrcDir },
+      { find: '@craft-agent/core', replacement: `${coreSrcDir}index.ts` },
+      { find: /^@craft-agent\/core\/(.*)$/, replacement: `${coreSrcDir}$1` },
+      { find: '@craft-agent/ui', replacement: `${uiSrcDir}index.ts` },
+      { find: /^@craft-agent\/ui\/(.*)$/, replacement: `${uiSrcDir}$1` },
+    ],
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,9 +19,10 @@
   "scripts": {
     "lint": "eslint src/ --max-warnings=0",
     "typecheck": "tsc --noEmit",
-    "test": "bun test src/"
+    "test": "vitest run"
   },
   "devDependencies": {
-    "@types/uuid": "^11.0.0"
+    "@types/uuid": "^11.0.0",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect } from "vitest";
 
 describe("core", () => {
   test("package.json is valid", async () => {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -10,7 +10,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "bun test src/__tests__/",
+    "test": "vitest run",
     "samples": "node --import tsx index.ts",
     "dev": "node --import tsx dev.ts",
     "bench": "bun run bench.ts",
@@ -26,6 +26,7 @@
     "chokidar": "^5.0.0",
     "esbuild": "^0.28.0",
     "shiki": "^4.0.2",
-    "tsx": "^4.20.6"
+    "tsx": "^4.20.6",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/mermaid/src/__tests__/ascii.test.ts
+++ b/packages/mermaid/src/__tests__/ascii.test.ts
@@ -7,10 +7,11 @@
  *
  * Test data: 44 ASCII files + 22 Unicode files = 66 total.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { renderMermaidAscii } from '../ascii/index.ts'
 import { readdirSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 // ============================================================================
 // Test case parser — matches Go's testutil.ReadTestCase format
@@ -151,7 +152,7 @@ function runGoldenTests(dir: string, useAscii: boolean): void {
 // Test suites
 // ============================================================================
 
-const testdataDir = join(import.meta.dir, 'testdata')
+const testdataDir = join(dirname(fileURLToPath(import.meta.url)), 'testdata')
 
 describe('ASCII rendering', () => {
   runGoldenTests(join(testdataDir, 'ascii'), true)

--- a/packages/mermaid/src/__tests__/class-arrow-directions.test.ts
+++ b/packages/mermaid/src/__tests__/class-arrow-directions.test.ts
@@ -7,7 +7,7 @@
  * - Composition/Aggregation: diamonds are omnidirectional
  */
 
-import { describe, test, expect } from 'bun:test'
+import { describe, test, expect } from 'vitest'
 import { renderMermaidAscii } from '../ascii/index.ts'
 
 describe('Class Diagram Arrow Directions', () => {

--- a/packages/mermaid/src/__tests__/class-integration.test.ts
+++ b/packages/mermaid/src/__tests__/class-integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration tests for class diagrams — end-to-end parse → layout → render.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { renderMermaid } from '../index.ts'
 
 describe('renderMermaid – class diagrams', () => {

--- a/packages/mermaid/src/__tests__/class-parser.test.ts
+++ b/packages/mermaid/src/__tests__/class-parser.test.ts
@@ -4,7 +4,7 @@
  * Covers: class blocks, attributes, methods, visibility, annotations,
  * relationships (all 6 types), cardinality, labels, inline attributes.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { parseClassDiagram } from '../class/parser.ts'
 
 /** Helper to parse — preprocesses text the same way index.ts does */

--- a/packages/mermaid/src/__tests__/dagre-adapter.test.ts
+++ b/packages/mermaid/src/__tests__/dagre-adapter.test.ts
@@ -4,7 +4,7 @@
  * Verifies that edge endpoints are correctly clipped to node boundaries
  * after orthogonal snapping changes the approach direction.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { clipEndpointsToNodes, snapToOrthogonal, type NodeRect } from '../dagre-adapter.ts'
 
 /** A node centered at (200, 250) with width=120, height=68 (like a class box) */

--- a/packages/mermaid/src/__tests__/er-integration.test.ts
+++ b/packages/mermaid/src/__tests__/er-integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration tests for ER diagrams — end-to-end parse → layout → render.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { renderMermaid } from '../index.ts'
 
 describe('renderMermaid – ER diagrams', () => {

--- a/packages/mermaid/src/__tests__/er-parser.test.ts
+++ b/packages/mermaid/src/__tests__/er-parser.test.ts
@@ -4,7 +4,7 @@
  * Covers: entity definitions, attribute parsing (types, names, keys, comments),
  * relationships with all cardinality types, identifying/non-identifying lines.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { parseErDiagram } from '../er/parser.ts'
 
 /** Helper to parse — preprocesses text the same way index.ts does */

--- a/packages/mermaid/src/__tests__/integration.test.ts
+++ b/packages/mermaid/src/__tests__/integration.test.ts
@@ -7,7 +7,7 @@
  * Covers: original features, Batch 1 (new shapes), Batch 2 (edges, styles),
  * and Batch 3 (state diagrams).
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { renderMermaid } from '../index.ts'
 
 // ============================================================================

--- a/packages/mermaid/src/__tests__/parser.test.ts
+++ b/packages/mermaid/src/__tests__/parser.test.ts
@@ -9,7 +9,7 @@
  *   state aliases, direction override
  * - Comments and error cases
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { parseMermaid } from '../parser.ts'
 
 // ============================================================================

--- a/packages/mermaid/src/__tests__/renderer.test.ts
+++ b/packages/mermaid/src/__tests__/renderer.test.ts
@@ -4,7 +4,7 @@
  * Uses hand-crafted PositionedGraph data to test SVG output without
  * depending on the layout engine.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { renderSvg } from '../renderer.ts'
 import type { DiagramColors } from '../theme.ts'
 import type { PositionedGraph, PositionedNode, PositionedEdge, PositionedGroup } from '../types.ts'

--- a/packages/mermaid/src/__tests__/sequence-integration.test.ts
+++ b/packages/mermaid/src/__tests__/sequence-integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration tests for sequence diagrams — end-to-end parse → layout → render.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { renderMermaid } from '../index.ts'
 
 describe('renderMermaid – sequence diagrams', () => {

--- a/packages/mermaid/src/__tests__/sequence-layout.test.ts
+++ b/packages/mermaid/src/__tests__/sequence-layout.test.ts
@@ -5,7 +5,7 @@
  * These tests call parseSequenceDiagram + layoutSequenceDiagram directly
  * to inspect Y coordinates, rather than checking SVG output.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { parseSequenceDiagram } from '../sequence/parser.ts'
 import { layoutSequenceDiagram } from '../sequence/layout.ts'
 

--- a/packages/mermaid/src/__tests__/sequence-parser.test.ts
+++ b/packages/mermaid/src/__tests__/sequence-parser.test.ts
@@ -4,7 +4,7 @@
  * Covers: participants, actors, messages (solid/dashed, filled/open arrows),
  * activation/deactivation, blocks (loop/alt/opt/par), notes, auto-created actors.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { parseSequenceDiagram } from '../sequence/parser.ts'
 
 /** Helper to parse — preprocesses text the same way index.ts does */

--- a/packages/mermaid/src/__tests__/styles.test.ts
+++ b/packages/mermaid/src/__tests__/styles.test.ts
@@ -2,7 +2,7 @@
  * Tests for styles module — text measurement and constants.
  * Theme resolution tests are in theme.test.ts (CSS custom property system).
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { estimateTextWidth, FONT_SIZES, FONT_WEIGHTS, NODE_PADDING, STROKE_WIDTHS, ARROW_HEAD } from '../styles.ts'
 import { THEMES, DEFAULTS, fromShikiTheme, buildStyleBlock, svgOpenTag } from '../theme.ts'
 import type { DiagramColors } from '../theme.ts'

--- a/packages/mermaid/vitest.config.ts
+++ b/packages/mermaid/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,8 +7,8 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "test": "bun test",
-    "test:watch": "bun test --watch",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
     "lint": "eslint src/ --max-warnings=150",
     "typecheck": "tsc --noEmit"
   },
@@ -74,6 +74,7 @@
     "zod": ">=3.0.0"
   },
   "devDependencies": {
-    "@types/shell-quote": "^1.7.5"
+    "@types/shell-quote": "^1.7.5",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/shared/src/agent/__tests__/daemon-permission.test.ts
+++ b/packages/shared/src/agent/__tests__/daemon-permission.test.ts
@@ -6,7 +6,7 @@
  * via SHIFT+TAB and is intended for background daemon sessions.
  */
 
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { shouldAllowToolInMode } from '../mode-manager.ts'
 import {
   DAEMON_DEFAULT_ALLOWLIST,

--- a/packages/shared/src/agent/__tests__/source-state.test.ts
+++ b/packages/shared/src/agent/__tests__/source-state.test.ts
@@ -7,7 +7,7 @@
  * Bug fix: Sources with authType: "none" were incorrectly showing "needs auth" because
  * the code checked `!isAuthenticated` without first checking if auth is required.
  */
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import { sourceNeedsAuthentication } from '../../sources/credential-manager.ts';
 import type { LoadedSource } from '../../sources/types.ts';
 

--- a/packages/shared/src/agent/__tests__/tool-matching-sdk-fixtures.test.ts
+++ b/packages/shared/src/agent/__tests__/tool-matching-sdk-fixtures.test.ts
@@ -7,7 +7,7 @@
  * the output matches expected AgentEvents.
  */
 
-import { describe, it, expect, beforeEach } from 'bun:test'
+import { describe, it, expect, beforeEach } from 'vitest'
 import {
   ToolIndex,
   extractToolStarts,

--- a/packages/shared/src/agent/__tests__/tool-matching.test.ts
+++ b/packages/shared/src/agent/__tests__/tool-matching.test.ts
@@ -8,7 +8,7 @@
  * Key property under test: same SDK messages → same AgentEvents, regardless of order.
  */
 
-import { describe, it, expect, beforeEach } from 'bun:test'
+import { describe, it, expect, beforeEach } from 'vitest'
 import {
   ToolIndex,
   extractToolStarts,

--- a/packages/shared/src/auth/__tests__/state.test.ts
+++ b/packages/shared/src/auth/__tests__/state.test.ts
@@ -6,7 +6,7 @@
  * - Setup needs derivation from auth state
  * - Migration detection for legacy CLI tokens
  */
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   getSetupNeeds,
   performTokenRefresh,
@@ -194,7 +194,7 @@ describe('performTokenRefresh', () => {
   describe('successful refresh', () => {
     it('should return accessToken on successful refresh', async () => {
       // Mock the refreshClaudeToken import
-      const mockRefresh = mock(async () => ({
+      const mockRefresh = vi.fn(async () => ({
         accessToken: 'new-access-token',
         refreshToken: 'new-refresh-token',
         expiresAt: Date.now() + 3600000,

--- a/packages/shared/src/auth/__tests__/state.test.ts
+++ b/packages/shared/src/auth/__tests__/state.test.ts
@@ -193,18 +193,7 @@ describe('performTokenRefresh', () => {
 
   describe('successful refresh', () => {
     it('should return accessToken on successful refresh', async () => {
-      // Mock the refreshClaudeToken import
-      const mockRefresh = vi.fn(async () => ({
-        accessToken: 'new-access-token',
-        refreshToken: 'new-refresh-token',
-        expiresAt: Date.now() + 3600000,
-      }));
-
-      // We need to test with a real-ish scenario
-      // Since we can't easily mock the import, test the interface
-      const manager = createMockCredentialManager();
-
-      // For this test, we'll verify the TokenResult structure
+      // For this test, verify the TokenResult structure returned on success.
       const successResult: TokenResult = {
         accessToken: 'new-access-token',
       };

--- a/packages/shared/src/auth/__tests__/state.test.ts
+++ b/packages/shared/src/auth/__tests__/state.test.ts
@@ -6,41 +6,14 @@
  * - Setup needs derivation from auth state
  * - Migration detection for legacy CLI tokens
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   getSetupNeeds,
-  performTokenRefresh,
   _resetRefreshMutex,
   type AuthState,
   type TokenResult,
   type MigrationInfo,
 } from '../state.ts';
-
-// ============================================
-// Mock credential manager
-// ============================================
-
-function createMockCredentialManager(initialCreds?: {
-  accessToken: string;
-  refreshToken?: string;
-  expiresAt?: number;
-  source?: 'native' | 'cli';
-}) {
-  let storedCreds = initialCreds;
-
-  return {
-    getClaudeOAuthCredentials: async () => storedCreds ?? null,
-    setClaudeOAuthCredentials: async (creds: {
-      accessToken: string;
-      refreshToken?: string;
-      expiresAt?: number;
-      source?: 'native' | 'cli';
-    }) => {
-      storedCreds = creds;
-    },
-    getApiKey: async () => null,
-  };
-}
 
 // ============================================
 // getSetupNeeds tests (pure function)

--- a/packages/shared/src/channels/__tests__/session-resolver.test.ts
+++ b/packages/shared/src/channels/__tests__/session-resolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from 'vitest';
 import { resolveSessionKey } from '../session-resolver.ts';
 
 describe('resolveSessionKey', () => {

--- a/packages/shared/src/channels/__tests__/slack-adapter.test.ts
+++ b/packages/shared/src/channels/__tests__/slack-adapter.test.ts
@@ -1,42 +1,40 @@
-import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { SlackChannelAdapter } from '../adapters/slack-adapter.ts';
-import type { ChannelConfig, ChannelMessage } from '../types.ts';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SlackChannelAdapter } from '../adapters/slack-adapter.ts'
+import type { ChannelConfig, ChannelMessage } from '../types.ts'
 
-// Mock @slack/web-api
-const mockAuthTest = mock(() =>
-  Promise.resolve({ user_id: 'U_BOT', bot_id: 'B_BOT' }),
-);
-const mockConversationsHistory = mock(() =>
-  Promise.resolve({ messages: [] as Record<string, unknown>[] }),
-);
-const mockChatPostMessage = mock(() => Promise.resolve({ ok: true }));
+type SocketEventHandler = (args: {
+  body: Record<string, string>
+  ack: (response?: Record<string, string>) => Promise<void>
+}) => Promise<void>
 
-mock.module('@slack/web-api', () => ({
+const slackMocks = vi.hoisted(() => ({
+  authTest: vi.fn(() => Promise.resolve({ user_id: 'U_BOT', bot_id: 'B_BOT' })),
+  conversationsHistory: vi.fn(() => Promise.resolve({ messages: [] as Record<string, unknown>[] })),
+  chatPostMessage: vi.fn(() => Promise.resolve({ ok: true })),
+  socketStart: vi.fn(() => Promise.resolve({})),
+  socketDisconnect: vi.fn(() => Promise.resolve()),
+  socketEventHandlers: new Map<string, SocketEventHandler>(),
+}))
+
+vi.mock('@slack/web-api', () => ({
   WebClient: class MockWebClient {
-    auth = { test: mockAuthTest };
-    conversations = { history: mockConversationsHistory };
-    chat = { postMessage: mockChatPostMessage };
+    auth = { test: slackMocks.authTest }
+    conversations = { history: slackMocks.conversationsHistory }
+    chat = { postMessage: slackMocks.chatPostMessage }
     constructor(_token: string, _opts?: unknown) {}
   },
-}));
+}))
 
-// Mock @slack/socket-mode
-type SocketEventHandler = (args: { body: Record<string, string>; ack: (response?: Record<string, string>) => Promise<void> }) => Promise<void>;
-
-const mockSocketStart = mock(() => Promise.resolve({}));
-const mockSocketDisconnect = mock(() => Promise.resolve());
-let socketEventHandlers: Map<string, SocketEventHandler> = new Map();
-
-mock.module('@slack/socket-mode', () => ({
+vi.mock('@slack/socket-mode', () => ({
   SocketModeClient: class MockSocketModeClient {
     constructor(_opts: { appToken: string }) {}
     on(event: string, handler: SocketEventHandler) {
-      socketEventHandlers.set(event, handler);
+      slackMocks.socketEventHandlers.set(event, handler)
     }
-    start = mockSocketStart;
-    disconnect = mockSocketDisconnect;
+    start = slackMocks.socketStart
+    disconnect = slackMocks.socketDisconnect
   },
-}));
+}))
 
 function makeConfig(overrides?: Partial<ChannelConfig>): ChannelConfig {
   return {
@@ -47,7 +45,7 @@ function makeConfig(overrides?: Partial<ChannelConfig>): ChannelConfig {
     credentials: { sourceSlug: 'slack-creds' },
     filter: { channelIds: ['C_GENERAL'], triggerPatterns: [] },
     ...overrides,
-  };
+  }
 }
 
 function makeSlackMessage(overrides: Record<string, unknown> = {}) {
@@ -57,390 +55,372 @@ function makeSlackMessage(overrides: Record<string, unknown> = {}) {
     text: 'hello world',
     team: 'T_TEAM',
     ...overrides,
-  };
+  }
 }
 
 describe('SlackChannelAdapter', () => {
-  let adapter: SlackChannelAdapter;
+  let adapter: SlackChannelAdapter
 
   beforeEach(() => {
-    adapter = new SlackChannelAdapter();
-    mockAuthTest.mockReset();
-    mockAuthTest.mockImplementation(() =>
+    adapter = new SlackChannelAdapter()
+    slackMocks.authTest.mockReset()
+    slackMocks.authTest.mockImplementation(() =>
       Promise.resolve({ user_id: 'U_BOT', bot_id: 'B_BOT' }),
-    );
-    mockConversationsHistory.mockReset();
-    mockConversationsHistory.mockImplementation(() =>
+    )
+    slackMocks.conversationsHistory.mockReset()
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [] as Record<string, unknown>[] }),
-    );
-    mockChatPostMessage.mockReset();
-    mockChatPostMessage.mockImplementation(() => Promise.resolve({ ok: true }));
-    mockSocketStart.mockReset();
-    mockSocketStart.mockImplementation(() => Promise.resolve({}));
-    mockSocketDisconnect.mockReset();
-    mockSocketDisconnect.mockImplementation(() => Promise.resolve());
-    socketEventHandlers = new Map();
-  });
+    )
+    slackMocks.chatPostMessage.mockReset()
+    slackMocks.chatPostMessage.mockImplementation(() => Promise.resolve({ ok: true }))
+    slackMocks.socketStart.mockReset()
+    slackMocks.socketStart.mockImplementation(() => Promise.resolve({}))
+    slackMocks.socketDisconnect.mockReset()
+    slackMocks.socketDisconnect.mockImplementation(() => Promise.resolve())
+    slackMocks.socketEventHandlers = new Map()
+  })
 
   afterEach(async () => {
-    await adapter.stop();
-  });
+    await adapter.stop()
+  })
 
   test('configure() stores client; start() calls auth.test and begins polling', async () => {
-    adapter.configure('xoxb-test-token');
-    const onMessage = mock(() => {});
+    adapter.configure('xoxb-test-token')
+    const onMessage = vi.fn(() => {})
 
-    await adapter.start(makeConfig(), onMessage);
+    await adapter.start(makeConfig(), onMessage)
 
-    expect(mockAuthTest).toHaveBeenCalledTimes(1);
-    expect(adapter.id).toBe('test-slack');
-    expect(adapter.isHealthy()).toBe(true);
-  });
+    expect(slackMocks.authTest).toHaveBeenCalledTimes(1)
+    expect(adapter.id).toBe('test-slack')
+    expect(adapter.isHealthy()).toBe(true)
+  })
 
   test('start() throws if configure() was not called', async () => {
-    const onMessage = mock(() => {});
+    const onMessage = vi.fn(() => {})
     await expect(adapter.start(makeConfig(), onMessage)).rejects.toThrow(
       'configure() must be called before start()',
-    );
-  });
+    )
+  })
 
   test('poll() calls conversations.history with oldest timestamp', async () => {
-    adapter.configure('xoxb-test-token');
-    const msg = makeSlackMessage({ ts: '1700000002.000200' });
-    mockConversationsHistory.mockImplementation(() =>
+    adapter.configure('xoxb-test-token')
+    const msg = makeSlackMessage({ ts: '1700000002.000200' })
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [msg] }),
-    );
+    )
 
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m) => received.push(m));
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m) => received.push(m))
 
-    expect(mockConversationsHistory).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const firstCall = (mockConversationsHistory.mock.calls as any)[0][0] as Record<string, unknown>;
-    expect(firstCall.oldest).toBeUndefined();
-    expect(firstCall.channel).toBe('C_GENERAL');
-    expect(firstCall.inclusive).toBe(false);
-    expect(firstCall.limit).toBe(100);
-  });
+    expect(slackMocks.conversationsHistory).toHaveBeenCalledTimes(1)
+    const firstCall = (slackMocks.conversationsHistory.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0]
+    expect(firstCall.oldest).toBeUndefined()
+    expect(firstCall.channel).toBe('C_GENERAL')
+    expect(firstCall.inclusive).toBe(false)
+    expect(firstCall.limit).toBe(100)
+  })
 
   test('poll() skips messages from bot (bot_id match)', async () => {
-    adapter.configure('xoxb-test-token');
-    const botMsg = makeSlackMessage({ ts: '1700000002.000200', bot_id: 'B_BOT', user: 'U_OTHER' });
-    const humanMsg = makeSlackMessage({ ts: '1700000003.000300', user: 'U_ALICE' });
-    // Slack returns newest-first
-    mockConversationsHistory.mockImplementation(() =>
+    adapter.configure('xoxb-test-token')
+    const botMsg = makeSlackMessage({ ts: '1700000002.000200', bot_id: 'B_BOT', user: 'U_OTHER' })
+    const humanMsg = makeSlackMessage({ ts: '1700000003.000300', user: 'U_ALICE' })
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [humanMsg, botMsg] }),
-    );
+    )
 
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m) => received.push(m));
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m) => received.push(m))
 
-    expect(received).toHaveLength(1);
-    expect(received[0]!.source).toBe('U_ALICE');
-  });
+    expect(received).toHaveLength(1)
+    expect(received[0]!.source).toBe('U_ALICE')
+  })
 
   test('poll() skips messages from bot (user match)', async () => {
-    adapter.configure('xoxb-test-token');
-    const botMsg = makeSlackMessage({ ts: '1700000002.000200', user: 'U_BOT' });
-    const humanMsg = makeSlackMessage({ ts: '1700000003.000300', user: 'U_ALICE' });
-    mockConversationsHistory.mockImplementation(() =>
+    adapter.configure('xoxb-test-token')
+    const botMsg = makeSlackMessage({ ts: '1700000002.000200', user: 'U_BOT' })
+    const humanMsg = makeSlackMessage({ ts: '1700000003.000300', user: 'U_ALICE' })
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [humanMsg, botMsg] }),
-    );
+    )
 
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m) => received.push(m));
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m) => received.push(m))
 
-    expect(received).toHaveLength(1);
-    expect(received[0]!.source).toBe('U_ALICE');
-  });
+    expect(received).toHaveLength(1)
+    expect(received[0]!.source).toBe('U_ALICE')
+  })
 
   test('toChannelMessage correctly maps Slack message fields', async () => {
-    adapter.configure('xoxb-test-token');
+    adapter.configure('xoxb-test-token')
     const msg = makeSlackMessage({
       ts: '1700000010.000100',
       user: 'U_ALICE',
       text: 'test message',
       team: 'T_MYTEAM',
-    });
-    mockConversationsHistory.mockImplementation(() =>
+    })
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [msg] }),
-    );
+    )
 
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m) => received.push(m));
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m) => received.push(m))
 
-    expect(received).toHaveLength(1);
-    const cm = received[0]!;
-    expect(cm.id).toBe('1700000010.000100');
-    expect(cm.channelId).toBe('test-slack');
-    expect(cm.source).toBe('U_ALICE');
-    expect(cm.timestamp).toBeCloseTo(1700000010000.1, 0);
-    expect(cm.content).toBe('test message');
-    expect(cm.metadata).toEqual({ slackChannel: 'C_GENERAL', team: 'T_MYTEAM' });
-    expect(cm.replyTo).toBeUndefined();
-  });
+    expect(received).toHaveLength(1)
+    const cm = received[0]!
+    expect(cm.id).toBe('1700000010.000100')
+    expect(cm.channelId).toBe('test-slack')
+    expect(cm.source).toBe('U_ALICE')
+    expect(cm.timestamp).toBeCloseTo(1700000010000.1, 0)
+    expect(cm.content).toBe('test message')
+    expect(cm.metadata).toEqual({ slackChannel: 'C_GENERAL', team: 'T_MYTEAM' })
+    expect(cm.replyTo).toBeUndefined()
+  })
 
   test('toChannelMessage sets replyTo for threaded messages', async () => {
-    adapter.configure('xoxb-test-token');
+    adapter.configure('xoxb-test-token')
     const msg = makeSlackMessage({
       ts: '1700000020.000200',
       thread_ts: '1700000010.000100',
-    });
-    mockConversationsHistory.mockImplementation(() =>
+    })
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [msg] }),
-    );
+    )
 
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m) => received.push(m));
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m) => received.push(m))
 
-    expect(received).toHaveLength(1);
+    expect(received).toHaveLength(1)
     expect(received[0]!.replyTo).toEqual({
       threadId: '1700000010.000100',
       messageId: '1700000020.000200',
-    });
-  });
+    })
+  })
 
   test('toChannelMessage omits replyTo for non-threaded messages', async () => {
-    adapter.configure('xoxb-test-token');
-    // thread_ts equals ts means it's the thread parent, not a reply
+    adapter.configure('xoxb-test-token')
     const msg = makeSlackMessage({
       ts: '1700000030.000300',
       thread_ts: '1700000030.000300',
-    });
-    mockConversationsHistory.mockImplementation(() =>
+    })
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [msg] }),
-    );
+    )
 
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m) => received.push(m));
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m) => received.push(m))
 
-    expect(received).toHaveLength(1);
-    expect(received[0]!.replyTo).toBeUndefined();
-  });
+    expect(received).toHaveLength(1)
+    expect(received[0]!.replyTo).toBeUndefined()
+  })
 
   test('stop() clears interval and sets healthy to false', async () => {
-    adapter.configure('xoxb-test-token');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('xoxb-test-token')
+    await adapter.start(makeConfig(), () => {})
 
-    expect(adapter.isHealthy()).toBe(true);
+    expect(adapter.isHealthy()).toBe(true)
 
-    await adapter.stop();
+    await adapter.stop()
 
-    expect(adapter.isHealthy()).toBe(false);
-  });
+    expect(adapter.isHealthy()).toBe(false)
+  })
 
   test('isHealthy() returns false after poll error', async () => {
-    adapter.configure('xoxb-test-token');
-    mockConversationsHistory.mockImplementation(() =>
+    adapter.configure('xoxb-test-token')
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.reject(new Error('rate_limited')),
-    );
+    )
 
-    await adapter.start(makeConfig(), () => {});
+    await adapter.start(makeConfig(), () => {})
 
-    expect(adapter.isHealthy()).toBe(false);
-  });
+    expect(adapter.isHealthy()).toBe(false)
+  })
 
   test('getLastError() returns error message after poll failure', async () => {
-    adapter.configure('xoxb-test-token');
-    mockConversationsHistory.mockImplementation(() =>
+    adapter.configure('xoxb-test-token')
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.reject(new Error('channel_not_found')),
-    );
+    )
 
-    await adapter.start(makeConfig(), () => {});
+    await adapter.start(makeConfig(), () => {})
 
-    expect(adapter.getLastError()).toBe('channel_not_found');
-  });
+    expect(adapter.getLastError()).toBe('channel_not_found')
+  })
 
   test('polling state get/set callbacks invoked when provided', async () => {
-    const getState = mock(() => '1700000000.000000');
-    const setState = mock(() => {});
+    const getState = vi.fn(() => '1700000000.000000')
+    const setState = vi.fn(() => {})
 
-    adapter.configure('xoxb-test-token', { get: getState, set: setState });
+    adapter.configure('xoxb-test-token', { get: getState, set: setState })
 
-    const msg = makeSlackMessage({ ts: '1700000050.000500' });
-    mockConversationsHistory.mockImplementation(() =>
+    const msg = makeSlackMessage({ ts: '1700000050.000500' })
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [msg] }),
-    );
+    )
 
-    await adapter.start(makeConfig(), () => {});
+    await adapter.start(makeConfig(), () => {})
 
-    // get called during start for each channelId
-    expect(getState).toHaveBeenCalledWith('test-slack', 'C_GENERAL');
-    // set called after poll with newest timestamp
-    expect(setState).toHaveBeenCalledWith('test-slack', 'C_GENERAL', '1700000050.000500');
-  });
+    expect(getState).toHaveBeenCalledWith('test-slack', 'C_GENERAL')
+    expect(setState).toHaveBeenCalledWith('test-slack', 'C_GENERAL', '1700000050.000500')
+  })
 
   test('messages are delivered in chronological order', async () => {
-    adapter.configure('xoxb-test-token');
-    const msg1 = makeSlackMessage({ ts: '1700000060.000600', text: 'newer' });
-    const msg2 = makeSlackMessage({ ts: '1700000050.000500', text: 'older' });
-    // Slack returns newest-first
-    mockConversationsHistory.mockImplementation(() =>
+    adapter.configure('xoxb-test-token')
+    const msg1 = makeSlackMessage({ ts: '1700000060.000600', text: 'newer' })
+    const msg2 = makeSlackMessage({ ts: '1700000050.000500', text: 'older' })
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [msg1, msg2] }),
-    );
+    )
 
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m) => received.push(m));
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m) => received.push(m))
 
-    expect(received).toHaveLength(2);
-    expect(received[0]!.content).toBe('older');
-    expect(received[1]!.content).toBe('newer');
-  });
+    expect(received).toHaveLength(2)
+    expect(received[0]!.content).toBe('older')
+    expect(received[1]!.content).toBe('newer')
+  })
 
   test('start() throws and sets unhealthy when auth.test() fails', async () => {
-    adapter.configure('xoxb-bad-token');
-    mockAuthTest.mockImplementation(() =>
+    adapter.configure('xoxb-bad-token')
+    slackMocks.authTest.mockImplementation(() =>
       Promise.reject(new Error('invalid_auth')),
-    );
+    )
 
-    const onMessage = mock(() => {});
-    await expect(adapter.start(makeConfig(), onMessage)).rejects.toThrow('invalid_auth');
-    expect(adapter.isHealthy()).toBe(false);
-  });
+    const onMessage = vi.fn(() => {})
+    await expect(adapter.start(makeConfig(), onMessage)).rejects.toThrow('invalid_auth')
+    expect(adapter.isHealthy()).toBe(false)
+  })
 
   test('isHealthy() recovers after successful poll following error', async () => {
-    adapter.configure('xoxb-test-token');
-    // First poll fails
-    mockConversationsHistory.mockImplementationOnce(() =>
+    adapter.configure('xoxb-test-token')
+    slackMocks.conversationsHistory.mockImplementationOnce(() =>
       Promise.reject(new Error('rate_limited')),
-    );
+    )
 
-    await adapter.start(makeConfig(), () => {});
-    expect(adapter.isHealthy()).toBe(false);
+    await adapter.start(makeConfig(), () => {})
+    expect(adapter.isHealthy()).toBe(false)
 
-    // Next poll succeeds (empty messages)
-    mockConversationsHistory.mockImplementation(() =>
+    slackMocks.conversationsHistory.mockImplementation(() =>
       Promise.resolve({ messages: [] as Record<string, unknown>[] }),
-    );
+    )
 
-    // Trigger poll manually via a second start (or directly access poll)
-    // We'll re-configure and start to get a clean poll
-    await adapter.stop();
-    adapter = new SlackChannelAdapter();
-    adapter.configure('xoxb-test-token');
-    mockAuthTest.mockImplementation(() =>
+    await adapter.stop()
+    adapter = new SlackChannelAdapter()
+    adapter.configure('xoxb-test-token')
+    slackMocks.authTest.mockImplementation(() =>
       Promise.resolve({ user_id: 'U_BOT', bot_id: 'B_BOT' }),
-    );
-    await adapter.start(makeConfig(), () => {});
-    expect(adapter.isHealthy()).toBe(true);
-    expect(adapter.getLastError()).toBeNull();
-  });
+    )
+    await adapter.start(makeConfig(), () => {})
+    expect(adapter.isHealthy()).toBe(true)
+    expect(adapter.getLastError()).toBeNull()
+  })
 
   test('adapter name and type are correct', () => {
-    expect(adapter.name).toBe('Slack');
-    expect(adapter.type).toBe('poll');
-  });
+    expect(adapter.name).toBe('Slack')
+    expect(adapter.type).toBe('poll')
+  })
 
   test('send() converts markdown bold to mrkdwn bold', async () => {
-    adapter.configure('xoxb-test-token');
+    adapter.configure('xoxb-test-token')
 
     await adapter.send({
       channelId: 'C_GENERAL',
       content: 'Hello **world**!',
-    });
+    })
 
-    expect(mockChatPostMessage).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const call = (mockChatPostMessage.mock.calls as any)[0][0] as Record<string, unknown>;
-    expect(call.text).toBe('Hello *world*!');
-    expect(call.channel).toBe('C_GENERAL');
-  });
+    expect(slackMocks.chatPostMessage).toHaveBeenCalledTimes(1)
+    const call = (slackMocks.chatPostMessage.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0]
+    expect(call.text).toBe('Hello *world*!')
+    expect(call.channel).toBe('C_GENERAL')
+  })
 
   test('send() converts markdown italic to mrkdwn italic', async () => {
-    adapter.configure('xoxb-test-token');
+    adapter.configure('xoxb-test-token')
 
     await adapter.send({
       channelId: 'C_GENERAL',
       content: 'This is *emphasized* text',
-    });
+    })
 
-    expect(mockChatPostMessage).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const call = (mockChatPostMessage.mock.calls as any)[0][0] as Record<string, unknown>;
-    expect(call.text).toBe('This is _emphasized_ text');
-  });
+    expect(slackMocks.chatPostMessage).toHaveBeenCalledTimes(1)
+    const call = (slackMocks.chatPostMessage.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0]
+    expect(call.text).toBe('This is _emphasized_ text')
+  })
 
   test('send() passes thread_ts for threaded replies', async () => {
-    adapter.configure('xoxb-test-token');
+    adapter.configure('xoxb-test-token')
 
     await adapter.send({
       channelId: 'C_GENERAL',
       content: 'Thread reply',
       threadId: '1700000001.000100',
-    });
+    })
 
-    expect(mockChatPostMessage).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const call = (mockChatPostMessage.mock.calls as any)[0][0] as Record<string, unknown>;
-    expect(call.thread_ts).toBe('1700000001.000100');
-  });
+    expect(slackMocks.chatPostMessage).toHaveBeenCalledTimes(1)
+    const call = (slackMocks.chatPostMessage.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0]
+    expect(call.thread_ts).toBe('1700000001.000100')
+  })
 
   test('send() truncates messages exceeding 39K chars', async () => {
-    adapter.configure('xoxb-test-token');
-    const longContent = 'a'.repeat(40_000);
+    adapter.configure('xoxb-test-token')
+    const longContent = 'a'.repeat(40_000)
 
     await adapter.send({
       channelId: 'C_GENERAL',
       content: longContent,
-    });
+    })
 
-    expect(mockChatPostMessage).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const call = (mockChatPostMessage.mock.calls as any)[0][0] as Record<string, unknown>;
-    const text = call.text as string;
-    expect(text.length).toBeLessThan(40_000);
-    expect(text).toContain('... (response truncated)');
-  });
+    expect(slackMocks.chatPostMessage).toHaveBeenCalledTimes(1)
+    const call = (slackMocks.chatPostMessage.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0]
+    const text = call.text as string
+    expect(text.length).toBeLessThan(40_000)
+    expect(text).toContain('... (response truncated)')
+  })
 
   test('send() does not truncate messages under 39K chars', async () => {
-    adapter.configure('xoxb-test-token');
-    const content = 'a'.repeat(38_000);
+    adapter.configure('xoxb-test-token')
+    const content = 'a'.repeat(38_000)
 
     await adapter.send({
       channelId: 'C_GENERAL',
       content,
-    });
+    })
 
-    expect(mockChatPostMessage).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const call = (mockChatPostMessage.mock.calls as any)[0][0] as Record<string, unknown>;
-    const text = call.text as string;
-    expect(text).not.toContain('... (response truncated)');
-  });
+    expect(slackMocks.chatPostMessage).toHaveBeenCalledTimes(1)
+    const call = (slackMocks.chatPostMessage.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0]
+    const text = call.text as string
+    expect(text).not.toContain('... (response truncated)')
+  })
 
   test('send() throws if not configured', async () => {
     await expect(
       adapter.send({ channelId: 'C_GENERAL', content: 'test' }),
-    ).rejects.toThrow('SlackChannelAdapter not configured');
-  });
-
-  // Socket Mode (slash commands) tests
+    ).rejects.toThrow('SlackChannelAdapter not configured')
+  })
 
   test('start() does NOT create SocketModeClient when no appToken provided', async () => {
-    adapter.configure('xoxb-test-token');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('xoxb-test-token')
+    await adapter.start(makeConfig(), () => {})
 
-    expect(mockSocketStart).not.toHaveBeenCalled();
-    expect(socketEventHandlers.size).toBe(0);
-  });
+    expect(slackMocks.socketStart).not.toHaveBeenCalled()
+    expect(slackMocks.socketEventHandlers.size).toBe(0)
+  })
 
   test('start() creates and starts SocketModeClient when appToken provided', async () => {
-    adapter.configure('xoxb-test-token', undefined, 'xapp-test-app-token');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('xoxb-test-token', undefined, 'xapp-test-app-token')
+    await adapter.start(makeConfig(), () => {})
 
-    expect(mockSocketStart).toHaveBeenCalledTimes(1);
-    expect(socketEventHandlers.has('slash_commands')).toBe(true);
-    expect(adapter.isHealthy()).toBe(true);
-  });
+    expect(slackMocks.socketStart).toHaveBeenCalledTimes(1)
+    expect(slackMocks.socketEventHandlers.has('slash_commands')).toBe(true)
+    expect(adapter.isHealthy()).toBe(true)
+  })
 
   test('slash command handler acknowledges and produces ChannelMessage', async () => {
-    adapter.configure('xoxb-test-token', undefined, 'xapp-test-app-token');
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m) => received.push(m));
+    adapter.configure('xoxb-test-token', undefined, 'xapp-test-app-token')
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m) => received.push(m))
 
-    // Simulate a slash command event
-    const handler = socketEventHandlers.get('slash_commands')!;
-    const ackFn = mock(() => Promise.resolve());
+    const handler = slackMocks.socketEventHandlers.get('slash_commands')!
+    const ackFn = vi.fn(() => Promise.resolve())
     await handler({
       body: {
         trigger_id: 'T123456',
@@ -452,32 +432,29 @@ describe('SlackChannelAdapter', () => {
         response_url: 'https://hooks.slack.com/commands/T_TEAM/resp',
       },
       ack: ackFn,
-    });
+    })
 
-    // Acknowledge was called
-    expect(ackFn).toHaveBeenCalledTimes(1);
-    expect(ackFn).toHaveBeenCalledWith({ text: 'Processing...' });
-
-    // ChannelMessage was produced
-    expect(received).toHaveLength(1);
-    const msg = received[0]!;
-    expect(msg.id).toBe('cmd-T123456');
-    expect(msg.channelId).toBe('test-slack');
-    expect(msg.source).toBe('U_ALICE');
-    expect(msg.content).toBe('/kata ask about the deployment');
-    expect(msg.metadata.command).toBe('/kata');
-    expect(msg.metadata.triggerId).toBe('T123456');
-    expect(msg.metadata.responseUrl).toBe('https://hooks.slack.com/commands/T_TEAM/resp');
-    expect(msg.metadata.slackChannel).toBe('C_GENERAL');
-    expect(msg.metadata.team).toBe('T_TEAM');
-  });
+    expect(ackFn).toHaveBeenCalledTimes(1)
+    expect(ackFn).toHaveBeenCalledWith({ text: 'Processing...' })
+    expect(received).toHaveLength(1)
+    const msg = received[0]!
+    expect(msg.id).toBe('cmd-T123456')
+    expect(msg.channelId).toBe('test-slack')
+    expect(msg.source).toBe('U_ALICE')
+    expect(msg.content).toBe('/kata ask about the deployment')
+    expect(msg.metadata.command).toBe('/kata')
+    expect(msg.metadata.triggerId).toBe('T123456')
+    expect(msg.metadata.responseUrl).toBe('https://hooks.slack.com/commands/T_TEAM/resp')
+    expect(msg.metadata.slackChannel).toBe('C_GENERAL')
+    expect(msg.metadata.team).toBe('T_TEAM')
+  })
 
   test('slash command with no text produces command-only content', async () => {
-    adapter.configure('xoxb-test-token', undefined, 'xapp-test-app-token');
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m) => received.push(m));
+    adapter.configure('xoxb-test-token', undefined, 'xapp-test-app-token')
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m) => received.push(m))
 
-    const handler = socketEventHandlers.get('slash_commands')!;
+    const handler = slackMocks.socketEventHandlers.get('slash_commands')!
     await handler({
       body: {
         trigger_id: 'T789',
@@ -488,31 +465,31 @@ describe('SlackChannelAdapter', () => {
         text: '',
         response_url: 'https://hooks.slack.com/resp',
       },
-      ack: mock(() => Promise.resolve()),
-    });
+      ack: vi.fn(() => Promise.resolve()),
+    })
 
-    expect(received).toHaveLength(1);
-    expect(received[0]!.content).toBe('/kata');
-  });
+    expect(received).toHaveLength(1)
+    expect(received[0]!.content).toBe('/kata')
+  })
 
   test('stop() disconnects SocketModeClient', async () => {
-    adapter.configure('xoxb-test-token', undefined, 'xapp-test-app-token');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('xoxb-test-token', undefined, 'xapp-test-app-token')
+    await adapter.start(makeConfig(), () => {})
 
-    expect(mockSocketStart).toHaveBeenCalledTimes(1);
+    expect(slackMocks.socketStart).toHaveBeenCalledTimes(1)
 
-    await adapter.stop();
+    await adapter.stop()
 
-    expect(mockSocketDisconnect).toHaveBeenCalledTimes(1);
-    expect(adapter.isHealthy()).toBe(false);
-  });
+    expect(slackMocks.socketDisconnect).toHaveBeenCalledTimes(1)
+    expect(adapter.isHealthy()).toBe(false)
+  })
 
   test('stop() does not call disconnect when no socket client', async () => {
-    adapter.configure('xoxb-test-token');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('xoxb-test-token')
+    await adapter.start(makeConfig(), () => {})
 
-    await adapter.stop();
+    await adapter.stop()
 
-    expect(mockSocketDisconnect).not.toHaveBeenCalled();
-  });
-});
+    expect(slackMocks.socketDisconnect).not.toHaveBeenCalled()
+  })
+})

--- a/packages/shared/src/channels/__tests__/trigger-matcher.test.ts
+++ b/packages/shared/src/channels/__tests__/trigger-matcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect } from "vitest";
 import { TriggerMatcher } from "../trigger-matcher.ts";
 
 describe("TriggerMatcher", () => {

--- a/packages/shared/src/channels/__tests__/whatsapp-adapter.test.ts
+++ b/packages/shared/src/channels/__tests__/whatsapp-adapter.test.ts
@@ -1,58 +1,54 @@
-import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
-import type { ChannelConfig, ChannelMessage } from '../types.ts';
-import type { WhatsAppChannelAdapter as WhatsAppType } from '../adapters/whatsapp-adapter.ts';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { ChannelConfig, ChannelMessage } from '../types.ts'
+import type { WhatsAppChannelAdapter as WhatsAppType } from '../adapters/whatsapp-adapter.ts'
 
-// Event handler storage for the mock socket
-type EventHandler = (...args: unknown[]) => void;
-let eventHandlers: Map<string, EventHandler[]>;
-let mockEnd: ReturnType<typeof mock>;
+type EventHandler = (...args: unknown[]) => void
 
-// Mock saveCreds
-const mockSaveCreds = mock(() => Promise.resolve());
+const whatsappMocks = vi.hoisted(() => ({
+  eventHandlers: new Map<string, EventHandler[]>(),
+  end: vi.fn(() => {}),
+  saveCreds: vi.fn(() => Promise.resolve()),
+}))
 
-// Mock Baileys module
-mock.module('@whiskeysockets/baileys', () => {
-  return {
-    default: function makeWASocket() {
-      eventHandlers = new Map();
-      mockEnd = mock(() => {});
-      return {
-        ev: {
-          on(event: string, handler: EventHandler) {
-            const handlers = eventHandlers.get(event) ?? [];
-            handlers.push(handler);
-            eventHandlers.set(event, handlers);
-          },
+vi.mock('@whiskeysockets/baileys', () => ({
+  default: function makeWASocket() {
+    whatsappMocks.eventHandlers = new Map()
+    whatsappMocks.end = vi.fn(() => {})
+    return {
+      ev: {
+        on(event: string, handler: EventHandler) {
+          const handlers = whatsappMocks.eventHandlers.get(event) ?? []
+          handlers.push(handler)
+          whatsappMocks.eventHandlers.set(event, handlers)
         },
-        end: mockEnd,
-      };
-    },
-    useMultiFileAuthState: () =>
-      Promise.resolve({
-        state: { creds: {}, keys: {} },
-        saveCreds: mockSaveCreds,
-      }),
-    makeCacheableSignalKeyStore: (keys: unknown) => keys,
-    DisconnectReason: { loggedOut: 401 },
-  };
-});
-
-mock.module('@hapi/boom', () => ({
-  Boom: class Boom extends Error {
-    output: { statusCode: number };
-    constructor(message?: string, options?: { statusCode?: number }) {
-      super(message);
-      this.output = { statusCode: options?.statusCode ?? 500 };
+      },
+      end: whatsappMocks.end,
     }
   },
-}));
+  useMultiFileAuthState: () =>
+    Promise.resolve({
+      state: { creds: {}, keys: {} },
+      saveCreds: whatsappMocks.saveCreds,
+    }),
+  makeCacheableSignalKeyStore: (keys: unknown) => keys,
+  DisconnectReason: { loggedOut: 401 },
+}))
 
-mock.module('pino', () => ({
+vi.mock('@hapi/boom', () => ({
+  Boom: class Boom extends Error {
+    output: { statusCode: number }
+    constructor(message?: string, options?: { statusCode?: number }) {
+      super(message)
+      this.output = { statusCode: options?.statusCode ?? 500 }
+    }
+  },
+}))
+
+vi.mock('pino', () => ({
   default: () => ({}),
-}));
+}))
 
-// Import after mocks are registered
-const { WhatsAppChannelAdapter } = await import('../adapters/whatsapp-adapter.ts');
+const { WhatsAppChannelAdapter } = await import('../adapters/whatsapp-adapter.ts')
 
 function makeConfig(overrides?: Partial<ChannelConfig>): ChannelConfig {
   return {
@@ -61,57 +57,58 @@ function makeConfig(overrides?: Partial<ChannelConfig>): ChannelConfig {
     adapter: 'whatsapp',
     credentials: { sourceSlug: 'wa-creds' },
     ...overrides,
-  };
+  }
 }
 
 function fireEvent(event: string, ...args: unknown[]) {
-  const handlers = eventHandlers.get(event) ?? [];
+  const handlers = whatsappMocks.eventHandlers.get(event) ?? []
   for (const handler of handlers) {
-    handler(...args);
+    handler(...args)
   }
 }
 
 describe('WhatsAppChannelAdapter', () => {
-  let adapter: WhatsAppType;
+  let adapter: WhatsAppType
 
   beforeEach(() => {
-    adapter = new WhatsAppChannelAdapter();
-    mockSaveCreds.mockClear();
-  });
+    adapter = new WhatsAppChannelAdapter()
+    whatsappMocks.saveCreds.mockClear()
+    whatsappMocks.eventHandlers = new Map()
+  })
 
   afterEach(async () => {
-    await adapter.stop();
-  });
+    await adapter.stop()
+  })
 
   test('adapter name and type are correct', () => {
-    expect(adapter.name).toBe('WhatsApp');
-    expect(adapter.type).toBe('subscribe');
-  });
+    expect(adapter.name).toBe('WhatsApp')
+    expect(adapter.type).toBe('subscribe')
+  })
 
   test('start() throws if configure() was not called', async () => {
-    const onMessage = mock(() => {});
+    const onMessage = vi.fn(() => {})
     await expect(adapter.start(makeConfig(), onMessage)).rejects.toThrow(
       'configure() must be called before start()',
-    );
-  });
+    )
+  })
 
   test('start() creates socket with auth state but is not healthy until connection opens', async () => {
-    adapter.configure('/tmp/test-auth');
-    const onMessage = mock(() => {});
+    adapter.configure('/tmp/test-auth')
+    const onMessage = vi.fn(() => {})
 
-    await adapter.start(makeConfig(), onMessage);
+    await adapter.start(makeConfig(), onMessage)
 
-    expect(adapter.id).toBe('test-whatsapp');
-    expect(adapter.isHealthy()).toBe(false);
-    expect(eventHandlers.has('connection.update')).toBe(true);
-    expect(eventHandlers.has('messages.upsert')).toBe(true);
-    expect(eventHandlers.has('creds.update')).toBe(true);
-  });
+    expect(adapter.id).toBe('test-whatsapp')
+    expect(adapter.isHealthy()).toBe(false)
+    expect(whatsappMocks.eventHandlers.has('connection.update')).toBe(true)
+    expect(whatsappMocks.eventHandlers.has('messages.upsert')).toBe(true)
+    expect(whatsappMocks.eventHandlers.has('creds.update')).toBe(true)
+  })
 
   test('messages.upsert handler skips fromMe messages', async () => {
-    adapter.configure('/tmp/test-auth');
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m));
+    adapter.configure('/tmp/test-auth')
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m))
 
     fireEvent('messages.upsert', {
       type: 'notify',
@@ -122,15 +119,15 @@ describe('WhatsAppChannelAdapter', () => {
           messageTimestamp: 1700000001,
         },
       ],
-    });
+    })
 
-    expect(received).toHaveLength(0);
-  });
+    expect(received).toHaveLength(0)
+  })
 
   test('messages.upsert handler skips messages without content', async () => {
-    adapter.configure('/tmp/test-auth');
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m));
+    adapter.configure('/tmp/test-auth')
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m))
 
     fireEvent('messages.upsert', {
       type: 'notify',
@@ -141,15 +138,15 @@ describe('WhatsAppChannelAdapter', () => {
           messageTimestamp: 1700000001,
         },
       ],
-    });
+    })
 
-    expect(received).toHaveLength(0);
-  });
+    expect(received).toHaveLength(0)
+  })
 
   test('messages.upsert handler skips non-notify type', async () => {
-    adapter.configure('/tmp/test-auth');
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m));
+    adapter.configure('/tmp/test-auth')
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m))
 
     fireEvent('messages.upsert', {
       type: 'append',
@@ -160,15 +157,15 @@ describe('WhatsAppChannelAdapter', () => {
           messageTimestamp: 1700000001,
         },
       ],
-    });
+    })
 
-    expect(received).toHaveLength(0);
-  });
+    expect(received).toHaveLength(0)
+  })
 
   test('messages.upsert handler converts conversation text to ChannelMessage', async () => {
-    adapter.configure('/tmp/test-auth');
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m));
+    adapter.configure('/tmp/test-auth')
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m))
 
     fireEvent('messages.upsert', {
       type: 'notify',
@@ -179,23 +176,23 @@ describe('WhatsAppChannelAdapter', () => {
           messageTimestamp: 1700000010,
         },
       ],
-    });
+    })
 
-    expect(received).toHaveLength(1);
-    const cm = received[0]!;
-    expect(cm.id).toBe('msg-42');
-    expect(cm.channelId).toBe('test-whatsapp');
-    expect(cm.source).toBe('5551234@s.whatsapp.net');
-    expect(cm.timestamp).toBe(1700000010000);
-    expect(cm.content).toBe('hello from whatsapp');
-    expect(cm.metadata).toEqual({ jid: '5551234@s.whatsapp.net', participant: undefined });
-    expect(cm.replyTo).toBeUndefined();
-  });
+    expect(received).toHaveLength(1)
+    const cm = received[0]!
+    expect(cm.id).toBe('msg-42')
+    expect(cm.channelId).toBe('test-whatsapp')
+    expect(cm.source).toBe('5551234@s.whatsapp.net')
+    expect(cm.timestamp).toBe(1700000010000)
+    expect(cm.content).toBe('hello from whatsapp')
+    expect(cm.metadata).toEqual({ jid: '5551234@s.whatsapp.net', participant: undefined })
+    expect(cm.replyTo).toBeUndefined()
+  })
 
   test('messages.upsert handler extracts text from extendedTextMessage', async () => {
-    adapter.configure('/tmp/test-auth');
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m));
+    adapter.configure('/tmp/test-auth')
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m))
 
     fireEvent('messages.upsert', {
       type: 'notify',
@@ -211,24 +208,23 @@ describe('WhatsAppChannelAdapter', () => {
           messageTimestamp: 1700000020,
         },
       ],
-    });
+    })
 
-    expect(received).toHaveLength(1);
-    const cm = received[0]!;
-    expect(cm.content).toBe('extended text content');
-    expect(cm.metadata).toEqual({ jid: '5559999@s.whatsapp.net', participant: 'part-1' });
+    expect(received).toHaveLength(1)
+    const cm = received[0]!
+    expect(cm.content).toBe('extended text content')
+    expect(cm.metadata).toEqual({ jid: '5559999@s.whatsapp.net', participant: 'part-1' })
     expect(cm.replyTo).toEqual({
       threadId: '5559999@s.whatsapp.net',
       messageId: 'reply-to-msg-50',
-    });
-  });
+    })
+  })
 
   test('messages.upsert handler skips messages with no text', async () => {
-    adapter.configure('/tmp/test-auth');
-    const received: ChannelMessage[] = [];
-    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m));
+    adapter.configure('/tmp/test-auth')
+    const received: ChannelMessage[] = []
+    await adapter.start(makeConfig(), (m: ChannelMessage) => received.push(m))
 
-    // Message with an image but no text
     fireEvent('messages.upsert', {
       type: 'notify',
       messages: [
@@ -238,98 +234,92 @@ describe('WhatsAppChannelAdapter', () => {
           messageTimestamp: 1700000030,
         },
       ],
-    });
+    })
 
-    expect(received).toHaveLength(0);
-  });
+    expect(received).toHaveLength(0)
+  })
 
   test('connection.update handler sets healthy on open', async () => {
-    adapter.configure('/tmp/test-auth');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('/tmp/test-auth')
+    await adapter.start(makeConfig(), () => {})
 
-    // Simulate connection open
-    fireEvent('connection.update', { connection: 'open' });
+    fireEvent('connection.update', { connection: 'open' })
 
-    expect(adapter.isHealthy()).toBe(true);
-    expect(adapter.getLastError()).toBeNull();
-  });
+    expect(adapter.isHealthy()).toBe(true)
+    expect(adapter.getLastError()).toBeNull()
+  })
 
   test('connection.update handler sets unhealthy on close', async () => {
-    adapter.configure('/tmp/test-auth');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('/tmp/test-auth')
+    await adapter.start(makeConfig(), () => {})
 
-    // Simulate close with loggedOut reason (no reconnect)
-    const error = new Error('logged out');
-    (error as any).output = { statusCode: 401 };
+    const error = new Error('logged out') as Error & { output?: { statusCode: number } }
+    error.output = { statusCode: 401 }
     fireEvent('connection.update', {
       connection: 'close',
       lastDisconnect: { error },
-    });
+    })
 
-    expect(adapter.isHealthy()).toBe(false);
-    expect(adapter.getLastError()).toBe('logged out');
-  });
+    expect(adapter.isHealthy()).toBe(false)
+    expect(adapter.getLastError()).toBe('logged out')
+  })
 
   test('connection.update close with non-logout triggers reconnect attempt', async () => {
-    adapter.configure('/tmp/test-auth');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('/tmp/test-auth')
+    await adapter.start(makeConfig(), () => {})
 
-    // Simulate connection open first
-    fireEvent('connection.update', { connection: 'open' });
-    expect(adapter.isHealthy()).toBe(true);
+    fireEvent('connection.update', { connection: 'open' })
+    expect(adapter.isHealthy()).toBe(true)
 
-    // Simulate close with non-logout status code (should reconnect)
-    const error = new Error('connection lost');
-    (error as any).output = { statusCode: 500 };
+    const error = new Error('connection lost') as Error & { output?: { statusCode: number } }
+    error.output = { statusCode: 500 }
     fireEvent('connection.update', {
       connection: 'close',
       lastDisconnect: { error },
-    });
+    })
 
-    expect(adapter.isHealthy()).toBe(false);
-    expect(adapter.getLastError()).toBe('connection lost');
-    // Socket end should have been called to clean up old socket
-    expect(mockEnd).toHaveBeenCalled();
-  });
+    expect(adapter.isHealthy()).toBe(false)
+    expect(adapter.getLastError()).toBe('connection lost')
+    expect(whatsappMocks.end).toHaveBeenCalled()
+  })
 
   test('connection.update handler invokes QR callback', async () => {
-    const qrData: string[] = [];
-    adapter.configure('/tmp/test-auth', (qr: string) => qrData.push(qr));
-    await adapter.start(makeConfig(), () => {});
+    const qrData: string[] = []
+    adapter.configure('/tmp/test-auth', (qr: string) => qrData.push(qr))
+    await adapter.start(makeConfig(), () => {})
 
-    fireEvent('connection.update', { qr: 'QR_CODE_DATA_HERE' });
+    fireEvent('connection.update', { qr: 'QR_CODE_DATA_HERE' })
 
-    expect(qrData).toHaveLength(1);
-    expect(qrData[0]).toBe('QR_CODE_DATA_HERE');
-  });
+    expect(qrData).toHaveLength(1)
+    expect(qrData[0]).toBe('QR_CODE_DATA_HERE')
+  })
 
   test('creds.update handler calls saveCreds', async () => {
-    adapter.configure('/tmp/test-auth');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('/tmp/test-auth')
+    await adapter.start(makeConfig(), () => {})
 
-    fireEvent('creds.update');
+    fireEvent('creds.update')
 
-    expect(mockSaveCreds).toHaveBeenCalledTimes(1);
-  });
+    expect(whatsappMocks.saveCreds).toHaveBeenCalledTimes(1)
+  })
 
   test('stop() calls end and sets healthy to false', async () => {
-    adapter.configure('/tmp/test-auth');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('/tmp/test-auth')
+    await adapter.start(makeConfig(), () => {})
 
-    // Simulate connection open to set healthy
-    fireEvent('connection.update', { connection: 'open' });
-    expect(adapter.isHealthy()).toBe(true);
+    fireEvent('connection.update', { connection: 'open' })
+    expect(adapter.isHealthy()).toBe(true)
 
-    await adapter.stop();
+    await adapter.stop()
 
-    expect(adapter.isHealthy()).toBe(false);
-    expect(mockEnd).toHaveBeenCalledTimes(1);
-  });
+    expect(adapter.isHealthy()).toBe(false)
+    expect(whatsappMocks.end).toHaveBeenCalledTimes(1)
+  })
 
   test('getLastError() returns null when healthy', async () => {
-    adapter.configure('/tmp/test-auth');
-    await adapter.start(makeConfig(), () => {});
+    adapter.configure('/tmp/test-auth')
+    await adapter.start(makeConfig(), () => {})
 
-    expect(adapter.getLastError()).toBeNull();
-  });
-});
+    expect(adapter.getLastError()).toBeNull()
+  })
+})

--- a/packages/shared/src/channels/__tests__/whatsapp-adapter.test.ts
+++ b/packages/shared/src/channels/__tests__/whatsapp-adapter.test.ts
@@ -265,22 +265,33 @@ describe('WhatsAppChannelAdapter', () => {
   })
 
   test('connection.update close with non-logout triggers reconnect attempt', async () => {
-    adapter.configure('/tmp/test-auth')
-    await adapter.start(makeConfig(), () => {})
+    vi.useFakeTimers()
 
-    fireEvent('connection.update', { connection: 'open' })
-    expect(adapter.isHealthy()).toBe(true)
+    try {
+      adapter.configure('/tmp/test-auth')
+      await adapter.start(makeConfig(), () => {})
 
-    const error = new Error('connection lost') as Error & { output?: { statusCode: number } }
-    error.output = { statusCode: 500 }
-    fireEvent('connection.update', {
-      connection: 'close',
-      lastDisconnect: { error },
-    })
+      fireEvent('connection.update', { connection: 'open' })
+      expect(adapter.isHealthy()).toBe(true)
 
-    expect(adapter.isHealthy()).toBe(false)
-    expect(adapter.getLastError()).toBe('connection lost')
-    expect(whatsappMocks.end).toHaveBeenCalled()
+      const socketEnd = whatsappMocks.end
+      const error = new Error('connection lost') as Error & { output?: { statusCode: number } }
+      error.output = { statusCode: 500 }
+      fireEvent('connection.update', {
+        connection: 'close',
+        lastDisconnect: { error },
+      })
+
+      expect(socketEnd).toHaveBeenCalledTimes(1)
+
+      await vi.runOnlyPendingTimersAsync()
+
+      expect(adapter.isHealthy()).toBe(false)
+      expect(adapter.getLastError()).toBe('connection lost')
+      expect(whatsappMocks.eventHandlers.has('connection.update')).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('connection.update handler invokes QR callback', async () => {

--- a/packages/shared/src/config/__tests__/preferences.test.ts
+++ b/packages/shared/src/config/__tests__/preferences.test.ts
@@ -9,7 +9,7 @@
  * Note: These are pure unit tests that test the merging logic directly,
  * without file I/O, to ensure test isolation.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import type { UserPreferences, MessageDisplayPreferences, DiffViewerPreferences } from '../preferences'
 
 // ============================================================================

--- a/packages/shared/src/git/__tests__/git-service.test.ts
+++ b/packages/shared/src/git/__tests__/git-service.test.ts
@@ -7,7 +7,7 @@
  * - Error handling and graceful degradation
  * - Detached HEAD state detection
  */
-import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test'
+import { describe, it, expect, afterEach } from 'vitest'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { mkdirSync, rmSync, writeFileSync } from 'fs'

--- a/packages/shared/src/git/__tests__/pr-service.test.ts
+++ b/packages/shared/src/git/__tests__/pr-service.test.ts
@@ -9,39 +9,34 @@
  * - getPrStatus returns null silently for non-git directories
  * - Unexpected errors are logged and return null
  */
-import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 import type { PrInfo } from '../types'
 
-// ============================================
-// Mock setup
-// ============================================
+const prMocks = vi.hoisted(() => ({
+  execResult: {} as { stdout?: string; error?: Error & { code?: string; stderr?: string } },
+}))
 
-// Mock result storage - updated by tests before each call
-let mockExecResult: { stdout?: string; error?: Error & { code?: string; stderr?: string } } = {}
-
-// Mock the child_process module before importing getPrStatus
-mock.module('node:child_process', () => ({
+vi.mock('node:child_process', () => ({
   execFile: (
     _cmd: string,
     _args: string[],
     _opts: object,
-    callback: (error: Error | null, result: { stdout: string; stderr: string }) => void
+    callback: (error: Error | null, result: { stdout: string; stderr: string }) => void,
   ) => {
-    if (mockExecResult.error) {
-      callback(mockExecResult.error, { stdout: '', stderr: mockExecResult.error.stderr || '' })
-    } else {
-      callback(null, { stdout: mockExecResult.stdout || '', stderr: '' })
+    if (prMocks.execResult.error) {
+      callback(prMocks.execResult.error, {
+        stdout: '',
+        stderr: prMocks.execResult.error.stderr || '',
+      })
+      return
     }
+
+    callback(null, { stdout: prMocks.execResult.stdout || '', stderr: '' })
   },
 }))
 
-// Import after mocking
 const { getPrStatus } = await import('../pr-service')
-
-// ============================================
-// Test utilities
-// ============================================
 
 function createValidPrInfo(): PrInfo {
   return {
@@ -60,20 +55,15 @@ function createError(code: string, stderr: string): Error & { code: string; stde
   return error
 }
 
-// ============================================
-// getPrStatus tests
-// ============================================
-
 describe('getPrStatus', () => {
   beforeEach(() => {
-    // Reset mock state before each test
-    mockExecResult = {}
+    prMocks.execResult = {}
   })
 
   describe('success path', () => {
     it('should return PrInfo when gh CLI returns valid JSON', async () => {
       const expectedPrInfo = createValidPrInfo()
-      mockExecResult = { stdout: JSON.stringify(expectedPrInfo) }
+      prMocks.execResult = { stdout: JSON.stringify(expectedPrInfo) }
 
       const result = await getPrStatus('/some/repo/path')
 
@@ -88,7 +78,7 @@ describe('getPrStatus', () => {
         isDraft: true,
         url: 'https://github.com/example/project/pull/123',
       }
-      mockExecResult = { stdout: JSON.stringify(prInfo) }
+      prMocks.execResult = { stdout: JSON.stringify(prInfo) }
 
       const result = await getPrStatus('/path/to/repo')
 
@@ -108,7 +98,7 @@ describe('getPrStatus', () => {
         isDraft: false,
         url: 'https://github.com/org/repo/pull/99',
       }
-      mockExecResult = { stdout: JSON.stringify(prInfo) }
+      prMocks.execResult = { stdout: JSON.stringify(prInfo) }
 
       const result = await getPrStatus('/repo')
 
@@ -119,7 +109,7 @@ describe('getPrStatus', () => {
 
   describe('ENOENT (gh not installed)', () => {
     it('should return null when gh CLI is not installed', async () => {
-      mockExecResult = { error: createError('ENOENT', '') }
+      prMocks.execResult = { error: createError('ENOENT', '') }
 
       const result = await getPrStatus('/some/path')
 
@@ -127,9 +117,8 @@ describe('getPrStatus', () => {
     })
 
     it('should not throw when gh CLI is not found', async () => {
-      mockExecResult = { error: createError('ENOENT', 'spawn gh ENOENT') }
+      prMocks.execResult = { error: createError('ENOENT', 'spawn gh ENOENT') }
 
-      // Should not throw
       const result = await getPrStatus('/some/path')
       expect(result).toBeNull()
     })
@@ -137,7 +126,7 @@ describe('getPrStatus', () => {
 
   describe('no PR found', () => {
     it('should return null when no pull requests found for branch', async () => {
-      mockExecResult = {
+      prMocks.execResult = {
         error: createError('1', 'no pull requests found for branch "feature-x"'),
       }
 
@@ -147,7 +136,7 @@ describe('getPrStatus', () => {
     })
 
     it('should return null when could not resolve to PullRequest', async () => {
-      mockExecResult = {
+      prMocks.execResult = {
         error: createError('1', 'Could not resolve to a PullRequest with the number 999'),
       }
 
@@ -159,7 +148,7 @@ describe('getPrStatus', () => {
 
   describe('not authenticated', () => {
     it('should return null when gh is not logged in', async () => {
-      mockExecResult = {
+      prMocks.execResult = {
         error: createError('1', 'You are not logged into any GitHub hosts. Run gh auth login to authenticate.'),
       }
 
@@ -169,7 +158,7 @@ describe('getPrStatus', () => {
     })
 
     it('should return null when authentication required message appears', async () => {
-      mockExecResult = {
+      prMocks.execResult = {
         error: createError('1', 'authentication required for this operation'),
       }
 
@@ -181,8 +170,8 @@ describe('getPrStatus', () => {
 
   describe('not a git repository', () => {
     it('should return null silently for non-git directory', async () => {
-      const consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
-      mockExecResult = {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      prMocks.execResult = {
         error: createError('1', 'failed to run git: fatal: not a git repository (or any of the parent directories): .git\n'),
       }
 
@@ -195,10 +184,10 @@ describe('getPrStatus', () => {
   })
 
   describe('unexpected errors', () => {
-    let consoleErrorSpy: ReturnType<typeof spyOn>
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
-      consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+      consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     })
 
     afterEach(() => {
@@ -206,7 +195,7 @@ describe('getPrStatus', () => {
     })
 
     it('should return null and log error for unexpected errors', async () => {
-      mockExecResult = {
+      prMocks.execResult = {
         error: createError('UNKNOWN', 'Something completely unexpected happened'),
       }
 
@@ -214,32 +203,31 @@ describe('getPrStatus', () => {
 
       expect(result).toBeNull()
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
-      expect(consoleErrorSpy.mock.calls[0][0]).toContain('[PrService] Unexpected error')
+      expect(consoleErrorSpy.mock.calls[0]?.[0]).toContain('[PrService] Unexpected error')
     })
 
     it('should include dirPath in error log', async () => {
-      mockExecResult = {
+      prMocks.execResult = {
         error: createError('ETIMEOUT', 'Connection timed out'),
       }
 
       await getPrStatus('/specific/repo/path')
 
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
-      const loggedObject = consoleErrorSpy.mock.calls[0][1]
+      const loggedObject = consoleErrorSpy.mock.calls[0]?.[1] as { dirPath: string }
       expect(loggedObject.dirPath).toBe('/specific/repo/path')
     })
 
     it('should truncate long stderr in error log', async () => {
       const longStderr = 'x'.repeat(300)
-      mockExecResult = {
+      prMocks.execResult = {
         error: createError('UNKNOWN', longStderr),
       }
 
       await getPrStatus('/repo')
 
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
-      const loggedObject = consoleErrorSpy.mock.calls[0][1]
-      // stderr should be truncated to 200 chars
+      const loggedObject = consoleErrorSpy.mock.calls[0]?.[1] as { stderr: string }
       expect(loggedObject.stderr.length).toBe(200)
     })
   })

--- a/packages/shared/src/plugins/__tests__/plugin-manager.test.ts
+++ b/packages/shared/src/plugins/__tests__/plugin-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { PluginManager } from '../plugin-manager.ts';
 import { SlackChannelAdapter } from '../../channels/adapters/slack-adapter.ts';
 import { WhatsAppChannelAdapter } from '../../channels/adapters/whatsapp-adapter.ts';

--- a/packages/shared/src/prompts/__tests__/git-context.test.ts
+++ b/packages/shared/src/prompts/__tests__/git-context.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test'
+import { describe, test, expect } from 'vitest'
 import { formatGitContext } from '../system'
 
 describe('formatGitContext', () => {

--- a/packages/shared/src/prompts/__tests__/lifecycle.test.ts
+++ b/packages/shared/src/prompts/__tests__/lifecycle.test.ts
@@ -1,10 +1,11 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
 import { mkdirSync, rmSync } from 'fs'
-import { join } from 'path'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
 import { formatSessionLifecycleContext } from '../lifecycle'
 import { getBundledAssetsDir } from '../../utils/paths'
 
-const TEST_WORKSPACE = join(import.meta.dir, '__fixtures__', 'test-workspace')
+const TEST_WORKSPACE = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'test-workspace')
 
 // Bundled system-skills assets are only available inside a built Electron app
 // or when process.cwd() matches the monorepo root. Skip when unavailable.

--- a/packages/shared/src/prompts/__tests__/template-loader.test.ts
+++ b/packages/shared/src/prompts/__tests__/template-loader.test.ts
@@ -1,10 +1,11 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
 import { mkdirSync, writeFileSync, rmSync } from 'fs'
-import { join, resolve } from 'path'
+import { join, resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
 import { loadPromptTemplates, interpolateVariables, clearTemplateCache } from '../template-loader'
 import { DOC_REFS } from '../../docs/index.ts'
 
-const TEST_DIR = join(import.meta.dir, '__fixtures__', 'templates')
+const TEST_DIR = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'templates')
 
 beforeEach(() => {
   clearTemplateCache()
@@ -105,7 +106,7 @@ describe('loadPromptTemplates', () => {
 })
 
 describe('production templates', () => {
-  const templatesDir = resolve(import.meta.dir, '..', '..', '..', 'assets', 'prompt-templates')
+  const templatesDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'assets', 'prompt-templates')
 
   test('loads all production template sections', () => {
     clearTemplateCache()

--- a/packages/shared/src/sessions/__tests__/hierarchy.test.ts
+++ b/packages/shared/src/sessions/__tests__/hierarchy.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'bun:test'
+import { expect, test } from 'vitest'
 import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'

--- a/packages/shared/src/sources/__tests__/authScheme-empty.test.ts
+++ b/packages/shared/src/sources/__tests__/authScheme-empty.test.ts
@@ -5,7 +5,7 @@
  * the production code behaves correctly.
  */
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import { buildAuthorizationHeader } from '../api-tools.ts';
 
 describe('buildAuthorizationHeader', () => {

--- a/packages/shared/src/sources/__tests__/basic-auth.test.ts
+++ b/packages/shared/src/sources/__tests__/basic-auth.test.ts
@@ -10,7 +10,7 @@
  * 3. api-tools.ts encodes at request time: Buffer.from(`${username}:${password}`).toString('base64')
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from 'vitest';
 
 // Type definitions matching the actual code
 interface BasicAuthCredential {

--- a/packages/shared/src/sources/__tests__/server-builder-authScheme.test.ts
+++ b/packages/shared/src/sources/__tests__/server-builder-authScheme.test.ts
@@ -5,7 +5,7 @@
  * which transforms source configs before they reach buildAuthorizationHeader.
  */
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import { SourceServerBuilder } from '../server-builder.ts';
 import type { LoadedSource } from '../types.ts';
 

--- a/packages/shared/src/utils/__tests__/cli-icon-resolver.test.ts
+++ b/packages/shared/src/utils/__tests__/cli-icon-resolver.test.ts
@@ -8,7 +8,7 @@
  * - resolveToolIcon: end-to-end resolution with config and icon files
  */
 
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -309,7 +309,7 @@ describe('resolveToolIcon', () => {
     const result = resolveToolIcon('git status', testDir);
     expect(result).toBeDefined();
     expect(result!.displayName).toBe('Git');
-    expect(result!.iconDataUrl).toStartWith('data:image/png;base64,');
+    expect(result!.iconDataUrl).toMatch(/^data:image\/png;base64,/);
   });
 
   test('resolves npm command', () => {
@@ -376,6 +376,6 @@ describe('resolveToolIcon', () => {
     expect(result).toBeDefined();
     expect(result!.displayName).toBe('Git');
     expect(result!.id).toBe('git');
-    expect(result!.iconDataUrl).toStartWith('data:image/');
+    expect(result!.iconDataUrl).toMatch(/^data:image\//);
   });
 });

--- a/packages/shared/src/workspaces/__tests__/system-skills.test.ts
+++ b/packages/shared/src/workspaces/__tests__/system-skills.test.ts
@@ -1,10 +1,11 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
 import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
 import { seedSystemSkills } from '../storage'
 import { getBundledAssetsDir } from '../../utils/paths'
 
-const TEST_WORKSPACE = join(import.meta.dir, '__fixtures__', 'test-ws')
+const TEST_WORKSPACE = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'test-ws')
 
 // Bundled system-skills assets are only available inside a built Electron app
 // or when process.cwd() matches the monorepo root. Skip when unavailable.

--- a/packages/shared/tests/content-validators.test.ts
+++ b/packages/shared/tests/content-validators.test.ts
@@ -2,7 +2,7 @@
  * Tests for content-based config validators used by PreToolUse hook.
  * These validators check file content in memory before it reaches disk.
  */
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import {
   validateSourceConfigContent,
   validateSkillContent,

--- a/packages/shared/tests/mode-manager.test.ts
+++ b/packages/shared/tests/mode-manager.test.ts
@@ -4,7 +4,7 @@
  * These tests verify that dangerous shell commands are blocked in Safe (Explore) mode
  * while legitimate read-only commands are allowed.
  */
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import {
   hasDangerousShellOperators,
   hasDangerousSubstitution,

--- a/packages/shared/tests/models.test.ts
+++ b/packages/shared/tests/models.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for model detection utilities in config/models.ts
  */
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect } from "vitest";
 import {
   isClaudeModel,
   isOpusModel,

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const coreSrcDir = fileURLToPath(new URL('../core/src/', import.meta.url))
+const mermaidSrcDir = fileURLToPath(new URL('../mermaid/src/', import.meta.url))
+const sharedSrcDir = fileURLToPath(new URL('./src/', import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: '@craft-agent/core', replacement: `${coreSrcDir}index.ts` },
+      { find: /^@craft-agent\/core\/(.*)$/, replacement: `${coreSrcDir}$1` },
+      { find: '@craft-agent/mermaid', replacement: `${mermaidSrcDir}index.ts` },
+      { find: /^@craft-agent\/mermaid\/(.*)$/, replacement: `${mermaidSrcDir}$1` },
+      { find: '@craft-agent/shared', replacement: `${sharedSrcDir}index.ts` },
+      { find: /^@craft-agent\/shared\/(.*)$/, replacement: `${sharedSrcDir}$1` },
+    ],
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
+  },
+})

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "lint": "eslint src/ --max-warnings=50",
     "typecheck": "tsc --noEmit",
-    "test": "bun test src/"
+    "test": "vitest run"
   },
   "dependencies": {
     "@craft-agent/core": "workspace:*",
@@ -51,7 +51,8 @@
     "tailwindcss": ">=4.0.0"
   },
   "devDependencies": {
-    "react-pdf": "^10.4.1"
+    "react-pdf": "^10.4.1",
+    "vitest": "^4.1.2"
   },
   "peerDependenciesMeta": {
     "@radix-ui/react-context-menu": {

--- a/packages/ui/src/components/chat/__tests__/response-card-expand.test.ts
+++ b/packages/ui/src/components/chat/__tests__/response-card-expand.test.ts
@@ -8,7 +8,7 @@
  * - Default value handling
  */
 
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 
 // ============================================================================
 // Constants (mirrored from TurnCard.tsx)

--- a/packages/ui/src/components/chat/__tests__/turn-lifecycle.test.ts
+++ b/packages/ui/src/components/chat/__tests__/turn-lifecycle.test.ts
@@ -6,7 +6,7 @@
  * handles all common use cases.
  */
 
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { deriveTurnPhase, finalizeTurnsForIdleSession, groupMessagesByTurn, type AssistantTurn } from '../turn-utils'
 import type { Message } from '@craft-agent/core'
 

--- a/packages/ui/src/components/chat/__tests__/turn-phase.test.ts
+++ b/packages/ui/src/components/chat/__tests__/turn-phase.test.ts
@@ -12,7 +12,7 @@
  * - complete: Turn is finished
  */
 
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { deriveTurnPhase, shouldShowThinkingIndicator, type TurnPhase, type AssistantTurn } from '../turn-utils'
 import type { ActivityItem, ResponseContent } from '../TurnCard'
 

--- a/packages/ui/src/components/chat/__tests__/turn-utils-grouping.test.ts
+++ b/packages/ui/src/components/chat/__tests__/turn-utils-grouping.test.ts
@@ -8,7 +8,7 @@
  * - extractTaskOutputData() - TaskOutput JSON parsing (internal, tested indirectly)
  */
 
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import {
   groupActivitiesByParent,
   computeLastChildSet,

--- a/packages/ui/src/components/markdown/__tests__/linkify.test.ts
+++ b/packages/ui/src/components/markdown/__tests__/linkify.test.ts
@@ -6,7 +6,7 @@
  * and double-wrap them, producing broken nested markdown.
  */
 
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect } from 'vitest'
 import { preprocessLinks, detectLinks } from '../linkify'
 
 // ============================================================================

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const coreSrcDir = fileURLToPath(new URL('../core/src/', import.meta.url))
+const mermaidSrcDir = fileURLToPath(new URL('../mermaid/src/', import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: '@craft-agent/core', replacement: `${coreSrcDir}index.ts` },
+      { find: /^@craft-agent\/core\/(.*)$/, replacement: `${coreSrcDir}$1` },
+      { find: '@craft-agent/mermaid', replacement: `${mermaidSrcDir}index.ts` },
+      { find: /^@craft-agent\/mermaid\/(.*)$/, replacement: `${mermaidSrcDir}$1` },
+    ],
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,6 +601,9 @@ importers:
       vite:
         specifier: ^8.0.2
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -617,6 +620,9 @@ importers:
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mermaid:
     dependencies:
@@ -636,6 +642,9 @@ importers:
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/shared:
     dependencies:
@@ -682,6 +691,9 @@ importers:
       '@types/shell-quote':
         specifier: ^1.7.5
         version: 1.7.5
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/ui:
     dependencies:
@@ -761,6 +773,9 @@ importers:
       react-pdf:
         specifier: ^10.4.1
         version: 10.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 


### PR DESCRIPTION
## Summary
- add package-local Vitest entrypoints for core, ui, viewer, mermaid, and shared
- migrate the remaining in-scope `bun:test` suites to Vitest across core, mermaid, shared, ui, and viewer
- replace Bun `mock.module()` usage in shared Slack, WhatsApp, and PR-service tests with Vitest-compatible hoisted mocks

## Validation
- `pnpm --dir packages/core exec vitest run`
- `pnpm --dir packages/ui exec vitest run`
- `pnpm --dir apps/viewer exec vitest run`
- `pnpm --dir packages/mermaid exec vitest run --help`
- `pnpm --dir packages/shared exec vitest run --help`
- `pnpm --dir packages/mermaid exec vitest run src/__tests__/ascii.test.ts src/__tests__/class-arrow-directions.test.ts src/__tests__/class-parser.test.ts src/__tests__/dagre-adapter.test.ts src/__tests__/parser.test.ts src/__tests__/sequence-layout.test.ts src/__tests__/sequence-parser.test.ts src/__tests__/styles.test.ts`
- `pnpm --dir packages/mermaid exec vitest run`
- `pnpm --dir packages/shared exec vitest run src/agent/__tests__/daemon-permission.test.ts src/agent/__tests__/source-state.test.ts src/auth/__tests__/state.test.ts src/config/__tests__/preferences.test.ts src/prompts/__tests__/git-context.test.ts src/prompts/__tests__/lifecycle.test.ts src/prompts/__tests__/template-loader.test.ts tests/models.test.ts`
- `pnpm --dir packages/shared exec vitest run src/agent/__tests__/tool-matching.test.ts src/agent/__tests__/tool-matching-sdk-fixtures.test.ts src/plugins/__tests__/plugin-manager.test.ts src/sessions/__tests__/hierarchy.test.ts src/sources/__tests__/basic-auth.test.ts src/sources/__tests__/authScheme-empty.test.ts src/sources/__tests__/server-builder-authScheme.test.ts src/workspaces/__tests__/system-skills.test.ts`
- `pnpm --dir packages/shared exec vitest run`
- `pnpm exec turbo run test --filter=@craft-agent/core --filter=@craft-agent/mermaid --filter=@craft-agent/shared --filter=@craft-agent/ui --filter=@craft-agent/viewer`
- `rg "from 'bun:test'|from \"bun:test\"" packages/core packages/mermaid packages/shared packages/ui apps/viewer --glob '!**/node_modules/**' --glob '!**/dist/**' --glob '!**/coverage/**'`
- `rg "mock\.module\(" packages/core packages/mermaid packages/shared packages/ui apps/viewer --glob '!**/node_modules/**' --glob '!**/dist/**' --glob '!**/coverage/**'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Migrated test infrastructure from Bun to Vitest as the primary test runner across all packages.
* Updated test configurations and dependencies to support the new testing framework while maintaining existing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the remaining `bun:test` suites in `core`, `mermaid`, `shared`, `ui`, and `viewer` to Vitest, adding package-local `vitest.config.ts` entrypoints and replacing `mock.module()` with Vitest-compatible `vi.hoisted()` + `vi.mock()` patterns. The migration is mechanical and thorough — `import.meta.dir` is correctly replaced with `dirname(fileURLToPath(import.meta.url))`, Bun-only `toStartWith()` calls are replaced with `toMatch(/regex/)`, and all `package.json` test scripts are updated.

<h3>Confidence Score: 5/5</h3>

Safe to merge — mechanical migration with no logic changes and validated test runs.

All findings are P2 or lower. The vi.hoisted() + shared-mock-object pattern used in the channel adapter tests is correct (property reads happen at call time). import.meta.dir replacements, toStartWith → toMatch, and mock.module → vi.mock conversions are all accurate.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/vitest.config.ts | New Vitest config with correct path aliases for core, mermaid, and shared; includes both src/ and tests/ globs. |
| packages/shared/src/channels/__tests__/slack-adapter.test.ts | mock.module() replaced with vi.hoisted() + vi.mock(); shared mock object pattern is correct — property mutation in beforeEach works because mock factory reads slackMocks.socketEventHandlers at call time, not at init time. |
| packages/shared/src/channels/__tests__/whatsapp-adapter.test.ts | Correct vi.hoisted() pattern; makeWASocket() re-assigns whatsappMocks.end and whatsappMocks.eventHandlers on each socket creation, keeping test references in sync. |
| packages/shared/src/git/__tests__/pr-service.test.ts | Clean migration; added early return after error callback (minor correctness improvement); spyOn usage retained with same beforeEach/afterEach restore pattern. |
| packages/mermaid/src/__tests__/ascii.test.ts | import.meta.dir correctly replaced with dirname(fileURLToPath(import.meta.url)) for test data path resolution. |
| packages/shared/src/utils/__tests__/cli-icon-resolver.test.ts | toStartWith() correctly replaced with toMatch(/regex/) for Vitest compatibility. |
| packages/ui/vitest.config.ts | New config; correctly aliases core and mermaid workspace packages; node environment appropriate since UI tests are unit tests not rendering tests. |
| apps/viewer/vitest.config.ts | New config with @ alias for viewer src and workspace package aliases; node environment correct for smoke tests. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun:test import] -->|replaced with| B[vitest import]
    C[mock.module + module-level mock vars] -->|replaced with| D[vi.hoisted + vi.mock]
    E[import.meta.dir] -->|replaced with| F[dirname fileURLToPath import.meta.url]
    G[expect.toStartWith] -->|replaced with| H[expect.toMatch regex]
    I[mock / spyOn from bun:test] -->|replaced with| J[vi.fn / vi.spyOn]
    
    D --> K[Shared mock object mutated in beforeEach]
    K --> L[Mock factory reads props at call time — safe]
    
    subgraph "New vitest.config.ts per package"
        M[core]
        N[mermaid]
        O[shared — aliases core + mermaid + self]
        P[ui — aliases core + mermaid]
        Q[viewer — aliases core + ui + self]
    end
```

<sub>Reviews (1): Last reviewed commit: ["KAT-2520 migrate shared adapter mocks to..."](https://github.com/gannonh/kata/commit/8cfe45e7920137d6f6f38e7c7d93a20a604cc780) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28155958)</sub>

<!-- /greptile_comment -->