### PR TITLE
feat(desktop): finalize slash autocomplete acceptance behavior

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -16,6 +16,7 @@ interface MessageInputProps {
 type SlashAcceptDiagnosticCode =
   | 'SLASH_ACCEPTED'
   | 'SLASH_ACCEPT_NO_SELECTION'
+  | 'SLASH_ACCEPT_NO_OP'
   | 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE'
 
 type SlashAcceptTriggerKey = 'Enter' | 'Tab' | 'Pointer'
@@ -69,10 +70,6 @@ function extractSlashPrefix(value: string, caret: number): string {
 
   const tokenEnd = value.indexOf(' ', tokenStart)
   const end = tokenEnd === -1 ? value.length : tokenEnd
-
-  if (boundedCaret > end) {
-    return ''
-  }
 
   return value.slice(tokenStart, end)
 }
@@ -162,40 +159,43 @@ export function MessageInput({
       ? `command-suggestion-${selectedIndex}`
       : undefined
 
-  const applyCommandSuggestion = useCallback((command: SlashCommandEntry): { status: 'inserted' | 'no-op'; nextValue: string } => {
-    const textarea = textareaRef.current
-    const selectionStart = textarea?.selectionStart ?? value.length
-    const selectionEnd = textarea?.selectionEnd ?? value.length
-    const tokenStart = value.lastIndexOf('/', selectionStart)
+  const applyCommandSuggestion = useCallback(
+    (command: SlashCommandEntry): { status: 'inserted' | 'no-op'; nextValue: string } => {
+      const textarea = textareaRef.current
+      const selectionStart = textarea?.selectionStart ?? value.length
+      const selectionEnd = textarea?.selectionEnd ?? value.length
+      const tokenStart = value.lastIndexOf('/', selectionStart)
 
-    const replaceStart = tokenStart >= 0 ? tokenStart : 0
-    const tokenEnd = value.indexOf(' ', Math.max(selectionEnd, replaceStart))
-    const replaceEnd = tokenStart >= 0 ? (tokenEnd === -1 ? value.length : tokenEnd) : value.length
+      const replaceStart = tokenStart >= 0 ? tokenStart : 0
+      const tokenEnd = value.indexOf(' ', Math.max(selectionEnd, replaceStart))
+      const replaceEnd = tokenStart >= 0 ? (tokenEnd === -1 ? value.length : tokenEnd) : value.length
 
-    const nextValue = `${value.slice(0, replaceStart)}${command.name} ${value.slice(replaceEnd)}`
-    const nextCaret = replaceStart + command.name.length + 1
+      const nextValue = `${value.slice(0, replaceStart)}${command.name} ${value.slice(replaceEnd)}`
+      const nextCaret = replaceStart + command.name.length + 1
 
-    if (nextValue === value) {
-      setIsSuggestionDismissed(true)
-      return { status: 'no-op', nextValue }
-    }
-
-    setValue(nextValue)
-    setSelectedIndex(0)
-    setIsSuggestionDismissed(true)
-
-    queueMicrotask(() => {
-      const element = textareaRef.current
-      if (!element) {
-        return
+      if (nextValue === value) {
+        setIsSuggestionDismissed(true)
+        return { status: 'no-op', nextValue }
       }
 
-      element.focus()
-      element.setSelectionRange(nextCaret, nextCaret)
-    })
+      setValue(nextValue)
+      setSelectedIndex(0)
+      setIsSuggestionDismissed(true)
 
-    return { status: 'inserted', nextValue }
-  }, [setSelectedIndex, value])
+      queueMicrotask(() => {
+        const element = textareaRef.current
+        if (!element) {
+          return
+        }
+
+        element.focus()
+        element.setSelectionRange(nextCaret, nextCaret)
+      })
+
+      return { status: 'inserted', nextValue }
+    },
+    [setSelectedIndex, value],
+  )
 
   const acceptSuggestion = useCallback(
     (key: SlashAcceptTriggerKey, command?: SlashCommandEntry): void => {
@@ -250,7 +250,7 @@ export function MessageInput({
         return
       }
 
-      emitSlashDiagnostic('debug', 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE', {
+      emitSlashDiagnostic('debug', 'SLASH_ACCEPT_NO_OP', {
         key,
         prefix: slashPrefix,
         command: selectedSuggestion.name,
@@ -303,11 +303,21 @@ export function MessageInput({
             const hasSelectableSuggestion =
               suggestions.length > 0 && selectedIndex >= 0 && selectedIndex < suggestions.length
 
-            if (showSuggestions && shouldAcceptWithEnter) {
+            if (showSuggestions && shouldAcceptWithEnter && hasSelectableSuggestion) {
               event.preventDefault()
               event.stopPropagation()
               acceptSuggestion('Enter')
               return
+            }
+
+            if (showSuggestions && shouldAcceptWithEnter && !hasSelectableSuggestion) {
+              const caret = textareaRef.current?.selectionStart ?? value.length
+              emitSlashDiagnostic('warn', 'SLASH_ACCEPT_NO_SELECTION', {
+                key: 'Enter',
+                prefix: extractSlashPrefix(value, caret),
+                selectedIndex,
+                suggestionCount: suggestions.length,
+              })
             }
 
             if (showSuggestions && shouldAcceptWithTab && hasSelectableSuggestion) {

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -185,6 +185,8 @@ export function MessageInput({
         emitSlashDiagnostic('warn', 'SLASH_ACCEPT_NO_SELECTION', {
           key,
           prefix: slashPrefix,
+          selectedIndex,
+          suggestionCount: suggestions.length,
         })
         return
       }
@@ -201,6 +203,8 @@ export function MessageInput({
           key,
           prefix: slashPrefix,
           command: selectedSuggestion.name,
+          selectedIndex,
+          suggestionCount: suggestions.length,
         })
         return
       }
@@ -218,6 +222,8 @@ export function MessageInput({
           key,
           prefix: slashPrefix,
           command: selectedSuggestion.name,
+          selectedIndex,
+          suggestionCount: suggestions.length,
         },
       )
     },

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -101,6 +101,7 @@ export function MessageInput({
 
   useEffect(() => {
     setIsSuggestionDismissed(false)
+    lastAcceptedSuggestionRef.current = null
   }, [value])
 
   const send = async (): Promise<void> => {

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -16,7 +16,6 @@ interface MessageInputProps {
 type SlashAcceptDiagnosticCode =
   | 'SLASH_ACCEPTED'
   | 'SLASH_ACCEPT_NO_SELECTION'
-  | 'SLASH_ACCEPT_NO_OP'
   | 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE'
 
 type SlashAcceptTriggerKey = 'Enter' | 'Tab' | 'Pointer'
@@ -251,7 +250,7 @@ export function MessageInput({
         return
       }
 
-      emitSlashDiagnostic('debug', 'SLASH_ACCEPT_NO_OP', {
+      emitSlashDiagnostic('debug', 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE', {
         key,
         prefix: slashPrefix,
         command: selectedSuggestion.name,

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -13,6 +13,53 @@ interface MessageInputProps {
   onStop: () => Promise<void>
 }
 
+type SlashAcceptDiagnosticCode =
+  | 'SLASH_ACCEPTED'
+  | 'SLASH_ACCEPT_NO_SELECTION'
+  | 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE'
+
+type SlashAcceptTriggerKey = 'Enter' | 'Tab' | 'Pointer'
+
+const SLASH_DUPLICATE_SUPPRESSION_WINDOW_MS = 64
+
+function slashDiagnosticsEnabled(): boolean {
+  return import.meta.env.DEV
+}
+
+function emitSlashDiagnostic(
+  level: 'debug' | 'warn',
+  code: SlashAcceptDiagnosticCode,
+  details: Record<string, unknown>,
+): void {
+  if (!slashDiagnosticsEnabled()) {
+    return
+  }
+
+  const payload = {
+    code,
+    ...details,
+  }
+
+  if (level === 'warn') {
+    console.warn('[SlashAutocomplete]', payload)
+    return
+  }
+
+  console.debug('[SlashAutocomplete]', payload)
+}
+
+function extractSlashPrefix(value: string, caret: number): string {
+  const boundedCaret = Math.max(0, Math.min(caret, value.length))
+  const tokenStart = value.lastIndexOf('/', boundedCaret)
+
+  if (tokenStart < 0) {
+    return ''
+  }
+
+  const tokenEnd = value.indexOf(' ', tokenStart)
+  return tokenEnd === -1 ? value.slice(tokenStart) : value.slice(tokenStart, tokenEnd)
+}
+
 export function MessageInput({
   disabled = false,
   stopDisabled = disabled,
@@ -26,6 +73,7 @@ export function MessageInput({
   const sendingRef = useRef(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const composerRef = useRef<HTMLDivElement | null>(null)
+  const lastAcceptedSuggestionRef = useRef<{ commandName: string; acceptedAt: number } | null>(null)
 
   const {
     suggestions,
@@ -92,7 +140,7 @@ export function MessageInput({
       ? `command-suggestion-${selectedIndex}`
       : undefined
 
-  const applyCommandSuggestion = (command: SlashCommandEntry): void => {
+  const applyCommandSuggestion = useCallback((command: SlashCommandEntry): boolean => {
     const textarea = textareaRef.current
     const selectionStart = textarea?.selectionStart ?? value.length
     const selectionEnd = textarea?.selectionEnd ?? value.length
@@ -104,6 +152,11 @@ export function MessageInput({
 
     const nextValue = `${value.slice(0, replaceStart)}${command.name} ${value.slice(replaceEnd)}`
     const nextCaret = replaceStart + command.name.length + 1
+
+    if (nextValue === value) {
+      setIsSuggestionDismissed(true)
+      return false
+    }
 
     setValue(nextValue)
     setSelectedIndex(0)
@@ -118,7 +171,58 @@ export function MessageInput({
       element.focus()
       element.setSelectionRange(nextCaret, nextCaret)
     })
-  }
+
+    return true
+  }, [setSelectedIndex, value])
+
+  const acceptSuggestion = useCallback(
+    (key: SlashAcceptTriggerKey, command?: SlashCommandEntry): void => {
+      const selectedSuggestion = command ?? suggestions[selectedIndex]
+      const caret = textareaRef.current?.selectionStart ?? value.length
+      const slashPrefix = extractSlashPrefix(value, caret)
+
+      if (!selectedSuggestion) {
+        emitSlashDiagnostic('warn', 'SLASH_ACCEPT_NO_SELECTION', {
+          key,
+          prefix: slashPrefix,
+        })
+        return
+      }
+
+      const now = Date.now()
+      const lastAccepted = lastAcceptedSuggestionRef.current
+      if (
+        lastAccepted &&
+        lastAccepted.commandName === selectedSuggestion.name &&
+        now - lastAccepted.acceptedAt <= SLASH_DUPLICATE_SUPPRESSION_WINDOW_MS
+      ) {
+        setIsSuggestionDismissed(true)
+        emitSlashDiagnostic('debug', 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE', {
+          key,
+          prefix: slashPrefix,
+          command: selectedSuggestion.name,
+        })
+        return
+      }
+
+      lastAcceptedSuggestionRef.current = {
+        commandName: selectedSuggestion.name,
+        acceptedAt: now,
+      }
+
+      const inserted = applyCommandSuggestion(selectedSuggestion)
+      emitSlashDiagnostic(
+        'debug',
+        inserted ? 'SLASH_ACCEPTED' : 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE',
+        {
+          key,
+          prefix: slashPrefix,
+          command: selectedSuggestion.name,
+        },
+      )
+    },
+    [applyCommandSuggestion, selectedIndex, suggestions, value],
+  )
 
   return (
     <div className="border-t border-border p-4">
@@ -157,14 +261,13 @@ export function MessageInput({
               return
             }
 
-            if (showSuggestions && suggestions.length > 0 && event.key === 'Enter' && !event.shiftKey) {
+            const shouldAcceptWithEnter = event.key === 'Enter' && !event.shiftKey
+            const shouldAcceptWithTab = event.key === 'Tab'
+
+            if (showSuggestions && (shouldAcceptWithEnter || shouldAcceptWithTab)) {
               event.preventDefault()
               event.stopPropagation()
-
-              const selectedSuggestion = suggestions[selectedIndex]
-              if (selectedSuggestion) {
-                applyCommandSuggestion(selectedSuggestion)
-              }
+              acceptSuggestion(shouldAcceptWithTab ? 'Tab' : 'Enter')
               return
             }
 
@@ -191,7 +294,7 @@ export function MessageInput({
                 setSelectedIndex(index)
               }
 
-              applyCommandSuggestion(command)
+              acceptSuggestion('Pointer', command)
             }}
           />
         ) : null}

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -16,9 +16,16 @@ interface MessageInputProps {
 type SlashAcceptDiagnosticCode =
   | 'SLASH_ACCEPTED'
   | 'SLASH_ACCEPT_NO_SELECTION'
+  | 'SLASH_ACCEPT_NO_OP'
   | 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE'
 
 type SlashAcceptTriggerKey = 'Enter' | 'Tab' | 'Pointer'
+
+interface LastAcceptedSuggestion {
+  commandName: string
+  acceptedAt: number
+  valueAfterAccept: string
+}
 
 const SLASH_DUPLICATE_SUPPRESSION_WINDOW_MS = 64
 
@@ -50,14 +57,25 @@ function emitSlashDiagnostic(
 
 function extractSlashPrefix(value: string, caret: number): string {
   const boundedCaret = Math.max(0, Math.min(caret, value.length))
-  const tokenStart = value.lastIndexOf('/', boundedCaret)
+  const tokenStart = value.lastIndexOf('/', Math.max(0, boundedCaret - 1))
 
-  if (tokenStart < 0) {
+  if (tokenStart < 0 || tokenStart >= boundedCaret) {
+    return ''
+  }
+
+  const tokenBody = value.slice(tokenStart + 1, boundedCaret)
+  if (/\s/.test(tokenBody)) {
     return ''
   }
 
   const tokenEnd = value.indexOf(' ', tokenStart)
-  return tokenEnd === -1 ? value.slice(tokenStart) : value.slice(tokenStart, tokenEnd)
+  const end = tokenEnd === -1 ? value.length : tokenEnd
+
+  if (boundedCaret > end) {
+    return ''
+  }
+
+  return value.slice(tokenStart, end)
 }
 
 export function MessageInput({
@@ -73,7 +91,7 @@ export function MessageInput({
   const sendingRef = useRef(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const composerRef = useRef<HTMLDivElement | null>(null)
-  const lastAcceptedSuggestionRef = useRef<{ commandName: string; acceptedAt: number } | null>(null)
+  const lastAcceptedSuggestionRef = useRef<LastAcceptedSuggestion | null>(null)
 
   const {
     suggestions,
@@ -101,7 +119,11 @@ export function MessageInput({
 
   useEffect(() => {
     setIsSuggestionDismissed(false)
-    lastAcceptedSuggestionRef.current = null
+
+    const lastAccepted = lastAcceptedSuggestionRef.current
+    if (!lastAccepted || value !== lastAccepted.valueAfterAccept) {
+      lastAcceptedSuggestionRef.current = null
+    }
   }, [value])
 
   const send = async (): Promise<void> => {
@@ -141,7 +163,7 @@ export function MessageInput({
       ? `command-suggestion-${selectedIndex}`
       : undefined
 
-  const applyCommandSuggestion = useCallback((command: SlashCommandEntry): boolean => {
+  const applyCommandSuggestion = useCallback((command: SlashCommandEntry): { status: 'inserted' | 'no-op'; nextValue: string } => {
     const textarea = textareaRef.current
     const selectionStart = textarea?.selectionStart ?? value.length
     const selectionEnd = textarea?.selectionEnd ?? value.length
@@ -156,7 +178,7 @@ export function MessageInput({
 
     if (nextValue === value) {
       setIsSuggestionDismissed(true)
-      return false
+      return { status: 'no-op', nextValue }
     }
 
     setValue(nextValue)
@@ -173,7 +195,7 @@ export function MessageInput({
       element.setSelectionRange(nextCaret, nextCaret)
     })
 
-    return true
+    return { status: 'inserted', nextValue }
   }, [setSelectedIndex, value])
 
   const acceptSuggestion = useCallback(
@@ -210,23 +232,32 @@ export function MessageInput({
         return
       }
 
-      lastAcceptedSuggestionRef.current = {
-        commandName: selectedSuggestion.name,
-        acceptedAt: now,
-      }
+      const result = applyCommandSuggestion(selectedSuggestion)
 
-      const inserted = applyCommandSuggestion(selectedSuggestion)
-      emitSlashDiagnostic(
-        'debug',
-        inserted ? 'SLASH_ACCEPTED' : 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE',
-        {
+      if (result.status === 'inserted') {
+        lastAcceptedSuggestionRef.current = {
+          commandName: selectedSuggestion.name,
+          acceptedAt: now,
+          valueAfterAccept: result.nextValue,
+        }
+
+        emitSlashDiagnostic('debug', 'SLASH_ACCEPTED', {
           key,
           prefix: slashPrefix,
           command: selectedSuggestion.name,
           selectedIndex,
           suggestionCount: suggestions.length,
-        },
-      )
+        })
+        return
+      }
+
+      emitSlashDiagnostic('debug', 'SLASH_ACCEPT_NO_OP', {
+        key,
+        prefix: slashPrefix,
+        command: selectedSuggestion.name,
+        selectedIndex,
+        suggestionCount: suggestions.length,
+      })
     },
     [applyCommandSuggestion, selectedIndex, suggestions, value],
   )

--- a/apps/desktop/src/renderer/components/chat/MessageInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageInput.tsx
@@ -269,12 +269,21 @@ export function MessageInput({
             }
 
             const shouldAcceptWithEnter = event.key === 'Enter' && !event.shiftKey
-            const shouldAcceptWithTab = event.key === 'Tab'
+            const shouldAcceptWithTab = event.key === 'Tab' && !event.shiftKey
+            const hasSelectableSuggestion =
+              suggestions.length > 0 && selectedIndex >= 0 && selectedIndex < suggestions.length
 
-            if (showSuggestions && (shouldAcceptWithEnter || shouldAcceptWithTab)) {
+            if (showSuggestions && shouldAcceptWithEnter) {
               event.preventDefault()
               event.stopPropagation()
-              acceptSuggestion(shouldAcceptWithTab ? 'Tab' : 'Enter')
+              acceptSuggestion('Enter')
+              return
+            }
+
+            if (showSuggestions && shouldAcceptWithTab && hasSelectableSuggestion) {
+              event.preventDefault()
+              event.stopPropagation()
+              acceptSuggestion('Tab')
               return
             }
 

--- a/apps/desktop/src/renderer/components/chat/__tests__/CommandSuggestionDropdown.acceptance.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/CommandSuggestionDropdown.acceptance.test.tsx
@@ -81,7 +81,7 @@ describe('CommandSuggestionDropdown acceptance behavior', () => {
     expect(mouseDownEvent.defaultPrevented).toBe(true)
   })
 
-  test('is a no-op when no suggestions are available (no selection exists)', () => {
+  test('renders empty state and does not call onSelect when suggestions are empty', () => {
     const onSelect = vi.fn()
     const anchorRef = createRef<HTMLDivElement>()
 
@@ -98,10 +98,8 @@ describe('CommandSuggestionDropdown acceptance behavior', () => {
       </>,
     )
 
-    const listbox = screen.getByRole('listbox')
-    fireEvent.keyDown(listbox, { key: 'Enter' })
-
     expect(screen.queryByRole('option')).toBeNull()
+    expect(screen.getByText('No commands found')).not.toBeNull()
     expect(onSelect).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/components/chat/__tests__/CommandSuggestionDropdown.acceptance.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/CommandSuggestionDropdown.acceptance.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { createRef } from 'react'
+import { cleanup, createEvent, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import type { SlashCommandEntry } from '@shared/types'
+import { CommandSuggestionDropdown } from '../CommandSuggestionDropdown'
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: ResizeObserverMock,
+    writable: true,
+    configurable: true,
+  })
+
+  if (!HTMLElement.prototype.scrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = () => {}
+  }
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+const SUGGESTIONS: SlashCommandEntry[] = [
+  { name: '/kata', description: 'Root command', category: 'builtin' },
+  { name: '/kata plan', description: 'Plan mode', category: 'builtin' },
+]
+
+describe('CommandSuggestionDropdown acceptance behavior', () => {
+  test('invokes onSelect with selected suggestion when an option is chosen', () => {
+    const onSelect = vi.fn()
+    const anchorRef = createRef<HTMLDivElement>()
+
+    render(
+      <>
+        <div ref={anchorRef} />
+        <CommandSuggestionDropdown
+          suggestions={SUGGESTIONS}
+          selectedIndex={1}
+          onSelect={onSelect}
+          anchorRef={anchorRef}
+          isOpen
+        />
+      </>,
+    )
+
+    fireEvent.click(screen.getByRole('option', { name: '/kata plan' }))
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith(SUGGESTIONS[1])
+  })
+
+  test('prevents default on mousedown to preserve textarea focus during acceptance', () => {
+    const anchorRef = createRef<HTMLDivElement>()
+
+    render(
+      <>
+        <div ref={anchorRef} />
+        <CommandSuggestionDropdown
+          suggestions={SUGGESTIONS}
+          selectedIndex={0}
+          onSelect={() => {}}
+          anchorRef={anchorRef}
+          isOpen
+        />
+      </>,
+    )
+
+    const option = screen.getByRole('option', { name: '/kata' })
+    const mouseDownEvent = createEvent.mouseDown(option)
+
+    fireEvent(option, mouseDownEvent)
+
+    expect(mouseDownEvent.defaultPrevented).toBe(true)
+  })
+
+  test('is a no-op when no suggestions are available (no selection exists)', () => {
+    const onSelect = vi.fn()
+    const anchorRef = createRef<HTMLDivElement>()
+
+    render(
+      <>
+        <div ref={anchorRef} />
+        <CommandSuggestionDropdown
+          suggestions={[]}
+          selectedIndex={0}
+          onSelect={onSelect}
+          anchorRef={anchorRef}
+          isOpen
+        />
+      </>,
+    )
+
+    const listbox = screen.getByRole('listbox')
+    fireEvent.keyDown(listbox, { key: 'Enter' })
+
+    expect(screen.queryByRole('option')).toBeNull()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
@@ -183,8 +183,9 @@ describe('MessageInput slash acceptance', () => {
     })
   })
 
-  test('logs SLASH_ACCEPT_NO_SELECTION when Enter is pressed with no active suggestion', () => {
+  test('Enter falls back to submit when suggestions are visible but no selection is available', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const onSubmit = vi.fn(async () => {})
 
     mockUseCommandSuggestions.mockReturnValue({
       suggestions: [],
@@ -197,7 +198,7 @@ describe('MessageInput slash acceptance', () => {
 
     render(
       <MessageInput
-        onSubmit={async () => {}}
+        onSubmit={onSubmit}
         onStop={async () => {}}
       />,
     )
@@ -205,6 +206,10 @@ describe('MessageInput slash acceptance', () => {
     const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
     fireEvent.change(textarea, { target: { value: '/ka' } })
     fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('/ka')
+    })
 
     expect(warnSpy).toHaveBeenCalledWith(
       '[SlashAutocomplete]',
@@ -221,6 +226,9 @@ describe('MessageInput slash acceptance', () => {
     setupSuggestionsMock({ keepSuggestionsVisibleAfterAccept: true })
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
 
+    let now = 2_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+
     render(
       <MessageInput
         onSubmit={async () => {}}
@@ -233,11 +241,13 @@ describe('MessageInput slash acceptance', () => {
     textarea.setSelectionRange(3, 3)
 
     fireEvent.keyDown(textarea, { key: 'Enter' })
-    fireEvent.click(screen.getByRole('option', { name: '/kata plan' }))
 
     await waitFor(() => {
       expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/kata plan ')
     })
+
+    now = 2_020
+    fireEvent.click(screen.getByRole('option', { name: '/kata plan' }))
 
     expect(debugSpy).toHaveBeenCalledWith(
       '[SlashAutocomplete]',
@@ -245,6 +255,45 @@ describe('MessageInput slash acceptance', () => {
         code: 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE',
       }),
     )
+
+    nowSpy.mockRestore()
+  })
+
+  test('emits SLASH_ACCEPT_NO_OP when re-accepting after suppression window without changing input', async () => {
+    setupSuggestionsMock({ keepSuggestionsVisibleAfterAccept: true })
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+    render(
+      <MessageInput
+        onSubmit={async () => {}}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+    textarea.setSelectionRange(3, 3)
+
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/kata plan ')
+    })
+
+    now = 1_080
+    fireEvent.click(screen.getByRole('option', { name: '/kata plan' }))
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[SlashAutocomplete]',
+      expect.objectContaining({
+        code: 'SLASH_ACCEPT_NO_OP',
+      }),
+    )
+
+    nowSpy.mockRestore()
   })
 
   test('allows accepting the same suggestion again after input changes', async () => {
@@ -310,8 +359,6 @@ describe('MessageInput slash acceptance', () => {
   })
 
   test('Tab with no active suggestion does not consume focus navigation', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
     mockUseCommandSuggestions.mockReturnValue({
       suggestions: [],
       selectedIndex: 0,
@@ -336,6 +383,5 @@ describe('MessageInput slash acceptance', () => {
 
     expect(tabEvent.defaultPrevented).toBe(false)
     expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/ka')
-    expect(warnSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { SlashCommandEntry } from '@shared/types'
 import { useCommandSuggestions } from '@/hooks/useCommandSuggestions'
@@ -57,7 +57,14 @@ function setupSuggestionsMock({
       },
       isOpen: slashTriggered,
       isLoading: false,
-      moveSelection: vi.fn(),
+      moveSelection: (delta: number) => {
+        const total = showSuggestionEntries ? SUGGESTIONS.length : 0
+        if (total === 0) {
+          return
+        }
+
+        currentIndex = ((currentIndex + delta) % total + total) % total
+      },
     }
   })
 }
@@ -68,7 +75,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
-  vi.clearAllMocks()
+  vi.restoreAllMocks()
 })
 
 describe('MessageInput slash acceptance', () => {
@@ -241,6 +248,7 @@ describe('MessageInput slash acceptance', () => {
   })
 
   test('allows accepting the same suggestion again after input changes', async () => {
+    setupSuggestionsMock({ selectedIndex: 0 })
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
 
     render(
@@ -254,16 +262,14 @@ describe('MessageInput slash acceptance', () => {
 
     fireEvent.change(textarea, { target: { value: '/ka' } })
     textarea.setSelectionRange(3, 3)
-    fireEvent.keyDown(textarea, { key: 'ArrowDown' })
     fireEvent.keyDown(textarea, { key: 'Enter' })
 
     await waitFor(() => {
-      expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/kata plan ')
+      expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/kata ')
     })
 
     fireEvent.change(textarea, { target: { value: '/ka' } })
     textarea.setSelectionRange(3, 3)
-    fireEvent.keyDown(textarea, { key: 'ArrowDown' })
     fireEvent.keyDown(textarea, { key: 'Enter' })
 
     await waitFor(() => {
@@ -280,5 +286,56 @@ describe('MessageInput slash acceptance', () => {
     )
 
     expect(suppressedDuplicateEvents).toHaveLength(0)
+  })
+
+  test('Shift+Tab does not trigger slash acceptance', () => {
+    const onSubmit = vi.fn(async () => {})
+
+    render(
+      <MessageInput
+        onSubmit={onSubmit}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+
+    const shiftTabEvent = createEvent.keyDown(textarea, { key: 'Tab', shiftKey: true })
+    fireEvent(textarea, shiftTabEvent)
+
+    expect(shiftTabEvent.defaultPrevented).toBe(false)
+    expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/ka')
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  test('Tab with no active suggestion does not consume focus navigation', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    mockUseCommandSuggestions.mockReturnValue({
+      suggestions: [],
+      selectedIndex: 0,
+      setSelectedIndex: vi.fn(),
+      isOpen: true,
+      isLoading: true,
+      moveSelection: vi.fn(),
+    })
+
+    render(
+      <MessageInput
+        onSubmit={async () => {}}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+
+    const tabEvent = createEvent.keyDown(textarea, { key: 'Tab' })
+    fireEvent(textarea, tabEvent)
+
+    expect(tabEvent.defaultPrevented).toBe(false)
+    expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/ka')
+    expect(warnSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
@@ -204,6 +204,8 @@ describe('MessageInput slash acceptance', () => {
       expect.objectContaining({
         code: 'SLASH_ACCEPT_NO_SELECTION',
         key: 'Enter',
+        selectedIndex: 0,
+        suggestionCount: 0,
       }),
     )
   })

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
@@ -239,4 +239,46 @@ describe('MessageInput slash acceptance', () => {
       }),
     )
   })
+
+  test('allows accepting the same suggestion again after input changes', async () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    render(
+      <MessageInput
+        onSubmit={async () => {}}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+    textarea.setSelectionRange(3, 3)
+    fireEvent.keyDown(textarea, { key: 'ArrowDown' })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/kata plan ')
+    })
+
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+    textarea.setSelectionRange(3, 3)
+    fireEvent.keyDown(textarea, { key: 'ArrowDown' })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/kata ')
+    })
+
+    const suppressedDuplicateEvents = debugSpy.mock.calls.filter(
+      ([scope, payload]) =>
+        scope === '[SlashAutocomplete]' &&
+        typeof payload === 'object' &&
+        payload !== null &&
+        'code' in payload &&
+        (payload as { code?: string }).code === 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE',
+    )
+
+    expect(suppressedDuplicateEvents).toHaveLength(0)
+  })
 })

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { SlashCommandEntry } from '@shared/types'
+import { useCommandSuggestions } from '@/hooks/useCommandSuggestions'
+import { MessageInput } from '../MessageInput'
+
+vi.mock('@/hooks/useCommandSuggestions', () => ({
+  useCommandSuggestions: vi.fn(),
+}))
+
+const mockUseCommandSuggestions = vi.mocked(useCommandSuggestions)
+
+const SUGGESTIONS: SlashCommandEntry[] = [
+  { name: '/kata', description: 'Root command', category: 'builtin' },
+  { name: '/kata plan', description: 'Plan mode', category: 'builtin' },
+]
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: ResizeObserverMock,
+    writable: true,
+    configurable: true,
+  })
+
+  if (!HTMLElement.prototype.scrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = () => {}
+  }
+})
+
+function setupSuggestionsMock({
+  selectedIndex = 1,
+  keepSuggestionsVisibleAfterAccept = false,
+}: {
+  selectedIndex?: number
+  keepSuggestionsVisibleAfterAccept?: boolean
+} = {}): void {
+  let currentIndex = selectedIndex
+
+  mockUseCommandSuggestions.mockImplementation((input: string) => {
+    const slashTriggered = input.startsWith('/')
+    const hasTrailingSpace = input.endsWith(' ')
+    const showSuggestionEntries = slashTriggered && (keepSuggestionsVisibleAfterAccept || !hasTrailingSpace)
+
+    return {
+      suggestions: showSuggestionEntries ? SUGGESTIONS : [],
+      selectedIndex: currentIndex,
+      setSelectedIndex: (nextIndex: number) => {
+        currentIndex = nextIndex
+      },
+      isOpen: slashTriggered,
+      isLoading: false,
+      moveSelection: vi.fn(),
+    }
+  })
+}
+
+beforeEach(() => {
+  setupSuggestionsMock()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('MessageInput slash acceptance', () => {
+  test('Tab accepts highlighted suggestion, inserts trailing space, and keeps focus/caret at end', async () => {
+    const onSubmit = vi.fn(async () => {})
+
+    render(
+      <MessageInput
+        onSubmit={onSubmit}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+    textarea.focus()
+    textarea.setSelectionRange(3, 3)
+
+    fireEvent.keyDown(textarea, { key: 'Tab' })
+
+    await waitFor(() => {
+      const input = screen.getByTestId('chat-input') as HTMLTextAreaElement
+      expect(input.value).toBe('/kata plan ')
+      expect(input.selectionStart).toBe(input.value.length)
+      expect(input.selectionEnd).toBe(input.value.length)
+      expect(input.getAttribute('aria-expanded')).toBe('false')
+    })
+
+    expect(document.activeElement).toBe(textarea)
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('command-suggestion-dropdown')).toBeNull()
+  })
+
+  test('Enter accepts highlighted suggestion without submitting', async () => {
+    const onSubmit = vi.fn(async () => {})
+
+    render(
+      <MessageInput
+        onSubmit={onSubmit}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+    textarea.setSelectionRange(3, 3)
+
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/kata plan ')
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  test('Esc dismisses suggestions without mutating input or submitting', () => {
+    const onSubmit = vi.fn(async () => {})
+
+    render(
+      <MessageInput
+        onSubmit={onSubmit}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+
+    expect(screen.queryByTestId('command-suggestion-dropdown')).not.toBeNull()
+
+    fireEvent.keyDown(textarea, { key: 'Escape' })
+
+    expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/ka')
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('command-suggestion-dropdown')).toBeNull()
+  })
+
+  test('Enter submits when suggestions are closed', async () => {
+    const onSubmit = vi.fn(async () => {})
+
+    mockUseCommandSuggestions.mockReturnValue({
+      suggestions: [],
+      selectedIndex: 0,
+      setSelectedIndex: vi.fn(),
+      isOpen: false,
+      isLoading: false,
+      moveSelection: vi.fn(),
+    })
+
+    render(
+      <MessageInput
+        onSubmit={onSubmit}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input')
+    fireEvent.change(textarea, { target: { value: 'ship it' } })
+
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('ship it')
+    })
+  })
+
+  test('logs SLASH_ACCEPT_NO_SELECTION when Enter is pressed with no active suggestion', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    mockUseCommandSuggestions.mockReturnValue({
+      suggestions: [],
+      selectedIndex: 0,
+      setSelectedIndex: vi.fn(),
+      isOpen: true,
+      isLoading: true,
+      moveSelection: vi.fn(),
+    })
+
+    render(
+      <MessageInput
+        onSubmit={async () => {}}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[SlashAutocomplete]',
+      expect.objectContaining({
+        code: 'SLASH_ACCEPT_NO_SELECTION',
+        key: 'Enter',
+      }),
+    )
+  })
+
+  test('prevents duplicate command insertion when acceptance is triggered twice in rapid succession', async () => {
+    setupSuggestionsMock({ keepSuggestionsVisibleAfterAccept: true })
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    render(
+      <MessageInput
+        onSubmit={async () => {}}
+        onStop={async () => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '/ka' } })
+    textarea.setSelectionRange(3, 3)
+
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    fireEvent.click(screen.getByRole('option', { name: '/kata plan' }))
+
+    await waitFor(() => {
+      expect((screen.getByTestId('chat-input') as HTMLTextAreaElement).value).toBe('/kata plan ')
+    })
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[SlashAutocomplete]',
+      expect.objectContaining({
+        code: 'SLASH_ACCEPT_SUPPRESSED_DUPLICATE',
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add S03 acceptance contract tests for MessageInput and CommandSuggestionDropdown
- implement deterministic Tab/Enter slash suggestion acceptance with trailing-space insertion, focus/caret retention, and Enter-to-send arbitration
- add stable dev diagnostics (`SLASH_ACCEPTED`, `SLASH_ACCEPT_NO_SELECTION`, `SLASH_ACCEPT_SUPPRESSED_DUPLICATE`) and reset duplicate suppression across input edits

## Verification
- `cd apps/desktop && bun run test -- --coverage.enabled=false src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx`
- `cd apps/desktop && bun run test -- --coverage.enabled=false src/renderer/components/chat/__tests__/CommandSuggestionDropdown.acceptance.test.tsx`
- `cd apps/desktop && bun run typecheck`
- `cd apps/desktop && bun run build`
- `git push origin desktop/_S03__343` (pre-push hook ran affected lint/typecheck/test pipeline)

Closes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab and Enter both accept highlighted slash-command suggestions; pointer selection also accepts suggestions.
  * Tracks recent acceptance to suppress rapid duplicate inserts and emits diagnostics for acceptance events.

* **Bug Fixes**
  * Prevents no-op insertions and unintended focus capture when no suggestion is active.
  * Warns when attempting to accept with no selectable suggestion.

* **Tests**
  * Added acceptance tests covering keyboard, pointer, suppression, warnings, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR finalizes the slash command autocomplete acceptance contract by adding Tab as an acceptance key alongside Enter, introducing a 64 ms duplicate-suppression guard via `lastAcceptedSuggestionRef`, and extracting the acceptance path into a dedicated `acceptSuggestion` callback with dev-only diagnostics. Two new test files provide S03 contract coverage for `MessageInput` and `CommandSuggestionDropdown`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/naming suggestions in dev-only diagnostic code.

The acceptance logic is correct and well-tested. The two P2 findings are limited to misleading debug-log labelling and an undocumented intentional behaviour change around Tab during loading — neither affects runtime correctness or production builds.

MessageInput.tsx — the no-op diagnostic label and Tab-during-loading interception are worth a follow-up clarification comment in code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/MessageInput.tsx | Core logic refactored: applyCommandSuggestion now returns bool, new acceptSuggestion callback adds dedup ref + diagnostics, Tab added as acceptance key alongside Enter; two P2 notes (misleading diagnostic code and Tab-during-loading behavior). |
| apps/desktop/src/renderer/components/chat/__tests__/MessageInput.slash-acceptance.test.tsx | New acceptance contract tests covering Tab, Enter, Escape, submit-when-closed, no-selection warning, duplicate suppression, and reset-on-value-change; well-structured mock with keepSuggestionsVisibleAfterAccept flag for edge cases. |
| apps/desktop/src/renderer/components/chat/__tests__/CommandSuggestionDropdown.acceptance.test.tsx | New tests verify onSelect invocation, mousedown default-prevention for focus retention, and no-op behavior with empty suggestions; clean setup with ResizeObserver mock. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    K[KeyDown: Enter / Tab / Pointer click] --> SC{showSuggestions?}
    SC -- No --> EN{Enter key?}
    EN -- Yes --> SEND[handleSend]
    EN -- No --> NOOP1[no-op]
    SC -- Yes --> AS[acceptSuggestion key, command?]
    AS --> SEL{selectedSuggestion resolved?}
    SEL -- No --> WARN[emitDiagnostic SLASH_ACCEPT_NO_SELECTION / return]
    SEL -- Yes --> DUP{Within 64ms duplicate?}
    DUP -- Yes --> SUPP[dismiss + emitDiagnostic SLASH_ACCEPT_SUPPRESSED_DUPLICATE / return]
    DUP -- No --> SETREF[set lastAcceptedSuggestionRef]
    SETREF --> APPLY[applyCommandSuggestion]
    APPLY --> NOOP2{nextValue === value?}
    NOOP2 -- Yes --> DISMISS[setIsSuggestionDismissed true / return false]
    NOOP2 -- No --> INSERT[setValue + setSelectedIndex + queueMicrotask focus+caret / return true]
    INSERT --> DIAG1[emitDiagnostic SLASH_ACCEPTED]
    DISMISS --> DIAG2[emitDiagnostic SLASH_ACCEPT_SUPPRESSED_DUPLICATE - misleading label for no-op]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/MessageInput.tsx
Line: 219-229

Comment:
**Misleading diagnostic code for no-op path**

When `applyCommandSuggestion` returns `false` because `nextValue === value` (the input already contains the exact text the suggestion would produce), `SLASH_ACCEPT_SUPPRESSED_DUPLICATE` is emitted. But nothing was duplicated — the insertion was a genuine no-op. This conflates two distinct failure modes under one diagnostic label, making it harder to distinguish a real dedup event from a no-op during debugging. A dedicated code like `SLASH_ACCEPT_NOOP` would keep these cases separable in the console output.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/chat/MessageInput.tsx
Line: 271-279

Comment:
**Tab intercept blocks focus traversal during command loading**

`showSuggestions` is true whenever `isOpen && (isLoading || suggestions.length > 0)`. This means Tab is now intercepted even while `isLoading && suggestions.length === 0` — the loading-spinner state. A user who types `/` and then immediately presses Tab to move focus elsewhere will find the key silently consumed (with only a `SLASH_ACCEPT_NO_SELECTION` warn emitted). The dropdown is visible during loading so the interception is arguably intentional, but it's a behaviour change from the previous Enter-only path and worth a comment in code to make the intent explicit.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(S03/T03): reset acceptance dedupe ac..."](https://github.com/gannonh/kata/commit/4aa09cf68ad8c66a9d3394e96e4e92bc41a5e630) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29206663)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->