### PR TITLE
KAT-2707: add CI GitHub backend validation lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,12 +120,53 @@ jobs:
           path: apps/symphony/coverage/
           retention-days: 30
 
+  github-backend-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/symphony/target
+          key: ${{ runner.os }}-cargo-github-backend-${{ hashFiles('apps/symphony/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-github-backend-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run GitHub backend validation lane
+        run: bash scripts/ci/github-backend-validation.sh
+
   # Legacy desktop e2e-mocked job removed — apps/desktop is the only active desktop target.
   # Desktop unit tests run via Turborepo in the validate job (npx vitest run --coverage).
   # Desktop e2e tests will be added in a future milestone.
 
   gate:
-    needs: [validate, symphony-coverage]
+    needs: [validate, symphony-coverage, github-backend-validation]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -133,9 +174,11 @@ jobs:
         run: |
           echo "validate: ${{ needs.validate.result }}"
           echo "symphony-coverage: ${{ needs.symphony-coverage.result }}"
+          echo "github-backend-validation: ${{ needs.github-backend-validation.result }}"
 
           if [[ "${{ needs.validate.result }}" == "failure" || \
-                "${{ needs.symphony-coverage.result }}" == "failure" ]]; then
+                "${{ needs.symphony-coverage.result }}" == "failure" || \
+                "${{ needs.github-backend-validation.result }}" == "failure" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/scripts/ci/github-backend-validation.sh
+++ b/scripts/ci/github-backend-validation.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+run_segment() {
+  local segment="$1"
+  shift
+
+  echo "::group::${segment}"
+  if "$@"; then
+    echo "✅ ${segment} passed"
+    echo "::endgroup::"
+    return 0
+  else
+    local exit_code=$?
+    echo "::error title=GitHub backend validation failed::${segment} failed (exit ${exit_code})."
+    echo "::error::Review the grouped output above to see the exact backend contract that regressed."
+    echo "::endgroup::"
+    return "$exit_code"
+  fi
+}
+
+echo "Running deterministic GitHub backend validation lane"
+echo "Negative-path signal checks included in this lane:"
+echo "- CLI: missing token + timeout diagnostics (github-backend.integration.test.ts)"
+echo "- Desktop: structured GitHub HTTP/GraphQL error mapping (github-workflow-client.test.ts)"
+echo "- Symphony: unknown Project v2 status actionable error (github_execution_contract_tests.rs)"
+
+run_segment \
+  "CLI GitHub backend contract suites (Vitest)" \
+  pnpm --dir apps/cli exec vitest run \
+  src/resources/extensions/kata/tests/github-planning-contract.vitest.test.ts \
+  src/resources/extensions/kata/tests/github-config.integration.vitest.test.ts \
+  src/resources/extensions/kata/tests/github-planning.integration.vitest.test.ts \
+  src/resources/extensions/kata/tests/github-backend.artifacts.vitest.test.ts \
+  src/resources/extensions/kata/tests/github-artifacts.vitest.test.ts \
+  src/resources/extensions/kata/tests/github-dependency-materialization.vitest.test.ts \
+  src/resources/extensions/kata/tests/github-backend-plan-prompt.vitest.test.ts
+
+run_segment \
+  "CLI GitHub backend integration harness (bun test)" \
+  pnpm --dir apps/cli exec bun test \
+  src/resources/extensions/kata/tests/github-config.test.ts \
+  src/resources/extensions/kata/tests/github-state.test.ts \
+  src/resources/extensions/kata/tests/github-backend.integration.test.ts
+
+run_segment \
+  "Desktop GitHub workflow backend contracts (Vitest)" \
+  pnpm --dir apps/desktop exec vitest run \
+  src/main/__tests__/github-workflow-client.test.ts \
+  src/main/__tests__/workflow-board-service.test.ts
+
+run_segment \
+  "Symphony GitHub backend execution contracts (cargo test)" \
+  pnpm --dir apps/symphony exec cargo test \
+  --test github_adapter_tests \
+  --test github_execution_contract_tests
+
+echo "GitHub backend validation lane completed successfully."


### PR DESCRIPTION
## Summary
- add a dedicated `github-backend-validation` job to `.github/workflows/ci.yml`
- add `scripts/ci/github-backend-validation.sh` to run deterministic CLI/Desktop/Symphony GitHub backend contract + integration suites
- wire CI gate job to fail when the new GitHub backend lane fails

## Validation
- `bash scripts/ci/github-backend-validation.sh`
- `pnpm exec turbo run lint typecheck test --affected`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a dedicated `github-backend-validation` CI job that runs deterministic GitHub backend contract tests across CLI (Vitest + bun test), Desktop (Vitest), and Symphony (cargo test), then wires it into the existing `gate` aggregator job. The shell script is well-structured with `set -euo pipefail`, GitHub Actions log groups, and structured `::error` annotations.

- The gate condition checks for `\"failure\"` but not `\"cancelled\"` — if the new job is cancelled by the `cancel-in-progress: true` concurrency group, the gate still passes. This pre-existing gap is now extended to the new lane whose explicit goal is to block bad merges.
- The new job omits the `Rebuild native addons` step present in the `validate` job; likely harmless for these tests, but worth confirming or documenting.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the cancelled-state gap noted — low practical risk, but easy to fix before landing.

All inline findings are P2. The gate cancellation gap is a pre-existing pattern extended to the new lane; it doesn't break normal CI but does weaken the stated guarantee. The script itself is clean and correct.

.github/workflows/ci.yml — gate condition and missing native-addon rebuild step.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds github-backend-validation job (Node/Bun/Rust setup, runs the shell script) and wires it into the gate; gate inherits the pre-existing cancelled-state gap now extended to the new lane. |
| scripts/ci/github-backend-validation.sh | Clean, self-contained script with proper set -euo pipefail, GitHub Actions log grouping, and structured error annotations. Runs four deterministic test segments across CLI (Vitest + bun), Desktop (Vitest), and Symphony (cargo). |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR([Pull Request]) --> validate
    PR --> symphony-coverage
    PR --> github-backend-validation

    subgraph github-backend-validation["github-backend-validation (NEW)"]
        A1[Checkout + Setup Node/Bun/pnpm/Rust]
        A1 --> A2[pnpm install]
        A2 --> A3[bash scripts/ci/github-backend-validation.sh]
        A3 --> A4[CLI Vitest: 7 github-*.vitest tests]
        A3 --> A5[CLI bun: 3 github-*.test.ts tests]
        A3 --> A6[Desktop Vitest: 2 github-workflow tests]
        A3 --> A7[Symphony cargo test: 2 integration suites]
    end

    subgraph validate["validate (existing)"]
        B1[Checkout + Setup Node/Bun/pnpm/Rust]
        B1 --> B2[Install ripgrep + pnpm install]
        B2 --> B3[Rebuild native addons]
        B3 --> B4[turbo run lint typecheck test --affected]
    end

    subgraph gate["gate"]
        C1{validate == failure?}
        C2{symphony-coverage == failure?}
        C3{github-backend-validation == failure?}
        C1 -- No --> C2
        C2 -- No --> C3
        C3 -- No --> PASS([✅ All passed])
        C1 -- Yes --> FAIL([❌ Exit 1])
        C2 -- Yes --> FAIL
        C3 -- Yes --> FAIL
    end

    validate --> gate
    symphony-coverage --> gate
    github-backend-validation --> gate
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 179-184

Comment:
**Gate silently passes on `cancelled` result**

The gate only tests for `"failure"`, so if `github-backend-validation` is cancelled mid-run (e.g., by the top-level `cancel-in-progress: true` concurrency group), the gate still exits 0 and reports "All jobs passed or were skipped." This was already the case for `validate` and `symphony-coverage`, but the PR's stated goal is to make the gate fail when the new lane fails — a cancelled run is a failure mode worth catching.

```suggestion
          if [[ "${{ needs.validate.result }}" == "failure" || \
                "${{ needs.validate.result }}" == "cancelled" || \
                "${{ needs.symphony-coverage.result }}" == "failure" || \
                "${{ needs.symphony-coverage.result }}" == "cancelled" || \
                "${{ needs.github-backend-validation.result }}" == "failure" || \
                "${{ needs.github-backend-validation.result }}" == "cancelled" ]]; then
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 123-162

Comment:
**Missing `Rebuild native addons` step**

The `validate` job includes a `Rebuild native addons` step (`pnpm --dir apps/context rebuild better-sqlite3 tree-sitter`) that is absent here. The listed tests are all GitHub-backend focused and likely don't touch `apps/context` directly, but if any transitive import pulls in better-sqlite3 on a fresh Ubuntu runner the tests would fail with a native binding error. Worth adding as a defensive measure, or at minimum adding a comment that these tests have no context-package dependency.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add deterministic github backend val..."](https://github.com/gannonh/kata/commit/9858f561e8007592079ab25e46b722895e842686) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28777181)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->