### PR TITLE
feat(desktop): add chat archiving with settings restore

### DIFF
--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.4
+
+### Features
+
+- **Session archiving workflow** — Desktop now supports archiving chats from the session list, excluding archived sessions from the default sidebar view, and restoring them from a dedicated Settings panel.
+- **Archived Chats settings panel** — Added an "Archived Chats" tab that lists archived sessions with timestamp and project directory metadata plus one-click unarchive actions.
+- **Workspace Git context in chat shell** — Chat footer now surfaces workspace Git branch and pull request context via new main/preload IPC plumbing.
+
+### Fixes
+
+- **Session sidebar archive affordance** — Archive actions are now exposed with hover controls on each session row, reducing accidental clutter while keeping archive operations discoverable.
+- **Chat pane interaction polish** — Refined composer/list UI behavior and associated desktop shell layout wiring to improve day-to-day chat usability.
+
 ## 0.2.3
 
 ### Fixes

--- a/apps/desktop/e2e/tests/app-shell.e2e.ts
+++ b/apps/desktop/e2e/tests/app-shell.e2e.ts
@@ -13,10 +13,11 @@ test.describe('App shell', () => {
     await expect(mainWindow.getByPlaceholder('Ask Kata to help with your code...')).toBeVisible()
   })
 
-  test('shows permission mode selector with Explore / Ask / Auto', async ({ mainWindow }) => {
-    await expect(mainWindow.getByLabel(/Explore/i)).toBeVisible()
-    await expect(mainWindow.getByLabel(/Ask/i)).toBeVisible()
-    await expect(mainWindow.getByLabel(/Auto/i)).toBeVisible()
+  test('does not render the legacy permission mode selector', async ({ mainWindow }) => {
+    await expect(mainWindow.getByText(/Permission mode/i)).toHaveCount(0)
+    await expect(mainWindow.getByLabel(/Explore/i)).toHaveCount(0)
+    await expect(mainWindow.getByLabel(/Ask/i)).toHaveCount(0)
+    await expect(mainWindow.getByLabel(/Auto/i)).toHaveCount(0)
   })
 
   test('shows workflow board pane in right pane', async ({ mainWindow }) => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata/desktop",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Kata Desktop — native desktop app for the Kata coding agent",
   "private": true,
   "type": "module",

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -2172,10 +2172,25 @@ async function readWorkspaceGitInfo(workspacePath: string): Promise<WorkspaceGit
     }
   }
 
-  const pullRequestUrl =
-    branch === 'HEAD'
-      ? null
-      : await runOptionalCommand('gh', ['pr', 'view', '--head', branch, '--json', 'url', '--jq', '.url'], workspacePath, 250)
+  let pullRequestUrl: string | null = null
+
+  if (branch !== 'HEAD') {
+    const prQueryAttempts: string[][] = [
+      // Modern gh syntax: branch argument is positional.
+      ['pr', 'view', branch, '--json', 'url', '--jq', '.url'],
+      // Compatibility fallback for gh versions that support --head.
+      ['pr', 'view', '--head', branch, '--json', 'url', '--jq', '.url'],
+      // Last resort: resolve PR from current branch context.
+      ['pr', 'view', '--json', 'url', '--jq', '.url'],
+    ]
+
+    for (const args of prQueryAttempts) {
+      pullRequestUrl = await runOptionalCommand('gh', args, workspacePath, 1000)
+      if (pullRequestUrl) {
+        break
+      }
+    }
+  }
 
   return {
     branch: displayBranch,

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,5 +1,7 @@
+import { execFile as execFileCallback } from 'node:child_process'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { promisify } from 'node:util'
 import { dialog, ipcMain, shell, type BrowserWindow } from 'electron'
 import log from './logger'
 import { AuthBridge } from './auth-bridge'
@@ -50,6 +52,7 @@ import {
   type SetThinkingLevelResponse,
   type ThinkingLevel,
   type WorkspaceInfo,
+  type WorkspaceGitInfo,
   type ArtifactType,
   type WorkflowBoardSnapshotResponse,
   type WorkflowBoardLifecycleResponse,
@@ -90,6 +93,8 @@ import {
   type StabilitySnapshot,
   type StabilitySnapshotResponse,
 } from '../shared/types'
+
+const execFile = promisify(execFileCallback)
 
 interface RegisterIpcOptions {
   bridge: PiAgentBridge
@@ -886,6 +891,7 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.workspaceGet)
   ipcMain.removeHandler(IPC_CHANNELS.workspaceSet)
   ipcMain.removeHandler(IPC_CHANNELS.workspacePick)
+  ipcMain.removeHandler(IPC_CHANNELS.workspaceGetGitInfo)
   ipcMain.removeHandler(IPC_CHANNELS.authGetProviders)
   ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
   ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)
@@ -1326,6 +1332,10 @@ export function registerSessionIpc({
     return {
       path: selectedPath,
     }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.workspaceGetGitInfo, async (): Promise<WorkspaceGitInfo> => {
+    return readWorkspaceGitInfo(bridge.getWorkspacePath())
   })
 
   ipcMain.handle(IPC_CHANNELS.authGetProviders, async (): Promise<AuthProvidersResponse> => {
@@ -1987,6 +1997,7 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.workspaceGet)
     ipcMain.removeHandler(IPC_CHANNELS.workspaceSet)
     ipcMain.removeHandler(IPC_CHANNELS.workspacePick)
+    ipcMain.removeHandler(IPC_CHANNELS.workspaceGetGitInfo)
     ipcMain.removeHandler(IPC_CHANNELS.authGetProviders)
     ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
     ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)
@@ -2114,6 +2125,61 @@ async function readLinearProjectReference(workspacePath: string): Promise<string
   }
 
   return null
+}
+
+async function runOptionalCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<string | null> {
+  try {
+    const { stdout } = await execFile(command, args, {
+      cwd,
+      timeout: 1500,
+      maxBuffer: 64 * 1024,
+    })
+
+    const trimmed = stdout.trim()
+    return trimmed.length > 0 ? trimmed : null
+  } catch {
+    return null
+  }
+}
+
+async function readWorkspaceGitInfo(workspacePath: string): Promise<WorkspaceGitInfo> {
+  const branch = await runOptionalCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'], workspacePath)
+
+  if (!branch) {
+    return {
+      branch: null,
+      pullRequestUrl: null,
+    }
+  }
+
+  const normalizedBranch = branch === 'HEAD'
+    ? await runOptionalCommand('git', ['rev-parse', '--short', 'HEAD'], workspacePath)
+    : branch
+
+  const displayBranch = normalizedBranch
+    ? branch === 'HEAD' ? `detached@${normalizedBranch}` : normalizedBranch
+    : null
+
+  if (!displayBranch) {
+    return {
+      branch: null,
+      pullRequestUrl: null,
+    }
+  }
+
+  const pullRequestUrl =
+    branch === 'HEAD'
+      ? null
+      : await runOptionalCommand('gh', ['pr', 'view', '--head', branch, '--json', 'url', '--jq', '.url'], workspacePath)
+
+  return {
+    branch: displayBranch,
+    pullRequestUrl,
+  }
 }
 
 function stripYamlWrapping(value: string): string {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -2131,11 +2131,12 @@ async function runOptionalCommand(
   command: string,
   args: string[],
   cwd: string,
+  timeoutMs = 300,
 ): Promise<string | null> {
   try {
     const { stdout } = await execFile(command, args, {
       cwd,
-      timeout: 1500,
+      timeout: timeoutMs,
       maxBuffer: 64 * 1024,
     })
 
@@ -2147,7 +2148,7 @@ async function runOptionalCommand(
 }
 
 async function readWorkspaceGitInfo(workspacePath: string): Promise<WorkspaceGitInfo> {
-  const branch = await runOptionalCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'], workspacePath)
+  const branch = await runOptionalCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'], workspacePath, 250)
 
   if (!branch) {
     return {
@@ -2157,7 +2158,7 @@ async function readWorkspaceGitInfo(workspacePath: string): Promise<WorkspaceGit
   }
 
   const normalizedBranch = branch === 'HEAD'
-    ? await runOptionalCommand('git', ['rev-parse', '--short', 'HEAD'], workspacePath)
+    ? await runOptionalCommand('git', ['rev-parse', '--short', 'HEAD'], workspacePath, 250)
     : branch
 
   const displayBranch = normalizedBranch
@@ -2174,7 +2175,7 @@ async function readWorkspaceGitInfo(workspacePath: string): Promise<WorkspaceGit
   const pullRequestUrl =
     branch === 'HEAD'
       ? null
-      : await runOptionalCommand('gh', ['pr', 'view', '--head', branch, '--json', 'url', '--jq', '.url'], workspacePath)
+      : await runOptionalCommand('gh', ['pr', 'view', '--head', branch, '--json', 'url', '--jq', '.url'], workspacePath, 250)
 
   return {
     branch: displayBranch,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -106,6 +106,9 @@ const api: DesktopApi = {
     pick: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.workspacePick)
     },
+    getGitInfo: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.workspaceGetGitInfo)
+    },
   },
   auth: {
     getProviders: async () => {

--- a/apps/desktop/src/renderer/atoms/__tests__/session-archive.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/session-archive.test.ts
@@ -1,11 +1,13 @@
 import { createStore } from 'jotai'
 import { describe, expect, test } from 'vitest'
 import type { SessionListItem } from '@shared/types'
+import { isStreamingAtom } from '../chat'
 import {
   archiveSessionAtom,
   archivedSessionsAtom,
   currentSessionIdAtom,
   sessionListAtom,
+  sessionListErrorAtom,
   unarchiveSessionAtom,
   visibleSessionListAtom,
   workingDirectoryAtom,
@@ -87,5 +89,36 @@ describe('session archive atoms', () => {
 
     expect(store.get(currentSessionIdAtom)).toBeNull()
     expect(store.get(visibleSessionListAtom)).toHaveLength(0)
+  })
+
+  test('archives and hides sessions when workspace path is missing', async () => {
+    const store = createStore()
+    store.set(archivedSessionsAtom, [])
+    const session = createSession({ id: 'unknown', title: 'No workspace session' })
+
+    store.set(workingDirectoryAtom, '')
+    store.set(sessionListAtom, [session])
+
+    await store.set(archiveSessionAtom, session)
+
+    expect(store.get(visibleSessionListAtom)).toHaveLength(0)
+    expect(store.get(archivedSessionsAtom)[0]?.projectDir).toBe('Unknown workspace')
+  })
+
+  test('rejects archiving the active session while streaming', async () => {
+    const store = createStore()
+    store.set(archivedSessionsAtom, [])
+    const activeSession = createSession({ id: 'streaming', title: 'Streaming session' })
+
+    store.set(workingDirectoryAtom, '/workspace/streaming')
+    store.set(sessionListAtom, [activeSession])
+    store.set(currentSessionIdAtom, activeSession.id)
+    store.set(isStreamingAtom, true)
+
+    await store.set(archiveSessionAtom, activeSession)
+
+    expect(store.get(archivedSessionsAtom)).toHaveLength(0)
+    expect(store.get(currentSessionIdAtom)).toBe(activeSession.id)
+    expect(store.get(sessionListErrorAtom)).toBe('Stop the active run before archiving this chat.')
   })
 })

--- a/apps/desktop/src/renderer/atoms/__tests__/session-archive.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/session-archive.test.ts
@@ -1,0 +1,91 @@
+import { createStore } from 'jotai'
+import { describe, expect, test } from 'vitest'
+import type { SessionListItem } from '@shared/types'
+import {
+  archiveSessionAtom,
+  archivedSessionsAtom,
+  currentSessionIdAtom,
+  sessionListAtom,
+  unarchiveSessionAtom,
+  visibleSessionListAtom,
+  workingDirectoryAtom,
+} from '../session'
+
+function createSession(overrides: Partial<SessionListItem>): SessionListItem {
+  const now = new Date().toISOString()
+
+  return {
+    id: 'session-id',
+    path: '/tmp/session.jsonl',
+    name: null,
+    title: 'Session title',
+    model: null,
+    provider: null,
+    created: now,
+    modified: now,
+    messageCount: 0,
+    firstMessagePreview: null,
+    ...overrides,
+  }
+}
+
+describe('session archive atoms', () => {
+  test('archives a session for the active workspace and hides it from the sidebar list', async () => {
+    const store = createStore()
+    store.set(archivedSessionsAtom, [])
+    const first = createSession({ id: 's1', title: 'First session' })
+    const second = createSession({ id: 's2', title: 'Second session' })
+
+    store.set(workingDirectoryAtom, '/workspace/alpha')
+    store.set(sessionListAtom, [first, second])
+    store.set(currentSessionIdAtom, first.id)
+
+    await store.set(archiveSessionAtom, second)
+
+    const archived = store.get(archivedSessionsAtom)
+    expect(archived).toHaveLength(1)
+    expect(archived[0]).toMatchObject({
+      sessionId: second.id,
+      title: second.title,
+      projectDir: '/workspace/alpha',
+    })
+
+    const visible = store.get(visibleSessionListAtom)
+    expect(visible.map((item) => item.id)).toEqual([first.id])
+  })
+
+  test('unarchive restores a hidden session to the visible sidebar list', async () => {
+    const store = createStore()
+    store.set(archivedSessionsAtom, [])
+    const archivedSession = createSession({ id: 's-archived', title: 'Archived session' })
+
+    store.set(workingDirectoryAtom, '/workspace/alpha')
+    store.set(sessionListAtom, [archivedSession])
+
+    await store.set(archiveSessionAtom, archivedSession)
+    expect(store.get(visibleSessionListAtom)).toHaveLength(0)
+
+    store.set(unarchiveSessionAtom, {
+      sessionId: archivedSession.id,
+      projectDir: '/workspace/alpha',
+    })
+
+    const visible = store.get(visibleSessionListAtom)
+    expect(visible.map((item) => item.id)).toEqual([archivedSession.id])
+  })
+
+  test('archiving the current session with no remaining visible sessions clears selection', async () => {
+    const store = createStore()
+    store.set(archivedSessionsAtom, [])
+    const onlySession = createSession({ id: 'only', title: 'Only session' })
+
+    store.set(workingDirectoryAtom, '/workspace/solo')
+    store.set(sessionListAtom, [onlySession])
+    store.set(currentSessionIdAtom, onlySession.id)
+
+    await store.set(archiveSessionAtom, onlySession)
+
+    expect(store.get(currentSessionIdAtom)).toBeNull()
+    expect(store.get(visibleSessionListAtom)).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/renderer/atoms/right-pane.ts
+++ b/apps/desktop/src/renderer/atoms/right-pane.ts
@@ -7,7 +7,7 @@ import type {
   WorkflowContextSnapshot,
 } from '@shared/types'
 
-export type SettingsTabId = 'providers' | 'mcp' | 'general' | 'appearance' | 'symphony'
+export type SettingsTabId = 'providers' | 'mcp' | 'archives' | 'general' | 'appearance' | 'symphony'
 
 export const RIGHT_PANE_OVERRIDE_STORAGE_KEY = 'kata-desktop:right-pane-override'
 

--- a/apps/desktop/src/renderer/atoms/session.ts
+++ b/apps/desktop/src/renderer/atoms/session.ts
@@ -8,6 +8,7 @@ const CURRENT_SESSION_STORAGE_KEY = 'kata-desktop:current-session-id'
 const WORKING_DIRECTORY_STORAGE_KEY = 'kata-desktop:working-directory'
 const SESSION_SIDEBAR_OPEN_STORAGE_KEY = 'kata-desktop:session-sidebar-open'
 const ARCHIVED_SESSIONS_STORAGE_KEY = 'kata-desktop:archived-sessions:v1'
+const UNKNOWN_WORKSPACE_LABEL = 'Unknown workspace'
 
 export interface ArchivedSessionRecord {
   sessionId: string
@@ -70,7 +71,8 @@ export const archivedSessionsAtom = atomWithStorage<ArchivedSessionRecord[]>(
 )
 
 export const workspaceArchivedSessionIdsAtom = atom((get) => {
-  const normalizedWorkspacePath = normalizeWorkspacePath(get(workingDirectoryAtom))
+  const normalizedWorkspacePath =
+    normalizeWorkspacePath(get(workingDirectoryAtom)) || UNKNOWN_WORKSPACE_LABEL
   const archived = get(archivedSessionsAtom)
 
   return new Set(
@@ -380,10 +382,18 @@ export const archiveSessionAtom = atom(
       return
     }
 
+    const isCurrentSession = get(currentSessionIdAtom) === sessionId
+    if (isCurrentSession && get(isStreamingAtom)) {
+      set(sessionListErrorAtom, 'Stop the active run before archiving this chat.')
+      return
+    }
+
+    set(sessionListErrorAtom, null)
+
     const normalizedWorkspacePath = normalizeWorkspacePath(get(workingDirectoryAtom))
     const archivedAt = new Date().toISOString()
-    const projectDir = normalizedWorkspacePath || 'Unknown workspace'
-    const projectWorkspaceKey = normalizeWorkspacePath(projectDir)
+    const projectWorkspaceKey = normalizedWorkspacePath || UNKNOWN_WORKSPACE_LABEL
+    const projectDir = projectWorkspaceKey
 
     set(archivedSessionsAtom, (current) => {
       const withoutExisting = current.filter(
@@ -402,7 +412,7 @@ export const archiveSessionAtom = atom(
       ]
     })
 
-    if (get(currentSessionIdAtom) !== sessionId) {
+    if (!isCurrentSession) {
       return
     }
 

--- a/apps/desktop/src/renderer/atoms/session.ts
+++ b/apps/desktop/src/renderer/atoms/session.ts
@@ -7,6 +7,31 @@ import { requestPlanningReloadAtom, resetPlanningSessionStateAtom } from './plan
 const CURRENT_SESSION_STORAGE_KEY = 'kata-desktop:current-session-id'
 const WORKING_DIRECTORY_STORAGE_KEY = 'kata-desktop:working-directory'
 const SESSION_SIDEBAR_OPEN_STORAGE_KEY = 'kata-desktop:session-sidebar-open'
+const ARCHIVED_SESSIONS_STORAGE_KEY = 'kata-desktop:archived-sessions:v1'
+
+export interface ArchivedSessionRecord {
+  sessionId: string
+  title: string
+  archivedAt: string
+  modified: string
+  projectDir: string
+}
+
+function normalizeWorkspacePath(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return ''
+  }
+
+  return trimmed.replace(/[\\/]+$/, '') || trimmed
+}
+
+function isArchivedForWorkspace(
+  archived: ArchivedSessionRecord,
+  normalizedWorkspacePath: string,
+): boolean {
+  return normalizeWorkspacePath(archived.projectDir) === normalizedWorkspacePath
+}
 
 export const sessionListAtom = atom<SessionListItem[]>([])
 export const sessionWarningsAtom = atom<string[]>([])
@@ -39,6 +64,31 @@ export const sessionSidebarOpenAtom = atomWithStorage<boolean>(
   true,
 )
 
+export const archivedSessionsAtom = atomWithStorage<ArchivedSessionRecord[]>(
+  ARCHIVED_SESSIONS_STORAGE_KEY,
+  [],
+)
+
+export const workspaceArchivedSessionIdsAtom = atom((get) => {
+  const normalizedWorkspacePath = normalizeWorkspacePath(get(workingDirectoryAtom))
+  const archived = get(archivedSessionsAtom)
+
+  return new Set(
+    archived
+      .filter((entry) => isArchivedForWorkspace(entry, normalizedWorkspacePath))
+      .map((entry) => entry.sessionId),
+  )
+})
+
+export const visibleSessionListAtom = atom((get) => {
+  const archivedIds = get(workspaceArchivedSessionIdsAtom)
+  return get(sessionListAtom).filter((session) => !archivedIds.has(session.id))
+})
+
+export const archivedSessionsForSettingsAtom = atom((get) =>
+  [...get(archivedSessionsAtom)].sort((a, b) => b.archivedAt.localeCompare(a.archivedAt)),
+)
+
 const applySessionListResponseAtom = atom(
   null,
   (get, set, response: SessionListResponse) => {
@@ -59,21 +109,24 @@ const applySessionListResponseAtom = atom(
       ? response.sessions.some((session) => session.id === existingSessionId)
       : false
 
-    if (placeholder && !inDiskResponse) {
-      set(sessionListAtom, [placeholder, ...response.sessions])
-    } else {
-      set(sessionListAtom, response.sessions)
-    }
+    const nextSessions = placeholder && !inDiskResponse
+      ? [placeholder, ...response.sessions]
+      : response.sessions
 
+    set(sessionListAtom, nextSessions)
     set(sessionWarningsAtom, response.warnings)
     set(sessionDirectoryAtom, response.directory)
 
+    const archivedSessionIds = get(workspaceArchivedSessionIdsAtom)
+
     // Current session is accounted for — either in disk response or preserved as placeholder.
-    if (existingSessionId && (inDiskResponse || Boolean(placeholder))) {
+    // If the current session is archived, fall through and pick the first visible session.
+    if (existingSessionId && (inDiskResponse || Boolean(placeholder)) && !archivedSessionIds.has(existingSessionId)) {
       return
     }
 
-    set(currentSessionIdAtom, response.sessions[0]?.id ?? null)
+    const nextVisibleSession = nextSessions.find((session) => !archivedSessionIds.has(session.id))
+    set(currentSessionIdAtom, nextVisibleSession?.id ?? null)
   },
 )
 
@@ -318,6 +371,68 @@ export const switchSessionAtom = atom(null, async (get, set, sessionId: string) 
     set(sessionSwitchingAtom, false)
   }
 })
+
+export const archiveSessionAtom = atom(
+  null,
+  async (get, set, session: SessionListItem) => {
+    const sessionId = session.id.trim()
+    if (!sessionId) {
+      return
+    }
+
+    const normalizedWorkspacePath = normalizeWorkspacePath(get(workingDirectoryAtom))
+    const archivedAt = new Date().toISOString()
+    const projectDir = normalizedWorkspacePath || 'Unknown workspace'
+    const projectWorkspaceKey = normalizeWorkspacePath(projectDir)
+
+    set(archivedSessionsAtom, (current) => {
+      const withoutExisting = current.filter(
+        (entry) => !(entry.sessionId === sessionId && isArchivedForWorkspace(entry, projectWorkspaceKey)),
+      )
+
+      return [
+        {
+          sessionId,
+          title: session.title,
+          archivedAt,
+          modified: session.modified,
+          projectDir,
+        },
+        ...withoutExisting,
+      ]
+    })
+
+    if (get(currentSessionIdAtom) !== sessionId) {
+      return
+    }
+
+    const archivedSessionIds = get(workspaceArchivedSessionIdsAtom)
+    const nextSession = get(sessionListAtom).find((entry) => !archivedSessionIds.has(entry.id))
+
+    if (nextSession) {
+      await set(switchSessionAtom, nextSession.id)
+      return
+    }
+
+    set(currentSessionIdAtom, null)
+    set(resetChatStateAtom)
+    set(resetPlanningSessionStateAtom)
+  },
+)
+
+export const unarchiveSessionAtom = atom(
+  null,
+  (_get, set, { sessionId, projectDir }: { sessionId: string; projectDir: string }) => {
+    const trimmedSessionId = sessionId.trim()
+    const normalizedProjectDir = normalizeWorkspacePath(projectDir)
+
+    set(archivedSessionsAtom, (current) =>
+      current.filter(
+        (entry) => !(entry.sessionId === trimmedSessionId && isArchivedForWorkspace(entry, normalizedProjectDir)),
+      ),
+    )
+  },
+)
 
 export const pickWorkspaceAtom = atom(null, async () => {
   return window.api.workspace.pick()

--- a/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/LeftPane.tsx
@@ -4,7 +4,6 @@ import { sessionSidebarOpenAtom } from '@/atoms/session'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { ChatPanel } from '../chat/ChatPanel'
-import { ModelSelector } from './ModelSelector'
 import { SessionSidebar } from './SessionSidebar'
 import { WorkspaceIndicator } from './WorkspaceIndicator'
 import { SymphonyStatusBadge } from './SymphonyStatusBadge'
@@ -37,7 +36,6 @@ export function LeftPane({ onOpenSettings }: LeftPaneProps) {
         </div>
 
         <div className="flex flex-1 items-center justify-end gap-2">
-          <ModelSelector />
           {!sessionSidebarOpen ? (
             <Button type="button" variant="outline" size="sm" onClick={onOpenSettings}>
               <Settings data-icon="inline-start" />

--- a/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { MODELS_REFRESH_EVENT, PROVIDER_METADATA } from '@/constants/providers'
+import { cn } from '@/lib/utils'
 
 function toModelIdentifier(provider: string, id: string): string {
   return `${provider}/${id}`
@@ -27,7 +28,12 @@ function formatProviderLabel(provider: string): string {
   return metadata?.name ?? provider
 }
 
-export function ModelSelector() {
+interface ModelSelectorProps {
+  compact?: boolean
+  className?: string
+}
+
+export function ModelSelector({ compact = false, className }: ModelSelectorProps) {
   const [selectedModel, setSelectedModel] = useAtom(selectedModelAtom)
   const [availableModels, setAvailableModels] = useAtom(availableModelsAtom)
   const [loading, setLoading] = useAtom(modelLoadingAtom)
@@ -137,7 +143,7 @@ export function ModelSelector() {
       : 'Select a model'
 
   return (
-    <div className="flex min-w-[16rem] flex-col gap-1">
+    <div className={cn(compact ? 'min-w-[11rem]' : 'flex min-w-[16rem] flex-col gap-1', className)}>
       <Select
         value={selectedModel ?? ''}
         disabled={loading || availableModels.length === 0}
@@ -166,7 +172,7 @@ export function ModelSelector() {
         </SelectContent>
       </Select>
 
-      {error && <p className="text-[11px] text-destructive">{error}</p>}
+      {!compact && error && <p className="text-[11px] text-destructive">{error}</p>}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/ModelSelector.tsx
@@ -172,7 +172,15 @@ export function ModelSelector({ compact = false, className }: ModelSelectorProps
         </SelectContent>
       </Select>
 
-      {!compact && error && <p className="text-[11px] text-destructive">{error}</p>}
+      {error && (
+        <p
+          className={cn('text-[11px] text-destructive', compact && 'truncate')}
+          title={compact ? error : undefined}
+          aria-live="polite"
+        >
+          {error}
+        </p>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import type { SessionListItem as SessionListItemType } from '@shared/types'
 import { cn } from '@/lib/utils'
 
@@ -7,6 +8,12 @@ interface SessionListItemProps {
   disabled?: boolean
   onSelect: (sessionId: string) => void
 }
+
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+const SHORT_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+})
 
 function formatRelativeTime(value: string): string {
   const date = new Date(value)
@@ -22,24 +29,19 @@ function formatRelativeTime(value: string): string {
   const hour = 60 * minute
   const day = 24 * hour
 
-  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
-
   if (absDeltaMs < hour) {
-    return rtf.format(Math.round(deltaMs / minute), 'minute')
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaMs / minute), 'minute')
   }
 
   if (absDeltaMs < day) {
-    return rtf.format(Math.round(deltaMs / hour), 'hour')
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaMs / hour), 'hour')
   }
 
   if (absDeltaMs < 7 * day) {
-    return rtf.format(Math.round(deltaMs / day), 'day')
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaMs / day), 'day')
   }
 
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-  }).format(date)
+  return SHORT_DATE_FORMATTER.format(date)
 }
 
 /**
@@ -57,7 +59,7 @@ function shortModelName(session: SessionListItemType): string {
   return slashIndex >= 0 ? model.slice(slashIndex + 1) : model
 }
 
-export function SessionListItem({
+export const SessionListItem = memo(function SessionListItem({
   session,
   isCurrent,
   disabled = false,
@@ -98,4 +100,4 @@ export function SessionListItem({
       </p>
     </button>
   )
-}
+})

--- a/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx
@@ -1,5 +1,7 @@
 import { memo } from 'react'
+import { Archive } from 'lucide-react'
 import type { SessionListItem as SessionListItemType } from '@shared/types'
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 interface SessionListItemProps {
@@ -7,6 +9,7 @@ interface SessionListItemProps {
   isCurrent: boolean
   disabled?: boolean
   onSelect: (sessionId: string) => void
+  onArchive: (session: SessionListItemType) => void
 }
 
 const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
@@ -64,40 +67,60 @@ export const SessionListItem = memo(function SessionListItem({
   isCurrent,
   disabled = false,
   onSelect,
+  onArchive,
 }: SessionListItemProps) {
   const model = shortModelName(session)
 
   return (
-    <button
-      type="button"
-      title={session.title}
-      disabled={disabled}
-      onClick={() => onSelect(session.id)}
-      className={cn(
-        'w-full min-w-0 overflow-hidden rounded-lg px-2.5 py-2 text-left transition-colors',
-        isCurrent
-          ? 'bg-accent/50'
-          : 'hover:bg-accent/20',
-        disabled && 'cursor-not-allowed opacity-50',
-      )}
-    >
-      <p
-        className="min-w-0 text-xs font-medium leading-snug text-card-foreground [overflow-wrap:anywhere]"
-        style={{
-          display: '-webkit-box',
-          overflow: 'hidden',
-          WebkitLineClamp: 2,
-          WebkitBoxOrient: 'vertical',
-        }}
+    <div className="group relative">
+      <button
+        type="button"
+        title={session.title}
+        disabled={disabled}
+        onClick={() => onSelect(session.id)}
+        className={cn(
+          'w-full min-w-0 overflow-hidden rounded-lg px-2.5 py-2 pr-9 text-left transition-colors',
+          isCurrent ? 'bg-accent/50' : 'hover:bg-accent/20',
+          disabled && 'cursor-not-allowed opacity-50',
+        )}
       >
-        {session.title}
-      </p>
+        <p
+          className="min-w-0 text-xs font-medium leading-snug text-card-foreground [overflow-wrap:anywhere]"
+          style={{
+            display: '-webkit-box',
+            overflow: 'hidden',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+          }}
+        >
+          {session.title}
+        </p>
 
-      <p className="mt-1 truncate text-[10px] text-muted-foreground">
-        {[model, formatRelativeTime(session.modified), `${session.messageCount} msgs`]
-          .filter(Boolean)
-          .join(' · ')}
-      </p>
-    </button>
+        <p className="mt-1 truncate text-[10px] text-muted-foreground">
+          {[model, formatRelativeTime(session.modified), `${session.messageCount} msgs`]
+            .filter(Boolean)
+            .join(' · ')}
+        </p>
+      </button>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        title="Archive chat"
+        aria-label={`Archive ${session.title}`}
+        disabled={disabled}
+        onClick={(event) => {
+          event.stopPropagation()
+          onArchive(session)
+        }}
+        className={cn(
+          'absolute right-1 bottom-1 opacity-0 transition-opacity',
+          'group-hover:opacity-100 group-focus-within:opacity-100',
+        )}
+      >
+        <Archive />
+      </Button>
+    </div>
   )
 })

--- a/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { Plus, RefreshCw, Settings } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import {
@@ -35,6 +36,10 @@ export function SessionSidebar({ open, onOpenSettings }: SessionSidebarProps) {
   const createSession = useSetAtom(createSessionAtom)
   const switchSession = useSetAtom(switchSessionAtom)
   const refreshSessions = useSetAtom(refreshSessionListAtom)
+
+  const handleSelectSession = useCallback((sessionId: string) => {
+    void switchSession(sessionId)
+  }, [switchSession])
 
   if (!open) {
     return null
@@ -106,9 +111,7 @@ export function SessionSidebar({ open, onOpenSettings }: SessionSidebarProps) {
               session={session}
               isCurrent={session.id === currentSessionId}
               disabled={switchingSession || creatingSession}
-              onSelect={(sessionId) => {
-                void switchSession(sessionId)
-              }}
+              onSelect={handleSelectSession}
             />
           ))}
         </div>

--- a/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
@@ -2,16 +2,18 @@ import { useCallback } from 'react'
 import { Plus, RefreshCw, Settings } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import {
+  archiveSessionAtom,
   createSessionAtom,
   currentSessionIdAtom,
   refreshSessionListAtom,
   sessionCreatingAtom,
-  sessionListAtom,
   sessionListErrorAtom,
   sessionListLoadingAtom,
   sessionSwitchingAtom,
   sessionWarningsAtom,
   switchSessionAtom,
+  visibleSessionListAtom,
+  workspaceArchivedSessionIdsAtom,
 } from '@/atoms/session'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -25,7 +27,8 @@ interface SessionSidebarProps {
 }
 
 export function SessionSidebar({ open, onOpenSettings }: SessionSidebarProps) {
-  const sessions = useAtomValue(sessionListAtom)
+  const sessions = useAtomValue(visibleSessionListAtom)
+  const archivedSessionIds = useAtomValue(workspaceArchivedSessionIdsAtom)
   const currentSessionId = useAtomValue(currentSessionIdAtom)
   const loading = useAtomValue(sessionListLoadingAtom)
   const creatingSession = useAtomValue(sessionCreatingAtom)
@@ -36,6 +39,7 @@ export function SessionSidebar({ open, onOpenSettings }: SessionSidebarProps) {
   const createSession = useSetAtom(createSessionAtom)
   const switchSession = useSetAtom(switchSessionAtom)
   const refreshSessions = useSetAtom(refreshSessionListAtom)
+  const archiveSession = useSetAtom(archiveSessionAtom)
 
   const handleSelectSession = useCallback((sessionId: string) => {
     void switchSession(sessionId)
@@ -102,7 +106,11 @@ export function SessionSidebar({ open, onOpenSettings }: SessionSidebarProps) {
           )}
 
           {!loading && !error && sessions.length === 0 && (
-            <p className="p-2 text-xs text-muted-foreground">No sessions for this workspace yet.</p>
+            <p className="p-2 text-xs text-muted-foreground">
+              {archivedSessionIds.size > 0
+                ? 'All sessions are archived for this workspace.'
+                : 'No sessions for this workspace yet.'}
+            </p>
           )}
 
           {sessions.map((session) => (
@@ -112,6 +120,9 @@ export function SessionSidebar({ open, onOpenSettings }: SessionSidebarProps) {
               isCurrent={session.id === currentSessionId}
               disabled={switchingSession || creatingSession}
               onSelect={handleSelectSession}
+              onArchive={(session) => {
+                void archiveSession(session)
+              }}
             />
           ))}
         </div>

--- a/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/SessionSidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { Plus, RefreshCw, Settings } from 'lucide-react'
+import type { SessionListItem as SessionListItemType } from '@shared/types'
 import { useAtomValue, useSetAtom } from 'jotai'
 import {
   archiveSessionAtom,
@@ -44,6 +45,10 @@ export function SessionSidebar({ open, onOpenSettings }: SessionSidebarProps) {
   const handleSelectSession = useCallback((sessionId: string) => {
     void switchSession(sessionId)
   }, [switchSession])
+
+  const handleArchiveSession = useCallback((session: SessionListItemType) => {
+    void archiveSession(session)
+  }, [archiveSession])
 
   if (!open) {
     return null
@@ -120,9 +125,7 @@ export function SessionSidebar({ open, onOpenSettings }: SessionSidebarProps) {
               isCurrent={session.id === currentSessionId}
               disabled={switchingSession || creatingSession}
               onSelect={handleSelectSession}
-              onArchive={(session) => {
-                void archiveSession(session)
-              }}
+              onArchive={handleArchiveSession}
             />
           ))}
         </div>

--- a/apps/desktop/src/renderer/components/chat/BashOutputCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/BashOutputCard.tsx
@@ -20,6 +20,14 @@ interface BashViewModel {
   exitCode?: number
 }
 
+function truncateCommand(command: string, maxLength = 120): string {
+  if (command.length <= maxLength) {
+    return command
+  }
+
+  return `${command.slice(0, maxLength - 1)}…`
+}
+
 function buildBashViewModel(tool: ToolCallView): BashViewModel {
   const args = asRecord(tool.args)
   const result = asRecord(tool.result)
@@ -60,6 +68,7 @@ function getStatusBadgeClass(status: ToolCallView['status']): string {
 export function BashOutputCard({ tool }: BashOutputCardProps) {
   const [isOpen, setIsOpen] = useState(tool.status !== 'done')
   const view = useMemo(() => buildBashViewModel(tool), [tool])
+  const commandLabel = useMemo(() => truncateCommand(view.command), [view.command])
 
   const exitClass = cn(
     'border text-[10px]',
@@ -76,25 +85,29 @@ export function BashOutputCard({ tool }: BashOutputCardProps) {
             <Button
               type="button"
               variant="ghost"
-              className="h-auto w-full justify-between rounded-none px-3 py-2 hover:bg-accent"
+              className="h-auto w-full min-w-0 shrink justify-start whitespace-normal rounded-none px-3 py-2 hover:bg-accent"
             >
-              <div className="min-w-0 text-left">
-                <p className="truncate text-xs font-semibold text-foreground">bash · {view.command}</p>
-                <div className="mt-1 flex items-center gap-2">
-                  {view.exitCode !== undefined && (
-                    <Badge variant="outline" className={exitClass}>
-                      exit {view.exitCode}
-                    </Badge>
-                  )}
-                  <span className="text-[11px] text-muted-foreground">
-                    {(view.output || '').split('\n').filter(Boolean).length} lines
-                  </span>
+              <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2">
+                <div className="min-w-0 overflow-hidden text-left">
+                  <p className="truncate text-xs font-semibold text-foreground" title={view.command}>
+                    bash · {commandLabel}
+                  </p>
+                  <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2">
+                    {view.exitCode !== undefined && (
+                      <Badge variant="outline" className={exitClass}>
+                        exit {view.exitCode}
+                      </Badge>
+                    )}
+                    <span className="text-[11px] text-muted-foreground">
+                      {(view.output || '').split('\n').filter(Boolean).length} lines
+                    </span>
+                  </div>
                 </div>
-              </div>
 
-              <Badge variant="outline" className={getStatusBadgeClass(tool.status)}>
-                {tool.status}
-              </Badge>
+                <Badge variant="outline" className={cn(getStatusBadgeClass(tool.status), 'shrink-0')}>
+                  {tool.status}
+                </Badge>
+              </div>
             </Button>
           </CollapsibleTrigger>
         </CardHeader>

--- a/apps/desktop/src/renderer/components/chat/BashOutputCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/BashOutputCard.tsx
@@ -17,6 +17,7 @@ interface BashViewModel {
   stdout: string
   stderr: string
   output: string
+  lineCount: number
   exitCode?: number
 }
 
@@ -44,6 +45,7 @@ function buildBashViewModel(tool: ToolCallView): BashViewModel {
   const stderr = asString(result?.stderr) ?? ''
 
   const output = [stdout, stderr].filter(Boolean).join(stdout && stderr ? '\n' : '')
+  const lineCount = output.split('\n').filter(Boolean).length
 
   const exitCode = asNumber(result?.exitCode)
 
@@ -52,6 +54,7 @@ function buildBashViewModel(tool: ToolCallView): BashViewModel {
     stdout,
     stderr,
     output,
+    lineCount,
     exitCode,
   }
 }
@@ -98,9 +101,7 @@ export function BashOutputCard({ tool }: BashOutputCardProps) {
                         exit {view.exitCode}
                       </Badge>
                     )}
-                    <span className="text-[11px] text-muted-foreground">
-                      {(view.output || '').split('\n').filter(Boolean).length} lines
-                    </span>
+                    <span className="text-[11px] text-muted-foreground">{view.lineCount} lines</span>
                   </div>
                 </div>
 

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -72,27 +72,48 @@ export function ChatPanel() {
   useEffect(() => {
     let active = true
 
-    void window.api.workspace.getGitInfo()
-      .then((info) => {
-        if (!active) {
-          return
-        }
+    const loadWorkspaceGitInfo = () => {
+      void window.api.workspace.getGitInfo()
+        .then((info) => {
+          if (!active) {
+            return
+          }
 
-        setWorkspaceGitInfo(info)
-      })
-      .catch(() => {
-        if (!active) {
-          return
-        }
-
-        setWorkspaceGitInfo({
-          branch: null,
-          pullRequestUrl: null,
+          setWorkspaceGitInfo(info)
         })
-      })
+        .catch(() => {
+          if (!active) {
+            return
+          }
+
+          setWorkspaceGitInfo({
+            branch: null,
+            pullRequestUrl: null,
+          })
+        })
+    }
+
+    let idleHandle: number | null = null
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null
+
+    if ('requestIdleCallback' in window) {
+      idleHandle = window.requestIdleCallback(() => {
+        loadWorkspaceGitInfo()
+      }, { timeout: 1500 })
+    } else {
+      timeoutHandle = setTimeout(loadWorkspaceGitInfo, 200)
+    }
 
     return () => {
       active = false
+
+      if (idleHandle !== null && 'cancelIdleCallback' in window) {
+        window.cancelIdleCallback(idleHandle)
+      }
+
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle)
+      }
     }
   }, [workingDirectory])
 

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { GitBranch } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import {
@@ -19,6 +19,15 @@ import { ExtensionUIHandler } from './ExtensionUIHandler'
 import { MessageInput } from './MessageInput'
 import { MessageList } from './MessageList'
 import { ThinkingLevelToggle } from './ThinkingLevelToggle'
+
+function getPullRequestLabel(url: string): string {
+  const match = url.match(/\/pull\/(\d+)(?:\/|$)/)
+  if (match?.[1]) {
+    return `PR #${match[1]}`
+  }
+
+  return 'Open PR'
+}
 
 export function ChatPanel() {
   const messages = useAtomValue(messagesAtom)
@@ -41,12 +50,26 @@ export function ChatPanel() {
 
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
+  const refreshWorkspaceGitInfo = useCallback(() => {
+    void window.api.workspace.getGitInfo()
+      .then((info) => {
+        setWorkspaceGitInfo(info)
+      })
+      .catch(() => {
+        setWorkspaceGitInfo({
+          branch: null,
+          pullRequestUrl: null,
+        })
+      })
+  }, [])
+
   useEffect(() => {
     const unsubscribeChatEvents = window.api.onChatEvent((event) => {
       applyChatEvent(event)
 
       if (event.type === 'agent_end') {
         void refreshSessions()
+        refreshWorkspaceGitInfo()
       }
     })
 
@@ -66,46 +89,21 @@ export function ChatPanel() {
       unsubscribeChatEvents()
       unsubscribeBridgeStatus()
     }
-  }, [applyBridgeStatus, applyChatEvent, refreshSessions])
+  }, [applyBridgeStatus, applyChatEvent, refreshSessions, refreshWorkspaceGitInfo])
 
   useEffect(() => {
-    let active = true
-
-    const loadWorkspaceGitInfo = () => {
-      void window.api.workspace.getGitInfo()
-        .then((info) => {
-          if (!active) {
-            return
-          }
-
-          setWorkspaceGitInfo(info)
-        })
-        .catch(() => {
-          if (!active) {
-            return
-          }
-
-          setWorkspaceGitInfo({
-            branch: null,
-            pullRequestUrl: null,
-          })
-        })
-    }
-
     let idleHandle: number | null = null
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null
 
     if ('requestIdleCallback' in window) {
       idleHandle = window.requestIdleCallback(() => {
-        loadWorkspaceGitInfo()
+        refreshWorkspaceGitInfo()
       }, { timeout: 1500 })
     } else {
-      timeoutHandle = setTimeout(loadWorkspaceGitInfo, 200)
+      timeoutHandle = setTimeout(refreshWorkspaceGitInfo, 200)
     }
 
     return () => {
-      active = false
-
       if (idleHandle !== null && 'cancelIdleCallback' in window) {
         window.cancelIdleCallback(idleHandle)
       }
@@ -114,7 +112,15 @@ export function ChatPanel() {
         clearTimeout(timeoutHandle)
       }
     }
-  }, [workingDirectory])
+  }, [workingDirectory, refreshWorkspaceGitInfo])
+
+  useEffect(() => {
+    window.addEventListener('focus', refreshWorkspaceGitInfo)
+
+    return () => {
+      window.removeEventListener('focus', refreshWorkspaceGitInfo)
+    }
+  }, [refreshWorkspaceGitInfo])
 
   // Auto-scroll: pinned to bottom by default. Detaches when the user scrolls
   // up manually, re-attaches when they scroll back near the bottom or when a
@@ -226,13 +232,25 @@ export function ChatPanel() {
 
         <div className="flex max-w-full items-center gap-3">
           {workspaceGitInfo.branch ? (
-            <span className="inline-flex max-w-56 items-center gap-1">
+            <span className="inline-flex max-w-72 items-center gap-1">
               <GitBranch size={12} aria-hidden="true" />
               <span className="truncate">{workspaceGitInfo.branch}</span>
+              {workspaceGitInfo.pullRequestUrl ? (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <button
+                    type="button"
+                    className="shrink-0 text-primary hover:underline"
+                    onClick={() => {
+                      window.open(workspaceGitInfo.pullRequestUrl ?? '', '_blank', 'noopener,noreferrer')
+                    }}
+                  >
+                    {getPullRequestLabel(workspaceGitInfo.pullRequestUrl)}
+                  </button>
+                </>
+              ) : null}
             </span>
-          ) : null}
-
-          {workspaceGitInfo.pullRequestUrl ? (
+          ) : workspaceGitInfo.pullRequestUrl ? (
             <button
               type="button"
               className="text-primary hover:underline"
@@ -240,7 +258,7 @@ export function ChatPanel() {
                 window.open(workspaceGitInfo.pullRequestUrl ?? '', '_blank', 'noopener,noreferrer')
               }}
             >
-              Open PR
+              {getPullRequestLabel(workspaceGitInfo.pullRequestUrl)}
             </button>
           ) : null}
         </div>

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -14,6 +14,7 @@ import {
 import { refreshSessionListAtom, sessionHistoryErrorAtom, workingDirectoryAtom } from '@/atoms/session'
 import { type WorkspaceGitInfo } from '@shared/types'
 import { ModelSelector } from '@/components/app-shell/ModelSelector'
+import { Button } from '@/components/ui/button'
 import { ErrorBanner } from './ErrorBanner'
 import { ExtensionUIHandler } from './ExtensionUIHandler'
 import { MessageInput } from './MessageInput'
@@ -27,6 +28,23 @@ function getPullRequestLabel(url: string): string {
   }
 
   return 'Open PR'
+}
+
+function toSafeHttpUrl(rawUrl: string | null | undefined): string | null {
+  if (!rawUrl) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(rawUrl)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null
+    }
+
+    return parsed.toString()
+  } catch {
+    return null
+  }
 }
 
 export function ChatPanel() {
@@ -49,6 +67,15 @@ export function ChatPanel() {
   const refreshSessions = useSetAtom(refreshSessionListAtom)
 
   const scrollRef = useRef<HTMLDivElement | null>(null)
+
+  const openPullRequest = useCallback(() => {
+    const safeUrl = toSafeHttpUrl(workspaceGitInfo.pullRequestUrl)
+    if (!safeUrl) {
+      return
+    }
+
+    window.open(safeUrl, '_blank', 'noopener,noreferrer')
+  }, [workspaceGitInfo.pullRequestUrl])
 
   const refreshWorkspaceGitInfo = useCallback(() => {
     void window.api.workspace.getGitInfo()
@@ -238,28 +265,28 @@ export function ChatPanel() {
               {workspaceGitInfo.pullRequestUrl ? (
                 <>
                   <span aria-hidden="true">·</span>
-                  <button
+                  <Button
                     type="button"
-                    className="shrink-0 text-primary hover:underline"
-                    onClick={() => {
-                      window.open(workspaceGitInfo.pullRequestUrl ?? '', '_blank', 'noopener,noreferrer')
-                    }}
+                    variant="link"
+                    size="sm"
+                    className="h-auto shrink-0 p-0 text-[11px]"
+                    onClick={openPullRequest}
                   >
                     {getPullRequestLabel(workspaceGitInfo.pullRequestUrl)}
-                  </button>
+                  </Button>
                 </>
               ) : null}
             </span>
           ) : workspaceGitInfo.pullRequestUrl ? (
-            <button
+            <Button
               type="button"
-              className="text-primary hover:underline"
-              onClick={() => {
-                window.open(workspaceGitInfo.pullRequestUrl ?? '', '_blank', 'noopener,noreferrer')
-              }}
+              variant="link"
+              size="sm"
+              className="h-auto p-0 text-[11px]"
+              onClick={openPullRequest}
             >
               {getPullRequestLabel(workspaceGitInfo.pullRequestUrl)}
-            </button>
+            </Button>
           ) : null}
         </div>
       </div>

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import {
   appendUserMessageAtom,
@@ -10,7 +10,9 @@ import {
   messagesAtom,
   toolCallsAtom,
 } from '@/atoms/chat'
-import { refreshSessionListAtom, sessionHistoryErrorAtom } from '@/atoms/session'
+import { refreshSessionListAtom, sessionHistoryErrorAtom, workingDirectoryAtom } from '@/atoms/session'
+import { type WorkspaceGitInfo } from '@shared/types'
+import { ModelSelector } from '@/components/app-shell/ModelSelector'
 import { ErrorBanner } from './ErrorBanner'
 import { ExtensionUIHandler } from './ExtensionUIHandler'
 import { MessageInput } from './MessageInput'
@@ -25,6 +27,12 @@ export function ChatPanel() {
   const isStreaming = useAtomValue(isStreamingAtom)
   const bridgeStatus = useAtomValue(bridgeStatusAtom)
   const sessionHistoryError = useAtomValue(sessionHistoryErrorAtom)
+  const workingDirectory = useAtomValue(workingDirectoryAtom)
+
+  const [workspaceGitInfo, setWorkspaceGitInfo] = useState<WorkspaceGitInfo>({
+    branch: null,
+    pullRequestUrl: null,
+  })
 
   const appendUserMessage = useSetAtom(appendUserMessageAtom)
   const applyChatEvent = useSetAtom(applyChatEventAtom)
@@ -59,6 +67,33 @@ export function ChatPanel() {
       unsubscribeBridgeStatus()
     }
   }, [applyBridgeStatus, applyChatEvent, refreshSessions])
+
+  useEffect(() => {
+    let active = true
+
+    void window.api.workspace.getGitInfo()
+      .then((info) => {
+        if (!active) {
+          return
+        }
+
+        setWorkspaceGitInfo(info)
+      })
+      .catch(() => {
+        if (!active) {
+          return
+        }
+
+        setWorkspaceGitInfo({
+          branch: null,
+          pullRequestUrl: null,
+        })
+      })
+
+    return () => {
+      active = false
+    }
+  }, [workingDirectory])
 
   // Auto-scroll: pinned to bottom by default. Detaches when the user scrolls
   // up manually, re-attaches when they scroll back near the bottom or when a
@@ -137,11 +172,15 @@ export function ChatPanel() {
         <MessageList messages={messages} tools={tools} />
       </div>
 
-      <ThinkingLevelToggle />
-
       <MessageInput
         disabled={inputDisabled}
         stopDisabled={stopDisabled}
+        footerControls={(
+          <div className="flex items-center gap-2">
+            <ModelSelector compact />
+            <ThinkingLevelToggle compact />
+          </div>
+        )}
         onSubmit={async (value) => {
           appendUserMessage(value)
 
@@ -160,12 +199,32 @@ export function ChatPanel() {
         }}
       />
 
-      <div className="border-t border-border px-4 py-2 text-[11px] text-muted-foreground">
-        {isStreaming
-          ? 'Streaming response…'
-          : bridgeStatus.state === 'running'
-            ? 'Ready'
-            : `Bridge ${bridgeStatus.state}`}
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-t border-border px-4 py-2 text-[11px] text-muted-foreground">
+        <span>
+          {isStreaming
+            ? 'Streaming response…'
+            : bridgeStatus.state === 'running'
+              ? 'Ready'
+              : `Bridge ${bridgeStatus.state}`}
+        </span>
+
+        <div className="flex max-w-full items-center gap-3">
+          {workspaceGitInfo.branch ? (
+            <span className="max-w-56 truncate">Branch: {workspaceGitInfo.branch}</span>
+          ) : null}
+
+          {workspaceGitInfo.pullRequestUrl ? (
+            <button
+              type="button"
+              className="text-primary hover:underline"
+              onClick={() => {
+                window.open(workspaceGitInfo.pullRequestUrl ?? '', '_blank', 'noopener,noreferrer')
+              }}
+            >
+              Open PR
+            </button>
+          ) : null}
+        </div>
       </div>
     </div>
   )

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -18,7 +18,6 @@ import { ErrorBanner } from './ErrorBanner'
 import { ExtensionUIHandler } from './ExtensionUIHandler'
 import { MessageInput } from './MessageInput'
 import { MessageList } from './MessageList'
-import { PermissionModeSelector } from './PermissionModeSelector'
 import { ThinkingLevelToggle } from './ThinkingLevelToggle'
 
 export function ChatPanel() {
@@ -179,11 +178,6 @@ export function ChatPanel() {
           onRestart={bridgeStatus.state !== 'spawning' ? () => window.api.restartAgent() : undefined}
         />
       )}
-
-      <div className="flex items-center justify-between border-b border-border px-4 py-2">
-        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Permission mode</p>
-        <PermissionModeSelector />
-      </div>
 
       <div ref={scrollRef} className="flex-1 overflow-auto">
         {sessionHistoryError && (

--- a/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { GitBranch } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import {
   appendUserMessageAtom,
@@ -210,7 +211,10 @@ export function ChatPanel() {
 
         <div className="flex max-w-full items-center gap-3">
           {workspaceGitInfo.branch ? (
-            <span className="max-w-56 truncate">Branch: {workspaceGitInfo.branch}</span>
+            <span className="inline-flex max-w-56 items-center gap-1">
+              <GitBranch size={12} aria-hidden="true" />
+              <span className="truncate">{workspaceGitInfo.branch}</span>
+            </span>
           ) : null}
 
           {workspaceGitInfo.pullRequestUrl ? (

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -67,7 +67,7 @@ export function MessageInput({
               handleSend()
             }
           }}
-          className="h-20 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-sm text-foreground shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent"
+          className="min-h-[5rem] resize-none overflow-hidden rounded-none border-0 bg-transparent px-0 py-0 text-sm text-foreground shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent"
           placeholder="Ask Kata to help with your code..."
           disabled={disabled || submitting}
         />

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -1,15 +1,22 @@
-import { useRef, useState } from 'react'
+import { type ReactNode, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 
 interface MessageInputProps {
   disabled?: boolean
   stopDisabled?: boolean
+  footerControls?: ReactNode
   onSubmit: (value: string) => Promise<void>
   onStop: () => Promise<void>
 }
 
-export function MessageInput({ disabled = false, stopDisabled = disabled, onSubmit, onStop }: MessageInputProps) {
+export function MessageInput({
+  disabled = false,
+  stopDisabled = disabled,
+  footerControls,
+  onSubmit,
+  onStop,
+}: MessageInputProps) {
   const [value, setValue] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const sendingRef = useRef(false)
@@ -45,7 +52,7 @@ export function MessageInput({ disabled = false, stopDisabled = disabled, onSubm
 
   return (
     <div className="border-t border-border p-4">
-      <div className="flex flex-col gap-2 rounded-lg border border-border bg-card p-2">
+      <div className="flex flex-col gap-2 rounded-lg border border-border bg-input/30 p-3">
         <Textarea
           data-testid="chat-input"
           value={value}
@@ -60,30 +67,34 @@ export function MessageInput({ disabled = false, stopDisabled = disabled, onSubm
               handleSend()
             }
           }}
-          className="h-20 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-sm text-foreground shadow-none focus-visible:border-transparent focus-visible:ring-0"
+          className="h-20 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-sm text-foreground shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent"
           placeholder="Ask Kata to help with your code..."
           disabled={disabled || submitting}
         />
 
-        <div className="flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={handleStop}
-            disabled={stopDisabled}
-          >
-            Stop
-          </Button>
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0 flex-1">{footerControls}</div>
 
-          <Button
-            type="button"
-            size="sm"
-            onClick={handleSend}
-            disabled={disabled || submitting}
-          >
-            Send
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleStop}
+              disabled={stopDisabled}
+            >
+              Stop
+            </Button>
+
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleSend}
+              disabled={disabled || submitting}
+            >
+              Send
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 
@@ -20,6 +20,22 @@ export function MessageInput({
   const [value, setValue] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const sendingRef = useRef(false)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  const adjustTextareaHeight = useCallback((): void => {
+    const textarea = textareaRef.current
+    if (!textarea) {
+      return
+    }
+
+    textarea.style.height = '0px'
+    const nextHeight = Math.max(textarea.scrollHeight, 80)
+    textarea.style.height = `${nextHeight}px`
+  }, [])
+
+  useLayoutEffect(() => {
+    adjustTextareaHeight()
+  }, [adjustTextareaHeight, value])
 
   const send = async (): Promise<void> => {
     const trimmed = value.trim()
@@ -54,6 +70,7 @@ export function MessageInput({
     <div className="border-t border-border p-4">
       <div className="flex flex-col gap-2 rounded-lg border border-border bg-input/30 p-3">
         <Textarea
+          ref={textareaRef}
           data-testid="chat-input"
           value={value}
           onChange={(event) => setValue(event.target.value)}
@@ -67,7 +84,7 @@ export function MessageInput({
               handleSend()
             }
           }}
-          className="min-h-[5rem] resize-none overflow-hidden rounded-none border-0 bg-transparent px-0 py-0 text-sm text-foreground shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent"
+          className="min-h-[5rem] resize-none overflow-hidden rounded-none border-0 bg-transparent px-0 py-0 text-sm text-foreground shadow-none [field-sizing:fixed] focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent"
           placeholder="Ask Kata to help with your code..."
           disabled={disabled || submitting}
         />

--- a/apps/desktop/src/renderer/components/chat/MessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageList.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useMemo, useState } from 'react'
 import type { ChatMessageView, ToolCallView } from '@/atoms/chat'
+import { Button } from '@/components/ui/button'
 import { StreamingMessage } from './StreamingMessage'
 import { ThinkingBlock } from './ThinkingBlock'
 import { ToolCallCard } from './ToolCallCard'
@@ -8,22 +10,55 @@ interface MessageListProps {
   tools: ToolCallView[]
 }
 
+const MAX_RENDERED_MESSAGES = 80
+
 export function MessageList({ messages, tools }: MessageListProps) {
+  const [showAllMessages, setShowAllMessages] = useState(false)
+
+  const oldestMessageId = messages[0]?.id ?? null
+
+  useEffect(() => {
+    setShowAllMessages(false)
+  }, [oldestMessageId])
+
+  const hiddenMessageCount = Math.max(0, messages.length - MAX_RENDERED_MESSAGES)
+  const visibleMessages =
+    showAllMessages || hiddenMessageCount === 0
+      ? messages
+      : messages.slice(-MAX_RENDERED_MESSAGES)
+
   // Index tool calls by parentMessageId so we can render them inline after their
   // triggering assistant message.
-  const toolsByParent = new Map<string, ToolCallView[]>()
+  const toolsByParent = useMemo(() => {
+    const map = new Map<string, ToolCallView[]>()
 
-  for (const tool of tools) {
-    if (tool.parentMessageId) {
-      const existing = toolsByParent.get(tool.parentMessageId) ?? []
-      existing.push(tool)
-      toolsByParent.set(tool.parentMessageId, existing)
+    for (const tool of tools) {
+      if (tool.parentMessageId) {
+        const existing = map.get(tool.parentMessageId) ?? []
+        existing.push(tool)
+        map.set(tool.parentMessageId, existing)
+      }
     }
-  }
+
+    return map
+  }, [tools])
 
   return (
     <div className="flex flex-col gap-6 px-5 py-6">
-      {messages.map((message) => {
+      {hiddenMessageCount > 0 && !showAllMessages ? (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setShowAllMessages(true)}
+          >
+            Show {hiddenMessageCount} older message{hiddenMessageCount === 1 ? '' : 's'}
+          </Button>
+        </div>
+      ) : null}
+
+      {visibleMessages.map((message) => {
         const ownedTools = toolsByParent.get(message.id) ?? []
 
         // Filter ghost entries: assistant messages with no visible content and no tool calls

--- a/apps/desktop/src/renderer/components/chat/ThinkingLevelToggle.tsx
+++ b/apps/desktop/src/renderer/components/chat/ThinkingLevelToggle.tsx
@@ -2,22 +2,35 @@ import { useMemo } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import type { ThinkingLevel } from '@shared/types'
 import { availableModelsAtom, selectedModelAtom, thinkingLevelAtom } from '@/atoms/model'
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 
 const STANDARD_LEVELS: { value: ThinkingLevel; label: string }[] = [
-  { value: 'off', label: 'off' },
-  { value: 'minimal', label: 'minimal' },
-  { value: 'low', label: 'low' },
-  { value: 'medium', label: 'med' },
-  { value: 'high', label: 'high' },
+  { value: 'off', label: 'Off' },
+  { value: 'minimal', label: 'Minimal' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
 ]
 
 const XHIGH_LEVELS: { value: ThinkingLevel; label: string }[] = [
   ...STANDARD_LEVELS,
-  { value: 'xhigh', label: 'xhigh' },
+  { value: 'xhigh', label: 'XHigh' },
 ]
 
-export function ThinkingLevelToggle() {
+interface ThinkingLevelToggleProps {
+  compact?: boolean
+  className?: string
+}
+
+export function ThinkingLevelToggle({ compact = false, className }: ThinkingLevelToggleProps) {
   const selectedModel = useAtomValue(selectedModelAtom)
   const availableModels = useAtomValue(availableModelsAtom)
   const [thinkingLevel, setThinkingLevel] = useAtom(thinkingLevelAtom)
@@ -41,17 +54,24 @@ export function ThinkingLevelToggle() {
   }
 
   return (
-    <div className="flex items-center gap-3 border-t border-border px-4 py-1.5">
-      <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Thinking</span>
-      <Tabs value={thinkingLevel} onValueChange={(value) => { void handleChange(value) }}>
-        <TabsList className="h-7">
-          {levels.map(({ value, label }) => (
-            <TabsTrigger key={value} value={value} className="h-5 px-2 text-[10px]">
-              {label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </Tabs>
+    <div className={cn(compact ? 'min-w-[8.5rem]' : 'flex items-center gap-2', className)}>
+      {!compact ? (
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Thinking</span>
+      ) : null}
+      <Select value={thinkingLevel} onValueChange={(value) => { void handleChange(value) }}>
+        <SelectTrigger size="sm" className="w-full">
+          <SelectValue placeholder="Thinking" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {levels.map(({ value, label }) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/components/onboarding/CompletionStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/CompletionStep.tsx
@@ -46,7 +46,7 @@ export function CompletionStep({ selectedModel, readiness, onBack, onFinish }: C
             </p>
             {!selectedModel && (
               <p className="pt-1 text-xs text-muted-foreground">
-                You can choose a model anytime from the toolbar model picker.
+                You can choose a model anytime from the chat composer controls.
               </p>
             )}
           </CardContent>

--- a/apps/desktop/src/renderer/components/settings/ArchivedChatsPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/ArchivedChatsPanel.tsx
@@ -1,0 +1,91 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import {
+  archivedSessionsForSettingsAtom,
+  unarchiveSessionAtom,
+} from '@/atoms/session'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+const ARCHIVE_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
+
+function formatArchiveDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown date'
+  }
+
+  return ARCHIVE_DATE_FORMATTER.format(date)
+}
+
+export function ArchivedChatsPanel() {
+  const archivedSessions = useAtomValue(archivedSessionsForSettingsAtom)
+  const unarchiveSession = useSetAtom(unarchiveSessionAtom)
+
+  return (
+    <Card className="border border-border bg-card/60 py-0">
+      <CardHeader className="flex flex-col gap-2 px-4 pt-4 pb-0">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-sm text-foreground">Archived chats</CardTitle>
+          <Badge variant="secondary" className="font-normal">
+            {archivedSessions.length}
+          </Badge>
+        </div>
+        <CardDescription className="text-xs text-muted-foreground">
+          Archived chats are hidden from the sidebar until you unarchive them.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-2 p-4 pt-2">
+        {archivedSessions.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No archived chats yet.</p>
+        ) : (
+          archivedSessions.map((chat) => (
+            <div
+              key={`${chat.projectDir}::${chat.sessionId}`}
+              className="flex items-start justify-between gap-3 rounded-lg border border-border/70 bg-background/60 p-3"
+            >
+              <div className="min-w-0 flex flex-col gap-1">
+                <p
+                  className="text-xs font-medium text-foreground [overflow-wrap:anywhere]"
+                  title={chat.title}
+                >
+                  {chat.title}
+                </p>
+                <p className="text-[11px] text-muted-foreground">
+                  Archived {formatArchiveDate(chat.archivedAt)}
+                </p>
+                <p className="truncate text-[11px] text-muted-foreground" title={chat.projectDir}>
+                  {chat.projectDir}
+                </p>
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                onClick={() => {
+                  unarchiveSession({
+                    sessionId: chat.sessionId,
+                    projectDir: chat.projectDir,
+                  })
+                }}
+              >
+                Unarchive
+              </Button>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsPanel.tsx
@@ -18,6 +18,7 @@ import { ProviderAuthPanel } from './ProviderAuthPanel'
 import { SymphonyRuntimePanel } from './SymphonyRuntimePanel'
 import { SymphonyDashboard } from '../symphony/SymphonyDashboard'
 import { McpServerPanel } from './McpServerPanel'
+import { ArchivedChatsPanel } from './ArchivedChatsPanel'
 
 interface SettingsPanelProps {
   open: boolean
@@ -29,6 +30,7 @@ interface SettingsPanelProps {
 const SETTINGS_TABS: Array<{ id: SettingsTabId; label: string }> = [
   { id: 'providers', label: 'Providers' },
   { id: 'mcp', label: 'MCP' },
+  { id: 'archives', label: 'Archived Chats' },
   { id: 'symphony', label: 'Symphony' },
   { id: 'general', label: 'General' },
   { id: 'appearance', label: 'Appearance' },
@@ -108,8 +110,12 @@ export function SettingsPanel({
               <McpServerPanel />
             </TabsContent>
 
+            <TabsContent value="archives" className="mt-0 h-full overflow-auto p-4">
+              <ArchivedChatsPanel />
+            </TabsContent>
+
             <TabsContent value="symphony" className="mt-0 h-full overflow-auto p-4">
-              <div className="space-y-4">
+              <div className="flex flex-col gap-4">
                 <SymphonyRuntimePanel />
                 <SymphonyDashboard />
               </div>

--- a/apps/desktop/src/renderer/components/ui/textarea.tsx
+++ b/apps/desktop/src/renderer/components/ui/textarea.tsx
@@ -2,17 +2,21 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
-  return (
-    <textarea
-      data-slot="textarea"
-      className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className
-      )}
-      {...props}
-    />
-  )
-}
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"textarea">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        data-slot="textarea"
+        className={cn(
+          "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
 
 export { Textarea }

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -19,6 +19,7 @@ export const IPC_CHANNELS = {
   workspaceGet: 'workspace:get',
   workspaceSet: 'workspace:set',
   workspacePick: 'workspace:pick',
+  workspaceGetGitInfo: 'workspace:get-git-info',
   authGetProviders: 'auth:get-providers',
   authSetKey: 'auth:set-key',
   authRemoveKey: 'auth:remove-key',
@@ -223,6 +224,11 @@ export interface SessionSwitchResponse {
   sessionId: string | null
   sessionPath?: string | null
   error?: string
+}
+
+export interface WorkspaceGitInfo {
+  branch: string | null
+  pullRequestUrl: string | null
 }
 
 export interface WorkspaceInfo {
@@ -1682,6 +1688,7 @@ export interface DesktopApi {
     get: () => Promise<WorkspaceInfo>
     set: (workspacePath: string) => Promise<WorkspaceInfo>
     pick: () => Promise<WorkspaceInfo | null>
+    getGitInfo: () => Promise<WorkspaceGitInfo>
   }
   auth: {
     getProviders: () => Promise<AuthProvidersResponse>


### PR DESCRIPTION
## Summary
- add session archiving support in desktop state atoms with per-workspace filtering
- show archive action on session item hover (bottom-right icon) and hide archived chats from sidebar
- add **Archived Chats** settings tab with title, archived date, project directory, and unarchive action
- add coverage for archive/unarchive behavior in renderer atom tests

## Verification
- `pnpm run typecheck`
- `npx vitest run src/renderer/atoms/__tests__/session-archive.test.ts src/renderer/components/settings/__tests__/SettingsPanel.test.tsx`
- pre-push hook suite passed (`@kata/desktop:test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- **Session archiving**: Archive and restore chat sessions within your workspace
- **Git integration**: Displays current branch and pull request information in the chat footer
- **Archived chats management**: New settings panel to view and restore archived chat sessions

## Improvements
- Reorganized chat composer controls and footer layout
- Message list now limits displayed messages for performance optimization with option to view older messages
- Removed legacy permission mode UI from chat interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds client-side chat archiving to Kata Desktop. Sessions can be archived from the sidebar hover action and restored via a new **Archived Chats** settings tab. Archive state is persisted with `atomWithStorage` (keyed by workspace path), and `visibleSessionListAtom` filters the sidebar in real time. The PR also ships several unrelated UI improvements: workspace git branch / PR URL display in the chat footer, message virtualization (`MAX_RENDERED_MESSAGES = 80`), removal of the legacy permission-mode selector, and a compact mode for `ModelSelector` and `ThinkingLevelToggle`.

- The `gh pr view` call in `readWorkspaceGitInfo` uses a 250 ms timeout — shorter than a typical GitHub API round-trip — so `pullRequestUrl` will silently return `null` on most connections and the \"Open PR\" button won't appear in practice.
- Sessions archived while `workingDirectoryAtom` is empty are stored with `projectDir = 'Unknown workspace'`, but `workspaceArchivedSessionIdsAtom` filters against `normalizeWorkspacePath('') = ''`, so those entries never match and the sessions remain visible.

<h3>Confidence Score: 5/5</h3>

Safe to merge; archive feature is correct for the normal path and all findings are P2

No P0/P1 blockers. The two logic notes (gh timeout, Unknown workspace sentinel) are edge cases that don't affect the primary archive/unarchive flow covered by the new tests. The git-info staleness is a UX quality issue.

apps/desktop/src/main/ipc.ts (gh timeout) and apps/desktop/src/renderer/atoms/session.ts (Unknown workspace sentinel)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/atoms/session.ts | Core archive/unarchive logic: introduces archivedSessionsAtom (atomWithStorage), visibleSessionListAtom, archiveSessionAtom, and unarchiveSessionAtom — minor edge case when archiving with no workspace set |
| apps/desktop/src/main/ipc.ts | Adds workspaceGetGitInfo IPC handler; gh pr view called with 250 ms timeout which is too short for a network request |
| apps/desktop/src/renderer/components/settings/ArchivedChatsPanel.tsx | New settings tab rendering archived chats from all workspaces with unarchive action; clean and correct |
| apps/desktop/src/renderer/components/app-shell/SessionListItem.tsx | Adds archive button on hover/focus-within; wraps in memo; moves Intl formatters to module-level constants |
| apps/desktop/src/renderer/components/chat/ChatPanel.tsx | Removes PermissionModeSelector, adds git branch/PR display; git info fetched once per workspace change with stale-safe active flag |
| apps/desktop/src/renderer/components/chat/MessageList.tsx | Adds soft message virtualization (MAX_RENDERED_MESSAGES=80) with show-older button; toolsByParent moved into useMemo |
| apps/desktop/src/renderer/components/chat/MessageInput.tsx | Adds footerControls slot, auto-resize textarea via useLayoutEffect, layout polish |
| apps/desktop/src/renderer/components/ui/textarea.tsx | Converts to React.forwardRef to enable ref prop for auto-resize in MessageInput |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Archive button on SessionListItem] --> B[archiveSessionAtom write]
    B --> C[Append to archivedSessionsAtom with projectDir + archivedAt]
    C --> D{Is archived session the current session?}
    D -- No --> E[Return early - sidebar updates via visibleSessionListAtom]
    D -- Yes --> F[get workspaceArchivedSessionIdsAtom now includes new entry]
    F --> G{Any remaining visible sessions?}
    G -- Yes --> H[switchSessionAtom to first visible session]
    G -- No --> I[Clear currentSessionIdAtom + reset chat state]

    J[User opens Settings - Archived Chats] --> K[archivedSessionsForSettingsAtom all workspaces sorted by archivedAt]
    K --> L[ArchivedChatsPanel renders list]
    L --> M[User clicks Unarchive]
    M --> N[unarchiveSessionAtom removes entry from archivedSessionsAtom]
    N --> O[visibleSessionListAtom updates - session reappears in sidebar]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/ipc.ts`, line 129 ([link](https://github.com/gannonh/kata/blob/c20ca51951b7b356176885fbb805a39c90687311/apps/desktop/src/main/ipc.ts#L129)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`gh pr view` timeout too short for a network request**

   250 ms is far below the round-trip time of a GitHub API call on any realistic network (typically 300–2 000 ms). `runOptionalCommand` silently returns `null` on timeout, so `pullRequestUrl` will be `null` almost every time and the "Open PR" button will never appear in practice.

   Consider raising the timeout to at least 5 000 ms, or making the `gh` step a lazy/on-demand query rather than blocking the idle callback.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/ipc.ts
   Line: 129

   Comment:
   **`gh pr view` timeout too short for a network request**

   250 ms is far below the round-trip time of a GitHub API call on any realistic network (typically 300–2 000 ms). `runOptionalCommand` silently returns `null` on timeout, so `pullRequestUrl` will be `null` almost every time and the "Open PR" button will never appear in practice.

   Consider raising the timeout to at least 5 000 ms, or making the `gh` step a lazy/on-demand query rather than blocking the idle callback.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/ipc.ts
Line: 129

Comment:
**`gh pr view` timeout too short for a network request**

250 ms is far below the round-trip time of a GitHub API call on any realistic network (typically 300–2 000 ms). `runOptionalCommand` silently returns `null` on timeout, so `pullRequestUrl` will be `null` almost every time and the "Open PR" button will never appear in practice.

Consider raising the timeout to at least 5 000 ms, or making the `gh` step a lazy/on-demand query rather than blocking the idle callback.

```suggestion
    : await runOptionalCommand('gh', ['pr', 'view', '--head', branch, '--json', 'url', '--jq', '.url'], workspacePath, 5000)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/session.ts
Line: 378-379

Comment:
**"Unknown workspace" sentinel doesn't round-trip through `workspaceArchivedSessionIdsAtom`**

When `workingDirectoryAtom` is empty, `archiveSessionAtom` stores `projectDir = 'Unknown workspace'`. But `workspaceArchivedSessionIdsAtom` compares against `normalizeWorkspacePath('')` which is `''`, not `'Unknown workspace'`, so those archived entries never match and the sessions remain visible in the sidebar.

A simple fix is to use the same sentinel in both places:

```ts
// in workspaceArchivedSessionIdsAtom
const normalizedWorkspacePath = normalizeWorkspacePath(get(workingDirectoryAtom)) || 'Unknown workspace'
```

Or normalize both sides to the same empty-fallback before comparison.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/ChatPanel.tsx
Line: 68-86

Comment:
**Git info fetched once; display goes stale on branch switch**

The effect's dependency array is `[workingDirectory]`, so git info is fetched once when the workspace is first loaded and never refreshed. If the user switches branches in the terminal while Kata is open, the displayed branch (and PR URL) will remain stale for the entire session.

Consider periodically re-fetching (e.g. on window focus or on a slow interval) or adding a manual refresh affordance so users can pull the current branch without switching workspaces.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): add chat archiving with s..."](https://github.com/gannonh/kata/commit/c20ca51951b7b356176885fbb805a39c90687311) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28534597)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->