### PR TITLE
feat(desktop): add slash command + skill discovery substrate

### DIFF
--- a/apps/desktop/src/main/__tests__/command-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/command-registry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest'
+import { listBuiltinCommands } from '../command-registry'
+
+describe('command-registry', () => {
+  test('listBuiltinCommands returns the expected command names', () => {
+    const commands = listBuiltinCommands()
+
+    expect(commands.map((entry) => entry.name)).toEqual([
+      'kata',
+      'symphony',
+      'gh',
+      'bg',
+      'mcp',
+      'create-extension',
+      'create-slash-command',
+      'audit',
+      'subagent',
+      'skill',
+    ])
+  })
+
+  test('listBuiltinCommands returns entries with required shape and builtin category', () => {
+    const commands = listBuiltinCommands()
+
+    expect(commands).toHaveLength(10)
+
+    for (const command of commands) {
+      expect(command).toMatchObject({
+        name: expect.any(String),
+        category: 'builtin',
+      })
+    }
+  })
+
+  test('listBuiltinCommands returns a defensive copy', () => {
+    const first = listBuiltinCommands()
+    const second = listBuiltinCommands()
+
+    first[0]!.name = 'mutated'
+
+    expect(second[0]?.name).toBe('kata')
+  })
+})

--- a/apps/desktop/src/main/__tests__/skill-scanner.test.ts
+++ b/apps/desktop/src/main/__tests__/skill-scanner.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('../logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import {
+  clearSkillCache,
+  getCachedSkills,
+  parseSkillFrontmatter,
+  refreshSkillCache,
+  scanAllSkillDirectories,
+  scanSkillDirectory,
+} from '../skill-scanner'
+
+async function writeSkill(baseDir: string, skillName: string, frontmatter?: string): Promise<void> {
+  const skillDir = path.join(baseDir, skillName)
+  await fs.mkdir(skillDir, { recursive: true })
+
+  const body =
+    frontmatter ??
+    `---\nname: ${skillName}\ndescription: ${skillName} description\n---\n\n# ${skillName}\n`
+
+  await fs.writeFile(path.join(skillDir, 'SKILL.md'), body, 'utf8')
+}
+
+describe('skill-scanner', () => {
+  let testRoot: string
+  let fakeHome: string
+  let fakeWorkspace: string
+
+  beforeEach(async () => {
+    clearSkillCache()
+    testRoot = mkdtempSync(path.join(tmpdir(), 'kata-desktop-skill-scanner-'))
+    fakeHome = path.join(testRoot, 'home')
+    fakeWorkspace = path.join(testRoot, 'workspace')
+
+    await fs.mkdir(fakeHome, { recursive: true })
+    await fs.mkdir(fakeWorkspace, { recursive: true })
+    await fs.mkdir(path.join(fakeHome, 'Library', 'Logs', '@kata', 'desktop'), {
+      recursive: true,
+    })
+
+    vi.spyOn(os, 'homedir').mockReturnValue(fakeHome)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    clearSkillCache()
+    rmSync(testRoot, { recursive: true, force: true })
+  })
+
+  test('parseSkillFrontmatter extracts name and description', () => {
+    const parsed = parseSkillFrontmatter(
+      ['---', 'name: debug-like-expert', 'description: Deep investigation mode', '---'].join('\n'),
+    )
+
+    expect(parsed).toEqual({
+      name: 'debug-like-expert',
+      description: 'Deep investigation mode',
+    })
+  })
+
+  test('parseSkillFrontmatter handles missing fields and malformed input', () => {
+    expect(parseSkillFrontmatter('not-frontmatter')).toEqual({})
+    expect(parseSkillFrontmatter(['---', 'name: skill-only', '---'].join('\n'))).toEqual({
+      name: 'skill-only',
+      description: undefined,
+    })
+  })
+
+  test('scanSkillDirectory reads direct child directories with SKILL.md', async () => {
+    const skillsDir = path.join(fakeWorkspace, '.agents', 'skills')
+    await writeSkill(skillsDir, 'frontend-design')
+    await writeSkill(
+      skillsDir,
+      'quoted-skill',
+      ['---', "name: 'quoted-skill'", 'description: "Quoted description"', '---'].join('\n'),
+    )
+    await fs.mkdir(path.join(skillsDir, 'missing-file'), { recursive: true })
+
+    const skills = await scanSkillDirectory(skillsDir)
+
+    expect(skills).toEqual([
+      { name: 'frontend-design', description: 'frontend-design description' },
+      { name: 'quoted-skill', description: 'Quoted description' },
+    ])
+  })
+
+  test('scanSkillDirectory gracefully handles missing directories', async () => {
+    const skills = await scanSkillDirectory(path.join(fakeWorkspace, 'does-not-exist'))
+    expect(skills).toEqual([])
+  })
+
+  test('scanAllSkillDirectories dedupes by skill name across configured locations', async () => {
+    const kataSkillsDir = path.join(fakeHome, '.kata-cli', 'agent', 'skills')
+    const userSkillsDir = path.join(fakeHome, '.agents', 'skills')
+    const workspaceSkillsDir = path.join(fakeWorkspace, '.agents', 'skills')
+
+    await writeSkill(kataSkillsDir, 'debug-like-expert')
+    await writeSkill(userSkillsDir, 'shared-skill', ['---', 'name: shared-skill', 'description: user copy', '---'].join('\n'))
+    await writeSkill(workspaceSkillsDir, 'shared-skill', ['---', 'name: shared-skill', 'description: workspace copy', '---'].join('\n'))
+    await writeSkill(workspaceSkillsDir, 'frontend-design')
+
+    const commands = await scanAllSkillDirectories(fakeWorkspace)
+
+    expect(commands).toEqual([
+      {
+        name: '/skill:debug-like-expert',
+        description: 'debug-like-expert description',
+        category: 'skill',
+      },
+      {
+        name: '/skill:frontend-design',
+        description: 'frontend-design description',
+        category: 'skill',
+      },
+      {
+        name: '/skill:shared-skill',
+        description: 'user copy',
+        category: 'skill',
+      },
+    ])
+  })
+
+  test('refreshSkillCache debounces rescans for 2 seconds and caches results', async () => {
+    const workspaceSkillsDir = path.join(fakeWorkspace, '.agents', 'skills')
+    await writeSkill(workspaceSkillsDir, 'initial-skill')
+
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    const first = await refreshSkillCache(fakeWorkspace)
+    expect(first.map((entry) => entry.name)).toEqual(['/skill:initial-skill'])
+
+    await writeSkill(workspaceSkillsDir, 'added-later')
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'))
+    const second = await refreshSkillCache(fakeWorkspace)
+    expect(second.map((entry) => entry.name)).toEqual(['/skill:initial-skill'])
+
+    const cached = getCachedSkills()
+    expect(cached?.map((entry) => entry.name)).toEqual(['/skill:initial-skill'])
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:03.100Z'))
+    const third = await refreshSkillCache(fakeWorkspace)
+
+    expect(third.map((entry) => entry.name)).toEqual(['/skill:added-later', '/skill:initial-skill'])
+  })
+})

