### PR TITLE
chore(release): cli v0.15.7, symphony v2.2.2, desktop v0.2.5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,29 +1,21 @@
-# Required: Anthropic API Key for Claude
-ANTHROPIC_API_KEY=sk-ant-...
+# Kata monorepo — canonical local secrets
+# Copy to .env and fill real values.
+# This is the single source of truth for local auth across CLI, Desktop, and Symphony.
 
-# Required: Craft MCP Server URL
-# Format: http://localhost:3000/v1/links/{secretLinkId}/mcp
-CRAFT_MCP_URL=http://localhost:3000/v1/links/YOUR_SECRET_LINK_ID/mcp
+# --- Required for GitHub-backed Kata workflow operations ---
+# Use a classic PAT for Projects v2 status updates (repo + project scopes).
+GH_TOKEN=ghp_replace_me
 
-# Required: Bearer token for MCP authentication
-CRAFT_MCP_TOKEN=your-bearer-token-here
+# --- Required for Linear-backed operations ---
+LINEAR_API_KEY=lin_api_replace_me
 
-# Google OAuth Configuration (for Gmail, Calendar, Drive connection features)
-# Get these from Google Cloud Console > APIs & Services > Credentials
-# Note: Create a "Desktop app" OAuth client - client_secret is required by Google
-GOOGLE_OAUTH_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GOOGLE_OAUTH_CLIENT_SECRET=your-client-secret
+# --- Enforce explicit token auth (disable local gh auth fallback) ---
+KATA_GITHUB_ENABLE_GH_CLI_FALLBACK=0
+SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK=0
 
-# Slack OAuth Configuration (for Slack workspace integration)
-# Get these from Slack API > Your Apps > OAuth & Permissions
-SLACK_OAUTH_CLIENT_ID=your-slack-client-id
-SLACK_OAUTH_CLIENT_SECRET=your-slack-client-secret
+# --- Optional ---
+# Slack webhook used by Symphony notifications (if configured in WORKFLOW.md)
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
 
-# Microsoft OAuth Configuration (for Outlook, OneDrive, Teams integration)
-# Get these from Azure Portal > App Registrations
-# Note: Create a "Mobile and desktop applications" platform OAuth client - PKCE is used so no client_secret is needed
-MICROSOFT_OAUTH_CLIENT_ID=your-microsoft-client-id
-
-# Sentry Error Tracking (captures crashes and chat/SDK errors)
-# Get the ingest URL from Sentry > Project Settings > Client Keys (DSN)
-SENTRY_ELECTRON_INGEST_URL=https://your-public-key@o0.ingest.sentry.io/0
+# Desktop/Symphony runtime verbosity
+# RUST_LOG=info

--- a/.kata/preferences.md
+++ b/.kata/preferences.md
@@ -29,7 +29,7 @@ skill_discovery: suggest
 auto_supervisor: {}
 symphony:
   url: http://localhost:8080
-  workflow_path: /Volumes/EVO/kata/kata-mono.worktrees/wt-desktop/apps/symphony/WORKFLOW-desktop-github.md
+  workflow_path: apps/symphony/WORKFLOW-desktop-github.md
 ---
 
 # Kata Preferences

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.15.7
+
+### Features
+
+- **Backend-neutral Kata workflow contract for Symphony and GitHub mode** — expanded `kata_*` backend abstractions so worker prompts, planning flows, and artifact handling are aligned across Linear and GitHub-backed projects.
+- **GitHub planning artifact authoring parity** — milestone and slice planning paths now materialize GitHub-native artifact content and dependency wiring with stronger contract coverage.
+
+### Improvements
+
+- **Upgrade to latest pi agent runtime packages** — bumped `@mariozechner/pi-coding-agent` and `@mariozechner/pi-tui` to `0.67.6`.
+
+### Bug Fixes
+
+- **Actionable Projects v2 permission diagnostics for `kata_update_issue_state`** — in `projects_v2` mode, permission-denied project status mutations now fail with a clear scope diagnosis and token-resolution hint (instead of a generic GraphQL error), making it explicit that the GitHub token needs Projects write access.
+- **Harden GitHub token resolution to use `gh auth token` automatically** — when env tokens are unset, Kata now prefers the authenticated GitHub CLI token before falling back to persisted auth.json credentials. This reduces breakage across worktrees without requiring manual token exports.
+
 ## 0.15.6
 
 ### Bug Fixes

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Kata CLI coding agent",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/loader.ts
+++ b/apps/cli/src/loader.ts
@@ -1,9 +1,96 @@
 #!/usr/bin/env node
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "url";
-import { dirname, resolve, join } from "path";
+import { dirname, resolve, join, isAbsolute } from "path";
 import { existsSync, readFileSync } from "fs";
 import { agentDir, appRoot } from "./app-paths.js";
 import { resolveEffectiveMcpConfigPath } from "./mcp-config.js";
+
+function stripWrappingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function expandEnvReferences(value: string, loadedValues: Map<string, string>): string {
+  return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_match, name: string) => {
+    const fromProcess = process.env[name];
+    if (fromProcess !== undefined) return fromProcess;
+    const fromLoaded = loadedValues.get(name);
+    return fromLoaded ?? "";
+  });
+}
+
+function loadEnvFileIfPresent(filePath: string): void {
+  if (!existsSync(filePath)) return;
+
+  const content = readFileSync(filePath, "utf8");
+  const loadedValues = new Map<string, string>();
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const match = rawLine.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!match) continue;
+
+    const key = match[1];
+    const rawValue = match[2] ?? "";
+    const value = expandEnvReferences(stripWrappingQuotes(rawValue), loadedValues);
+    loadedValues.set(key, value);
+
+    if (process.env[key] === undefined || process.env[key] === "") {
+      process.env[key] = value;
+    }
+  }
+}
+
+function resolveGitCommonRoot(startDir: string): string | null {
+  try {
+    const commonDirRaw = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+      cwd: startDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1500,
+      windowsHide: true,
+    }).trim();
+
+    if (!commonDirRaw) return null;
+
+    const absoluteCommonDir = isAbsolute(commonDirRaw)
+      ? commonDirRaw
+      : resolve(startDir, commonDirRaw);
+
+    return dirname(absoluteCommonDir);
+  } catch {
+    return null;
+  }
+}
+
+function loadCanonicalProjectEnv(): void {
+  const root = resolveGitCommonRoot(process.cwd());
+  if (!root) return;
+
+  loadEnvFileIfPresent(join(root, ".env"));
+}
+
+function applyGithubTokenAliases(): void {
+  const ghToken = process.env.GH_TOKEN?.trim();
+  if (!ghToken) return;
+
+  if (!process.env.GITHUB_TOKEN) {
+    process.env.GITHUB_TOKEN = ghToken;
+  }
+
+  if (!process.env.KATA_GITHUB_TOKEN) {
+    process.env.KATA_GITHUB_TOKEN = ghToken;
+  }
+}
+
+loadCanonicalProjectEnv();
+applyGithubTokenAliases();
 
 // pkg/ is a shim directory: contains kata's piConfig (package.json) and pi's
 // theme assets (dist/modes/interactive/theme/) without a src/ directory.

--- a/apps/cli/src/resources/extensions/kata/backend-factory.ts
+++ b/apps/cli/src/resources/extensions/kata/backend-factory.ts
@@ -101,7 +101,7 @@ async function createGithubBackend(
         {
           code: "missing_github_token",
           message:
-            "No GitHub token found. Set KATA_GITHUB_TOKEN/GH_TOKEN/GITHUB_TOKEN, run `gh auth login`, or add a github credential entry to ~/.kata-cli/agent/auth.json.",
+            "No GitHub token found. Token resolution order is KATA_GITHUB_TOKEN -> GH_TOKEN -> GITHUB_TOKEN -> gh auth token (when KATA_GITHUB_ENABLE_GH_CLI_FALLBACK is enabled) -> ~/.kata-cli/agent/auth.json (github.key). Set KATA_GITHUB_TOKEN/GH_TOKEN/GITHUB_TOKEN, run `gh auth login`, or add a github credential entry to ~/.kata-cli/agent/auth.json. Set KATA_GITHUB_ENABLE_GH_CLI_FALLBACK=false to skip gh CLI fallback.",
           field: "KATA_GITHUB_TOKEN",
           retryable: false,
         },

--- a/apps/cli/src/resources/extensions/kata/backend-factory.ts
+++ b/apps/cli/src/resources/extensions/kata/backend-factory.ts
@@ -101,7 +101,7 @@ async function createGithubBackend(
         {
           code: "missing_github_token",
           message:
-            "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, or add a github credential entry to ~/.kata-cli/agent/auth.json.",
+            "No GitHub token found. Set KATA_GITHUB_TOKEN/GH_TOKEN/GITHUB_TOKEN, run `gh auth login`, or add a github credential entry to ~/.kata-cli/agent/auth.json.",
           field: "KATA_GITHUB_TOKEN",
           retryable: false,
         },

--- a/apps/cli/src/resources/extensions/kata/github-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/github-backend.ts
@@ -990,7 +990,7 @@ function isProjectsV2PermissionError(error: unknown): boolean {
   return (
     normalized.includes("resource not accessible by personal access token") ||
     normalized.includes("resource not accessible by integration") ||
-    normalized.includes("not authorized") ||
+    (normalized.includes("not authorized to") && normalized.includes("project")) ||
     (normalized.includes("forbidden") && normalized.includes("project"))
   );
 }
@@ -1003,7 +1003,7 @@ function formatProjectsV2PermissionErrorMessage(
     `GitHub Projects v2 status update failed for issue #${issueNumber}.`,
     "The token used by Kata does not have permission to mutate GitHub Projects v2 fields.",
     "Grant Projects write access (classic PAT: `project` scope) to the token used by Kata, then retry.",
-    "Token resolution order: KATA_GITHUB_TOKEN -> GH_TOKEN -> GITHUB_TOKEN -> ~/.kata-cli/agent/auth.json (github.key).",
+    "Token resolution order: KATA_GITHUB_TOKEN -> GH_TOKEN -> GITHUB_TOKEN -> gh auth token (when KATA_GITHUB_ENABLE_GH_CLI_FALLBACK is enabled) -> ~/.kata-cli/agent/auth.json (github.key).",
     `Original error: ${originalMessage}`,
   ].join(" ");
 }

--- a/apps/cli/src/resources/extensions/kata/github-backend.ts
+++ b/apps/cli/src/resources/extensions/kata/github-backend.ts
@@ -984,6 +984,30 @@ function phaseToProjectsV2StatusName(phase: KataIssueStatePhase): string {
   }
 }
 
