### PR TITLE
Add Kata preference parsing, onboarding, and GitHub backend flow

### DIFF
--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -77,6 +77,57 @@ import { deriveUnitType, deriveUnitId, peekNext } from "./auto-dispatch.js";
 export { deriveUnitType, deriveUnitId, peekNext } from "./auto-dispatch.js";
 const providerBackoffMs = [5000, 10000, 30000];
 
+// ─── globalThis persistence ───────────────────────────────────────────────────
+// jiti's moduleCache:false re-evaluates this module on every newSession(),
+// resetting all module-level variables. We use globalThis to persist state
+// that must survive across session rebuilds.
+
+const _KS = Symbol.for('kata:autoState');
+const _KP = Symbol.for('kata:latestPi');
+
+/** Called from index.ts every time the extension factory runs. */
+export function setLatestPi(pi: ExtensionAPI): void {
+  (globalThis as any)[_KP] = pi;
+}
+
+function getLatestPi(): ExtensionAPI | null {
+  return ((globalThis as any)[_KP] as ExtensionAPI) ?? null;
+}
+
+/** Persist all mutable auto-mode state to globalThis before newSession(). */
+function syncToGlobal(): void {
+  (globalThis as any)[_KS] = {
+    active, paused, stepActive, verbose,
+    basePath, lastUnit, retryCount, providerErrorStreak,
+    currentMilestoneId, originalModelId, autoStartTime,
+    pendingCrashRecovery, currentUnit, completedUnits,
+    // Object references — survive because globalThis keeps them alive
+    cmdCtx, backend,
+  };
+}
+
+/** Restore auto-mode state from globalThis after module reload. */
+function syncFromGlobal(): void {
+  const s = (globalThis as any)[_KS];
+  if (!s) return;
+  active = s.active ?? false;
+  paused = s.paused ?? false;
+  stepActive = s.stepActive ?? false;
+  verbose = s.verbose ?? false;
+  basePath = s.basePath ?? '';
+  lastUnit = s.lastUnit ?? null;
+  retryCount = s.retryCount ?? 0;
+  providerErrorStreak = s.providerErrorStreak ?? 0;
+  currentMilestoneId = s.currentMilestoneId ?? null;
+  originalModelId = s.originalModelId ?? null;
+  autoStartTime = s.autoStartTime ?? 0;
+  pendingCrashRecovery = s.pendingCrashRecovery ?? null;
+  currentUnit = s.currentUnit ?? null;
+  completedUnits = s.completedUnits ?? [];
+  cmdCtx = s.cmdCtx ?? null;
+  backend = s.backend ?? null;
+}
+
 // ─── State ────────────────────────────────────────────────────────────────────
 
 let active = false;
@@ -114,6 +165,9 @@ let currentMilestoneId: string | null = null;
 
 /** Model the user had selected before auto-mode started */
 let originalModelId: string | null = null;
