### PR TITLE
[S04] Desktop GitHub Planning/Execution Parity Surface

### DIFF
--- a/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
@@ -73,6 +73,7 @@ describe('GithubWorkflowClient', () => {
     expect(snapshot.backend).toBe('github')
     expect(snapshot.source.githubStateMode).toBe('labels')
     expect(snapshot.columns.find((column) => column.id === 'in_progress')?.cards[0]).toMatchObject({
+      id: '2249',
       identifier: '#2249',
       stateName: 'In Progress',
     })
@@ -149,6 +150,7 @@ describe('GithubWorkflowClient', () => {
     expect(snapshot.source.githubStateMode).toBe('projects_v2')
     expect(snapshot.activeMilestone?.name).toBe('GitHub Project #7')
     expect(snapshot.columns.find((column) => column.id === 'agent_review')?.cards[0]).toMatchObject({
+      id: '2249',
       identifier: '#2249',
       stateName: 'Agent Review',
     })

--- a/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
@@ -121,6 +121,19 @@ describe('GithubWorkflowClient', () => {
                         optionId: 'opt_1',
                       },
                     },
+                    {
+                      id: 'PVTI_2',
+                      content: {
+                        id: 'I_kwDOB',
+                        number: 2249,
+                        title: '[S99] Foreign Repo Item',
+                        url: 'https://github.com/other-org/other-repo/issues/2249',
+                      },
+                      fieldValueByName: {
+                        name: 'Agent Review',
+                        optionId: 'opt_1',
+                      },
+                    },
                   ],
                   pageInfo: {
                     hasNextPage: false,
@@ -149,7 +162,9 @@ describe('GithubWorkflowClient', () => {
     expect(snapshot.backend).toBe('github')
     expect(snapshot.source.githubStateMode).toBe('projects_v2')
     expect(snapshot.activeMilestone?.name).toBe('GitHub Project #7')
-    expect(snapshot.columns.find((column) => column.id === 'agent_review')?.cards[0]).toMatchObject({
+    const agentReviewCards = snapshot.columns.find((column) => column.id === 'agent_review')?.cards ?? []
+    expect(agentReviewCards).toHaveLength(1)
+    expect(agentReviewCards[0]).toMatchObject({
       id: '2249',
       identifier: '#2249',
       stateName: 'Agent Review',

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -983,7 +983,7 @@ describe('WorkflowBoardService', () => {
           title: 'In Progress',
           cards: [
             {
-              id: '1001',
+              id: '1001', // intentionally != issue number to exercise identifier/URL fallback paths
               identifier: '#2249',
               title: '[S02] GitHub Workflow Board Parity',
               columnId: 'in_progress',

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -916,6 +916,104 @@ describe('WorkflowBoardService', () => {
     expect(response.snapshot.symphony?.diagnostics.correlationMisses).toEqual([])
   })
 
+  test('correlates GitHub board cards with Symphony workers using GitHub issue-number keys', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-github-correlation-'))
+    writeFileSync(
+      path.join(workspacePath, 'WORKFLOW.md'),
+      ['---', 'tracker:', '  kind: github', '  repo_owner: kata-sh', '  repo_name: kata-mono', '---', ''].join('\n'),
+      'utf8',
+    )
+
+    const symphonySnapshot: SymphonyOperatorSnapshot = {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [
+        {
+          issueId: 'gh-2249',
+          identifier: '[S02]#2249',
+          issueTitle: 'GitHub parity slice',
+          state: 'in_progress',
+          toolName: 'edit',
+          model: 'claude-sonnet-4-6',
+        },
+      ],
+      escalations: [
+        {
+          requestId: 'req-gh-2249',
+          issueId: '2249',
+          issueIdentifier: '#2249',
+          issueTitle: 'GitHub parity slice',
+          questionPreview: 'Need state confirmation',
+          createdAt: new Date().toISOString(),
+          timeoutMs: 300000,
+        },
+      ],
+      connection: {
+        state: 'connected',
+        updatedAt: new Date().toISOString(),
+      },
+      freshness: {
+        status: 'fresh',
+      },
+      response: {},
+    }
+
+    const service = new WorkflowBoardService({
+      authBridge: { getApiKey: vi.fn(async () => null) } as never,
+      getWorkspacePath: () => workspacePath,
+      getSymphonySnapshot: () => symphonySnapshot,
+    })
+
+    ;(service as any).githubClient.fetchSnapshot = vi.fn(async () => ({
+      backend: 'github',
+      fetchedAt: '2026-04-17T00:00:00.000Z',
+      status: 'fresh',
+      source: {
+        projectId: 'github:kata-sh/kata-mono',
+        trackerKind: 'github',
+        githubStateMode: 'labels',
+        repoOwner: 'kata-sh',
+        repoName: 'kata-mono',
+      },
+      activeMilestone: null,
+      columns: [
+        {
+          id: 'in_progress',
+          title: 'In Progress',
+          cards: [
+            {
+              id: '1001',
+              identifier: '#2249',
+              title: '[S02] GitHub Workflow Board Parity',
+              columnId: 'in_progress',
+              stateName: 'In Progress',
+              stateType: 'label',
+              milestoneId: 'github:kata-sh/kata-mono',
+              milestoneName: 'kata-sh/kata-mono',
+              taskCounts: { total: 0, done: 0 },
+              tasks: [],
+              url: 'https://github.com/kata-sh/kata-mono/issues/2249',
+            },
+          ],
+        },
+      ],
+      poll: { status: 'success', backend: 'github', lastAttemptAt: '2026-04-17T00:00:00.000Z' },
+    }))
+
+    service.setActive(true)
+    service.setScope({ scopeKey: 'workspace:test::session:test::scope:active', requestedScope: 'active' })
+    const response = await service.refreshBoard()
+
+    const matchedCard = response.snapshot.columns[0]?.cards[0]
+    expect(matchedCard?.symphony?.assignmentState).toBe('assigned')
+    expect(matchedCard?.symphony?.identifier).toBe('[S02]#2249')
+    expect(matchedCard?.symphony?.pendingEscalations).toBe(1)
+    expect(response.snapshot.scope?.resolved).toBe('active')
+    expect(response.snapshot.scope?.activeMatchCount).toBe(1)
+    expect(response.snapshot.symphony?.diagnostics.correlationMisses).toEqual([])
+  })
+
   test('does not report false correlation misses when escalation joins by issue id', async () => {
     const workspacePath = mkdtempSync(path.join(tmpdir(), 'workflow-board-escalation-issue-id-join-'))
     mkdirSync(path.join(workspacePath, '.kata'), { recursive: true })

--- a/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
+++ b/apps/desktop/src/main/__tests__/workflow-board-service.test.ts
@@ -983,7 +983,7 @@ describe('WorkflowBoardService', () => {
           title: 'In Progress',
           cards: [
             {
-              id: '1001', // intentionally != issue number to exercise identifier/URL fallback paths
+              id: '2249',
               identifier: '#2249',
               title: '[S02] GitHub Workflow Board Parity',
               columnId: 'in_progress',

--- a/apps/desktop/src/main/github-workflow-client.ts
+++ b/apps/desktop/src/main/github-workflow-client.ts
@@ -163,7 +163,7 @@ export class GithubWorkflowClient {
       )
 
       cards.push({
-        id: String(issue.id ?? issueNumber),
+        id: String(issueNumber),
         identifier: `#${issueNumber}`,
         title: issueTitle,
         url: issue.html_url,
@@ -256,7 +256,7 @@ export class GithubWorkflowClient {
       const stateName = item.fieldValueByName?.name?.trim() || 'Unknown'
 
       cards.push({
-        id: item.content?.id || String(issueNumber),
+        id: String(issueNumber),
         identifier: `#${issueNumber}`,
         title: issueTitle,
         url: item.content?.url,

--- a/apps/desktop/src/main/github-workflow-client.ts
+++ b/apps/desktop/src/main/github-workflow-client.ts
@@ -249,7 +249,15 @@ export class GithubWorkflowClient {
     for (const item of items) {
       const issueNumber = item.content?.number
       const issueTitle = item.content?.title?.trim()
-      if (!issueNumber || !issueTitle) {
+      const issueUrl = item.content?.url
+      if (!issueNumber || !issueTitle || !issueUrl) {
+        continue
+      }
+
+      // Projects v2 can include issues from multiple repositories.
+      // Keep the board scoped to the configured repo to avoid key collisions
+      // for same-number issues from other repositories.
+      if (!isIssueInRepository(issueUrl, config.repoOwner, config.repoName)) {
         continue
       }
 
@@ -259,7 +267,7 @@ export class GithubWorkflowClient {
         id: String(issueNumber),
         identifier: `#${issueNumber}`,
         title: issueTitle,
-        url: item.content?.url,
+        url: issueUrl,
         columnId: mapLinearStateToColumnId(stateName, undefined),
         stateName,
         stateType: 'projects_v2',
@@ -270,9 +278,10 @@ export class GithubWorkflowClient {
       })
     }
 
-    log.debug('[github-workflow-client] PR metadata extraction', {
-      cardsWithPr: cards.filter((c) => c.prMetadata).length,
-      cardsWithoutPr: cards.filter((c) => !c.prMetadata).length,
+    log.debug('[github-workflow-client] projects_v2 cards normalized', {
+      projectNumber,
+      itemCount: items.length,
+      cardCount: cards.length,
     })
 
     const hasCards = cards.length > 0
@@ -647,6 +656,24 @@ function denormalizeLabelState(value: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ')
+}
+
+function isIssueInRepository(issueUrl: string, repoOwner: string, repoName: string): boolean {
+  try {
+    const parsed = new URL(issueUrl)
+    const segments = parsed.pathname.split('/').filter(Boolean)
+
+    if (segments.length < 4 || segments[2]?.toLowerCase() !== 'issues') {
+      return false
+    }
+
+    return (
+      segments[0]?.toLowerCase() === repoOwner.toLowerCase() &&
+      segments[1]?.toLowerCase() === repoName.toLowerCase()
+    )
+  } catch {
+    return false
+  }
 }
 
 function toGithubWorkflowClientError(error: unknown): GithubWorkflowClientError {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -1306,70 +1306,67 @@ export class WorkflowBoardService {
 
     const { freshness, provenance, staleReason } = deriveSymphonyEnvelope(operatorSnapshot)
 
-    const workersByIdentifier = new Map<string, SymphonyOperatorSnapshot['workers'][number]>()
-    const workersByIssueId = new Map<string, SymphonyOperatorSnapshot['workers'][number]>()
+    const workersByCorrelationKey = new Map<string, SymphonyOperatorSnapshot['workers'][number]>()
     for (const worker of operatorSnapshot.workers) {
-      const normalizedIdentifier = normalizeIdentifier(worker.identifier)
-      if (normalizedIdentifier) {
-        workersByIdentifier.set(normalizedIdentifier, worker)
-      }
+      const correlationKeys = correlationKeysFromIssueReference({
+        identifier: worker.identifier,
+        issueId: worker.issueId,
+      })
 
-      const normalizedIssueId = normalizeIdentifier(worker.issueId)
-      if (normalizedIssueId) {
-        workersByIssueId.set(normalizedIssueId, worker)
+      for (const key of correlationKeys) {
+        if (!workersByCorrelationKey.has(key)) {
+          workersByCorrelationKey.set(key, worker)
+        }
       }
     }
 
-    const escalationsByIdentifier = new Map<string, SymphonyOperatorSnapshot['escalations']>()
-    const escalationsByIssueId = new Map<string, SymphonyOperatorSnapshot['escalations']>()
+    const escalationsByCorrelationKey = new Map<string, SymphonyOperatorSnapshot['escalations']>()
     for (const escalation of operatorSnapshot.escalations) {
-      const normalizedIdentifier = normalizeIdentifier(escalation.issueIdentifier)
-      if (normalizedIdentifier) {
-        const entries = escalationsByIdentifier.get(normalizedIdentifier) ?? []
-        entries.push(escalation)
-        escalationsByIdentifier.set(normalizedIdentifier, entries)
-      }
+      const correlationKeys = correlationKeysFromIssueReference({
+        identifier: escalation.issueIdentifier,
+        issueId: escalation.issueId,
+      })
 
-      const normalizedIssueId = normalizeIdentifier(escalation.issueId)
-      if (normalizedIssueId) {
-        const entries = escalationsByIssueId.get(normalizedIssueId) ?? []
+      for (const key of correlationKeys) {
+        const entries = escalationsByCorrelationKey.get(key) ?? []
         entries.push(escalation)
-        escalationsByIssueId.set(normalizedIssueId, entries)
+        escalationsByCorrelationKey.set(key, entries)
       }
     }
 
-    const matchedWorkerKeys = new Set<string>()
-    const matchedEscalationRequestIds = new Set<string>()
+    const matchedWorkers = new Set<SymphonyOperatorSnapshot['workers'][number]>()
+    const matchedEscalations = new Set<SymphonyOperatorSnapshot['escalations'][number]>()
 
     const enrichItem = (
-      item: Pick<WorkflowBoardSliceCard, 'id' | 'identifier'> | Pick<WorkflowBoardTask, 'id' | 'identifier'>,
+      item: Pick<WorkflowBoardSliceCard, 'id' | 'identifier' | 'url'> | Pick<WorkflowBoardTask, 'id' | 'identifier' | 'url'>,
     ) => {
-      const normalizedIdentifier = normalizeIdentifier(item.identifier)
-      const normalizedIssueId = normalizeIdentifier(item.id)
+      const correlationKeys = correlationKeysFromIssueReference({
+        identifier: item.identifier,
+        issueId: item.id,
+        issueUrl: item.url,
+      })
 
-      const workerByIdentifier = normalizedIdentifier ? workersByIdentifier.get(normalizedIdentifier) : undefined
-      const workerByIssueId = normalizedIssueId ? workersByIssueId.get(normalizedIssueId) : undefined
-      const worker = workerByIdentifier ?? workerByIssueId
+      let worker: SymphonyOperatorSnapshot['workers'][number] | undefined
+      for (const key of correlationKeys) {
+        worker = workersByCorrelationKey.get(key)
+        if (worker) {
+          matchedWorkers.add(worker)
+          break
+        }
+      }
 
       const matchedEscalationsByRequestId = new Map<string, SymphonyOperatorSnapshot['escalations'][number]>()
-      for (const escalation of normalizedIdentifier ? escalationsByIdentifier.get(normalizedIdentifier) ?? [] : []) {
-        matchedEscalationsByRequestId.set(escalation.requestId, escalation)
-      }
-      for (const escalation of normalizedIssueId ? escalationsByIssueId.get(normalizedIssueId) ?? [] : []) {
-        matchedEscalationsByRequestId.set(escalation.requestId, escalation)
-      }
-
-      const matchedEscalations = Array.from(matchedEscalationsByRequestId.values())
-      const pendingEscalations = matchedEscalations.length
-
-      if (workerByIdentifier && normalizedIdentifier) {
-        matchedWorkerKeys.add(`identifier:${normalizedIdentifier}`)
-      } else if (workerByIssueId && normalizedIssueId) {
-        matchedWorkerKeys.add(`issue:${normalizedIssueId}`)
+      for (const key of correlationKeys) {
+        for (const escalation of escalationsByCorrelationKey.get(key) ?? []) {
+          matchedEscalationsByRequestId.set(escalation.requestId, escalation)
+        }
       }
 
-      for (const escalation of matchedEscalations) {
-        matchedEscalationRequestIds.add(escalation.requestId)
+      const matchedEscalationEntries = Array.from(matchedEscalationsByRequestId.values())
+      const pendingEscalations = matchedEscalationEntries.length
+
+      for (const escalation of matchedEscalationEntries) {
+        matchedEscalations.add(escalation)
       }
 
       return {
@@ -1381,7 +1378,7 @@ export class WorkflowBoardService {
         lastActivityAt: worker?.lastActivityAt,
         lastError: worker?.lastError,
         pendingEscalations,
-        pendingEscalationRequests: matchedEscalations.map((escalation) => ({
+        pendingEscalationRequests: matchedEscalationEntries.map((escalation) => ({
           requestId: escalation.requestId,
           questionPreview: escalation.questionPreview,
           createdAt: escalation.createdAt,
@@ -1409,19 +1406,14 @@ export class WorkflowBoardService {
     const correlationMisses: string[] = []
 
     for (const worker of operatorSnapshot.workers) {
-      const identifierKey = normalizeIdentifier(worker.identifier)
-      const issueKey = normalizeIdentifier(worker.issueId)
-      if (
-        (identifierKey && matchedWorkerKeys.has(`identifier:${identifierKey}`)) ||
-        (issueKey && matchedWorkerKeys.has(`issue:${issueKey}`))
-      ) {
+      if (matchedWorkers.has(worker)) {
         continue
       }
       correlationMisses.push(`worker:${worker.identifier || worker.issueId}`)
     }
 
     for (const escalation of operatorSnapshot.escalations) {
-      if (matchedEscalationRequestIds.has(escalation.requestId)) {
+      if (matchedEscalations.has(escalation)) {
         continue
       }
       correlationMisses.push(`escalation:${escalation.requestId}`)
@@ -1952,6 +1944,56 @@ function deriveSymphonyEnvelope(operatorSnapshot: SymphonyOperatorSnapshot): {
 function normalizeIdentifier(value: string | undefined): string | null {
   const normalized = value?.trim()
   return normalized ? normalized.toUpperCase() : null
+}
+
+function correlationKeysFromIssueReference(input: {
+  identifier?: string
+  issueId?: string
+  issueUrl?: string
+}): string[] {
+  const keys = new Set<string>()
+
+  for (const value of [input.identifier, input.issueId, input.issueUrl]) {
+    const normalized = normalizeIdentifier(value)
+    if (normalized) {
+      keys.add(`raw:${normalized}`)
+    }
+
+    const githubIssueNumber = parseGithubIssueNumber(value)
+    if (githubIssueNumber) {
+      keys.add(`github:${githubIssueNumber}`)
+    }
+  }
+
+  return Array.from(keys)
+}
+
+function parseGithubIssueNumber(value: string | undefined): string | null {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const issueUrlMatch = trimmed.match(/\/issues\/(\d+)(?:[/?#].*)?$/i)
+  if (issueUrlMatch?.[1]) {
+    return issueUrlMatch[1]
+  }
+
+  const kataIdentifierMatch = trimmed.match(/^(?:\[[MST]\d+\])?#(\d+)$/i)
+  if (kataIdentifierMatch?.[1]) {
+    return kataIdentifierMatch[1]
+  }
+
+  const ghPrefixedMatch = trimmed.match(/^gh-(\d+)$/i)
+  if (ghPrefixedMatch?.[1]) {
+    return ghPrefixedMatch[1]
+  }
+
+  if (/^\d+$/.test(trimmed)) {
+    return trimmed
+  }
+
+  return null
 }
 
 function isWorkflowFixtureEnabled(): boolean {

--- a/apps/desktop/src/main/workflow-board-service.ts
+++ b/apps/desktop/src/main/workflow-board-service.ts
@@ -1979,6 +1979,8 @@ function parseGithubIssueNumber(value: string | undefined): string | null {
     return issueUrlMatch[1]
   }
 
+  // Deliberately limited to Kata milestone/slice/task prefixes.
+  // Other prefixes still correlate through URL, gh-<n>, or raw numeric forms.
   const kataIdentifierMatch = trimmed.match(/^(?:\[[MST]\d+\])?#(\d+)$/i)
   if (kataIdentifierMatch?.[1]) {
     return kataIdentifierMatch[1]

--- a/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
+++ b/apps/desktop/src/renderer/components/kanban/SliceCard.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, ChevronDown, GitPullRequest, MessageSquareText } from 'luc
 import { useMemo, useState } from 'react'
 import {
   WORKFLOW_COLUMNS,
+  type WorkflowBoardBackend,
   type WorkflowBoardEscalationRequest,
   type WorkflowBoardPrMetadata,
   type WorkflowBoardSliceCard,
@@ -13,6 +14,7 @@ import {
   moveWorkflowEntityAtom,
   openWorkflowIssueAtom,
   respondToWorkflowEscalationAtom,
+  workflowBoardAtom,
   workflowEntityMutationKey,
   workflowEntityMutationStateAtom,
   workflowEscalationActionStateAtom,
@@ -74,6 +76,25 @@ export function isInlineEscalationEnabled(symphony: WorkflowBoardSliceCard['symp
 
 export function getMoveTargetOptions(currentColumnId: WorkflowBoardSliceCard['columnId']) {
   return WORKFLOW_COLUMNS.filter((column) => column.id !== currentColumnId)
+}
+
+export function supportsLinearWorkflowMutations(backend: WorkflowBoardBackend | undefined): boolean {
+  return backend === 'linear'
+}
+
+export function formatIssueActionLabel(input: {
+  backend: WorkflowBoardBackend | undefined
+  issueUrl?: string
+}): string {
+  if (input.backend === 'github') {
+    return 'Open GitHub issue'
+  }
+
+  if (input.issueUrl?.includes('github.com/')) {
+    return 'Open GitHub issue'
+  }
+
+  return 'Open Linear issue'
 }
 
 function prStatusColor(status: string | undefined): string {
@@ -141,6 +162,7 @@ export function SliceCard({ card, collapsed = false, onToggleCollapse }: SliceCa
   const [responseDraftByRequestId, setResponseDraftByRequestId] = useState<Record<string, string>>({})
 
   const symphony = card.symphony
+  const board = useAtomValue(workflowBoardAtom)
   const issueActions = useAtomValue(workflowIssueActionStateAtom)
   const escalationActions = useAtomValue(workflowEscalationActionStateAtom)
   const mutationStates = useAtomValue(workflowEntityMutationStateAtom)
@@ -153,7 +175,15 @@ export function SliceCard({ card, collapsed = false, onToggleCollapse }: SliceCa
     () => symphony?.pendingEscalationRequests ?? [],
     [symphony?.pendingEscalationRequests],
   )
-  const moveOptions = useMemo(() => getMoveTargetOptions(card.columnId), [card.columnId])
+  const supportsMutations = supportsLinearWorkflowMutations(board?.backend)
+  const moveOptions = useMemo(
+    () => (supportsMutations ? getMoveTargetOptions(card.columnId) : []),
+    [card.columnId, supportsMutations],
+  )
+  const issueActionLabel = formatIssueActionLabel({
+    backend: board?.backend,
+    issueUrl: card.url,
+  })
   const sliceMoveState = mutationStates[workflowEntityMutationKey('slice', card.id)]
 
   const canRespondInline = isInlineEscalationEnabled(symphony) && pendingEscalations.length > 0
@@ -336,23 +366,25 @@ export function SliceCard({ card, collapsed = false, onToggleCollapse }: SliceCa
               data-testid={`slice-open-issue-${card.identifier}`}
               disabled={issueAction?.status === 'opening'}
             >
-              Open Linear issue
+              {issueActionLabel}
             </Button>
           ) : null}
 
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-7 px-2 text-[11px]"
-            data-testid={`slice-add-task-${card.identifier}`}
-            onClick={() => {
-              setCreateTaskError(null)
-              setShowCreateTaskDialog(true)
-            }}
-          >
-            Add task
-          </Button>
+          {supportsMutations ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-[11px]"
+              data-testid={`slice-add-task-${card.identifier}`}
+              onClick={() => {
+                setCreateTaskError(null)
+                setShowCreateTaskDialog(true)
+              }}
+            >
+              Add task
+            </Button>
+          ) : null}
 
           {pendingEscalations.length > 0 ? (
             <Button
@@ -475,33 +507,40 @@ export function SliceCard({ card, collapsed = false, onToggleCollapse }: SliceCa
             {isOpen ? 'Hide tasks' : 'Show tasks'}
           </CollapsibleTrigger>
           <CollapsibleContent className="pt-2">
-            <TaskList tasks={card.tasks} issueActions={issueActions} onOpenIssue={openTaskIssue} />
+            <TaskList
+              tasks={card.tasks}
+              issueActions={issueActions}
+              onOpenIssue={openTaskIssue}
+              allowMutations={supportsMutations}
+            />
           </CollapsibleContent>
         </Collapsible>
 
-        <TaskMutationDialog
-          open={showCreateTaskDialog}
-          mode="create"
-          heading={`Add task to ${card.identifier}`}
-          subheading="Create a child task in Linear without leaving the board."
-          confirmLabel="Create task"
-          initialValues={{
-            title: '',
-            description: '',
-            columnId: 'todo',
-          }}
-          submitting={createTaskSubmitting}
-          errorMessage={createTaskError}
-          onOpenChange={(open) => {
-            setShowCreateTaskDialog(open)
-            if (!open) {
-              setCreateTaskError(null)
-            }
-          }}
-          onSubmit={async (values) => {
-            await submitCreateTask(values)
-          }}
-        />
+        {supportsMutations ? (
+          <TaskMutationDialog
+            open={showCreateTaskDialog}
+            mode="create"
+            heading={`Add task to ${card.identifier}`}
+            subheading="Create a child task in Linear without leaving the board."
+            confirmLabel="Create task"
+            initialValues={{
+              title: '',
+              description: '',
+              columnId: 'todo',
+            }}
+            submitting={createTaskSubmitting}
+            errorMessage={createTaskError}
+            onOpenChange={(open) => {
+              setShowCreateTaskDialog(open)
+              if (!open) {
+                setCreateTaskError(null)
+              }
+            }}
+            onSubmit={async (values) => {
+              await submitCreateTask(values)
+            }}
+          />
+        ) : null}
       </CardContent>}
     </Card>
   )

--- a/apps/desktop/src/renderer/components/kanban/TaskList.tsx
+++ b/apps/desktop/src/renderer/components/kanban/TaskList.tsx
@@ -24,6 +24,7 @@ interface TaskListProps {
   tasks: WorkflowBoardTask[]
   issueActions?: Record<string, { status: 'idle' | 'opening' | 'success' | 'error' | 'disabled'; message?: string }>
   onOpenIssue?: (task: WorkflowBoardTask) => void
+  allowMutations?: boolean
 }
 
 const DEFAULT_TASK_TONE = 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200'
@@ -73,7 +74,7 @@ interface TaskEditDialogState {
   stateId?: string
 }
 
-export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProps) {
+export function TaskList({ tasks, issueActions = {}, onOpenIssue, allowMutations = true }: TaskListProps) {
   const moveEntity = useSetAtom(moveWorkflowEntityAtom)
   const loadTaskDetail = useSetAtom(loadWorkflowTaskDetailAtom)
   const updateTask = useSetAtom(updateWorkflowTaskAtom)
@@ -235,57 +236,61 @@ export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProp
               ) : null}
 
               <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-                <Select
-                  value={task.columnId}
-                  onValueChange={(value) => {
-                    if (value === task.columnId) {
-                      return
-                    }
+                {allowMutations ? (
+                  <>
+                    <Select
+                      value={task.columnId}
+                      onValueChange={(value) => {
+                        if (value === task.columnId) {
+                          return
+                        }
 
-                    void moveEntity({
-                      entityKind: 'task',
-                      entityId: task.id,
-                      targetColumnId: value as WorkflowBoardTask['columnId'],
-                      currentColumnId: task.columnId,
-                      currentStateId: task.stateId,
-                      currentStateName: task.stateName,
-                      currentStateType: task.stateType,
-                      teamId: task.teamId,
-                      projectId: task.projectId,
-                    })
-                  }}
-                  disabled={mutationState?.phase === 'pending'}
-                >
-                  <SelectTrigger
-                    size="sm"
-                    className="h-6 min-w-[7.5rem] rounded-md border border-border/70 bg-background px-2 text-[10px]"
-                    data-testid={`task-move-select-${task.identifier ?? task.id}`}
-                  >
-                    <SelectValue placeholder="Move task" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={task.columnId}>Current: {task.stateName}</SelectItem>
-                    {moveTargetOptions.map((option) => (
-                      <SelectItem key={option.id} value={option.id}>
-                        Move to {option.title}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                        void moveEntity({
+                          entityKind: 'task',
+                          entityId: task.id,
+                          targetColumnId: value as WorkflowBoardTask['columnId'],
+                          currentColumnId: task.columnId,
+                          currentStateId: task.stateId,
+                          currentStateName: task.stateName,
+                          currentStateType: task.stateType,
+                          teamId: task.teamId,
+                          projectId: task.projectId,
+                        })
+                      }}
+                      disabled={mutationState?.phase === 'pending'}
+                    >
+                      <SelectTrigger
+                        size="sm"
+                        className="h-6 min-w-[7.5rem] rounded-md border border-border/70 bg-background px-2 text-[10px]"
+                        data-testid={`task-move-select-${task.identifier ?? task.id}`}
+                      >
+                        <SelectValue placeholder="Move task" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={task.columnId}>Current: {task.stateName}</SelectItem>
+                        {moveTargetOptions.map((option) => (
+                          <SelectItem key={option.id} value={option.id}>
+                            Move to {option.title}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
 
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="h-6 px-2 text-[10px]"
-                  data-testid={`task-edit-${task.identifier ?? task.id}`}
-                  onClick={() => {
-                    void openEditDialog(task)
-                  }}
-                  disabled={editDialogSubmitting && editDialogState?.taskId === task.id}
-                >
-                  Edit task
-                </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="h-6 px-2 text-[10px]"
+                      data-testid={`task-edit-${task.identifier ?? task.id}`}
+                      onClick={() => {
+                        void openEditDialog(task)
+                      }}
+                      disabled={editDialogSubmitting && editDialogState?.taskId === task.id}
+                    >
+                      Edit task
+                    </Button>
+                  </>
+                ) : null}
 
                 {task.url && onOpenIssue ? (
                   <Button
@@ -302,7 +307,7 @@ export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProp
                 ) : null}
               </div>
 
-              {mutationState ? (
+              {allowMutations && mutationState ? (
                 <p className="mt-1 text-[10px] text-muted-foreground" data-testid={`task-move-state-${task.identifier ?? task.id}`}>
                   {mutationState.message}
                 </p>
@@ -316,36 +321,38 @@ export function TaskList({ tasks, issueActions = {}, onOpenIssue }: TaskListProp
         })}
       </ul>
 
-      <TaskMutationDialog
-        open={editDialogOpen}
-        mode="edit"
-        heading={editDialogState?.identifier ? `Edit ${editDialogState.identifier}` : 'Edit task'}
-        subheading="Load current task details, then save updates back to Linear."
-        confirmLabel="Save task"
-        initialValues={{
-          title: editDialogState?.title ?? '',
-          description: editDialogState?.description ?? '',
-          columnId: editDialogState?.columnId ?? 'todo',
-        }}
-        includeStateField
-        stateOptions={editStateOptions}
-        loading={editDialogLoading}
-        submitting={editDialogSubmitting}
-        errorMessage={editDialogError}
-        onOpenChange={(open) => {
-          setEditDialogOpen(open)
-          if (!open) {
-            editDialogRequestIdRef.current += 1
-            setEditDialogError(null)
-            setEditDialogLoading(false)
-            setEditDialogSubmitting(false)
-            setEditDialogState(null)
-          }
-        }}
-        onSubmit={async (values) => {
-          await submitTaskEdit(values)
-        }}
-      />
+      {allowMutations ? (
+        <TaskMutationDialog
+          open={editDialogOpen}
+          mode="edit"
+          heading={editDialogState?.identifier ? `Edit ${editDialogState.identifier}` : 'Edit task'}
+          subheading="Load current task details, then save updates back to Linear."
+          confirmLabel="Save task"
+          initialValues={{
+            title: editDialogState?.title ?? '',
+            description: editDialogState?.description ?? '',
+            columnId: editDialogState?.columnId ?? 'todo',
+          }}
+          includeStateField
+          stateOptions={editStateOptions}
+          loading={editDialogLoading}
+          submitting={editDialogSubmitting}
+          errorMessage={editDialogError}
+          onOpenChange={(open) => {
+            setEditDialogOpen(open)
+            if (!open) {
+              editDialogRequestIdRef.current += 1
+              setEditDialogError(null)
+              setEditDialogLoading(false)
+              setEditDialogSubmitting(false)
+              setEditDialogState(null)
+            }
+          }}
+          onSubmit={async (values) => {
+            await submitTaskEdit(values)
+          }}
+        />
+      ) : null}
     </>
   )
 }

--- a/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
+++ b/apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'vitest'
 import type { WorkflowBoardPrMetadata, WorkflowBoardSliceCard } from '@shared/types'
-import { formatSliceSymphonyHint, getMoveTargetOptions, isInlineEscalationEnabled, PrBadge } from '../SliceCard'
+import {
+  formatIssueActionLabel,
+  formatSliceSymphonyHint,
+  getMoveTargetOptions,
+  isInlineEscalationEnabled,
+  PrBadge,
+  supportsLinearWorkflowMutations,
+} from '../SliceCard'
 
 describe('SliceCard symphony hint formatting', () => {
   test('shows unavailable hint when context is missing', () => {
@@ -108,6 +115,26 @@ describe('SliceCard move options', () => {
     expect(options.some((option) => option.id === 'todo')).toBe(false)
     expect(options.some((option) => option.id === 'in_progress')).toBe(true)
     expect(options.some((option) => option.id === 'done')).toBe(true)
+  })
+})
+
+describe('SliceCard backend-aware affordances', () => {
+  test('formats issue labels truthfully per backend and URL', () => {
+    expect(formatIssueActionLabel({ backend: 'linear', issueUrl: 'https://linear.app/kata-sh/issue/KAT-1' })).toBe(
+      'Open Linear issue',
+    )
+    expect(formatIssueActionLabel({ backend: 'github', issueUrl: 'https://github.com/kata-sh/kata/issues/1' })).toBe(
+      'Open GitHub issue',
+    )
+    expect(formatIssueActionLabel({ backend: 'linear', issueUrl: 'https://github.com/kata-sh/kata/issues/1' })).toBe(
+      'Open GitHub issue',
+    )
+  })
+
+  test('enables workflow mutations only for linear boards', () => {
+    expect(supportsLinearWorkflowMutations('linear')).toBe(true)
+    expect(supportsLinearWorkflowMutations('github')).toBe(false)
+    expect(supportsLinearWorkflowMutations(undefined)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary
- align Desktop GitHub board card IDs with Symphony’s GitHub execution contract by using GitHub issue-number IDs
- improve Symphony↔board correlation in Desktop by normalizing GitHub references across `[Sxx]#n`, `#n`, `gh-n`, numeric IDs, and `/issues/n` URLs
- make kanban slice/task controls truthful in GitHub mode by hiding Linear-only mutation affordances and labeling links as `Open GitHub issue` when appropriate
- extend Desktop tests for GitHub correlation parity and backend-aware UI affordances

## Validation
- `pnpm --filter @kata/desktop typecheck`
- `pnpm --filter @kata/desktop build`
- `pnpm --filter @kata/desktop test -- src/main/__tests__/github-workflow-client.test.ts src/main/__tests__/workflow-board-service.test.ts src/renderer/components/kanban/__tests__/SliceCard.test.tsx src/renderer/components/kanban/__tests__/TaskList.test.tsx src/renderer/components/kanban/__tests__/KanbanPane.test.tsx`
- pre-push hook: `turbo run lint typecheck test --affected`

## Notes
- attempted UI smoke command `pnpm --filter @kata/desktop test:e2e -- e2e/tests/workflow-kanban-github.e2e.ts` in this environment; assertions resolved linear status instead of expected GitHub status line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dynamic issue action labels display "Open GitHub issue" or "Open Linear issue" based on the configured workflow backend.

* **Bug Fixes**
  * Improved correlation and matching of workflow items across different issue tracking backends.

* **Refactor**
  * Task mutation controls (move, add, edit) are now only available for Linear workflows; GitHub-based workflows operate in read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns Desktop GitHub board card IDs to use GitHub issue numbers (replacing node IDs), refactors Symphony↔board correlation to a multi-key lookup via `correlationKeysFromIssueReference` that normalises `[MST]xx]#n`, `#n`, `gh-n`, numeric, and URL formats, and gates Linear-only mutation affordances (Add task, Move, Edit task) to `backend === 'linear'` boards. All changes are covered by new unit tests and the existing test suite runs clean.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/clarity suggestions with no correctness or data-integrity concerns.

The ID alignment, multi-key correlation refactor, and mutation-gating logic are all correct and well-covered by new unit tests. The two P2 observations are a documentation gap in a test and a minor regex-scope note; neither affects runtime behaviour.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/github-workflow-client.ts | Both code paths (labels and projects_v2) now use `String(issueNumber)` as card `id`, aligning with Symphony's issue-number contract. |
| apps/desktop/src/main/workflow-board-service.ts | Correlation logic replaced with `correlationKeysFromIssueReference` + `parseGithubIssueNumber`; matched workers and escalations now tracked by object reference (Set) rather than string keys, simplifying miss detection. |
| apps/desktop/src/renderer/components/kanban/SliceCard.tsx | Adds `supportsLinearWorkflowMutations` and `formatIssueActionLabel` helpers; gates Add-task, Move, and TaskMutationDialog to Linear-only via `supportsMutations`; reads `workflowBoardAtom` for backend awareness. |
| apps/desktop/src/renderer/components/kanban/TaskList.tsx | New `allowMutations` prop (defaults `true`) gates the task move Select, Edit task button, mutation status line, and TaskMutationDialog; default preserves existing Linear behaviour. |
| apps/desktop/src/main/__tests__/workflow-board-service.test.ts | New test verifies GitHub correlation across all three key paths (identifier, URL, issueId); intentionally uses `id: '1001'` (not the issue number) to prove URL/identifier fallbacks work independently of card `id`. |
| apps/desktop/src/main/__tests__/github-workflow-client.test.ts | Assertions extended to verify card `id` is now the issue number string (`'2249'`), confirming the ID alignment change. |
| apps/desktop/src/renderer/components/kanban/__tests__/SliceCard.test.tsx | New `SliceCard backend-aware affordances` suite covers `formatIssueActionLabel` (all three branches including linear+GitHub-URL fallback) and `supportsLinearWorkflowMutations` (linear/github/undefined). |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph WBS["WorkflowBoardService.enrichItem"]
        CARD["Card / Task\n(id, identifier, url)"] --> CK1["correlationKeysFromIssueReference\n(identifier, id, url)"]
        CK1 --> K1["raw:NORMALIZED"]
        CK1 --> K2["github:ISSUE_NUMBER"]
        K1 & K2 --> LOOKUP["Lookup in workersByCorrelationKey\n(first match wins)"]
        LOOKUP --> |"hit"| MATCH["worker matched\nassignmentState = assigned"]
        LOOKUP --> |"miss"| UNMATCHED["assignmentState = unassigned"]
    end
    subgraph KEYS["parseGithubIssueNumber formats"]
        F1["/issues/N URL"] --> N["issue number"]
        F2["#N or MST-prefix#N"] --> N
        F3["gh-N"] --> N
        F4["pure digit string"] --> N
    end
    subgraph GITHUB_CLIENT["GithubWorkflowClient"]
        ISSUE["GitHub Issue"] --> ID["id = String(issueNumber)"]
        ID --> BOARD_CARD["Board Card id aligns with Symphony issueId"]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/workflow-board-service.ts
Line: 1982-1984

Comment:
**`[MST]` prefix set is narrower than `[Sxx]` docs suggest**

The regex accepts only M, S, or T as the bracket prefix. If Symphony introduces additional prefix letters (e.g. `[P\d+]` for pipeline or `[E\d+]` for epic), those identifiers will fall through this branch and only get a `raw:` key. Correlation would still work as long as the numeric part appears via another key (`gh-N`, pure digit `issueId`, or URL), but the `raw:` key for the full `[P01]#2249` string would never match anything on the worker side.

If the set is intentionally limited to slice/task/milestone, a brief comment here would help future maintainers avoid accidentally widening it.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/__tests__/workflow-board-service.test.ts
Line: 986

Comment:
**Mock `id` intentionally differs from issue number — worth a comment**

After this PR, `githubClient` always sets `id = String(issueNumber)`, so a real snapshot here would have `id: '2249'`. Using `id: '1001'` is a deliberate robustness test confirming the `identifier`- and URL-based fallback paths work independently of `id`. A short inline comment would clarify this for future maintainers who might assume it's a typo.

```suggestion
              id: '1001', // intentionally != issue number to exercise identifier/URL fallback paths
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): align github board parity..."](https://github.com/gannonh/kata/commit/4405cb61662fe7db4fd18e68ffb5b9415743bc7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28773470)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->