### PR TITLE
KAT-2705: align Symphony GitHub execution contract with CLI semantics

### DIFF
--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -11,10 +11,10 @@ use serde::Deserialize;
 use serde_yaml::{Mapping, Value};
 
 use crate::domain::{
-    AgentBackend, AgentConfig, ApiKey, CodexConfig, DockerCodexAuth, DockerConfig, HooksConfig,
-    NotificationsConfig, PiAgentConfig, PollingConfig, PromptsConfig, ServerConfig, ServiceConfig,
-    SharedContextConfig, SlackConfig, SupervisorConfig, TrackerConfig, WorkerConfig,
-    WorkspaceConfig, WorkspaceIsolation, WorkspaceRepoStrategy,
+    canonical_kata_phase_name, AgentBackend, AgentConfig, ApiKey, CodexConfig, DockerCodexAuth,
+    DockerConfig, HooksConfig, NotificationsConfig, PiAgentConfig, PollingConfig, PromptsConfig,
+    ServerConfig, ServiceConfig, SharedContextConfig, SlackConfig, SupervisorConfig, TrackerConfig,
+    WorkerConfig, WorkspaceConfig, WorkspaceIsolation, WorkspaceRepoStrategy, KATA_PHASE_NAMES,
 };
 use crate::error::{Result, SymphonyError};
 use crate::notifications;
@@ -1145,6 +1145,23 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
             return Err(SymphonyError::MissingTrackerKind);
         }
     };