+
+// Restore state from globalThis on module reload (after newSession)
+syncFromGlobal();
 
 /** Progress-aware timeout supervision */
 let unitTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -1278,12 +1332,20 @@ async function dispatchNextUnit(
   updateProgressWidget(ctx, unitType, unitId, state);
 
   // 14. Fresh session
+  // Sync all auto-mode state to globalThis BEFORE newSession() — jiti's
+  // moduleCache:false will re-evaluate this module, and syncFromGlobal()
+  // at the top restores the state in the new instance.
+  syncToGlobal();
   const result = await cmdCtx!.newSession();
   if (result.cancelled) {
     await stopAuto(ctx, pi);
     ctx.ui.notify("New session cancelled — auto-mode stopped.", "warning");
     return;
   }
+
+  // After newSession(), `pi` is stale (old session torn down). Resolve the
+  // live pi that the new session's extension factory stored in globalThis.
+  const livePi = getLatestPi() ?? pi;
 
   // 16. Lock file
   const sessionFile = ctx.sessionManager.getSessionFile();
@@ -1317,7 +1379,7 @@ async function dispatchNextUnit(
   if (switchResult.action === "switch") {
     const model = ctx.modelRegistry.getAll().find((m) => m.id === switchResult.preferredModelId);
     if (model) {
-      const ok = await pi.setModel(model);
+      const ok = await livePi.setModel(model);
       if (ok) ctx.ui.notify(`Model: ${switchResult.preferredModelId}`, "info");
     }
   } else if (switchResult.action === "not-found") {
@@ -1343,7 +1405,7 @@ async function dispatchNextUnit(
       phase: "wrapup-warning-sent",
       wrapupWarningSent: true,
     });
-    pi.sendMessage(
+    livePi.sendMessage(
       {
         customType: "kata-auto-wrapup",
         display: verbose,
@@ -1440,7 +1502,7 @@ async function dispatchNextUnit(
   }, hardTimeoutMs);
 
   // 20. Dispatch
-  pi.sendMessage(
+  livePi.sendMessage(
     { customType: "kata-auto", content: finalPrompt, display: verbose },
     { triggerTurn: true },
   );
@@ -1506,7 +1568,7 @@ async function recoverTimedOutUnit(
           "If blocked, record the blocker explicitly instead of going silent.",
         ];
 
-    pi.sendMessage(
+    livePi.sendMessage(
       {
         customType: "kata-auto-timeout-recovery",
         display: verbose,

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -1581,7 +1581,7 @@ async function recoverTimedOutUnit(
           "If blocked, record the blocker explicitly instead of going silent.",
         ];
 
-    livePi.sendMessage(
+    (getLatestPi() ?? pi).sendMessage(
       {
         customType: "kata-auto-timeout-recovery",
         display: verbose,

--- a/apps/cli/src/resources/extensions/kata/auto.ts
+++ b/apps/cli/src/resources/extensions/kata/auto.ts
@@ -94,6 +94,10 @@ function getLatestPi(): ExtensionAPI | null {
   return ((globalThis as any)[_KP] as ExtensionAPI) ?? null;
 }
 
+function clearSyncedState(): void {
+  delete (globalThis as any)[_KS];
+}
+
 /** Persist all mutable auto-mode state to globalThis before newSession(). */
 function syncToGlobal(): void {
   (globalThis as any)[_KS] = {
@@ -110,6 +114,10 @@ function syncToGlobal(): void {
 function syncFromGlobal(): void {
   const s = (globalThis as any)[_KS];
   if (!s) return;
+  if (!s.active && !s.paused) {
+    clearSyncedState();
+    return;
+  }
   active = s.active ?? false;
   paused = s.paused ?? false;
   stepActive = s.stepActive ?? false;
@@ -126,6 +134,7 @@ function syncFromGlobal(): void {
   completedUnits = s.completedUnits ?? [];
   cmdCtx = s.cmdCtx ?? null;
   backend = s.backend ?? null;
+  clearSyncedState();
 }
 
 // ─── State ────────────────────────────────────────────────────────────────────
@@ -289,6 +298,7 @@ export async function stopAuto(
   }
 
   cmdCtx = null;
+  clearSyncedState();
 }
 
 /**
@@ -324,6 +334,9 @@ export async function startAuto(
   base: string,
   verboseMode: boolean,
 ): Promise<void> {
+  // Starting a fresh run should never inherit stale cached session state.
+  clearSyncedState();
+
   const modeGate = getWorkflowEntrypointGuard("auto");
   if (!modeGate.allow) {
     ctx.ui.notify(

--- a/apps/cli/src/resources/extensions/kata/backend-factory.ts
+++ b/apps/cli/src/resources/extensions/kata/backend-factory.ts
@@ -87,7 +87,7 @@ async function createGithubBackend(basePath: string): Promise<KataBackend> {
         {
           code: "missing_github_token",
           message:
-            "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, or store a credential via Kata onboarding.",
+            "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, or add a github credential entry to ~/.kata-cli/agent/auth.json.",
           field: "KATA_GITHUB_TOKEN",
           retryable: false,
         },

--- a/apps/cli/src/resources/extensions/kata/backend-factory.ts
+++ b/apps/cli/src/resources/extensions/kata/backend-factory.ts
@@ -1,35 +1,130 @@
 /**
- * Backend factory — creates the LinearBackend.
+ * Backend factory — creates the workflow backend for the active mode.
  *
- * Separate file to avoid circular imports: backend.ts defines the interface,
- * this file imports the implementation.
+ * Supported modes:
+ * - linear (default)
+ * - github
  */
 
 import type { KataBackend } from "./backend.js";
+import { GithubBackend } from "./github-backend.js";
+import {
+  formatGithubConfigStatus,
+  resolveGithubToken,
+  validateGithubConfig,
+  type GithubConfigValidationResult,
+} from "./github-config.js";
 import {
   loadEffectiveLinearProjectConfig,
   resolveConfiguredLinearProjectId,
   resolveConfiguredLinearTeamId,
 } from "./linear-config.js";
-import { loadEffectiveKataPreferences } from "./preferences.js";
+import { loadEffectiveKataPreferences, type LoadedKataPreferences } from "./preferences.js";
 import { LinearClient } from "../linear/linear-client.js";
 import { ensureKataLabels } from "../linear/linear-entities.js";
 import { LinearBackend } from "./linear-backend.js";
 
-/**
- * Create the Linear backend.
- *
- * Async because LinearBackend config resolution requires API calls
- * (team ID resolution, label set lookup).
- *
- * Called once at the start of auto-mode or step-mode.
- */
-export async function createBackend(basePath: string): Promise<KataBackend> {
-  const loadedPreferences = loadEffectiveKataPreferences(basePath);
-  const config = loadEffectiveLinearProjectConfig(loadedPreferences);
+interface BackendBootstrapEvent {
+  backend: "linear" | "github";
+  status: "ready" | "invalid_config" | "error";
+  detail?: string;
+  diagnostics?: string[];
+}
+
+function emitBackendBootstrap(event: BackendBootstrapEvent): void {
+  process.stderr.write(`[kata][backend-bootstrap] ${JSON.stringify(event)}\n`);
+}
+
+function buildGithubBootstrapError(
+  validation: GithubConfigValidationResult,
+): Error {
+  const report = formatGithubConfigStatus(validation);
+  const relevantLines = report.lines.filter((line) =>
+    line.startsWith("GITHUB_TOKEN:") ||
+    line.startsWith("tracker.") ||
+    line.startsWith("validation:") ||
+    line.startsWith("diagnostic:") ||
+    line.startsWith("action:"),
+  );
+
+  const message = [
+    "GitHub backend is not ready.",
+    ...relevantLines,
+    "Run /kata prefs status for full diagnostics.",
+  ].join("\n");
+
+  return new Error(message);
+}
+
+async function createGithubBackend(basePath: string): Promise<KataBackend> {
+  const validation = validateGithubConfig({ basePath });
+
+  if (!validation.ok || !validation.trackerConfig) {
+    const diagnostics = validation.diagnostics.map((diagnostic) => diagnostic.code);
+    emitBackendBootstrap({
+      backend: "github",
+      status: "invalid_config",
+      diagnostics,
+    });
+    throw buildGithubBootstrapError(validation);
+  }
+
+  const tokenResolution = resolveGithubToken();
+  if (!tokenResolution.token) {
+    emitBackendBootstrap({
+      backend: "github",
+      status: "invalid_config",
+      diagnostics: ["missing_github_token"],
+    });
+    throw buildGithubBootstrapError({
+      ...validation,
+      ok: false,
+      status: "invalid",
+      tokenPresent: false,
+      tokenSource: null,
+      diagnostics: [
+        ...validation.diagnostics,
+        {
+          code: "missing_github_token",
+          message:
+            "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, or store a credential via Kata onboarding.",
+          field: "KATA_GITHUB_TOKEN",
+          retryable: false,
+        },
+      ],
+    });
+  }
+
+  emitBackendBootstrap({
+    backend: "github",
+    status: "ready",
+    detail: `${validation.trackerConfig.repoOwner}/${validation.trackerConfig.repoName} (${validation.trackerConfig.stateMode})`,
+  });
+
+  return new GithubBackend(basePath, {
+    token: tokenResolution.token,
+    repoOwner: validation.trackerConfig.repoOwner,
+    repoName: validation.trackerConfig.repoName,
+    stateMode: validation.trackerConfig.stateMode,
+    labelPrefix: validation.trackerConfig.labelPrefix ?? "kata:",
+    apiBaseUrl: process.env.KATA_GITHUB_API_BASE_URL,
+  });
+}
+
+async function createLinearBackend(
+  basePath: string,
+  loadedPreferences: LoadedKataPreferences | null,
+): Promise<KataBackend> {
   const apiKey = process.env.KATA_LINEAR_API_KEY ?? process.env.LINEAR_API_KEY;
   if (!apiKey) {
-    throw new Error("LINEAR_API_KEY is not set. Set it in your environment to use Linear mode (KATA_LINEAR_API_KEY or LINEAR_API_KEY).");
+    emitBackendBootstrap({
+      backend: "linear",
+      status: "invalid_config",
+      diagnostics: ["missing_linear_api_key"],
+    });
+    throw new Error(
+      "LINEAR_API_KEY is not set. Set it in your environment to use Linear mode (KATA_LINEAR_API_KEY or LINEAR_API_KEY).",
+    );
   }
 
   const client = new LinearClient(apiKey);
@@ -37,7 +132,15 @@ export async function createBackend(basePath: string): Promise<KataBackend> {
   // Resolve projectId slug → UUID if needed (filter expressions require UUIDs).
   const projectResolution = await resolveConfiguredLinearProjectId(client, loadedPreferences);
   if (!projectResolution.projectId) {
-    throw new Error(projectResolution.error ?? "Linear project not configured \u2014 set linear.projectSlug in .kata/preferences.md.");
+    emitBackendBootstrap({
+      backend: "linear",
+      status: "invalid_config",
+      diagnostics: ["missing_linear_project"],
+    });
+    throw new Error(
+      projectResolution.error ??
+        "Linear project not configured — set linear.projectSlug in .kata/preferences.md.",
+    );
   }
   const projectId = projectResolution.projectId;
 
@@ -50,10 +153,19 @@ export async function createBackend(basePath: string): Promise<KataBackend> {
         loadedPreferences,
       );
       if (!teamResolution.teamId) {
-        throw new Error(teamResolution.error ?? "Linear team could not be resolved. Check linear.teamId or linear.teamKey in preferences.");
+        throw new Error(
+          teamResolution.error ??
+            "Linear team could not be resolved. Check linear.teamId or linear.teamKey in preferences.",
+        );
       }
 
       const labelSet = await ensureKataLabels(client, teamResolution.teamId);
+
+      emitBackendBootstrap({
+        backend: "linear",
+        status: "ready",
+        detail: `${projectId} / ${teamResolution.teamId}`,
+      });
 
       return new LinearBackend(basePath, {
         apiKey,
@@ -66,13 +178,42 @@ export async function createBackend(basePath: string): Promise<KataBackend> {
       const msg = err instanceof Error ? err.message : String(err);
       // Don't retry config errors — they won't resolve on retry.
       // Rate-limit errors ARE retriable (backoff handles the wait).
-      if (msg.includes("not set") || msg.includes("not configured") || msg.includes("could not be resolved")) {
+      if (
+        msg.includes("not set") ||
+        msg.includes("not configured") ||
+        msg.includes("could not be resolved")
+      ) {
+        emitBackendBootstrap({
+          backend: "linear",
+          status: "invalid_config",
+          detail: msg,
+        });
         throw err;
       }
       if (attempt < 2) {
-        await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+        await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
       }
     }
   }
+
+  emitBackendBootstrap({
+    backend: "linear",
+    status: "error",
+    detail: lastError instanceof Error ? lastError.message : String(lastError ?? "unknown"),
+  });
   throw lastError ?? new Error("LinearBackend initialization failed after retries");
+}
+
+/**
+ * Create the configured workflow backend for the current project.
+ */
+export async function createBackend(basePath: string): Promise<KataBackend> {
+  const loadedPreferences = loadEffectiveKataPreferences(basePath);
+  const config = loadEffectiveLinearProjectConfig(loadedPreferences);
+
+  if (config.isGithubMode) {
+    return createGithubBackend(basePath);
+  }
+
+  return createLinearBackend(basePath, loadedPreferences);
 }

--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -81,7 +81,7 @@ async function ensureOnboarding(
     title: "Kata Setup",
     summary: [
       "This project hasn't been set up with Kata yet.",
-      "You can configure a Linear or GitHub backend to get started.",
+      "You can run onboarding now to set up credentials and initialize .kata/.",
     ],
     actions: [
       {

--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -42,6 +42,12 @@ import {
   type LinearConfigValidationResult,
   type ValidateLinearProjectConfigOptions,
 } from "./linear-config.js";
+import {
+  validateGithubConfig,
+  formatGithubConfigStatus,
+  type GithubConfigValidationResult,
+  type ValidateGithubConfigOptions,
+} from "./github-config.js";
 import { getCurrentBranch } from "../pr-lifecycle/gh-utils.js";
 import { getPRNumber } from "../pr-lifecycle/pr-merge-utils.js";
 import { loadPrompt } from "./prompt-loader.js";
@@ -122,6 +128,9 @@ export interface PrefsStatusDependencies {
   validateLinearProjectConfig: (
     options?: ValidateLinearProjectConfigOptions,
   ) => Promise<LinearConfigValidationResult>;
+  validateGithubConfig: (
+    options?: ValidateGithubConfigOptions,
+  ) => GithubConfigValidationResult;
 }
 
 const defaultPrefsStatusDependencies: PrefsStatusDependencies = {
@@ -133,6 +142,7 @@ const defaultPrefsStatusDependencies: PrefsStatusDependencies = {
   loadEffectiveKataPreferences,
   resolveAllSkillReferences,
   validateLinearProjectConfig,
+  validateGithubConfig,
 };
 
 export async function buildPrefsStatusReport(
@@ -141,9 +151,29 @@ export async function buildPrefsStatusReport(
   const globalPrefs = deps.loadGlobalKataPreferences();
   const projectPrefs = deps.loadProjectKataPreferences();
   const effective = deps.loadEffectiveKataPreferences();
-  const validation = await deps.validateLinearProjectConfig({
-    loadedPreferences: effective,
-  });
+
+  // Detect workflow mode to decide which backend validation to show.
+  const workflowMode = effective?.preferences.workflow?.mode ?? "linear";
+  const isGithubMode = workflowMode === "github";
+
+  // Run backend-appropriate config validation.
+  let backendStatusLines: string[];
+  let backendValidationOk: boolean;
+  let resolvedMode: string = workflowMode;
+
+  if (isGithubMode) {
+    const githubValidation = deps.validateGithubConfig();
+    backendStatusLines = formatGithubConfigStatus(githubValidation).lines;
+    backendValidationOk = githubValidation.ok;
+    resolvedMode = githubValidation.mode;
+  } else {
+    const validation = await deps.validateLinearProjectConfig({
+      loadedPreferences: effective,
+    });
+    backendStatusLines = formatLinearConfigStatus(validation).lines;
+    backendValidationOk = validation.ok;
+    resolvedMode = validation.mode;
+  }
 
   const globalStatus = describeGlobalPreferences(globalPrefs, deps);
   const projectStatus = projectPrefs
@@ -155,11 +185,11 @@ export async function buildPrefsStatusReport(
 
   const lines = [
     "Kata prefs status",
-    `mode: ${validation.mode}`,
+    `mode: ${resolvedMode}`,
     `effective preferences: ${effectiveStatus}`,
     `global preferences: ${globalStatus}`,
     `project preferences: ${projectStatus}`,
-    ...formatLinearConfigStatus(validation).lines,
+    ...backendStatusLines,
   ];
 
   let hasUnresolvedSkills = false;
@@ -183,7 +213,7 @@ export async function buildPrefsStatusReport(
 
   return {
     level:
-      validation.status === "invalid" || hasUnresolvedSkills ? "warning" : "info",
+      !backendValidationOk || hasUnresolvedSkills ? "warning" : "info",
     message: lines.join("\n"),
   };
 }

--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -56,7 +56,7 @@ import { clearHeaderHint } from "./header.js";
 // ─── Onboarding gate ──────────────────────────────────────────────────────────
 
 /**
- * Ensure the project is configured (has .kata/ with linear config).
+ * Ensure the project is configured (has .kata/ with workflow backend config).
  * If not configured and not skipped, shows a setup-or-skip prompt.
  *
  * Returns true if the project is configured (or was just configured).
@@ -75,13 +75,13 @@ async function ensureOnboarding(
     title: "Kata Setup",
     summary: [
       "This project hasn't been set up with Kata yet.",
-      "You'll need a Linear API key to get started.",
+      "You can configure a Linear or GitHub backend to get started.",
     ],
     actions: [
       {
         id: "setup",
         label: "Set up Kata (Recommended)",
-        description: "Configure Linear integration and create .kata/ directory.",
+        description: "Configure workflow backend integration and create .kata/ directory.",
         recommended: true,
       },
     ],

--- a/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
+++ b/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
@@ -27,10 +27,12 @@ Full documentation for `~/.kata-cli/preferences.md` (global) and `.kata/preferen
   - When current tracked cost reaches/exceeds this value, auto-mode pauses and asks you to resume explicitly.
 
 - `workflow`: workflow-mode configuration.
-  - `workflow.mode`: `linear`.
-    - File mode has been removed; all Kata workflow state is Linear-backed.
+  - `workflow.mode`: `linear` (default) or `github`.
+    - `linear` — Kata workflow state is Linear-backed (milestones, slices, tasks as Linear issues/milestones).
+    - `github` — Kata workflow state is GitHub-backed (milestones, slices, tasks as GitHub issues). Requires a `WORKFLOW.md` tracker block (see below).
+    - File mode has been removed; file-backed `.kata/` workflow artifacts are no longer used.
 
-- `linear`: Linear binding configuration. Required for Linear mode.
+- `linear`: Linear binding configuration. Required when `workflow.mode: linear`.
   - `linear.teamKey`: Linear team key such as `KAT`. Required.
   - `linear.projectSlug`: Linear project slug from the project URL (e.g. `459f9835e809`). Required.
   - `linear.teamId`: optional Linear team UUID (alternative to `teamKey`).
@@ -69,6 +71,58 @@ Full documentation for `~/.kata-cli/preferences.md` (global) and `.kata/preferen
   - `soft_timeout_minutes`: minutes before the supervisor issues a soft warning (default: 20).
   - `idle_timeout_minutes`: minutes of inactivity before the supervisor intervenes (default: 10).
   - `hard_timeout_minutes`: minutes before the supervisor forces termination (default: 30).
+
+---
+
+## GitHub Mode Configuration
+
+To use GitHub as the Kata workflow backend, set `workflow.mode: github` in `.kata/preferences.md` and add a `tracker:` block to `WORKFLOW.md` in the project root.
+
+### `.kata/preferences.md` (project preferences)
+
+```yaml
+---
+workflow:
+  mode: github
+---
+```
+
+### `WORKFLOW.md` (project root — tracker block)
+
+```yaml
+---
+tracker:
+  kind: github
+  repo_owner: my-org             # GitHub org or user name (required)
+  repo_name: my-repo             # GitHub repository name (required)
+  github_project_number: 7       # GitHub Projects v2 number (optional; enables projects_v2 state mode)
+  label_prefix: kata:            # Issue label prefix for state derivation (optional; default: kata:)
+---
+```
+
+When `github_project_number` is present, Kata derives workflow phase from GitHub Projects v2 status fields. When absent, Kata uses issue labels with the configured `label_prefix`.
+
+### GitHub Token
+
+Kata resolves the GitHub token in this order:
+
+1. `KATA_GITHUB_TOKEN` (env) — Kata-specific override
+2. `GH_TOKEN` (env) — `gh` CLI standard
+3. `GITHUB_TOKEN` (env) — broad GitHub convention
+4. `auth.json` `github` provider — stored via Kata onboarding
+
+To check GitHub mode readiness:
+
+```text
+Kata prefs status
+mode: github
+GITHUB_TOKEN: present (via KATA_GITHUB_TOKEN)
+tracker.repo: my-org/my-repo
+tracker.state_mode: labels
+validation: valid
+```
+
+If GitHub mode is configured but not ready, the status output is actionable — for example `GITHUB_TOKEN: missing`, `diagnostic: missing_repo_owner`, or `diagnostic: unsupported_tracker_kind`.
 
 ---
 

--- a/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
+++ b/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
@@ -10,7 +10,7 @@ Full documentation for `~/.kata-cli/preferences.md` (global) and `.kata/preferen
 - Project preferences live at `.kata/preferences.md`.
 - Kata still reads the legacy `.kata/PREFERENCES.md` filename for backward compatibility, but new projects should use the lowercase canonical path.
 - Do not store secrets in preferences files.
-- Kata stores provider credentials in `~/.kata-cli/agent/auth.json` (for example via onboarding prompts) and hydrates runtime env vars like `LINEAR_API_KEY` automatically.
+- Kata stores provider credentials in `~/.kata-cli/agent/auth.json` and hydrates runtime env vars like `LINEAR_API_KEY` automatically.
 - Manually setting env vars is still supported, but `.env` is optional.
 
 ---
@@ -95,12 +95,12 @@ tracker:
   kind: github
   repo_owner: my-org             # GitHub org or user name (required)
   repo_name: my-repo             # GitHub repository name (required)
-  github_project_number: 7       # GitHub Projects v2 number (optional; enables projects_v2 state mode)
+  github_project_number: 7       # GitHub Projects v2 number (optional; reserved for future project-board integration)
   label_prefix: kata:            # Issue label prefix for state derivation (optional; default: kata:)
 ---
 ```
 
-When `github_project_number` is present, Kata derives workflow phase from GitHub Projects v2 status fields. When absent, Kata uses issue labels with the configured `label_prefix`.
+Kata currently derives workflow phase from issue labels with the configured `label_prefix`. `github_project_number` is parsed and validated for forward compatibility, but it does not yet switch phase derivation to Projects v2 fields.
 
 ### GitHub Token
 
@@ -109,7 +109,7 @@ Kata resolves the GitHub token in this order:
 1. `KATA_GITHUB_TOKEN` (env) — Kata-specific override
 2. `GH_TOKEN` (env) — `gh` CLI standard
 3. `GITHUB_TOKEN` (env) — broad GitHub convention
-4. `auth.json` `github` provider — stored via Kata onboarding
+4. `auth.json` `github` provider — add manually under `~/.kata-cli/agent/auth.json`
 
 To check GitHub mode readiness:
 

--- a/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
+++ b/apps/cli/src/resources/extensions/kata/docs/preferences-reference.md
@@ -124,6 +124,8 @@ validation: valid
 
 If GitHub mode is configured but not ready, the status output is actionable — for example `GITHUB_TOKEN: missing`, `diagnostic: missing_repo_owner`, or `diagnostic: unsupported_tracker_kind`.
 
+`/kata status` and `/kata` smart-entry now surface the same backend bootstrap diagnostics. If runtime initialization fails, the message includes diagnostic codes plus remediation actions and points back to `/kata prefs status` for full detail.
+
 ---
 
 ## Inspecting Active Mode

--- a/apps/cli/src/resources/extensions/kata/github-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/github-backend.ts
@@ -38,8 +38,11 @@ class GithubApiClient implements GithubStateClient {
 
   async listIssues(): Promise<GithubIssueSummary[]> {
     const issues: GithubIssueSummary[] = [];
+    const configuredTimeoutMs = Number(process.env.KATA_GITHUB_API_TIMEOUT_MS ?? "15000");
+    const timeoutMs =
+      Number.isFinite(configuredTimeoutMs) && configuredTimeoutMs > 0 ? configuredTimeoutMs : 15000;
 
-    for (let page = 1; page <= 10; page++) {
+    for (let page = 1; ; page++) {
       const url = new URL(
         `/repos/${this.config.repoOwner}/${this.config.repoName}/issues`,
         this.config.apiBaseUrl ?? "https://api.github.com",
@@ -48,15 +51,30 @@ class GithubApiClient implements GithubStateClient {
       url.searchParams.set("per_page", "100");
       url.searchParams.set("page", String(page));
 
-      const response = await fetch(url, {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${this.config.token}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-          "User-Agent": "kata-cli-github-backend",
-        },
-      });
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${this.config.token}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "kata-cli-github-backend",
+          },
+          signal: controller.signal,
+        });
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") {
+          throw new Error(
+            `GitHub API request timed out after ${timeoutMs}ms for ${this.config.repoOwner}/${this.config.repoName} (page ${page})`,
+          );
+        }
+        throw err;
+      } finally {
+        clearTimeout(timer);
+      }
 
       if (!response.ok) {
         const body = await response.text();

--- a/apps/cli/src/resources/extensions/kata/github-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/github-backend.ts
@@ -1,0 +1,220 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import type {
+  DashboardData,
+  DocumentScope,
+  KataBackend,
+  PrContext,
+  PromptOptions,
+} from "./backend.js";
+import type { GithubStateMode } from "./github-config.js";
+import { deriveGithubState, type GithubIssueSummary, type GithubStateClient } from "./github-state.js";
+import type { KataState, Phase } from "./types.js";
+import { ensureGitignore } from "./gitignore.js";
+import { ensureGitRepo, resolveGitRoot } from "./git-utils.js";
+import { getCurrentBranch } from "./worktree.js";
+
+export interface GithubBackendConfig {
+  token: string;
+  repoOwner: string;
+  repoName: string;
+  stateMode: GithubStateMode;
+  labelPrefix: string;
+  apiBaseUrl?: string;
+}
+
+interface GithubApiIssue {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  labels: Array<{ name: string }>;
+  body?: string | null;
+  pull_request?: unknown;
+}
+
+class GithubApiClient implements GithubStateClient {
+  constructor(private readonly config: GithubBackendConfig) {}
+
+  async listIssues(): Promise<GithubIssueSummary[]> {
+    const issues: GithubIssueSummary[] = [];
+
+    for (let page = 1; page <= 10; page++) {
+      const url = new URL(
+        `/repos/${this.config.repoOwner}/${this.config.repoName}/issues`,
+        this.config.apiBaseUrl ?? "https://api.github.com",
+      );
+      url.searchParams.set("state", "all");
+      url.searchParams.set("per_page", "100");
+      url.searchParams.set("page", String(page));
+
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this.config.token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "User-Agent": "kata-cli-github-backend",
+        },
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(
+          `GitHub API request failed (${response.status}) for ${this.config.repoOwner}/${this.config.repoName}: ${body || response.statusText}`,
+        );
+      }
+
+      const pageIssues = (await response.json()) as GithubApiIssue[];
+      const filtered = pageIssues.filter((issue) => issue.pull_request === undefined);
+
+      issues.push(
+        ...filtered.map((issue) => ({
+          number: issue.number,
+          title: issue.title,
+          state: issue.state,
+          labels: issue.labels.map((label) => label.name),
+          body: issue.body,
+        })),
+      );
+
+      if (pageIssues.length < 100) break;
+    }
+
+    return issues;
+  }
+}
+
+const UNSUPPORTED_MESSAGE =
+  "GitHub backend bootstrap is enabled for S01 status/derive flows only. Planning and artifact write operations land in later slices.";
+
+export class GithubBackend implements KataBackend {
+  readonly basePath: string;
+  readonly gitRoot: string;
+  readonly isLinearMode = false;
+
+  private readonly config: GithubBackendConfig;
+  private readonly client: GithubApiClient;
+  private stateCache: { state: KataState; timestamp: number } | null = null;
+  private static readonly STATE_CACHE_TTL_MS = 10_000;
+
+  constructor(basePath: string, config: GithubBackendConfig) {
+    this.basePath = basePath;
+    this.gitRoot = resolveGitRoot(basePath);
+    this.config = config;
+    this.client = new GithubApiClient(config);
+  }
+
+  async deriveState(): Promise<KataState> {
+    if (
+      this.stateCache &&
+      Date.now() - this.stateCache.timestamp < GithubBackend.STATE_CACHE_TTL_MS
+    ) {
+      return this.stateCache.state;
+    }
+
+    const state = await deriveGithubState(this.client, {
+      repoOwner: this.config.repoOwner,
+      repoName: this.config.repoName,
+      stateMode: this.config.stateMode,
+      labelPrefix: this.config.labelPrefix,
+      basePath: this.basePath,
+    });
+
+    this.stateCache = { state, timestamp: Date.now() };
+    return state;
+  }
+
+  invalidateStateCache(): void {
+    this.stateCache = null;
+  }
+
+  async readDocument(_name: string, _scope?: DocumentScope): Promise<string | null> {
+    return null;
+  }
+
+  async writeDocument(_name: string, _content: string, _scope?: DocumentScope): Promise<void> {
+    throw new Error(UNSUPPORTED_MESSAGE);
+  }
+
+  async documentExists(_name: string, _scope?: DocumentScope): Promise<boolean> {
+    return false;
+  }
+
+  async listDocuments(_scope?: DocumentScope): Promise<string[]> {
+    return [];
+  }
+
+  async buildPrompt(
+    phase: Phase,
+    _state: KataState,
+    _options?: PromptOptions,
+  ): Promise<string> {
+    throw new Error(
+      `GitHub prompt generation for phase \"${phase}\" is not yet supported. ${UNSUPPORTED_MESSAGE}`,
+    );
+  }
+
+  buildDiscussPrompt(nextId: string, preamble: string): string {
+    return [
+      preamble,
+      "",
+      `Requested milestone: ${nextId}`,
+      "",
+      UNSUPPORTED_MESSAGE,
+      "Use /kata status and /kata prefs status to inspect backend readiness while S01 is in progress.",
+    ].join("\n");
+  }
+
+  async bootstrap(): Promise<void> {
+    ensureGitRepo(this.basePath, this.gitRoot);
+    ensureGitignore(this.gitRoot);
+    mkdirSync(join(this.basePath, ".kata"), { recursive: true });
+  }
+
+  async checkMilestoneCreated(milestoneId: string): Promise<boolean> {
+    const state = await this.deriveState();
+    return state.activeMilestone?.id === milestoneId;
+  }
+
+  async loadDashboardData(): Promise<DashboardData> {
+    const state = await this.deriveState();
+
+    const sliceViews = state.activeSlice
+      ? [
+          {
+            id: state.activeSlice.id,
+            title: state.activeSlice.title,
+            done: false,
+            risk: "",
+            active: true,
+            tasks: state.activeTask
+              ? [
+                  {
+                    id: state.activeTask.id,
+                    title: state.activeTask.title,
+                    done: false,
+                    active: true,
+                  },
+                ]
+              : [],
+            taskProgress: state.progress?.tasks,
+          },
+        ]
+      : [];
+
+    return {
+      state,
+      sliceProgress: state.progress?.slices ?? null,
+      taskProgress: state.progress?.tasks ?? null,
+      sliceViews,
+    };
+  }
+
+  async preparePrContext(_milestoneId: string, _sliceId: string): Promise<PrContext> {
+    return {
+      branch: getCurrentBranch(this.basePath),
+      documents: {},
+    };
+  }
+}

--- a/apps/cli/src/resources/extensions/kata/github-config.ts
+++ b/apps/cli/src/resources/extensions/kata/github-config.ts
@@ -222,7 +222,9 @@ export function loadGithubTrackerConfig(
     config: {
       repoOwner,
       repoName,
-      stateMode: githubProjectNumber ? "projects_v2" : "labels",
+      // Projects v2 phase derivation is not implemented yet. Keep label-based
+      // state derivation active even when a project number is configured.
+      stateMode: "labels",
       ...(githubProjectNumber !== undefined && { githubProjectNumber }),
       ...(labelPrefix !== undefined && { labelPrefix }),
     },
@@ -332,7 +334,7 @@ export function validateGithubConfig(
     diagnostics.push({
       code: "missing_github_token",
       message:
-        "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, or store a credential via Kata onboarding.",
+        "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, or add a github credential entry to ~/.kata-cli/agent/auth.json.",
       field: "KATA_GITHUB_TOKEN",
       retryable: false,
     });

--- a/apps/cli/src/resources/extensions/kata/github-config.ts
+++ b/apps/cli/src/resources/extensions/kata/github-config.ts
@@ -22,8 +22,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { debuglog } from "node:util";
 
 import type { WorkflowMode } from "./preferences.js";
+
+const debug = debuglog("kata:github-config");
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -258,8 +261,9 @@ export function resolveGithubToken(authFilePath?: string): ResolvedGithubToken {
 
   // 4. auth.json "github" provider — Kata auth store
   const authPath = authFilePath ?? join(homedir(), ".kata-cli", "agent", "auth.json");
+  const authExists = existsSync(authPath);
   try {
-    if (existsSync(authPath)) {
+    if (authExists) {
       const raw = readFileSync(authPath, "utf-8");
       const parsed: unknown = JSON.parse(raw);
       if (parsed && typeof parsed === "object") {
@@ -276,8 +280,15 @@ export function resolveGithubToken(authFilePath?: string): ResolvedGithubToken {
         }
       }
     }
-  } catch {
-    // auth.json read failure is non-fatal — fall through to not-found
+  } catch (err) {
+    if (authExists) {
+      debug(
+        "Failed to parse auth.json (github provider) at %s: %s",
+        authPath,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    // auth.json read/parse failure is non-fatal — fall through to not-found
   }
 
   return { token: null, source: null };

--- a/apps/cli/src/resources/extensions/kata/github-config.ts
+++ b/apps/cli/src/resources/extensions/kata/github-config.ts
@@ -1,0 +1,469 @@
+/**
+ * GitHub Tracker Config Resolver
+ *
+ * Reads GitHub tracker settings from WORKFLOW.md frontmatter,
+ * resolves auth token from environment / auth store, and emits
+ * actionable, redacted diagnostics when configuration is incomplete.
+ *
+ * Field contract (matches Symphony config.rs `RawTrackerConfig` + Desktop workflow-config-reader):
+ *   tracker:
+ *     kind: github
+ *     repo_owner: <org-or-user>
+ *     repo_name: <repo>
+ *     github_project_number: <positive-integer>   (optional; enables Projects v2 mode)
+ *     label_prefix: kata:                          (optional; defaults to "kata:")
+ *
+ * Token resolution order:
+ *   KATA_GITHUB_TOKEN → GH_TOKEN → GITHUB_TOKEN → auth.json "github" provider
+ *
+ * Redaction constraint: diagnostics reference key names only — never token values.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { WorkflowMode } from "./preferences.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type GithubStateMode = "projects_v2" | "labels";
+
+/** Parsed GitHub tracker configuration from WORKFLOW.md frontmatter. */
+export interface GithubTrackerConfig {
+  repoOwner: string;
+  repoName: string;
+  stateMode: GithubStateMode;
+  githubProjectNumber?: number;
+  labelPrefix?: string;
+}
+
+export type GithubConfigDiagnosticCode =
+  | "missing_workflow_file"
+  | "invalid_workflow_file"
+  | "unsupported_tracker_kind"
+  | "missing_repo_owner"
+  | "missing_repo_name"
+  | "invalid_github_project_number"
+  | "missing_github_token";
+
+export interface GithubConfigDiagnostic {
+  code: GithubConfigDiagnosticCode;
+  message: string;
+  field?: string;
+  retryable: boolean;
+}
+
+export interface GithubConfigStatusReport {
+  level: "info" | "warning";
+  lines: string[];
+}
+
+export interface GithubConfigValidationResult {
+  ok: boolean;
+  status: "valid" | "invalid" | "skipped";
+  mode: WorkflowMode;
+  tokenPresent: boolean;
+  /** Key name of the token source, never the value (e.g. "KATA_GITHUB_TOKEN"). */
+  tokenSource: string | null;
+  trackerConfig: GithubTrackerConfig | null;
+  diagnostics: GithubConfigDiagnostic[];
+}
+
+// ─── WORKFLOW.md parsing ──────────────────────────────────────────────────────
+
+/**
+ * Resolve the WORKFLOW.md path for the given base directory.
+ * Checks KATA_GITHUB_WORKFLOW_PATH env var first (enables testing override).
+ * Falls back to `<basePath>/WORKFLOW.md`.
+ */
+export function resolveGithubWorkflowPath(basePath: string = process.cwd()): string {
+  return process.env.KATA_GITHUB_WORKFLOW_PATH ?? join(basePath, "WORKFLOW.md");
+}
+
+/**
+ * Parse WORKFLOW.md frontmatter and extract GitHub tracker configuration.
+ * Returns a diagnostic on every error so callers get field-specific feedback.
+ */
+export function loadGithubTrackerConfig(
+  workflowPath?: string,
+  basePath?: string,
+): { config: GithubTrackerConfig | null; diagnostic: GithubConfigDiagnostic | null } {
+  const resolvedPath = workflowPath ?? resolveGithubWorkflowPath(basePath);
+
+  if (!existsSync(resolvedPath)) {
+    return {
+      config: null,
+      diagnostic: {
+        code: "missing_workflow_file",
+        message: `WORKFLOW.md not found at ${resolvedPath}. Create it with a tracker: block to configure GitHub mode.`,
+        field: "WORKFLOW.md",
+        retryable: false,
+      },
+    };
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(resolvedPath, "utf-8");
+  } catch (err) {
+    return {
+      config: null,
+      diagnostic: {
+        code: "invalid_workflow_file",
+        message: `Unable to read WORKFLOW.md: ${err instanceof Error ? err.message : String(err)}`,
+        field: "WORKFLOW.md",
+        retryable: false,
+      },
+    };
+  }
+
+  // Strip optional BOM, extract YAML frontmatter
+  const frontmatterMatch = content.replace(/^\uFEFF/, "").match(/^---\s*\r?\n([\s\S]*?)\r?\n---/);
+  if (!frontmatterMatch?.[1]) {
+    return {
+      config: null,
+      diagnostic: {
+        code: "invalid_workflow_file",
+        message: "WORKFLOW.md is missing YAML frontmatter (---). Add a tracker: block at the top.",
+        field: "WORKFLOW.md",
+        retryable: false,
+      },
+    };
+  }
+
+  const frontmatter = frontmatterMatch[1];
+  const trackerBlock = extractNestedBlock(frontmatter, "tracker");
+
+  if (!trackerBlock) {
+    // No tracker block means default Linear — but caller is in GitHub mode,
+    // so this is a missing-config situation.
+    return {
+      config: null,
+      diagnostic: {
+        code: "unsupported_tracker_kind",
+        message:
+          "No tracker: block found in WORKFLOW.md. Add `tracker:\\n  kind: github` (plus repo_owner and repo_name) to configure GitHub mode.",
+        field: "tracker.kind",
+        retryable: false,
+      },
+    };
+  }
+
+  const fields = parseSimpleYamlObject(trackerBlock);
+  const kind = stripYamlWrapping(fields.kind ?? "").toLowerCase();
+
+  if (kind !== "github") {
+    return {
+      config: null,
+      diagnostic: {
+        code: "unsupported_tracker_kind",
+        message: `tracker.kind is "${kind || "(unset)"}" but workflow.mode is "github". Set tracker.kind: github in WORKFLOW.md.`,
+        field: "tracker.kind",
+        retryable: false,
+      },
+    };
+  }
+
+  const repoOwner = stripYamlWrapping(fields.repo_owner ?? "");
+  if (!repoOwner) {
+    return {
+      config: null,
+      diagnostic: {
+        code: "missing_repo_owner",
+        message:
+          "tracker.repo_owner is required when tracker.kind is github. Add it to WORKFLOW.md.",
+        field: "tracker.repo_owner",
+        retryable: false,
+      },
+    };
+  }
+
+  const repoName = stripYamlWrapping(fields.repo_name ?? "");
+  if (!repoName) {
+    return {
+      config: null,
+      diagnostic: {
+        code: "missing_repo_name",
+        message:
+          "tracker.repo_name is required when tracker.kind is github. Add it to WORKFLOW.md.",
+        field: "tracker.repo_name",
+        retryable: false,
+      },
+    };
+  }
+
+  const projectNumberRaw = stripYamlWrapping(fields.github_project_number ?? "");
+  let githubProjectNumber: number | undefined;
+  if (projectNumberRaw) {
+    const parsed = Number(projectNumberRaw);
+    if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+      return {
+        config: null,
+        diagnostic: {
+          code: "invalid_github_project_number",
+          message:
+            "tracker.github_project_number must be a positive integer in WORKFLOW.md.",
+          field: "tracker.github_project_number",
+          retryable: false,
+        },
+      };
+    }
+    githubProjectNumber = parsed;
+  }
+
+  const labelPrefix =
+    stripYamlWrapping(fields.label_prefix ?? "") || undefined;
+
+  return {
+    config: {
+      repoOwner,
+      repoName,
+      stateMode: githubProjectNumber ? "projects_v2" : "labels",
+      ...(githubProjectNumber !== undefined && { githubProjectNumber }),
+      ...(labelPrefix !== undefined && { labelPrefix }),
+    },
+    diagnostic: null,
+  };
+}
+
+// ─── Token resolution ─────────────────────────────────────────────────────────
+
+export interface ResolvedGithubToken {
+  /** The token value, or null if not found. Never log or display this. */
+  token: string | null;
+  /** Human-readable key name of the token source (safe to display). */
+  source: string | null;
+}
+
+/**
+ * Resolve GitHub auth token using the canonical priority order:
+ *   KATA_GITHUB_TOKEN → GH_TOKEN → GITHUB_TOKEN → auth.json "github" provider
+ *
+ * Returns { token, source } where token is null when not found.
+ * Safe to call without an auth store — auth.json lookup is best-effort.
+ */
+export function resolveGithubToken(authFilePath?: string): ResolvedGithubToken {
+  // 1. KATA_GITHUB_TOKEN — Kata-specific override
+  const kataToken = process.env.KATA_GITHUB_TOKEN;
+  if (kataToken) return { token: kataToken, source: "KATA_GITHUB_TOKEN" };
+
+  // 2. GH_TOKEN — gh CLI standard
+  const ghToken = process.env.GH_TOKEN;
+  if (ghToken) return { token: ghToken, source: "GH_TOKEN" };
+
+  // 3. GITHUB_TOKEN — broad GitHub convention
+  const githubToken = process.env.GITHUB_TOKEN;
+  if (githubToken) return { token: githubToken, source: "GITHUB_TOKEN" };
+
+  // 4. auth.json "github" provider — Kata auth store
+  const authPath = authFilePath ?? join(homedir(), ".kata-cli", "agent", "auth.json");
+  try {
+    if (existsSync(authPath)) {
+      const raw = readFileSync(authPath, "utf-8");
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        const record = (parsed as Record<string, unknown>)["github"];
+        if (
+          record &&
+          typeof record === "object" &&
+          "type" in record &&
+          "key" in record &&
+          typeof (record as { key: unknown }).key === "string"
+        ) {
+          const key = (record as { key: string }).key;
+          if (key) return { token: key, source: "auth.json (github provider)" };
+        }
+      }
+    }
+  } catch {
+    // auth.json read failure is non-fatal — fall through to not-found
+  }
+
+  return { token: null, source: null };
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+export interface ValidateGithubConfigOptions {
+  workflowPath?: string;
+  basePath?: string;
+  authFilePath?: string;
+}
+
+/**
+ * Validate the full GitHub configuration (tracker config + token).
+ * Returns a structured result with diagnostics for every failure mode.
+ *
+ * This is the single entry point for GitHub config readiness checks,
+ * consumed by `/kata prefs status` and backend initialization.
+ */
+export function validateGithubConfig(
+  options: ValidateGithubConfigOptions = {},
+): GithubConfigValidationResult {
+  const { workflowPath, basePath, authFilePath } = options;
+
+  const { token, source } = resolveGithubToken(authFilePath);
+  const tokenPresent = token !== null;
+
+  const { config, diagnostic: trackerDiagnostic } = loadGithubTrackerConfig(
+    workflowPath,
+    basePath,
+  );
+
+  const diagnostics: GithubConfigDiagnostic[] = [];
+
+  if (trackerDiagnostic) {
+    diagnostics.push(trackerDiagnostic);
+  }
+
+  if (!tokenPresent) {
+    diagnostics.push({
+      code: "missing_github_token",
+      message:
+        "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, or store a credential via Kata onboarding.",
+      field: "KATA_GITHUB_TOKEN",
+      retryable: false,
+    });
+  }
+
+  const ok = diagnostics.length === 0;
+
+  return {
+    ok,
+    status: ok ? "valid" : "invalid",
+    mode: "github",
+    tokenPresent,
+    tokenSource: source,
+    trackerConfig: config,
+    diagnostics,
+  };
+}
+
+// ─── Status formatting ────────────────────────────────────────────────────────
+
+/**
+ * Format a GitHub config validation result into human-readable status lines.
+ * Mirrors `formatLinearConfigStatus` — safe to display, no secret values.
+ */
+export function formatGithubConfigStatus(
+  result: GithubConfigValidationResult,
+): GithubConfigStatusReport {
+  const lines: string[] = [
+    `GITHUB_TOKEN: ${result.tokenPresent ? `present (via ${result.tokenSource})` : "missing"}`,
+  ];
+
+  if (result.trackerConfig) {
+    lines.push(`tracker.repo: ${result.trackerConfig.repoOwner}/${result.trackerConfig.repoName}`);
+    lines.push(`tracker.state_mode: ${result.trackerConfig.stateMode}`);
+    if (result.trackerConfig.githubProjectNumber !== undefined) {
+      lines.push(`tracker.github_project_number: ${result.trackerConfig.githubProjectNumber}`);
+    }
+    if (result.trackerConfig.labelPrefix !== undefined) {
+      lines.push(`tracker.label_prefix: ${result.trackerConfig.labelPrefix}`);
+    }
+  }
+
+  lines.push(`validation: ${result.status}`);
+
+  for (const diagnostic of result.diagnostics) {
+    lines.push(`diagnostic: ${diagnostic.code} — ${diagnostic.message}`);
+    const action = getGithubDiagnosticAction(diagnostic);
+    if (action) lines.push(`action: ${action}`);
+  }
+
+  return {
+    level: result.ok ? "info" : "warning",
+    lines,
+  };
+}
+
+function getGithubDiagnosticAction(
+  diagnostic: GithubConfigDiagnostic,
+): string | null {
+  switch (diagnostic.code) {
+    case "missing_github_token":
+      return "set KATA_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN in your environment.";
+    case "missing_workflow_file":
+      return "create WORKFLOW.md in the project root with a tracker: block.";
+    case "invalid_workflow_file":
+      return "check WORKFLOW.md for valid YAML frontmatter (--- delimiters).";
+    case "unsupported_tracker_kind":
+      return "set tracker.kind: github in WORKFLOW.md.";
+    case "missing_repo_owner":
+      return "add tracker.repo_owner: <org-or-user> to WORKFLOW.md.";
+    case "missing_repo_name":
+      return "add tracker.repo_name: <repo> to WORKFLOW.md.";
+    case "invalid_github_project_number":
+      return "set tracker.github_project_number to a positive integer, or remove it to use label mode.";
+    default:
+      return null;
+  }
+}
+
+// ─── YAML parsing helpers ─────────────────────────────────────────────────────
+// Minimal YAML parsers — handles only the simple key: value structure
+// used in WORKFLOW.md tracker blocks. No dependency on a full YAML library.
+
+function extractNestedBlock(frontmatter: string, key: string): string | null {
+  const lines = frontmatter.split(/\r?\n/);
+  const anchorIndex = lines.findIndex((line) =>
+    new RegExp(`^\\s*${escapeRegex(key)}:\\s*$`).test(line),
+  );
+
+  if (anchorIndex === -1) return null;
+
+  const anchorIndent = indentationOf(lines[anchorIndex] ?? "");
+  const nested: string[] = [];
+
+  for (let i = anchorIndex + 1; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (!line.trim()) {
+      nested.push(line);
+      continue;
+    }
+    const indent = indentationOf(line);
+    if (indent <= anchorIndent) break;
+    nested.push(line.slice(anchorIndent + 2));
+  }
+
+  return nested.join("\n");
+}
+
+function parseSimpleYamlObject(block: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const match = line.match(/^([a-zA-Z0-9_]+)\s*:\s*(.*)$/);
+    if (!match) continue;
+    const key = match[1] ?? "";
+    const raw = match[2] ?? "";
+    result[key] = stripInlineComment(raw).trim();
+  }
+  return result;
+}
+
+function stripInlineComment(value: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === "'" && !inDouble) { inSingle = !inSingle; continue; }
+    if (ch === '"' && !inSingle) { inDouble = !inDouble; continue; }
+    if (ch === "#" && !inSingle && !inDouble) return value.slice(0, i);
+  }
+  return value;
+}
+
+function stripYamlWrapping(value: string): string {
+  return value.replace(/^['"]/, "").replace(/['"]$/, "").trim();
+}
+
+function indentationOf(line: string): number {
+  return (line.match(/^\s*/)?.[0].length) ?? 0;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/apps/cli/src/resources/extensions/kata/github-state.ts
+++ b/apps/cli/src/resources/extensions/kata/github-state.ts
@@ -132,6 +132,31 @@ function nextActionForPhase(phase: Phase): string {
   }
 }
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function taskBelongsToSlice(
+  issue: GithubIssueSummary,
+  sliceId: string,
+): boolean {
+  const normalizedSliceId = sliceId.trim().toLowerCase();
+  if (!normalizedSliceId) return false;
+
+  const labels = labelSet(issue);
+  if (
+    labels.has(`kata:slice:${normalizedSliceId}`) ||
+    labels.has(`slice:${normalizedSliceId}`) ||
+    labels.has(`kata:parent:${normalizedSliceId}`)
+  ) {
+    return true;
+  }
+
+  const contextText = `${issue.title}\n${issue.body ?? ""}`;
+  const sliceIdMatcher = new RegExp(`\\b${escapeRegex(sliceId)}\\b`, "i");
+  return sliceIdMatcher.test(contextText);
+}
+
 export async function deriveGithubState(
   client: GithubStateClient,
   config: DeriveGithubStateConfig,
@@ -253,7 +278,15 @@ export async function deriveGithubState(
   const openTasks = tasks.filter((task) => task.issue.state !== "closed");
   const closedTasks = tasks.filter((task) => task.issue.state === "closed");
 
-  const activeTaskEntry = openTasks[0] ?? null;
+  const activeSliceId = activeSliceEntry?.parsed.id ?? null;
+  const scopedOpenTasks = activeSliceId
+    ? openTasks.filter((task) => taskBelongsToSlice(task.issue, activeSliceId))
+    : [];
+  const scopedClosedTasks = activeSliceId
+    ? closedTasks.filter((task) => taskBelongsToSlice(task.issue, activeSliceId))
+    : [];
+
+  const activeTaskEntry = scopedOpenTasks[0] ?? null;
 
   let phase: Phase;
 
@@ -263,7 +296,11 @@ export async function deriveGithubState(
         ? resolvePhaseFromSliceLabels(activeSliceEntry.issue, labelPrefix)
         : null;
 
-    phase = labelPhase ?? computePhaseFallback(activeSliceEntry.issue, openTasks.map((t) => t.issue), closedTasks.map((t) => t.issue));
+    phase = labelPhase ?? computePhaseFallback(
+      activeSliceEntry.issue,
+      scopedOpenTasks.map((t) => t.issue),
+      scopedClosedTasks.map((t) => t.issue),
+    );
   } else {
     phase = "pre-planning";
   }
@@ -282,7 +319,7 @@ export async function deriveGithubState(
 
   // If the active slice has no open task but there are closed tasks, this slice
   // is likely complete and ready for summary.
-  if (activeSlice && !activeTask && closedTasks.length > 0) {
+  if (activeSlice && !activeTask && scopedClosedTasks.length > 0) {
     phase = "summarizing";
   }
 

--- a/apps/cli/src/resources/extensions/kata/github-state.ts
+++ b/apps/cli/src/resources/extensions/kata/github-state.ts
@@ -57,7 +57,7 @@ function toActiveRef(issue: GithubIssueSummary, parsed: ParsedKataTitle): Active
   return {
     id: parsed.id,
     title: parsed.title,
-    linearIssueId: String(issue.number),
+    trackerIssueId: String(issue.number),
   };
 }
 
@@ -291,10 +291,7 @@ export async function deriveGithubState(
   let phase: Phase;
 
   if (activeSliceEntry) {
-    const labelPhase =
-      config.stateMode === "labels"
-        ? resolvePhaseFromSliceLabels(activeSliceEntry.issue, labelPrefix)
-        : null;
+    const labelPhase = resolvePhaseFromSliceLabels(activeSliceEntry.issue, labelPrefix);
 
     phase = labelPhase ?? computePhaseFallback(
       activeSliceEntry.issue,

--- a/apps/cli/src/resources/extensions/kata/github-state.ts
+++ b/apps/cli/src/resources/extensions/kata/github-state.ts
@@ -1,0 +1,314 @@
+import type { GithubStateMode } from "./github-config.js";
+import type { ActiveRef, KataState, MilestoneRegistryEntry, Phase } from "./types.js";
+import { getActiveSliceBranch, parseSliceBranchName } from "./worktree.js";
+
+export interface GithubIssueSummary {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  labels: string[];
+  body?: string | null;
+}
+
+export interface GithubStateClient {
+  listIssues(): Promise<GithubIssueSummary[]>;
+}
+
+export interface DeriveGithubStateConfig {
+  repoOwner: string;
+  repoName: string;
+  stateMode: GithubStateMode;
+  labelPrefix?: string;
+  basePath?: string;
+}
+
+interface ParsedKataTitle {
+  id: string;
+  title: string;
+}
+
+const MILESTONE_RE = /^M\d{3}$/;
+const SLICE_RE = /^S\d{2}$/;
+const TASK_RE = /^T\d{2}$/;
+
+function parseKataTitle(title: string): ParsedKataTitle | null {
+  const match = title.match(/^\[([A-Z]\d+)\]\s*(.+)$/);
+  if (!match) return null;
+  return {
+    id: match[1] ?? "",
+    title: (match[2] ?? "").trim(),
+  };
+}
+
+function parseOrdinal(id: string): number {
+  const digits = id.slice(1);
+  const parsed = Number.parseInt(digits, 10);
+  return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
+}
+
+function compareKataIds(a: string, b: string): number {
+  const aPrefix = a[0] ?? "";
+  const bPrefix = b[0] ?? "";
+  if (aPrefix !== bPrefix) return aPrefix.localeCompare(bPrefix);
+  return parseOrdinal(a) - parseOrdinal(b);
+}
+
+function toActiveRef(issue: GithubIssueSummary, parsed: ParsedKataTitle): ActiveRef {
+  return {
+    id: parsed.id,
+    title: parsed.title,
+    linearIssueId: String(issue.number),
+  };
+}
+
+function labelSet(issue: GithubIssueSummary): Set<string> {
+  return new Set(issue.labels.map((label) => label.trim().toLowerCase()));
+}
+
+function resolvePhaseFromSliceLabels(
+  issue: GithubIssueSummary,
+  labelPrefix: string,
+): Phase | null {
+  const prefix = labelPrefix.trim().toLowerCase();
+  const labels = labelSet(issue);
+
+  const mapping: Array<{ suffix: string; phase: Phase }> = [
+    { suffix: "planning", phase: "planning" },
+    { suffix: "executing", phase: "executing" },
+    { suffix: "verifying", phase: "verifying" },
+    { suffix: "summarizing", phase: "summarizing" },
+    { suffix: "blocked", phase: "blocked" },
+  ];
+
+  for (const entry of mapping) {
+    if (labels.has(`${prefix}${entry.suffix}`)) {
+      return entry.phase;
+    }
+  }
+
+  return null;
+}
+
+function computePhaseFallback(
+  activeSlice: GithubIssueSummary | null,
+  openTasks: GithubIssueSummary[],
+  closedTasks: GithubIssueSummary[],
+): Phase {
+  if (!activeSlice) return "pre-planning";
+
+  if (openTasks.length === 0 && closedTasks.length === 0) {
+    return "planning";
+  }
+
+  if (openTasks.length === 0 && closedTasks.length > 0) {
+    return "summarizing";
+  }
+
+  if (closedTasks.length === 0) {
+    return "executing";
+  }
+
+  return "verifying";
+}
+
+function nextActionForPhase(phase: Phase): string {
+  switch (phase) {
+    case "pre-planning":
+      return "Create the next milestone roadmap.";
+    case "planning":
+      return "Plan the active slice tasks.";
+    case "executing":
+      return "Execute the next open task.";
+    case "verifying":
+      return "Verify and finish remaining open tasks.";
+    case "summarizing":
+      return "Write the active slice summary.";
+    case "completing-milestone":
+      return "Write the milestone completion summary.";
+    case "complete":
+      return "Start the next milestone.";
+    default:
+      return "";
+  }
+}
+
+export async function deriveGithubState(
+  client: GithubStateClient,
+  config: DeriveGithubStateConfig,
+): Promise<KataState> {
+  const labelPrefix = config.labelPrefix ?? "kata:";
+  const basePath = config.basePath ?? process.cwd();
+  const activeBranch = getActiveSliceBranch(basePath) ?? undefined;
+  const branchRef = activeBranch ? parseSliceBranchName(activeBranch) : null;
+
+  const issues = await client.listIssues();
+  const parsedIssues = issues
+    .map((issue) => {
+      const parsed = parseKataTitle(issue.title);
+      if (!parsed) return null;
+      return { issue, parsed };
+    })
+    .filter((entry): entry is { issue: GithubIssueSummary; parsed: ParsedKataTitle } => entry !== null);
+
+  const milestones = parsedIssues
+    .filter((entry) => MILESTONE_RE.test(entry.parsed.id))
+    .sort((a, b) => compareKataIds(a.parsed.id, b.parsed.id));
+
+  const slices = parsedIssues
+    .filter((entry) => SLICE_RE.test(entry.parsed.id))
+    .sort((a, b) => compareKataIds(a.parsed.id, b.parsed.id));
+
+  const tasks = parsedIssues
+    .filter((entry) => TASK_RE.test(entry.parsed.id))
+    .sort((a, b) => compareKataIds(a.parsed.id, b.parsed.id));
+
+  const registry: MilestoneRegistryEntry[] = [];
+
+  let activeMilestoneEntry: (typeof milestones)[number] | null = null;
+
+  if (milestones.length > 0) {
+    const openMilestones = milestones.filter((entry) => entry.issue.state !== "closed");
+
+    if (branchRef?.milestoneId) {
+      activeMilestoneEntry =
+        openMilestones.find((entry) => entry.parsed.id === branchRef.milestoneId) ?? null;
+    }
+
+    if (!activeMilestoneEntry) {
+      activeMilestoneEntry = openMilestones[0] ?? null;
+    }
+
+    for (const milestone of milestones) {
+      const status: MilestoneRegistryEntry["status"] =
+        milestone.issue.state === "closed"
+          ? "complete"
+          : milestone.parsed.id === activeMilestoneEntry?.parsed.id
+            ? "active"
+            : "pending";
+
+      registry.push({
+        id: milestone.parsed.id,
+        title: milestone.parsed.title,
+        status,
+      });
+    }
+  }
+
+  const allMilestonesDone =
+    milestones.length > 0 && milestones.every((milestone) => milestone.issue.state === "closed");
+
+  if (milestones.length === 0) {
+    return {
+      activeMilestone: null,
+      activeSlice: null,
+      activeTask: null,
+      phase: "pre-planning",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: nextActionForPhase("pre-planning"),
+      activeBranch,
+      registry,
+      progress: {
+        milestones: { done: 0, total: 0 },
+        slices: { done: slices.filter((slice) => slice.issue.state === "closed").length, total: slices.length },
+        tasks: { done: tasks.filter((task) => task.issue.state === "closed").length, total: tasks.length },
+      },
+    };
+  }
+
+  if (allMilestonesDone) {
+    return {
+      activeMilestone: null,
+      activeSlice: null,
+      activeTask: null,
+      phase: "complete",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: nextActionForPhase("complete"),
+      activeBranch,
+      registry,
+      progress: {
+        milestones: {
+          done: milestones.length,
+          total: milestones.length,
+        },
+        slices: { done: slices.filter((slice) => slice.issue.state === "closed").length, total: slices.length },
+        tasks: { done: tasks.filter((task) => task.issue.state === "closed").length, total: tasks.length },
+      },
+    };
+  }
+
+  const openSlices = slices.filter((slice) => slice.issue.state !== "closed");
+  const closedSlices = slices.filter((slice) => slice.issue.state === "closed");
+
+  let activeSliceEntry: (typeof openSlices)[number] | null = null;
+  if (branchRef?.sliceId) {
+    activeSliceEntry =
+      openSlices.find((slice) => slice.parsed.id === branchRef.sliceId) ?? null;
+  }
+  if (!activeSliceEntry) {
+    activeSliceEntry = openSlices[0] ?? null;
+  }
+
+  const openTasks = tasks.filter((task) => task.issue.state !== "closed");
+  const closedTasks = tasks.filter((task) => task.issue.state === "closed");
+
+  const activeTaskEntry = openTasks[0] ?? null;
+
+  let phase: Phase;
+
+  if (activeSliceEntry) {
+    const labelPhase =
+      config.stateMode === "labels"
+        ? resolvePhaseFromSliceLabels(activeSliceEntry.issue, labelPrefix)
+        : null;
+
+    phase = labelPhase ?? computePhaseFallback(activeSliceEntry.issue, openTasks.map((t) => t.issue), closedTasks.map((t) => t.issue));
+  } else {
+    phase = "pre-planning";
+  }
+
+  const activeMilestone = activeMilestoneEntry
+    ? toActiveRef(activeMilestoneEntry.issue, activeMilestoneEntry.parsed)
+    : null;
+
+  const activeSlice = activeSliceEntry
+    ? toActiveRef(activeSliceEntry.issue, activeSliceEntry.parsed)
+    : null;
+
+  const activeTask = activeTaskEntry
+    ? toActiveRef(activeTaskEntry.issue, activeTaskEntry.parsed)
+    : null;
+
+  // If the active slice has no open task but there are closed tasks, this slice
+  // is likely complete and ready for summary.
+  if (activeSlice && !activeTask && closedTasks.length > 0) {
+    phase = "summarizing";
+  }
+
+  return {
+    activeMilestone,
+    activeSlice,
+    activeTask,
+    phase,
+    recentDecisions: [],
+    blockers: [],
+    nextAction: nextActionForPhase(phase),
+    activeBranch,
+    registry,
+    progress: {
+      milestones: {
+        done: milestones.filter((milestone) => milestone.issue.state === "closed").length,
+        total: milestones.length,
+      },
+      slices: {
+        done: closedSlices.length,
+        total: slices.length,
+      },
+      tasks: {
+        done: closedTasks.length,
+        total: tasks.length,
+      },
+    },
+  };
+}

--- a/apps/cli/src/resources/extensions/kata/guided-flow.ts
+++ b/apps/cli/src/resources/extensions/kata/guided-flow.ts
@@ -2,7 +2,7 @@
  * Kata Guided Flow — Smart Entry Wizard
  *
  * Contextual command entry points for /kata.
- * Linear mode only — no filesystem artifact fallbacks.
+ * Backend-aware for Linear and GitHub workflow modes.
  */
 
 import type {
@@ -878,7 +878,10 @@ export async function showSmartEntry(
   // Onboarding guard: if unconfigured, show a brief message and return.
   // commands.ts is the authoritative entry point for triggering the wizard.
   if (!isProjectConfigured(basePath)) {
-    ctx.ui.notify("Run /kata to set up Linear integration.", "info");
+    const workflowMode =
+      loadEffectiveKataPreferences(basePath)?.preferences.workflow?.mode ?? "linear";
+    const backendLabel = workflowMode === "github" ? "GitHub" : "Linear";
+    ctx.ui.notify(`Run /kata to set up ${backendLabel} integration.`, "info");
     return;
   }
 

--- a/apps/cli/src/resources/extensions/kata/index.ts
+++ b/apps/cli/src/resources/extensions/kata/index.ts
@@ -30,6 +30,7 @@ import {
   isAutoPaused,
   isStepActive,
   setStepActive,
+  setLatestPi,
   handleAgentEnd,
   handleProviderError,
   pauseAuto,
@@ -60,6 +61,10 @@ import { readFile } from "node:fs/promises";
 // Provider error retry is handled in auto.ts — see handleProviderError()
 
 export default function (pi: ExtensionAPI) {
+  // Keep latestPi in globalThis so auto-mode can reach the live session
+  // after newSession() rebuilds extensions (jiti moduleCache:false).
+  setLatestPi(pi);
+
   registerKataCommand(pi);
 
   // ── session_start: render branded Kata header ───────────────────────────

--- a/apps/cli/src/resources/extensions/kata/linear-config.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-config.ts
@@ -15,6 +15,7 @@ export interface EffectiveLinearProjectConfig {
   scope: LoadedKataPreferences["scope"] | null;
   workflowMode: WorkflowMode;
   isLinearMode: boolean;
+  isGithubMode: boolean;
   linear: {
     teamId: string | null;
     teamKey: string | null;
@@ -101,24 +102,24 @@ export interface WorkflowEntrypointGuard {
 export function normalizeWorkflowMode(mode: unknown): WorkflowMode {
   if (mode === "file") {
     throw new Error(
-      'File mode has been removed. Set workflow.mode to "linear" in your Kata preferences.',
+      'File mode has been removed. Set workflow.mode to "linear" or "github" in your Kata preferences.',
     );
   }
 
   if (mode === undefined || mode === null) return "linear";
 
   if (typeof mode !== "string") {
-    throw new Error('Invalid workflow.mode value. Set workflow.mode to "linear".');
+    throw new Error('Invalid workflow.mode value. Set workflow.mode to "linear" or "github".');
   }
 
   const normalized = mode.trim().toLowerCase();
-  if (normalized !== "linear") {
-    throw new Error(
-      `Unsupported workflow.mode "${normalized}". Set workflow.mode to "linear".`,
-    );
+  if (normalized === "linear" || normalized === "github") {
+    return normalized as WorkflowMode;
   }
 
-  return "linear";
+  throw new Error(
+    `Unsupported workflow.mode "${normalized}". Set workflow.mode to "linear" or "github".`,
+  );
 }
 
 export function loadEffectiveLinearProjectConfig(
@@ -139,6 +140,7 @@ export function loadEffectiveLinearProjectConfig(
     scope: loadedPreferences?.scope ?? null,
     workflowMode,
     isLinearMode: workflowMode === "linear",
+    isGithubMode: workflowMode === "github",
     linear: {
       teamId: preferences?.linear?.teamId ?? null,
       teamKey: preferences?.linear?.teamKey ?? null,
@@ -157,6 +159,12 @@ export function isLinearMode(
   loadedPreferences: LoadedKataPreferences | null = loadEffectiveKataPreferences(),
 ): boolean {
   return loadEffectiveLinearProjectConfig(loadedPreferences).isLinearMode;
+}
+
+export function isGithubMode(
+  loadedPreferences: LoadedKataPreferences | null = loadEffectiveKataPreferences(),
+): boolean {
+  return loadEffectiveLinearProjectConfig(loadedPreferences).isGithubMode;
 }
 
 export function getLinearTeamId(
@@ -295,7 +303,7 @@ export function resolveWorkflowProtocol(
 ): WorkflowProtocolResolution {
   const mode = getWorkflowMode(loadedPreferences);
 
-  // Linear mode uses the unified workflow document.
+  // Both Linear and GitHub modes use the unified workflow document.
   const kataPath =
     process.env.KATA_WORKFLOW_PATH ??
     join(process.env.HOME ?? homedir(), ".kata-cli", "agent", "KATA-WORKFLOW.md");
@@ -313,6 +321,9 @@ export function getWorkflowEntrypointGuard(
   loadedPreferences: LoadedKataPreferences | null = loadEffectiveKataPreferences(),
 ): WorkflowEntrypointGuard {
   const protocol = resolveWorkflowProtocol(loadedPreferences);
+  if (protocol.mode === "github") {
+    return buildGithubEntrypointGuard(entrypoint, protocol);
+  }
   return buildLinearEntrypointGuard(entrypoint, protocol);
 }
 
@@ -496,6 +507,56 @@ function buildLinearEntrypointGuard(
         "This project is configured for Linear mode. This file-backed Kata entrypoint is blocked until the Linear workflow runtime is wired.",
       );
   }
+}
+
+function buildGithubEntrypointGuard(
+  entrypoint: WorkflowEntrypoint,
+  protocol: WorkflowProtocolResolution,
+): WorkflowEntrypointGuard {
+  // GitHub mode supports the same entrypoints as Linear mode.
+  // S01 scope: deriveState, status, smart-entry are functional.
+  // Other entrypoints are allowed so downstream slices can wire them.
+  const supportedEntrypoints: WorkflowEntrypoint[] = [
+    "smart-entry",
+    "status",
+    "dashboard",
+    "plan",
+    "discuss",
+    "auto",
+    "system-prompt",
+  ];
+
+  if (supportedEntrypoints.includes(entrypoint)) {
+    const noticeMap: Partial<Record<WorkflowEntrypoint, string>> = {
+      "smart-entry": "Running in GitHub mode. Milestone artifacts stored in GitHub.",
+      status: "Showing live progress derived from GitHub API.",
+      dashboard: "Showing live progress derived from GitHub API.",
+      plan: "Running in GitHub mode. Planning artifacts stored in GitHub.",
+      discuss: "Running in GitHub mode. Discussion artifacts stored in GitHub.",
+      auto: "Running in GitHub mode. State derived from GitHub API.",
+      "system-prompt": protocol.ready
+        ? "Workflow mode is GitHub. Follow the GitHub mode instructions in KATA-WORKFLOW.md. Do not fall back to file-backed .kata artifacts."
+        : "Workflow mode is GitHub. Do not fall back to file-backed .kata artifacts. Workflow document not found — use `/kata prefs status` to inspect config.",
+    };
+    return {
+      mode: "github",
+      isLinearMode: false,
+      allow: true,
+      noticeLevel: entrypoint === "system-prompt" ? "warning" : "info",
+      notice: noticeMap[entrypoint] ?? `Running in GitHub mode.`,
+      protocol,
+    };
+  }
+
+  // Block unsupported file-backed entrypoints
+  return {
+    mode: "github",
+    isLinearMode: false,
+    allow: false,
+    noticeLevel: "warning",
+    notice: "This project is configured for GitHub mode. This file-backed Kata entrypoint is not supported in GitHub mode.",
+    protocol,
+  };
 }
 
 function blockedLinearEntrypoint(

--- a/apps/cli/src/resources/extensions/kata/linear-config.ts
+++ b/apps/cli/src/resources/extensions/kata/linear-config.ts
@@ -513,16 +513,12 @@ function buildGithubEntrypointGuard(
   entrypoint: WorkflowEntrypoint,
   protocol: WorkflowProtocolResolution,
 ): WorkflowEntrypointGuard {
-  // GitHub mode supports the same entrypoints as Linear mode.
-  // S01 scope: deriveState, status, smart-entry are functional.
-  // Other entrypoints are allowed so downstream slices can wire them.
+  // GitHub mode in S01 supports read-only/status-oriented flows.
   const supportedEntrypoints: WorkflowEntrypoint[] = [
     "smart-entry",
     "status",
     "dashboard",
-    "plan",
     "discuss",
-    "auto",
     "system-prompt",
   ];
 
@@ -531,9 +527,7 @@ function buildGithubEntrypointGuard(
       "smart-entry": "Running in GitHub mode. Milestone artifacts stored in GitHub.",
       status: "Showing live progress derived from GitHub API.",
       dashboard: "Showing live progress derived from GitHub API.",
-      plan: "Running in GitHub mode. Planning artifacts stored in GitHub.",
       discuss: "Running in GitHub mode. Discussion artifacts stored in GitHub.",
-      auto: "Running in GitHub mode. State derived from GitHub API.",
       "system-prompt": protocol.ready
         ? "Workflow mode is GitHub. Follow the GitHub mode instructions in KATA-WORKFLOW.md. Do not fall back to file-backed .kata artifacts."
         : "Workflow mode is GitHub. Do not fall back to file-backed .kata artifacts. Workflow document not found — use `/kata prefs status` to inspect config.",
@@ -544,6 +538,18 @@ function buildGithubEntrypointGuard(
       allow: true,
       noticeLevel: entrypoint === "system-prompt" ? "warning" : "info",
       notice: noticeMap[entrypoint] ?? `Running in GitHub mode.`,
+      protocol,
+    };
+  }
+
+  if (entrypoint === "plan" || entrypoint === "auto") {
+    return {
+      mode: "github",
+      isLinearMode: false,
+      allow: false,
+      noticeLevel: "warning",
+      notice:
+        "GitHub mode planning and auto execution are not available yet. Use `/kata status` or `/kata discuss` for S01 read-only workflows.",
       protocol,
     };
   }

--- a/apps/cli/src/resources/extensions/kata/onboarding.ts
+++ b/apps/cli/src/resources/extensions/kata/onboarding.ts
@@ -2,17 +2,18 @@
  * Kata Onboarding — Project Setup Wizard
  *
  * Provides:
- * - `isProjectConfigured(basePath)` — check if .kata/preferences.md exists with linear config
- * - `runOnboarding(ctx)` — interactive wizard to collect LINEAR_API_KEY and create .kata/
+ * - `isProjectConfigured(basePath)` — check if .kata/preferences.md exists with workflow config
+ * - `runOnboarding(ctx)` — interactive wizard to collect credentials and create .kata/
  * - `shouldSkipOnboarding()` / `setSkipOnboarding()` — session-scoped skip flag
  *
  * The wizard:
  * 1. Guards non-TTY environments (returns "skipped" with warning)
- * 2. Prompts for LINEAR_API_KEY via ctx.ui.input (masked)
- * 3. Validates via LinearClient.getViewer() (one retry on failure)
+ * 2. In Linear mode: prompts for LINEAR_API_KEY via ctx.ui.input (masked)
+ *    In GitHub mode: checks for existing GH_TOKEN/GITHUB_TOKEN
+ * 3. Validates credentials
  * 4. Stores key in auth.json via AuthStorage
  * 5. Creates .kata/preferences.md from template + ensures .gitignore
- * 6. Hydrates process.env.LINEAR_API_KEY for same-session use
+ * 6. Hydrates env vars for same-session use
  */
 
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
@@ -46,7 +47,9 @@ export function _resetSkipFlag(): void {
 
 /**
  * Returns true if the project at `basePath` has a `.kata/preferences.md`
- * file AND has either `linear.teamKey` or `linear.projectSlug` set.
+ * file AND has valid workflow backend configuration:
+ * - In Linear mode (default): requires `linear.teamKey` or `linear.projectSlug`.
+ * - In GitHub mode: requires `workflow.mode: github` (tracker config validated separately).
  */
 export function isProjectConfigured(basePath: string): boolean {
   const preferencesPath = join(basePath, ".kata", "preferences.md");
@@ -59,6 +62,13 @@ export function isProjectConfigured(basePath: string): boolean {
   const loaded = loadEffectiveKataPreferences(basePath);
   if (!loaded) return false;
 
+  // GitHub mode: preferences file exists with workflow.mode: github is sufficient.
+  // Detailed tracker config (repo owner, token, etc.) is validated separately by
+  // the GitHub config resolver — not gated at the onboarding level.
+  const workflowMode = loaded.preferences.workflow?.mode;
+  if (workflowMode === "github") return true;
+
+  // Linear mode (default): require Linear-specific fields.
   const linear = loaded.preferences.linear;
   if (!linear) return false;
 

--- a/apps/cli/src/resources/extensions/kata/onboarding.ts
+++ b/apps/cli/src/resources/extensions/kata/onboarding.ts
@@ -6,10 +6,9 @@
  * - `runOnboarding(ctx)` — interactive wizard to collect credentials and create .kata/
  * - `shouldSkipOnboarding()` / `setSkipOnboarding()` — session-scoped skip flag
  *
- * The wizard:
+ * The wizard currently:
  * 1. Guards non-TTY environments (returns "skipped" with warning)
- * 2. In Linear mode: prompts for LINEAR_API_KEY via ctx.ui.input (masked)
- *    In GitHub mode: checks for existing GH_TOKEN/GITHUB_TOKEN
+ * 2. Prompts for LINEAR_API_KEY via ctx.ui.input (masked)
  * 3. Validates credentials
  * 4. Stores key in auth.json via AuthStorage
  * 5. Creates .kata/preferences.md from template + ensures .gitignore

--- a/apps/cli/src/resources/extensions/kata/preferences.ts
+++ b/apps/cli/src/resources/extensions/kata/preferences.ts
@@ -63,7 +63,7 @@ export interface ResolvedAutoSupervisorConfig {
   hard_timeout_minutes: number;
 }
 
-export type WorkflowMode = "linear";
+export type WorkflowMode = "linear" | "github";
 
 export interface KataWorkflowPreferences {
   mode?: WorkflowMode;
@@ -965,21 +965,21 @@ function normalizeWorkflowPreferences(value: unknown): {
   }
 
   const mode = rawMode.trim().toLowerCase();
-  if (mode === "linear") {
-    return { value: { mode }, errors: [] };
+  if (mode === "linear" || mode === "github") {
+    return { value: { mode: mode as WorkflowMode }, errors: [] };
   }
 
   if (mode === "file") {
     return {
       value: { mode: mode as WorkflowMode },
       errors: [
-        'workflow.mode "file" has been removed. Set workflow.mode to "linear".',
+        'workflow.mode "file" has been removed. Set workflow.mode to "linear" or "github".',
       ],
     };
   }
 
   return {
-    errors: ['workflow.mode must be "linear"'],
+    errors: ['workflow.mode must be "linear" or "github"'],
   };
 }
 

--- a/apps/cli/src/resources/extensions/kata/preferences.ts
+++ b/apps/cli/src/resources/extensions/kata/preferences.ts
@@ -971,7 +971,6 @@ function normalizeWorkflowPreferences(value: unknown): {
 
   if (mode === "file") {
     return {
-      value: { mode: mode as WorkflowMode },
       errors: [
         'workflow.mode "file" has been removed. Set workflow.mode to "linear" or "github".',
       ],

--- a/apps/cli/src/resources/extensions/kata/prefs-model.ts
+++ b/apps/cli/src/resources/extensions/kata/prefs-model.ts
@@ -131,8 +131,8 @@ export const PREFS_FIELD_DEFINITIONS: readonly PrefsFieldDefinition[] = [
     label: "Mode",
     path: ["workflow", "mode"],
     type: "enum",
-    enumValues: ["linear"],
-    description: "Workflow mode. Currently only 'linear' is supported.",
+    enumValues: ["linear", "github"],
+    description: "Workflow mode. Supported: 'linear' (default), 'github'.",
   },
 
   // ── Linear ────────────────────────────────────────────────────────────────

--- a/apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts
@@ -66,6 +66,7 @@ function startMockGithubServer(): Promise<{ server: Server; baseUrl: string }> {
         title: "[T04] Wire /kata surfaces",
         state: "open",
         labels: [{ name: "kata:task" }],
+        body: "Tracking implementation for slice S01",
       },
     ],
     "2": [],

--- a/apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts
@@ -99,6 +99,79 @@ function startMockGithubServer(): Promise<{ server: Server; baseUrl: string }> {
   });
 }
 
+function startDeepPaginationMockGithubServer(): Promise<{ server: Server; baseUrl: string }> {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (!url.pathname.endsWith("/issues")) {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ message: "not found" }));
+      return;
+    }
+
+    const page = Number(url.searchParams.get("page") ?? "1");
+    let payload: Array<Record<string, unknown>> = [];
+
+    if (page >= 1 && page <= 11) {
+      payload = Array.from({ length: 100 }, (_, idx) => ({
+        number: page * 1000 + idx,
+        title: `Noise issue ${page}-${idx}`,
+        state: "open",
+        labels: [{ name: "kata:task" }],
+      }));
+    } else if (page === 12) {
+      payload = [
+        {
+          number: 999999,
+          title: "[M123] Deep pagination milestone",
+          state: "open",
+          labels: [{ name: "kata:milestone" }],
+        },
+      ];
+    }
+
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(payload));
+  });
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Mock GitHub server failed to bind"));
+        return;
+      }
+      resolve({ server, baseUrl: `http://127.0.0.1:${address.port}` });
+    });
+  });
+}
+
+function startSlowGithubServer(delayMs: number): Promise<{ server: Server; baseUrl: string }> {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (!url.pathname.endsWith("/issues")) {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ message: "not found" }));
+      return;
+    }
+
+    setTimeout(() => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify([]));
+    }, delayMs);
+  });
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Mock GitHub server failed to bind"));
+        return;
+      }
+      resolve({ server, baseUrl: `http://127.0.0.1:${address.port}` });
+    });
+  });
+}
+
 const WORKFLOW = `---
 tracker:
   kind: github
@@ -174,13 +247,72 @@ test("createBackend returns actionable diagnostics when GitHub token is missing"
   }
 });
 
+test("createBackend fetches beyond 10 pages when GitHub issues exceed 1000", async () => {
+  const workspace = makeWorkspace({ workflow: WORKFLOW });
+  const { server, baseUrl } = await startDeepPaginationMockGithubServer();
+
+  try {
+    await withEnv(
+      {
+        KATA_GITHUB_TOKEN: "ghp_test_token",
+        GH_TOKEN: undefined,
+        GITHUB_TOKEN: undefined,
+        KATA_GITHUB_API_BASE_URL: baseUrl,
+        KATA_GITHUB_WORKFLOW_PATH: undefined,
+      },
+      async () => {
+        const backend = await createBackend(workspace);
+        const state = await backend.deriveState();
+
+        assert.equal(state.activeMilestone?.id, "M123");
+      },
+    );
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("createBackend surfaces timeout diagnostics when GitHub API calls hang", async () => {
+  const workspace = makeWorkspace({ workflow: WORKFLOW });
+  const { server, baseUrl } = await startSlowGithubServer(150);
+
+  try {
+    await withEnv(
+      {
+        KATA_GITHUB_TOKEN: "ghp_test_token",
+        GH_TOKEN: undefined,
+        GITHUB_TOKEN: undefined,
+        KATA_GITHUB_API_BASE_URL: baseUrl,
+        KATA_GITHUB_API_TIMEOUT_MS: "10",
+        KATA_GITHUB_WORKFLOW_PATH: undefined,
+      },
+      async () => {
+        const backend = await createBackend(workspace);
+        await assert.rejects(
+          async () => backend.deriveState(),
+          (err: unknown) => {
+            assert.ok(err instanceof Error);
+            assert.match(err.message, /timed out after 10ms/);
+            return true;
+          },
+        );
+      },
+    );
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
 test("runtime smoke: GitHub backend derives state against real GitHub API when token is available", async () => {
+  const optedIn = process.env.KATA_GITHUB_SMOKE === "1";
   const tokenPresent =
     Boolean(process.env.KATA_GITHUB_TOKEN) ||
     Boolean(process.env.GH_TOKEN) ||
     Boolean(process.env.GITHUB_TOKEN);
 
-  if (!tokenPresent) {
+  if (!optedIn || !tokenPresent) {
     return;
   }
 

--- a/apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { createBackend } from "../backend-factory.ts";
+
+function makeWorkspace(contents: { workflow: string; prefs?: string }): string {
+  const dir = mkdtempSync(join(tmpdir(), "kata-github-backend-"));
+  mkdirSync(join(dir, ".kata"), { recursive: true });
+  writeFileSync(
+    join(dir, ".kata", "preferences.md"),
+    contents.prefs ?? "---\nworkflow:\n  mode: github\n---\n",
+    "utf-8",
+  );
+  writeFileSync(join(dir, "WORKFLOW.md"), contents.workflow, "utf-8");
+  return dir;
+}
+
+function withEnv<T>(
+  vars: Partial<Record<string, string | undefined>>,
+  run: () => Promise<T> | T,
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    previous[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  return Promise.resolve()
+    .then(run)
+    .finally(() => {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    });
+}
+
+function startMockGithubServer(): Promise<{ server: Server; baseUrl: string }> {
+  const pages: Record<string, unknown> = {
+    "1": [
+      {
+        number: 101,
+        title: "[M009] GitHub Backend Parity",
+        state: "open",
+        labels: [{ name: "kata:milestone" }],
+      },
+      {
+        number: 102,
+        title: "[S01] CLI GitHub Workflow Mode Bootstrap",
+        state: "open",
+        labels: [{ name: "kata:slice" }, { name: "kata:executing" }],
+      },
+      {
+        number: 103,
+        title: "[T04] Wire /kata surfaces",
+        state: "open",
+        labels: [{ name: "kata:task" }],
+      },
+    ],
+    "2": [],
+  };
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (!url.pathname.endsWith("/issues")) {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ message: "not found" }));
+      return;
+    }
+
+    const page = url.searchParams.get("page") ?? "1";
+    const payload = pages[page] ?? [];
+
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(payload));
+  });
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Mock GitHub server failed to bind"));
+        return;
+      }
+      resolve({ server, baseUrl: `http://127.0.0.1:${address.port}` });
+    });
+  });
+}
+
+const WORKFLOW = `---
+tracker:
+  kind: github
+  repo_owner: acme
+  repo_name: demo
+  label_prefix: kata:
+---
+# Workflow
+`;
+
+test("createBackend boots GitHub mode and derives active refs", async () => {
+  const workspace = makeWorkspace({ workflow: WORKFLOW });
+  const { server, baseUrl } = await startMockGithubServer();
+
+  try {
+    await withEnv(
+      {
+        KATA_GITHUB_TOKEN: "ghp_test_token",
+        GH_TOKEN: undefined,
+        GITHUB_TOKEN: undefined,
+        KATA_GITHUB_API_BASE_URL: baseUrl,
+        KATA_GITHUB_WORKFLOW_PATH: undefined,
+      },
+      async () => {
+        const backend = await createBackend(workspace);
+        await backend.bootstrap();
+
+        const state = await backend.deriveState();
+        assert.equal(backend.isLinearMode, false);
+        assert.equal(state.phase, "executing");
+        assert.equal(state.activeMilestone?.id, "M009");
+        assert.equal(state.activeSlice?.id, "S01");
+        assert.equal(state.activeTask?.id, "T04");
+
+        const dashboard = await backend.loadDashboardData();
+        assert.equal(dashboard.state.phase, "executing");
+      },
+    );
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("createBackend returns actionable diagnostics when GitHub token is missing", async () => {
+  const workspace = makeWorkspace({ workflow: WORKFLOW });
+
+  try {
+    await withEnv(
+      {
+        KATA_GITHUB_TOKEN: undefined,
+        GH_TOKEN: undefined,
+        GITHUB_TOKEN: undefined,
+        KATA_GITHUB_API_BASE_URL: undefined,
+        KATA_GITHUB_WORKFLOW_PATH: undefined,
+      },
+      async () => {
+        await assert.rejects(
+          async () => createBackend(workspace),
+          (err: unknown) => {
+            assert.ok(err instanceof Error);
+            assert.match(err.message, /GitHub backend is not ready/);
+            assert.match(err.message, /diagnostic: missing_github_token/);
+            assert.match(err.message, /action: set KATA_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN/);
+            assert.match(err.message, /\/kata prefs status/);
+            return true;
+          },
+        );
+      },
+    );
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runtime smoke: GitHub backend derives state against real GitHub API when token is available", async () => {
+  const tokenPresent =
+    Boolean(process.env.KATA_GITHUB_TOKEN) ||
+    Boolean(process.env.GH_TOKEN) ||
+    Boolean(process.env.GITHUB_TOKEN);
+
+  if (!tokenPresent) {
+    return;
+  }
+
+  const workspace = makeWorkspace({
+    workflow: `---
+tracker:
+  kind: github
+  repo_owner: gannonh
+  repo_name: kata
+  label_prefix: kata:
+---
+# Runtime smoke
+`,
+  });
+
+  try {
+    await withEnv(
+      {
+        KATA_GITHUB_API_BASE_URL: undefined,
+        KATA_GITHUB_WORKFLOW_PATH: undefined,
+      },
+      async () => {
+        const backend = await createBackend(workspace);
+        const state = await backend.deriveState();
+
+        assert.ok(state.phase.length > 0, "phase should be present");
+        assert.ok(Array.isArray(state.registry), "registry should be present");
+      },
+    );
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});

--- a/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Tests for github-config.ts
+ *
+ * Covers:
+ * - WORKFLOW.md parsing (valid, missing, malformed, wrong kind, missing required fields)
+ * - Token resolution order (KATA_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN > auth.json)
+ * - Full validation result (ok/invalid, diagnostics, tokenPresent, trackerConfig)
+ * - formatGithubConfigStatus output
+ * - Redaction: token values never appear in diagnostic output
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, before, after, beforeEach, afterEach } from "node:test";
+
+import {
+  loadGithubTrackerConfig,
+  resolveGithubToken,
+  validateGithubConfig,
+  formatGithubConfigStatus,
+  resolveGithubWorkflowPath,
+} from "../github-config.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "kata-github-config-"));
+}
+
+function writeWorkflowMd(dir: string, content: string): string {
+  const path = join(dir, "WORKFLOW.md");
+  writeFileSync(path, content, "utf-8");
+  return path;
+}
+
+function makeValidWorkflowMd(extras: Record<string, string> = {}): string {
+  const extraLines = Object.entries(extras)
+    .map(([k, v]) => `    ${k}: ${v}`)
+    .join("\n");
+  return `---\ntracker:\n  kind: github\n  repo_owner: kata-sh\n  repo_name: kata-mono${extraLines ? "\n" + extraLines : ""}\n---\n# Project\n`;
+}
+
+/** Save and restore env vars across a test. */
+function withEnv<T>(
+  vars: Partial<Record<string, string | undefined>>,
+  fn: () => T,
+): T {
+  const saved: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(vars)) {
+    saved[k] = process.env[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  }
+}
+
+// Save env vars that could bleed from the host environment
+let savedEnv: Record<string, string | undefined> = {};
+
+before(() => {
+  for (const k of ["KATA_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN", "KATA_GITHUB_WORKFLOW_PATH"]) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+after(() => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+});
+
+// ─── resolveGithubWorkflowPath ────────────────────────────────────────────────
+
+test("resolveGithubWorkflowPath uses KATA_GITHUB_WORKFLOW_PATH when set", () => {
+  withEnv({ KATA_GITHUB_WORKFLOW_PATH: "/override/WORKFLOW.md" }, () => {
+    assert.equal(resolveGithubWorkflowPath("/some/dir"), "/override/WORKFLOW.md");
+  });
+});
+
+test("resolveGithubWorkflowPath falls back to basePath/WORKFLOW.md", () => {
+  withEnv({ KATA_GITHUB_WORKFLOW_PATH: undefined }, () => {
+    assert.equal(resolveGithubWorkflowPath("/project"), "/project/WORKFLOW.md");
+  });
+});
+
+// ─── loadGithubTrackerConfig ──────────────────────────────────────────────────
+
+test("loadGithubTrackerConfig returns config for valid minimal WORKFLOW.md", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(dir, makeValidWorkflowMd());
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(diagnostic, null);
+  assert.deepEqual(config, {
+    repoOwner: "kata-sh",
+    repoName: "kata-mono",
+    stateMode: "labels",
+  });
+});
+
+test("loadGithubTrackerConfig includes githubProjectNumber and sets stateMode projects_v2", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(
+    dir,
+    makeValidWorkflowMd({ github_project_number: "42" }),
+  );
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(diagnostic, null);
+  assert.deepEqual(config, {
+    repoOwner: "kata-sh",
+    repoName: "kata-mono",
+    stateMode: "projects_v2",
+    githubProjectNumber: 42,
+  });
+});
+
+test("loadGithubTrackerConfig includes optional labelPrefix", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(dir, makeValidWorkflowMd({ label_prefix: "kata:" }));
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(diagnostic, null);
+  assert.equal(config?.labelPrefix, "kata:");
+});
+
+test("loadGithubTrackerConfig returns missing_workflow_file when WORKFLOW.md absent", () => {
+  const { config, diagnostic } = loadGithubTrackerConfig("/nonexistent/path/WORKFLOW.md");
+  assert.equal(config, null);
+  assert.equal(diagnostic?.code, "missing_workflow_file");
+  assert.equal(diagnostic?.retryable, false);
+});
+
+test("loadGithubTrackerConfig returns invalid_workflow_file for missing frontmatter", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(dir, "# No frontmatter here\n");
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(config, null);
+  assert.equal(diagnostic?.code, "invalid_workflow_file");
+});
+
+test("loadGithubTrackerConfig returns unsupported_tracker_kind when tracker block is absent", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(dir, "---\nversion: 1\n---\n# no tracker\n");
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(config, null);
+  assert.equal(diagnostic?.code, "unsupported_tracker_kind");
+});
+
+test("loadGithubTrackerConfig returns unsupported_tracker_kind when kind is not github", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(
+    dir,
+    "---\ntracker:\n  kind: linear\n  repo_owner: kata-sh\n  repo_name: kata-mono\n---\n",
+  );
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(config, null);
+  assert.equal(diagnostic?.code, "unsupported_tracker_kind");
+  assert.equal(diagnostic?.field, "tracker.kind");
+});
+
+test("loadGithubTrackerConfig returns missing_repo_owner when repo_owner absent", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(
+    dir,
+    "---\ntracker:\n  kind: github\n  repo_name: kata-mono\n---\n",
+  );
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(config, null);
+  assert.equal(diagnostic?.code, "missing_repo_owner");
+  assert.equal(diagnostic?.field, "tracker.repo_owner");
+});
+
+test("loadGithubTrackerConfig returns missing_repo_name when repo_name absent", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(
+    dir,
+    "---\ntracker:\n  kind: github\n  repo_owner: kata-sh\n---\n",
+  );
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(config, null);
+  assert.equal(diagnostic?.code, "missing_repo_name");
+  assert.equal(diagnostic?.field, "tracker.repo_name");
+});
+
+test("loadGithubTrackerConfig returns invalid_github_project_number for non-integer value", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(
+    dir,
+    makeValidWorkflowMd({ github_project_number: "not-a-number" }),
+  );
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(config, null);
+  assert.equal(diagnostic?.code, "invalid_github_project_number");
+});
+
+test("loadGithubTrackerConfig returns invalid_github_project_number for zero", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(dir, makeValidWorkflowMd({ github_project_number: "0" }));
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(config, null);
+  assert.equal(diagnostic?.code, "invalid_github_project_number");
+});
+
+test("loadGithubTrackerConfig returns invalid_github_project_number for negative value", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(dir, makeValidWorkflowMd({ github_project_number: "-5" }));
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(config, null);
+  assert.equal(diagnostic?.code, "invalid_github_project_number");
+});
+
+test("loadGithubTrackerConfig handles KATA_GITHUB_WORKFLOW_PATH env override", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(dir, makeValidWorkflowMd());
+
+  withEnv({ KATA_GITHUB_WORKFLOW_PATH: path }, () => {
+    // No explicit path passed — relies on env var
+    const { config, diagnostic } = loadGithubTrackerConfig(undefined, "/wrong/basepath");
+    assert.equal(diagnostic, null);
+    assert.equal(config?.repoOwner, "kata-sh");
+  });
+});
+
+test("loadGithubTrackerConfig strips YAML inline comments and quotes", () => {
+  const dir = makeTmpDir();
+  const path = writeWorkflowMd(
+    dir,
+    '---\ntracker:\n  kind: "github"\n  repo_owner: "kata-sh" # org\n  repo_name: kata-mono\n---\n',
+  );
+
+  const { config, diagnostic } = loadGithubTrackerConfig(path);
+  assert.equal(diagnostic, null);
+  assert.equal(config?.repoOwner, "kata-sh");
+  assert.equal(config?.repoName, "kata-mono");
+});
+
+// ─── resolveGithubToken ───────────────────────────────────────────────────────
+
+test("resolveGithubToken returns KATA_GITHUB_TOKEN with correct source", () => {
+  withEnv(
+    { KATA_GITHUB_TOKEN: "secret-kata", GH_TOKEN: "secret-gh", GITHUB_TOKEN: "secret-github" },
+    () => {
+      const { token, source } = resolveGithubToken("/nonexistent/auth.json");
+      assert.equal(token, "secret-kata");
+      assert.equal(source, "KATA_GITHUB_TOKEN");
+    },
+  );
+});
+
+test("resolveGithubToken falls through to GH_TOKEN when KATA_GITHUB_TOKEN absent", () => {
+  withEnv(
+    { KATA_GITHUB_TOKEN: undefined, GH_TOKEN: "secret-gh", GITHUB_TOKEN: "secret-github" },
+    () => {
+      const { token, source } = resolveGithubToken("/nonexistent/auth.json");
+      assert.equal(token, "secret-gh");
+      assert.equal(source, "GH_TOKEN");
+    },
+  );
+});
+
+test("resolveGithubToken falls through to GITHUB_TOKEN when both KATA and GH absent", () => {
+  withEnv(
+    { KATA_GITHUB_TOKEN: undefined, GH_TOKEN: undefined, GITHUB_TOKEN: "secret-github" },
+    () => {
+      const { token, source } = resolveGithubToken("/nonexistent/auth.json");
+      assert.equal(token, "secret-github");
+      assert.equal(source, "GITHUB_TOKEN");
+    },
+  );
+});
+
+test("resolveGithubToken reads auth.json github provider when all env vars absent", () => {
+  const dir = makeTmpDir();
+  const authPath = join(dir, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({ github: { type: "api_key", key: "secret-from-auth" } }),
+    "utf-8",
+  );
+
+  withEnv(
+    { KATA_GITHUB_TOKEN: undefined, GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
+    () => {
+      const { token, source } = resolveGithubToken(authPath);
+      assert.equal(token, "secret-from-auth");
+      assert.equal(source, "auth.json (github provider)");
+    },
+  );
+});
+
+test("resolveGithubToken returns null when no sources available", () => {
+  withEnv(
+    { KATA_GITHUB_TOKEN: undefined, GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
+    () => {
+      const { token, source } = resolveGithubToken("/nonexistent/auth.json");
+      assert.equal(token, null);
+      assert.equal(source, null);
+    },
+  );
+});
+
+// ─── validateGithubConfig ─────────────────────────────────────────────────────
+
+test("validateGithubConfig returns ok:true when token and tracker config are valid", () => {
+  const dir = makeTmpDir();
+  const wfPath = writeWorkflowMd(dir, makeValidWorkflowMd());
+
+  withEnv({ KATA_GITHUB_TOKEN: "secret", GH_TOKEN: undefined, GITHUB_TOKEN: undefined }, () => {
+    const result = validateGithubConfig({
+      workflowPath: wfPath,
+      authFilePath: "/nonexistent/auth.json",
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "valid");
+    assert.equal(result.tokenPresent, true);
+    assert.equal(result.tokenSource, "KATA_GITHUB_TOKEN");
+    assert.ok(result.trackerConfig);
+    assert.equal(result.diagnostics.length, 0);
+  });
+});
+
+test("validateGithubConfig collects both tracker and token diagnostics", () => {
+  withEnv(
+    { KATA_GITHUB_TOKEN: undefined, GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
+    () => {
+      const result = validateGithubConfig({
+        workflowPath: "/nonexistent/WORKFLOW.md",
+        authFilePath: "/nonexistent/auth.json",
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.status, "invalid");
+      assert.equal(result.tokenPresent, false);
+
+      const codes = result.diagnostics.map((d) => d.code);
+      assert.ok(codes.includes("missing_workflow_file"), "missing_workflow_file expected");
+      assert.ok(codes.includes("missing_github_token"), "missing_github_token expected");
+    },
+  );
+});
+
+test("validateGithubConfig reports only token diagnostic when tracker config is valid", () => {
+  const dir = makeTmpDir();
+  const wfPath = writeWorkflowMd(dir, makeValidWorkflowMd());
+
+  withEnv(
+    { KATA_GITHUB_TOKEN: undefined, GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
+    () => {
+      const result = validateGithubConfig({
+        workflowPath: wfPath,
+        authFilePath: "/nonexistent/auth.json",
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.diagnostics.length, 1);
+      assert.equal(result.diagnostics[0]?.code, "missing_github_token");
+      assert.ok(result.trackerConfig); // tracker parsed successfully
+    },
+  );
+});
+
+// ─── Redaction check ──────────────────────────────────────────────────────────
+
+test("token values never appear in diagnostic messages (redaction)", () => {
+  const secretToken = "ghp_super_secret_value_12345";
+  const dir = makeTmpDir();
+  const wfPath = writeWorkflowMd(dir, makeValidWorkflowMd());
+
+  withEnv(
+    { KATA_GITHUB_TOKEN: secretToken, GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
+    () => {
+      const result = validateGithubConfig({ workflowPath: wfPath });
+      const allText = JSON.stringify(result);
+      assert.equal(
+        allText.includes(secretToken),
+        false,
+        "Token value must not appear in validation result",
+      );
+    },
+  );
+});
+
+test("formatGithubConfigStatus output never contains token values", () => {
+  const secretToken = "ghp_super_secret_value_12345";
+  const dir = makeTmpDir();
+  const wfPath = writeWorkflowMd(dir, makeValidWorkflowMd());
+
+  withEnv(
+    { KATA_GITHUB_TOKEN: secretToken, GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
+    () => {
+      const result = validateGithubConfig({ workflowPath: wfPath });
+      const report = formatGithubConfigStatus(result);
+      const allOutput = report.lines.join("\n");
+      assert.equal(
+        allOutput.includes(secretToken),
+        false,
+        "Token value must not appear in status lines",
+      );
+    },
+  );
+});
+
+// ─── formatGithubConfigStatus ─────────────────────────────────────────────────
+
+test("formatGithubConfigStatus shows valid status for complete config", () => {
+  const dir = makeTmpDir();
+  const wfPath = writeWorkflowMd(dir, makeValidWorkflowMd({ github_project_number: "7" }));
+
+  withEnv({ KATA_GITHUB_TOKEN: "token", GH_TOKEN: undefined, GITHUB_TOKEN: undefined }, () => {
+    const result = validateGithubConfig({ workflowPath: wfPath });
+    const { lines, level } = formatGithubConfigStatus(result);
+
+    assert.equal(level, "info");
+    assert.ok(lines.some((l) => l.includes("present")), "token presence expected");
+    assert.ok(lines.some((l) => l.includes("kata-sh/kata-mono")), "repo expected");
+    assert.ok(lines.some((l) => l.includes("projects_v2")), "state mode expected");
+    assert.ok(lines.some((l) => l.includes("7")), "project number expected");
+    assert.ok(lines.some((l) => l.includes("valid")), "validation status expected");
+  });
+});
+
+test("formatGithubConfigStatus shows warning level and diagnostics on failure", () => {
+  withEnv(
+    { KATA_GITHUB_TOKEN: undefined, GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
+    () => {
+      const result = validateGithubConfig({
+        workflowPath: "/nonexistent/WORKFLOW.md",
+        authFilePath: "/nonexistent/auth.json",
+      });
+      const { lines, level } = formatGithubConfigStatus(result);
+
+      assert.equal(level, "warning");
+      assert.ok(lines.some((l) => l.includes("missing")), "missing token expected");
+      assert.ok(lines.some((l) => l.includes("diagnostic:")), "diagnostic line expected");
+      assert.ok(lines.some((l) => l.includes("action:")), "action line expected");
+    },
+  );
+});

--- a/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
@@ -328,6 +328,21 @@ test("resolveGithubToken returns null when no sources available", () => {
   );
 });
 
+test("resolveGithubToken returns null when auth.json exists but is malformed", () => {
+  const dir = makeTmpDir();
+  const authPath = join(dir, "auth.json");
+  writeFileSync(authPath, "{not-valid-json", "utf-8");
+
+  withEnv(
+    { KATA_GITHUB_TOKEN: undefined, GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
+    () => {
+      const { token, source } = resolveGithubToken(authPath);
+      assert.equal(token, null);
+      assert.equal(source, null);
+    },
+  );
+});
+
 // ─── validateGithubConfig ─────────────────────────────────────────────────────
 
 test("validateGithubConfig returns ok:true when token and tracker config are valid", () => {

--- a/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
@@ -118,7 +118,7 @@ test("loadGithubTrackerConfig returns config for valid minimal WORKFLOW.md", () 
   });
 });
 
-test("loadGithubTrackerConfig includes githubProjectNumber and sets stateMode projects_v2", () => {
+test("loadGithubTrackerConfig includes githubProjectNumber and keeps label-based stateMode", () => {
   const dir = makeTmpDir();
   const path = writeWorkflowMd(
     dir,
@@ -130,7 +130,7 @@ test("loadGithubTrackerConfig includes githubProjectNumber and sets stateMode pr
   assert.deepEqual(config, {
     repoOwner: "kata-sh",
     repoName: "kata-mono",
-    stateMode: "projects_v2",
+    stateMode: "labels",
     githubProjectNumber: 42,
   });
 });
@@ -455,7 +455,7 @@ test("formatGithubConfigStatus shows valid status for complete config", () => {
     assert.equal(level, "info");
     assert.ok(lines.some((l) => l.includes("present")), "token presence expected");
     assert.ok(lines.some((l) => l.includes("kata-sh/kata-mono")), "repo expected");
-    assert.ok(lines.some((l) => l.includes("projects_v2")), "state mode expected");
+    assert.ok(lines.some((l) => l.includes("labels")), "state mode expected");
     assert.ok(lines.some((l) => l.includes("7")), "project number expected");
     assert.ok(lines.some((l) => l.includes("valid")), "validation status expected");
   });

--- a/apps/cli/src/resources/extensions/kata/tests/github-state.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-state.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deriveGithubState,
+  type GithubIssueSummary,
+  type GithubStateClient,
+} from "../github-state.ts";
+
+function makeClient(issues: GithubIssueSummary[]): GithubStateClient {
+  return {
+    async listIssues() {
+      return issues;
+    },
+  };
+}
+
+test("deriveGithubState returns pre-planning when no milestone issues exist", async () => {
+  const state = await deriveGithubState(makeClient([]), {
+    repoOwner: "kata-sh",
+    repoName: "kata-mono",
+    stateMode: "labels",
+    labelPrefix: "kata:",
+  });
+
+  assert.equal(state.phase, "pre-planning");
+  assert.equal(state.activeMilestone, null);
+  assert.equal(state.registry.length, 0);
+  assert.deepEqual(state.progress?.milestones, { done: 0, total: 0 });
+});
+
+test("deriveGithubState derives active milestone/slice/task and executing phase", async () => {
+  const issues: GithubIssueSummary[] = [
+    {
+      number: 10,
+      title: "[M009] GitHub backend parity",
+      state: "open",
+      labels: ["kata:milestone"],
+    },
+    {
+      number: 11,
+      title: "[S01] CLI bootstrap",
+      state: "open",
+      labels: ["kata:slice", "kata:executing"],
+    },
+    {
+      number: 12,
+      title: "[T04] Wire status diagnostics",
+      state: "open",
+      labels: ["kata:task"],
+    },
+  ];
+
+  const state = await deriveGithubState(makeClient(issues), {
+    repoOwner: "kata-sh",
+    repoName: "kata-mono",
+    stateMode: "labels",
+    labelPrefix: "kata:",
+  });
+
+  assert.equal(state.phase, "executing");
+  assert.equal(state.activeMilestone?.id, "M009");
+  assert.equal(state.activeSlice?.id, "S01");
+  assert.equal(state.activeTask?.id, "T04");
+  assert.equal(state.registry[0]?.status, "active");
+  assert.deepEqual(state.progress?.tasks, { done: 0, total: 1 });
+});
+
+test("deriveGithubState falls back to verifying when some tasks are closed", async () => {
+  const issues: GithubIssueSummary[] = [
+    {
+      number: 20,
+      title: "[M010] Follow-up",
+      state: "open",
+      labels: ["kata:milestone"],
+    },
+    {
+      number: 21,
+      title: "[S02] Add integrations",
+      state: "open",
+      labels: ["kata:slice"],
+    },
+    {
+      number: 22,
+      title: "[T01] First task",
+      state: "closed",
+      labels: ["kata:task"],
+    },
+    {
+      number: 23,
+      title: "[T02] Second task",
+      state: "open",
+      labels: ["kata:task"],
+    },
+  ];
+
+  const state = await deriveGithubState(makeClient(issues), {
+    repoOwner: "kata-sh",
+    repoName: "kata-mono",
+    stateMode: "labels",
+    labelPrefix: "kata:",
+  });
+
+  assert.equal(state.phase, "verifying");
+  assert.equal(state.activeTask?.id, "T02");
+  assert.deepEqual(state.progress?.tasks, { done: 1, total: 2 });
+});
+
+test("deriveGithubState marks workflow complete when all milestones are closed", async () => {
+  const issues: GithubIssueSummary[] = [
+    {
+      number: 30,
+      title: "[M001] Foundation",
+      state: "closed",
+      labels: ["kata:milestone"],
+    },
+    {
+      number: 31,
+      title: "[M002] Follow-up",
+      state: "closed",
+      labels: ["kata:milestone"],
+    },
+  ];
+
+  const state = await deriveGithubState(makeClient(issues), {
+    repoOwner: "kata-sh",
+    repoName: "kata-mono",
+    stateMode: "labels",
+    labelPrefix: "kata:",
+  });
+
+  assert.equal(state.phase, "complete");
+  assert.equal(state.activeMilestone, null);
+  assert.equal(state.progress?.milestones.done, 2);
+  assert.equal(state.progress?.milestones.total, 2);
+});

--- a/apps/cli/src/resources/extensions/kata/tests/github-state.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-state.test.ts
@@ -48,6 +48,7 @@ test("deriveGithubState derives active milestone/slice/task and executing phase"
       title: "[T04] Wire status diagnostics",
       state: "open",
       labels: ["kata:task"],
+      body: "Implements active slice S01",
     },
   ];
 
@@ -85,12 +86,14 @@ test("deriveGithubState falls back to verifying when some tasks are closed", asy
       title: "[T01] First task",
       state: "closed",
       labels: ["kata:task"],
+      body: "Completed work for S02",
     },
     {
       number: 23,
       title: "[T02] Second task",
       state: "open",
       labels: ["kata:task"],
+      body: "Remaining work for S02",
     },
   ];
 

--- a/apps/cli/src/resources/extensions/kata/tests/github-state.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-state.test.ts
@@ -63,6 +63,8 @@ test("deriveGithubState derives active milestone/slice/task and executing phase"
   assert.equal(state.activeMilestone?.id, "M009");
   assert.equal(state.activeSlice?.id, "S01");
   assert.equal(state.activeTask?.id, "T04");
+  assert.equal(state.activeTask?.trackerIssueId, "12");
+  assert.equal(state.activeTask?.linearIssueId, undefined);
   assert.equal(state.registry[0]?.status, "active");
   assert.deepEqual(state.progress?.tasks, { done: 0, total: 1 });
 });

--- a/apps/cli/src/resources/extensions/kata/tests/linear-config.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/linear-config.test.ts
@@ -61,6 +61,7 @@ test("workflow helpers read normalized Linear config from effective preferences"
     scope: "project",
     workflowMode: "linear",
     isLinearMode: true,
+    isGithubMode: false,
     linear: {
       teamId: "team-123",
       teamKey: "KAT",

--- a/apps/cli/src/resources/extensions/kata/tests/mode-switching.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/mode-switching.test.ts
@@ -116,10 +116,8 @@ test("github mode entrypoint guards allow supported entrypoints", () => {
   const supported = [
     "smart-entry",
     "discuss",
-    "plan",
     "status",
     "dashboard",
-    "auto",
     "system-prompt",
   ] as const;
 
@@ -133,6 +131,14 @@ test("github mode entrypoint guards allow supported entrypoints", () => {
   const queue = getWorkflowEntrypointGuard("queue", loaded);
   assert.equal(queue.mode, "github", "queue: mode");
   assert.equal(queue.allow, false, "queue blocked in github mode");
+
+  const plan = getWorkflowEntrypointGuard("plan", loaded);
+  assert.equal(plan.mode, "github", "plan: mode");
+  assert.equal(plan.allow, false, "plan blocked in github mode S01");
+
+  const auto = getWorkflowEntrypointGuard("auto", loaded);
+  assert.equal(auto.mode, "github", "auto: mode");
+  assert.equal(auto.allow, false, "auto blocked in github mode S01");
 });
 
 test("github mode workflow protocol resolves correctly", () => {

--- a/apps/cli/src/resources/extensions/kata/tests/mode-switching.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/mode-switching.test.ts
@@ -75,6 +75,19 @@ test("default mode (unset) resolves to linear", () => {
   assert.equal(normalizeWorkflowMode(null), "linear");
 });
 
+test("github mode resolves correctly", () => {
+  assert.equal(normalizeWorkflowMode("github"), "github");
+  assert.equal(normalizeWorkflowMode("GitHub"), "github");
+  assert.equal(normalizeWorkflowMode("  GITHUB  "), "github");
+});
+
+test("unknown mode throws with allowed values", () => {
+  assert.throws(
+    () => normalizeWorkflowMode("jira"),
+    /Unsupported workflow\.mode "jira"/,
+  );
+});
+
 test("linear mode entrypoint guards allow supported entrypoints", () => {
   const loaded = makeLoadedPreferences({ workflow: { mode: "linear" } });
   const supported = [
@@ -96,4 +109,46 @@ test("linear mode entrypoint guards allow supported entrypoints", () => {
 
   const queue = getWorkflowEntrypointGuard("queue", loaded);
   assert.equal(queue.allow, false, "queue remains blocked until Linear support lands");
+});
+
+test("github mode entrypoint guards allow supported entrypoints", () => {
+  const loaded = makeLoadedPreferences({ workflow: { mode: "github" } });
+  const supported = [
+    "smart-entry",
+    "discuss",
+    "plan",
+    "status",
+    "dashboard",
+    "auto",
+    "system-prompt",
+  ] as const;
+
+  for (const entrypoint of supported) {
+    const guard = getWorkflowEntrypointGuard(entrypoint, loaded);
+    assert.equal(guard.mode, "github", `${entrypoint}: mode`);
+    assert.equal(guard.isLinearMode, false, `${entrypoint}: isLinearMode`);
+    assert.equal(guard.allow, true, `${entrypoint}: allow`);
+  }
+
+  const queue = getWorkflowEntrypointGuard("queue", loaded);
+  assert.equal(queue.mode, "github", "queue: mode");
+  assert.equal(queue.allow, false, "queue blocked in github mode");
+});
+
+test("github mode workflow protocol resolves correctly", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-mode-github-"));
+  const workflowPath = join(tmp, "KATA-WORKFLOW.md");
+  writeFileSync(workflowPath, "# github workflow\n", "utf-8");
+
+  const loaded = makeLoadedPreferences({ workflow: { mode: "github" } });
+
+  withWorkflowEnv({ KATA_WORKFLOW_PATH: workflowPath }, () => {
+    const protocol = resolveWorkflowProtocol(loaded);
+    assert.deepEqual(protocol, {
+      mode: "github",
+      documentName: "KATA-WORKFLOW.md",
+      path: workflowPath,
+      ready: true,
+    });
+  });
 });

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-model.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-model.vitest.test.ts
@@ -120,10 +120,10 @@ describe("field types", () => {
     expect(findField("models.research")?.type).toBe("string");
   });
 
-  it("workflow.mode is enum with 'linear'", () => {
+  it("workflow.mode is enum with 'linear' and 'github'", () => {
     const f = findField("workflow.mode");
     expect(f?.type).toBe("enum");
-    expect(f?.enumValues).toEqual(["linear"]);
+    expect(f?.enumValues).toEqual(["linear", "github"]);
   });
 
   it("skill_discovery is enum with auto/suggest/off", () => {

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-status.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-status.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import type { LoadedKataPreferences } from "../preferences.ts";
 import type { LinearConfigValidationResult } from "../linear-config.ts";
+import type { GithubConfigValidationResult } from "../github-config.ts";
 import {
   buildPrefsStatusReport,
   type PrefsStatusDependencies,
@@ -45,6 +46,7 @@ function makeDeps(
         scope: null,
         workflowMode: "linear",
         isLinearMode: true,
+        isGithubMode: false,
         linear: {
           teamId: null,
           teamKey: null,
@@ -57,6 +59,19 @@ function makeDeps(
         project: null,
       },
     }),
+    validateGithubConfig: () => ({
+      ok: true,
+      status: "valid",
+      mode: "github",
+      tokenPresent: true,
+      tokenSource: "KATA_GITHUB_TOKEN",
+      trackerConfig: {
+        repoOwner: "kata-sh",
+        repoName: "kata-mono",
+        stateMode: "labels",
+      },
+      diagnostics: [],
+    } as GithubConfigValidationResult),
     ...overrides,
   };
 }
@@ -288,4 +303,74 @@ test("buildPrefsStatusReport includes pr: disabled when pr.enabled is explicitly
     /^pr: disabled$/m,
     "report must show 'pr: disabled' when pr.enabled is false",
   );
+});
+
+test("buildPrefsStatusReport shows GitHub mode status when workflow.mode is github", async () => {
+  const projectPrefs = makeLoadedPreferences({
+    preferences: { workflow: { mode: "github" } },
+  });
+
+  const githubValidation: GithubConfigValidationResult = {
+    ok: true,
+    status: "valid",
+    mode: "github",
+    tokenPresent: true,
+    tokenSource: "KATA_GITHUB_TOKEN",
+    trackerConfig: {
+      repoOwner: "my-org",
+      repoName: "my-repo",
+      stateMode: "labels",
+    },
+    diagnostics: [],
+  };
+
+  const report = await buildPrefsStatusReport(
+    makeDeps({
+      loadProjectKataPreferences: () => projectPrefs,
+      loadEffectiveKataPreferences: () => projectPrefs,
+      validateGithubConfig: () => githubValidation,
+    }),
+  );
+
+  assert.equal(report.level, "info");
+  assert.match(report.message, /^mode: github$/m, "mode must be github");
+  assert.match(report.message, /GITHUB_TOKEN: present/m, "token presence expected");
+  assert.match(report.message, /my-org\/my-repo/m, "repo expected");
+  assert.match(report.message, /validation: valid/m, "validation status expected");
+});
+
+test("buildPrefsStatusReport shows warning level for github mode with invalid config", async () => {
+  const projectPrefs = makeLoadedPreferences({
+    preferences: { workflow: { mode: "github" } },
+  });
+
+  const githubValidation: GithubConfigValidationResult = {
+    ok: false,
+    status: "invalid",
+    mode: "github",
+    tokenPresent: false,
+    tokenSource: null,
+    trackerConfig: null,
+    diagnostics: [
+      {
+        code: "missing_github_token",
+        message: "No GitHub token found.",
+        field: "KATA_GITHUB_TOKEN",
+        retryable: false,
+      },
+    ],
+  };
+
+  const report = await buildPrefsStatusReport(
+    makeDeps({
+      loadProjectKataPreferences: () => projectPrefs,
+      loadEffectiveKataPreferences: () => projectPrefs,
+      validateGithubConfig: () => githubValidation,
+    }),
+  );
+
+  assert.equal(report.level, "warning");
+  assert.match(report.message, /^mode: github$/m, "mode must be github");
+  assert.match(report.message, /GITHUB_TOKEN: missing/m, "missing token expected");
+  assert.match(report.message, /diagnostic: missing_github_token/m, "diagnostic expected");
 });

--- a/apps/cli/src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/prefs-validator.vitest.test.ts
@@ -63,6 +63,10 @@ describe("validatePreferencesModel — accepts valid configs", () => {
     const m1 = buildModelFromConfig({ workflow: { mode: "linear" } });
     expect(validatePreferencesModel(m1)).toEqual([]);
 
+    // workflow.mode = "github"
+    const m1b = buildModelFromConfig({ workflow: { mode: "github" } });
+    expect(validatePreferencesModel(m1b)).toEqual([]);
+
     // skill_discovery = "suggest"
     const m2 = buildModelFromConfig({ skill_discovery: "suggest" });
     expect(validatePreferencesModel(m2)).toEqual([]);
@@ -110,7 +114,7 @@ describe("validatePreferencesModel — accepts valid configs", () => {
 // ---------------------------------------------------------------------------
 
 describe("validatePreferencesModel — rejects invalid enums", () => {
-  it('rejects workflow.mode = "file" (only "linear" is valid)', () => {
+  it('rejects workflow.mode = "file" (only "linear" and "github" are valid)', () => {
     const model = buildModelFromConfig({ workflow: { mode: "file" } });
     const issues = validatePreferencesModel(model);
     expect(issues).toHaveLength(1);

--- a/apps/cli/src/resources/extensions/kata/types.ts
+++ b/apps/cli/src/resources/extensions/kata/types.ts
@@ -127,6 +127,11 @@ export interface ActiveRef {
    * Pass this value as `milestoneId` to `kata_list_slices` when scoping to an active milestone.
    */
   linearIssueId?: string;
+  /**
+   * Backend-specific issue identifier for non-Linear backends.
+   * In GitHub mode this is the issue number string.
+   */
+  trackerIssueId?: string;
 }
 
 export interface MilestoneRegistryEntry {


### PR DESCRIPTION
## Summary
- Add Kata extension support for parsing and validating preferences and related state
- Introduce guided onboarding and mode-switching logic for Kata workflows
- Update GitHub backend/config handling and refresh the preferences reference docs
- Add integration and unit coverage for preferences, backend behavior, and state transitions

## Testing
- Added/updated Vitest and integration tests in `apps/cli/src/resources/extensions/kata/tests`
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub workflow backend support as an alternative to Linear for tracking work
  * GitHub Issues integration for milestone, slice, and task management
  * GitHub configuration validation and setup guidance
  * Improved session state persistence for auto-mode operations

* **Documentation**
  * Updated setup and onboarding flow to support both Linear and GitHub backends

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a GitHub Issues backend for the Kata workflow engine alongside preference parsing and onboarding updates that make it a first-class alternative to Linear. The three new core files (`github-backend.ts`, `github-config.ts`, `github-state.ts`) are well-structured and cover the S01 bootstrap scope — state derivation, config validation, and token resolution — cleanly.

- **P1 — `livePi` out of scope in `recoverTimedOutUnit` (`auto.ts` line 1571):** `livePi` is a `const` local defined inside `dispatchNextUnit`; `recoverTimedOutUnit` is a separate top-level function that only receives `pi` as a parameter. This is both a TypeScript compile error and a `ReferenceError` at runtime when timeout recovery fires. Fix: use `getLatestPi() ?? pi` inline or pass it as a parameter.
- **P2 — New test files use legacy bun runner:** Four new test files (`github-backend.integration.test.ts`, `github-config.test.ts`, `github-state.test.ts`, `prefs-status.test.ts`) use `node:test`/`node:assert/strict` and are not named `*.vitest.test.ts`. The CLI testing policy requires all new test files to use Vitest, and migration is also required for existing bun files (`mode-switching.test.ts`, `linear-config.test.ts`) whose source modules were touched.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is — the `livePi` out-of-scope reference will fail TypeScript typecheck (CI gate) and throw at runtime during timeout recovery.

One P1 defect: `livePi` used in `recoverTimedOutUnit` is not in scope — it's a local from `dispatchNextUnit`. This will be caught by the `typecheck` step in CI and would be a ReferenceError at runtime. All other findings are P2 (test runner policy, minor missing case). The overall architecture, config validation, state derivation, and backend factory routing are solid.

apps/cli/src/resources/extensions/kata/auto.ts — the livePi scope bug must be fixed before merge.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/auto.ts | Adds globalThis-based state persistence across jiti module reloads; introduces `livePi` local variable in `dispatchNextUnit` but incorrectly references it in standalone `recoverTimedOutUnit` function — ReferenceError at runtime and TypeScript compile failure. |
| apps/cli/src/resources/extensions/kata/github-backend.ts | New GitHub backend implementing `KataBackend` interface with paginated issue fetching (capped at 10 pages/1000 issues), 10-second state cache, and stub implementations for unsupported document/prompt operations; logic is sound for the S01 bootstrap scope. |
| apps/cli/src/resources/extensions/kata/github-config.ts | New GitHub config resolver with WORKFLOW.md frontmatter parsing, token resolution (KATA_GITHUB_TOKEN → GH_TOKEN → GITHUB_TOKEN → auth.json), full validation with actionable diagnostics, and redaction-safe status formatting; custom YAML parser assumes 2-space indentation which is fine for the target format. |
| apps/cli/src/resources/extensions/kata/github-state.ts | New GitHub state derivation from flat GitHub Issues with Kata ID parsing, phase resolution (label-based + heuristic fallback), and progress tracking; `blocked` phase is missing from `nextActionForPhase` switch returning empty string instead of an action description. |
| apps/cli/src/resources/extensions/kata/backend-factory.ts | Refactored to route `createBackend` to either `createLinearBackend` or `createGithubBackend` based on workflow mode; adds structured bootstrap telemetry to stderr; second `resolveGithubToken()` call after successful `validateGithubConfig` is redundant dead code but harmless. |
| apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts | New integration test using mock HTTP server to verify GitHub backend state derivation; uses legacy `node:test` runner instead of required Vitest format for new files. |
| apps/cli/src/resources/extensions/kata/tests/github-config.test.ts | Comprehensive new test suite covering WORKFLOW.md parsing, token resolution priority, validation, redaction, and status formatting; uses legacy `node:test` runner instead of required Vitest format. |
| apps/cli/src/resources/extensions/kata/tests/github-state.test.ts | New tests for `deriveGithubState` covering pre-planning, active execution, verifying, and complete phases; uses legacy `node:test` runner instead of required Vitest format. |
| apps/cli/src/resources/extensions/kata/tests/mode-switching.test.ts | Adds GitHub mode tests for entrypoint guards, workflow protocol, and mode normalization to existing bun test file; source module was touched so migration to Vitest is required by policy. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CP[createBackend] --> LP[loadEffectiveKataPreferences]
    LP --> ModeCheck{workflow.mode?}
    ModeCheck -->|github| VGC[validateGithubConfig]
    ModeCheck -->|linear| VLC[Linear config check]

    VGC --> TokenCheck{token + tracker valid?}
    TokenCheck -->|no| GErr[throw with diagnostics]
    TokenCheck -->|yes| RGT[resolveGithubToken]
    RGT --> GB[new GithubBackend]

    VLC --> APICheck{LINEAR_API_KEY set?}
    APICheck -->|no| LErr[throw missing key]
    APICheck -->|yes| LB[new LinearBackend]

    GB --> DS[deriveState]
    DS --> LC[GithubApiClient.listIssues paginated]
    LC --> PI[parseKataTitle M/S/T IDs]
    PI --> PH{phase resolution}
    PH -->|labels mode| LPH[resolvePhaseFromSliceLabels]
    PH -->|projects_v2 / fallback| CPH[computePhaseFallback]
    LPH & CPH --> KS[KataState]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/cli/src/resources/extensions/kata/github-state.ts`, line 820-840 ([link](https://github.com/gannonh/kata/blob/94a8c81c97d7795ffdb27cf7a99be83f80965ab2/apps/cli/src/resources/extensions/kata/github-state.ts#L820-L840)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`blocked` phase has no `nextAction` text**

   `resolvePhaseFromSliceLabels` can return `"blocked"` (via the label mapping), but `nextActionForPhase` has no case for it and falls through to `default: return ""`. The resulting `KataState` would carry an empty `nextAction` string, which looks like a missing value rather than intentional silence.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/resources/extensions/kata/github-state.ts
   Line: 820-840

   Comment:
   **`blocked` phase has no `nextAction` text**

   `resolvePhaseFromSliceLabels` can return `"blocked"` (via the label mapping), but `nextActionForPhase` has no case for it and falls through to `default: return ""`. The resulting `KataState` would carry an empty `nextAction` string, which looks like a missing value rather than intentional silence.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/auto.ts
Line: 1571

Comment:
**`livePi` is not in scope — ReferenceError at runtime**

`livePi` is defined as a `const` local variable inside `dispatchNextUnit` (line 1348) but is used here inside `recoverTimedOutUnit`, which is a separate top-level function. JavaScript closures do not allow a standalone function to access locals from an unrelated caller's stack frame. This will throw `ReferenceError: livePi is not defined` whenever timeout recovery fires, and TypeScript's `typecheck` step will reject it as a compile error.

The function already receives `pi` as its second parameter — either use that, or resolve the live reference inline:

```suggestion
    (getLatestPi() ?? pi).sendMessage(
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts
Line: 1-7

Comment:
**New test files must use Vitest per project testing policy**

Four new test files in this PR (`github-backend.integration.test.ts`, `github-config.test.ts`, `github-state.test.ts`, `prefs-status.test.ts`) import from `node:test` / `node:assert/strict` and are named without the `.vitest.test.ts` suffix, making them bun-runner tests. The project's testing policy explicitly requires: *"New test files must use Vitest (`*.vitest.test.ts`, import from `vitest`)"*. Additionally, `mode-switching.test.ts` and `linear-config.test.ts` are existing bun tests whose source module (`linear-config.ts`) was touched in this PR, triggering the mandatory migration rule.

Migration is mechanical: rename to `*.vitest.test.ts`, replace `import { ... } from "node:test"` with `import { ... } from "vitest"`, and replace `assert.*` with `expect()`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/github-state.ts
Line: 820-840

Comment:
**`blocked` phase has no `nextAction` text**

`resolvePhaseFromSliceLabels` can return `"blocked"` (via the label mapping), but `nextActionForPhase` has no case for it and falls through to `default: return ""`. The resulting `KataState` would carry an empty `nextAction` string, which looks like a missing value rather than intentional silence.

```suggestion
    case "blocked":
      return "Resolve the active blocker before continuing.";
    default:
      return "";
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(S01/T04): wire GitHub bootstrap dia..."](https://github.com/gannonh/kata/commit/94a8c81c97d7795ffdb27cf7a99be83f80965ab2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28705608)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - apps/cli/src/resources/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=029a01c9-cff2-4f1d-bfaf-bcdcef0feeac))

<!-- /greptile_comment -->