+function isProjectsV2PermissionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("resource not accessible by personal access token") ||
+    normalized.includes("resource not accessible by integration") ||
+    normalized.includes("not authorized") ||
+    (normalized.includes("forbidden") && normalized.includes("project"))
+  );
+}
+
+function formatProjectsV2PermissionErrorMessage(
+  issueNumber: number,
+  originalMessage: string,
+): string {
+  return [
+    `GitHub Projects v2 status update failed for issue #${issueNumber}.`,
+    "The token used by Kata does not have permission to mutate GitHub Projects v2 fields.",
+    "Grant Projects write access (classic PAT: `project` scope) to the token used by Kata, then retry.",
+    "Token resolution order: KATA_GITHUB_TOKEN -> GH_TOKEN -> GITHUB_TOKEN -> ~/.kata-cli/agent/auth.json (github.key).",
+    `Original error: ${originalMessage}`,
+  ].join(" ");
+}
+
 function defaultGithubLabelColor(labelName: string): string {
   const normalized = labelName.trim().toLowerCase();
   if (normalized.endsWith("milestone")) return "7C3AED";
@@ -2017,21 +2041,32 @@ export class GithubBackend implements KataBackend {
     const shouldClose = phase === "done" || phase === "closed";
     const nextLabels = [...preservedLabels, nextPhaseLabel];
 
-    // Projects v2 mode: mutate the project board Status field directly and keep
-    // canonical phase labels synchronized so label-based state derivation stays accurate.
+    // Projects v2 mode: mutate the project board Status field and keep
+    // canonical phase labels synchronized. If Projects permissions are missing,
+    // fail with an explicit actionable diagnostic.
     if (this.config.stateMode === "projects_v2" && this.config.githubProjectNumber) {
       const displayName = phaseToProjectsV2StatusName(phase);
-      const actualStatus = await this.client.updateProjectV2ItemStatus(number, displayName);
+      let actualStatus: string;
 
-      await this.updateIssue(number, {
+      try {
+        actualStatus = await this.client.updateProjectV2ItemStatus(number, displayName);
+      } catch (error) {
+        if (!isProjectsV2PermissionError(error)) {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(formatProjectsV2PermissionErrorMessage(number, message));
+      }
+
+      const updated = await this.updateIssue(number, {
         labels: nextLabels,
         state: shouldClose ? "closed" : "open",
       });
 
       this.invalidateStateCache();
       return {
-        issueId: String(number),
-        identifier: `#${number}`,
+        issueId: String(updated.number),
+        identifier: `#${updated.number}`,
         phase,
         state: actualStatus,
       };

--- a/apps/cli/src/resources/extensions/kata/github-config.ts
+++ b/apps/cli/src/resources/extensions/kata/github-config.ts
@@ -6,6 +6,7 @@
  * redacted diagnostics when configuration is incomplete.
  */
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -208,6 +209,28 @@ export interface ResolvedGithubToken {
   source: string | null;
 }
 
+function resolveGithubTokenFromGhCli(): ResolvedGithubToken {
+  if (process.env.KATA_GITHUB_ENABLE_GH_CLI_FALLBACK === "0") {
+    return { token: null, source: null };
+  }
+
+  try {
+    const output = execFileSync("gh", ["auth", "token"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 2000,
+    }).trim();
+    if (!output) return { token: null, source: null };
+    return { token: output, source: "gh auth token" };
+  } catch (err) {
+    debug(
+      "Unable to resolve token from gh auth token: %s",
+      err instanceof Error ? err.message : String(err),
+    );
+    return { token: null, source: null };
+  }
+}
+
 export function resolveGithubToken(authFilePath?: string): ResolvedGithubToken {
   const kataToken = process.env.KATA_GITHUB_TOKEN;
   if (kataToken) return { token: kataToken, source: "KATA_GITHUB_TOKEN" };
@@ -217,6 +240,11 @@ export function resolveGithubToken(authFilePath?: string): ResolvedGithubToken {
 
   const githubToken = process.env.GITHUB_TOKEN;
   if (githubToken) return { token: githubToken, source: "GITHUB_TOKEN" };
+
+  // Prefer the authenticated GitHub CLI token over stale persisted keys so
+  // projects-v2 updates keep working without manual exports.
+  const ghCliToken = resolveGithubTokenFromGhCli();
+  if (ghCliToken.token) return ghCliToken;
 
   const authPath =
     authFilePath ?? join(homedir(), ".kata-cli", "agent", "auth.json");
@@ -280,7 +308,7 @@ export function validateGithubConfig(
     diagnostics.push({
       code: "missing_github_token",
       message:
-        "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, or add a github credential entry to ~/.kata-cli/agent/auth.json.",
+        "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN; run `gh auth login`; or add a github credential entry to ~/.kata-cli/agent/auth.json.",
       field: "KATA_GITHUB_TOKEN",
       retryable: false,
     });
@@ -340,7 +368,7 @@ function getGithubDiagnosticAction(
 ): string | null {
   switch (diagnostic.code) {
     case "missing_github_token":
-      return "set KATA_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN in your environment.";
+      return "set KATA_GITHUB_TOKEN/GH_TOKEN/GITHUB_TOKEN, or run `gh auth login` (Kata auto-reads `gh auth token`).";
     case "missing_github_config":
       return "add a github: block to .kata/preferences.md with repoOwner and repoName.";
     case "missing_repo_owner":

--- a/apps/cli/src/resources/extensions/kata/github-config.ts
+++ b/apps/cli/src/resources/extensions/kata/github-config.ts
@@ -270,10 +270,16 @@ function resolveGithubTokenFromGhCli(): ResolvedGithubToken {
   const forcedOutput = process.env.KATA_TEST_GH_AUTH_TOKEN_OUTPUT;
   if (forcedOutput !== undefined) {
     if (forcedOutput === "__THROW__") {
-      return { token: null, source: null };
+      const unresolved = { token: null, source: null };
+      ghCliTokenCache.set(hostname, unresolved);
+      return unresolved;
     }
     const value = forcedOutput.trim();
-    if (!value) return { token: null, source: null };
+    if (!value) {
+      const unresolved = { token: null, source: null };
+      ghCliTokenCache.set(hostname, unresolved);
+      return unresolved;
+    }
     const resolved = {
       token: value,
       source: `gh auth token (${hostname})`,
@@ -289,7 +295,11 @@ function resolveGithubTokenFromGhCli(): ResolvedGithubToken {
       timeout: 2000,
       windowsHide: true,
     }).trim();
-    if (!output) return { token: null, source: null };
+    if (!output) {
+      const unresolved = { token: null, source: null };
+      ghCliTokenCache.set(hostname, unresolved);
+      return unresolved;
+    }
     const resolved = {
       token: output,
       source: `gh auth token (${hostname})`,
@@ -302,7 +312,9 @@ function resolveGithubTokenFromGhCli(): ResolvedGithubToken {
       hostname,
       err instanceof Error ? err.message : String(err),
     );
-    return { token: null, source: null };
+    const unresolved = { token: null, source: null };
+    ghCliTokenCache.set(hostname, unresolved);
+    return unresolved;
   }
 }
 

--- a/apps/cli/src/resources/extensions/kata/github-config.ts
+++ b/apps/cli/src/resources/extensions/kata/github-config.ts
@@ -218,6 +218,7 @@ const GH_CLI_FALLBACK_DISABLE_VALUES = new Set([
 ]);
 
 const ghCliTokenCache = new Map<string, ResolvedGithubToken>();
+let warnedInvalidGhCliApiBase = false;
 
 function isGhCliFallbackEnabled(): boolean {
   const raw = (process.env.KATA_GITHUB_ENABLE_GH_CLI_FALLBACK ?? "")
@@ -234,11 +235,18 @@ function resolveGithubHostnameForGhCli(): string {
     const parsed = new URL(apiBase);
     return parsed.hostname || "github.com";
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     debug(
       "Invalid KATA_GITHUB_API_BASE_URL for gh CLI host resolution (%s): %s",
       apiBase,
-      err instanceof Error ? err.message : String(err),
+      message,
     );
+    if (!warnedInvalidGhCliApiBase) {
+      warnedInvalidGhCliApiBase = true;
+      console.warn(
+        `[kata:github-config] Invalid KATA_GITHUB_API_BASE_URL for gh CLI host resolution (${apiBase}): ${message}. Falling back to github.com.`,
+      );
+    }
     return "github.com";
   }
 }

--- a/apps/cli/src/resources/extensions/kata/github-config.ts
+++ b/apps/cli/src/resources/extensions/kata/github-config.ts
@@ -209,22 +209,89 @@ export interface ResolvedGithubToken {
   source: string | null;
 }
 
+const GH_CLI_FALLBACK_DISABLE_VALUES = new Set([
+  "0",
+  "false",
+  "no",
+  "off",
+  "disabled",
+]);
+
+const ghCliTokenCache = new Map<string, ResolvedGithubToken>();
+
+function isGhCliFallbackEnabled(): boolean {
+  const raw = (process.env.KATA_GITHUB_ENABLE_GH_CLI_FALLBACK ?? "")
+    .trim()
+    .toLowerCase();
+  return !GH_CLI_FALLBACK_DISABLE_VALUES.has(raw);
+}
+
+function resolveGithubHostnameForGhCli(): string {
+  const apiBase = process.env.KATA_GITHUB_API_BASE_URL?.trim();
+  if (!apiBase) return "github.com";
+
+  try {
+    const parsed = new URL(apiBase);
+    return parsed.hostname || "github.com";
+  } catch (err) {
+    debug(
+      "Invalid KATA_GITHUB_API_BASE_URL for gh CLI host resolution (%s): %s",
+      apiBase,
+      err instanceof Error ? err.message : String(err),
+    );
+    return "github.com";
+  }
+}
+
+/**
+ * Test-only hook for deterministic gh-cli fallback tests.
+ */
+export function resetGithubTokenResolutionCacheForTests(): void {
+  ghCliTokenCache.clear();
+}
+
 function resolveGithubTokenFromGhCli(): ResolvedGithubToken {
-  if (process.env.KATA_GITHUB_ENABLE_GH_CLI_FALLBACK === "0") {
+  if (!isGhCliFallbackEnabled()) {
     return { token: null, source: null };
   }
 
+  const hostname = resolveGithubHostnameForGhCli();
+  const cached = ghCliTokenCache.get(hostname);
+  if (cached) return cached;
+
+  const forcedOutput = process.env.KATA_TEST_GH_AUTH_TOKEN_OUTPUT;
+  if (forcedOutput !== undefined) {
+    if (forcedOutput === "__THROW__") {
+      return { token: null, source: null };
+    }
+    const value = forcedOutput.trim();
+    if (!value) return { token: null, source: null };
+    const resolved = {
+      token: value,
+      source: `gh auth token (${hostname})`,
+    };
+    ghCliTokenCache.set(hostname, resolved);
+    return resolved;
+  }
+
   try {
-    const output = execFileSync("gh", ["auth", "token"], {
+    const output = execFileSync("gh", ["auth", "token", "--hostname", hostname], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 2000,
+      windowsHide: true,
     }).trim();
     if (!output) return { token: null, source: null };
-    return { token: output, source: "gh auth token" };
+    const resolved = {
+      token: output,
+      source: `gh auth token (${hostname})`,
+    };
+    ghCliTokenCache.set(hostname, resolved);
+    return resolved;
   } catch (err) {
     debug(
-      "Unable to resolve token from gh auth token: %s",
+      "Unable to resolve token from gh auth token for host %s: %s",
+      hostname,
       err instanceof Error ? err.message : String(err),
     );
     return { token: null, source: null };
@@ -305,10 +372,13 @@ export function validateGithubConfig(
   if (trackerDiagnostic) diagnostics.push(trackerDiagnostic);
 
   if (!tokenPresent) {
+    const loginHint = isGhCliFallbackEnabled()
+      ? "; run `gh auth login`"
+      : "";
     diagnostics.push({
       code: "missing_github_token",
       message:
-        "No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN; run `gh auth login`; or add a github credential entry to ~/.kata-cli/agent/auth.json.",
+        `No GitHub token found. Set KATA_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN${loginHint}; or add a github credential entry to ~/.kata-cli/agent/auth.json.`,
       field: "KATA_GITHUB_TOKEN",
       retryable: false,
     });
@@ -368,7 +438,9 @@ function getGithubDiagnosticAction(
 ): string | null {
   switch (diagnostic.code) {
     case "missing_github_token":
-      return "set KATA_GITHUB_TOKEN/GH_TOKEN/GITHUB_TOKEN, or run `gh auth login` (Kata auto-reads `gh auth token`).";
+      return isGhCliFallbackEnabled()
+        ? "set KATA_GITHUB_TOKEN/GH_TOKEN/GITHUB_TOKEN, or run `gh auth login` (Kata auto-reads `gh auth token`)."
+        : "set KATA_GITHUB_TOKEN/GH_TOKEN/GITHUB_TOKEN in your environment or auth.json.";
     case "missing_github_config":
       return "add a github: block to .kata/preferences.md with repoOwner and repoName.";
     case "missing_repo_owner":

--- a/apps/cli/src/resources/extensions/kata/tests/github-backend.artifacts.vitest.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-backend.artifacts.vitest.test.ts
@@ -30,6 +30,7 @@ class FakeGithubClient implements GithubBackendClient {
   }>>();
   private nextCommentId = 1;
   private projectStatusUpdates: Array<{ issueNumber: number; stateName: string }> = [];
+  private projectStatusError: Error | null = null;
 
   constructor(seed: MutableIssue[] = []) {
     this.issues = seed.map((issue) => ({ ...issue, labels: [...issue.labels], updatedAt: issue.updatedAt ?? "2026-04-12T00:00:00.000Z" }));
@@ -160,11 +161,22 @@ class FakeGithubClient implements GithubBackendClient {
 
   async updateProjectV2ItemStatus(issueNumber: number, stateName: string): Promise<string> {
     this.projectStatusUpdates.push({ issueNumber, stateName });
+    if (this.projectStatusError) {
+      throw this.projectStatusError;
+    }
     return stateName;
   }
 
   getProjectStatusUpdates(): Array<{ issueNumber: number; stateName: string }> {
     return [...this.projectStatusUpdates];
+  }
+
+  setProjectStatusError(error: Error | string | null): void {
+    if (!error) {
+      this.projectStatusError = null;
+      return;
+    }
+    this.projectStatusError = error instanceof Error ? error : new Error(error);
   }
 
   updatedCommentBodies(): string[] {
@@ -445,6 +457,50 @@ describe("GithubBackend canonical worker operations", () => {
     expect(issue?.labels).toContain("kata:slice");
     expect(issue?.labels).toContain("kata:agent-review");
     expect(issue?.labels).not.toContain("kata:in-progress");
+  });
+
+  it("updateIssueState in projects_v2 mode returns actionable error when project status mutation is forbidden", async () => {
+    const client = new FakeGithubClient([
+      { number: 54, title: "[S06] Projects permissions", state: "open", labels: ["kata:slice", "kata:in-progress"] },
+    ]);
+    client.setProjectStatusError(
+      "GitHub GraphQL request failed for gannonh/kata: Resource not accessible by personal access token",
+    );
+
+    const backend = makeBackend(client, {
+      ...CONFIG,
+      stateMode: "projects_v2",
+      githubProjectNumber: 17,
+    });
+
+    await expect(backend.updateIssueState("54", "agent-review")).rejects.toThrow(
+      "Grant Projects write access (classic PAT: `project` scope)",
+    );
+
+    const issue = await client.getIssue(54);
+    expect(issue?.labels).toContain("kata:in-progress");
+    expect(issue?.labels).not.toContain("kata:agent-review");
+  });
+
+  it("updateIssueState in projects_v2 mode still throws for non-permission project status errors", async () => {
+    const client = new FakeGithubClient([
+      { number: 55, title: "[S07] Projects strict", state: "open", labels: ["kata:slice", "kata:in-progress"] },
+    ]);
+    client.setProjectStatusError("Projects v2 status option 'Agent Review' not found");
+
+    const backend = makeBackend(client, {
+      ...CONFIG,
+      stateMode: "projects_v2",
+      githubProjectNumber: 17,
+    });
+
+    await expect(backend.updateIssueState("55", "agent-review")).rejects.toThrow(
+      "Projects v2 status option 'Agent Review' not found",
+    );
+
+    const issue = await client.getIssue(55);
+    expect(issue?.labels).toContain("kata:in-progress");
+    expect(issue?.labels).not.toContain("kata:agent-review");
   });
 
   it("isSlicePlanned falls back to metadata-linked tasks when no sub-issue links exist yet", async () => {

--- a/apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-backend.integration.test.ts
@@ -220,8 +220,10 @@ test("createBackend returns actionable diagnostics when GitHub token is missing"
         KATA_GITHUB_TOKEN: undefined,
         GH_TOKEN: undefined,
         GITHUB_TOKEN: undefined,
+        KATA_GITHUB_ENABLE_GH_CLI_FALLBACK: "0",
         KATA_GITHUB_API_BASE_URL: undefined,
         KATA_GITHUB_WORKFLOW_PATH: undefined,
+        HOME: workspace,
       },
       async () => {
         await assert.rejects(
@@ -230,7 +232,10 @@ test("createBackend returns actionable diagnostics when GitHub token is missing"
             assert.ok(err instanceof Error);
             assert.match(err.message, /GitHub backend is not ready/);
             assert.match(err.message, /diagnostic: missing_github_token/);
-            assert.match(err.message, /action: set KATA_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN/);
+            assert.match(
+              err.message,
+              /action: set KATA_GITHUB_TOKEN\/GH_TOKEN\/GITHUB_TOKEN/,
+            );
             assert.match(err.message, /\/kata prefs status/);
             return true;
           },

--- a/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
@@ -300,6 +300,38 @@ test("resolveGithubToken falls back to auth.json when gh-cli fallback fails", ()
   );
 });
 
+test("resolveGithubToken caches unresolved gh-cli fallback results per host", () => {
+  const dir = makeProjectDir();
+  const authPath = join(dir, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({ github: { type: "api_key", key: "from-auth-json" } }, null, 2),
+    "utf-8",
+  );
+
+  withEnv(
+    {
+      KATA_GITHUB_TOKEN: undefined,
+      GH_TOKEN: undefined,
+      GITHUB_TOKEN: undefined,
+      KATA_GITHUB_ENABLE_GH_CLI_FALLBACK: "1",
+      KATA_TEST_GH_AUTH_TOKEN_OUTPUT: "__THROW__",
+      KATA_GITHUB_API_BASE_URL: "https://ghe.example.com/api/v3",
+    },
+    () => {
+      const first = resolveGithubToken(authPath);
+      assert.equal(first.token, "from-auth-json");
+      assert.equal(first.source, "auth.json (github provider)");
+
+      process.env.KATA_TEST_GH_AUTH_TOKEN_OUTPUT = "from-gh";
+
+      const second = resolveGithubToken(authPath);
+      assert.equal(second.token, "from-auth-json");
+      assert.equal(second.source, "auth.json (github provider)");
+    },
+  );
+});
+
 test("resolveGithubToken disables gh-cli fallback for false/no values", () => {
   const dir = makeProjectDir();
   const authPath = join(dir, "auth.json");

--- a/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import {
   formatGithubConfigStatus,
   loadGithubTrackerConfig,
+  resetGithubTokenResolutionCacheForTests,
   resolveGithubToken,
   resolveGithubWorkflowPath,
   validateGithubConfig,
@@ -40,6 +41,7 @@ function withEnv<T>(values: Record<string, string | undefined>, fn: () => T): T 
       process.env[key] = value;
     }
   }
+  resetGithubTokenResolutionCacheForTests();
   try {
     return fn();
   } finally {
@@ -47,8 +49,10 @@ function withEnv<T>(values: Record<string, string | undefined>, fn: () => T): T 
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
+    resetGithubTokenResolutionCacheForTests();
   }
 }
+
 
 test("resolveGithubWorkflowPath now points to .kata/preferences.md", () => {
   assert.equal(resolveGithubWorkflowPath("/project"), "/project/.kata/preferences.md");
@@ -243,6 +247,84 @@ test("resolveGithubToken priority order", () => {
       assert.equal(token.source, "GH_TOKEN");
     },
   );
+});
+
+test("resolveGithubToken prefers gh-cli fallback over auth.json and uses configured hostname", () => {
+  const dir = makeProjectDir();
+  const authPath = join(dir, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({ github: { type: "api_key", key: "from-auth-json" } }, null, 2),
+    "utf-8",
+  );
+
+  withEnv(
+    {
+      KATA_GITHUB_TOKEN: undefined,
+      GH_TOKEN: undefined,
+      GITHUB_TOKEN: undefined,
+      KATA_GITHUB_ENABLE_GH_CLI_FALLBACK: "1",
+      KATA_GITHUB_API_BASE_URL: "https://ghe.example.com/api/v3",
+      KATA_TEST_GH_AUTH_TOKEN_OUTPUT: "from-gh",
+    },
+    () => {
+      const resolved = resolveGithubToken(authPath);
+      assert.equal(resolved.token, "from-gh");
+      assert.equal(resolved.source, "gh auth token (ghe.example.com)");
+    },
+  );
+});
+
+test("resolveGithubToken falls back to auth.json when gh-cli fallback fails", () => {
+  const dir = makeProjectDir();
+  const authPath = join(dir, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({ github: { type: "api_key", key: "from-auth-json" } }, null, 2),
+    "utf-8",
+  );
+
+  withEnv(
+    {
+      KATA_GITHUB_TOKEN: undefined,
+      GH_TOKEN: undefined,
+      GITHUB_TOKEN: undefined,
+      KATA_GITHUB_ENABLE_GH_CLI_FALLBACK: "1",
+      KATA_TEST_GH_AUTH_TOKEN_OUTPUT: "__THROW__",
+    },
+    () => {
+      const resolved = resolveGithubToken(authPath);
+      assert.equal(resolved.token, "from-auth-json");
+      assert.equal(resolved.source, "auth.json (github provider)");
+    },
+  );
+});
+
+test("resolveGithubToken disables gh-cli fallback for false/no values", () => {
+  const dir = makeProjectDir();
+  const authPath = join(dir, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({ github: { type: "api_key", key: "from-auth-json" } }, null, 2),
+    "utf-8",
+  );
+
+  for (const disabled of ["false", "no"]) {
+    withEnv(
+      {
+        KATA_GITHUB_TOKEN: undefined,
+        GH_TOKEN: undefined,
+        GITHUB_TOKEN: undefined,
+        KATA_GITHUB_ENABLE_GH_CLI_FALLBACK: disabled,
+        KATA_TEST_GH_AUTH_TOKEN_OUTPUT: "from-gh",
+      },
+      () => {
+        const resolved = resolveGithubToken(authPath);
+        assert.equal(resolved.token, "from-auth-json");
+        assert.equal(resolved.source, "auth.json (github provider)");
+      },
+    );
+  }
 });
 
 test("validateGithubConfig includes token and github diagnostics", () => {

--- a/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/github-config.test.ts
@@ -26,7 +26,13 @@ function writePrefs(dir: string, yaml: string): string {
 
 function withEnv<T>(values: Record<string, string | undefined>, fn: () => T): T {
   const previous: Record<string, string | undefined> = {};
-  for (const [key, value] of Object.entries(values)) {
+  const effectiveValues = {
+    KATA_GITHUB_ENABLE_GH_CLI_FALLBACK:
+      values.KATA_GITHUB_ENABLE_GH_CLI_FALLBACK ?? "0",
+    ...values,
+  };
+
+  for (const [key, value] of Object.entries(effectiveValues)) {
     previous[key] = process.env[key];
     if (value === undefined) {
       delete process.env[key];
@@ -260,7 +266,11 @@ test("validateGithubConfig includes token and github diagnostics", () => {
       GH_TOKEN: undefined,
       GITHUB_TOKEN: undefined,
     },
-    () => validateGithubConfig({ basePath: dir }),
+    () =>
+      validateGithubConfig({
+        basePath: dir,
+        authFilePath: join(dir, "missing-auth.json"),
+      }),
   );
 
   assert.equal(result.ok, false);
@@ -291,7 +301,11 @@ test("validateGithubConfig succeeds with github prefs + token", () => {
       GH_TOKEN: undefined,
       GITHUB_TOKEN: undefined,
     },
-    () => validateGithubConfig({ basePath: dir }),
+    () =>
+      validateGithubConfig({
+        basePath: dir,
+        authFilePath: join(dir, "missing-auth.json"),
+      }),
   );
 
   assert.equal(result.ok, true);

--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -1,6 +1,8 @@
 # Kata Desktop — development environment
 # Copy this file to .env.development and fill in real values.
 # .env.development is gitignored and loaded by the Electron main process at startup.
+#
+# NOTE: Auth secrets are loaded from <repo-root>/.env (canonical).
 
 # ── Desktop ──────────────────────────────────────────────────
 # Path to the Kata CLI loader (required for the agent bridge)
@@ -11,17 +13,13 @@ KATA_BIN_PATH=../../apps/cli/dist/loader.js
 KATA_SYMPHONY_BIN_PATH=/absolute/path/to/apps/symphony/target/release/symphony
 
 # ── Symphony subprocess env ──────────────────────────────────
-# The managed Symphony process inherits these from the Electron process.
-# It does NOT read apps/symphony/.env — copy the values you need here.
+# The managed Symphony process inherits process env from Desktop.
+# Put auth keys in <repo-root>/.env (GH_TOKEN, LINEAR_API_KEY).
+#
+# Optional local override values can still be set here when needed.
 
-# Linear API key (required — Symphony polls Linear for work)
-LINEAR_API_KEY=lin_api_...
-
-# GitHub token (required if Symphony workflow uses GitHub integration)
-GH_TOKEN=ghp_...
-
-# Slack webhook (required if WORKFLOW.md configures Slack notifications)
-SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+# Slack webhook (optional; required only if WORKFLOW.md configures Slack notifications)
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
 
 # ── Optional ─────────────────────────────────────────────────
 # Symphony log verbosity (default: warn)

--- a/apps/desktop/.kata/preferences.md
+++ b/apps/desktop/.kata/preferences.md
@@ -29,7 +29,7 @@ skill_discovery: suggest
 auto_supervisor: {}
 symphony:
   url: http://localhost:8080
-  workflow_path: /Volumes/EVO/kata/kata-mono.worktrees/wt-desktop/apps/symphony/WORKFLOW-desktop-github.md
+  workflow_path: ../symphony/WORKFLOW-desktop-github.md
 ---
 
 # Kata Preferences

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.2.5
+
+### Features
+
+- **Chat composer slash-command autocomplete** — added in-composer command suggestions with keyboard-friendly selection and supporting command UI primitives.
+- **Slash command + skill discovery substrate** — introduced desktop-side command registry and skill scanning plumbing for richer command discovery.
+- **GitHub planning/execution parity surface** — improved workflow board behavior for GitHub-backed Kata planning and execution flows.
+
+### Improvements
+
+- **Cross-suite GitHub acceptance bundle** — added M009 UAT runbook, evidence bundle, and end-to-end coverage for GitHub workflow parity.
+
 ## 0.2.4
 
 ### Features

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata/desktop",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Kata Desktop — native desktop app for the Kata coding agent",
   "private": true,
   "type": "module",

--- a/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
@@ -152,6 +152,16 @@ describe('GithubWorkflowClient', () => {
                         number: 2249,
                         title: '[S02] GitHub Workflow Board Parity',
                         url: 'https://github.com/kata-sh/kata/issues/2249',
+                        subIssues: {
+                          nodes: [
+                            {
+                              number: 2250,
+                              title: '[T01] Subtask on board',
+                              url: 'https://github.com/kata-sh/kata/issues/2250',
+                              state: 'CLOSED',
+                            },
+                          ],
+                        },
                       },
                       fieldValueByName: {
                         name: 'Agent Review',
@@ -249,9 +259,102 @@ describe('GithubWorkflowClient', () => {
         title: '[T01] Subtask on board',
         columnId: 'done',
         parentSliceId: '2249',
-        stateType: 'projects_v2',
+        stateType: 'issue_state',
       }),
     ])
+  })
+
+  test('projects_v2 never renders orphan task items without a parent relationship', async () => {
+    process.env.GH_TOKEN = 'ghp_test'
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              repository: {
+                owner: {
+                  __typename: 'User',
+                  login: 'kata-sh',
+                  projectV2: {
+                    id: 'PVT_kwDOG7',
+                    field: { id: 'PVTSSF_kwDOG7_status' },
+                  },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              node: {
+                items: {
+                  nodes: [
+                    {
+                      id: 'PVTI_slice',
+                      content: {
+                        id: 'I_kwDOA',
+                        number: 2249,
+                        title: '[S02] GitHub Workflow Board Parity',
+                        url: 'https://github.com/kata-sh/kata/issues/2249',
+                        subIssues: { nodes: [] },
+                      },
+                      fieldValueByName: {
+                        name: 'Backlog',
+                        optionId: 'opt_backlog',
+                      },
+                    },
+                    {
+                      id: 'PVTI_task_orphan',
+                      content: {
+                        id: 'I_kwDOT',
+                        number: 2255,
+                        title: '[T99] Orphan task item',
+                        url: 'https://github.com/kata-sh/kata/issues/2255',
+                        labels: {
+                          nodes: [{ name: 'kata:task' }],
+                        },
+                      },
+                      fieldValueByName: {
+                        name: 'Done',
+                        optionId: 'opt_done',
+                      },
+                    },
+                  ],
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 })) as unknown as typeof fetch
+
+    const client = new GithubWorkflowClient({ getApiKey: vi.fn(async () => null) } as never)
+
+    const snapshot = await client.fetchSnapshot({
+      config: {
+        kind: 'github',
+        repoOwner: 'kata-sh',
+        repoName: 'kata',
+        stateMode: 'projects_v2',
+        githubProjectNumber: 7,
+      },
+    })
+
+    const allCards = snapshot.columns.flatMap((column) => column.cards)
+    expect(allCards).toHaveLength(1)
+    expect(allCards[0]?.id).toBe('2249')
+    expect(allCards[0]?.tasks).toEqual([])
   })
 
   test('projects_v2 owner resolution uses repository owner union (no org-only lookup)', async () => {

--- a/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-workflow-client.test.ts
@@ -160,6 +160,17 @@ describe('GithubWorkflowClient', () => {
                               url: 'https://github.com/kata-sh/kata/issues/2250',
                               state: 'CLOSED',
                             },
+                            {
+                              number: 991,
+                              title: '[T99] Foreign sub-issue',
+                              url: 'https://github.com/other-org/other-repo/issues/991',
+                              state: 'OPEN',
+                            },
+                            {
+                              number: 992,
+                              title: '[T98] Missing URL sub-issue',
+                              state: 'OPEN',
+                            },
                           ],
                         },
                       },

--- a/apps/desktop/src/main/github-workflow-client.ts
+++ b/apps/desktop/src/main/github-workflow-client.ts
@@ -873,6 +873,8 @@ function mapGithubIssueStateToTaskColumn(issueState: string | undefined): {
   columnId: 'todo' | 'done'
   stateName: string
 } {
+  // Task cards intentionally follow canonical GitHub issue lifecycle (OPEN/CLOSED),
+  // not per-item Projects v2 "Status", so task state is consistent across boards.
   const normalized = issueState?.trim().toUpperCase()
   if (normalized === 'CLOSED') {
     return {

--- a/apps/desktop/src/main/github-workflow-client.ts
+++ b/apps/desktop/src/main/github-workflow-client.ts
@@ -67,6 +67,14 @@ interface GithubProjectItemNode {
     parent?: {
       number?: number
     } | null
+    subIssues?: {
+      nodes?: Array<{
+        number?: number
+        title?: string
+        url?: string
+        state?: string
+      }>
+    } | null
   } | null
   fieldValueByName?: {
     name?: string
@@ -272,9 +280,14 @@ export class GithubWorkflowClient {
       issueTitle: string
       issueUrl: string
       stateName: string
-      parentIssueNumber: number | null
       isTask: boolean
       isSlice: boolean
+      subIssues: Array<{
+        issueNumber: number
+        issueTitle: string
+        issueUrl: string | null
+        issueState: string | undefined
+      }>
     }> = []
 
     for (const item of items) {
@@ -299,46 +312,59 @@ export class GithubWorkflowClient {
       const parentIssueNumber = item.content?.parent?.number ?? null
       const hasTaskLabel = labelNames.some((label) => label.endsWith(':task'))
       const hasSliceLabel = labelNames.some((label) => label.endsWith(':slice'))
-      const isTask = hasTaskLabel || Boolean(parentIssueNumber)
+      const hasTaskTitlePrefix = /^\s*\[T\d+\]/i.test(issueTitle)
+      const isTask = hasTaskLabel || Boolean(parentIssueNumber) || hasTaskTitlePrefix
       const isSlice = !isTask && (hasSliceLabel || !hasTaskLabel)
+      const subIssues = (item.content?.subIssues?.nodes ?? [])
+        .map((subIssue) => ({
+          issueNumber: subIssue.number,
+          issueTitle: subIssue.title?.trim(),
+          issueUrl: subIssue.url?.trim() || null,
+          issueState: subIssue.state?.trim(),
+        }))
+        .filter(
+          (subIssue): subIssue is {
+            issueNumber: number
+            issueTitle: string
+            issueUrl: string | null
+            issueState: string | undefined
+          } => Boolean(subIssue.issueNumber && subIssue.issueTitle),
+        )
 
       normalizedIssues.push({
         issueNumber,
         issueTitle,
         issueUrl,
         stateName,
-        parentIssueNumber,
         isTask,
         isSlice,
+        subIssues,
       })
-    }
-
-    const tasksByParent = new Map<number, WorkflowBoardTask[]>()
-    for (const issue of normalizedIssues) {
-      if (!issue.isTask || !issue.parentIssueNumber) {
-        continue
-      }
-
-      const nextTask = {
-        id: String(issue.issueNumber),
-        identifier: `#${issue.issueNumber}`,
-        title: issue.issueTitle,
-        columnId: mapLinearStateToColumnId(issue.stateName, undefined),
-        stateName: issue.stateName,
-        stateType: 'projects_v2',
-        parentSliceId: String(issue.parentIssueNumber),
-        url: issue.issueUrl,
-      } satisfies WorkflowBoardTask
-
-      const currentTasks = tasksByParent.get(issue.parentIssueNumber) ?? []
-      currentTasks.push(nextTask)
-      tasksByParent.set(issue.parentIssueNumber, currentTasks)
     }
 
     const cards: WorkflowBoardSliceCard[] = normalizedIssues
       .filter((issue) => issue.isSlice)
       .map((issue) => {
-        const tasks = tasksByParent.get(issue.issueNumber) ?? []
+        const tasks = issue.subIssues
+          .map((subIssue) => {
+            const mappedTaskState = mapGithubIssueStateToTaskColumn(subIssue.issueState)
+            const taskUrl =
+              subIssue.issueUrl ??
+              `https://github.com/${config.repoOwner}/${config.repoName}/issues/${subIssue.issueNumber}`
+
+            return {
+              id: String(subIssue.issueNumber),
+              identifier: `#${subIssue.issueNumber}`,
+              title: subIssue.issueTitle,
+              columnId: mappedTaskState.columnId,
+              stateName: mappedTaskState.stateName,
+              stateType: 'issue_state',
+              parentSliceId: String(issue.issueNumber),
+              url: taskUrl,
+            } satisfies WorkflowBoardTask
+          })
+          .sort((left, right) => left.identifier.localeCompare(right.identifier))
+
         const doneCount = tasks.filter((task) => task.columnId === 'done').length
 
         return {
@@ -361,7 +387,7 @@ export class GithubWorkflowClient {
       itemCount: items.length,
       issueCount: normalizedIssues.length,
       cardCount: cards.length,
-      attachedTaskCount: Array.from(tasksByParent.values()).reduce((count, tasks) => count + tasks.length, 0),
+      attachedTaskCount: cards.reduce((count, card) => count + card.tasks.length, 0),
     })
 
     const hasCards = cards.length > 0
@@ -475,6 +501,14 @@ export class GithubWorkflowClient {
                     }
                     parent {
                       number
+                    }
+                    subIssues(first: 100) {
+                      nodes {
+                        number
+                        title
+                        url
+                        state
+                      }
                     }
                   }
                 }
@@ -822,6 +856,24 @@ function parseKataMilestoneOrdinal(title: string): number | null {
 
   const ordinal = Number(match[1])
   return Number.isFinite(ordinal) ? ordinal : null
+}
+
+function mapGithubIssueStateToTaskColumn(issueState: string | undefined): {
+  columnId: 'todo' | 'done'
+  stateName: string
+} {
+  const normalized = issueState?.trim().toUpperCase()
+  if (normalized === 'CLOSED') {
+    return {
+      columnId: 'done',
+      stateName: 'Closed',
+    }
+  }
+
+  return {
+    columnId: 'todo',
+    stateName: 'Open',
+  }
 }
 
 function isIssueInRepository(issueUrl: string, repoOwner: string, repoName: string): boolean {

--- a/apps/desktop/src/main/github-workflow-client.ts
+++ b/apps/desktop/src/main/github-workflow-client.ts
@@ -285,7 +285,7 @@ export class GithubWorkflowClient {
       subIssues: Array<{
         issueNumber: number
         issueTitle: string
-        issueUrl: string | null
+        issueUrl: string
         issueState: string | undefined
       }>
     }> = []
@@ -316,19 +316,34 @@ export class GithubWorkflowClient {
       const isTask = hasTaskLabel || Boolean(parentIssueNumber) || hasTaskTitlePrefix
       const isSlice = !isTask && (hasSliceLabel || !hasTaskLabel)
       const subIssues = (item.content?.subIssues?.nodes ?? [])
-        .map((subIssue) => ({
-          issueNumber: subIssue.number,
-          issueTitle: subIssue.title?.trim(),
-          issueUrl: subIssue.url?.trim() || null,
-          issueState: subIssue.state?.trim(),
-        }))
+        .map((subIssue) => {
+          const issueNumber = subIssue.number
+          const issueTitle = subIssue.title?.trim()
+          const issueUrl = subIssue.url?.trim()
+          const issueState = subIssue.state?.trim()
+
+          if (!issueNumber || !issueTitle || !issueUrl) {
+            return null
+          }
+
+          if (!isIssueInRepository(issueUrl, config.repoOwner, config.repoName)) {
+            return null
+          }
+
+          return {
+            issueNumber,
+            issueTitle,
+            issueUrl,
+            issueState,
+          }
+        })
         .filter(
           (subIssue): subIssue is {
             issueNumber: number
             issueTitle: string
-            issueUrl: string | null
+            issueUrl: string
             issueState: string | undefined
-          } => Boolean(subIssue.issueNumber && subIssue.issueTitle),
+          } => Boolean(subIssue),
         )
 
       normalizedIssues.push({
@@ -348,10 +363,6 @@ export class GithubWorkflowClient {
         const tasks = issue.subIssues
           .map((subIssue) => {
             const mappedTaskState = mapGithubIssueStateToTaskColumn(subIssue.issueState)
-            const taskUrl =
-              subIssue.issueUrl ??
-              `https://github.com/${config.repoOwner}/${config.repoName}/issues/${subIssue.issueNumber}`
-
             return {
               id: String(subIssue.issueNumber),
               identifier: `#${subIssue.issueNumber}`,
@@ -360,7 +371,7 @@ export class GithubWorkflowClient {
               stateName: mappedTaskState.stateName,
               stateType: 'issue_state',
               parentSliceId: String(issue.issueNumber),
-              url: taskUrl,
+              url: subIssue.issueUrl,
             } satisfies WorkflowBoardTask
           })
           .sort((left, right) => left.identifier.localeCompare(right.identifier))

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,29 +1,126 @@
+import { execFileSync } from 'node:child_process'
 import { readFileSync, existsSync } from 'node:fs'
 import { promises as fs } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { app, BrowserWindow, nativeImage } from 'electron'
 
-// Load .env.development in dev mode — provides KATA_BIN_PATH for monorepo dev.
+function stripWrappingQuotes(value: string): string {
+  const trimmed = value.trim()
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+function expandEnvReferences(value: string, loadedValues: Map<string, string>): string {
+  return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_match, name: string) => {
+    const fromProcess = process.env[name]
+    if (fromProcess !== undefined) {
+      return fromProcess
+    }
+
+    const fromLoaded = loadedValues.get(name)
+    return fromLoaded ?? ''
+  })
+}
+
+function loadEnvFileIfPresent(envPath: string): void {
+  if (!existsSync(envPath)) {
+    return
+  }
+
+  const envContent = readFileSync(envPath, 'utf8')
+  const loadedValues = new Map<string, string>()
+
+  for (const rawLine of envContent.split(/\r?\n/)) {
+    const trimmed = rawLine.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+
+    const match = rawLine.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/)
+    if (!match) continue
+
+    const key = match[1]?.trim()
+    if (!key) continue
+
+    const rawValue = match[2] ?? ''
+    const value = expandEnvReferences(stripWrappingQuotes(rawValue), loadedValues)
+    loadedValues.set(key, value)
+
+    if (!process.env[key]) {
+      process.env[key] = value
+    }
+  }
+}
+
+function resolveGitCommonRoot(startDir: string): string | null {
+  try {
+    const commonDirRaw = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+      cwd: startDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1500,
+      windowsHide: true,
+    }).trim()
+
+    if (!commonDirRaw) return null
+
+    const absoluteCommonDir = path.isAbsolute(commonDirRaw)
+      ? commonDirRaw
+      : path.resolve(startDir, commonDirRaw)
+
+    return path.dirname(absoluteCommonDir)
+  } catch {
+    return null
+  }
+}
+
+function applyGithubTokenAliases(): void {
+  const ghToken = process.env.GH_TOKEN?.trim()
+  if (!ghToken) return
+
+  if (!process.env.GITHUB_TOKEN) {
+    process.env.GITHUB_TOKEN = ghToken
+  }
+
+  if (!process.env.KATA_GITHUB_TOKEN) {
+    process.env.KATA_GITHUB_TOKEN = ghToken
+  }
+}
+
+function loadDevEnvironment(): void {
+  // Canonical project secrets live in <repo-root>/.env.
+  // Resolve git common root so worktrees still use one shared secret location.
+  const commonRoot =
+    resolveGitCommonRoot(process.cwd()) ??
+    resolveGitCommonRoot(path.resolve(__dirname, '..')) ??
+    resolveGitCommonRoot(path.resolve(__dirname, '..', '..'))
+
+  if (commonRoot) {
+    loadEnvFileIfPresent(path.join(commonRoot, '.env'))
+  }
+
+  // Keep local desktop-only dev overrides (non-secret machine config) in
+  // .env.development for convenience.
+  const desktopEnvCandidates = [
+    path.join(__dirname, '..', '.env.development'),
+    path.resolve(process.cwd(), 'apps', 'desktop', '.env.development'),
+    path.resolve(process.cwd(), '.env.development'),
+  ]
+
+  for (const candidate of desktopEnvCandidates) {
+    if (existsSync(candidate)) {
+      loadEnvFileIfPresent(candidate)
+      break
+    }
+  }
+
+  applyGithubTokenAliases()
+}
+
 // Must run before any code reads process.env.
 if (!app.isPackaged) {
-  try {
-    const envPath = path.join(__dirname, '..', '.env.development')
-    const envContent = readFileSync(envPath, 'utf8')
-    for (const line of envContent.split('\n')) {
-      const trimmed = line.trim()
-      if (!trimmed || trimmed.startsWith('#')) continue
-      const eqIndex = trimmed.indexOf('=')
-      if (eqIndex <= 0) continue
-      const key = trimmed.slice(0, eqIndex).trim()
-      const value = trimmed.slice(eqIndex + 1).trim()
-      if (!process.env[key]) {
-        process.env[key] = value
-      }
-    }
-  } catch {
-    // No .env.development — that's fine, KATA_BIN_PATH can be set externally
-  }
+  loadDevEnvironment()
 }
 import { AuthBridge } from './auth-bridge'
 import log from './logger'

--- a/apps/desktop/src/main/symphony-config.ts
+++ b/apps/desktop/src/main/symphony-config.ts
@@ -74,6 +74,7 @@ export async function resolveSymphonyLaunch(
     resourcesPath: options.resourcesPath,
     env,
     workspacePath: options.workspacePath,
+    workflowPath: resolvedWorkflowPath.workflowPath,
   })
   if (!resolvedBinary.ok) {
     return resolvedBinary
@@ -260,6 +261,7 @@ function resolveBinaryPath(options: {
   resourcesPath?: string
   env: NodeJS.ProcessEnv
   workspacePath: string
+  workflowPath: string
 }):
   | { ok: true; command: string; source: SymphonyLaunchSource }
   | { ok: false; error: SymphonyRuntimeError } {
@@ -291,6 +293,26 @@ function resolveBinaryPath(options: {
       if (isExecutableFile(bundledPath)) {
         return { ok: true, command: bundledPath, source: 'bundled' }
       }
+    }
+  }
+
+  // Dev-mode default: if workflow_path points at an apps/symphony WORKFLOW file,
+  // prefer the sibling target/release binary before PATH lookup.
+  const workflowDir = path.dirname(options.workflowPath)
+  const workflowBinaryCandidates =
+    process.platform === 'win32'
+      ? [
+          path.join(workflowDir, 'target', 'release', 'symphony.exe'),
+          path.join(workflowDir, 'target', 'debug', 'symphony.exe'),
+        ]
+      : [
+          path.join(workflowDir, 'target', 'release', 'symphony'),
+          path.join(workflowDir, 'target', 'debug', 'symphony'),
+        ]
+
+  for (const candidate of workflowBinaryCandidates) {
+    if (isExecutableFile(candidate)) {
+      return { ok: true, command: candidate, source: 'path' }
     }
   }
 

--- a/apps/symphony/.env.example
+++ b/apps/symphony/.env.example
@@ -1,5 +1,16 @@
+# Symphony (monorepo) — env template
+#
+# Canonical secrets now live at repo root: ../../.env
+# Symphony runtime resolves <git-common-root>/.env automatically.
+#
+# Keep this file only as a standalone reference when running Symphony
+# outside the monorepo with a local .env in apps/symphony.
+
 # Required
 LINEAR_API_KEY=lin_api_...
+
+# GitHub (required when tracker.kind: github)
+GH_TOKEN=ghp_replace_me
 
 # Agent auth — set the key for your chosen backend/provider:
 # ANTHROPIC_API_KEY=sk-ant-...

--- a/apps/symphony/CHANGELOG.md
+++ b/apps/symphony/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.2.2
+
+### Improvements
+
+- **Align GitHub execution contract with Kata CLI semantics** — harmonized state/transition behavior and workspace prompt shaping so Symphony and Kata CLI interpret GitHub issue workflows consistently.
+- **Backend-neutral worker contract support** — updated prompts, adapter/config plumbing, and tests to operate cleanly across Linear and GitHub backends via shared `kata_*` abstractions.
+
 ## 2.2.1
 
 ### Bug Fixes

--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -2187,7 +2187,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphony"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/symphony/Cargo.toml
+++ b/apps/symphony/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symphony"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 description = "Symphony orchestrator — polls Linear or GitHub Issues, dispatches agent sessions"
 license = "MIT"

--- a/apps/symphony/README.md
+++ b/apps/symphony/README.md
@@ -183,7 +183,7 @@ Minimal GitHub tracker configuration:
 ```yaml
 tracker:
   kind: github
-  api_key: $GH_TOKEN          # or $GITHUB_TOKEN
+  api_key: $GH_TOKEN          # or $GITHUB_TOKEN (recommended for cloud/VPS)
   repo_owner: your-org
   repo_name: your-repo
 
@@ -200,9 +200,16 @@ tracker:
     - Done
 ```
 
-Authentication:
+Authentication (source order):
 
-- Use a GitHub **PAT** (personal access token) via `GH_TOKEN` or `GITHUB_TOKEN`.
+1. `tracker.api_key`
+2. `GH_TOKEN`
+3. `GITHUB_TOKEN`
+4. `gh auth token` (local fallback only; requires `gh auth login`)
+
+Notes:
+
+- For cloud/VPS deployments, use explicit env secrets (`GH_TOKEN`/`GITHUB_TOKEN`) and do not rely on `gh` CLI fallback.
 - `tracker.api_key` supports `$VAR` indirection like other secrets.
 
 State management modes:

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -51,6 +51,14 @@ tracker:
   # Tracker API token (supports $VAR indirection).
   # - Linear: personal API key (for example $LINEAR_API_KEY)
   # - GitHub: PAT (for example $GH_TOKEN or $GITHUB_TOKEN)
+  #
+  # GitHub token source order:
+  #   1) tracker.api_key
+  #   2) GH_TOKEN
+  #   3) GITHUB_TOKEN
+  #   4) `gh auth token` (local fallback only; requires `gh auth login`)
+  #
+  # For cloud/VPS, prefer explicit env secrets (GH_TOKEN/GITHUB_TOKEN).
   api_key: $LINEAR_API_KEY
 
   # Optional tracker endpoint override.

--- a/apps/symphony/src/codex/dynamic_tool.rs
+++ b/apps/symphony/src/codex/dynamic_tool.rs
@@ -269,7 +269,7 @@ fn tool_error_payload(err: &SymphonyError) -> Value {
         }),
         SymphonyError::MissingGithubApiToken => json!({
             "error": {
-                "message": "Symphony is missing GitHub auth. Set `tracker.api_key` in `WORKFLOW.md` or export `GITHUB_TOKEN`/`GH_TOKEN`."
+                "message": "Symphony is missing GitHub auth. Set `tracker.api_key` in `WORKFLOW.md`, export `GITHUB_TOKEN`/`GH_TOKEN` (cloud), or run `gh auth login` for local fallback."
             }
         }),
         SymphonyError::GithubApiStatus { status, message } => json!({

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -17,6 +17,7 @@ use crate::domain::{
     WorkerConfig, WorkspaceConfig, WorkspaceIsolation, WorkspaceRepoStrategy, KATA_PHASE_NAMES,
 };
 use crate::error::{Result, SymphonyError};
+use crate::github::auth::{github_token_missing_message, resolve_github_token};
 use crate::notifications;
 use crate::repo_url::repo_is_remote;
 
@@ -1182,22 +1183,9 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
     }
 
     if tracker_kind == "github" {
-        let has_config_token = config
-            .tracker
-            .api_key
-            .as_deref()
-            .map(|key| !key.trim().is_empty())
-            .unwrap_or(false);
-        let has_env_token = ["GH_TOKEN", "GITHUB_TOKEN"].iter().any(|name| {
-            std::env::var(name)
-                .ok()
-                .map(|value| !value.trim().is_empty())
-                .unwrap_or(false)
-        });
-
-        if !(has_config_token || has_env_token) {
+        if resolve_github_token(&config.tracker).is_none() {
             return Err(SymphonyError::InvalidWorkflowConfig(
-                "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github".to_string(),
+                github_token_missing_message().to_string(),
             ));
         }
 

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -13,6 +13,9 @@ use crate::domain::{
     WorkspaceRepoStrategy,
 };
 use crate::error::SymphonyError;
+use crate::github::auth::{
+    github_token_missing_message, github_token_source_name, resolve_github_token,
+};
 use crate::github::client::GithubClient;
 use crate::github::projects_v2::ProjectsV2Client;
 use crate::linear::adapter::TrackerAdapter;
@@ -250,32 +253,15 @@ pub fn check_config(workflow_path: &Path) -> Vec<DoctorCheckResult> {
 pub async fn check_github(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
     let mut results = Vec::new();
 
-    let token = config
-        .api_key
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-        .or_else(|| {
-            std::env::var("GH_TOKEN")
-                .ok()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty())
-        })
-        .or_else(|| {
-            std::env::var("GITHUB_TOKEN")
-                .ok()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty())
-        });
-
-    let Some(token) = token else {
+    let Some(resolved_token) = resolve_github_token(config) else {
         results.push(DoctorCheckResult::error(
             "GitHub PAT",
-            "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github",
+            github_token_missing_message(),
         ));
         return results;
     };
+    let token_source = resolved_token.source;
+    let token = resolved_token.token;
 
     let Some(repo_owner) = config
         .repo_owner
@@ -337,7 +323,10 @@ pub async fn check_github(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
                         .unwrap_or("authenticated");
                     results.push(DoctorCheckResult::pass(
                         "GitHub PAT",
-                        format!("PAT authenticated as {login}"),
+                        format!(
+                            "PAT authenticated as {login} (source: {})",
+                            github_token_source_name(token_source)
+                        ),
                     ));
                 }
                 Err(err) => {

--- a/apps/symphony/src/github/auth.rs
+++ b/apps/symphony/src/github/auth.rs
@@ -1,4 +1,7 @@
-use std::process::Command;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::domain::TrackerConfig;
 
@@ -18,6 +21,8 @@ pub struct ResolvedGithubToken {
 
 const GITHUB_TOKEN_MISSING_MESSAGE: &str =
     "GitHub token required when tracker.kind is github. Set tracker.api_key, GH_TOKEN/GITHUB_TOKEN, or authenticate gh CLI via `gh auth login` (local fallback).";
+const GH_CLI_FALLBACK_DISABLE_VALUES: [&str; 5] = ["0", "false", "no", "off", "disabled"];
+const GH_CLI_FALLBACK_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub fn github_token_missing_message() -> &'static str {
     GITHUB_TOKEN_MISSING_MESSAGE
@@ -54,7 +59,7 @@ pub fn resolve_github_token(tracker: &TrackerConfig) -> Option<ResolvedGithubTok
                 })
         })
         .or_else(|| {
-            resolve_github_token_from_gh_cli().map(|token| ResolvedGithubToken {
+            resolve_github_token_from_gh_cli(&tracker.endpoint).map(|token| ResolvedGithubToken {
                 token,
                 source: GithubTokenSource::GhCli,
             })
@@ -70,37 +75,88 @@ pub fn github_token_source_name(source: GithubTokenSource) -> &'static str {
     }
 }
 
-fn resolve_github_token_from_gh_cli() -> Option<String> {
-    if std::env::var("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK")
+fn is_gh_cli_fallback_enabled() -> bool {
+    let raw = std::env::var("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK")
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    !GH_CLI_FALLBACK_DISABLE_VALUES.contains(&raw.as_str())
+}
+
+fn resolve_github_hostname_for_gh_cli(endpoint: &str) -> String {
+    let trimmed = endpoint.trim();
+    if trimmed.is_empty() {
+        return "github.com".to_string();
+    }
+
+    reqwest::Url::parse(trimmed)
         .ok()
-        .as_deref()
-        == Some("0")
-    {
+        .and_then(|url| {
+            url.host_str()
+                .map(str::trim)
+                .filter(|host| !host.is_empty())
+                .map(ToString::to_string)
+        })
+        .unwrap_or_else(|| "github.com".to_string())
+}
+
+fn resolve_github_token_from_gh_cli(endpoint: &str) -> Option<String> {
+    if !is_gh_cli_fallback_enabled() {
         return None;
     }
 
-    let output = Command::new("gh")
-        .args(["auth", "token"])
+    let hostname = resolve_github_hostname_for_gh_cli(endpoint);
+    let mut child = Command::new("gh")
+        .args(["auth", "token", "--hostname", hostname.as_str()])
         .env("GH_PROMPT_DISABLED", "1")
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
         .ok()?;
 
-    if !output.status.success() {
-        return None;
-    }
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    return None;
+                }
 
-    let token = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    if token.is_empty() {
-        return None;
-    }
+                let mut stdout = Vec::new();
+                if let Some(mut pipe) = child.stdout.take() {
+                    if pipe.read_to_end(&mut stdout).is_err() {
+                        return None;
+                    }
+                }
 
-    Some(token)
+                let token = String::from_utf8(stdout).ok()?.trim().to_string();
+                if token.is_empty() {
+                    return None;
+                }
+
+                return Some(token);
+            }
+            Ok(None) => {
+                if started.elapsed() >= GH_CLI_FALLBACK_TIMEOUT {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(_) => return None,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_github_token, GithubTokenSource};
+    use super::{
+        is_gh_cli_fallback_enabled, resolve_github_hostname_for_gh_cli, resolve_github_token,
+        GithubTokenSource,
+    };
     use crate::domain::{ApiKey, TrackerConfig};
+    use serial_test::serial;
 
     fn with_env<T>(values: &[(&str, Option<&str>)], f: impl FnOnce() -> T) -> T {
         let mut previous: Vec<(String, Option<String>)> = Vec::with_capacity(values.len());
@@ -125,6 +181,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn resolve_github_token_prefers_tracker_api_key() {
         with_env(
             &[
@@ -143,6 +200,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn resolve_github_token_prefers_gh_token_over_github_token() {
         with_env(
             &[
@@ -160,6 +218,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn resolve_github_token_returns_none_when_no_sources_available() {
         with_env(
             &[
@@ -172,6 +231,43 @@ mod tests {
                 let resolved = resolve_github_token(&tracker);
                 assert!(resolved.is_none());
             },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn gh_cli_fallback_disable_values_match_cli_behavior() {
+        with_env(
+            &[("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK", Some("false"))],
+            || {
+                assert!(!is_gh_cli_fallback_enabled());
+            },
+        );
+
+        with_env(
+            &[("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK", Some("disabled"))],
+            || {
+                assert!(!is_gh_cli_fallback_enabled());
+            },
+        );
+
+        with_env(
+            &[("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK", Some(""))],
+            || {
+                assert!(is_gh_cli_fallback_enabled());
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_github_hostname_for_gh_cli_prefers_endpoint_host() {
+        assert_eq!(
+            resolve_github_hostname_for_gh_cli("https://ghe.example.com/api/v3/graphql"),
+            "ghe.example.com"
+        );
+        assert_eq!(
+            resolve_github_hostname_for_gh_cli("not-a-url"),
+            "github.com"
         );
     }
 }

--- a/apps/symphony/src/github/auth.rs
+++ b/apps/symphony/src/github/auth.rs
@@ -94,8 +94,15 @@ fn resolve_github_hostname_for_gh_cli(endpoint: &str) -> String {
         .and_then(|url| {
             url.host_str()
                 .map(str::trim)
+                .map(|host| host.trim_end_matches('.').to_ascii_lowercase())
                 .filter(|host| !host.is_empty())
-                .map(ToString::to_string)
+                .map(|host| {
+                    if host == "api.github.com" {
+                        "github.com".to_string()
+                    } else {
+                        host
+                    }
+                })
         })
         .unwrap_or_else(|| "github.com".to_string())
 }
@@ -264,6 +271,14 @@ mod tests {
         assert_eq!(
             resolve_github_hostname_for_gh_cli("https://ghe.example.com/api/v3/graphql"),
             "ghe.example.com"
+        );
+        assert_eq!(
+            resolve_github_hostname_for_gh_cli("https://api.github.com"),
+            "github.com"
+        );
+        assert_eq!(
+            resolve_github_hostname_for_gh_cli("https://api.github.com./graphql"),
+            "github.com"
         );
         assert_eq!(
             resolve_github_hostname_for_gh_cli("not-a-url"),

--- a/apps/symphony/src/github/auth.rs
+++ b/apps/symphony/src/github/auth.rs
@@ -1,0 +1,177 @@
+use std::process::Command;
+
+use crate::domain::TrackerConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GithubTokenSource {
+    TrackerApiKey,
+    GhTokenEnv,
+    GithubTokenEnv,
+    GhCli,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedGithubToken {
+    pub token: String,
+    pub source: GithubTokenSource,
+}
+
+const GITHUB_TOKEN_MISSING_MESSAGE: &str =
+    "GitHub token required when tracker.kind is github. Set tracker.api_key, GH_TOKEN/GITHUB_TOKEN, or authenticate gh CLI via `gh auth login` (local fallback).";
+
+pub fn github_token_missing_message() -> &'static str {
+    GITHUB_TOKEN_MISSING_MESSAGE
+}
+
+pub fn resolve_github_token(tracker: &TrackerConfig) -> Option<ResolvedGithubToken> {
+    tracker
+        .api_key
+        .as_ref()
+        .map(|api_key| api_key.as_str().trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(|token| ResolvedGithubToken {
+            token,
+            source: GithubTokenSource::TrackerApiKey,
+        })
+        .or_else(|| {
+            std::env::var("GH_TOKEN")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .map(|token| ResolvedGithubToken {
+                    token,
+                    source: GithubTokenSource::GhTokenEnv,
+                })
+        })
+        .or_else(|| {
+            std::env::var("GITHUB_TOKEN")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .map(|token| ResolvedGithubToken {
+                    token,
+                    source: GithubTokenSource::GithubTokenEnv,
+                })
+        })
+        .or_else(|| {
+            resolve_github_token_from_gh_cli().map(|token| ResolvedGithubToken {
+                token,
+                source: GithubTokenSource::GhCli,
+            })
+        })
+}
+
+pub fn github_token_source_name(source: GithubTokenSource) -> &'static str {
+    match source {
+        GithubTokenSource::TrackerApiKey => "tracker.api_key",
+        GithubTokenSource::GhTokenEnv => "GH_TOKEN",
+        GithubTokenSource::GithubTokenEnv => "GITHUB_TOKEN",
+        GithubTokenSource::GhCli => "gh auth token",
+    }
+}
+
+fn resolve_github_token_from_gh_cli() -> Option<String> {
+    if std::env::var("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK")
+        .ok()
+        .as_deref()
+        == Some("0")
+    {
+        return None;
+    }
+
+    let output = Command::new("gh")
+        .args(["auth", "token"])
+        .env("GH_PROMPT_DISABLED", "1")
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let token = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if token.is_empty() {
+        return None;
+    }
+
+    Some(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_github_token, GithubTokenSource};
+    use crate::domain::{ApiKey, TrackerConfig};
+
+    fn with_env<T>(values: &[(&str, Option<&str>)], f: impl FnOnce() -> T) -> T {
+        let mut previous: Vec<(String, Option<String>)> = Vec::with_capacity(values.len());
+        for (key, value) in values {
+            previous.push(((*key).to_string(), std::env::var(key).ok()));
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+
+        let result = f();
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => std::env::set_var(&key, value),
+                None => std::env::remove_var(&key),
+            }
+        }
+
+        result
+    }
+
+    #[test]
+    fn resolve_github_token_prefers_tracker_api_key() {
+        with_env(
+            &[
+                ("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK", Some("0")),
+                ("GH_TOKEN", Some("gh-env")),
+                ("GITHUB_TOKEN", Some("github-env")),
+            ],
+            || {
+                let mut tracker = TrackerConfig::default();
+                tracker.api_key = Some(ApiKey::new("config-token"));
+                let resolved = resolve_github_token(&tracker).expect("token should resolve");
+                assert_eq!(resolved.token, "config-token");
+                assert_eq!(resolved.source, GithubTokenSource::TrackerApiKey);
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_github_token_prefers_gh_token_over_github_token() {
+        with_env(
+            &[
+                ("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK", Some("0")),
+                ("GH_TOKEN", Some("gh-env")),
+                ("GITHUB_TOKEN", Some("github-env")),
+            ],
+            || {
+                let tracker = TrackerConfig::default();
+                let resolved = resolve_github_token(&tracker).expect("token should resolve");
+                assert_eq!(resolved.token, "gh-env");
+                assert_eq!(resolved.source, GithubTokenSource::GhTokenEnv);
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_github_token_returns_none_when_no_sources_available() {
+        with_env(
+            &[
+                ("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK", Some("0")),
+                ("GH_TOKEN", None),
+                ("GITHUB_TOKEN", None),
+            ],
+            || {
+                let tracker = TrackerConfig::default();
+                let resolved = resolve_github_token(&tracker);
+                assert!(resolved.is_none());
+            },
+        );
+    }
+}

--- a/apps/symphony/src/github/mod.rs
+++ b/apps/symphony/src/github/mod.rs
@@ -1,3 +1,4 @@
 pub mod adapter;
+pub mod auth;
 pub mod client;
 pub mod projects_v2;

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -26,6 +26,10 @@ use symphony::domain::Issue;
 #[cfg(not(test))]
 use symphony::github::adapter::GithubAdapter;
 #[cfg(not(test))]
+use symphony::github::auth::{
+    github_token_missing_message, github_token_source_name, resolve_github_token,
+};
+#[cfg(not(test))]
 use symphony::github::client::GithubClient;
 #[cfg(not(test))]
 use symphony::http_server::{
@@ -196,28 +200,11 @@ struct GithubAdapterInputs {
 fn github_adapter_inputs(
     tracker: &symphony::domain::TrackerConfig,
 ) -> error::Result<GithubAdapterInputs> {
-    let token = tracker
-        .api_key
-        .as_ref()
-        .map(|api_key| api_key.as_str().trim().to_string())
-        .filter(|value| !value.is_empty())
-        .or_else(|| {
-            std::env::var("GH_TOKEN")
-                .ok()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty())
-        })
-        .or_else(|| {
-            std::env::var("GITHUB_TOKEN")
-                .ok()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty())
-        })
-        .ok_or_else(|| {
-            error::SymphonyError::InvalidWorkflowConfig(
-                "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github".to_string(),
-            )
-        })?;
+    let resolved = resolve_github_token(tracker).ok_or_else(|| {
+        error::SymphonyError::InvalidWorkflowConfig(github_token_missing_message().to_string())
+    })?;
+    let token_source = resolved.source;
+    let token = resolved.token;
 
     let repo_owner = tracker
         .repo_owner
@@ -254,6 +241,11 @@ fn github_adapter_inputs(
     } else {
         endpoint.to_string()
     };
+
+    tracing::debug!(
+        token_source = github_token_source_name(token_source),
+        "resolved GitHub tracker token source"
+    );
 
     Ok(GithubAdapterInputs {
         token,

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -16,6 +16,8 @@ use symphony::{config, error};
 #[cfg(not(test))]
 use std::future::{pending, Future};
 #[cfg(not(test))]
+use std::process::Command;
+#[cfg(not(test))]
 use std::io::Write;
 #[cfg(not(test))]
 use std::sync::{Arc, Mutex, Once};
@@ -1100,10 +1102,76 @@ fn run_entrypoint(args: impl IntoIterator<Item = OsString>) -> i32 {
 }
 
 #[cfg(not(test))]
+fn resolve_git_common_root(start_dir: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(start_dir)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let raw = String::from_utf8(output.stdout).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let common_dir = PathBuf::from(trimmed);
+    let absolute_common_dir = if common_dir.is_absolute() {
+        common_dir
+    } else {
+        start_dir.join(common_dir)
+    };
+
+    absolute_common_dir.parent().map(Path::to_path_buf)
+}
+
+#[cfg(not(test))]
+fn load_canonical_project_env() {
+    let cwd = match std::env::current_dir() {
+        Ok(cwd) => cwd,
+        Err(_) => {
+            let _ = dotenvy::dotenv();
+            return;
+        }
+    };
+
+    if let Some(common_root) = resolve_git_common_root(&cwd) {
+        let env_path = common_root.join(".env");
+        if env_path.is_file() {
+            let _ = dotenvy::from_path(&env_path);
+            return;
+        }
+    }
+
+    // Backward-compatible fallback outside git repos.
+    let _ = dotenvy::dotenv();
+}
+
+#[cfg(not(test))]
+fn apply_github_token_aliases() {
+    let gh_token = match std::env::var("GH_TOKEN") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => return,
+    };
+
+    if std::env::var("GITHUB_TOKEN").map(|v| v.trim().is_empty()).unwrap_or(true) {
+        std::env::set_var("GITHUB_TOKEN", &gh_token);
+    }
+
+    if std::env::var("KATA_GITHUB_TOKEN").map(|v| v.trim().is_empty()).unwrap_or(true) {
+        std::env::set_var("KATA_GITHUB_TOKEN", &gh_token);
+    }
+}
+
+#[cfg(not(test))]
 #[tokio::main]
 async fn main() {
-    // Load .env file if present (silently ignore if missing)
-    let _ = dotenvy::dotenv();
+    load_canonical_project_env();
+    apply_github_token_aliases();
 
     let code = run_entrypoint(std::env::args_os());
     flush_file_logs();

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -16,9 +16,9 @@ use symphony::{config, error};
 #[cfg(not(test))]
 use std::future::{pending, Future};
 #[cfg(not(test))]
-use std::process::Command;
-#[cfg(not(test))]
 use std::io::Write;
+#[cfg(not(test))]
+use std::process::Command;
 #[cfg(not(test))]
 use std::sync::{Arc, Mutex, Once};
 #[cfg(not(test))]
@@ -1143,8 +1143,9 @@ fn load_canonical_project_env() {
         let env_path = common_root.join(".env");
         if env_path.is_file() {
             let _ = dotenvy::from_path(&env_path);
-            return;
         }
+        // Inside a git repo we only load the canonical <repo-root>/.env.
+        return;
     }
 
     // Backward-compatible fallback outside git repos.
@@ -1158,11 +1159,17 @@ fn apply_github_token_aliases() {
         _ => return,
     };
 
-    if std::env::var("GITHUB_TOKEN").map(|v| v.trim().is_empty()).unwrap_or(true) {
+    if std::env::var("GITHUB_TOKEN")
+        .map(|v| v.trim().is_empty())
+        .unwrap_or(true)
+    {
         std::env::set_var("GITHUB_TOKEN", &gh_token);
     }
 
-    if std::env::var("KATA_GITHUB_TOKEN").map(|v| v.trim().is_empty()).unwrap_or(true) {
+    if std::env::var("KATA_GITHUB_TOKEN")
+        .map(|v| v.trim().is_empty())
+        .unwrap_or(true)
+    {
         std::env::set_var("KATA_GITHUB_TOKEN", &gh_token);
     }
 }

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -542,12 +542,27 @@ fn should_continue_issue_in_session(
 
 /// Build a boxed `TrackerAdapter` appropriate for the given `TrackerConfig`.
 /// Used for inter-turn issue state refresh — routes to GitHub or Linear based on `tracker.kind`.
-fn build_tracker_adapter(tracker_config: &TrackerConfig) -> Box<dyn TrackerAdapter> {
+async fn build_tracker_adapter(tracker_config: &TrackerConfig) -> Box<dyn TrackerAdapter> {
     let kind = tracker_config.kind.as_deref().unwrap_or("linear");
     if kind.eq_ignore_ascii_case("github") {
         use crate::github::adapter::GithubAdapter;
         use crate::github::client::GithubClient;
-        let token = resolve_github_token(tracker_config)
+        let resolved_token = match tokio::task::spawn_blocking({
+            let tracker_config = tracker_config.clone();
+            move || resolve_github_token(&tracker_config)
+        })
+        .await
+        {
+            Ok(resolved) => resolved,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "failed to join blocking GitHub token resolution task for inter-turn refresh"
+                );
+                None
+            }
+        };
+        let token = resolved_token
             .map(|resolved| {
                 tracing::debug!(
                     token_source = github_token_source_name(resolved.source),
@@ -638,7 +653,7 @@ where
     let capped_max_turns = max_turns.max(1);
     let mut turn_number: u32 = 1;
     let mut current_issue = issue.clone();
-    let issue_state_client = build_tracker_adapter(tracker_config);
+    let issue_state_client = build_tracker_adapter(tracker_config).await;
     let mut observed_events: Vec<AgentEvent> = Vec::new();
     let mut metrics: Option<TurnMetrics> = None;
     let mut schedule_continuation = true;
@@ -741,7 +756,7 @@ where
     let capped_max_turns = max_turns.max(1);
     let mut turn_number: u32 = 1;
     let mut current_issue = issue.clone();
-    let issue_state_client = build_tracker_adapter(tracker_config);
+    let issue_state_client = build_tracker_adapter(tracker_config).await;
     let mut observed_events: Vec<AgentEvent> = Vec::new();
     let mut metrics: Option<TurnMetrics> = None;
     let mut schedule_continuation = true;

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -21,6 +21,7 @@ use crate::domain::{
 };
 use crate::error::{Result, SymphonyError};
 use crate::event_stream::EventHub;
+use crate::github::auth::{github_token_source_name, resolve_github_token};
 use crate::linear::adapter::TrackerAdapter;
 use crate::notifications;
 use crate::pi_agent::rpc_bridge;
@@ -546,23 +547,13 @@ fn build_tracker_adapter(tracker_config: &TrackerConfig) -> Box<dyn TrackerAdapt
     if kind.eq_ignore_ascii_case("github") {
         use crate::github::adapter::GithubAdapter;
         use crate::github::client::GithubClient;
-        let token = tracker_config
-            .api_key
-            .as_deref()
-            .map(str::trim)
-            .filter(|v| !v.is_empty())
-            .map(str::to_string)
-            .or_else(|| {
-                std::env::var("GH_TOKEN")
-                    .ok()
-                    .map(|v| v.trim().to_string())
-                    .filter(|v| !v.is_empty())
-            })
-            .or_else(|| {
-                std::env::var("GITHUB_TOKEN")
-                    .ok()
-                    .map(|v| v.trim().to_string())
-                    .filter(|v| !v.is_empty())
+        let token = resolve_github_token(tracker_config)
+            .map(|resolved| {
+                tracing::debug!(
+                    token_source = github_token_source_name(resolved.source),
+                    "resolved GitHub token source for inter-turn refresh"
+                );
+                resolved.token
             })
             .unwrap_or_else(|| {
                 tracing::warn!(

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -1504,6 +1504,8 @@ fn test_config_validation_github_valid() {
 fn test_config_validation_github_missing_token_errors() {
     let previous_gh_token = std::env::var("GH_TOKEN").ok();
     let previous_github_token = std::env::var("GITHUB_TOKEN").ok();
+    let previous_gh_cli_fallback = std::env::var("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK").ok();
+    std::env::set_var("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK", "0");
     std::env::remove_var("GH_TOKEN");
     std::env::remove_var("GITHUB_TOKEN");
 
@@ -1522,7 +1524,7 @@ fn test_config_validation_github_missing_token_errors() {
     let validation_failed_for_missing_token = matches!(
         result,
         Err(SymphonyError::InvalidWorkflowConfig(ref msg))
-            if msg == "GH_TOKEN or GITHUB_TOKEN is required when tracker.kind is github"
+            if msg.contains("GitHub token required when tracker.kind is github")
     );
 
     match previous_gh_token {
@@ -1532,6 +1534,10 @@ fn test_config_validation_github_missing_token_errors() {
     match previous_github_token {
         Some(value) => std::env::set_var("GITHUB_TOKEN", value),
         None => std::env::remove_var("GITHUB_TOKEN"),
+    }
+    match previous_gh_cli_fallback {
+        Some(value) => std::env::set_var("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK", value),
+        None => std::env::remove_var("SYMPHONY_GITHUB_ENABLE_GH_CLI_FALLBACK"),
     }
 
     assert!(


### PR DESCRIPTION
## Summary
- release @kata-sh/cli to **0.15.7**
- release @kata/symphony to **2.2.2**
- release Kata Desktop to **0.2.5**

## Included changes
- version bumps + changelog entries for CLI, Symphony, and Desktop
- harden GitHub token resolution for Kata GitHub mode:
  - prefer `gh auth token` automatically when env vars are unset
  - keep strict Projects v2 status behavior (no label fallback)
  - improved actionable diagnostics for Projects v2 permission failures

## Verification
- CLI: `npx tsc`, `npm test`, targeted kata github tests
- Symphony: `cargo test && cargo clippy -- -D warnings && cargo fmt --check`
- Desktop: `bun run test && bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical .env loading from repo root with variable expansion and GH token aliasing
  * Optional GH CLI fallback for resolving GitHub tokens, with explicit enable/disable flags
  * Projects v2: sub-issue-based task extraction and improved board normalization
  * Symphony: unified GitHub token resolution with token-source reporting

* **Bug Fixes**
  * Clearer, actionable GitHub auth guidance and permission-error messages

* **Chores**
  * Bumped CLI, Desktop, and Symphony package versions

* **Tests**
  * Added and updated tests covering token resolution and Projects v2 error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR (CLI 0.15.7 / Symphony 2.2.2 / Desktop 0.2.5) introduces two hardening changes to the GitHub backend: automatic `gh auth token` fallback for token resolution when env vars are unset, and explicit actionable diagnostics when Projects v2 status mutations are denied. The logic is well-structured and the new behaviour is covered by tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/UX suggestions with no impact on correctness.

The permission-error wrapper is well-tested (both the permission path and the non-permission passthrough path). Token resolution order is explicit and the gh-CLI fallback is opt-out-able. The only concerns are the synchronous subprocess call (could cause a brief event-loop stall on slow machines) and a slightly over-broad error-message heuristic — neither affects data integrity or correctness.

apps/cli/src/resources/extensions/kata/github-config.ts — synchronous `execFileSync` in the token resolution path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/github-config.ts | Adds `resolveGithubTokenFromGhCli()` using synchronous `execFileSync` with a 2-second timeout; inserts gh-CLI fallback between env-var and auth.json resolution; updates diagnostic messages. |
| apps/cli/src/resources/extensions/kata/github-backend.ts | Wraps `updateProjectV2ItemStatus` in a try/catch that converts permission errors to actionable diagnostics; returns issue number from the updated object; adds `isProjectsV2PermissionError` and `formatProjectsV2PermissionErrorMessage` helpers. |
| apps/cli/src/resources/extensions/kata/tests/github-backend.artifacts.vitest.test.ts | Adds `setProjectStatusError` to `FakeGithubClient` and two new test cases covering forbidden-permission and non-permission project-status errors; verifies label state is unchanged on failure. |
| apps/cli/src/resources/extensions/kata/tests/github-config.test.ts | Disables gh-CLI fallback in all tests by defaulting `KATA_GITHUB_ENABLE_GH_CLI_FALLBACK=0`; passes explicit `authFilePath` to avoid reading real auth.json from disk. |
| apps/cli/src/resources/extensions/kata/backend-factory.ts | Updates `missing_github_token` error message to mention `gh auth login` alongside env-var options. |
| apps/cli/package.json | Version bump from 0.15.6 → 0.15.7. |
| apps/symphony/Cargo.toml | Version bump from 2.2.1 → 2.2.2 in both Cargo.toml and Cargo.lock. |
| apps/desktop/package.json | Version bump from 0.2.4 → 0.2.5. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Kata as Kata CLI
    participant Cfg as resolveGithubToken
    participant GhCli as gh auth token
    participant AuthJSON as auth.json
    participant API as GitHub API

    Kata->>Cfg: resolve token
    Cfg-->>Cfg: check KATA_GITHUB_TOKEN
    Cfg-->>Cfg: check GH_TOKEN
    Cfg-->>Cfg: check GITHUB_TOKEN
    Cfg->>GhCli: execFileSync("gh", ["auth","token"]) [2s timeout]
    GhCli-->>Cfg: token or empty/error
    alt token found
        Cfg-->>Kata: {token, source:"gh auth token"}
    else no token
        Cfg->>AuthJSON: read ~/.kata-cli/agent/auth.json
        AuthJSON-->>Cfg: github.key or missing
        Cfg-->>Kata: {token, source} or {null, null}
    end

    Kata->>API: updateProjectV2ItemStatus
    alt success
        API-->>Kata: actualStatus
        Kata->>API: updateIssue (labels + state)
    else permission error
        API-->>Kata: "Resource not accessible by PAT"
        Kata-->>Kata: isProjectsV2PermissionError → true
        Kata-->>Kata: throw formatProjectsV2PermissionErrorMessage
    else other error
        API-->>Kata: other error
        Kata-->>Kata: rethrow original error
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/github-config.ts
Line: 218-222

Comment:
**Synchronous subprocess blocks the event loop**

`execFileSync` is a blocking call — it suspends the entire Node.js event loop for up to 2 seconds while waiting for `gh auth token`. Because `resolveGithubToken` is called during backend initialization (which itself runs in an async context), this can cause a multi-second freeze on any machine where `gh` is installed but unauthenticated, or where the binary is slow to start. Consider using `execFile` with a `promisify` wrapper and making `resolveGithubTokenFromGhCli` async, or offloading it via `spawnSync` in a short-lived worker.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/github-config.ts
Line: 213-215

Comment:
**Opt-out flag only recognises the string `"0"`**

`KATA_GITHUB_ENABLE_GH_CLI_FALLBACK === "0"` means setting it to `"false"`, `"no"`, or `"disabled"` silently keeps the fallback active. Users following conventional boolean-env conventions would be surprised. Consider also treating `"false"` and `"no"` as opt-out values, or rename the variable to `KATA_GITHUB_DISABLE_GH_CLI_FALLBACK=1` to make the truthiness intuitive.

```suggestion
  const disableFallback = ["0", "false", "no"].includes(
    (process.env.KATA_GITHUB_ENABLE_GH_CLI_FALLBACK ?? "").toLowerCase(),
  );
  if (disableFallback) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/github-backend.ts
Line: 994-997

Comment:
**`"not authorized"` match is too broad**

`normalized.includes("not authorized")` will catch error messages like `"OAuth application is not authorized"` (app approval issue) or `"action not authorized for this resource"` (unrelated endpoint), and wrap them with "Grant Projects write access (classic PAT: `project` scope)" — advice that would be incorrect and misleading in those cases. Tightening the match (e.g. requiring `"personal access token"` or `"integration"` to also be present) would make the heuristic safer.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump cli/desktop/symphon..."](https://github.com/gannonh/kata/commit/fcc7cbd2c9b089571cc1c22164af1a3d8be5a318) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29213323)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->