--- a/apps/desktop/src/main/__tests__/skill-scanner.test.ts
+++ b/apps/desktop/src/main/__tests__/skill-scanner.test.ts
@@ -72,29 +72,46 @@ describe('skill-scanner', () => {
     })
   })
 
-  test('parseSkillFrontmatter handles missing fields and malformed input', () => {
+  test('parseSkillFrontmatter handles missing fields, malformed input, and quote mismatches', () => {
     expect(parseSkillFrontmatter('not-frontmatter')).toEqual({})
     expect(parseSkillFrontmatter(['---', 'name: skill-only', '---'].join('\n'))).toEqual({
       name: 'skill-only',
       description: undefined,
     })
+
+    expect(
+      parseSkillFrontmatter(
+        ['---', `name: 'mismatched"`, 'description: "Valid quoted description"', '---'].join('\n'),
+      ),
+    ).toEqual({
+      name: `'mismatched"`,
+      description: 'Valid quoted description',
+    })
   })
 
-  test('scanSkillDirectory reads direct child directories with SKILL.md', async () => {
+  test('scanSkillDirectory discovers SKILL.md recursively, including root-level files', async () => {
     const skillsDir = path.join(fakeWorkspace, '.agents', 'skills')
     await writeSkill(skillsDir, 'frontend-design')
+    await writeSkill(path.join(skillsDir, 'nested'), 'inner-skill')
     await writeSkill(
       skillsDir,
       'quoted-skill',
       ['---', "name: 'quoted-skill'", 'description: "Quoted description"', '---'].join('\n'),
     )
     await fs.mkdir(path.join(skillsDir, 'missing-file'), { recursive: true })
+    await fs.writeFile(
+      path.join(skillsDir, 'SKILL.md'),
+      ['---', 'name: root-skill', 'description: root skill description', '---'].join('\n'),
+      'utf8',
+    )
 
     const skills = await scanSkillDirectory(skillsDir)
 
     expect(skills).toEqual([
       { name: 'frontend-design', description: 'frontend-design description' },
+      { name: 'inner-skill', description: 'inner-skill description' },
       { name: 'quoted-skill', description: 'Quoted description' },
+      { name: 'root-skill', description: 'root skill description' },
     ])
   })
 
@@ -112,6 +129,12 @@ describe('skill-scanner', () => {
     await writeSkill(userSkillsDir, 'shared-skill', ['---', 'name: shared-skill', 'description: user copy', '---'].join('\n'))
     await writeSkill(workspaceSkillsDir, 'shared-skill', ['---', 'name: shared-skill', 'description: workspace copy', '---'].join('\n'))
     await writeSkill(workspaceSkillsDir, 'frontend-design')
+    await writeSkill(path.join(workspaceSkillsDir, 'nested'), 'deep-skill')
+    await fs.writeFile(
+      path.join(workspaceSkillsDir, 'SKILL.md'),
+      ['---', 'name: root-workspace-skill', 'description: root workspace copy', '---'].join('\n'),
+      'utf8',
+    )
 
     const commands = await scanAllSkillDirectories(fakeWorkspace)
 
@@ -122,13 +145,23 @@ describe('skill-scanner', () => {
         category: 'skill',
       },
       {
+        name: '/skill:deep-skill',
+        description: 'deep-skill description',
+        category: 'skill',
+      },
+      {
         name: '/skill:frontend-design',
         description: 'frontend-design description',
         category: 'skill',
       },
       {
+        name: '/skill:root-workspace-skill',
+        description: 'root workspace copy',
+        category: 'skill',
+      },
+      {
         name: '/skill:shared-skill',
-        description: 'user copy',
+        description: 'workspace copy',
         category: 'skill',
       },
     ])
@@ -157,5 +190,24 @@ describe('skill-scanner', () => {
     const third = await refreshSkillCache(fakeWorkspace)
 
     expect(third.map((entry) => entry.name)).toEqual(['/skill:added-later', '/skill:initial-skill'])
+  })
+
+  test('refreshSkillCache reuses in-flight scan for concurrent callers', async () => {
+    const workspaceSkillsDir = path.join(fakeWorkspace, '.agents', 'skills')
+    await writeSkill(workspaceSkillsDir, 'initial-skill')
+
+    const readFileSpy = vi.spyOn(fs, 'readFile')
+
+    const [first, second] = await Promise.all([
+      refreshSkillCache(fakeWorkspace),
+      refreshSkillCache(fakeWorkspace),
+    ])
+
+    expect(first).toEqual(second)
+
+    const skillReads = readFileSpy.mock.calls.filter(([filePath]) =>
+      String(filePath).endsWith(`${path.sep}SKILL.md`),
+    )
+    expect(skillReads).toHaveLength(1)
   })
 })

--- a/apps/desktop/src/main/command-registry.ts
+++ b/apps/desktop/src/main/command-registry.ts
@@ -1,0 +1,31 @@
+import log from './logger'
+import type { SlashCommandEntry } from '../shared/types'
+
+/**
+ * Static Desktop fallback for built-in slash commands.
+ *
+ * Revisability (D002): this can be replaced by a dynamic CLI RPC source once
+ * command discovery is exposed from the running Kata subprocess.
+ */
+export const BUILTIN_COMMANDS: ReadonlyArray<SlashCommandEntry> = [
+  { name: 'kata', description: 'Kata workflow command surface', category: 'builtin' },
+  { name: 'symphony', description: 'Symphony operator controls', category: 'builtin' },
+  { name: 'gh', description: 'GitHub helpers', category: 'builtin' },
+  { name: 'bg', description: 'Background process controls', category: 'builtin' },
+  { name: 'mcp', description: 'MCP server and tool gateway', category: 'builtin' },
+  { name: 'create-extension', description: 'Scaffold a new extension', category: 'builtin' },
+  {
+    name: 'create-slash-command',
+    description: 'Scaffold a slash command extension',
+    category: 'builtin',
+  },
+  { name: 'audit', description: 'Inspect slash command quality', category: 'builtin' },
+  { name: 'subagent', description: 'Run a delegated subagent', category: 'builtin' },
+  { name: 'skill', description: 'Execute installed skills', category: 'builtin' },
+]
+
+export function listBuiltinCommands(): SlashCommandEntry[] {
+  const commands = BUILTIN_COMMANDS.map((entry) => ({ ...entry }))
+  log.debug('[command-registry] listed builtin commands', { count: commands.length })
+  return commands
+}

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -4,6 +4,8 @@ import path from 'node:path'
 import { promisify } from 'node:util'
 import { dialog, ipcMain, shell, type BrowserWindow } from 'electron'
 import log from './logger'
+import { listBuiltinCommands } from './command-registry'
+import { refreshSkillCache } from './skill-scanner'
 import { AuthBridge } from './auth-bridge'
 import { LinearDocumentClient } from './linear-document-client'
 import { PiAgentBridge } from './pi-agent-bridge'
@@ -50,6 +52,8 @@ import {
   type SessionInfo,
   type SessionListResponse,
   type SetThinkingLevelResponse,
+  type SlashCommandEntry,
+  type SlashCommandsResponse,
   type ThinkingLevel,
   type WorkspaceInfo,
   type WorkspaceGitInfo,
@@ -874,6 +878,39 @@ export function registerSessionIpc({
   sendReliabilitySnapshot(reliabilityAggregator.getSnapshot())
   sendStabilitySnapshot(syncStabilityMetricsFromServices())
 
+  const refreshSkillCommands = async (reason: 'startup' | 'focus'): Promise<void> => {
+    const workspacePath = bridge.getWorkspacePath()
+
+    try {
+      const skills = await refreshSkillCache(workspacePath)
+      log.debug('[desktop-ipc] skill cache refreshed', {
+        reason,
+        workspacePath,
+        count: skills.length,
+      })
+    } catch (error) {
+      log.warn('[desktop-ipc] skill cache refresh failed', {
+        reason,
+        workspacePath,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const onWindowFocus = (): void => {
+    void refreshSkillCommands('focus')
+  }
+
+  const canBindWindowFocus =
+    typeof (window as Partial<BrowserWindow>).on === 'function' &&
+    typeof (window as Partial<BrowserWindow>).off === 'function'
+
+  if (canBindWindowFocus) {
+    window.on('focus', onWindowFocus)
+  }
+
+  void refreshSkillCommands('startup')
+
   ipcMain.removeHandler(IPC_CHANNELS.sessionSend)
   ipcMain.removeHandler(IPC_CHANNELS.sessionStop)
   ipcMain.removeHandler(IPC_CHANNELS.sessionRestart)
@@ -892,6 +929,7 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.workspaceSet)
   ipcMain.removeHandler(IPC_CHANNELS.workspacePick)
   ipcMain.removeHandler(IPC_CHANNELS.workspaceGetGitInfo)
+  ipcMain.removeHandler(IPC_CHANNELS.commandsGetAll)
   ipcMain.removeHandler(IPC_CHANNELS.authGetProviders)
   ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
   ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)
@@ -1336,6 +1374,34 @@ export function registerSessionIpc({
 
   ipcMain.handle(IPC_CHANNELS.workspaceGetGitInfo, async (): Promise<WorkspaceGitInfo> => {
     return readWorkspaceGitInfo(bridge.getWorkspacePath())
+  })
+
+  ipcMain.handle(IPC_CHANNELS.commandsGetAll, async (): Promise<SlashCommandsResponse> => {
+    try {
+      const workspacePath = bridge.getWorkspacePath() || process.cwd()
+      const builtinCommands = listBuiltinCommands()
+      const skillCommands = await refreshSkillCache(workspacePath)
+      const commands: SlashCommandEntry[] = [...builtinCommands, ...skillCommands].sort((left, right) =>
+        left.name.localeCompare(right.name),
+      )
+
+      return {
+        success: true,
+        commands,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+
+      log.warn('[desktop-ipc] get slash commands failed', {
+        error: message,
+      })
+
+      return {
+        success: false,
+        commands: [],
+        error: message,
+      }
+    }
   })
 
   ipcMain.handle(IPC_CHANNELS.authGetProviders, async (): Promise<AuthProvidersResponse> => {
@@ -1969,6 +2035,10 @@ export function registerSessionIpc({
   )
 
   return () => {
+    if (canBindWindowFocus) {
+      window.off('focus', onWindowFocus)
+    }
+
     bridge.off('rpc-event', onRpcEvent)
     bridge.off('extension-ui-request', onExtensionUiRequest)
     bridge.off('status', onStatus)
@@ -1998,6 +2068,7 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.workspaceSet)
     ipcMain.removeHandler(IPC_CHANNELS.workspacePick)
     ipcMain.removeHandler(IPC_CHANNELS.workspaceGetGitInfo)
+    ipcMain.removeHandler(IPC_CHANNELS.commandsGetAll)
     ipcMain.removeHandler(IPC_CHANNELS.authGetProviders)
     ipcMain.removeHandler(IPC_CHANNELS.authSetKey)
     ipcMain.removeHandler(IPC_CHANNELS.authRemoveKey)

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -901,6 +901,9 @@ export function registerSessionIpc({
     void refreshSkillCommands('focus')
   }
 
+  // Some unit tests intentionally provide partial BrowserWindow stubs that omit
+  // EventEmitter bindings. Guard this subscription to keep IPC registration
+  // resilient in those test harnesses.
   const canBindWindowFocus =
     typeof (window as Partial<BrowserWindow>).on === 'function' &&
     typeof (window as Partial<BrowserWindow>).off === 'function'

--- a/apps/desktop/src/main/skill-scanner.ts
+++ b/apps/desktop/src/main/skill-scanner.ts
@@ -15,6 +15,8 @@ export const SKILL_REFRESH_DEBOUNCE_MS = 2_000
 let cachedSkills: SlashCommandEntry[] | null = null
 let cachedWorkspacePath: string | null = null
 let lastRefreshAt = 0
+let inFlightRefresh: Promise<SlashCommandEntry[]> | null = null
+let inFlightWorkspacePath: string | null = null
 
 function resolveSkillDirectories(workspacePath?: string): string[] {
   const homeDirectory = os.homedir()
@@ -30,7 +32,15 @@ function resolveSkillDirectories(workspacePath?: string): string[] {
 }
 
 function stripYamlWrapping(value: string): string {
-  return value.replace(/^['"]/, '').replace(/['"]$/, '').trim()
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    return trimmed.slice(1, -1).trim()
+  }
+
+  return trimmed
 }
 
 export function parseSkillFrontmatter(content: string): { name?: string; description?: string } {
@@ -49,10 +59,7 @@ export function parseSkillFrontmatter(content: string): { name?: string; descrip
   }
 }
 
-export async function scanSkillDirectory(directoryPath: string): Promise<SkillEntry[]> {
-  const startedAt = Date.now()
-  log.debug('[skill-scanner] scanning directory', { directoryPath })
-
+async function listSkillFiles(directoryPath: string): Promise<string[]> {
   let directoryEntries: Array<import('node:fs').Dirent<string>>
 
   try {
@@ -81,19 +88,39 @@ export async function scanSkillDirectory(directoryPath: string): Promise<SkillEn
     return []
   }
 
-  const skills: SkillEntry[] = []
+  const sortedEntries = [...directoryEntries].sort((left, right) => left.name.localeCompare(right.name))
+  const discoveredSkillFiles: string[] = []
 
-  for (const entry of directoryEntries) {
-    if (!entry.isDirectory()) {
+  for (const entry of sortedEntries) {
+    const entryPath = path.join(directoryPath, entry.name)
+
+    if (entry.isDirectory()) {
+      discoveredSkillFiles.push(...(await listSkillFiles(entryPath)))
       continue
     }
 
-    const skillFilePath = path.join(directoryPath, entry.name, 'SKILL.md')
+    if (entry.isFile() && entry.name === 'SKILL.md') {
+      discoveredSkillFiles.push(entryPath)
+    }
+  }
+
+  return discoveredSkillFiles
+}
+
+export async function scanSkillDirectory(directoryPath: string): Promise<SkillEntry[]> {
+  const startedAt = Date.now()
+  log.debug('[skill-scanner] scanning directory', { directoryPath })
+
+  const skillFilePaths = await listSkillFiles(directoryPath)
+  const skills: SkillEntry[] = []
+
+  for (const skillFilePath of skillFilePaths) {
+    const skillDirectory = path.basename(path.dirname(skillFilePath))
 
     try {
       const content = await fs.readFile(skillFilePath, 'utf8')
       const frontmatter = parseSkillFrontmatter(content)
-      const skillName = frontmatter.name?.trim() || entry.name.trim()
+      const skillName = frontmatter.name?.trim() || skillDirectory.trim()
 
       if (!skillName) {
         continue
@@ -112,7 +139,7 @@ export async function scanSkillDirectory(directoryPath: string): Promise<SkillEn
       if (code !== 'ENOENT') {
         log.warn('[skill-scanner] failed to read SKILL.md', {
           directoryPath,
-          skillDirectory: entry.name,
+          skillDirectory,
           skillFilePath,
           code,
           error: error instanceof Error ? error.message : String(error),
@@ -121,13 +148,15 @@ export async function scanSkillDirectory(directoryPath: string): Promise<SkillEn
     }
   }
 
+  const sortedSkills = [...skills].sort((left, right) => left.name.localeCompare(right.name))
+
   log.debug('[skill-scanner] directory scan complete', {
     directoryPath,
-    discoveredSkillCount: skills.length,
+    discoveredSkillCount: sortedSkills.length,
     durationMs: Date.now() - startedAt,
   })
 
-  return skills
+  return sortedSkills
 }
 
 export async function scanAllSkillDirectories(workspacePath?: string): Promise<SlashCommandEntry[]> {
@@ -152,12 +181,10 @@ export async function scanAllSkillDirectories(workspacePath?: string): Promise<S
         }
 
         const dedupeKey = normalizedSkillName.toLowerCase()
-        if (!dedupedSkills.has(dedupeKey)) {
-          dedupedSkills.set(dedupeKey, {
-            ...skill,
-            name: normalizedSkillName,
-          })
-        }
+        dedupedSkills.set(dedupeKey, {
+          ...skill,
+          name: normalizedSkillName,
+        })
       }
     }
 
@@ -202,11 +229,33 @@ export async function refreshSkillCache(workspacePath?: string): Promise<SlashCo
     return cachedSkills.map((entry) => ({ ...entry }))
   }
 
-  const refreshedSkills = await scanAllSkillDirectories(resolvedWorkspacePath)
-  cachedSkills = refreshedSkills
-  cachedWorkspacePath = resolvedWorkspacePath
-  lastRefreshAt = now
+  if (inFlightRefresh && inFlightWorkspacePath === resolvedWorkspacePath) {
+    log.debug('[skill-scanner] awaiting in-flight refresh', {
+      workspacePath: resolvedWorkspacePath,
+    })
 
+    const inFlightSkills = await inFlightRefresh
+    return inFlightSkills.map((entry) => ({ ...entry }))
+  }
+
+  const refreshPromise = scanAllSkillDirectories(resolvedWorkspacePath)
+    .then((refreshedSkills) => {
+      cachedSkills = refreshedSkills
+      cachedWorkspacePath = resolvedWorkspacePath
+      lastRefreshAt = Date.now()
+      return refreshedSkills
+    })
+    .finally(() => {
+      if (inFlightRefresh === refreshPromise) {
+        inFlightRefresh = null
+        inFlightWorkspacePath = null
+      }
+    })
+
+  inFlightRefresh = refreshPromise
+  inFlightWorkspacePath = resolvedWorkspacePath
+
+  const refreshedSkills = await refreshPromise
   return refreshedSkills.map((entry) => ({ ...entry }))
 }
 
@@ -218,4 +267,6 @@ export function clearSkillCache(): void {
   cachedSkills = null
   cachedWorkspacePath = null
   lastRefreshAt = 0
+  inFlightRefresh = null
+  inFlightWorkspacePath = null
 }

--- a/apps/desktop/src/main/skill-scanner.ts
+++ b/apps/desktop/src/main/skill-scanner.ts
@@ -1,0 +1,221 @@
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import log from './logger'
+import type { SkillEntry, SlashCommandEntry } from '../shared/types'
+
+export const SKILL_DIRECTORIES = [
+  '~/.kata-cli/agent/skills/',
+  '~/.agents/skills/',
+  '.agents/skills/',
+] as const
+
+export const SKILL_REFRESH_DEBOUNCE_MS = 2_000
+
+let cachedSkills: SlashCommandEntry[] | null = null
+let cachedWorkspacePath: string | null = null
+let lastRefreshAt = 0
+
+function resolveSkillDirectories(workspacePath?: string): string[] {
+  const homeDirectory = os.homedir()
+  const resolvedWorkspacePath = workspacePath ? path.resolve(workspacePath) : process.cwd()
+
+  return SKILL_DIRECTORIES.map((directoryPath) => {
+    if (directoryPath.startsWith('~/')) {
+      return path.join(homeDirectory, directoryPath.slice(2))
+    }
+
+    return path.join(resolvedWorkspacePath, directoryPath)
+  })
+}
+
+function stripYamlWrapping(value: string): string {
+  return value.replace(/^['"]/, '').replace(/['"]$/, '').trim()
+}
+
+export function parseSkillFrontmatter(content: string): { name?: string; description?: string } {
+  const frontmatterMatch = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/)
+  if (!frontmatterMatch?.[1]) {
+    return {}
+  }
+
+  const frontmatter = frontmatterMatch[1]
+  const nameMatch = frontmatter.match(/^\s*name:\s*(.+)$/m)
+  const descriptionMatch = frontmatter.match(/^\s*description:\s*(.+)$/m)
+
+  return {
+    name: nameMatch?.[1] ? stripYamlWrapping(nameMatch[1]) : undefined,
+    description: descriptionMatch?.[1] ? stripYamlWrapping(descriptionMatch[1]) : undefined,
+  }
+}
+
+export async function scanSkillDirectory(directoryPath: string): Promise<SkillEntry[]> {
+  const startedAt = Date.now()
+  log.debug('[skill-scanner] scanning directory', { directoryPath })
+
+  let directoryEntries: Array<import('node:fs').Dirent<string>>
+
+  try {
+    directoryEntries = await fs.readdir(directoryPath, {
+      withFileTypes: true,
+      encoding: 'utf8',
+    })
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : undefined
+
+    const payload = {
+      directoryPath,
+      code,
+      error: error instanceof Error ? error.message : String(error),
+    }
+
+    if (code === 'ENOENT' || code === 'ENOTDIR' || code === 'EACCES' || code === 'EPERM') {
+      log.debug('[skill-scanner] skipping unreadable directory', payload)
+      return []
+    }
+
+    log.warn('[skill-scanner] failed to read skill directory', payload)
+    return []
+  }
+
+  const skills: SkillEntry[] = []
+
+  for (const entry of directoryEntries) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+
+    const skillFilePath = path.join(directoryPath, entry.name, 'SKILL.md')
+
+    try {
+      const content = await fs.readFile(skillFilePath, 'utf8')
+      const frontmatter = parseSkillFrontmatter(content)
+      const skillName = frontmatter.name?.trim() || entry.name.trim()
+
+      if (!skillName) {
+        continue
+      }
+
+      skills.push({
+        name: skillName,
+        description: frontmatter.description,
+      })
+    } catch (error) {
+      const code =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? String((error as { code?: unknown }).code)
+          : undefined
+
+      if (code !== 'ENOENT') {
+        log.warn('[skill-scanner] failed to read SKILL.md', {
+          directoryPath,
+          skillDirectory: entry.name,
+          skillFilePath,
+          code,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+  }
+
+  log.debug('[skill-scanner] directory scan complete', {
+    directoryPath,
+    discoveredSkillCount: skills.length,
+    durationMs: Date.now() - startedAt,
+  })
+
+  return skills
+}
+
+export async function scanAllSkillDirectories(workspacePath?: string): Promise<SlashCommandEntry[]> {
+  const startedAt = Date.now()
+  const resolvedDirectories = resolveSkillDirectories(workspacePath)
+
+  log.debug('[skill-scanner] scan start', {
+    workspacePath: workspacePath ? path.resolve(workspacePath) : process.cwd(),
+    directories: resolvedDirectories,
+  })
+
+  try {
+    const dedupedSkills = new Map<string, SkillEntry>()
+
+    for (const directoryPath of resolvedDirectories) {
+      const skills = await scanSkillDirectory(directoryPath)
+
+      for (const skill of skills) {
+        const normalizedSkillName = skill.name.trim()
+        if (!normalizedSkillName) {
+          continue
+        }
+
+        const dedupeKey = normalizedSkillName.toLowerCase()
+        if (!dedupedSkills.has(dedupeKey)) {
+          dedupedSkills.set(dedupeKey, {
+            ...skill,
+            name: normalizedSkillName,
+          })
+        }
+      }
+    }
+
+    const commands = Array.from(dedupedSkills.values())
+      .map<SlashCommandEntry>((skill) => ({
+        name: `/skill:${skill.name}`,
+        description: skill.description,
+        category: 'skill',
+      }))
+      .sort((left, right) => left.name.localeCompare(right.name))
+
+    log.debug('[skill-scanner] scan complete', {
+      discoveredSkillCount: commands.length,
+      durationMs: Date.now() - startedAt,
+    })
+
+    return commands
+  } catch (error) {
+    log.warn('[skill-scanner] failed to scan skill directories', {
+      workspacePath,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return []
+  }
+}
+
+export async function refreshSkillCache(workspacePath?: string): Promise<SlashCommandEntry[]> {
+  const now = Date.now()
+  const resolvedWorkspacePath = workspacePath ? path.resolve(workspacePath) : process.cwd()
+
+  if (
+    cachedSkills &&
+    cachedWorkspacePath === resolvedWorkspacePath &&
+    now - lastRefreshAt < SKILL_REFRESH_DEBOUNCE_MS
+  ) {
+    log.debug('[skill-scanner] returning cached skills (debounced)', {
+      workspacePath: resolvedWorkspacePath,
+      ageMs: now - lastRefreshAt,
+      cacheSize: cachedSkills.length,
+    })
+
+    return cachedSkills.map((entry) => ({ ...entry }))
+  }
+
+  const refreshedSkills = await scanAllSkillDirectories(resolvedWorkspacePath)
+  cachedSkills = refreshedSkills
+  cachedWorkspacePath = resolvedWorkspacePath
+  lastRefreshAt = now
+
+  return refreshedSkills.map((entry) => ({ ...entry }))
+}
+
+export function getCachedSkills(): SlashCommandEntry[] | null {
+  return cachedSkills ? cachedSkills.map((entry) => ({ ...entry })) : null
+}
+
+export function clearSkillCache(): void {
+  cachedSkills = null
+  cachedWorkspacePath = null
+  lastRefreshAt = 0
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -79,6 +79,9 @@ const api: DesktopApi = {
   setThinkingLevel: async (level: ThinkingLevel) => {
     return ipcRenderer.invoke(IPC_CHANNELS.sessionSetThinkingLevel, level)
   },
+  getSlashCommands: async () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.commandsGetAll)
+  },
   sessions: {
     list: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.sessionList)

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -61,11 +61,31 @@ export const IPC_CHANNELS = {
   reliabilityGetStabilitySnapshot: 'reliability:get-stability-snapshot',
   reliabilityStabilitySnapshot: 'reliability:stability-snapshot',
   reliabilityRequestRecoveryAction: 'reliability:request-recovery-action',
+  commandsGetAll: 'commands:get-all',
 } as const
 
 export type PermissionMode = 'explore' | 'ask' | 'auto'
 
 export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+
+export type SlashCommandCategory = 'builtin' | 'skill'
+
+export interface SlashCommandEntry {
+  name: string
+  description?: string
+  category: SlashCommandCategory
+}
+
+export interface SkillEntry {
+  name: string
+  description?: string
+}
+
+export interface SlashCommandsResponse {
+  success: boolean
+  commands: SlashCommandEntry[]
+  error?: string
+}
 
 export const ALL_AUTH_PROVIDERS = [
   'anthropic',
@@ -1677,6 +1697,7 @@ export interface DesktopApi {
   getAvailableModels: () => Promise<AvailableModelsResponse>
   setModel: (model: string) => Promise<SetModelResponse>
   setThinkingLevel: (level: ThinkingLevel) => Promise<SetThinkingLevelResponse>
+  getSlashCommands: () => Promise<SlashCommandsResponse>
   sessions: {
     list: () => Promise<SessionListResponse>
     create: () => Promise<CreateSessionResponse>


### PR DESCRIPTION
## Summary
Implements issue #341 by adding a desktop-side command/skill discovery substrate used by `window.api.getSlashCommands()`.

### What changed
- Added shared contract types:
  - `SlashCommandEntry`, `SkillEntry`, `SlashCommandsResponse`
  - `IPC_CHANNELS.commandsGetAll`
  - `DesktopApi.getSlashCommands()`
- Added main-process discovery pipeline:
  - `command-registry.ts` to aggregate slash commands + skills
  - `skill-scanner.ts` for multi-directory skill scanning, frontmatter parsing, dedupe, and filtering
- Wired IPC handler and preload exposure for renderer access
- Added unit tests:
  - `src/main/__tests__/command-registry.test.ts`
  - `src/main/__tests__/skill-scanner.test.ts`

## Validation
- `pnpm --filter @kata/desktop typecheck`
- `pnpm --filter @kata/desktop test`
- `pnpm --filter @kata/desktop build`
- Runtime proof via Electron dev run + `window.api.getSlashCommands()` inspection

Closes #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added slash command support to the desktop application, enabling quick access to commands
  * Built-in commands are provided by default for common operations
  * Skills are automatically discovered from configured directories and made available as slash commands

* **Tests**
  * Added comprehensive test coverage for command registry and skill discovery functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a desktop-side slash command and skill discovery substrate, wiring a new `commandsGetAll` IPC channel that aggregates static builtin commands from `command-registry.ts` and dynamically scanned skills from `skill-scanner.ts`, exposing the result to the renderer via `window.api.getSlashCommands()`. The shared contract types, IPC registration, preload exposure, and unit tests are all present and well-structured.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/improvement suggestions that do not affect correctness.

The implementation is well-structured with proper error handling, cleanup symmetry, and good test coverage. The three findings (dedup priority order, concurrent refresh window, mismatched-quote edge case) are all P2 — they describe edge cases or design choices rather than present defects that break the primary path. None block merge.

apps/desktop/src/main/skill-scanner.ts — dedup priority order and concurrent-refresh guard worth reviewing before future iteration.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/skill-scanner.ts | Core skill discovery pipeline — contains a counterintuitive global-first dedup order and a concurrent-refresh race window; otherwise well-structured with proper error handling and cache eviction. |
| apps/desktop/src/main/command-registry.ts | Simple static registry of builtin slash commands; defensive copy on read is correct and the shape matches the shared contract. |
| apps/desktop/src/main/ipc.ts | IPC wiring for commandsGetAll is correct and cleanup is symmetric; the canBindWindowFocus runtime guard is technically dead code given the static BrowserWindow type. |
| apps/desktop/src/shared/types.ts | Clean addition of SlashCommandEntry, SkillEntry, SlashCommandsResponse types and the commandsGetAll IPC channel constant; DesktopApi interface correctly extended. |
| apps/desktop/src/preload/index.ts | Minimal, correct preload addition that forwards commandsGetAll IPC invoke to the renderer via getSlashCommands(). |
| apps/desktop/src/main/__tests__/skill-scanner.test.ts | Good test coverage for scanning, dedup, frontmatter parsing, and cache debounce; dedup-priority test asserts global-wins behaviour which may be intentional but warrants confirmation. |
| apps/desktop/src/main/__tests__/command-registry.test.ts | Covers return shape, expected names, count, and defensive-copy behaviour; complete for the scope of the module. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Renderer
    participant Preload
    participant IPC as ipc.ts (main)
    participant Registry as command-registry.ts
    participant Scanner as skill-scanner.ts
    participant FS as Filesystem

    Note over IPC: registerSessionIpc() startup
    IPC->>Scanner: refreshSkillCache(workspacePath) [startup]
    Scanner->>FS: readdir ~/.kata-cli/agent/skills/
    Scanner->>FS: readdir ~/.agents/skills/
    Scanner->>FS: readdir .agents/skills/
    Scanner-->>IPC: SlashCommandEntry[] (cached)

    Note over IPC: window focus event
    IPC->>Scanner: refreshSkillCache(workspacePath) [focus]
    Scanner-->>IPC: SlashCommandEntry[] (debounced or rescanned)

    Renderer->>Preload: window.api.getSlashCommands()
    Preload->>IPC: ipcRenderer.invoke('commands:get-all')
    IPC->>Registry: listBuiltinCommands()
    Registry-->>IPC: SlashCommandEntry[] (builtin)
    IPC->>Scanner: refreshSkillCache(workspacePath)
    Scanner-->>IPC: SlashCommandEntry[] (cached/rescanned)
    IPC-->>Preload: SlashCommandsResponse { success, commands }
    Preload-->>Renderer: SlashCommandsResponse
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/skill-scanner.ts
Line: 7-11

Comment:
**Dedup priority is global > user > workspace**

`scanAllSkillDirectories` uses a "first-wins" map, so it scans in the order `global → user → workspace`. A user-level skill silently shadows a same-named workspace skill, and a global one shadows both. This is the inverse of standard layering conventions (workspace > user > global) where more-local config should override less-local. The test at line 129-133 of `skill-scanner.test.ts` even asserts the `user copy` beats the `workspace copy`, confirming this behavior.

If the intent is that workspace-level skills should be able to override user/global ones, the directory order in `SKILL_DIRECTORIES` should be reversed, or the loop should use "last-wins" semantics.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/skill-scanner.ts
Line: 187-211

Comment:
**Concurrent callers both bypass the debounce guard**

`refreshSkillCache` is an async function with no in-flight guard. If two callers `await refreshSkillCache()` before either completes (e.g., the startup preload and an immediate `commandsGetAll` IPC call arriving while the startup scan is still in progress), both will pass the `cachedSkills === null` check at the same time (since `await scanAllSkillDirectories` yields the event loop), trigger two full filesystem scans, and race to write `cachedSkills`. A simple in-flight promise variable would prevent the duplicate work:

```ts
let inFlight: Promise<SlashCommandEntry[]> | null = null

export async function refreshSkillCache(workspacePath?: string): Promise<SlashCommandEntry[]> {
  // … debounce check …
  if (inFlight) return inFlight
  inFlight = scanAllSkillDirectories(resolvedWorkspacePath).then((skills) => {
    cachedSkills = skills
    cachedWorkspacePath = resolvedWorkspacePath
    lastRefreshAt = Date.now()
    inFlight = null
    return skills
  })
  return inFlight
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/skill-scanner.ts
Line: 32-34

Comment:
**`stripYamlWrapping` allows mismatched quotes**

Each quote is stripped independently with two separate `replace` calls, so a value like `'value"` loses both the leading `'` and the trailing `"`, yielding `value`. While YAML with mismatched quotes is technically invalid, the custom parser here accepts it silently and produces a result that may not match the author's intent. Checking that opening and closing quote characters match would make the behaviour more correct:

```ts
function stripYamlWrapping(value: string): string {
  const trimmed = value.trim()
  if (
    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
    (trimmed.startsWith('"') && trimmed.endsWith('"'))
  ) {
    return trimmed.slice(1, -1).trim()
  }
  return trimmed
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/ipc.ts
Line: 904-910

Comment:
**Runtime type guard is dead code given the static type**

`window` is typed as `BrowserWindow` (line 107), which always has `.on()` and `.off()` defined. The `typeof (window as Partial<BrowserWindow>).on === 'function'` check will always be `true` in practice, so the `canBindWindowFocus` guard adds noise without protection. If this exists to support test-time partial mocks, consider documenting that explicitly, or accepting `BrowserWindow | Partial<BrowserWindow>` in `RegisterIpcOptions` so TypeScript can surface it.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(desktop): add command registry and ..."](https://github.com/gannonh/kata/commit/7cd6c2846673db27906a8e510a1cd1f912597262) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28910103)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->