+
+    for (field, states) in [
+        ("tracker.active_states", &config.tracker.active_states),
+        ("tracker.terminal_states", &config.tracker.terminal_states),
+    ] {
+        for configured_state in states {
+            if canonical_kata_phase_name(configured_state).is_none() {
+                tracing::info!(
+                    event = "symphony_state_vocabulary_check",
+                    field,
+                    configured_state = %configured_state,
+                    canonical_phases = ?KATA_PHASE_NAMES,
+                    "state name is non-canonical but allowed by config validation"
+                );
+            }
+        }
+    }
 
     if tracker_kind == "linear" {
         // tracker.api_key must be present and non-empty

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -46,6 +46,38 @@ fn default_true() -> bool {
     true
 }
 
+/// Canonical Kata workflow phase vocabulary shared across CLI/Desktop/Symphony.
+pub const KATA_PHASE_NAMES: [&str; 7] = [
+    "Backlog",
+    "Todo",
+    "In Progress",
+    "Agent Review",
+    "Human Review",
+    "Merging",
+    "Done",
+];
+
+/// Return the canonical Kata phase name when the provided value matches one.
+///
+/// Matching is case-insensitive and whitespace/underscore/hyphen agnostic.
+pub fn canonical_kata_phase_name(state_name: &str) -> Option<&'static str> {
+    let normalized = normalize_kata_phase_key(state_name);
+    KATA_PHASE_NAMES
+        .iter()
+        .copied()
+        .find(|phase| normalize_kata_phase_key(phase) == normalized)
+}
+
+fn normalize_kata_phase_key(value: &str) -> String {
+    value
+        .trim()
+        .to_ascii_lowercase()
+        .replace(['_', '-'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// A blocker reference from an inverse relation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockerRef {

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -78,6 +78,76 @@ fn normalize_kata_phase_key(value: &str) -> String {
         .join(" ")
 }
 
+/// Parse a Kata identifier prefix from a GitHub title, e.g. `[S01] Build`.
+///
+/// Accepted prefixes are `M`, `S`, and `T` with one or more trailing digits.
+pub fn parse_kata_identifier(title: &str) -> Option<String> {
+    let trimmed = title.trim_start();
+    let bracketed = trimmed.strip_prefix('[')?;
+    let end = bracketed.find(']')?;
+    let token = &bracketed[..end];
+
+    let mut chars = token.chars();
+    let prefix = chars.next()?.to_ascii_uppercase();
+    if !matches!(prefix, 'M' | 'S' | 'T') {
+        return None;
+    }
+
+    let digits = chars.as_str();
+    if digits.is_empty() || !digits.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(format!("[{prefix}{digits}]"))
+}
+
+/// Parse parent issue metadata from body lines such as:
+/// - `Parent: #10`
+/// - `Part of: #10`
+/// - `**Parent:** #10`
+pub fn parse_parent_issue_reference(body: &str) -> Option<String> {
+    for line in body.lines() {
+        let normalized = line.trim().replace('*', "");
+        let lower = normalized.to_ascii_lowercase();
+
+        if !(lower.starts_with("parent:") || lower.starts_with("part of:")) {
+            continue;
+        }
+
+        if let Some(identifier) = extract_first_issue_reference(&normalized) {
+            return Some(identifier);
+        }
+    }
+
+    None
+}
+
+fn extract_first_issue_reference(line: &str) -> Option<String> {
+    let chars: Vec<char> = line.chars().collect();
+    let mut index = 0usize;
+
+    while index < chars.len() {
+        if chars[index] != '#' {
+            index += 1;
+            continue;
+        }
+
+        let mut end = index + 1;
+        while end < chars.len() && chars[end].is_ascii_digit() {
+            end += 1;
+        }
+
+        if end > index + 1 {
+            let digits: String = chars[index + 1..end].iter().collect();
+            return Some(format!("#{digits}"));
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
 /// A blocker reference from an inverse relation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockerRef {

--- a/apps/symphony/src/github/adapter.rs
+++ b/apps/symphony/src/github/adapter.rs
@@ -66,25 +66,32 @@ impl GithubAdapter {
     }
 
     fn emit_state_vocabulary_diagnostics(config: &TrackerConfig) {
-        for (field, states) in [
-            ("active_states", &config.active_states),
-            ("terminal_states", &config.terminal_states),
-        ] {
-            for configured_state in states {
-                if canonical_kata_phase_name(configured_state).is_none() {
-                    tracing::warn!(
-                        event = "symphony_state_vocabulary_check",
-                        field,
-                        configured_state = %configured_state,
-                        canonical_phases = ?KATA_PHASE_NAMES,
-                        "configured GitHub state is outside canonical Kata phase vocabulary"
-                    );
-                    tracing::info!(
-                        event = "symphony_state_normalization_fallback",
-                        configured_state = %configured_state,
-                        "falling back to generic state normalization for non-canonical state"
-                    );
-                }
+        for configured_state in &config.active_states {
+            if canonical_kata_phase_name(configured_state).is_none() {
+                tracing::warn!(
+                    event = "symphony_state_vocabulary_check",
+                    field = "active_states",
+                    configured_state = %configured_state,
+                    canonical_phases = ?KATA_PHASE_NAMES,
+                    "configured GitHub active state is outside canonical Kata phase vocabulary"
+                );
+                tracing::info!(
+                    event = "symphony_state_normalization_fallback",
+                    configured_state = %configured_state,
+                    "falling back to generic state normalization for non-canonical state"
+                );
+            }
+        }
+
+        for configured_state in &config.terminal_states {
+            if canonical_kata_phase_name(configured_state).is_none() {
+                tracing::info!(
+                    event = "symphony_state_vocabulary_check",
+                    field = "terminal_states",
+                    configured_state = %configured_state,
+                    canonical_phases = ?KATA_PHASE_NAMES,
+                    "configured GitHub terminal state is non-canonical but allowed"
+                );
             }
         }
     }
@@ -120,7 +127,7 @@ impl GithubAdapter {
             .or_else(|| gh.assignee.as_ref().map(|assignee| assignee.login.clone()));
 
         let identifier = if let Some(kata_identifier) = parse_kata_identifier(&gh.title) {
-            tracing::info!(
+            tracing::debug!(
                 event = "kata_identifier_parsed",
                 issue_number = gh.number,
                 kata_identifier = %kata_identifier,
@@ -774,8 +781,16 @@ fn normalize_state_for_display(state_name: &str) -> String {
 }
 
 fn denormalize_label_state(normalized: &str) -> String {
+    if let Some(canonical) = canonical_kata_phase_name(normalized) {
+        return canonical.to_string();
+    }
+
     let compare = normalize_state_for_compare(normalized);
-    if let Some(canonical) = canonical_kata_phase_name(&compare) {
+    if let Some(canonical) = KATA_PHASE_NAMES
+        .iter()
+        .copied()
+        .find(|phase| normalize_state_for_compare(phase) == compare)
+    {
         return canonical.to_string();
     }
 

--- a/apps/symphony/src/github/adapter.rs
+++ b/apps/symphony/src/github/adapter.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use async_trait::async_trait;
 use tokio::sync::OnceCell;
 
-use crate::domain::{Issue, TrackerConfig};
+use crate::domain::{canonical_kata_phase_name, Issue, TrackerConfig, KATA_PHASE_NAMES};
 use crate::error::{Result, SymphonyError};
 use crate::github::client::{GithubClient, GithubIssue};
 use crate::github::projects_v2::{ProjectsV2Client, StatusFieldInfo, StatusOption};
@@ -46,6 +46,8 @@ impl GithubAdapter {
             None => StateMode::Labels,
         };
 
+        Self::emit_state_vocabulary_diagnostics(&config);
+
         tracing::info!(state_mode = %state_mode, "GithubAdapter initialized");
 
         Self {
@@ -60,6 +62,30 @@ impl GithubAdapter {
         &self.state_mode
     }
 
+    fn emit_state_vocabulary_diagnostics(config: &TrackerConfig) {
+        for (field, states) in [
+            ("active_states", &config.active_states),
+            ("terminal_states", &config.terminal_states),
+        ] {
+            for configured_state in states {
+                if canonical_kata_phase_name(configured_state).is_none() {
+                    tracing::warn!(
+                        event = "symphony_state_vocabulary_check",
+                        field,
+                        configured_state = %configured_state,
+                        canonical_phases = ?KATA_PHASE_NAMES,
+                        "configured GitHub state is outside canonical Kata phase vocabulary"
+                    );
+                    tracing::info!(
+                        event = "symphony_state_normalization_fallback",
+                        configured_state = %configured_state,
+                        "falling back to generic state normalization for non-canonical state"
+                    );
+                }
+            }
+        }
+    }
+
     fn state_prefix(&self) -> &str {
         self.config
             .label_prefix
@@ -68,11 +94,13 @@ impl GithubAdapter {
     }
 
     fn issue_to_domain_with_state(&self, gh: &GithubIssue, state_override: Option<&str>) -> Issue {
-        let state = state_override.map(ToString::to_string).unwrap_or_else(|| {
-            extract_state_from_labels(&gh.labels, self.state_prefix())
-                .map(|(_, display)| display)
-                .unwrap_or_default()
-        });
+        let state = state_override
+            .map(normalize_state_for_display)
+            .unwrap_or_else(|| {
+                extract_state_from_labels(&gh.labels, self.state_prefix())
+                    .map(|(_, display)| display)
+                    .unwrap_or_default()
+            });
 
         let labels = gh.labels.iter().map(|label| label.name.clone()).collect();
         let url = gh.html_url.clone().or_else(|| {
@@ -506,7 +534,19 @@ impl GithubAdapter {
             })?;
 
         let status_field = self.ensure_status_field().await?;
-        let target_option = self.status_option_for_name(status_field, state_name)?;
+        let target_option = match self.status_option_for_name(status_field, state_name) {
+            Ok(option) => option,
+            Err(err) => {
+                tracing::warn!(
+                    event = "github_projects_v2_status_option_missing",
+                    issue_number,
+                    attempted_state = %state_name,
+                    error = %err,
+                    "Projects v2 status option not found for requested state transition"
+                );
+                return Err(err);
+            }
+        };
 
         let no_filter: Vec<String> = Vec::new();
         let project_items = v2_client
@@ -686,6 +726,10 @@ fn issue_matches_assignee(issue: &GithubIssue, expected: &str) -> bool {
 }
 
 fn normalize_state_for_label(state_name: &str) -> String {
+    if let Some(canonical) = canonical_kata_phase_name(state_name) {
+        return canonical.to_ascii_lowercase().replace(' ', "-");
+    }
+
     state_name
         .trim()
         .to_ascii_lowercase()
@@ -696,16 +740,34 @@ fn normalize_state_for_label(state_name: &str) -> String {
 }
 
 fn normalize_state_for_compare(state_name: &str) -> String {
-    state_name
+    let normalized = canonical_kata_phase_name(state_name).unwrap_or(state_name);
+
+    normalized
         .trim()
         .to_ascii_lowercase()
-        .replace(['_', '-'], " ")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect()
+}
+
+fn normalize_state_for_display(state_name: &str) -> String {
+    canonical_kata_phase_name(state_name)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| denormalize_label_state(&normalize_state_for_label(state_name)))
 }
 
 fn denormalize_label_state(normalized: &str) -> String {
+    let compare = normalize_state_for_compare(normalized);
+    if let Some(canonical) = canonical_kata_phase_name(&compare) {
+        return canonical.to_string();
+    }
+
+    tracing::info!(
+        event = "symphony_state_normalization_fallback",
+        normalized_state = %normalized,
+        "using generic label state denormalization for non-canonical state"
+    );
+
     normalized
         .split('-')
         .filter(|part| !part.is_empty())

--- a/apps/symphony/src/github/adapter.rs
+++ b/apps/symphony/src/github/adapter.rs
@@ -3,7 +3,10 @@ use std::collections::{HashMap, HashSet};
 use async_trait::async_trait;
 use tokio::sync::OnceCell;
 
-use crate::domain::{canonical_kata_phase_name, Issue, TrackerConfig, KATA_PHASE_NAMES};
+use crate::domain::{
+    canonical_kata_phase_name, parse_kata_identifier, parse_parent_issue_reference, Issue,
+    TrackerConfig, KATA_PHASE_NAMES,
+};
 use crate::error::{Result, SymphonyError};
 use crate::github::client::{GithubClient, GithubIssue};
 use crate::github::projects_v2::{ProjectsV2Client, StatusFieldInfo, StatusOption};
@@ -116,9 +119,23 @@ impl GithubAdapter {
             .map(|assignee| assignee.login.clone())
             .or_else(|| gh.assignee.as_ref().map(|assignee| assignee.login.clone()));
 
+        let identifier = if let Some(kata_identifier) = parse_kata_identifier(&gh.title) {
+            tracing::info!(
+                event = "kata_identifier_parsed",
+                issue_number = gh.number,
+                kata_identifier = %kata_identifier,
+                "parsed kata identifier from GitHub issue title"
+            );
+            format!("{kata_identifier}#{}", gh.number)
+        } else {
+            format!("#{}", gh.number)
+        };
+
+        let parent_identifier = gh.body.as_deref().and_then(parse_parent_issue_reference);
+
         Issue {
             id: gh.number.to_string(),
-            identifier: format!("#{}", gh.number),
+            identifier,
             title: gh.title.clone(),
             description: gh.body.clone(),
             priority: None,
@@ -132,7 +149,7 @@ impl GithubAdapter {
             created_at: gh.created_at,
             updated_at: gh.updated_at,
             children_count: 0,
-            parent_identifier: None,
+            parent_identifier,
         }
     }
 

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1703,6 +1703,14 @@ struct RunningSessionStats {
 }
 
 #[derive(Debug, Clone)]
+struct CompletionCommentSummary {
+    turn_count: u32,
+    total_tokens: u64,
+    duration: chrono::Duration,
+    worker_host: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub enum WorkerCompletion {
     Completed { schedule_continuation: bool },
     Failed { error: String },
@@ -1952,6 +1960,7 @@ pub struct Orchestrator {
     worker_steer_tx:
         HashMap<String, tokio::sync::mpsc::UnboundedSender<rpc_bridge::FollowUpRequest>>,
     running_session_stats: HashMap<String, RunningSessionStats>,
+    completion_comment_summaries: HashMap<String, CompletionCommentSummary>,
     /// Blocked issues from the latest dispatch phase.
     blocked_issues: Vec<crate::domain::BlockedIssueEntry>,
     pending_terminal_cleanup: HashMap<String, PendingTerminalCleanup>,
@@ -2049,6 +2058,7 @@ impl Orchestrator {
             worker_session_ids: HashMap::new(),
             worker_steer_tx: HashMap::new(),
             running_session_stats: HashMap::new(),
+            completion_comment_summaries: HashMap::new(),
             blocked_issues: Vec::new(),
             pending_terminal_cleanup: HashMap::new(),
             running_issue_states: HashMap::new(),
@@ -3267,6 +3277,38 @@ impl Orchestrator {
         // Keep running_issue_states until reconciliation — needed for
         // state-change notification detection on the next poll cycle.
         self.worker_last_activity_ms.remove(issue_id);
+
+        let completed_turn_count = self
+            .running_session_stats
+            .get(issue_id)
+            .map(|stats| stats.turn_count)
+            .or_else(|| {
+                self.worker_session_info
+                    .get(issue_id)
+                    .map(|info| info.turn_count.saturating_sub(1))
+            })
+            .unwrap_or_default();
+        let completed_total_tokens = self
+            .running_session_stats
+            .get(issue_id)
+            .map(|stats| stats.total_tokens)
+            .or_else(|| {
+                self.worker_session_info
+                    .get(issue_id)
+                    .map(|info| info.session_tokens.total_tokens)
+            })
+            .unwrap_or_default();
+
+        self.completion_comment_summaries.insert(
+            issue_id.to_string(),
+            CompletionCommentSummary {
+                turn_count: completed_turn_count,
+                total_tokens: completed_total_tokens,
+                duration: Utc::now().signed_duration_since(run_attempt.started_at),
+                worker_host: run_attempt.worker_host.clone(),
+            },
+        );
+
         self.running_session_stats.remove(issue_id);
         self.worker_session_info.remove(issue_id);
         self.running_parent_identifiers.remove(issue_id);
@@ -3406,6 +3448,7 @@ impl Orchestrator {
             None
         };
 
+        self.completion_comment_summaries.remove(&issue.id);
         self.state.running.insert(
             issue.id.clone(),
             RunAttempt {
@@ -4837,6 +4880,7 @@ impl Orchestrator {
             issue_url: issue.url.clone(),
         };
 
+        self.completion_comment_summaries.remove(&issue.id);
         self.state.running.insert(issue.id.clone(), attempt);
         let _ = self.ensure_worker_session_info(&issue.id);
         self.state.claimed.insert(issue.id.clone());
@@ -5083,16 +5127,27 @@ impl Orchestrator {
 
     fn completion_comment_for_issue(&self, issue: &Issue, now: DateTime<Utc>) -> String {
         let run_attempt = self.state.running.get(&issue.id);
+        let running_stats = self.running_session_stats.get(&issue.id);
         let session_info = self.worker_session_info.get(&issue.id);
+        let summary = self.completion_comment_summaries.get(&issue.id);
 
-        let turn_count = session_info.map(|info| info.turn_count).unwrap_or_default();
-        let total_tokens = session_info
-            .map(|info| info.session_tokens.total_tokens)
+        let turn_count = running_stats
+            .map(|stats| stats.turn_count)
+            .or_else(|| session_info.map(|info| info.turn_count.saturating_sub(1)))
+            .or_else(|| summary.map(|cached| cached.turn_count))
+            .unwrap_or_default();
+        let total_tokens = running_stats
+            .map(|stats| stats.total_tokens)
+            .or_else(|| session_info.map(|info| info.session_tokens.total_tokens))
+            .or_else(|| summary.map(|cached| cached.total_tokens))
             .unwrap_or_default();
         let duration = run_attempt
             .map(|attempt| now.signed_duration_since(attempt.started_at))
+            .or_else(|| summary.map(|cached| cached.duration))
             .unwrap_or_else(chrono::Duration::zero);
-        let worker_host = run_attempt.and_then(|attempt| attempt.worker_host.as_deref());
+        let worker_host = run_attempt
+            .and_then(|attempt| attempt.worker_host.as_deref())
+            .or_else(|| summary.and_then(|cached| cached.worker_host.as_deref()));
 
         CompletionCommentBuilder::new(
             &issue.identifier,
@@ -5204,6 +5259,7 @@ impl Orchestrator {
         self.worker_session_ids.remove(issue_id);
         self.worker_steer_tx.remove(issue_id);
         self.running_session_stats.remove(issue_id);
+        self.completion_comment_summaries.remove(issue_id);
     }
 
     fn cleanup_workspace(&self, issue: &Issue, workspace_path: &str) {
@@ -5260,6 +5316,7 @@ impl Orchestrator {
         self.worker_session_ids.remove(issue_id);
         self.worker_steer_tx.remove(issue_id);
         self.running_session_stats.remove(issue_id);
+        self.completion_comment_summaries.remove(issue_id);
     }
 
     fn active_state_set(&self) -> HashSet<String> {

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -304,6 +304,105 @@ fn invalid_agent_review_note(issue: &Issue, branch: Option<&str>, reason: &str) 
     )
 }
 
+#[derive(Debug, Clone)]
+pub struct CompletionCommentBuilder<'a> {
+    issue_identifier: &'a str,
+    terminal_state: &'a str,
+    turn_count: u32,
+    total_tokens: u64,
+    duration: chrono::Duration,
+    worker_host: Option<&'a str>,
+}
+
+impl<'a> CompletionCommentBuilder<'a> {
+    pub fn new(
+        issue_identifier: &'a str,
+        terminal_state: &'a str,
+        turn_count: u32,
+        total_tokens: u64,
+        duration: chrono::Duration,
+        worker_host: Option<&'a str>,
+    ) -> Self {
+        Self {
+            issue_identifier,
+            terminal_state,
+            turn_count,
+            total_tokens,
+            duration,
+            worker_host,
+        }
+    }
+
+    pub fn build(&self) -> String {
+        format!(
+            "## Symphony Execution Summary\n\n**Issue:** {}\n**Status:** {}\n**Turns:** {}\n**Tokens:** {}\n**Duration:** {}\n**Worker:** {}",
+            self.issue_identifier,
+            self.terminal_state,
+            self.turn_count,
+            self.total_tokens,
+            format_elapsed_duration(self.duration),
+            self.worker_host.unwrap_or("local")
+        )
+    }
+}
+
+fn format_elapsed_duration(duration: chrono::Duration) -> String {
+    let total_seconds = duration.num_seconds().max(0);
+    let hours = total_seconds / 3600;
+    let minutes = (total_seconds % 3600) / 60;
+    let seconds = total_seconds % 60;
+
+    if hours > 0 {
+        format!("{hours}h {minutes}m {seconds}s")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+pub fn enrich_escalation_payload(
+    payload: &mut serde_json::Value,
+    issue_identifier: &str,
+    issue_state: Option<&str>,
+    parent_identifier: Option<&str>,
+) {
+    let mut payload_object = match std::mem::take(payload) {
+        serde_json::Value::Object(map) => map,
+        other => {
+            let mut map = serde_json::Map::new();
+            map.insert("raw_payload".to_string(), other);
+            map
+        }
+    };
+
+    payload_object.insert(
+        "issue_identifier".to_string(),
+        serde_json::Value::String(issue_identifier.to_string()),
+    );
+    payload_object.insert(
+        "issue_state".to_string(),
+        issue_state
+            .map(|state| serde_json::Value::String(state.to_string()))
+            .unwrap_or(serde_json::Value::Null),
+    );
+    payload_object.insert(
+        "parent_identifier".to_string(),
+        parent_identifier
+            .map(|identifier| serde_json::Value::String(identifier.to_string()))
+            .unwrap_or(serde_json::Value::Null),
+    );
+
+    *payload = serde_json::Value::Object(payload_object);
+}
+
+fn completion_comments_enabled(tracker: &TrackerConfig) -> bool {
+    tracker
+        .kind
+        .as_deref()
+        .is_some_and(|kind| kind.eq_ignore_ascii_case("github"))
+}
+
 // ── Standalone Worker Task ──────────────────────────────────────────────
 
 /// All configuration needed by a spawned worker task.
@@ -1858,6 +1957,8 @@ pub struct Orchestrator {
     pending_terminal_cleanup: HashMap<String, PendingTerminalCleanup>,
     /// Normalized running issue state cache used for per-state slot accounting.
     running_issue_states: HashMap<String, String>,
+    /// Parent identifier cache for currently running issues (if provided by tracker).
+    running_parent_identifiers: HashMap<String, Option<String>>,
     next_retry_token: u64,
     poll_count: u64,
     last_poll_at: Option<DateTime<Utc>>,
@@ -1951,6 +2052,7 @@ impl Orchestrator {
             blocked_issues: Vec::new(),
             pending_terminal_cleanup: HashMap::new(),
             running_issue_states: HashMap::new(),
+            running_parent_identifiers: HashMap::new(),
             next_retry_token: 0,
             poll_count: 0,
             last_poll_at: None,
@@ -2202,9 +2304,11 @@ impl Orchestrator {
             if normalize_issue_state(&d.issue.state) == "todo" {
                 if let Err(err) = port.update_issue_state(&d.issue.id, "In Progress") {
                     tracing::warn!(
-                        event = "writeback_failed",
+                        event = "state_transition_failed",
+                        tracker_kind = %self.config.tracker.kind.as_deref().unwrap_or("linear"),
                         issue_id = %d.issue.id,
                         issue_identifier = %d.issue.identifier,
+                        target_state = "In Progress",
                         error = %err,
                         "failed to move issue to In Progress; continuing with dispatch"
                     );
@@ -2334,7 +2438,30 @@ impl Orchestrator {
         drained
     }
 
-    fn handle_escalation_dispatch(&mut self, dispatch: rpc_bridge::EscalationDispatch) {
+    fn handle_escalation_dispatch(&mut self, mut dispatch: rpc_bridge::EscalationDispatch) {
+        let issue_state = self
+            .running_issue_states
+            .get(&dispatch.request.issue_id)
+            .cloned()
+            .or_else(|| {
+                self.state
+                    .running
+                    .get(&dispatch.request.issue_id)
+                    .and_then(|attempt| attempt.linear_state.clone())
+            });
+        let parent_identifier = self
+            .running_parent_identifiers
+            .get(&dispatch.request.issue_id)
+            .cloned()
+            .flatten();
+
+        enrich_escalation_payload(
+            &mut dispatch.request.payload,
+            &dispatch.request.issue_identifier,
+            issue_state.as_deref(),
+            parent_identifier.as_deref(),
+        );
+
         let request_id = dispatch.request.id.clone();
         self.escalation_registry
             .register(dispatch.request.clone(), dispatch.response_tx);
@@ -2343,6 +2470,7 @@ impl Orchestrator {
             event = "escalation_registered",
             issue_id = %dispatch.request.issue_id,
             issue_identifier = %dispatch.request.issue_identifier,
+            issue_state = %issue_state.unwrap_or_default(),
             request_id = %request_id,
             method = %dispatch.request.method,
             "registered pending escalation"
@@ -3141,6 +3269,7 @@ impl Orchestrator {
         self.worker_last_activity_ms.remove(issue_id);
         self.running_session_stats.remove(issue_id);
         self.worker_session_info.remove(issue_id);
+        self.running_parent_identifiers.remove(issue_id);
 
         let issue_identifier = run_attempt.issue_identifier.clone();
         let session_id = self.worker_session_ids.remove(issue_id);
@@ -3298,6 +3427,8 @@ impl Orchestrator {
         self.state.claimed.insert(issue.id.clone());
         self.running_issue_states
             .insert(issue.id.clone(), issue.state.clone());
+        self.running_parent_identifiers
+            .insert(issue.id.clone(), issue.parent_identifier.clone());
         self.running_session_stats
             .entry(issue.id.clone())
             .or_insert_with(|| RunningSessionStats {
@@ -4339,6 +4470,7 @@ impl Orchestrator {
             }
 
             if terminal_states.contains(&normalized_state) {
+                self.maybe_write_completion_comment(port, &issue);
                 self.mark_issue_terminal(&issue, None, true);
                 continue;
             }
@@ -4351,6 +4483,8 @@ impl Orchestrator {
             // Store display-cased state for human-readable notification messages.
             self.running_issue_states
                 .insert(issue.id.clone(), issue.state.clone());
+            self.running_parent_identifiers
+                .insert(issue.id.clone(), issue.parent_identifier.clone());
 
             // Keep dashboard linear_state current with actual Linear state.
             if let Some(attempt) = self.state.running.get_mut(&issue.id) {
@@ -4368,6 +4502,8 @@ impl Orchestrator {
         // in state.running (completed workers whose state was kept for
         // notification detection on this poll cycle).
         self.running_issue_states
+            .retain(|id, _| self.state.running.contains_key(id));
+        self.running_parent_identifiers
             .retain(|id, _| self.state.running.contains_key(id));
 
         Ok(())
@@ -4720,6 +4856,8 @@ impl Orchestrator {
         self.state.retry_attempts.remove(&issue.id);
         self.running_issue_states
             .insert(issue.id.clone(), issue.state.clone());
+        self.running_parent_identifiers
+            .insert(issue.id.clone(), issue.parent_identifier.clone());
     }
 
     fn process_due_retries(
@@ -4812,6 +4950,7 @@ impl Orchestrator {
                             state = %hidden_state,
                             "retry issue became terminal before active-candidate visibility; marking terminal"
                         );
+                        self.maybe_write_completion_comment(port, &hidden_issue);
                         self.mark_issue_terminal(
                             &hidden_issue,
                             retry.workspace_path.as_deref(),
@@ -4853,6 +4992,7 @@ impl Orchestrator {
 
             let normalized_state = normalize_issue_state(&issue.state);
             if self.terminal_state_set().contains(&normalized_state) {
+                self.maybe_write_completion_comment(port, &issue);
                 self.mark_issue_terminal(&issue, retry.workspace_path.as_deref(), true);
                 continue;
             }
@@ -4941,6 +5081,59 @@ impl Orchestrator {
             .to_string()
     }
 
+    fn completion_comment_for_issue(&self, issue: &Issue, now: DateTime<Utc>) -> String {
+        let run_attempt = self.state.running.get(&issue.id);
+        let session_info = self.worker_session_info.get(&issue.id);
+
+        let turn_count = session_info.map(|info| info.turn_count).unwrap_or_default();
+        let total_tokens = session_info
+            .map(|info| info.session_tokens.total_tokens)
+            .unwrap_or_default();
+        let duration = run_attempt
+            .map(|attempt| now.signed_duration_since(attempt.started_at))
+            .unwrap_or_else(chrono::Duration::zero);
+        let worker_host = run_attempt.and_then(|attempt| attempt.worker_host.as_deref());
+
+        CompletionCommentBuilder::new(
+            &issue.identifier,
+            &issue.state,
+            turn_count,
+            total_tokens,
+            duration,
+            worker_host,
+        )
+        .build()
+    }
+
+    fn maybe_write_completion_comment(&self, port: &mut dyn OrchestratorPort, issue: &Issue) {
+        if !completion_comments_enabled(&self.config.tracker) {
+            return;
+        }
+
+        let body = self.completion_comment_for_issue(issue, Utc::now());
+        match port.create_issue_comment(&issue.id, &body) {
+            Ok(()) => {
+                tracing::info!(
+                    event = "completion_comment_written",
+                    issue_id = %issue.id,
+                    issue_identifier = %issue.identifier,
+                    tracker_kind = %self.config.tracker.kind.as_deref().unwrap_or("linear"),
+                    "wrote structured completion comment"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    event = "completion_comment_failed",
+                    issue_id = %issue.id,
+                    issue_identifier = %issue.identifier,
+                    tracker_kind = %self.config.tracker.kind.as_deref().unwrap_or("linear"),
+                    error = %err,
+                    "failed to write structured completion comment"
+                );
+            }
+        }
+    }
+
     fn mark_issue_terminal(
         &mut self,
         issue: &Issue,
@@ -5004,6 +5197,7 @@ impl Orchestrator {
         self.state.claimed.remove(issue_id);
         self.state.retry_attempts.remove(issue_id);
         self.running_issue_states.remove(issue_id);
+        self.running_parent_identifiers.remove(issue_id);
         self.retry_tokens.remove(issue_id);
         self.worker_last_activity_ms.remove(issue_id);
         self.worker_session_info.remove(issue_id);
@@ -5060,6 +5254,7 @@ impl Orchestrator {
         self.state.claimed.remove(issue_id);
         self.state.retry_attempts.remove(issue_id);
         self.running_issue_states.remove(issue_id);
+        self.running_parent_identifiers.remove(issue_id);
         self.retry_tokens.remove(issue_id);
         self.worker_last_activity_ms.remove(issue_id);
         self.worker_session_ids.remove(issue_id);

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -1878,7 +1878,7 @@ impl EscalationRegistry {
             })
             .collect();
 
-        pending.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        pending.sort_by_key(|entry| entry.created_at);
         pending
     }
 }
@@ -4380,7 +4380,7 @@ impl Orchestrator {
 
         let claimed: BTreeSet<String> = self.state.claimed.iter().cloned().collect();
         let mut completed: Vec<CompletedEntry> = self.state.completed.values().cloned().collect();
-        completed.sort_by(|a, b| b.completed_at.cmp(&a.completed_at));
+        completed.sort_by_key(|entry| std::cmp::Reverse(entry.completed_at));
 
         let mut retry_queue: Vec<RetrySnapshotEntry> = self
             .state

--- a/apps/symphony/src/pi_agent/rpc_bridge.rs
+++ b/apps/symphony/src/pi_agent/rpc_bridge.rs
@@ -764,21 +764,21 @@ pub async fn run_turn_with_followups(
 
         match parsed {
             RpcOutputLine::AgentEnd { .. } => break,
-            RpcOutputLine::Response(response) if response.command == "prompt" => {
-                if !response.success {
-                    let err = response
-                        .error
-                        .unwrap_or_else(|| "prompt command failed".to_string());
-                    let failed = AgentEvent::TurnFailed {
-                        timestamp: Utc::now(),
-                        codex_app_server_pid: handle.pid.clone(),
-                        turn_id: turn_id.clone(),
-                        error: err.clone(),
-                    };
-                    event_callback(failed.clone());
-                    events.push(failed);
-                    return Err(SymphonyError::TurnFailed(err));
-                }
+            RpcOutputLine::Response(response)
+                if response.command == "prompt" && !response.success =>
+            {
+                let err = response
+                    .error
+                    .unwrap_or_else(|| "prompt command failed".to_string());
+                let failed = AgentEvent::TurnFailed {
+                    timestamp: Utc::now(),
+                    codex_app_server_pid: handle.pid.clone(),
+                    turn_id: turn_id.clone(),
+                    error: err.clone(),
+                };
+                event_callback(failed.clone());
+                events.push(failed);
+                return Err(SymphonyError::TurnFailed(err));
             }
             RpcOutputLine::ToolExecutionStart {
                 tool_name, args, ..

--- a/apps/symphony/src/workspace.rs
+++ b/apps/symphony/src/workspace.rs
@@ -276,7 +276,7 @@ fn bootstrap_repository(
         return Ok(());
     };
 
-    let branch_name = format!("{}/{}", config.branch_prefix, issue_identifier);
+    let branch_name = branch_name_for_issue(config, issue_identifier);
     let workspace_str = workspace.to_string_lossy().to_string();
     let effective_strategy = match config.strategy {
         WorkspaceRepoStrategy::Auto => {
@@ -362,6 +362,11 @@ fn bootstrap_repository(
         }
         WorkspaceRepoStrategy::Auto => unreachable!("auto strategy must resolve before bootstrap"),
     }
+}
+
+fn branch_name_for_issue(config: &WorkspaceConfig, issue_identifier: &str) -> String {
+    let sanitized_identifier = path_safety::sanitize_identifier(issue_identifier);
+    format!("{}/{}", config.branch_prefix, sanitized_identifier)
 }
 
 /// Inject skills from a `skills/` directory (sibling to the WORKFLOW.md file)
@@ -508,7 +513,7 @@ pub async fn docker_bootstrap_repository(
         WorkspaceRepoStrategy::Auto => unreachable!("auto strategy is resolved above"),
     }
 
-    let branch_name = format!("{}/{}", config.branch_prefix, issue_identifier);
+    let branch_name = branch_name_for_issue(config, issue_identifier);
 
     let clone_cmd = if let Some(clone_branch) = config.clone_branch.as_deref() {
         format!(

--- a/apps/symphony/tests/github_adapter_tests.rs
+++ b/apps/symphony/tests/github_adapter_tests.rs
@@ -149,12 +149,32 @@ fn issue_json(
     assignees: &[&str],
     html_url: Option<&str>,
 ) -> serde_json::Value {
+    issue_json_with_metadata(
+        number,
+        &format!("Issue {number}"),
+        Some(&format!("Body {number}")),
+        labels,
+        user_login,
+        assignees,
+        html_url,
+    )
+}
+
+fn issue_json_with_metadata(
+    number: u64,
+    title: &str,
+    body: Option<&str>,
+    labels: &[&str],
+    user_login: &str,
+    assignees: &[&str],
+    html_url: Option<&str>,
+) -> serde_json::Value {
     let first_assignee = assignees.first().copied().unwrap_or(user_login);
 
     json!({
         "number": number,
-        "title": format!("Issue {number}"),
-        "body": format!("Body {number}"),
+        "title": title,
+        "body": body,
         "state": "open",
         "user": { "login": user_login },
         "assignee": { "login": first_assignee },
@@ -816,6 +836,148 @@ async fn test_kata_phase_vocabulary_round_trip_in_projects_v2_mode() {
         assert_eq!(states.len(), 1);
         assert_eq!(states[0].state, phase);
     }
+}
+
+#[tokio::test]
+async fn test_issue_to_domain_enriches_kata_identifier_and_parent_reference() {
+    let mut server = Server::new_async().await;
+    let adapter = test_adapter(&server, None);
+
+    let kata_issue = issue_json_with_metadata(
+        42,
+        "[S01] Build feature",
+        Some("Context\n\n**Parent:** #10\n\nMore context"),
+        &["symphony:todo", "kata:task"],
+        "alice",
+        &["alice"],
+        Some("https://github.com/kata-sh/kata-mono/issues/42"),
+    );
+
+    let mock = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("state".into(), "open".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(json!([kata_issue]).to_string())
+        .create_async()
+        .await;
+
+    let issues = adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("fetch_candidate_issues should succeed");
+
+    mock.assert_async().await;
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].identifier, "[S01]#42");
+    assert_eq!(issues[0].parent_identifier.as_deref(), Some("#10"));
+    assert_eq!(issues[0].state, "Todo");
+    assert_eq!(
+        issues[0].url.as_deref(),
+        Some("https://github.com/kata-sh/kata-mono/issues/42")
+    );
+    assert!(issues[0].assigned_to_worker);
+    assert!(issues[0].labels.contains(&"kata:task".to_string()));
+}
+
+#[tokio::test]
+async fn test_issue_to_domain_parses_slice_task_and_milestone_kata_prefixes() {
+    let mut server = Server::new_async().await;
+    let adapter = test_adapter(&server, None);
+
+    let issues_payload = json!([
+        issue_json_with_metadata(
+            50,
+            "[S01] Slice",
+            Some("Body"),
+            &["symphony:todo"],
+            "alice",
+            &["alice"],
+            None
+        ),
+        issue_json_with_metadata(
+            51,
+            "[T1] Task",
+            Some("Body"),
+            &["symphony:todo"],
+            "alice",
+            &["alice"],
+            None
+        ),
+        issue_json_with_metadata(
+            52,
+            "[M001] Milestone",
+            Some("Body"),
+            &["symphony:todo"],
+            "alice",
+            &["alice"],
+            None
+        )
+    ]);
+
+    let mock = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("state".into(), "open".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(issues_payload.to_string())
+        .create_async()
+        .await;
+
+    let issues = adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("fetch_candidate_issues should succeed");
+
+    mock.assert_async().await;
+    assert_eq!(issues.len(), 3);
+    assert_eq!(issues[0].identifier, "[S01]#50");
+    assert_eq!(issues[1].identifier, "[T1]#51");
+    assert_eq!(issues[2].identifier, "[M001]#52");
+}
+
+#[tokio::test]
+async fn test_issue_to_domain_preserves_hash_identifier_for_non_kata_title() {
+    let mut server = Server::new_async().await;
+    let adapter = test_adapter(&server, None);
+
+    let regular_issue = issue_json_with_metadata(
+        43,
+        "Regular ticket title",
+        Some("Part of: #10"),
+        &["symphony:todo"],
+        "alice",
+        &["alice"],
+        None,
+    );
+
+    let mock = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("state".into(), "open".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(json!([regular_issue]).to_string())
+        .create_async()
+        .await;
+
+    let issues = adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("fetch_candidate_issues should succeed");
+
+    mock.assert_async().await;
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].identifier, "#43");
+    assert_eq!(issues[0].parent_identifier.as_deref(), Some("#10"));
 }
 
 #[tokio::test]

--- a/apps/symphony/tests/github_adapter_tests.rs
+++ b/apps/symphony/tests/github_adapter_tests.rs
@@ -490,6 +490,30 @@ async fn test_create_comment_delegates_to_client() {
 }
 
 #[tokio::test]
+async fn test_create_comment_preserves_structured_markdown_body() {
+    let mut server = Server::new_async().await;
+    let adapter = test_adapter(&server, None);
+
+    let structured_body = "## Symphony Execution Summary\n\n**Issue:** [S01]#7\n**Status:** Done\n**Turns:** 3\n**Tokens:** 1200\n**Duration:** 2m 1s\n**Worker:** local";
+
+    let mock = server
+        .mock("POST", "/repos/kata-sh/kata-mono/issues/7/comments")
+        .match_body(Matcher::PartialJson(json!({ "body": structured_body })))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .create_async()
+        .await;
+
+    adapter
+        .create_comment("7", structured_body)
+        .await
+        .expect("create_comment should preserve structured markdown");
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn test_update_issue_state_swaps_labels() {
     let mut server = Server::new_async().await;
     let adapter = test_adapter(&server, None);

--- a/apps/symphony/tests/github_adapter_tests.rs
+++ b/apps/symphony/tests/github_adapter_tests.rs
@@ -200,6 +200,16 @@ fn phase_to_label(phase: &str) -> String {
         .join("-")
 }
 
+fn projects_v2_option_name_for_phase(phase: &str) -> String {
+    match phase {
+        "Todo" => "to_do".to_string(),
+        "In Progress" => "in-progress".to_string(),
+        "Agent Review" => "agent_review".to_string(),
+        "Human Review" => "human review".to_string(),
+        _ => phase_to_label(phase),
+    }
+}
+
 fn pull_request_json(mut issue: serde_json::Value) -> serde_json::Value {
     issue["pull_request"] = json!({
         "url": "https://api.github.com/repos/kata-sh/kata-mono/pulls/123"
@@ -744,17 +754,8 @@ async fn test_kata_phase_vocabulary_round_trip_in_label_mode() {
 
 #[tokio::test]
 async fn test_kata_phase_vocabulary_round_trip_in_projects_v2_mode() {
-    let mapping = [
-        ("Backlog", "backlog"),
-        ("Todo", "to_do"),
-        ("In Progress", "in-progress"),
-        ("Agent Review", "agent_review"),
-        ("Human Review", "human review"),
-        ("Merging", "merging"),
-        ("Done", "done"),
-    ];
-
-    for (phase, option_name) in mapping {
+    for phase in KATA_PHASE_NAMES {
+        let option_name = projects_v2_option_name_for_phase(phase);
         let mut server = Server::new_async().await;
         let adapter = test_projects_adapter(&server, None, 42);
 
@@ -796,7 +797,7 @@ async fn test_kata_phase_vocabulary_round_trip_in_projects_v2_mode() {
                     "item_7",
                     7,
                     "opt_target",
-                    option_name,
+                    &option_name,
                 )])
                 .to_string(),
             )

--- a/apps/symphony/tests/github_adapter_tests.rs
+++ b/apps/symphony/tests/github_adapter_tests.rs
@@ -1,6 +1,6 @@
 use mockito::{Matcher, Server, ServerGuard};
 use serde_json::json;
-use symphony::domain::{ApiKey, TrackerConfig};
+use symphony::domain::{ApiKey, TrackerConfig, KATA_PHASE_NAMES};
 use symphony::error::SymphonyError;
 use symphony::github::adapter::{GithubAdapter, StateMode};
 use symphony::github::client::GithubClient;
@@ -169,6 +169,15 @@ fn issue_json(
 fn issue_state_json(mut issue: serde_json::Value, state: &str) -> serde_json::Value {
     issue["state"] = json!(state);
     issue
+}
+
+fn phase_to_label(phase: &str) -> String {
+    phase
+        .to_ascii_lowercase()
+        .replace('_', "-")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 fn pull_request_json(mut issue: serde_json::Value) -> serde_json::Value {
@@ -598,6 +607,215 @@ async fn test_update_issue_state_handles_missing_old_label() {
 
     get_mock.assert_async().await;
     add_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_kata_phase_vocabulary_round_trip_in_label_mode() {
+    for phase in KATA_PHASE_NAMES {
+        let mut server = Server::new_async().await;
+        let adapter = test_adapter(&server, None);
+
+        let initial_issue = issue_json(77, &["symphony:todo"], "alice", &["alice"], None);
+        let round_trip_label = format!("symphony:{}", phase_to_label(phase));
+        let round_trip_issue =
+            issue_json(77, &[round_trip_label.as_str()], "alice", &["alice"], None);
+
+        let get_for_update = server
+            .mock("GET", "/repos/kata-sh/kata-mono/issues/77")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(initial_issue.to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let remove_old = if phase != "Todo" {
+            Some(
+                server
+                    .mock(
+                        "DELETE",
+                        "/repos/kata-sh/kata-mono/issues/77/labels/symphony:todo",
+                    )
+                    .with_status(200)
+                    .with_header("content-type", "application/json")
+                    .with_body("{}")
+                    .expect(1)
+                    .create_async()
+                    .await,
+            )
+        } else {
+            None
+        };
+
+        let add_new = if phase != "Todo" {
+            Some(
+                server
+                    .mock("POST", "/repos/kata-sh/kata-mono/issues/77/labels")
+                    .match_body(Matcher::PartialJson(json!({
+                        "labels": [round_trip_label]
+                    })))
+                    .with_status(200)
+                    .with_header("content-type", "application/json")
+                    .with_body("[]")
+                    .expect(1)
+                    .create_async()
+                    .await,
+            )
+        } else {
+            None
+        };
+
+        let get_for_fetch = server
+            .mock("GET", "/repos/kata-sh/kata-mono/issues/77")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(round_trip_issue.to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        adapter
+            .update_issue_state("77", phase)
+            .await
+            .expect("update_issue_state should support canonical kata phases");
+
+        let issues = adapter
+            .fetch_issue_states_by_ids(&["77".to_string()])
+            .await
+            .expect("fetch_issue_states_by_ids should succeed");
+
+        get_for_update.assert_async().await;
+        if let Some(mock) = remove_old {
+            mock.assert_async().await;
+        }
+        if let Some(mock) = add_new {
+            mock.assert_async().await;
+        }
+        get_for_fetch.assert_async().await;
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].state, phase);
+    }
+}
+
+#[tokio::test]
+async fn test_kata_phase_vocabulary_round_trip_in_projects_v2_mode() {
+    let mapping = [
+        ("Backlog", "backlog"),
+        ("Todo", "to_do"),
+        ("In Progress", "in-progress"),
+        ("Agent Review", "agent_review"),
+        ("Human Review", "human review"),
+        ("Merging", "merging"),
+        ("Done", "done"),
+    ];
+
+    for (phase, option_name) in mapping {
+        let mut server = Server::new_async().await;
+        let adapter = test_projects_adapter(&server, None, 42);
+
+        let fields_mock = server
+            .mock("POST", "/graphql")
+            .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "data": {
+                        "user": {
+                            "projectV2": {
+                                "id": "project_42",
+                                "field": {
+                                    "id": "status_field",
+                                    "options": [
+                                        { "id": "opt_target", "name": option_name }
+                                    ]
+                                }
+                            }
+                        },
+                        "organization": null
+                    }
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let items_mock = server
+            .mock("POST", "/graphql")
+            .match_body(Matcher::Regex("fieldValueByName".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                projects_v2_items_payload(&[project_item_node(
+                    "item_7",
+                    7,
+                    "opt_target",
+                    option_name,
+                )])
+                .to_string(),
+            )
+            .expect(2)
+            .create_async()
+            .await;
+
+        let mutation_mock = server
+            .mock("POST", "/graphql")
+            .match_body(Matcher::AllOf(vec![
+                Matcher::Regex("updateProjectV2ItemFieldValue".to_string()),
+                Matcher::PartialJson(json!({
+                    "variables": {
+                        "projectId": "project_42",
+                        "itemId": "item_7",
+                        "fieldId": "status_field",
+                        "singleSelectOptionId": "opt_target"
+                    }
+                })),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "data": {
+                        "updateProjectV2ItemFieldValue": {
+                            "projectV2Item": { "id": "item_7" }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let issue_mock = server
+            .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(issue_json(7, &["symphony:todo"], "alice", &["alice"], None).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        adapter
+            .update_issue_state("7", phase)
+            .await
+            .expect("Projects v2 update should accept canonical kata phase names");
+
+        let states = adapter
+            .fetch_issue_states_by_ids(&["7".to_string()])
+            .await
+            .expect("Projects v2 state fetch should succeed");
+
+        fields_mock.assert_async().await;
+        items_mock.assert_async().await;
+        mutation_mock.assert_async().await;
+        issue_mock.assert_async().await;
+
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].state, phase);
+    }
 }
 
 #[tokio::test]

--- a/apps/symphony/tests/github_execution_contract_tests.rs
+++ b/apps/symphony/tests/github_execution_contract_tests.rs
@@ -1,0 +1,693 @@
+use mockito::{Matcher, Server, ServerGuard};
+use serde_json::json;
+use symphony::domain::{ApiKey, TrackerConfig};
+use symphony::error::SymphonyError;
+use symphony::github::adapter::GithubAdapter;
+use symphony::github::client::GithubClient;
+use symphony::linear::adapter::TrackerAdapter;
+
+fn base_config() -> TrackerConfig {
+    TrackerConfig {
+        kind: Some("github".to_string()),
+        endpoint: "https://api.github.com".to_string(),
+        api_key: Some(ApiKey::new("test-token")),
+        project_slug: None,
+        workspace_slug: None,
+        repo_owner: Some("kata-sh".to_string()),
+        repo_name: Some("kata-mono".to_string()),
+        github_project_number: None,
+        label_prefix: Some("symphony".to_string()),
+        assignee: None,
+        active_states: vec![
+            "Todo".to_string(),
+            "In Progress".to_string(),
+            "Agent Review".to_string(),
+            "Human Review".to_string(),
+            "Merging".to_string(),
+        ],
+        terminal_states: vec!["Done".to_string(), "Canceled".to_string()],
+        exclude_labels: vec![],
+    }
+}
+
+fn label_adapter(server: &ServerGuard) -> GithubAdapter {
+    let client = GithubClient::with_base_url(
+        "test-token",
+        "kata-sh",
+        "kata-mono",
+        "symphony",
+        server.url(),
+    );
+    GithubAdapter::new(client, base_config())
+}
+
+fn projects_adapter(server: &ServerGuard) -> GithubAdapter {
+    let mut config = base_config();
+    config.github_project_number = Some(42);
+    config.active_states = vec!["Todo".to_string(), "In Progress".to_string()];
+
+    let client = GithubClient::with_base_url(
+        "test-token",
+        "kata-sh",
+        "kata-mono",
+        "symphony",
+        server.url(),
+    );
+    GithubAdapter::new(client, config)
+}
+
+fn issue_json(number: u64, title: &str, body: Option<&str>, labels: &[&str]) -> serde_json::Value {
+    json!({
+        "number": number,
+        "title": title,
+        "body": body,
+        "state": "open",
+        "user": { "login": "alice" },
+        "assignee": { "login": "alice" },
+        "assignees": [{ "login": "alice" }],
+        "labels": labels
+            .iter()
+            .map(|name| json!({ "name": name, "color": "ffffff", "description": null }))
+            .collect::<Vec<_>>(),
+        "created_at": "2026-03-29T10:00:00Z",
+        "updated_at": "2026-03-29T10:30:00Z",
+        "html_url": format!("https://github.com/kata-sh/kata-mono/issues/{number}")
+    })
+}
+
+fn projects_field_payload(options: &[(&str, &str)]) -> serde_json::Value {
+    json!({
+        "data": {
+            "user": {
+                "projectV2": {
+                    "id": "project_42",
+                    "field": {
+                        "id": "status_field",
+                        "options": options
+                            .iter()
+                            .map(|(id, name)| json!({ "id": id, "name": name }))
+                            .collect::<Vec<_>>()
+                    }
+                }
+            },
+            "organization": null
+        }
+    })
+}
+
+fn project_items_payload(status_name: &str, option_id: &str) -> serde_json::Value {
+    json!({
+        "data": {
+            "node": {
+                "items": {
+                    "nodes": [
+                        {
+                            "id": "item_7",
+                            "content": { "number": 7 },
+                            "fieldValueByName": {
+                                "name": status_name,
+                                "optionId": option_id
+                            }
+                        }
+                    ],
+                    "pageInfo": {
+                        "hasNextPage": false,
+                        "endCursor": null
+                    }
+                }
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn test_label_mode_execution_lifecycle_contract() {
+    let mut server = Server::new_async().await;
+    let adapter = label_adapter(&server);
+
+    let todo_issue = issue_json(
+        7,
+        "[S01] Build feature",
+        Some("**Parent:** #10\n\nimplements feature"),
+        &["symphony:todo", "kata:slice"],
+    );
+    let in_progress_issue = issue_json(
+        7,
+        "[S01] Build feature",
+        Some("**Parent:** #10\n\nimplements feature"),
+        &["symphony:in-progress", "kata:slice"],
+    );
+    let done_issue = issue_json(
+        7,
+        "[S01] Build feature",
+        Some("**Parent:** #10\n\nimplements feature"),
+        &["symphony:done", "kata:slice"],
+    );
+
+    let list_mock = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("state".into(), "open".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(json!([todo_issue.clone()]).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let get_for_in_progress_update = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(todo_issue.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let remove_todo = server
+        .mock(
+            "DELETE",
+            "/repos/kata-sh/kata-mono/issues/7/labels/symphony:todo",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let add_in_progress = server
+        .mock("POST", "/repos/kata-sh/kata-mono/issues/7/labels")
+        .match_body(Matcher::PartialJson(
+            json!({ "labels": ["symphony:in-progress"] }),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("[]")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let get_for_in_progress_refresh = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(in_progress_issue.clone().to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let get_for_done_update = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(in_progress_issue.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let remove_in_progress = server
+        .mock(
+            "DELETE",
+            "/repos/kata-sh/kata-mono/issues/7/labels/symphony:in-progress",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let add_done = server
+        .mock("POST", "/repos/kata-sh/kata-mono/issues/7/labels")
+        .match_body(Matcher::PartialJson(json!({ "labels": ["symphony:done"] })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("[]")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let get_for_done_refresh = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(done_issue.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let candidates = adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("candidate dispatch fetch should succeed");
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].identifier, "[S01]#7");
+    assert_eq!(candidates[0].state, "Todo");
+    assert_eq!(candidates[0].parent_identifier.as_deref(), Some("#10"));
+
+    adapter
+        .update_issue_state("7", "In Progress")
+        .await
+        .expect("state transition to In Progress should succeed");
+
+    let in_progress_state = adapter
+        .fetch_issue_states_by_ids(&["7".to_string()])
+        .await
+        .expect("refresh after In Progress transition should succeed");
+    assert_eq!(in_progress_state.len(), 1);
+    assert_eq!(in_progress_state[0].identifier, "[S01]#7");
+    assert_eq!(in_progress_state[0].state, "In Progress");
+    assert_eq!(
+        in_progress_state[0].parent_identifier.as_deref(),
+        Some("#10")
+    );
+
+    adapter
+        .update_issue_state("7", "Done")
+        .await
+        .expect("state transition to Done should succeed");
+
+    let done_state = adapter
+        .fetch_issue_states_by_ids(&["7".to_string()])
+        .await
+        .expect("refresh after Done transition should succeed");
+    assert_eq!(done_state.len(), 1);
+    assert_eq!(done_state[0].identifier, "[S01]#7");
+    assert_eq!(done_state[0].state, "Done");
+    assert_eq!(done_state[0].parent_identifier.as_deref(), Some("#10"));
+    assert!(done_state[0].assigned_to_worker);
+
+    list_mock.assert_async().await;
+    get_for_in_progress_update.assert_async().await;
+    remove_todo.assert_async().await;
+    add_in_progress.assert_async().await;
+    get_for_in_progress_refresh.assert_async().await;
+    get_for_done_update.assert_async().await;
+    remove_in_progress.assert_async().await;
+    add_done.assert_async().await;
+    get_for_done_refresh.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_projects_v2_execution_lifecycle_contract() {
+    let mut server = Server::new_async().await;
+    let adapter = projects_adapter(&server);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_field_payload(&[
+                ("opt_todo", "Todo"),
+                ("opt_in_progress", "In Progress"),
+                ("opt_done", "Done"),
+            ])
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_candidate = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(project_items_payload("Todo", "opt_todo").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issue_for_candidate = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            issue_json(
+                7,
+                "[S01] Build feature",
+                Some("Part of: #10"),
+                &["symphony:todo", "kata:slice"],
+            )
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_update_in_progress = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(project_items_payload("Todo", "opt_todo").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mutation_in_progress = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::AllOf(vec![
+            Matcher::Regex("updateProjectV2ItemFieldValue".to_string()),
+            Matcher::PartialJson(json!({
+                "variables": {
+                    "projectId": "project_42",
+                    "itemId": "item_7",
+                    "fieldId": "status_field",
+                    "singleSelectOptionId": "opt_in_progress"
+                }
+            })),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(json!({ "data": { "updateProjectV2ItemFieldValue": { "projectV2Item": { "id": "item_7" }}}}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_refresh_in_progress = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(project_items_payload("In Progress", "opt_in_progress").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issue_for_refresh_in_progress = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            issue_json(
+                7,
+                "[S01] Build feature",
+                Some("Part of: #10"),
+                &["symphony:todo", "kata:slice"],
+            )
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_update_done = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(project_items_payload("In Progress", "opt_in_progress").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mutation_done = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::AllOf(vec![
+            Matcher::Regex("updateProjectV2ItemFieldValue".to_string()),
+            Matcher::PartialJson(json!({
+                "variables": {
+                    "projectId": "project_42",
+                    "itemId": "item_7",
+                    "fieldId": "status_field",
+                    "singleSelectOptionId": "opt_done"
+                }
+            })),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(json!({ "data": { "updateProjectV2ItemFieldValue": { "projectV2Item": { "id": "item_7" }}}}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_refresh_done = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(project_items_payload("Done", "opt_done").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issue_for_refresh_done = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            issue_json(
+                7,
+                "[S01] Build feature",
+                Some("Part of: #10"),
+                &["symphony:todo", "kata:slice"],
+            )
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let candidates = adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("projects v2 candidate fetch should succeed");
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].identifier, "[S01]#7");
+    assert_eq!(candidates[0].state, "Todo");
+
+    adapter
+        .update_issue_state("7", "In Progress")
+        .await
+        .expect("projects v2 transition to In Progress should succeed");
+
+    let in_progress_state = adapter
+        .fetch_issue_states_by_ids(&["7".to_string()])
+        .await
+        .expect("projects v2 refresh for In Progress should succeed");
+    assert_eq!(in_progress_state.len(), 1);
+    assert_eq!(in_progress_state[0].identifier, "[S01]#7");
+    assert_eq!(in_progress_state[0].state, "In Progress");
+    assert_eq!(
+        in_progress_state[0].parent_identifier.as_deref(),
+        Some("#10")
+    );
+
+    adapter
+        .update_issue_state("7", "Done")
+        .await
+        .expect("projects v2 transition to Done should succeed");
+
+    let done_state = adapter
+        .fetch_issue_states_by_ids(&["7".to_string()])
+        .await
+        .expect("projects v2 refresh for Done should succeed");
+    assert_eq!(done_state.len(), 1);
+    assert_eq!(done_state[0].identifier, "[S01]#7");
+    assert_eq!(done_state[0].state, "Done");
+    assert_eq!(done_state[0].parent_identifier.as_deref(), Some("#10"));
+
+    fields_mock.assert_async().await;
+    items_candidate.assert_async().await;
+    issue_for_candidate.assert_async().await;
+    items_update_in_progress.assert_async().await;
+    mutation_in_progress.assert_async().await;
+    items_refresh_in_progress.assert_async().await;
+    issue_for_refresh_in_progress.assert_async().await;
+    items_update_done.assert_async().await;
+    mutation_done.assert_async().await;
+    items_refresh_done.assert_async().await;
+    issue_for_refresh_done.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_projects_v2_unknown_status_reports_actionable_error() {
+    let mut server = Server::new_async().await;
+    let adapter = projects_adapter(&server);
+
+    let fields_mock = server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_field_payload(&[
+                ("opt_todo", "Todo"),
+                ("opt_in_progress", "In Progress"),
+                ("opt_done", "Done"),
+            ])
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let err = adapter
+        .update_issue_state("7", "Blocked")
+        .await
+        .expect_err("unknown status should fail in projects v2 mode");
+
+    fields_mock.assert_async().await;
+    match err {
+        SymphonyError::GithubProjectsV2Error(message) => {
+            assert!(message.contains("status option 'Blocked' not found"));
+            assert!(message.contains("Todo"));
+            assert!(message.contains("In Progress"));
+            assert!(message.contains("Done"));
+        }
+        other => panic!("expected GithubProjectsV2Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_refresh_deleted_issue_and_comment_on_closed_issue_do_not_panic() {
+    let mut server = Server::new_async().await;
+    let adapter = label_adapter(&server);
+
+    let missing_issue = server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/404")
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(json!({ "message": "Not Found" }).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let states = adapter
+        .fetch_issue_states_by_ids(&["404".to_string()])
+        .await
+        .expect("deleted issue refresh should skip gracefully");
+    assert!(states.is_empty());
+
+    let closed_comment = server
+        .mock("POST", "/repos/kata-sh/kata-mono/issues/404/comments")
+        .with_status(403)
+        .with_header("content-type", "application/json")
+        .with_body(json!({ "message": "Issue is closed" }).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let comment_result = adapter
+        .create_comment("404", "## Symphony Execution Summary")
+        .await;
+    assert!(
+        comment_result.is_err(),
+        "closed issue comments should return an error, not panic"
+    );
+
+    missing_issue.assert_async().await;
+    closed_comment.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_label_and_projects_modes_emit_identical_issue_contract_shape() {
+    let mut label_server = Server::new_async().await;
+    let label_adapter = label_adapter(&label_server);
+
+    let issue_payload = issue_json(
+        7,
+        "[S01] Build feature",
+        Some("Parent: #10"),
+        &["symphony:todo", "kata:slice"],
+    );
+
+    let label_list = label_server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("state".into(), "open".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(json!([issue_payload.clone()]).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mut projects_server = Server::new_async().await;
+    let projects_adapter = projects_adapter(&projects_server);
+
+    let fields_mock = projects_server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("projectV2\\(number".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            projects_field_payload(&[("opt_todo", "Todo"), ("opt_in_progress", "In Progress")])
+                .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let items_mock = projects_server
+        .mock("POST", "/graphql")
+        .match_body(Matcher::Regex("fieldValueByName".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(project_items_payload("Todo", "opt_todo").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let issue_mock = projects_server
+        .mock("GET", "/repos/kata-sh/kata-mono/issues/7")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(issue_payload.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let label_issue = label_adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("label mode candidate fetch should succeed")
+        .into_iter()
+        .next()
+        .expect("label mode should return one issue");
+
+    let projects_issue = projects_adapter
+        .fetch_candidate_issues()
+        .await
+        .expect("projects mode candidate fetch should succeed")
+        .into_iter()
+        .next()
+        .expect("projects mode should return one issue");
+
+    label_list.assert_async().await;
+    fields_mock.assert_async().await;
+    items_mock.assert_async().await;
+    issue_mock.assert_async().await;
+
+    let label_shape = (
+        label_issue.description.is_some(),
+        label_issue.url.is_some(),
+        label_issue.parent_identifier.is_some(),
+        !label_issue.labels.is_empty(),
+        label_issue.assignee_id.is_some(),
+    );
+    let projects_shape = (
+        projects_issue.description.is_some(),
+        projects_issue.url.is_some(),
+        projects_issue.parent_identifier.is_some(),
+        !projects_issue.labels.is_empty(),
+        projects_issue.assignee_id.is_some(),
+    );
+
+    assert_eq!(label_shape, projects_shape);
+    assert_eq!(label_issue.identifier, projects_issue.identifier);
+    assert_eq!(label_issue.state, projects_issue.state);
+    assert_eq!(
+        label_issue.parent_identifier,
+        projects_issue.parent_identifier
+    );
+    assert_eq!(label_issue.url, projects_issue.url);
+}

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -4743,7 +4743,7 @@ fn test_reconcile_terminal_github_writes_structured_completion_comment() {
     assert!(comment_call.contains("## Symphony Execution Summary"));
     assert!(comment_call.contains("**Issue:** #7"));
     assert!(comment_call.contains("**Status:** Done"));
-    assert!(comment_call.contains("**Turns:**"));
+    assert!(comment_call.contains("**Turns:** 1"));
     assert!(comment_call.contains("**Tokens:** 120"));
     assert!(comment_call.contains("**Duration:**"));
     assert!(comment_call.contains("**Worker:** local"));

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -18,9 +18,9 @@ use symphony::domain::{
 };
 use symphony::error::{Result, SymphonyError};
 use symphony::orchestrator::{
-    refresh_channel, EscalationRegistry, EscalationResolveResult, Orchestrator, OrchestratorPort,
-    RetryContext, RetryKind, RuntimeEvent, TurnMetrics, WorkerCompletion,
-    CONTINUATION_RETRY_DELAY_MS,
+    enrich_escalation_payload, refresh_channel, CompletionCommentBuilder, EscalationRegistry,
+    EscalationResolveResult, Orchestrator, OrchestratorPort, RetryContext, RetryKind, RuntimeEvent,
+    TurnMetrics, WorkerCompletion, CONTINUATION_RETRY_DELAY_MS,
 };
 use symphony::shared_context::ContextEntryDraft;
 use symphony::workflow_store::WorkflowStore;
@@ -4649,6 +4649,106 @@ fn test_e2e_github_snapshot_state_json_complete() {
     );
 }
 
+#[test]
+fn test_completion_comment_builder_outputs_structured_format() {
+    let body = CompletionCommentBuilder::new(
+        "[S01]#7",
+        "Done",
+        3,
+        1200,
+        Duration::seconds(121),
+        Some("worker-1"),
+    )
+    .build();
+
+    assert!(body.contains("## Symphony Execution Summary"));
+    assert!(body.contains("**Issue:** [S01]#7"));
+    assert!(body.contains("**Status:** Done"));
+    assert!(body.contains("**Turns:** 3"));
+    assert!(body.contains("**Tokens:** 1200"));
+    assert!(body.contains("**Duration:** 2m 1s"));
+    assert!(body.contains("**Worker:** worker-1"));
+}
+
+#[test]
+fn test_completion_comment_builder_handles_missing_optional_fields() {
+    let body =
+        CompletionCommentBuilder::new("#9", "Done", 0, 0, Duration::seconds(0), None).build();
+
+    assert!(body.contains("**Turns:** 0"));
+    assert!(body.contains("**Tokens:** 0"));
+    assert!(body.contains("**Duration:** 0s"));
+    assert!(body.contains("**Worker:** local"));
+}
+
+#[test]
+fn test_enrich_escalation_payload_adds_issue_context_fields() {
+    let mut payload = json!({
+        "questions": [
+            {
+                "id": "q1",
+                "question": "Pick one"
+            }
+        ]
+    });
+
+    enrich_escalation_payload(&mut payload, "[T01]#11", Some("In Progress"), Some("#7"));
+
+    assert_eq!(payload["issue_identifier"], json!("[T01]#11"));
+    assert_eq!(payload["issue_state"], json!("In Progress"));
+    assert_eq!(payload["parent_identifier"], json!("#7"));
+    assert!(payload["questions"].is_array());
+}
+
+#[test]
+fn test_reconcile_terminal_github_writes_structured_completion_comment() {
+    let mut orchestrator = Orchestrator::new(github_test_config(1), String::new());
+
+    let mut dispatch_port = FakePort {
+        candidate_issues: vec![github_issue("gh-7", 7, "Todo", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut dispatch_port)
+        .expect("dispatch tick should succeed");
+
+    orchestrator.ingest_agent_event(
+        "gh-7",
+        &AgentEvent::TurnCompleted {
+            timestamp: Utc::now(),
+            codex_app_server_pid: None,
+            turn_id: "turn-1".to_string(),
+            message: Some("completed".to_string()),
+            input_tokens: 50,
+            output_tokens: 70,
+            total_tokens: 120,
+            rate_limits: None,
+        },
+    );
+
+    let mut reconcile_port = FakePort {
+        reconciled_issues: vec![github_issue("gh-7", 7, "Done", -30)],
+        ..FakePort::default()
+    };
+    orchestrator
+        .tick(&mut reconcile_port)
+        .expect("reconcile tick should succeed");
+
+    let comment_call = reconcile_port
+        .call_history()
+        .iter()
+        .find(|call| call.starts_with("create_issue_comment:gh-7:"))
+        .expect("terminal github reconcile should write completion comment");
+
+    assert!(comment_call.contains("## Symphony Execution Summary"));
+    assert!(comment_call.contains("**Issue:** #7"));
+    assert!(comment_call.contains("**Status:** Done"));
+    assert!(comment_call.contains("**Turns:**"));
+    assert!(comment_call.contains("**Tokens:** 120"));
+    assert!(comment_call.contains("**Duration:**"));
+    assert!(comment_call.contains("**Worker:** local"));
+}
+
 // Covered by test_execute_worker_attempt_runs_multiple_turns_in_one_session:
 // same-state (In Progress → In Progress) continues normally for 2+ turns.
 // The Todo→In Progress auto-transition sets issue.state = effective_state in
@@ -5052,7 +5152,7 @@ fn test_exclude_labels_does_not_affect_slice() {
 
 #[test]
 fn test_exclude_labels_empty_skips_no_issues() {
-    let mut config = test_config(1);
+    let config = test_config(1);
     // No exclude_labels configured (default empty vec)
     assert!(config.tracker.exclude_labels.is_empty());
 

--- a/apps/symphony/tests/workspace_prompt_tests.rs
+++ b/apps/symphony/tests/workspace_prompt_tests.rs
@@ -565,6 +565,40 @@ fn test_workspace_clone_bootstrap_and_branch_creation() {
 }
 
 #[test]
+fn test_workspace_clone_bootstrap_sanitizes_issue_identifier_for_branch_name() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("workspaces");
+    let source_repo = tmp.path().join("source-repo");
+    fs::create_dir_all(&root).unwrap();
+    init_git_repo(&source_repo);
+
+    let config = WorkspaceConfig {
+        root: root.to_string_lossy().to_string(),
+        repo: Some(source_repo.to_string_lossy().to_string()),
+        strategy: WorkspaceRepoStrategy::CloneLocal,
+        isolation: WorkspaceIsolation::Local,
+        docker: None,
+        branch_prefix: "symphony".to_string(),
+        clone_branch: None,
+        base_branch: Some("main".to_string()),
+        cleanup_on_done: false,
+    };
+    let hooks = hooks_config_none();
+    let issue = make_test_issue("[S01]#7");
+
+    let ws = symphony::workspace::ensure_workspace_for_issue(&issue, &config, &hooks).unwrap();
+
+    let mut branch_cmd = Command::new("git");
+    branch_cmd.args(["-C", &ws.path, "rev-parse", "--abbrev-ref", "HEAD"]);
+    let branch = command_success(branch_cmd, "read sanitized branch name");
+
+    assert_eq!(
+        branch, "symphony/_S01__7",
+        "bootstrap should sanitize issue identifiers before creating git branches"
+    );
+}
+
+#[test]
 fn test_workspace_clone_remote_uses_single_branch_behavior() {
     let tmp = TempDir::new().unwrap();
     let root = tmp.path().join("workspaces");


### PR DESCRIPTION
## Summary
- align GitHub adapter state normalization with canonical Kata phase vocabulary across label and Projects v2 modes
- enrich GitHub issue identity with Kata prefixes (`[S##]#N`) and parent metadata extraction from issue body markers
- add structured Symphony completion comments and escalation payload context (`issue_identifier`, `issue_state`, `parent_identifier`)
- add end-to-end GitHub execution lifecycle contract tests for label and Projects v2 modes, including error-path coverage

## Validation
- `cd apps/symphony && cargo test --test github_adapter_tests`
- `cd apps/symphony && cargo test --test github_execution_contract_tests`
- `cd apps/symphony && cargo test --test orchestrator_tests`
- `cd apps/symphony && cargo test --test github_client_tests`
- `cd apps/symphony && cargo test`

Closes KAT-2705

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns Symphony's GitHub adapter with canonical Kata phase vocabulary (`KATA_PHASE_NAMES`), enriches issue identities with `[S##]#N` prefixes and parent-metadata extraction, adds structured completion comments on terminal transitions, and enriches escalation payloads with issue context. New E2E contract tests cover label and Projects v2 modes end-to-end including error paths. The implementation is functionally correct across all normalization paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all normalization paths produce correct output and the new test suite validates the full lifecycle contract.

Both findings are P2: the dead canonical branch in denormalize_label_state doesn't affect output (fallback is correct), and the WARN log level is cosmetic. The core logic is implemented correctly and thoroughly tested.

apps/symphony/src/github/adapter.rs — denormalize_label_state canonical lookup and diagnostic log level.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/domain.rs | Adds KATA_PHASE_NAMES constant, canonical_kata_phase_name lookup, parse_kata_identifier, and parse_parent_issue_reference — all well-implemented with correct normalization semantics. |
| apps/symphony/src/github/adapter.rs | State normalization pipeline is correct end-to-end; denormalize_label_state has a dead canonical lookup for multi-word phases (doesn't affect output); WARN-level diagnostic fires for valid non-Kata terminal states like "Canceled". |
| apps/symphony/src/orchestrator.rs | running_parent_identifiers lifecycle matches running_issue_states; CompletionCommentBuilder and enrich_escalation_payload cleanly extracted; maybe_write_completion_comment cannot double-fire within a tick. |
| apps/symphony/src/config.rs | Adds soft INFO-level vocabulary check for non-canonical states in validation; non-blocking, appropriate severity. |
| apps/symphony/tests/github_execution_contract_tests.rs | New E2E contract test file covering label mode lifecycle, Projects v2 lifecycle, unknown-status error path, deleted/closed issue graceful handling, and cross-mode issue shape parity — comprehensive coverage. |
| apps/symphony/tests/github_adapter_tests.rs | Adds round-trip tests for all 7 canonical phases in both label and Projects v2 modes, plus identifier/parent-reference enrichment tests — thorough and well-structured. |
| apps/symphony/tests/orchestrator_tests.rs | Adds unit tests for CompletionCommentBuilder, enrich_escalation_payload, and end-to-end completion comment writing on terminal GitHub reconcile — good coverage of new orchestrator features. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/symphony/src/github/adapter.rs
Line: 776-786

Comment:
**Dead canonical lookup for multi-word phases**

`normalize_state_for_compare` strips all non-alphanumeric characters, producing `"inprogress"` from `"in-progress"`. `canonical_kata_phase_name("inprogress")` returns `None` because the key function normalises with spaces (`"in progress"`), so the early-return never fires for any multi-word phase ("In Progress", "Agent Review", "Human Review"). The generic titlecase fallback produces the correct output, but the canonical branch is unreachable for those cases.

```suggestion
fn denormalize_label_state(normalized: &str) -> String {
    if let Some(canonical) = canonical_kata_phase_name(normalized) {
        return canonical.to_string();
    }

    tracing::info!(
        event = "symphony_state_normalization_fallback",
        normalized_state = %normalized,
        "using generic label state denormalization for non-canonical state"
    );

    normalized
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/symphony/src/github/adapter.rs
Line: 75-88

Comment:
**WARN fires for valid non-Kata terminal states**

The `tracing::warn!` here fires for any state outside `KATA_PHASE_NAMES`, including common GitHub-only terminal states like `"Canceled"`, `"Cancelled"`, and `"Closed"`. The default test configuration (`terminal_states: ["Done", "Canceled"]`) already triggers this. Because `tracing::warn!` conventionally signals conditions worth operator attention, emitting it for an expected, working configuration may produce noise in production logs and dashboards. `tracing::info!` (matching the level used in `config.rs` for the same check) seems more appropriate here.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(symphony): KAT-2719 add github exec..."](https://github.com/gannonh/kata/commit/59322e93e30b7a2300bf3993c7d89977f698fc0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28715615)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically parses Kata identifiers from GitHub issue titles and parent issue references from issue bodies
  * Creates Symphony Execution Summary comments with execution metrics upon issue completion

* **Improvements**
  * Enhanced Kata phase state validation and normalization
  * Improved branch name generation with safer identifier sanitization
  * Enriched escalation payloads with issue context information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->