### PR TITLE
Improve Desktop Agent Activity with pinnable events and runtime overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ apps/context/docs/superpowers/
 
 apps/desktop/.env.development
 apps/desktop/.claude/scheduled_tasks.lock
+apps/desktop/bin/pi-mcp-adapter

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.6
+
+### Features
+
+- **Agent Activity event pinning** — all timeline events now expose pin/unpin controls, errors auto-pin by default, and pinned entries can be manually unpinned.
+- **Agent Activity runtime overview** — added a dashboard summary panel with runtime/session health context before the event timeline.
+- **Observability terminology update** — renamed "Pinned Errors" to "Pinned Events" and the verbose timeline mode to "Event Log" for clearer behavior.
+
 ## 0.2.5
 
 ### Features

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata/desktop",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Kata Desktop — native desktop app for the Kata coding agent",
   "private": true,
   "type": "module",

--- a/apps/desktop/src/main/__tests__/agent-activity-journal.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-activity-journal.test.ts
@@ -137,4 +137,107 @@ describe('AgentActivityJournal', () => {
     expect(snapshot.pinnedErrors).toHaveLength(1)
     expect(snapshot.pinnedErrors[0]?.source).toBe('escalation')
   })
+
+  test('records CLI tool lifecycle and pins tool failures', () => {
+    const journal = new AgentActivityJournal()
+
+    journal.ingestCliChatEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-1',
+      toolName: 'bash',
+      args: { command: 'echo hello' },
+    })
+    journal.ingestCliChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-1',
+      toolName: 'bash',
+      isError: true,
+      error: 'Command failed with exit code 1.',
+    })
+
+    const snapshot = journal.getSnapshot()
+    expect(snapshot.events.some((event) => event.kind === 'cli.tool_start')).toBe(true)
+    expect(snapshot.events.some((event) => event.kind === 'cli.tool_error')).toBe(true)
+    expect(snapshot.pinnedErrors).toHaveLength(1)
+    expect(snapshot.pinnedErrors[0]?.kind).toBe('cli.tool_error')
+  })
+
+  test('records CLI lifecycle and verbose-only message/thinking events', () => {
+    const journal = new AgentActivityJournal()
+
+    journal.ingestCliChatEvent({ type: 'agent_start' })
+    journal.ingestCliChatEvent({ type: 'agent_end' })
+    journal.ingestCliChatEvent({ type: 'turn_start' })
+    journal.ingestCliChatEvent({ type: 'turn_end' })
+    journal.ingestCliChatEvent({
+      type: 'tool_update',
+      toolCallId: 'tool-2',
+      toolName: 'bash',
+      status: 'failed',
+      partialStdout: 'stderr',
+    })
+    journal.ingestCliChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-2',
+      toolName: 'bash',
+      isError: false,
+      result: { command: 'echo ok', stdout: 'ok', stderr: '' },
+    })
+    journal.ingestCliChatEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-3',
+      toolName: 'bash',
+      isError: true,
+    })
+    journal.ingestCliChatEvent({ type: 'agent_error', message: 'agent exploded' })
+    journal.ingestCliChatEvent({
+      type: 'subprocess_crash',
+      message: 'process crashed',
+      exitCode: 137,
+      signal: 'SIGKILL',
+      stderrLines: ['line-1'],
+    })
+    journal.ingestCliChatEvent({ type: 'thinking_start', messageId: 'm1' })
+    journal.ingestCliChatEvent({ type: 'thinking_delta', messageId: 'm1', delta: '...' })
+    journal.ingestCliChatEvent({ type: 'thinking_end', messageId: 'm1', content: 'done' })
+    journal.ingestCliChatEvent({ type: 'message_start', messageId: 'm1', role: 'assistant' })
+    journal.ingestCliChatEvent({ type: 'text_delta', messageId: 'm1', delta: 'hello' })
+    journal.ingestCliChatEvent({ type: 'message_end', messageId: 'm1', text: 'hello' })
+    journal.ingestCliChatEvent({ type: 'history_user_message', messageId: 'u1', text: 'hi' })
+    journal.ingestCliChatEvent({ type: 'tool_update', toolCallId: 'tool-4', toolName: 'read' })
+    journal.ingestCliChatEvent({ type: 'unknown_case' } as any)
+
+    const snapshot = journal.getSnapshot()
+    const eventKinds = new Set(snapshot.events.map((event) => event.kind))
+    const verboseKinds = new Set(snapshot.verbose.map((event) => event.kind))
+
+    expect(eventKinds.has('cli.agent_start')).toBe(true)
+    expect(eventKinds.has('cli.agent_end')).toBe(true)
+    expect(eventKinds.has('cli.turn_start')).toBe(true)
+    expect(eventKinds.has('cli.turn_end')).toBe(true)
+    expect(eventKinds.has('cli.tool_end')).toBe(true)
+    expect(eventKinds.has('cli.agent_error')).toBe(true)
+    expect(eventKinds.has('cli.subprocess_crash')).toBe(true)
+    expect(eventKinds.has('cli.tool_error')).toBe(true)
+
+    expect(snapshot.events.some((event) => event.kind === 'cli.tool_update')).toBe(false)
+    expect(verboseKinds.has('cli.tool_update')).toBe(true)
+    expect(verboseKinds.has('cli.message_start')).toBe(true)
+    expect(verboseKinds.has('cli.text_delta')).toBe(true)
+    expect(verboseKinds.has('cli.message_end')).toBe(true)
+    expect(verboseKinds.has('cli.thinking_start')).toBe(true)
+    expect(verboseKinds.has('cli.thinking_delta')).toBe(true)
+    expect(verboseKinds.has('cli.thinking_end')).toBe(true)
+    expect(verboseKinds.has('cli.history_user_message')).toBe(true)
+
+    expect(
+      snapshot.verbose.some((event) => event.kind === 'cli.tool_update' && event.severity === 'warning'),
+    ).toBe(true)
+    expect(
+      snapshot.verbose.some(
+        (event) => event.kind === 'cli.tool_update' && event.details?.status === null && event.severity === 'info',
+      ),
+    ).toBe(true)
+    expect(snapshot.events.some((event) => event.message === 'Tool failed: bash.')).toBe(true)
+  })
 })

--- a/apps/desktop/src/main/__tests__/agent-activity-journal.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-activity-journal.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'vitest'
+import type {
+  SymphonyEscalationResponseCommandResult,
+  SymphonyOperatorSnapshot,
+  SymphonyOperatorWorkerRow,
+  SymphonyRuntimeStatus,
+} from '@shared/types'
+import { AgentActivityJournal } from '../agent-activity-journal'
+
+function buildRuntimeStatus(
+  phase: SymphonyRuntimeStatus['phase'],
+  overrides: Partial<SymphonyRuntimeStatus> = {},
+): SymphonyRuntimeStatus {
+  return {
+    phase,
+    managedProcessRunning: phase === 'ready' || phase === 'starting' || phase === 'restarting',
+    pid: phase === 'ready' ? 1234 : null,
+    url: 'http://127.0.0.1:8080',
+    diagnostics: { stdout: [], stderr: [] },
+    updatedAt: new Date().toISOString(),
+    restartCount: 0,
+    ...overrides,
+  }
+}
+
+function buildSnapshot(
+  workers: SymphonyOperatorWorkerRow[],
+  overrides: Partial<SymphonyOperatorSnapshot> = {},
+): SymphonyOperatorSnapshot {
+  return {
+    fetchedAt: new Date().toISOString(),
+    queueCount: 0,
+    completedCount: 0,
+    workers,
+    escalations: [],
+    connection: {
+      state: 'connected',
+      updatedAt: new Date().toISOString(),
+    },
+    freshness: {
+      status: 'fresh',
+    },
+    response: {},
+    ...overrides,
+  }
+}
+
+describe('AgentActivityJournal', () => {
+  test('records runtime phase transitions into events and verbose streams', () => {
+    const journal = new AgentActivityJournal()
+    journal.ingestRuntimeStatus(buildRuntimeStatus('starting'))
+    journal.ingestRuntimeStatus(buildRuntimeStatus('ready'))
+
+    const snapshot = journal.getSnapshot()
+    expect(snapshot.events.some((event) => event.kind === 'runtime.phase_changed')).toBe(true)
+    expect(snapshot.events.some((event) => event.message.includes('ready'))).toBe(true)
+    expect(snapshot.verbose.some((event) => event.kind === 'runtime.phase_changed')).toBe(true)
+  })
+
+  test('records worker state/tool changes from operator snapshots', () => {
+    const journal = new AgentActivityJournal()
+
+    const baseWorker: SymphonyOperatorWorkerRow = {
+      issueId: 'slice-1',
+      identifier: 'KAT-1',
+      issueTitle: 'Slice 1',
+      state: 'in_progress',
+      toolName: 'edit',
+      model: 'gpt',
+      lastActivityAt: new Date().toISOString(),
+    }
+
+    journal.ingestOperatorSnapshot(buildSnapshot([baseWorker]))
+    journal.ingestOperatorSnapshot(
+      buildSnapshot([
+        {
+          ...baseWorker,
+          state: 'agent_review',
+          toolName: 'bash',
+        },
+      ]),
+    )
+
+    const events = journal.getSnapshot().events
+    expect(events.some((event) => event.kind === 'worker.state_changed')).toBe(true)
+    expect(events.some((event) => event.kind === 'worker.tool_changed')).toBe(true)
+  })
+
+  test('auto-pins error incidents, dismisses them, and re-pins on recurrence', () => {
+    const journal = new AgentActivityJournal()
+    journal.recordSystemError('Symphony stream dropped.')
+
+    const firstSnapshot = journal.getSnapshot()
+    expect(firstSnapshot.pinnedErrors).toHaveLength(1)
+    const firstIncidentId = firstSnapshot.pinnedErrors[0]!.incidentId
+
+    journal.dismissPinnedError(firstIncidentId)
+    expect(journal.getSnapshot().pinnedErrors).toHaveLength(0)
+
+    journal.recordSystemError('Symphony stream dropped.')
+    const secondSnapshot = journal.getSnapshot()
+    expect(secondSnapshot.pinnedErrors).toHaveLength(1)
+    expect(secondSnapshot.pinnedErrors[0]!.incidentId).not.toBe(firstIncidentId)
+  })
+
+  test('enforces ring buffer truncation caps', () => {
+    const journal = new AgentActivityJournal({ eventCap: 2, verboseCap: 3 })
+    journal.recordSystemError('error-a')
+    journal.recordSystemError('error-b')
+    journal.recordSystemError('error-c')
+
+    const snapshot = journal.getSnapshot()
+    expect(snapshot.events).toHaveLength(2)
+    expect(snapshot.events.map((event) => event.message)).toEqual(['error-b', 'error-c'])
+    expect(snapshot.verbose).toHaveLength(3)
+  })
+
+  test('records escalation response failures as pinned escalation errors', () => {
+    const journal = new AgentActivityJournal()
+    const response: SymphonyEscalationResponseCommandResult = {
+      success: false,
+      snapshot: buildSnapshot([]),
+      result: {
+        requestId: 'req-1',
+        ok: false,
+        status: 500,
+        message: 'Escalation response failed (500).',
+        submittedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      },
+    }
+
+    journal.ingestEscalationResponse(response)
+
+    const snapshot = journal.getSnapshot()
+    expect(snapshot.events.some((event) => event.kind === 'escalation.response')).toBe(true)
+    expect(snapshot.pinnedErrors).toHaveLength(1)
+    expect(snapshot.pinnedErrors[0]?.source).toBe('escalation')
+  })
+})

--- a/apps/desktop/src/main/__tests__/agent-activity-journal.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-activity-journal.test.ts
@@ -86,21 +86,22 @@ describe('AgentActivityJournal', () => {
     expect(events.some((event) => event.kind === 'worker.tool_changed')).toBe(true)
   })
 
-  test('auto-pins error incidents, dismisses them, and re-pins on recurrence', () => {
+  test('auto-pins errors and allows manual unpin/pin by event id', () => {
     const journal = new AgentActivityJournal()
     journal.recordSystemError('Symphony stream dropped.')
 
     const firstSnapshot = journal.getSnapshot()
-    expect(firstSnapshot.pinnedErrors).toHaveLength(1)
-    const firstIncidentId = firstSnapshot.pinnedErrors[0]!.incidentId
+    expect(firstSnapshot.pinnedEvents).toHaveLength(1)
+    const firstEventId = firstSnapshot.pinnedEvents[0]!.eventId
 
-    journal.dismissPinnedError(firstIncidentId)
-    expect(journal.getSnapshot().pinnedErrors).toHaveLength(0)
+    journal.setPinnedEvent(firstEventId, false)
+    expect(journal.getSnapshot().pinnedEvents).toHaveLength(0)
 
-    journal.recordSystemError('Symphony stream dropped.')
-    const secondSnapshot = journal.getSnapshot()
-    expect(secondSnapshot.pinnedErrors).toHaveLength(1)
-    expect(secondSnapshot.pinnedErrors[0]!.incidentId).not.toBe(firstIncidentId)
+    journal.setPinnedEvent(firstEventId, true)
+    const repinnedSnapshot = journal.getSnapshot()
+    expect(repinnedSnapshot.pinnedEvents).toHaveLength(1)
+    expect(repinnedSnapshot.pinnedEvents[0]!.eventId).toBe(firstEventId)
+    expect(repinnedSnapshot.pinnedEvents[0]!.automatic).toBe(false)
   })
 
   test('enforces ring buffer truncation caps', () => {
@@ -134,8 +135,8 @@ describe('AgentActivityJournal', () => {
 
     const snapshot = journal.getSnapshot()
     expect(snapshot.events.some((event) => event.kind === 'escalation.response')).toBe(true)
-    expect(snapshot.pinnedErrors).toHaveLength(1)
-    expect(snapshot.pinnedErrors[0]?.source).toBe('escalation')
+    expect(snapshot.pinnedEvents).toHaveLength(1)
+    expect(snapshot.pinnedEvents[0]?.source).toBe('escalation')
   })
 
   test('records CLI tool lifecycle and pins tool failures', () => {
@@ -158,8 +159,8 @@ describe('AgentActivityJournal', () => {
     const snapshot = journal.getSnapshot()
     expect(snapshot.events.some((event) => event.kind === 'cli.tool_start')).toBe(true)
     expect(snapshot.events.some((event) => event.kind === 'cli.tool_error')).toBe(true)
-    expect(snapshot.pinnedErrors).toHaveLength(1)
-    expect(snapshot.pinnedErrors[0]?.kind).toBe('cli.tool_error')
+    expect(snapshot.pinnedEvents).toHaveLength(1)
+    expect(snapshot.pinnedEvents[0]?.kind).toBe('cli.tool_error')
   })
 
   test('records CLI lifecycle and verbose-only message/thinking events', () => {

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -4,7 +4,7 @@ import { promises as fs } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { IPC_CHANNELS } from '@shared/types'
+import { ALL_AUTH_PROVIDERS, IPC_CHANNELS } from '@shared/types'
 
 const handlers = new Map<string, (...args: any[]) => any>()
 
@@ -63,6 +63,22 @@ function createWindowStub() {
       send: vi.fn(),
     },
   } as any
+}
+
+function createAuthProvidersResponse() {
+  return {
+    success: true,
+    providers: Object.fromEntries(
+      ALL_AUTH_PROVIDERS.map((provider) => [
+        provider,
+        {
+          provider,
+          status: 'valid',
+          authType: provider === 'github-copilot' ? 'oauth' : 'api_key',
+        },
+      ]),
+    ),
+  }
 }
 
 describe('symphony ipc handlers', () => {
@@ -152,7 +168,7 @@ describe('symphony ipc handlers', () => {
     const unregister = registerSessionIpc({
       bridge,
       authBridge: {
-        getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+        getProviders: vi.fn(async () => createAuthProvidersResponse()),
         setProviderKey: vi.fn(),
         removeProviderKey: vi.fn(),
         validateKey: vi.fn(),
@@ -230,6 +246,18 @@ describe('symphony ipc handlers', () => {
         type: 'tool_start',
         toolCallId: 'tool-1',
         toolName: 'bash',
+      }),
+    )
+
+    bridge.emit('crash', {
+      exitCode: 1,
+      signal: null,
+      stderrLines: ['bridge crashed'],
+    })
+    expect(agentActivityJournal.ingestCliChatEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'subprocess_crash',
+        message: 'bridge crashed',
       }),
     )
 
@@ -335,7 +363,7 @@ describe('symphony ipc handlers', () => {
     const unregister = registerSessionIpc({
       bridge,
       authBridge: {
-        getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+        getProviders: vi.fn(async () => createAuthProvidersResponse()),
         setProviderKey: vi.fn(),
         removeProviderKey: vi.fn(),
         validateKey: vi.fn(),
@@ -384,6 +412,55 @@ describe('symphony ipc handlers', () => {
           type: 'tool_start',
           toolCallId: 'tool-1',
           toolName: 'bash',
+        }),
+        expect.objectContaining({
+          issueId: 'issue-1',
+          issueIdentifier: 'KAT-1',
+        }),
+      )
+    })
+
+    await fs.writeFile(
+      sessionPath,
+      `${JSON.stringify({ type: 'session', id: 'worker-session', cwd: workerWorkspace })}\n` +
+        `${JSON.stringify({
+          type: 'message',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tool-2', name: 'read', input: { filePath: 'README.md' } }],
+          },
+        })}\n`,
+      'utf8',
+    )
+
+    operatorService.emit('snapshot', {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [
+        {
+          issueId: 'issue-1',
+          identifier: 'KAT-1',
+          issueTitle: 'Test issue',
+          state: 'in_progress',
+          toolName: 'read',
+          model: 'test-model',
+          sessionId: 'worker-session',
+          workspacePath: workerWorkspace,
+        },
+      ],
+      escalations: [],
+      connection: { state: 'connected', updatedAt: new Date().toISOString() },
+      freshness: { status: 'fresh' },
+      response: {},
+    })
+
+    await vi.waitFor(() => {
+      expect(agentActivityJournal.ingestCliChatEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tool_start',
+          toolCallId: 'tool-2',
+          toolName: 'read',
         }),
         expect.objectContaining({
           issueId: 'issue-1',

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -119,27 +119,27 @@ describe('symphony ipc handlers', () => {
       generatedAt: new Date().toISOString(),
       events: [],
       verbose: [],
-      pinnedErrors: [
+      pinnedEvents: [
         {
-          incidentId: 'incident-1',
-          fingerprint: 'system|error|x',
+          eventId: 'evt-1',
+          pinnedAt: new Date().toISOString(),
+          automatic: true,
+          timestamp: new Date().toISOString(),
           source: 'system',
           kind: 'system.error',
           message: 'Symphony service unavailable.',
           severity: 'error',
-          firstSeenAt: new Date().toISOString(),
-          lastSeenAt: new Date().toISOString(),
-          occurrences: 1,
-          lastEventId: 'evt-1',
         },
       ],
     }
 
     const agentActivityJournal = Object.assign(new EventEmitter(), {
       getSnapshot: vi.fn(() => agentActivitySnapshot),
-      dismissPinnedError: vi.fn((incidentId: string) => ({
+      setPinnedEvent: vi.fn((eventId: string, pinned: boolean) => ({
         ...agentActivitySnapshot,
-        pinnedErrors: agentActivitySnapshot.pinnedErrors.filter((incident) => incident.incidentId !== incidentId),
+        pinnedEvents: pinned
+          ? agentActivitySnapshot.pinnedEvents
+          : agentActivitySnapshot.pinnedEvents.filter((event) => event.eventId !== eventId),
       })),
       ingestRuntimeStatus: vi.fn(),
       ingestOperatorSnapshot: vi.fn(),
@@ -180,9 +180,10 @@ describe('symphony ipc handlers', () => {
       'Proceed',
     )
     const agentActivityResponse = await handlers.get(IPC_CHANNELS.agentActivityGetSnapshot)?.({})
-    const dismissPinnedResponse = await handlers.get(IPC_CHANNELS.agentActivityDismissPinnedError)?.(
+    const setPinnedResponse = await handlers.get(IPC_CHANNELS.agentActivitySetPinnedEvent)?.(
       {},
-      'incident-1',
+      'evt-1',
+      false,
     )
     const workflowRespondResult = await handlers.get(IPC_CHANNELS.workflowRespondEscalation)?.({}, {
       cardId: 'slice-1',
@@ -206,9 +207,9 @@ describe('symphony ipc handlers', () => {
     expect(respondResult.success).toBe(true)
     expect(agentActivityResponse.success).toBe(true)
     expect(agentActivityResponse.snapshot).toEqual(agentActivitySnapshot)
-    expect(dismissPinnedResponse.success).toBe(true)
-    expect(agentActivityJournal.dismissPinnedError).toHaveBeenCalledWith('incident-1')
-    expect(Array.isArray(dismissPinnedResponse.snapshot.pinnedErrors)).toBe(true)
+    expect(setPinnedResponse.success).toBe(true)
+    expect(agentActivityJournal.setPinnedEvent).toHaveBeenCalledWith('evt-1', false)
+    expect(Array.isArray(setPinnedResponse.snapshot.pinnedEvents)).toBe(true)
     expect(workflowRespondResult.success).toBe(true)
     expect(workflowRespondResult.code).toBe('SUBMITTED')
 
@@ -322,8 +323,8 @@ describe('symphony ipc handlers', () => {
     }) as any
 
     const agentActivityJournal = Object.assign(new EventEmitter(), {
-      getSnapshot: vi.fn(() => ({ generatedAt: new Date().toISOString(), events: [], verbose: [], pinnedErrors: [] })),
-      dismissPinnedError: vi.fn(),
+      getSnapshot: vi.fn(() => ({ generatedAt: new Date().toISOString(), events: [], verbose: [], pinnedEvents: [] })),
+      setPinnedEvent: vi.fn(),
       ingestRuntimeStatus: vi.fn(),
       ingestOperatorSnapshot: vi.fn(),
       ingestEscalationResponse: vi.fn(),

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -1,4 +1,8 @@
 import { EventEmitter } from 'node:events'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { IPC_CHANNELS } from '@shared/types'
 
@@ -140,6 +144,7 @@ describe('symphony ipc handlers', () => {
       ingestRuntimeStatus: vi.fn(),
       ingestOperatorSnapshot: vi.fn(),
       ingestEscalationResponse: vi.fn(),
+      ingestCliChatEvent: vi.fn(),
       recordSystemError: vi.fn(),
     }) as any
     const windowStub = createWindowStub()
@@ -213,6 +218,20 @@ describe('symphony ipc handlers', () => {
     expect(workflowOpenIssueResult.success).toBe(true)
     expect(workflowOpenIssueResult.code).toBe('OPENED')
 
+    bridge.emit('rpc-event', {
+      type: 'tool_execution_start',
+      toolCallId: 'tool-1',
+      toolName: 'bash',
+      args: { command: 'echo hello' },
+    })
+    expect(agentActivityJournal.ingestCliChatEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool_start',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+      }),
+    )
+
     agentActivityJournal.emit('update', {
       generatedAt: new Date().toISOString(),
       appendedEvents: [],
@@ -223,5 +242,156 @@ describe('symphony ipc handlers', () => {
     )
 
     unregister()
+  })
+
+  test('ingests worker CLI activity from Symphony session logs', async () => {
+    const bridge = createBridgeStub()
+    const workerWorkspace = path.join(tmpdir(), 'kata-worker-workspace')
+    bridge.getWorkspacePath.mockReturnValue(path.join(tmpdir(), 'kata-main-workspace'))
+
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'kata-desktop-worker-history-'))
+    const sessionPath = path.join(tempDir, '2026-04-23_worker-session.jsonl')
+
+    await fs.writeFile(
+      sessionPath,
+      `${JSON.stringify({ type: 'session', id: 'worker-session', cwd: workerWorkspace })}\n` +
+        `${JSON.stringify({
+          type: 'message',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tool-1', name: 'bash', input: { command: 'echo hi' } }],
+          },
+        })}\n` +
+        `${JSON.stringify({
+          type: 'message',
+          message: {
+            role: 'toolResult',
+            toolCallId: 'tool-1',
+            toolName: 'bash',
+            toolResult: 'hi\n',
+            isError: false,
+          },
+        })}\n`,
+      'utf8',
+    )
+
+    const supervisor = {
+      on: vi.fn(),
+      off: vi.fn(),
+      getStatus: vi.fn(() => ({
+        phase: 'idle',
+        managedProcessRunning: false,
+        pid: null,
+        url: null,
+        diagnostics: { stdout: [], stderr: [] },
+        updatedAt: new Date().toISOString(),
+        restartCount: 0,
+      })),
+    } as any
+
+    const operatorService = Object.assign(new EventEmitter(), {
+      on: EventEmitter.prototype.on,
+      off: EventEmitter.prototype.off,
+      syncRuntimeStatus: vi.fn(async () => undefined),
+      getSnapshot: vi.fn(() => ({
+        fetchedAt: new Date().toISOString(),
+        queueCount: 0,
+        completedCount: 0,
+        workers: [],
+        escalations: [],
+        connection: { state: 'connected', updatedAt: new Date().toISOString() },
+        freshness: { status: 'fresh' },
+        response: {},
+      })),
+      getStabilityMetrics: vi.fn(() => ({
+        reconnectSuccessRate: 1,
+        recoveryLatencyMs: 0,
+        collectedAt: new Date().toISOString(),
+      })),
+      refreshBaseline: vi.fn(async () => ({
+        fetchedAt: new Date().toISOString(),
+        queueCount: 0,
+        completedCount: 0,
+        workers: [],
+        escalations: [],
+        connection: { state: 'connected', updatedAt: new Date().toISOString() },
+        freshness: { status: 'fresh' },
+        response: {},
+      })),
+      respondToEscalation: vi.fn(async () => ({ success: true, snapshot: null })),
+    }) as any
+
+    const agentActivityJournal = Object.assign(new EventEmitter(), {
+      getSnapshot: vi.fn(() => ({ generatedAt: new Date().toISOString(), events: [], verbose: [], pinnedErrors: [] })),
+      dismissPinnedError: vi.fn(),
+      ingestRuntimeStatus: vi.fn(),
+      ingestOperatorSnapshot: vi.fn(),
+      ingestEscalationResponse: vi.fn(),
+      ingestCliChatEvent: vi.fn(),
+      recordSystemError: vi.fn(),
+    }) as any
+
+    const unregister = registerSessionIpc({
+      bridge,
+      authBridge: {
+        getProviders: vi.fn(async () => ({ success: true, providers: {} })),
+        setProviderKey: vi.fn(),
+        removeProviderKey: vi.fn(),
+        validateKey: vi.fn(),
+      } as any,
+      sessionManager: {
+        listSessions: vi.fn(async () => ({ sessions: [], warnings: [], directory: process.cwd() })),
+        getSessionInfo: vi.fn(),
+        resolveSessionPathById: vi.fn(async (sessionId: string, cwd: string) => {
+          if (sessionId === 'worker-session' && cwd === workerWorkspace) {
+            return sessionPath
+          }
+          return null
+        }),
+      } as any,
+      window: createWindowStub(),
+      symphonySupervisor: supervisor,
+      symphonyOperatorService: operatorService,
+      agentActivityJournal,
+    })
+
+    operatorService.emit('snapshot', {
+      fetchedAt: new Date().toISOString(),
+      queueCount: 0,
+      completedCount: 0,
+      workers: [
+        {
+          issueId: 'issue-1',
+          identifier: 'KAT-1',
+          issueTitle: 'Test issue',
+          state: 'in_progress',
+          toolName: 'bash',
+          model: 'test-model',
+          sessionId: 'worker-session',
+          workspacePath: workerWorkspace,
+        },
+      ],
+      escalations: [],
+      connection: { state: 'connected', updatedAt: new Date().toISOString() },
+      freshness: { status: 'fresh' },
+      response: {},
+    })
+
+    await vi.waitFor(() => {
+      expect(agentActivityJournal.ingestCliChatEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tool_start',
+          toolCallId: 'tool-1',
+          toolName: 'bash',
+        }),
+        expect.objectContaining({
+          issueId: 'issue-1',
+          issueIdentifier: 'KAT-1',
+        }),
+      )
+    })
+
+    unregister()
+    rmSync(tempDir, { recursive: true, force: true })
   })
 })

--- a/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-ipc.test.ts
@@ -111,6 +111,39 @@ describe('symphony ipc handlers', () => {
       respondToEscalation: vi.fn(async () => ({ success: true, snapshot: dashboardSnapshot })),
     } as any
 
+    const agentActivitySnapshot = {
+      generatedAt: new Date().toISOString(),
+      events: [],
+      verbose: [],
+      pinnedErrors: [
+        {
+          incidentId: 'incident-1',
+          fingerprint: 'system|error|x',
+          source: 'system',
+          kind: 'system.error',
+          message: 'Symphony service unavailable.',
+          severity: 'error',
+          firstSeenAt: new Date().toISOString(),
+          lastSeenAt: new Date().toISOString(),
+          occurrences: 1,
+          lastEventId: 'evt-1',
+        },
+      ],
+    }
+
+    const agentActivityJournal = Object.assign(new EventEmitter(), {
+      getSnapshot: vi.fn(() => agentActivitySnapshot),
+      dismissPinnedError: vi.fn((incidentId: string) => ({
+        ...agentActivitySnapshot,
+        pinnedErrors: agentActivitySnapshot.pinnedErrors.filter((incident) => incident.incidentId !== incidentId),
+      })),
+      ingestRuntimeStatus: vi.fn(),
+      ingestOperatorSnapshot: vi.fn(),
+      ingestEscalationResponse: vi.fn(),
+      recordSystemError: vi.fn(),
+    }) as any
+    const windowStub = createWindowStub()
+
     const unregister = registerSessionIpc({
       bridge,
       authBridge: {
@@ -124,9 +157,10 @@ describe('symphony ipc handlers', () => {
         getSessionInfo: vi.fn(),
         resolveSessionPathById: vi.fn(async () => null),
       } as any,
-      window: createWindowStub(),
+      window: windowStub,
       symphonySupervisor: supervisor,
       symphonyOperatorService: operatorService,
+      agentActivityJournal,
     })
 
     await handlers.get(IPC_CHANNELS.symphonyStart)?.({})
@@ -139,6 +173,11 @@ describe('symphony ipc handlers', () => {
       {},
       'req-1',
       'Proceed',
+    )
+    const agentActivityResponse = await handlers.get(IPC_CHANNELS.agentActivityGetSnapshot)?.({})
+    const dismissPinnedResponse = await handlers.get(IPC_CHANNELS.agentActivityDismissPinnedError)?.(
+      {},
+      'incident-1',
     )
     const workflowRespondResult = await handlers.get(IPC_CHANNELS.workflowRespondEscalation)?.({}, {
       cardId: 'slice-1',
@@ -160,6 +199,11 @@ describe('symphony ipc handlers', () => {
     expect(operatorService.refreshBaseline).toHaveBeenCalledTimes(1)
     expect(operatorService.respondToEscalation).toHaveBeenCalledWith('req-1', 'Proceed')
     expect(respondResult.success).toBe(true)
+    expect(agentActivityResponse.success).toBe(true)
+    expect(agentActivityResponse.snapshot).toEqual(agentActivitySnapshot)
+    expect(dismissPinnedResponse.success).toBe(true)
+    expect(agentActivityJournal.dismissPinnedError).toHaveBeenCalledWith('incident-1')
+    expect(Array.isArray(dismissPinnedResponse.snapshot.pinnedErrors)).toBe(true)
     expect(workflowRespondResult.success).toBe(true)
     expect(workflowRespondResult.code).toBe('SUBMITTED')
 
@@ -168,6 +212,15 @@ describe('symphony ipc handlers', () => {
     )
     expect(workflowOpenIssueResult.success).toBe(true)
     expect(workflowOpenIssueResult.code).toBe('OPENED')
+
+    agentActivityJournal.emit('update', {
+      generatedAt: new Date().toISOString(),
+      appendedEvents: [],
+    })
+    expect(windowStub.webContents.send).toHaveBeenCalledWith(
+      IPC_CHANNELS.agentActivityUpdate,
+      expect.objectContaining({ appendedEvents: [] }),
+    )
 
     unregister()
   })

--- a/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
+++ b/apps/desktop/src/main/__tests__/symphony-operator-service.test.ts
@@ -78,6 +78,7 @@ describe('SymphonyOperatorService', () => {
                 issue_title: 'Dashboard work',
                 status: 'in_progress',
                 model: 'claude-sonnet-4-6',
+                workspace_path: '/tmp/symphony/issue-1',
               },
             },
             retry_queue: [{ id: 'r1' }],
@@ -87,6 +88,11 @@ describe('SymphonyOperatorService', () => {
               '1': {
                 current_tool_name: 'edit',
                 last_activity_ms: Date.now(),
+              },
+            },
+            running_sessions: {
+              '1': {
+                session_id: 'session-worker-1',
               },
             },
           }),
@@ -122,6 +128,8 @@ describe('SymphonyOperatorService', () => {
     expect(snapshot.completedCount).toBe(2)
     expect(snapshot.workers).toHaveLength(1)
     expect(snapshot.workers[0]?.toolName).toBe('edit')
+    expect(snapshot.workers[0]?.sessionId).toBe('session-worker-1')
+    expect(snapshot.workers[0]?.workspacePath).toBe('/tmp/symphony/issue-1')
     expect(snapshot.escalations).toHaveLength(1)
     expect(snapshot.connection.state).toBe('connected')
     expect(snapshot.connection.lastBaselineRefreshAt).toBeTruthy()

--- a/apps/desktop/src/main/agent-activity-journal.ts
+++ b/apps/desktop/src/main/agent-activity-journal.ts
@@ -1,0 +1,585 @@
+import { EventEmitter } from 'node:events'
+import type {
+  AgentActivityEvent,
+  AgentActivitySeverity,
+  AgentActivitySnapshot,
+  AgentActivitySource,
+  AgentActivityUpdate,
+  AgentPinnedErrorIncident,
+  SymphonyEscalationResponseCommandResult,
+  SymphonyOperatorSnapshot,
+  SymphonyOperatorWorkerRow,
+  SymphonyRuntimeStatus,
+} from '../shared/types'
+
+export const AGENT_ACTIVITY_DEFAULT_EVENT_CAP = 2_000
+export const AGENT_ACTIVITY_DEFAULT_VERBOSE_CAP = 20_000
+
+interface AgentActivityJournalEvents {
+  update: (update: AgentActivityUpdate) => void
+}
+
+interface AgentActivityJournalOptions {
+  eventCap?: number
+  verboseCap?: number
+}
+
+interface DeltaAccumulator {
+  generatedAt: string
+  appendedEvents: AgentActivityEvent[]
+  appendedVerbose: AgentActivityEvent[]
+  upsertedPinnedErrors: AgentPinnedErrorIncident[]
+  removedPinnedErrorIds: string[]
+}
+
+interface EventInput {
+  timestamp?: string
+  source: AgentActivitySource
+  severity: AgentActivitySeverity
+  kind: string
+  message: string
+  workerId?: string
+  issueId?: string
+  issueIdentifier?: string
+  requestId?: string
+  connectionState?: AgentActivityEvent['connectionState']
+  details?: Record<string, unknown>
+}
+
+export class AgentActivityJournal extends EventEmitter {
+  private readonly eventCap: number
+  private readonly verboseCap: number
+  private readonly events: AgentActivityEvent[] = []
+  private readonly verbose: AgentActivityEvent[] = []
+  private readonly pinnedByFingerprint = new Map<string, AgentPinnedErrorIncident>()
+  private readonly fingerprintByIncidentId = new Map<string, string>()
+  private previousRuntimeStatus: SymphonyRuntimeStatus | null = null
+  private previousOperatorSnapshot: SymphonyOperatorSnapshot | null = null
+  private sequence = 0
+  private incidentSequence = 0
+
+  constructor(options: AgentActivityJournalOptions = {}) {
+    super()
+    this.eventCap = Math.max(1, options.eventCap ?? AGENT_ACTIVITY_DEFAULT_EVENT_CAP)
+    this.verboseCap = Math.max(1, options.verboseCap ?? AGENT_ACTIVITY_DEFAULT_VERBOSE_CAP)
+  }
+
+  override on<K extends keyof AgentActivityJournalEvents>(event: K, listener: AgentActivityJournalEvents[K]): this {
+    return super.on(event, listener)
+  }
+
+  override off<K extends keyof AgentActivityJournalEvents>(event: K, listener: AgentActivityJournalEvents[K]): this {
+    return super.off(event, listener)
+  }
+
+  override emit<K extends keyof AgentActivityJournalEvents>(
+    event: K,
+    ...args: Parameters<AgentActivityJournalEvents[K]>
+  ): boolean {
+    return super.emit(event, ...args)
+  }
+
+  public getSnapshot(): AgentActivitySnapshot {
+    return {
+      generatedAt: new Date().toISOString(),
+      events: this.events.slice(),
+      verbose: this.verbose.slice(),
+      pinnedErrors: Array.from(this.pinnedByFingerprint.values()).sort((left, right) =>
+        left.lastSeenAt.localeCompare(right.lastSeenAt),
+      ),
+    }
+  }
+
+  public dismissPinnedError(incidentId: string): AgentActivitySnapshot {
+    const trimmedIncidentId = incidentId.trim()
+    const fingerprint = this.fingerprintByIncidentId.get(trimmedIncidentId)
+    if (!fingerprint) {
+      return this.getSnapshot()
+    }
+
+    this.fingerprintByIncidentId.delete(trimmedIncidentId)
+    this.pinnedByFingerprint.delete(fingerprint)
+
+    this.emitUpdate({
+      generatedAt: new Date().toISOString(),
+      removedPinnedErrorIds: [trimmedIncidentId],
+    })
+
+    return this.getSnapshot()
+  }
+
+  public recordSystemError(message: string, details?: Record<string, unknown>): void {
+    const delta = this.createDelta()
+    this.recordEvent(
+      {
+        source: 'system',
+        severity: 'error',
+        kind: 'system.error',
+        message,
+        details,
+      },
+      delta,
+      { toEvents: true, toVerbose: true },
+    )
+    this.flushDelta(delta)
+  }
+
+  public ingestRuntimeStatus(status: SymphonyRuntimeStatus): void {
+    const delta = this.createDelta()
+    const previous = this.previousRuntimeStatus
+    const timestamp = status.updatedAt
+
+    if (!previous || previous.phase !== status.phase) {
+      this.recordEvent(
+        {
+          timestamp,
+          source: 'runtime',
+          severity: status.phase === 'failed' || status.phase === 'config_error' ? 'error' : 'info',
+          kind: 'runtime.phase_changed',
+          message: `Runtime phase is now ${status.phase}.`,
+          details: {
+            previousPhase: previous?.phase ?? null,
+            nextPhase: status.phase,
+            restartCount: status.restartCount,
+          },
+        },
+        delta,
+        { toEvents: true, toVerbose: true },
+      )
+    }
+
+    const previousErrorKey = previous?.lastError
+      ? `${previous.lastError.code}:${previous.lastError.message}`
+      : null
+    const nextErrorKey = status.lastError ? `${status.lastError.code}:${status.lastError.message}` : null
+    if (nextErrorKey && previousErrorKey !== nextErrorKey) {
+      this.recordEvent(
+        {
+          timestamp,
+          source: 'runtime',
+          severity: 'error',
+          kind: 'runtime.error',
+          message: status.lastError?.message ?? 'Runtime error',
+          details: {
+            code: status.lastError?.code ?? null,
+            phase: status.lastError?.phase ?? null,
+            details: status.lastError?.details ?? null,
+          },
+        },
+        delta,
+        { toEvents: true, toVerbose: true },
+      )
+    }
+
+    const prevStdoutLength = previous?.diagnostics.stdout.length ?? 0
+    const prevStderrLength = previous?.diagnostics.stderr.length ?? 0
+    const nextStdoutLength = status.diagnostics.stdout.length
+    const nextStderrLength = status.diagnostics.stderr.length
+    if (prevStdoutLength !== nextStdoutLength || prevStderrLength !== nextStderrLength) {
+      this.recordEvent(
+        {
+          timestamp,
+          source: 'runtime',
+          severity: nextStderrLength > prevStderrLength ? 'warning' : 'info',
+          kind: 'runtime.diagnostics_updated',
+          message: `Runtime diagnostics updated (stdout=${nextStdoutLength}, stderr=${nextStderrLength}).`,
+          details: {
+            prevStdoutLength,
+            nextStdoutLength,
+            prevStderrLength,
+            nextStderrLength,
+          },
+        },
+        delta,
+        { toEvents: false, toVerbose: true },
+      )
+    }
+
+    this.previousRuntimeStatus = structuredClone(status)
+    this.flushDelta(delta)
+  }
+
+  public ingestOperatorSnapshot(snapshot: SymphonyOperatorSnapshot): void {
+    const delta = this.createDelta()
+    const previous = this.previousOperatorSnapshot
+    const timestamp = snapshot.fetchedAt
+
+    if (
+      !previous ||
+      previous.connection.state !== snapshot.connection.state ||
+      previous.connection.lastError !== snapshot.connection.lastError
+    ) {
+      const severity: AgentActivitySeverity =
+        snapshot.connection.state === 'disconnected'
+          ? 'error'
+          : snapshot.connection.state === 'reconnecting'
+            ? 'warning'
+            : 'info'
+      this.recordEvent(
+        {
+          timestamp,
+          source: 'connection',
+          severity,
+          kind: 'connection.state_changed',
+          message: `Connection state is ${snapshot.connection.state}.`,
+          connectionState: snapshot.connection.state,
+          details: {
+            previousState: previous?.connection.state ?? null,
+            nextState: snapshot.connection.state,
+            lastError: snapshot.connection.lastError ?? null,
+          },
+        },
+        delta,
+        { toEvents: true, toVerbose: true },
+      )
+    }
+
+    const previousWorkers = new Map((previous?.workers ?? []).map((worker) => [worker.issueId, worker]))
+    const nextWorkers = new Map(snapshot.workers.map((worker) => [worker.issueId, worker]))
+
+    for (const nextWorker of snapshot.workers) {
+      const previousWorker = previousWorkers.get(nextWorker.issueId)
+      if (!previousWorker) {
+        this.recordWorkerAdded(nextWorker, timestamp, delta)
+        continue
+      }
+
+      if (previousWorker.state !== nextWorker.state) {
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'worker',
+            severity: 'info',
+            kind: 'worker.state_changed',
+            message: `${nextWorker.identifier} moved to ${nextWorker.state}.`,
+            workerId: nextWorker.identifier,
+            issueId: nextWorker.issueId,
+            issueIdentifier: nextWorker.identifier,
+            details: {
+              previousState: previousWorker.state,
+              nextState: nextWorker.state,
+            },
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+      }
+
+      if (previousWorker.toolName !== nextWorker.toolName) {
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'worker',
+            severity: 'info',
+            kind: 'worker.tool_changed',
+            message: `${nextWorker.identifier} switched tool to ${nextWorker.toolName}.`,
+            workerId: nextWorker.identifier,
+            issueId: nextWorker.issueId,
+            issueIdentifier: nextWorker.identifier,
+            details: {
+              previousTool: previousWorker.toolName,
+              nextTool: nextWorker.toolName,
+            },
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+      }
+
+      if (nextWorker.lastError && previousWorker.lastError !== nextWorker.lastError) {
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'worker',
+            severity: 'error',
+            kind: 'worker.error',
+            message: nextWorker.lastError,
+            workerId: nextWorker.identifier,
+            issueId: nextWorker.issueId,
+            issueIdentifier: nextWorker.identifier,
+            details: {
+              previousError: previousWorker.lastError ?? null,
+              nextError: nextWorker.lastError,
+            },
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+      }
+    }
+
+    for (const previousWorker of previous?.workers ?? []) {
+      if (nextWorkers.has(previousWorker.issueId)) {
+        continue
+      }
+      this.recordEvent(
+        {
+          timestamp,
+          source: 'worker',
+          severity: 'info',
+          kind: 'worker.removed',
+          message: `${previousWorker.identifier} is no longer active.`,
+          workerId: previousWorker.identifier,
+          issueId: previousWorker.issueId,
+          issueIdentifier: previousWorker.identifier,
+        },
+        delta,
+        { toEvents: true, toVerbose: true },
+      )
+    }
+
+    const previousEscalations = new Set((previous?.escalations ?? []).map((item) => item.requestId))
+    const nextEscalations = new Set(snapshot.escalations.map((item) => item.requestId))
+
+    for (const escalation of snapshot.escalations) {
+      if (previousEscalations.has(escalation.requestId)) {
+        continue
+      }
+      this.recordEvent(
+        {
+          timestamp,
+          source: 'escalation',
+          severity: 'warning',
+          kind: 'escalation.created',
+          message: `Escalation created for ${escalation.issueIdentifier}.`,
+          issueId: escalation.issueId,
+          issueIdentifier: escalation.issueIdentifier,
+          requestId: escalation.requestId,
+          details: {
+            questionPreview: escalation.questionPreview,
+            timeoutMs: escalation.timeoutMs,
+          },
+        },
+        delta,
+        { toEvents: true, toVerbose: true },
+      )
+    }
+
+    for (const previousEscalation of previous?.escalations ?? []) {
+      if (nextEscalations.has(previousEscalation.requestId)) {
+        continue
+      }
+      this.recordEvent(
+        {
+          timestamp,
+          source: 'escalation',
+          severity: 'info',
+          kind: 'escalation.resolved',
+          message: `Escalation resolved for ${previousEscalation.issueIdentifier}.`,
+          issueId: previousEscalation.issueId,
+          issueIdentifier: previousEscalation.issueIdentifier,
+          requestId: previousEscalation.requestId,
+        },
+        delta,
+        { toEvents: true, toVerbose: true },
+      )
+    }
+
+    if (!previous || previous.queueCount !== snapshot.queueCount || previous.completedCount !== snapshot.completedCount) {
+      this.recordEvent(
+        {
+          timestamp,
+          source: 'system',
+          severity: 'info',
+          kind: 'operator.counters_updated',
+          message: `Operator counters: queue=${snapshot.queueCount}, completed=${snapshot.completedCount}.`,
+          details: {
+            previousQueue: previous?.queueCount ?? null,
+            nextQueue: snapshot.queueCount,
+            previousCompleted: previous?.completedCount ?? null,
+            nextCompleted: snapshot.completedCount,
+          },
+        },
+        delta,
+        { toEvents: false, toVerbose: true },
+      )
+    }
+
+    this.previousOperatorSnapshot = structuredClone(snapshot)
+    this.flushDelta(delta)
+  }
+
+  public ingestEscalationResponse(response: SymphonyEscalationResponseCommandResult): void {
+    const delta = this.createDelta()
+    const result = response.result
+    const timestamp = result?.completedAt ?? new Date().toISOString()
+    const message = result?.message ?? 'Escalation response command completed.'
+
+    this.recordEvent(
+      {
+        timestamp,
+        source: 'escalation',
+        severity: response.success ? 'info' : 'error',
+        kind: 'escalation.response',
+        message,
+        requestId: result?.requestId,
+        details: {
+          status: result?.status ?? null,
+          ok: result?.ok ?? response.success,
+        },
+      },
+      delta,
+      { toEvents: true, toVerbose: true },
+    )
+
+    this.flushDelta(delta)
+  }
+
+  private recordWorkerAdded(worker: SymphonyOperatorWorkerRow, timestamp: string, delta: DeltaAccumulator): void {
+    this.recordEvent(
+      {
+        timestamp,
+        source: 'worker',
+        severity: 'info',
+        kind: 'worker.added',
+        message: `${worker.identifier} started ${worker.state}.`,
+        workerId: worker.identifier,
+        issueId: worker.issueId,
+        issueIdentifier: worker.identifier,
+        details: {
+          state: worker.state,
+          tool: worker.toolName,
+          model: worker.model,
+        },
+      },
+      delta,
+      { toEvents: true, toVerbose: true },
+    )
+  }
+
+  private recordEvent(
+    input: EventInput,
+    delta: DeltaAccumulator,
+    options: { toEvents: boolean; toVerbose: boolean },
+  ): void {
+    const timestamp = input.timestamp ?? new Date().toISOString()
+    const common = {
+      id: this.nextEventId(timestamp),
+      timestamp,
+      source: input.source,
+      severity: input.severity,
+      kind: input.kind,
+      message: input.message,
+      ...(input.workerId ? { workerId: input.workerId } : {}),
+      ...(input.issueId ? { issueId: input.issueId } : {}),
+      ...(input.issueIdentifier ? { issueIdentifier: input.issueIdentifier } : {}),
+      ...(input.requestId ? { requestId: input.requestId } : {}),
+      ...(input.connectionState ? { connectionState: input.connectionState } : {}),
+      ...(input.details ? { details: input.details } : {}),
+    } satisfies Omit<AgentActivityEvent, 'stream'>
+
+    let primaryEvent: AgentActivityEvent | null = null
+
+    if (options.toEvents) {
+      const event: AgentActivityEvent = { ...common, stream: 'events' }
+      this.events.push(event)
+      trimBuffer(this.events, this.eventCap)
+      delta.appendedEvents.push(event)
+      primaryEvent = event
+    }
+
+    if (options.toVerbose) {
+      const verboseEvent: AgentActivityEvent = { ...common, stream: 'verbose' }
+      this.verbose.push(verboseEvent)
+      trimBuffer(this.verbose, this.verboseCap)
+      delta.appendedVerbose.push(verboseEvent)
+      primaryEvent ??= verboseEvent
+    }
+
+    if (primaryEvent && primaryEvent.severity === 'error') {
+      this.upsertPinned(primaryEvent, delta)
+    }
+  }
+
+  private upsertPinned(event: AgentActivityEvent, delta: DeltaAccumulator): void {
+    const fingerprint = buildFingerprint(event)
+    const existing = this.pinnedByFingerprint.get(fingerprint)
+    if (existing) {
+      const updated: AgentPinnedErrorIncident = {
+        ...existing,
+        message: event.message,
+        lastSeenAt: event.timestamp,
+        occurrences: existing.occurrences + 1,
+        lastEventId: event.id,
+      }
+      this.pinnedByFingerprint.set(fingerprint, updated)
+      this.fingerprintByIncidentId.set(updated.incidentId, fingerprint)
+      delta.upsertedPinnedErrors.push(updated)
+      return
+    }
+
+    const incidentId = this.nextIncidentId(event.timestamp)
+    const incident: AgentPinnedErrorIncident = {
+      incidentId,
+      fingerprint,
+      source: event.source,
+      kind: event.kind,
+      message: event.message,
+      severity: 'error',
+      firstSeenAt: event.timestamp,
+      lastSeenAt: event.timestamp,
+      occurrences: 1,
+      lastEventId: event.id,
+    }
+    this.pinnedByFingerprint.set(fingerprint, incident)
+    this.fingerprintByIncidentId.set(incidentId, fingerprint)
+    delta.upsertedPinnedErrors.push(incident)
+  }
+
+  private nextEventId(timestamp: string): string {
+    this.sequence += 1
+    return `evt:${timestamp}:${this.sequence}`
+  }
+
+  private nextIncidentId(timestamp: string): string {
+    this.incidentSequence += 1
+    return `incident:${timestamp}:${this.incidentSequence}`
+  }
+
+  private createDelta(): DeltaAccumulator {
+    return {
+      generatedAt: new Date().toISOString(),
+      appendedEvents: [],
+      appendedVerbose: [],
+      upsertedPinnedErrors: [],
+      removedPinnedErrorIds: [],
+    }
+  }
+
+  private flushDelta(delta: DeltaAccumulator): void {
+    if (
+      delta.appendedEvents.length === 0 &&
+      delta.appendedVerbose.length === 0 &&
+      delta.upsertedPinnedErrors.length === 0 &&
+      delta.removedPinnedErrorIds.length === 0
+    ) {
+      return
+    }
+
+    this.emitUpdate({
+      generatedAt: delta.generatedAt,
+      ...(delta.appendedEvents.length > 0 ? { appendedEvents: delta.appendedEvents } : {}),
+      ...(delta.appendedVerbose.length > 0 ? { appendedVerbose: delta.appendedVerbose } : {}),
+      ...(delta.upsertedPinnedErrors.length > 0 ? { upsertedPinnedErrors: delta.upsertedPinnedErrors } : {}),
+      ...(delta.removedPinnedErrorIds.length > 0 ? { removedPinnedErrorIds: delta.removedPinnedErrorIds } : {}),
+    })
+  }
+
+  private emitUpdate(update: AgentActivityUpdate): void {
+    this.emit('update', update)
+  }
+}
+
+function trimBuffer<T>(buffer: T[], cap: number): void {
+  if (buffer.length <= cap) {
+    return
+  }
+  buffer.splice(0, buffer.length - cap)
+}
+
+function buildFingerprint(event: AgentActivityEvent): string {
+  const normalizedMessage = event.message.trim().toLowerCase()
+  const issue = event.issueIdentifier ?? event.issueId ?? ''
+  const request = event.requestId ?? ''
+  return `${event.source}|${event.kind}|${issue}|${request}|${normalizedMessage}`
+}

--- a/apps/desktop/src/main/agent-activity-journal.ts
+++ b/apps/desktop/src/main/agent-activity-journal.ts
@@ -5,7 +5,7 @@ import type {
   AgentActivitySnapshot,
   AgentActivitySource,
   AgentActivityUpdate,
-  AgentPinnedErrorIncident,
+  AgentPinnedEvent,
   ChatEvent,
   SymphonyEscalationResponseCommandResult,
   SymphonyOperatorSnapshot,
@@ -29,8 +29,8 @@ interface DeltaAccumulator {
   generatedAt: string
   appendedEvents: AgentActivityEvent[]
   appendedVerbose: AgentActivityEvent[]
-  upsertedPinnedErrors: AgentPinnedErrorIncident[]
-  removedPinnedErrorIds: string[]
+  upsertedPinnedEvents: AgentPinnedEvent[]
+  removedPinnedEventIds: string[]
 }
 
 interface EventInput {
@@ -58,12 +58,10 @@ export class AgentActivityJournal extends EventEmitter {
   private readonly verboseCap: number
   private readonly events: AgentActivityEvent[] = []
   private readonly verbose: AgentActivityEvent[] = []
-  private readonly pinnedByFingerprint = new Map<string, AgentPinnedErrorIncident>()
-  private readonly fingerprintByIncidentId = new Map<string, string>()
+  private readonly pinnedByEventId = new Map<string, AgentPinnedEvent>()
   private previousRuntimeStatus: SymphonyRuntimeStatus | null = null
   private previousOperatorSnapshot: SymphonyOperatorSnapshot | null = null
   private sequence = 0
-  private incidentSequence = 0
 
   constructor(options: AgentActivityJournalOptions = {}) {
     super()
@@ -91,27 +89,36 @@ export class AgentActivityJournal extends EventEmitter {
       generatedAt: new Date().toISOString(),
       events: this.events.slice(),
       verbose: this.verbose.slice(),
-      pinnedErrors: Array.from(this.pinnedByFingerprint.values()).sort((left, right) =>
-        left.lastSeenAt.localeCompare(right.lastSeenAt),
+      pinnedEvents: Array.from(this.pinnedByEventId.values()).sort((left, right) =>
+        left.pinnedAt.localeCompare(right.pinnedAt),
       ),
     }
   }
 
-  public dismissPinnedError(incidentId: string): AgentActivitySnapshot {
-    const trimmedIncidentId = incidentId.trim()
-    const fingerprint = this.fingerprintByIncidentId.get(trimmedIncidentId)
-    if (!fingerprint) {
+  public setPinnedEvent(eventId: string, pinned: boolean): AgentActivitySnapshot {
+    const trimmedEventId = eventId.trim()
+    if (!trimmedEventId) {
       return this.getSnapshot()
     }
 
-    this.fingerprintByIncidentId.delete(trimmedIncidentId)
-    this.pinnedByFingerprint.delete(fingerprint)
+    const delta = this.createDelta()
+    if (!pinned) {
+      if (!this.pinnedByEventId.has(trimmedEventId)) {
+        return this.getSnapshot()
+      }
+      this.pinnedByEventId.delete(trimmedEventId)
+      delta.removedPinnedEventIds.push(trimmedEventId)
+      this.flushDelta(delta)
+      return this.getSnapshot()
+    }
 
-    this.emitUpdate({
-      generatedAt: new Date().toISOString(),
-      removedPinnedErrorIds: [trimmedIncidentId],
-    })
+    const event = this.findEventById(trimmedEventId)
+    if (!event) {
+      return this.getSnapshot()
+    }
 
+    this.upsertPinned(event, delta, false)
+    this.flushDelta(delta)
     return this.getSnapshot()
   }
 
@@ -709,43 +716,52 @@ export class AgentActivityJournal extends EventEmitter {
     }
 
     if (primaryEvent && primaryEvent.severity === 'error') {
-      this.upsertPinned(primaryEvent, delta)
+      this.upsertPinned(primaryEvent, delta, true)
     }
   }
 
-  private upsertPinned(event: AgentActivityEvent, delta: DeltaAccumulator): void {
-    const fingerprint = buildFingerprint(event)
-    const existing = this.pinnedByFingerprint.get(fingerprint)
+  private upsertPinned(event: AgentActivityEvent, delta: DeltaAccumulator, automatic: boolean): void {
+    const existing = this.pinnedByEventId.get(event.id)
     if (existing) {
-      const updated: AgentPinnedErrorIncident = {
+      const updated: AgentPinnedEvent = {
         ...existing,
+        automatic: existing.automatic && automatic,
+        pinnedAt: existing.pinnedAt,
+        timestamp: event.timestamp,
+        source: event.source,
+        severity: event.severity,
+        kind: event.kind,
         message: event.message,
-        lastSeenAt: event.timestamp,
-        occurrences: existing.occurrences + 1,
-        lastEventId: event.id,
+        ...(event.workerId ? { workerId: event.workerId } : {}),
+        ...(event.issueId ? { issueId: event.issueId } : {}),
+        ...(event.issueIdentifier ? { issueIdentifier: event.issueIdentifier } : {}),
+        ...(event.requestId ? { requestId: event.requestId } : {}),
+        ...(event.connectionState ? { connectionState: event.connectionState } : {}),
+        ...(event.details ? { details: event.details } : {}),
       }
-      this.pinnedByFingerprint.set(fingerprint, updated)
-      this.fingerprintByIncidentId.set(updated.incidentId, fingerprint)
-      delta.upsertedPinnedErrors.push(updated)
+      this.pinnedByEventId.set(event.id, updated)
+      delta.upsertedPinnedEvents.push(updated)
       return
     }
 
-    const incidentId = this.nextIncidentId(event.timestamp)
-    const incident: AgentPinnedErrorIncident = {
-      incidentId,
-      fingerprint,
+    const nextPinnedEvent: AgentPinnedEvent = {
+      eventId: event.id,
+      pinnedAt: new Date().toISOString(),
+      automatic,
+      timestamp: event.timestamp,
       source: event.source,
+      severity: event.severity,
       kind: event.kind,
       message: event.message,
-      severity: 'error',
-      firstSeenAt: event.timestamp,
-      lastSeenAt: event.timestamp,
-      occurrences: 1,
-      lastEventId: event.id,
+      ...(event.workerId ? { workerId: event.workerId } : {}),
+      ...(event.issueId ? { issueId: event.issueId } : {}),
+      ...(event.issueIdentifier ? { issueIdentifier: event.issueIdentifier } : {}),
+      ...(event.requestId ? { requestId: event.requestId } : {}),
+      ...(event.connectionState ? { connectionState: event.connectionState } : {}),
+      ...(event.details ? { details: event.details } : {}),
     }
-    this.pinnedByFingerprint.set(fingerprint, incident)
-    this.fingerprintByIncidentId.set(incidentId, fingerprint)
-    delta.upsertedPinnedErrors.push(incident)
+    this.pinnedByEventId.set(event.id, nextPinnedEvent)
+    delta.upsertedPinnedEvents.push(nextPinnedEvent)
   }
 
   private nextEventId(timestamp: string): string {
@@ -753,9 +769,8 @@ export class AgentActivityJournal extends EventEmitter {
     return `evt:${timestamp}:${this.sequence}`
   }
 
-  private nextIncidentId(timestamp: string): string {
-    this.incidentSequence += 1
-    return `incident:${timestamp}:${this.incidentSequence}`
+  private findEventById(eventId: string): AgentActivityEvent | undefined {
+    return findEventByIdInStream(this.events, eventId) ?? findEventByIdInStream(this.verbose, eventId)
   }
 
   private createDelta(): DeltaAccumulator {
@@ -763,8 +778,8 @@ export class AgentActivityJournal extends EventEmitter {
       generatedAt: new Date().toISOString(),
       appendedEvents: [],
       appendedVerbose: [],
-      upsertedPinnedErrors: [],
-      removedPinnedErrorIds: [],
+      upsertedPinnedEvents: [],
+      removedPinnedEventIds: [],
     }
   }
 
@@ -772,8 +787,8 @@ export class AgentActivityJournal extends EventEmitter {
     if (
       delta.appendedEvents.length === 0 &&
       delta.appendedVerbose.length === 0 &&
-      delta.upsertedPinnedErrors.length === 0 &&
-      delta.removedPinnedErrorIds.length === 0
+      delta.upsertedPinnedEvents.length === 0 &&
+      delta.removedPinnedEventIds.length === 0
     ) {
       return
     }
@@ -782,8 +797,8 @@ export class AgentActivityJournal extends EventEmitter {
       generatedAt: delta.generatedAt,
       ...(delta.appendedEvents.length > 0 ? { appendedEvents: delta.appendedEvents } : {}),
       ...(delta.appendedVerbose.length > 0 ? { appendedVerbose: delta.appendedVerbose } : {}),
-      ...(delta.upsertedPinnedErrors.length > 0 ? { upsertedPinnedErrors: delta.upsertedPinnedErrors } : {}),
-      ...(delta.removedPinnedErrorIds.length > 0 ? { removedPinnedErrorIds: delta.removedPinnedErrorIds } : {}),
+      ...(delta.upsertedPinnedEvents.length > 0 ? { upsertedPinnedEvents: delta.upsertedPinnedEvents } : {}),
+      ...(delta.removedPinnedEventIds.length > 0 ? { removedPinnedEventIds: delta.removedPinnedEventIds } : {}),
     })
   }
 
@@ -799,11 +814,8 @@ function trimBuffer<T>(buffer: T[], cap: number): void {
   buffer.splice(0, buffer.length - cap)
 }
 
-function buildFingerprint(event: AgentActivityEvent): string {
-  const normalizedMessage = event.message.trim().toLowerCase()
-  const issue = event.issueIdentifier ?? event.issueId ?? ''
-  const request = event.requestId ?? ''
-  return `${event.source}|${event.kind}|${issue}|${request}|${normalizedMessage}`
+function findEventByIdInStream(stream: AgentActivityEvent[], eventId: string): AgentActivityEvent | undefined {
+  return stream.find((event) => event.id === eventId)
 }
 
 function toCliToolUpdateSeverity(status: string | undefined): AgentActivitySeverity {

--- a/apps/desktop/src/main/agent-activity-journal.ts
+++ b/apps/desktop/src/main/agent-activity-journal.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { AGENT_ACTIVITY_EVENT_CAP, AGENT_ACTIVITY_VERBOSE_CAP } from '../shared/types'
 import type {
   AgentActivityEvent,
   AgentActivitySeverity,
@@ -13,8 +14,8 @@ import type {
   SymphonyRuntimeStatus,
 } from '../shared/types'
 
-export const AGENT_ACTIVITY_DEFAULT_EVENT_CAP = 2_000
-export const AGENT_ACTIVITY_DEFAULT_VERBOSE_CAP = 20_000
+export const AGENT_ACTIVITY_DEFAULT_EVENT_CAP = AGENT_ACTIVITY_EVENT_CAP
+export const AGENT_ACTIVITY_DEFAULT_VERBOSE_CAP = AGENT_ACTIVITY_VERBOSE_CAP
 
 interface AgentActivityJournalEvents {
   update: (update: AgentActivityUpdate) => void

--- a/apps/desktop/src/main/agent-activity-journal.ts
+++ b/apps/desktop/src/main/agent-activity-journal.ts
@@ -6,6 +6,7 @@ import type {
   AgentActivitySource,
   AgentActivityUpdate,
   AgentPinnedErrorIncident,
+  ChatEvent,
   SymphonyEscalationResponseCommandResult,
   SymphonyOperatorSnapshot,
   SymphonyOperatorWorkerRow,
@@ -44,6 +45,12 @@ interface EventInput {
   requestId?: string
   connectionState?: AgentActivityEvent['connectionState']
   details?: Record<string, unknown>
+}
+
+interface CliEventContext {
+  workerId?: string
+  issueId?: string
+  issueIdentifier?: string
 }
 
 export class AgentActivityJournal extends EventEmitter {
@@ -425,6 +432,221 @@ export class AgentActivityJournal extends EventEmitter {
     this.flushDelta(delta)
   }
 
+  public ingestCliChatEvent(chatEvent: ChatEvent, context: CliEventContext = {}): void {
+    const delta = this.createDelta()
+    const timestamp = new Date().toISOString()
+    const issuePrefix = context.issueIdentifier ? `[${context.issueIdentifier}] ` : ''
+    const workerId = context.workerId ?? context.issueIdentifier
+
+    switch (chatEvent.type) {
+      case 'agent_start':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'runtime',
+            severity: 'info',
+            kind: 'cli.agent_start',
+            message: `${issuePrefix}CLI agent started.`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+        break
+
+      case 'agent_end':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'runtime',
+            severity: 'info',
+            kind: 'cli.agent_end',
+            message: `${issuePrefix}CLI agent ended.`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+        break
+
+      case 'turn_start':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'worker',
+            severity: 'info',
+            kind: 'cli.turn_start',
+            message: `${issuePrefix}Worker turn started.`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+        break
+
+      case 'turn_end':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'worker',
+            severity: 'info',
+            kind: 'cli.turn_end',
+            message: `${issuePrefix}Worker turn ended.`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+        break
+
+      case 'tool_start':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'worker',
+            severity: 'info',
+            kind: 'cli.tool_start',
+            message: `${issuePrefix}Tool started: ${chatEvent.toolName}.`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+            details: {
+              toolCallId: chatEvent.toolCallId,
+              toolName: chatEvent.toolName,
+              args: chatEvent.args,
+            },
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+        break
+
+      case 'tool_update':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'worker',
+            severity: toCliToolUpdateSeverity(chatEvent.status),
+            kind: 'cli.tool_update',
+            message: `${issuePrefix}Tool update: ${chatEvent.toolName}${chatEvent.status ? ` (${chatEvent.status})` : ''}.`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+            details: {
+              toolCallId: chatEvent.toolCallId,
+              toolName: chatEvent.toolName,
+              status: chatEvent.status ?? null,
+              partialStdout: chatEvent.partialStdout ?? null,
+              partialResult: chatEvent.partialResult ?? null,
+            },
+          },
+          delta,
+          { toEvents: false, toVerbose: true },
+        )
+        break
+
+      case 'tool_end':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'worker',
+            severity: chatEvent.isError ? 'error' : 'info',
+            kind: chatEvent.isError ? 'cli.tool_error' : 'cli.tool_end',
+            message: chatEvent.isError
+              ? `${issuePrefix}${chatEvent.error || `Tool failed: ${chatEvent.toolName}.`}`
+              : `${issuePrefix}Tool completed: ${chatEvent.toolName}.`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+            details: {
+              toolCallId: chatEvent.toolCallId,
+              toolName: chatEvent.toolName,
+              isError: chatEvent.isError,
+              result: chatEvent.result ?? null,
+            },
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+        break
+
+      case 'agent_error':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'runtime',
+            severity: 'error',
+            kind: 'cli.agent_error',
+            message: `${issuePrefix}${chatEvent.message}`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+        break
+
+      case 'subprocess_crash':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'runtime',
+            severity: 'error',
+            kind: 'cli.subprocess_crash',
+            message: `${issuePrefix}${chatEvent.message}`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+            details: {
+              exitCode: chatEvent.exitCode,
+              signal: chatEvent.signal,
+              stderrLines: chatEvent.stderrLines,
+            },
+          },
+          delta,
+          { toEvents: true, toVerbose: true },
+        )
+        break
+
+      case 'thinking_start':
+      case 'thinking_delta':
+      case 'thinking_end':
+      case 'message_start':
+      case 'text_delta':
+      case 'message_end':
+      case 'history_user_message':
+        this.recordEvent(
+          {
+            timestamp,
+            source: 'worker',
+            severity: 'info',
+            kind: `cli.${chatEvent.type}`,
+            message: `${issuePrefix}CLI event: ${chatEvent.type}.`,
+            workerId,
+            issueId: context.issueId,
+            issueIdentifier: context.issueIdentifier,
+          },
+          delta,
+          { toEvents: false, toVerbose: true },
+        )
+        break
+
+      default:
+        break
+    }
+
+    this.flushDelta(delta)
+  }
+
   private recordWorkerAdded(worker: SymphonyOperatorWorkerRow, timestamp: string, delta: DeltaAccumulator): void {
     this.recordEvent(
       {
@@ -582,4 +804,22 @@ function buildFingerprint(event: AgentActivityEvent): string {
   const issue = event.issueIdentifier ?? event.issueId ?? ''
   const request = event.requestId ?? ''
   return `${event.source}|${event.kind}|${issue}|${request}|${normalizedMessage}`
+}
+
+function toCliToolUpdateSeverity(status: string | undefined): AgentActivitySeverity {
+  const normalized = status?.trim().toLowerCase()
+  if (!normalized) {
+    return 'info'
+  }
+
+  if (
+    normalized.includes('error') ||
+    normalized.includes('failed') ||
+    normalized.includes('cancel') ||
+    normalized.includes('denied')
+  ) {
+    return 'warning'
+  }
+
+  return 'info'
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -130,6 +130,7 @@ import { registerSessionIpc } from './ipc'
 import { DesktopSessionManager } from './session-manager'
 import { SymphonySupervisor } from './symphony-supervisor'
 import { SymphonyOperatorService } from './symphony-operator-service'
+import { AgentActivityJournal } from './agent-activity-journal'
 
 const SETTINGS_PATH = path.join(homedir(), '.kata-cli', 'agent', 'settings.json')
 
@@ -137,6 +138,7 @@ let mainWindow: BrowserWindow | null = null
 let bridge: PiAgentBridge | null = null
 let symphonySupervisor: SymphonySupervisor | null = null
 let symphonyOperatorService: SymphonyOperatorService | null = null
+let agentActivityJournal: AgentActivityJournal | null = null
 let unregisterSessionIpc: (() => void) | null = null
 
 function createWindow(): BrowserWindow {
@@ -326,6 +328,7 @@ app.whenReady().then(async () => {
     resourcesPath: process.resourcesPath,
   })
   symphonyOperatorService = new SymphonyOperatorService({ env: process.env })
+  agentActivityJournal = new AgentActivityJournal()
 
   const authBridge = new AuthBridge()
   const sessionManager = new DesktopSessionManager()
@@ -347,6 +350,7 @@ app.whenReady().then(async () => {
     onWorkspaceSelected: persistWorkspacePath,
     symphonySupervisor,
     symphonyOperatorService,
+    agentActivityJournal,
   })
 
   mainWindow.on('closed', () => {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -19,6 +19,7 @@ import { WorkflowBoardService } from './workflow-board-service'
 import { McpConfigBridge } from './mcp-config-bridge'
 import { McpService } from './mcp-service'
 import { RuntimeHealthAggregator } from './runtime-health-aggregator'
+import { AgentActivityJournal } from './agent-activity-journal'
 import {
   isReliabilitySourceSurface,
   mapSymphonyOperatorSnapshotToReliability,
@@ -87,6 +88,9 @@ import {
   type SymphonyOperatorSnapshot,
   type SymphonyOperatorSnapshotResponse,
   type SymphonyEscalationResponseCommandResult,
+  type AgentActivityUpdate,
+  type AgentActivitySnapshotResponse,
+  type AgentActivityDismissPinnedErrorResponse,
   type McpConfigReadResponse,
   type McpServerDeleteResponse,
   type McpServerInput,
@@ -111,6 +115,7 @@ interface RegisterIpcOptions {
   onWorkspaceSelected?: (workspacePath: string) => Promise<void> | void
   symphonySupervisor?: SymphonySupervisor
   symphonyOperatorService?: SymphonyOperatorService
+  agentActivityJournal?: AgentActivityJournal
   mcpConfigBridge?: McpConfigBridge
   mcpService?: McpService
 }
@@ -123,6 +128,7 @@ export function registerSessionIpc({
   onWorkspaceSelected,
   symphonySupervisor,
   symphonyOperatorService,
+  agentActivityJournal,
   mcpConfigBridge,
   mcpService,
 }: RegisterIpcOptions): () => void {
@@ -414,6 +420,19 @@ export function registerSessionIpc({
       escalations: snapshot.escalations.length,
       queueCount: snapshot.queueCount,
       completedCount: snapshot.completedCount,
+    })
+  }
+
+  const sendAgentActivityUpdate = (update: AgentActivityUpdate): void => {
+    if (!safeSend(IPC_CHANNELS.agentActivityUpdate, update)) {
+      return
+    }
+
+    log.debug('[desktop-ipc] agent activity update', {
+      events: update.appendedEvents?.length ?? 0,
+      verbose: update.appendedVerbose?.length ?? 0,
+      pinnedUpserts: update.upsertedPinnedErrors?.length ?? 0,
+      pinnedRemovals: update.removedPinnedErrorIds?.length ?? 0,
     })
   }
 
@@ -838,6 +857,7 @@ export function registerSessionIpc({
 
   const onSymphonyStatus = (status: SymphonyRuntimeStatus): void => {
     sendSymphonyStatusToRenderer(status)
+    agentActivityJournal?.ingestRuntimeStatus(status)
     syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyRuntimeStatus(status)
     void symphonyOperatorService?.syncRuntimeStatus(status)
@@ -845,6 +865,7 @@ export function registerSessionIpc({
 
   const onSymphonyDashboardSnapshot = (snapshot: SymphonyOperatorSnapshot): void => {
     sendSymphonyDashboardSnapshot(snapshot)
+    agentActivityJournal?.ingestOperatorSnapshot(snapshot)
     syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
   }
@@ -857,8 +878,13 @@ export function registerSessionIpc({
     sendStabilitySnapshot(snapshot)
   }
 
+  const onAgentActivityUpdate = (update: AgentActivityUpdate): void => {
+    sendAgentActivityUpdate(update)
+  }
+
   symphonySupervisor?.on('status', onSymphonyStatus)
   symphonyOperatorService?.on('snapshot', onSymphonyDashboardSnapshot)
+  agentActivityJournal?.on('update', onAgentActivityUpdate)
   reliabilityAggregator.on('snapshot', onReliabilitySnapshot)
   reliabilityAggregator.on('stability', onStabilitySnapshot)
 
@@ -891,6 +917,7 @@ export function registerSessionIpc({
   if (symphonySupervisor) {
     const initialSymphonyStatus = symphonySupervisor.getStatus()
     sendSymphonyStatusToRenderer(initialSymphonyStatus)
+    agentActivityJournal?.ingestRuntimeStatus(initialSymphonyStatus)
     syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyRuntimeStatus(initialSymphonyStatus)
     void symphonyOperatorService?.syncRuntimeStatus(initialSymphonyStatus)
@@ -899,6 +926,7 @@ export function registerSessionIpc({
   if (symphonyOperatorService) {
     const initialDashboardSnapshot = symphonyOperatorService.getSnapshot()
     sendSymphonyDashboardSnapshot(initialDashboardSnapshot)
+    agentActivityJournal?.ingestOperatorSnapshot(initialDashboardSnapshot)
     syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyOperatorSnapshot(initialDashboardSnapshot)
   }
@@ -986,6 +1014,8 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.symphonyGetDashboard)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyRefreshDashboard)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyRespondEscalation)
+  ipcMain.removeHandler(IPC_CHANNELS.agentActivityGetSnapshot)
+  ipcMain.removeHandler(IPC_CHANNELS.agentActivityDismissPinnedError)
   ipcMain.removeHandler(IPC_CHANNELS.mcpListServers)
   ipcMain.removeHandler(IPC_CHANNELS.mcpGetServer)
   ipcMain.removeHandler(IPC_CHANNELS.mcpSaveServer)
@@ -1919,6 +1949,13 @@ export function registerSessionIpc({
     response: {},
   })
 
+  const createEmptyAgentActivitySnapshot = () => ({
+    generatedAt: new Date(0).toISOString(),
+    events: [],
+    verbose: [],
+    pinnedErrors: [],
+  })
+
   ipcMain.handle(IPC_CHANNELS.symphonyGetStatus, async (): Promise<SymphonyRuntimeStatusResponse> => {
     if (!symphonySupervisor) {
       const fallback = createSymphonyDisconnectedResult()
@@ -1995,6 +2032,7 @@ export function registerSessionIpc({
     IPC_CHANNELS.symphonyRespondEscalation,
     async (_event, requestId: string, responseText: string): Promise<SymphonyEscalationResponseCommandResult> => {
       if (!symphonyOperatorService) {
+        agentActivityJournal?.recordSystemError('Symphony operator service is unavailable for escalation response.')
         const snapshot = createUnavailableDashboardSnapshot()
         syncStabilityMetricsFromServices()
         reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
@@ -2005,9 +2043,39 @@ export function registerSessionIpc({
       }
 
       const response = await symphonyOperatorService.respondToEscalation(requestId, responseText)
+      agentActivityJournal?.ingestEscalationResponse(response)
       syncStabilityMetricsFromServices()
       reliabilityAggregator.ingestSymphonyOperatorSnapshot(response.snapshot)
       return response
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.agentActivityGetSnapshot,
+    async (): Promise<AgentActivitySnapshotResponse> => {
+      return {
+        success: true,
+        snapshot: agentActivityJournal?.getSnapshot() ?? createEmptyAgentActivitySnapshot(),
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.agentActivityDismissPinnedError,
+    async (_event, incidentId: string): Promise<AgentActivityDismissPinnedErrorResponse> => {
+      if (!agentActivityJournal) {
+        return {
+          success: false,
+          incidentId,
+          snapshot: createEmptyAgentActivitySnapshot(),
+        }
+      }
+
+      return {
+        success: true,
+        incidentId,
+        snapshot: agentActivityJournal.dismissPinnedError(incidentId),
+      }
     },
   )
 
@@ -2108,6 +2176,7 @@ export function registerSessionIpc({
     bridge.off('crash', onCrash)
     symphonySupervisor?.off('status', onSymphonyStatus)
     symphonyOperatorService?.off('snapshot', onSymphonyDashboardSnapshot)
+    agentActivityJournal?.off('update', onAgentActivityUpdate)
     reliabilityAggregator.off('snapshot', onReliabilitySnapshot)
     reliabilityAggregator.off('stability', onStabilitySnapshot)
     planningToolDetector.off('artifact', onPlanningArtifactEvent)
@@ -2156,6 +2225,8 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.symphonyGetDashboard)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyRefreshDashboard)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyRespondEscalation)
+    ipcMain.removeHandler(IPC_CHANNELS.agentActivityGetSnapshot)
+    ipcMain.removeHandler(IPC_CHANNELS.agentActivityDismissPinnedError)
     ipcMain.removeHandler(IPC_CHANNELS.mcpListServers)
     ipcMain.removeHandler(IPC_CHANNELS.mcpGetServer)
     ipcMain.removeHandler(IPC_CHANNELS.mcpSaveServer)

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -586,6 +586,21 @@ export function registerSessionIpc({
       })
     }
 
+    if (
+      (cursor.lastSize !== null && stat.size < cursor.lastSize) ||
+      loaded.events.length < cursor.lastEventCount
+    ) {
+      log.info('[desktop-ipc] worker session history appears truncated; resetting cursor', {
+        issueId: worker.issueId,
+        sessionId,
+        previousEventCount: cursor.lastEventCount,
+        nextEventCount: loaded.events.length,
+        previousSize: cursor.lastSize,
+        nextSize: stat.size,
+      })
+      cursor.lastEventCount = 0
+    }
+
     const startIndex = Math.min(cursor.lastEventCount, loaded.events.length)
     for (const event of loaded.events.slice(startIndex)) {
       agentActivityJournal.ingestCliChatEvent(event, {
@@ -1006,13 +1021,15 @@ export function registerSessionIpc({
 
   const onCrash = ({ exitCode, signal, stderrLines }: { exitCode: number | null; signal: NodeJS.Signals | null; stderrLines: string[] }): void => {
     const lastLine = stderrLines[stderrLines.length - 1] ?? 'kata subprocess exited unexpectedly'
-    sendEventToRenderer({
+    const crashEvent = {
       type: 'subprocess_crash',
       message: lastLine,
       exitCode,
       signal,
       stderrLines,
-    })
+    } as const
+    sendEventToRenderer(crashEvent)
+    agentActivityJournal?.ingestCliChatEvent(crashEvent)
     syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestChatSubprocessCrash({
       message: lastLine,

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -86,6 +86,7 @@ import {
   type SymphonyRuntimeCommandResult,
   type SymphonyRuntimeStatusResponse,
   type SymphonyOperatorSnapshot,
+  type SymphonyOperatorWorkerRow,
   type SymphonyOperatorSnapshotResponse,
   type SymphonyEscalationResponseCommandResult,
   type AgentActivityUpdate,
@@ -482,6 +483,177 @@ export function registerSessionIpc({
     })
   }
 
+  interface WorkerSessionActivityCursor {
+    sessionId: string
+    sessionPath: string | null
+    workspacePath: string | null
+    lastEventCount: number
+    lastMtimeMs: number | null
+    lastSize: number | null
+  }
+
+  const workerSessionActivityCursors = new Map<string, WorkerSessionActivityCursor>()
+  let pendingWorkerActivityWorkers: SymphonyOperatorWorkerRow[] | null = null
+  let workerActivitySyncInFlight = false
+
+  const getWorkerSessionActivityKey = (worker: SymphonyOperatorWorkerRow): string | null => {
+    const sessionId = worker.sessionId?.trim()
+    if (!sessionId) {
+      return null
+    }
+    return `${worker.issueId}:${sessionId}`
+  }
+
+  const resolveWorkerSessionPath = async (worker: SymphonyOperatorWorkerRow, sessionId: string): Promise<string | null> => {
+    const candidateWorkspaces = [worker.workspacePath?.trim(), bridge.getWorkspacePath()]
+      .filter((candidate): candidate is string => Boolean(candidate && candidate.length > 0))
+
+    const dedupedWorkspaces = Array.from(new Set(candidateWorkspaces))
+    for (const workspacePath of dedupedWorkspaces) {
+      const resolvedPath = await sessionManager.resolveSessionPathById(sessionId, workspacePath)
+      if (resolvedPath) {
+        return resolvedPath
+      }
+    }
+
+    return null
+  }
+
+  const syncWorkerSessionActivityForWorker = async (worker: SymphonyOperatorWorkerRow): Promise<void> => {
+    if (!agentActivityJournal) {
+      return
+    }
+
+    const sessionId = worker.sessionId?.trim()
+    if (!sessionId) {
+      return
+    }
+
+    const key = getWorkerSessionActivityKey(worker)
+    if (!key) {
+      return
+    }
+
+    let cursor = workerSessionActivityCursors.get(key)
+    if (!cursor) {
+      cursor = {
+        sessionId,
+        sessionPath: null,
+        workspacePath: worker.workspacePath?.trim() || null,
+        lastEventCount: 0,
+        lastMtimeMs: null,
+        lastSize: null,
+      }
+      workerSessionActivityCursors.set(key, cursor)
+    } else if (worker.workspacePath?.trim()) {
+      cursor.workspacePath = worker.workspacePath.trim()
+    }
+
+    if (!cursor.sessionPath) {
+      cursor.sessionPath = await resolveWorkerSessionPath(worker, sessionId)
+      if (!cursor.sessionPath) {
+        return
+      }
+    }
+
+    let stat
+    try {
+      stat = await fs.stat(cursor.sessionPath)
+    } catch {
+      // Session files can rotate while workers restart; retry path discovery.
+      cursor.sessionPath = await resolveWorkerSessionPath(worker, sessionId)
+      if (!cursor.sessionPath) {
+        return
+      }
+      stat = await fs.stat(cursor.sessionPath)
+    }
+
+    if (
+      cursor.lastMtimeMs !== null &&
+      cursor.lastSize !== null &&
+      stat.mtimeMs === cursor.lastMtimeMs &&
+      stat.size === cursor.lastSize
+    ) {
+      return
+    }
+
+    const loaded = await sessionHistoryLoader.load(cursor.sessionPath)
+    if (loaded.warnings.length > 0) {
+      log.debug('[desktop-ipc] worker session history warnings', {
+        issueId: worker.issueId,
+        sessionId,
+        warningCount: loaded.warnings.length,
+      })
+    }
+
+    const startIndex = Math.min(cursor.lastEventCount, loaded.events.length)
+    for (const event of loaded.events.slice(startIndex)) {
+      agentActivityJournal.ingestCliChatEvent(event, {
+        workerId: worker.identifier,
+        issueId: worker.issueId,
+        issueIdentifier: worker.identifier,
+      })
+    }
+
+    cursor.lastEventCount = loaded.events.length
+    cursor.lastMtimeMs = stat.mtimeMs
+    cursor.lastSize = stat.size
+  }
+
+  const syncWorkerSessionActivity = async (workers: SymphonyOperatorWorkerRow[]): Promise<void> => {
+    const activeKeys = new Set<string>()
+
+    for (const worker of workers) {
+      const key = getWorkerSessionActivityKey(worker)
+      if (!key) {
+        continue
+      }
+
+      activeKeys.add(key)
+
+      try {
+        await syncWorkerSessionActivityForWorker(worker)
+      } catch (error) {
+        log.warn('[desktop-ipc] worker session activity sync failed', {
+          issueId: worker.issueId,
+          sessionId: worker.sessionId ?? null,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    for (const existingKey of workerSessionActivityCursors.keys()) {
+      if (!activeKeys.has(existingKey)) {
+        workerSessionActivityCursors.delete(existingKey)
+      }
+    }
+  }
+
+  const processWorkerSessionActivityQueue = async (): Promise<void> => {
+    if (workerActivitySyncInFlight) {
+      return
+    }
+
+    workerActivitySyncInFlight = true
+    try {
+      while (pendingWorkerActivityWorkers) {
+        const workers = pendingWorkerActivityWorkers
+        pendingWorkerActivityWorkers = null
+        await syncWorkerSessionActivity(workers)
+      }
+    } finally {
+      workerActivitySyncInFlight = false
+      if (pendingWorkerActivityWorkers) {
+        void processWorkerSessionActivityQueue()
+      }
+    }
+  }
+
+  const enqueueWorkerSessionActivitySync = (snapshot: SymphonyOperatorSnapshot): void => {
+    pendingWorkerActivityWorkers = snapshot.workers.map((worker) => ({ ...worker }))
+    void processWorkerSessionActivityQueue()
+  }
+
   const getPlanningFetchContext = (
     title: string,
     artifactKey?: string,
@@ -804,6 +976,7 @@ export function registerSessionIpc({
     log.debug('[desktop-ipc] inbound rpc event', rpcEvent)
     for (const chatEvent of adapter.adapt(rpcEvent)) {
       sendEventToRenderer(chatEvent)
+      agentActivityJournal?.ingestCliChatEvent(chatEvent)
       planningToolDetector.handleChatEvent(chatEvent)
 
       if (chatEvent.type === 'agent_end') {
@@ -866,6 +1039,7 @@ export function registerSessionIpc({
   const onSymphonyDashboardSnapshot = (snapshot: SymphonyOperatorSnapshot): void => {
     sendSymphonyDashboardSnapshot(snapshot)
     agentActivityJournal?.ingestOperatorSnapshot(snapshot)
+    enqueueWorkerSessionActivitySync(snapshot)
     syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyOperatorSnapshot(snapshot)
   }
@@ -927,6 +1101,7 @@ export function registerSessionIpc({
     const initialDashboardSnapshot = symphonyOperatorService.getSnapshot()
     sendSymphonyDashboardSnapshot(initialDashboardSnapshot)
     agentActivityJournal?.ingestOperatorSnapshot(initialDashboardSnapshot)
+    enqueueWorkerSessionActivitySync(initialDashboardSnapshot)
     syncStabilityMetricsFromServices()
     reliabilityAggregator.ingestSymphonyOperatorSnapshot(initialDashboardSnapshot)
   }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -91,7 +91,7 @@ import {
   type SymphonyEscalationResponseCommandResult,
   type AgentActivityUpdate,
   type AgentActivitySnapshotResponse,
-  type AgentActivityDismissPinnedErrorResponse,
+  type AgentActivitySetPinnedEventResponse,
   type McpConfigReadResponse,
   type McpServerDeleteResponse,
   type McpServerInput,
@@ -432,8 +432,8 @@ export function registerSessionIpc({
     log.debug('[desktop-ipc] agent activity update', {
       events: update.appendedEvents?.length ?? 0,
       verbose: update.appendedVerbose?.length ?? 0,
-      pinnedUpserts: update.upsertedPinnedErrors?.length ?? 0,
-      pinnedRemovals: update.removedPinnedErrorIds?.length ?? 0,
+      pinnedUpserts: update.upsertedPinnedEvents?.length ?? 0,
+      pinnedRemovals: update.removedPinnedEventIds?.length ?? 0,
     })
   }
 
@@ -1190,7 +1190,7 @@ export function registerSessionIpc({
   ipcMain.removeHandler(IPC_CHANNELS.symphonyRefreshDashboard)
   ipcMain.removeHandler(IPC_CHANNELS.symphonyRespondEscalation)
   ipcMain.removeHandler(IPC_CHANNELS.agentActivityGetSnapshot)
-  ipcMain.removeHandler(IPC_CHANNELS.agentActivityDismissPinnedError)
+  ipcMain.removeHandler(IPC_CHANNELS.agentActivitySetPinnedEvent)
   ipcMain.removeHandler(IPC_CHANNELS.mcpListServers)
   ipcMain.removeHandler(IPC_CHANNELS.mcpGetServer)
   ipcMain.removeHandler(IPC_CHANNELS.mcpSaveServer)
@@ -2128,7 +2128,7 @@ export function registerSessionIpc({
     generatedAt: new Date(0).toISOString(),
     events: [],
     verbose: [],
-    pinnedErrors: [],
+    pinnedEvents: [],
   })
 
   ipcMain.handle(IPC_CHANNELS.symphonyGetStatus, async (): Promise<SymphonyRuntimeStatusResponse> => {
@@ -2236,20 +2236,22 @@ export function registerSessionIpc({
   )
 
   ipcMain.handle(
-    IPC_CHANNELS.agentActivityDismissPinnedError,
-    async (_event, incidentId: string): Promise<AgentActivityDismissPinnedErrorResponse> => {
+    IPC_CHANNELS.agentActivitySetPinnedEvent,
+    async (_event, eventId: string, pinned: boolean): Promise<AgentActivitySetPinnedEventResponse> => {
       if (!agentActivityJournal) {
         return {
           success: false,
-          incidentId,
+          eventId,
+          pinned,
           snapshot: createEmptyAgentActivitySnapshot(),
         }
       }
 
       return {
         success: true,
-        incidentId,
-        snapshot: agentActivityJournal.dismissPinnedError(incidentId),
+        eventId,
+        pinned,
+        snapshot: agentActivityJournal.setPinnedEvent(eventId, pinned),
       }
     },
   )
@@ -2401,7 +2403,7 @@ export function registerSessionIpc({
     ipcMain.removeHandler(IPC_CHANNELS.symphonyRefreshDashboard)
     ipcMain.removeHandler(IPC_CHANNELS.symphonyRespondEscalation)
     ipcMain.removeHandler(IPC_CHANNELS.agentActivityGetSnapshot)
-    ipcMain.removeHandler(IPC_CHANNELS.agentActivityDismissPinnedError)
+    ipcMain.removeHandler(IPC_CHANNELS.agentActivitySetPinnedEvent)
     ipcMain.removeHandler(IPC_CHANNELS.mcpListServers)
     ipcMain.removeHandler(IPC_CHANNELS.mcpGetServer)
     ipcMain.removeHandler(IPC_CHANNELS.mcpSaveServer)

--- a/apps/desktop/src/main/symphony-operator-service.ts
+++ b/apps/desktop/src/main/symphony-operator-service.ts
@@ -27,6 +27,7 @@ type WebSocketLike = {
 
 interface SymphonyStatePayload {
   running?: Record<string, Record<string, unknown>>
+  running_sessions?: Record<string, Record<string, unknown>>
   retry_queue?: unknown[]
   completed?: unknown[]
   pending_escalations?: Array<Record<string, unknown>>
@@ -521,10 +522,17 @@ export class SymphonyOperatorService extends EventEmitter {
   ): void {
     const nowIso = new Date().toISOString()
     const running = payload.running ?? {}
+    const runningSessions = payload.running_sessions ?? {}
     const sessionInfo = payload.running_session_info ?? {}
 
     this.snapshot.workers = Object.values(running)
-      .map((run) => this.mapWorker(run, sessionInfo[String(run.issue_id ?? '')]))
+      .map((run) =>
+        this.mapWorker(
+          run,
+          sessionInfo[String(run.issue_id ?? '')],
+          runningSessions[String(run.issue_id ?? '')],
+        ),
+      )
       .filter((worker): worker is SymphonyOperatorWorkerRow => Boolean(worker))
       .sort((left, right) => left.identifier.localeCompare(right.identifier))
 
@@ -682,6 +690,7 @@ export class SymphonyOperatorService extends EventEmitter {
   private mapWorker(
     run: Record<string, unknown>,
     info: Record<string, unknown> | undefined,
+    runningSession: Record<string, unknown> | undefined,
   ): SymphonyOperatorWorkerRow | null {
     const issueId = String(run.issue_id ?? '').trim()
     const identifier = String(run.issue_identifier ?? '').trim()
@@ -699,6 +708,12 @@ export class SymphonyOperatorService extends EventEmitter {
       state: String(run.linear_state ?? run.status ?? 'unknown').trim(),
       toolName: String(info?.current_tool_name ?? 'idle').trim() || 'idle',
       model: String(run.model ?? 'default').trim() || 'default',
+      ...(typeof runningSession?.session_id === 'string' && runningSession.session_id.trim()
+        ? { sessionId: runningSession.session_id.trim() }
+        : {}),
+      ...(typeof run.workspace_path === 'string' && run.workspace_path.trim()
+        ? { workspacePath: run.workspace_path.trim() }
+        : {}),
       ...(activityMs ? { lastActivityAt: new Date(activityMs).toISOString() } : startedAt ? { lastActivityAt: startedAt } : {}),
       ...(typeof run.error === 'string' && run.error.trim() ? { lastError: run.error.trim() } : {}),
     }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -256,8 +256,8 @@ const api: DesktopApi = {
     getSnapshot: async () => {
       return ipcRenderer.invoke(IPC_CHANNELS.agentActivityGetSnapshot)
     },
-    dismissPinnedError: async (incidentId: string) => {
-      return ipcRenderer.invoke(IPC_CHANNELS.agentActivityDismissPinnedError, incidentId)
+    setPinnedEvent: async (eventId: string, pinned: boolean) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.agentActivitySetPinnedEvent, eventId, pinned)
     },
     onUpdate: (listener: (update: AgentActivityUpdate) => void) => {
       const wrapped = (_event: Electron.IpcRendererEvent, update: AgentActivityUpdate) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -8,6 +8,7 @@ import {
   type ExtensionUIRequest,
   type PermissionMode,
   type PlanningArtifact,
+  type AgentActivityUpdate,
   type PlanningArtifactFetchStateEvent,
   type ThinkingLevel,
   type SymphonyRuntimeStatus,
@@ -248,6 +249,25 @@ const api: DesktopApi = {
 
       return () => {
         ipcRenderer.removeListener(IPC_CHANNELS.symphonyDashboardSnapshot, wrapped)
+      }
+    },
+  },
+  agentActivity: {
+    getSnapshot: async () => {
+      return ipcRenderer.invoke(IPC_CHANNELS.agentActivityGetSnapshot)
+    },
+    dismissPinnedError: async (incidentId: string) => {
+      return ipcRenderer.invoke(IPC_CHANNELS.agentActivityDismissPinnedError, incidentId)
+    },
+    onUpdate: (listener: (update: AgentActivityUpdate) => void) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, update: AgentActivityUpdate) => {
+        listener(update)
+      }
+
+      ipcRenderer.on(IPC_CHANNELS.agentActivityUpdate, wrapped)
+
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.agentActivityUpdate, wrapped)
       }
     },
   },

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { usePlanningArtifactBridge } from '@/atoms/planning'
 import { useWorkflowBoardBridge } from '@/atoms/workflow-board'
 import { useSymphonyBridge } from '@/atoms/symphony'
 import { useSymphonyDashboardBridge } from '@/atoms/symphony-dashboard'
+import { useAgentActivityBridge } from '@/atoms/agent-activity'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
 export default function App() {
@@ -15,6 +16,7 @@ export default function App() {
   useWorkflowBoardBridge()
   useSymphonyBridge()
   useSymphonyDashboardBridge()
+  useAgentActivityBridge()
 
   return (
     <TooltipProvider>

--- a/apps/desktop/src/renderer/atoms/__tests__/agent-activity-bridge.test.tsx
+++ b/apps/desktop/src/renderer/atoms/__tests__/agent-activity-bridge.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { Provider, createStore } from 'jotai'
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import type { AgentActivitySnapshotResponse, AgentActivityUpdate } from '@shared/types'
+import { agentActivitySnapshotAtom, useAgentActivityBridge } from '../agent-activity'
+
+function BridgeHarness() {
+  useAgentActivityBridge()
+  return null
+}
+
+describe('useAgentActivityBridge', () => {
+  test('hydrates snapshot even when a push update arrives before snapshot resolves', async () => {
+    const store = createStore()
+    let updateListener: ((update: AgentActivityUpdate) => void) | null = null
+    let resolveSnapshot: ((value: AgentActivitySnapshotResponse) => void) | null = null
+
+    const snapshotPromise = new Promise<AgentActivitySnapshotResponse>((resolve) => {
+      resolveSnapshot = resolve
+    })
+
+    ;(window as any).api = {
+      agentActivity: {
+        onUpdate: (listener: (update: AgentActivityUpdate) => void) => {
+          updateListener = listener
+          return () => {
+            updateListener = null
+          }
+        },
+        getSnapshot: vi.fn(async () => snapshotPromise),
+        setPinnedEvent: vi.fn(async () => ({
+          success: true,
+          eventId: 'evt-live',
+          pinned: true,
+          snapshot: {
+            generatedAt: '2026-04-23T16:20:01.000Z',
+            events: [],
+            verbose: [],
+            pinnedEvents: [],
+          },
+        })),
+      },
+    }
+
+    render(
+      <Provider store={store}>
+        <BridgeHarness />
+      </Provider>,
+    )
+
+    if (!updateListener) {
+      throw new Error('expected update listener to be registered')
+    }
+
+    ;(updateListener as (update: AgentActivityUpdate) => void)({
+      generatedAt: '2026-04-23T16:20:01.000Z',
+      appendedEvents: [
+        {
+          id: 'evt-live',
+          timestamp: '2026-04-23T16:20:01.000Z',
+          stream: 'events',
+          source: 'worker',
+          severity: 'info',
+          kind: 'worker.state_changed',
+          message: 'live update',
+        },
+      ],
+    })
+
+    if (!resolveSnapshot) {
+      throw new Error('expected snapshot resolver to be initialized')
+    }
+
+    ;(resolveSnapshot as (value: AgentActivitySnapshotResponse) => void)({
+      success: true,
+      snapshot: {
+        generatedAt: '2026-04-23T16:20:00.000Z',
+        events: [
+          {
+            id: 'evt-hydrated',
+            timestamp: '2026-04-23T16:20:00.000Z',
+            stream: 'events',
+            source: 'runtime',
+            severity: 'info',
+            kind: 'runtime.phase_changed',
+            message: 'hydrated snapshot',
+          },
+        ],
+        verbose: [],
+        pinnedEvents: [],
+      },
+    })
+
+    await waitFor(() => {
+      const eventIds = store.get(agentActivitySnapshotAtom).events.map((event) => event.id)
+      expect(eventIds).toEqual(['evt-hydrated', 'evt-live'])
+    })
+  })
+})

--- a/apps/desktop/src/renderer/atoms/__tests__/agent-activity.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/agent-activity.test.ts
@@ -46,35 +46,33 @@ describe('agent-activity atoms', () => {
     expect(snapshot.verbose).toHaveLength(1)
   })
 
-  test('upserts and removes pinned incidents through update deltas', () => {
+  test('upserts and removes pinned events through update deltas', () => {
     const store = createStore()
 
     store.set(applyAgentActivityUpdateAtom, {
       generatedAt: '2026-04-23T16:01:00.000Z',
-      upsertedPinnedErrors: [
+      upsertedPinnedEvents: [
         {
-          incidentId: 'incident-1',
-          fingerprint: 'runtime|error|x',
+          eventId: 'evt-err-1',
+          pinnedAt: '2026-04-23T16:01:05.000Z',
+          automatic: true,
+          timestamp: '2026-04-23T16:01:00.000Z',
           source: 'runtime',
           kind: 'runtime.error',
           message: 'Runtime crashed.',
           severity: 'error',
-          firstSeenAt: '2026-04-23T16:01:00.000Z',
-          lastSeenAt: '2026-04-23T16:01:00.000Z',
-          occurrences: 1,
-          lastEventId: 'evt-err-1',
         },
       ],
     })
 
-    expect(store.get(agentActivitySnapshotAtom).pinnedErrors).toHaveLength(1)
+    expect(store.get(agentActivitySnapshotAtom).pinnedEvents).toHaveLength(1)
 
     store.set(applyAgentActivityUpdateAtom, {
       generatedAt: '2026-04-23T16:02:00.000Z',
-      removedPinnedErrorIds: ['incident-1'],
+      removedPinnedEventIds: ['evt-err-1'],
     })
 
-    expect(store.get(agentActivitySnapshotAtom).pinnedErrors).toHaveLength(0)
+    expect(store.get(agentActivitySnapshotAtom).pinnedEvents).toHaveLength(0)
   })
 
   test('increments unseen count only when auto-follow is paused', () => {

--- a/apps/desktop/src/renderer/atoms/__tests__/agent-activity.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/agent-activity.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from 'vitest'
+import { createStore } from 'jotai'
+import {
+  agentActivitySnapshotAtom,
+  agentActivityUnseenCountAtom,
+  applyAgentActivityUpdateAtom,
+  filteredAgentActivityEventsAtom,
+  setAgentActivityAutoFollowAtom,
+  setAgentActivityModeAtom,
+  agentActivitySourceFilterAtom,
+  agentActivitySeverityFilterAtom,
+} from '../agent-activity'
+
+describe('agent-activity atoms', () => {
+  test('applies incremental updates by appending events and verbose entries', () => {
+    const store = createStore()
+
+    store.set(applyAgentActivityUpdateAtom, {
+      generatedAt: '2026-04-23T16:00:00.000Z',
+      appendedEvents: [
+        {
+          id: 'evt-1',
+          timestamp: '2026-04-23T16:00:00.000Z',
+          stream: 'events',
+          source: 'runtime',
+          severity: 'info',
+          kind: 'runtime.phase_changed',
+          message: 'Runtime ready.',
+        },
+      ],
+      appendedVerbose: [
+        {
+          id: 'verb-1',
+          timestamp: '2026-04-23T16:00:00.000Z',
+          stream: 'verbose',
+          source: 'runtime',
+          severity: 'info',
+          kind: 'runtime.diagnostics_updated',
+          message: 'Diagnostics updated.',
+        },
+      ],
+    })
+
+    const snapshot = store.get(agentActivitySnapshotAtom)
+    expect(snapshot.events).toHaveLength(1)
+    expect(snapshot.verbose).toHaveLength(1)
+  })
+
+  test('upserts and removes pinned incidents through update deltas', () => {
+    const store = createStore()
+
+    store.set(applyAgentActivityUpdateAtom, {
+      generatedAt: '2026-04-23T16:01:00.000Z',
+      upsertedPinnedErrors: [
+        {
+          incidentId: 'incident-1',
+          fingerprint: 'runtime|error|x',
+          source: 'runtime',
+          kind: 'runtime.error',
+          message: 'Runtime crashed.',
+          severity: 'error',
+          firstSeenAt: '2026-04-23T16:01:00.000Z',
+          lastSeenAt: '2026-04-23T16:01:00.000Z',
+          occurrences: 1,
+          lastEventId: 'evt-err-1',
+        },
+      ],
+    })
+
+    expect(store.get(agentActivitySnapshotAtom).pinnedErrors).toHaveLength(1)
+
+    store.set(applyAgentActivityUpdateAtom, {
+      generatedAt: '2026-04-23T16:02:00.000Z',
+      removedPinnedErrorIds: ['incident-1'],
+    })
+
+    expect(store.get(agentActivitySnapshotAtom).pinnedErrors).toHaveLength(0)
+  })
+
+  test('increments unseen count only when auto-follow is paused', () => {
+    const store = createStore()
+
+    store.set(setAgentActivityAutoFollowAtom, false)
+    store.set(applyAgentActivityUpdateAtom, {
+      generatedAt: '2026-04-23T16:03:00.000Z',
+      appendedEvents: [
+        {
+          id: 'evt-2',
+          timestamp: '2026-04-23T16:03:00.000Z',
+          stream: 'events',
+          source: 'worker',
+          severity: 'info',
+          kind: 'worker.state_changed',
+          message: 'Worker moved.',
+        },
+        {
+          id: 'evt-3',
+          timestamp: '2026-04-23T16:03:01.000Z',
+          stream: 'events',
+          source: 'worker',
+          severity: 'info',
+          kind: 'worker.tool_changed',
+          message: 'Tool switched.',
+        },
+      ],
+      appendedVerbose: [
+        {
+          id: 'verb-2',
+          timestamp: '2026-04-23T16:03:00.000Z',
+          stream: 'verbose',
+          source: 'worker',
+          severity: 'info',
+          kind: 'worker.trace',
+          message: 'trace',
+        },
+      ],
+    })
+    expect(store.get(agentActivityUnseenCountAtom)).toBe(2)
+
+    store.set(setAgentActivityModeAtom, 'verbose')
+    store.set(setAgentActivityAutoFollowAtom, false)
+    store.set(applyAgentActivityUpdateAtom, {
+      generatedAt: '2026-04-23T16:04:00.000Z',
+      appendedVerbose: [
+        {
+          id: 'verb-3',
+          timestamp: '2026-04-23T16:04:00.000Z',
+          stream: 'verbose',
+          source: 'system',
+          severity: 'warning',
+          kind: 'system.warning',
+          message: 'warning',
+        },
+      ],
+    })
+    expect(store.get(agentActivityUnseenCountAtom)).toBe(1)
+
+    store.set(setAgentActivityAutoFollowAtom, true)
+    expect(store.get(agentActivityUnseenCountAtom)).toBe(0)
+  })
+
+  test('filters rendered stream by source and severity', () => {
+    const store = createStore()
+
+    store.set(applyAgentActivityUpdateAtom, {
+      generatedAt: '2026-04-23T16:05:00.000Z',
+      appendedEvents: [
+        {
+          id: 'evt-4',
+          timestamp: '2026-04-23T16:05:00.000Z',
+          stream: 'events',
+          source: 'runtime',
+          severity: 'error',
+          kind: 'runtime.error',
+          message: 'Runtime error.',
+        },
+        {
+          id: 'evt-5',
+          timestamp: '2026-04-23T16:05:01.000Z',
+          stream: 'events',
+          source: 'worker',
+          severity: 'info',
+          kind: 'worker.state_changed',
+          message: 'Worker info.',
+        },
+      ],
+    })
+
+    store.set(agentActivitySourceFilterAtom, 'runtime')
+    store.set(agentActivitySeverityFilterAtom, 'error')
+
+    const filtered = store.get(filteredAgentActivityEventsAtom)
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.id).toBe('evt-4')
+  })
+})

--- a/apps/desktop/src/renderer/atoms/__tests__/agent-activity.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/agent-activity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { createStore } from 'jotai'
+import { AGENT_ACTIVITY_EVENT_CAP } from '@shared/types'
 import {
   agentActivitySnapshotAtom,
   agentActivityUnseenCountAtom,
@@ -9,6 +10,7 @@ import {
   setAgentActivityModeAtom,
   agentActivitySourceFilterAtom,
   agentActivitySeverityFilterAtom,
+  setPinnedEventAtom,
 } from '../agent-activity'
 
 describe('agent-activity atoms', () => {
@@ -170,5 +172,99 @@ describe('agent-activity atoms', () => {
     const filtered = store.get(filteredAgentActivityEventsAtom)
     expect(filtered).toHaveLength(1)
     expect(filtered[0]?.id).toBe('evt-4')
+  })
+
+  test('applies event ring-buffer cap when incremental updates append beyond retention', () => {
+    const store = createStore()
+    const existingEvents = Array.from({ length: AGENT_ACTIVITY_EVENT_CAP }, (_, index) => ({
+      id: `evt-${index + 1}`,
+      timestamp: `2026-04-23T16:00:${String(index % 60).padStart(2, '0')}.000Z`,
+      stream: 'events' as const,
+      source: 'worker' as const,
+      severity: 'info' as const,
+      kind: 'worker.trace',
+      message: `existing-${index + 1}`,
+    }))
+
+    store.set(agentActivitySnapshotAtom, {
+      generatedAt: '2026-04-23T16:10:00.000Z',
+      events: existingEvents,
+      verbose: [],
+      pinnedEvents: [],
+    })
+
+    store.set(applyAgentActivityUpdateAtom, {
+      generatedAt: '2026-04-23T16:11:00.000Z',
+      appendedEvents: [
+        {
+          id: 'evt-new',
+          timestamp: '2026-04-23T16:11:00.000Z',
+          stream: 'events',
+          source: 'runtime',
+          severity: 'info',
+          kind: 'runtime.phase_changed',
+          message: 'newest',
+        },
+      ],
+    })
+
+    const events = store.get(agentActivitySnapshotAtom).events
+    expect(events).toHaveLength(AGENT_ACTIVITY_EVENT_CAP)
+    expect(events[0]?.id).toBe('evt-2')
+    expect(events.at(-1)?.id).toBe('evt-new')
+  })
+
+  test('preserves local snapshot when pin update request fails', async () => {
+    const store = createStore()
+    const existingSnapshot = {
+      generatedAt: '2026-04-23T16:12:00.000Z',
+      events: [
+        {
+          id: 'evt-1',
+          timestamp: '2026-04-23T16:12:00.000Z',
+          stream: 'events' as const,
+          source: 'runtime' as const,
+          severity: 'error' as const,
+          kind: 'runtime.error',
+          message: 'failure',
+        },
+      ],
+      verbose: [],
+      pinnedEvents: [
+        {
+          eventId: 'evt-1',
+          pinnedAt: '2026-04-23T16:12:01.000Z',
+          automatic: true,
+          timestamp: '2026-04-23T16:12:00.000Z',
+          source: 'runtime' as const,
+          severity: 'error' as const,
+          kind: 'runtime.error',
+          message: 'failure',
+        },
+      ],
+    }
+
+    store.set(agentActivitySnapshotAtom, existingSnapshot)
+    ;(globalThis as unknown as { window: any }).window = {
+      api: {
+        agentActivity: {
+          setPinnedEvent: async () => ({
+            success: false,
+            eventId: 'evt-1',
+            pinned: false,
+            snapshot: {
+              generatedAt: '2026-04-23T16:13:00.000Z',
+              events: [],
+              verbose: [],
+              pinnedEvents: [],
+            },
+          }),
+        },
+      },
+    }
+
+    await store.set(setPinnedEventAtom, { eventId: 'evt-1', pinned: false })
+
+    expect(store.get(agentActivitySnapshotAtom)).toEqual(existingSnapshot)
   })
 })

--- a/apps/desktop/src/renderer/atoms/__tests__/right-pane-mode.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/right-pane-mode.test.ts
@@ -53,4 +53,14 @@ describe('right-pane mode resolver', () => {
     expect(store.get(rightPaneModeAtom)).toBe('planning')
     expect(store.get(rightPaneResolutionAtom).source).toBe('automatic')
   })
+
+  test('supports manual agent activity override', () => {
+    const store = createStore()
+    store.set(setWorkflowContextAtom, context('execution'))
+    store.set(setRightPaneOverrideAtom, 'agent_activity')
+
+    expect(store.get(rightPaneOverrideAtom)).toBe('agent_activity')
+    expect(store.get(rightPaneModeAtom)).toBe('agent_activity')
+    expect(store.get(rightPaneResolutionAtom).source).toBe('manual')
+  })
 })

--- a/apps/desktop/src/renderer/atoms/__tests__/workflow-board.test.ts
+++ b/apps/desktop/src/renderer/atoms/__tests__/workflow-board.test.ts
@@ -28,4 +28,13 @@ describe('workflow board scope sync refresh guard', () => {
       }),
     ).toBe(false)
   })
+
+  test('never refreshes for agent activity mode', () => {
+    expect(
+      shouldRefreshAfterScopeSync({
+        rightPaneMode: 'agent_activity',
+        boardActivationReady: true,
+      }),
+    ).toBe(false)
+  })
 })

--- a/apps/desktop/src/renderer/atoms/agent-activity.ts
+++ b/apps/desktop/src/renderer/atoms/agent-activity.ts
@@ -1,5 +1,9 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { useEffect } from 'react'
+import {
+  AGENT_ACTIVITY_EVENT_CAP,
+  AGENT_ACTIVITY_VERBOSE_CAP,
+} from '@shared/types'
 import type {
   AgentActivityEvent,
   AgentActivitySeverity,
@@ -27,16 +31,71 @@ export const agentActivitySeverityFilterAtom = atom<AgentActivitySeverityFilter>
 export const agentActivityAutoFollowAtom = atom<boolean>(true)
 export const agentActivityUnseenCountAtom = atom<number>(0)
 
+function trimStream<T>(stream: T[], cap: number): T[] {
+  if (stream.length <= cap) {
+    return stream
+  }
+
+  return stream.slice(stream.length - cap)
+}
+
+function appendAndTrim(
+  current: AgentActivityEvent[],
+  appended: AgentActivityEvent[] | undefined,
+  cap: number,
+): AgentActivityEvent[] {
+  if (!appended?.length) {
+    return current
+  }
+
+  return trimStream([...current, ...appended], cap)
+}
+
+function mergeHydratedStream(
+  incoming: AgentActivityEvent[],
+  current: AgentActivityEvent[],
+  cap: number,
+): AgentActivityEvent[] {
+  if (current.length === 0) {
+    return trimStream(incoming, cap)
+  }
+
+  const merged = incoming.slice()
+  const knownIds = new Set(merged.map((event) => event.id))
+  for (const event of current) {
+    if (!knownIds.has(event.id)) {
+      merged.push(event)
+      knownIds.add(event.id)
+    }
+  }
+
+  return trimStream(merged, cap)
+}
+
+function mergeHydratedSnapshot(
+  current: AgentActivitySnapshot,
+  incoming: AgentActivitySnapshot,
+): AgentActivitySnapshot {
+  const pinnedById = new Map(incoming.pinnedEvents.map((event) => [event.eventId, event]))
+  for (const event of current.pinnedEvents) {
+    pinnedById.set(event.eventId, event)
+  }
+
+  return {
+    generatedAt:
+      current.generatedAt.localeCompare(incoming.generatedAt) > 0 ? current.generatedAt : incoming.generatedAt,
+    events: mergeHydratedStream(incoming.events, current.events, AGENT_ACTIVITY_EVENT_CAP),
+    verbose: mergeHydratedStream(incoming.verbose, current.verbose, AGENT_ACTIVITY_VERBOSE_CAP),
+    pinnedEvents: Array.from(pinnedById.values()),
+  }
+}
+
 function applyAgentActivityUpdate(
   snapshot: AgentActivitySnapshot,
   update: AgentActivityUpdate,
 ): AgentActivitySnapshot {
-  const nextEvents = update.appendedEvents?.length
-    ? [...snapshot.events, ...update.appendedEvents]
-    : snapshot.events
-  const nextVerbose = update.appendedVerbose?.length
-    ? [...snapshot.verbose, ...update.appendedVerbose]
-    : snapshot.verbose
+  const nextEvents = appendAndTrim(snapshot.events, update.appendedEvents, AGENT_ACTIVITY_EVENT_CAP)
+  const nextVerbose = appendAndTrim(snapshot.verbose, update.appendedVerbose, AGENT_ACTIVITY_VERBOSE_CAP)
 
   const pinnedById = new Map(snapshot.pinnedEvents.map((event) => [event.eventId, event]))
   for (const event of update.upsertedPinnedEvents ?? []) {
@@ -102,7 +161,9 @@ export const setPinnedEventAtom = atom(
   null,
   async (_get, set, payload: { eventId: string; pinned: boolean }) => {
     const response = await window.api.agentActivity.setPinnedEvent(payload.eventId, payload.pinned)
-    set(agentActivitySnapshotAtom, response.snapshot)
+    if (response.success) {
+      set(agentActivitySnapshotAtom, response.snapshot)
+    }
     return response
   },
 )
@@ -119,7 +180,9 @@ export const isEventPinnedAtom = atom((get) => {
 export const togglePinnedEventAtom = atom(null, async (get, set, eventId: string) => {
   const isPinned = get(isEventPinnedAtom)(eventId)
   const response = await window.api.agentActivity.setPinnedEvent(eventId, !isPinned)
-  set(agentActivitySnapshotAtom, response.snapshot)
+  if (response.success) {
+    set(agentActivitySnapshotAtom, response.snapshot)
+  }
   return response
 })
 
@@ -145,10 +208,8 @@ export function useAgentActivityBridge(): void {
 
   useEffect(() => {
     let cancelled = false
-    let receivedPush = false
 
     const unsubscribe = window.api.agentActivity.onUpdate((update) => {
-      receivedPush = true
       applyUpdate(update)
     })
 
@@ -156,8 +217,8 @@ export function useAgentActivityBridge(): void {
       setLoading(true)
       try {
         const response = await window.api.agentActivity.getSnapshot()
-        if (!cancelled && !receivedPush) {
-          setSnapshot(response.snapshot)
+        if (!cancelled) {
+          setSnapshot((current) => mergeHydratedSnapshot(current, response.snapshot))
         }
       } finally {
         if (!cancelled) {

--- a/apps/desktop/src/renderer/atoms/agent-activity.ts
+++ b/apps/desktop/src/renderer/atoms/agent-activity.ts
@@ -1,0 +1,161 @@
+import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { useEffect } from 'react'
+import type {
+  AgentActivityEvent,
+  AgentActivitySeverity,
+  AgentActivitySnapshot,
+  AgentActivitySource,
+  AgentActivityUpdate,
+} from '@shared/types'
+
+export type AgentActivityMode = 'events' | 'verbose'
+export type AgentActivitySourceFilter = AgentActivitySource | 'all'
+export type AgentActivitySeverityFilter = AgentActivitySeverity | 'all'
+
+const EMPTY_SNAPSHOT: AgentActivitySnapshot = {
+  generatedAt: new Date(0).toISOString(),
+  events: [],
+  verbose: [],
+  pinnedErrors: [],
+}
+
+export const agentActivitySnapshotAtom = atom<AgentActivitySnapshot>(EMPTY_SNAPSHOT)
+export const agentActivityLoadingAtom = atom<boolean>(false)
+export const agentActivityModeAtom = atom<AgentActivityMode>('events')
+export const agentActivitySourceFilterAtom = atom<AgentActivitySourceFilter>('all')
+export const agentActivitySeverityFilterAtom = atom<AgentActivitySeverityFilter>('all')
+export const agentActivityAutoFollowAtom = atom<boolean>(true)
+export const agentActivityUnseenCountAtom = atom<number>(0)
+
+function applyAgentActivityUpdate(
+  snapshot: AgentActivitySnapshot,
+  update: AgentActivityUpdate,
+): AgentActivitySnapshot {
+  const nextEvents = update.appendedEvents?.length
+    ? [...snapshot.events, ...update.appendedEvents]
+    : snapshot.events
+  const nextVerbose = update.appendedVerbose?.length
+    ? [...snapshot.verbose, ...update.appendedVerbose]
+    : snapshot.verbose
+
+  const pinnedById = new Map(snapshot.pinnedErrors.map((incident) => [incident.incidentId, incident]))
+  for (const incident of update.upsertedPinnedErrors ?? []) {
+    pinnedById.set(incident.incidentId, incident)
+  }
+  for (const incidentId of update.removedPinnedErrorIds ?? []) {
+    pinnedById.delete(incidentId)
+  }
+
+  return {
+    generatedAt: update.generatedAt,
+    events: nextEvents,
+    verbose: nextVerbose,
+    pinnedErrors: Array.from(pinnedById.values()),
+  }
+}
+
+function countIncoming(update: AgentActivityUpdate, mode: AgentActivityMode): number {
+  if (mode === 'events') {
+    return update.appendedEvents?.length ?? 0
+  }
+
+  return update.appendedVerbose?.length ?? 0
+}
+
+export const applyAgentActivityUpdateAtom = atom(
+  null,
+  (get, set, update: AgentActivityUpdate) => {
+    const currentSnapshot = get(agentActivitySnapshotAtom)
+    const nextSnapshot = applyAgentActivityUpdate(currentSnapshot, update)
+    set(agentActivitySnapshotAtom, nextSnapshot)
+
+    if (get(agentActivityAutoFollowAtom)) {
+      return
+    }
+
+    const mode = get(agentActivityModeAtom)
+    const incoming = countIncoming(update, mode)
+    if (incoming > 0) {
+      set(agentActivityUnseenCountAtom, (count) => count + incoming)
+    }
+  },
+)
+
+export const setAgentActivityModeAtom = atom(null, (_get, set, mode: AgentActivityMode) => {
+  set(agentActivityModeAtom, mode)
+  set(agentActivityUnseenCountAtom, 0)
+})
+
+export const setAgentActivityAutoFollowAtom = atom(null, (_get, set, autoFollow: boolean) => {
+  set(agentActivityAutoFollowAtom, autoFollow)
+  if (autoFollow) {
+    set(agentActivityUnseenCountAtom, 0)
+  }
+})
+
+export const jumpToLatestAgentActivityAtom = atom(null, (_get, set) => {
+  set(agentActivityAutoFollowAtom, true)
+  set(agentActivityUnseenCountAtom, 0)
+})
+
+export const dismissPinnedErrorAtom = atom(null, async (_get, set, incidentId: string) => {
+  const response = await window.api.agentActivity.dismissPinnedError(incidentId)
+  set(agentActivitySnapshotAtom, response.snapshot)
+  return response
+})
+
+export const filteredAgentActivityEventsAtom = atom((get): AgentActivityEvent[] => {
+  const snapshot = get(agentActivitySnapshotAtom)
+  const mode = get(agentActivityModeAtom)
+  const sourceFilter = get(agentActivitySourceFilterAtom)
+  const severityFilter = get(agentActivitySeverityFilterAtom)
+
+  const stream = mode === 'events' ? snapshot.events : snapshot.verbose
+
+  return stream.filter((event) => {
+    const sourceMatches = sourceFilter === 'all' || event.source === sourceFilter
+    const severityMatches = severityFilter === 'all' || event.severity === severityFilter
+    return sourceMatches && severityMatches
+  })
+})
+
+export function useAgentActivityBridge(): void {
+  const setSnapshot = useSetAtom(agentActivitySnapshotAtom)
+  const setLoading = useSetAtom(agentActivityLoadingAtom)
+  const applyUpdate = useSetAtom(applyAgentActivityUpdateAtom)
+
+  useEffect(() => {
+    let cancelled = false
+    let receivedPush = false
+
+    const unsubscribe = window.api.agentActivity.onUpdate((update) => {
+      receivedPush = true
+      applyUpdate(update)
+    })
+
+    const loadInitial = async () => {
+      setLoading(true)
+      try {
+        const response = await window.api.agentActivity.getSnapshot()
+        if (!cancelled && !receivedPush) {
+          setSnapshot(response.snapshot)
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void loadInitial()
+
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [applyUpdate, setLoading, setSnapshot])
+}
+
+export function useAgentActivitySnapshot(): AgentActivitySnapshot {
+  return useAtomValue(agentActivitySnapshotAtom)
+}

--- a/apps/desktop/src/renderer/atoms/agent-activity.ts
+++ b/apps/desktop/src/renderer/atoms/agent-activity.ts
@@ -16,7 +16,7 @@ const EMPTY_SNAPSHOT: AgentActivitySnapshot = {
   generatedAt: new Date(0).toISOString(),
   events: [],
   verbose: [],
-  pinnedErrors: [],
+  pinnedEvents: [],
 }
 
 export const agentActivitySnapshotAtom = atom<AgentActivitySnapshot>(EMPTY_SNAPSHOT)
@@ -38,19 +38,19 @@ function applyAgentActivityUpdate(
     ? [...snapshot.verbose, ...update.appendedVerbose]
     : snapshot.verbose
 
-  const pinnedById = new Map(snapshot.pinnedErrors.map((incident) => [incident.incidentId, incident]))
-  for (const incident of update.upsertedPinnedErrors ?? []) {
-    pinnedById.set(incident.incidentId, incident)
+  const pinnedById = new Map(snapshot.pinnedEvents.map((event) => [event.eventId, event]))
+  for (const event of update.upsertedPinnedEvents ?? []) {
+    pinnedById.set(event.eventId, event)
   }
-  for (const incidentId of update.removedPinnedErrorIds ?? []) {
-    pinnedById.delete(incidentId)
+  for (const eventId of update.removedPinnedEventIds ?? []) {
+    pinnedById.delete(eventId)
   }
 
   return {
     generatedAt: update.generatedAt,
     events: nextEvents,
     verbose: nextVerbose,
-    pinnedErrors: Array.from(pinnedById.values()),
+    pinnedEvents: Array.from(pinnedById.values()),
   }
 }
 
@@ -98,8 +98,27 @@ export const jumpToLatestAgentActivityAtom = atom(null, (_get, set) => {
   set(agentActivityUnseenCountAtom, 0)
 })
 
-export const dismissPinnedErrorAtom = atom(null, async (_get, set, incidentId: string) => {
-  const response = await window.api.agentActivity.dismissPinnedError(incidentId)
+export const setPinnedEventAtom = atom(
+  null,
+  async (_get, set, payload: { eventId: string; pinned: boolean }) => {
+    const response = await window.api.agentActivity.setPinnedEvent(payload.eventId, payload.pinned)
+    set(agentActivitySnapshotAtom, response.snapshot)
+    return response
+  },
+)
+
+export const pinnedEventIdsAtom = atom((get) => {
+  return new Set(get(agentActivitySnapshotAtom).pinnedEvents.map((event) => event.eventId))
+})
+
+export const isEventPinnedAtom = atom((get) => {
+  const pinnedIds = get(pinnedEventIdsAtom)
+  return (eventId: string) => pinnedIds.has(eventId)
+})
+
+export const togglePinnedEventAtom = atom(null, async (get, set, eventId: string) => {
+  const isPinned = get(isEventPinnedAtom)(eventId)
+  const response = await window.api.agentActivity.setPinnedEvent(eventId, !isPinned)
   set(agentActivitySnapshotAtom, response.snapshot)
   return response
 })

--- a/apps/desktop/src/renderer/atoms/workflow-board.ts
+++ b/apps/desktop/src/renderer/atoms/workflow-board.ts
@@ -11,6 +11,7 @@ import {
   type WorkflowMoveEntityResult,
   type WorkflowTaskDetailResponse,
   type WorkflowUpdateTaskResult,
+  type RightPaneMode,
 } from '@shared/types'
 import { currentSessionIdAtom, workingDirectoryAtom } from './session'
 import { rightPaneModeAtom, setWorkflowContextAtom } from './right-pane'
@@ -666,7 +667,7 @@ function buildScopeKey(params: {
 }
 
 export function shouldRefreshAfterScopeSync(params: {
-  rightPaneMode: 'planning' | 'kanban'
+  rightPaneMode: RightPaneMode
   boardActivationReady: boolean
 }): boolean {
   return params.rightPaneMode === 'kanban' && params.boardActivationReady

--- a/apps/desktop/src/renderer/components/agent-activity/ActivityTimeline.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/ActivityTimeline.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
+import { Pin } from 'lucide-react'
 import {
   agentActivityLoadingAtom,
   agentActivityAutoFollowAtom,
   agentActivityModeAtom,
   agentActivityUnseenCountAtom,
   filteredAgentActivityEventsAtom,
+  pinnedEventIdsAtom,
   jumpToLatestAgentActivityAtom,
   setAgentActivityAutoFollowAtom,
+  setPinnedEventAtom,
 } from '@/atoms/agent-activity'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -37,9 +40,11 @@ export function ActivityTimeline() {
   const loading = useAtomValue(agentActivityLoadingAtom)
   const autoFollow = useAtomValue(agentActivityAutoFollowAtom)
   const events = useAtomValue(filteredAgentActivityEventsAtom)
+  const pinnedEventIds = useAtomValue(pinnedEventIdsAtom)
   const unseenCount = useAtomValue(agentActivityUnseenCountAtom)
   const setAutoFollow = useSetAtom(setAgentActivityAutoFollowAtom)
   const jumpToLatest = useSetAtom(jumpToLatestAgentActivityAtom)
+  const setPinnedEvent = useSetAtom(setPinnedEventAtom)
   const scrollViewportRef = useRef<HTMLDivElement | null>(null)
   const shouldAutoFollow = autoFollow
 
@@ -56,12 +61,12 @@ export function ActivityTimeline() {
     viewport.scrollTop = viewport.scrollHeight
   }, [events.length, shouldAutoFollow])
 
-  const streamLabel = useMemo(() => (mode === 'events' ? 'Events' : 'Verbose'), [mode])
+  const streamLabel = useMemo(() => (mode === 'events' ? 'Events Timeline' : 'Event Log'), [mode])
 
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-2" data-testid="agent-activity-timeline">
       <div className="flex items-center justify-between gap-2">
-        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{streamLabel} Timeline</h3>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{streamLabel}</h3>
         {unseenCount > 0 ? (
           <Button
             type="button"
@@ -103,6 +108,19 @@ export function ActivityTimeline() {
                 <Badge variant="outline">{event.source}</Badge>
                 <Badge variant={severityVariant(event.severity)}>{event.severity}</Badge>
                 <Badge variant="secondary">{event.kind}</Badge>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="ml-auto size-6"
+                  aria-label={pinnedEventIds.has(event.id) ? 'Unpin event' : 'Pin event'}
+                  data-testid={`agent-activity-pin-${event.id}`}
+                  onClick={() => {
+                    void setPinnedEvent({ eventId: event.id, pinned: !pinnedEventIds.has(event.id) })
+                  }}
+                >
+                  <Pin className={`size-3.5 ${pinnedEventIds.has(event.id) ? 'fill-current' : ''}`} />
+                </Button>
               </div>
               <p className="mt-1 text-xs text-foreground">{event.message}</p>
               {event.details ? (

--- a/apps/desktop/src/renderer/components/agent-activity/ActivityTimeline.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/ActivityTimeline.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import {
+  agentActivityLoadingAtom,
+  agentActivityAutoFollowAtom,
+  agentActivityModeAtom,
+  agentActivityUnseenCountAtom,
+  filteredAgentActivityEventsAtom,
+  jumpToLatestAgentActivityAtom,
+  setAgentActivityAutoFollowAtom,
+} from '@/atoms/agent-activity'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+
+function formatTime(value: string): string {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return 'unknown'
+  }
+
+  return parsed.toLocaleTimeString()
+}
+
+function severityVariant(severity: 'info' | 'warning' | 'error'): 'secondary' | 'destructive' | 'default' {
+  if (severity === 'error') {
+    return 'destructive'
+  }
+  if (severity === 'warning') {
+    return 'default'
+  }
+  return 'secondary'
+}
+
+export function ActivityTimeline() {
+  const mode = useAtomValue(agentActivityModeAtom)
+  const loading = useAtomValue(agentActivityLoadingAtom)
+  const autoFollow = useAtomValue(agentActivityAutoFollowAtom)
+  const events = useAtomValue(filteredAgentActivityEventsAtom)
+  const unseenCount = useAtomValue(agentActivityUnseenCountAtom)
+  const setAutoFollow = useSetAtom(setAgentActivityAutoFollowAtom)
+  const jumpToLatest = useSetAtom(jumpToLatestAgentActivityAtom)
+  const scrollViewportRef = useRef<HTMLDivElement | null>(null)
+  const shouldAutoFollow = autoFollow
+
+  useEffect(() => {
+    if (!shouldAutoFollow) {
+      return
+    }
+
+    const viewport = scrollViewportRef.current
+    if (!viewport) {
+      return
+    }
+
+    viewport.scrollTop = viewport.scrollHeight
+  }, [events.length, shouldAutoFollow])
+
+  const streamLabel = useMemo(() => (mode === 'events' ? 'Events' : 'Verbose'), [mode])
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-2" data-testid="agent-activity-timeline">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{streamLabel} Timeline</h3>
+        {unseenCount > 0 ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => jumpToLatest()}
+            data-testid="agent-activity-jump-latest"
+          >
+            Jump to latest ({unseenCount})
+          </Button>
+        ) : null}
+      </div>
+
+      <div
+        ref={scrollViewportRef}
+        className="min-h-0 flex-1 space-y-2 overflow-y-auto rounded-md border border-border p-3"
+        onScroll={(event) => {
+          const element = event.currentTarget
+          const distanceToBottom = element.scrollHeight - element.scrollTop - element.clientHeight
+          setAutoFollow(distanceToBottom < 24)
+        }}
+        data-testid="agent-activity-scroll-area"
+      >
+          {loading ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Spinner className="size-3.5" />
+              Loading activity…
+            </div>
+          ) : null}
+
+          {!loading && events.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No activity yet. New events appear here in real time.</p>
+          ) : null}
+
+          {events.map((event) => (
+            <div key={`${event.stream}:${event.id}`} className="rounded-md border border-border/80 bg-card/40 p-2" data-testid={`agent-activity-row-${event.id}`}>
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] text-muted-foreground">{formatTime(event.timestamp)}</span>
+                <Badge variant="outline">{event.source}</Badge>
+                <Badge variant={severityVariant(event.severity)}>{event.severity}</Badge>
+                <Badge variant="secondary">{event.kind}</Badge>
+              </div>
+              <p className="mt-1 text-xs text-foreground">{event.message}</p>
+              {event.details ? (
+                <details className="mt-1 text-[11px] text-muted-foreground">
+                  <summary className="cursor-pointer">Details</summary>
+                  <pre className="mt-1 whitespace-pre-wrap break-words">{JSON.stringify(event.details, null, 2)}</pre>
+                </details>
+              ) : null}
+            </div>
+          ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/components/agent-activity/AgentActivityPane.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/AgentActivityPane.tsx
@@ -18,6 +18,7 @@ import {
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { ActivityTimeline } from './ActivityTimeline'
 import { PinnedErrorPanel } from './PinnedErrorPanel'
+import { RuntimeOverviewPanel } from './RuntimeOverviewPanel'
 
 export function AgentActivityPane() {
   const mode = useAtomValue(agentActivityModeAtom)
@@ -120,6 +121,7 @@ export function AgentActivityPane() {
         </CardHeader>
 
         <CardContent className="flex min-h-0 flex-1 flex-col gap-4 p-4 pt-2">
+          <RuntimeOverviewPanel />
           <PinnedErrorPanel />
           <ActivityTimeline />
         </CardContent>

--- a/apps/desktop/src/renderer/components/agent-activity/AgentActivityPane.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/AgentActivityPane.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/select'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { ActivityTimeline } from './ActivityTimeline'
-import { PinnedErrorPanel } from './PinnedErrorPanel'
+import { PinnedEventPanel } from './PinnedEventPanel'
 import { RuntimeOverviewPanel } from './RuntimeOverviewPanel'
 
 export function AgentActivityPane() {
@@ -122,7 +122,7 @@ export function AgentActivityPane() {
 
         <CardContent className="flex min-h-0 flex-1 flex-col gap-4 p-4 pt-2">
           <RuntimeOverviewPanel />
-          <PinnedErrorPanel />
+          <PinnedEventPanel />
           <ActivityTimeline />
         </CardContent>
       </Card>

--- a/apps/desktop/src/renderer/components/agent-activity/AgentActivityPane.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/AgentActivityPane.tsx
@@ -1,0 +1,129 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import {
+  agentActivityModeAtom,
+  agentActivitySeverityFilterAtom,
+  agentActivitySourceFilterAtom,
+  setAgentActivityModeAtom,
+} from '@/atoms/agent-activity'
+import { clearRightPaneOverrideAtom, setRightPaneOverrideAtom } from '@/atoms/right-pane'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { ActivityTimeline } from './ActivityTimeline'
+import { PinnedErrorPanel } from './PinnedErrorPanel'
+
+export function AgentActivityPane() {
+  const mode = useAtomValue(agentActivityModeAtom)
+  const sourceFilter = useAtomValue(agentActivitySourceFilterAtom)
+  const severityFilter = useAtomValue(agentActivitySeverityFilterAtom)
+  const setMode = useSetAtom(setAgentActivityModeAtom)
+  const setSourceFilter = useSetAtom(agentActivitySourceFilterAtom)
+  const setSeverityFilter = useSetAtom(agentActivitySeverityFilterAtom)
+  const setRightPaneOverride = useSetAtom(setRightPaneOverrideAtom)
+  const clearRightPaneOverride = useSetAtom(clearRightPaneOverrideAtom)
+
+  return (
+    <aside className="flex h-full flex-col bg-muted/40" data-testid="agent-activity-pane">
+      <Card className="m-3 flex min-h-0 flex-1 flex-col border border-border bg-card/60 py-0">
+        <CardHeader className="space-y-2 px-4 pt-4 pb-2">
+          <div className="flex items-center justify-between gap-2">
+            <CardTitle className="text-sm text-foreground">Agent Activity</CardTitle>
+            <div className="flex items-center gap-2">
+              <ToggleGroup
+                type="single"
+                value={mode}
+                onValueChange={(value) => {
+                  if (value === 'events' || value === 'verbose') {
+                    setMode(value)
+                  }
+                }}
+                variant="outline"
+                size="sm"
+              >
+                <ToggleGroupItem value="events" data-testid="agent-activity-mode-events">
+                  Events
+                </ToggleGroupItem>
+                <ToggleGroupItem value="verbose" data-testid="agent-activity-mode-verbose">
+                  Verbose
+                </ToggleGroupItem>
+              </ToggleGroup>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => setRightPaneOverride('kanban')}
+                data-testid="agent-activity-open-kanban"
+              >
+                Kanban
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => setRightPaneOverride('planning')}
+                data-testid="agent-activity-open-planning"
+              >
+                Planning
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => clearRightPaneOverride()}
+                data-testid="agent-activity-return-auto"
+              >
+                Auto
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Select
+              value={sourceFilter}
+              onValueChange={(value) => setSourceFilter(value as typeof sourceFilter)}
+            >
+              <SelectTrigger size="sm" className="w-40" data-testid="agent-activity-source-filter">
+                <SelectValue placeholder="Source" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All sources</SelectItem>
+                <SelectItem value="runtime">Runtime</SelectItem>
+                <SelectItem value="worker">Worker</SelectItem>
+                <SelectItem value="escalation">Escalation</SelectItem>
+                <SelectItem value="connection">Connection</SelectItem>
+                <SelectItem value="system">System</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={severityFilter}
+              onValueChange={(value) => setSeverityFilter(value as typeof severityFilter)}
+            >
+              <SelectTrigger size="sm" className="w-40" data-testid="agent-activity-severity-filter">
+                <SelectValue placeholder="Severity" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All severities</SelectItem>
+                <SelectItem value="info">Info</SelectItem>
+                <SelectItem value="warning">Warning</SelectItem>
+                <SelectItem value="error">Error</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+
+        <CardContent className="flex min-h-0 flex-1 flex-col gap-4 p-4 pt-2">
+          <PinnedErrorPanel />
+          <ActivityTimeline />
+        </CardContent>
+      </Card>
+    </aside>
+  )
+}

--- a/apps/desktop/src/renderer/components/agent-activity/PinnedErrorPanel.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/PinnedErrorPanel.tsx
@@ -1,0 +1,58 @@
+import { useSetAtom } from 'jotai'
+import { useAgentActivitySnapshot, dismissPinnedErrorAtom } from '@/atoms/agent-activity'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+
+function formatTime(value: string): string {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return 'unknown'
+  }
+
+  return parsed.toLocaleTimeString()
+}
+
+export function PinnedErrorPanel() {
+  const snapshot = useAgentActivitySnapshot()
+  const dismiss = useSetAtom(dismissPinnedErrorAtom)
+
+  return (
+    <section className="space-y-2" data-testid="agent-activity-pinned-errors">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pinned Errors</h3>
+
+      {snapshot.pinnedErrors.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
+          No pinned errors.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {snapshot.pinnedErrors.map((incident) => (
+            <Alert key={incident.incidentId} variant="destructive" data-testid={`agent-activity-pinned-${incident.incidentId}`}>
+              <div className="flex items-start justify-between gap-2">
+                <div className="space-y-1">
+                  <AlertTitle>{incident.kind}</AlertTitle>
+                  <AlertDescription>{incident.message}</AlertDescription>
+                  <p className="text-[11px] text-muted-foreground">
+                    First seen {formatTime(incident.firstSeenAt)} · Last seen {formatTime(incident.lastSeenAt)} ·{' '}
+                    {incident.occurrences} occurrence{incident.occurrences === 1 ? '' : 's'}
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    void dismiss(incident.incidentId)
+                  }}
+                  data-testid={`agent-activity-dismiss-${incident.incidentId}`}
+                >
+                  Dismiss
+                </Button>
+              </div>
+            </Alert>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/components/agent-activity/PinnedErrorPanel.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/PinnedErrorPanel.tsx
@@ -1,5 +1,5 @@
 import { useSetAtom } from 'jotai'
-import { useAgentActivitySnapshot, dismissPinnedErrorAtom } from '@/atoms/agent-activity'
+import { useAgentActivitySnapshot, setPinnedEventAtom } from '@/atoms/agent-activity'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 
@@ -12,29 +12,33 @@ function formatTime(value: string): string {
   return parsed.toLocaleTimeString()
 }
 
+function alertVariant(severity: 'info' | 'warning' | 'error'): 'default' | 'destructive' {
+  return severity === 'error' ? 'destructive' : 'default'
+}
+
 export function PinnedErrorPanel() {
   const snapshot = useAgentActivitySnapshot()
-  const dismiss = useSetAtom(dismissPinnedErrorAtom)
+  const setPinnedEvent = useSetAtom(setPinnedEventAtom)
 
   return (
     <section className="space-y-2" data-testid="agent-activity-pinned-errors">
-      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pinned Errors</h3>
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pinned Events</h3>
 
-      {snapshot.pinnedErrors.length === 0 ? (
+      {snapshot.pinnedEvents.length === 0 ? (
         <p className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
-          No pinned errors.
+          No pinned events.
         </p>
       ) : (
         <div className="space-y-2">
-          {snapshot.pinnedErrors.map((incident) => (
-            <Alert key={incident.incidentId} variant="destructive" data-testid={`agent-activity-pinned-${incident.incidentId}`}>
+          {snapshot.pinnedEvents.map((event) => (
+            <Alert key={event.eventId} variant={alertVariant(event.severity)} data-testid={`agent-activity-pinned-${event.eventId}`}>
               <div className="flex items-start justify-between gap-2">
                 <div className="space-y-1">
-                  <AlertTitle>{incident.kind}</AlertTitle>
-                  <AlertDescription>{incident.message}</AlertDescription>
+                  <AlertTitle>{event.kind}</AlertTitle>
+                  <AlertDescription>{event.message}</AlertDescription>
                   <p className="text-[11px] text-muted-foreground">
-                    First seen {formatTime(incident.firstSeenAt)} · Last seen {formatTime(incident.lastSeenAt)} ·{' '}
-                    {incident.occurrences} occurrence{incident.occurrences === 1 ? '' : 's'}
+                    Event at {formatTime(event.timestamp)} · Pinned at {formatTime(event.pinnedAt)}
+                    {event.automatic ? ' · Auto-pinned error' : ' · Manually pinned'}
                   </p>
                 </div>
                 <Button
@@ -42,11 +46,11 @@ export function PinnedErrorPanel() {
                   size="sm"
                   variant="outline"
                   onClick={() => {
-                    void dismiss(incident.incidentId)
+                    void setPinnedEvent({ eventId: event.eventId, pinned: false })
                   }}
-                  data-testid={`agent-activity-dismiss-${incident.incidentId}`}
+                  data-testid={`agent-activity-dismiss-${event.eventId}`}
                 >
-                  Dismiss
+                  Unpin
                 </Button>
               </div>
             </Alert>

--- a/apps/desktop/src/renderer/components/agent-activity/PinnedEventPanel.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/PinnedEventPanel.tsx
@@ -16,12 +16,12 @@ function alertVariant(severity: 'info' | 'warning' | 'error'): 'default' | 'dest
   return severity === 'error' ? 'destructive' : 'default'
 }
 
-export function PinnedErrorPanel() {
+export function PinnedEventPanel() {
   const snapshot = useAgentActivitySnapshot()
   const setPinnedEvent = useSetAtom(setPinnedEventAtom)
 
   return (
-    <section className="space-y-2" data-testid="agent-activity-pinned-errors">
+    <section className="space-y-2" data-testid="agent-activity-pinned-events">
       <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pinned Events</h3>
 
       {snapshot.pinnedEvents.length === 0 ? (

--- a/apps/desktop/src/renderer/components/agent-activity/RuntimeOverviewPanel.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/RuntimeOverviewPanel.tsx
@@ -1,0 +1,96 @@
+import { useSymphonyDashboardSnapshot } from '@/atoms/symphony-dashboard'
+import { useSymphonyStatus } from '@/atoms/symphony'
+
+function formatTime(value?: string): string {
+  if (!value) {
+    return '—'
+  }
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return '—'
+  }
+  return parsed.toLocaleTimeString()
+}
+
+function formatAge(value?: string): string {
+  if (!value) {
+    return '—'
+  }
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return '—'
+  }
+  const seconds = Math.max(0, Math.floor((Date.now() - parsed.getTime()) / 1000))
+  return `${seconds}s ago`
+}
+
+export function RuntimeOverviewPanel() {
+  const snapshot = useSymphonyDashboardSnapshot()
+  const status = useSymphonyStatus()
+
+  return (
+    <section className="space-y-2" data-testid="agent-activity-runtime-overview">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Runtime Overview</h3>
+      <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+        <SummaryStat label="Running" value={snapshot.workers.length} />
+        <SummaryStat label="Queue" value={snapshot.queueCount} />
+        <SummaryStat label="Completed" value={snapshot.completedCount} />
+        <SummaryStat label="Escalations" value={snapshot.escalations.length} />
+      </div>
+
+      <div className="rounded-md border border-border/80 bg-card/40 px-3 py-2 text-xs text-muted-foreground">
+        <p>
+          Runtime phase: <span className="text-foreground">{status.phase}</span> · Connection:{' '}
+          <span className="text-foreground">{snapshot.connection.state}</span> · Freshness:{' '}
+          <span className="text-foreground">{snapshot.freshness.status}</span>
+        </p>
+        <p>
+          Snapshot fetched {formatAge(snapshot.fetchedAt)} ({formatTime(snapshot.fetchedAt)}) · Status updated{' '}
+          {formatAge(status.updatedAt)} ({formatTime(status.updatedAt)})
+        </p>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border border-border">
+        <table className="w-full text-left text-xs">
+          <thead className="bg-muted/40 text-muted-foreground">
+            <tr>
+              <th className="px-2 py-2 font-medium">ID</th>
+              <th className="px-2 py-2 font-medium">State</th>
+              <th className="px-2 py-2 font-medium">Tool</th>
+              <th className="px-2 py-2 font-medium">Last Activity</th>
+              <th className="px-2 py-2 font-medium">Model</th>
+            </tr>
+          </thead>
+          <tbody>
+            {snapshot.workers.length === 0 ? (
+              <tr>
+                <td className="px-2 py-2 text-muted-foreground" colSpan={5}>
+                  No running sessions.
+                </td>
+              </tr>
+            ) : (
+              snapshot.workers.map((worker) => (
+                <tr key={worker.issueId} className="border-t border-border/80">
+                  <td className="px-2 py-2 align-top text-foreground">{worker.identifier}</td>
+                  <td className="px-2 py-2 align-top text-foreground">{worker.state}</td>
+                  <td className="px-2 py-2 align-top text-foreground">{worker.toolName}</td>
+                  <td className="px-2 py-2 align-top text-foreground">{formatAge(worker.lastActivityAt)}</td>
+                  <td className="px-2 py-2 align-top text-foreground">{worker.model}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function SummaryStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border border-border bg-background/50 px-2 py-2" data-testid={`agent-activity-runtime-${label.toLowerCase()}`}>
+      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="text-sm font-semibold text-foreground">{value}</p>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/agent-activity/__tests__/AgentActivityPane.test.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/__tests__/AgentActivityPane.test.tsx
@@ -21,14 +21,15 @@ describe('AgentActivityPane', () => {
   beforeEach(() => {
     ;(window as unknown as { api: any }).api = {
       agentActivity: {
-        dismissPinnedError: vi.fn(async () => ({
+        setPinnedEvent: vi.fn(async (_eventId: string, _pinned: boolean) => ({
           success: true,
-          incidentId: 'incident-1',
+          eventId: 'evt-1',
+          pinned: false,
           snapshot: {
             generatedAt: new Date().toISOString(),
             events: [],
             verbose: [],
-            pinnedErrors: [],
+            pinnedEvents: [],
           },
         })),
       },
@@ -61,7 +62,7 @@ describe('AgentActivityPane', () => {
           message: 'Verbose row',
         },
       ],
-      pinnedErrors: [],
+      pinnedEvents: [],
     })
 
     renderWithStore(store)
@@ -71,36 +72,35 @@ describe('AgentActivityPane', () => {
     await waitFor(() => expect(screen.getByText('Verbose row')).toBeTruthy())
   })
 
-  test('renders pinned incidents and dismisses them', async () => {
-    const dismissSpy = vi.fn(async () => ({
+  test('renders pinned events and unpins them', async () => {
+    const setPinnedEventSpy = vi.fn(async () => ({
       success: true,
-      incidentId: 'incident-1',
+      eventId: 'evt-1',
+      pinned: false,
       snapshot: {
         generatedAt: new Date().toISOString(),
         events: [],
         verbose: [],
-        pinnedErrors: [],
+        pinnedEvents: [],
       },
     }))
-    ;(window as unknown as { api: any }).api.agentActivity.dismissPinnedError = dismissSpy
+    ;(window as unknown as { api: any }).api.agentActivity.setPinnedEvent = setPinnedEventSpy
 
     const store = createStore()
     store.set(agentActivitySnapshotAtom, {
       generatedAt: new Date().toISOString(),
       events: [],
       verbose: [],
-      pinnedErrors: [
+      pinnedEvents: [
         {
-          incidentId: 'incident-1',
-          fingerprint: 'system|error',
+          eventId: 'evt-1',
+          pinnedAt: new Date().toISOString(),
+          automatic: true,
+          timestamp: new Date().toISOString(),
           source: 'system',
           kind: 'system.error',
           message: 'Pinned error row',
           severity: 'error',
-          firstSeenAt: new Date().toISOString(),
-          lastSeenAt: new Date().toISOString(),
-          occurrences: 1,
-          lastEventId: 'evt-1',
         },
       ],
     })
@@ -108,8 +108,8 @@ describe('AgentActivityPane', () => {
     renderWithStore(store)
 
     expect(screen.getByText('Pinned error row')).toBeTruthy()
-    fireEvent.click(screen.getByTestId('agent-activity-dismiss-incident-1'))
-    await waitFor(() => expect(dismissSpy).toHaveBeenCalledWith('incident-1'))
+    fireEvent.click(screen.getByTestId('agent-activity-dismiss-evt-1'))
+    await waitFor(() => expect(setPinnedEventSpy).toHaveBeenCalledWith('evt-1', false))
   })
 
   test('shows jump-to-latest button when unseen events are present', () => {
@@ -119,5 +119,42 @@ describe('AgentActivityPane', () => {
     renderWithStore(store)
 
     expect(screen.getByTestId('agent-activity-jump-latest')).toBeTruthy()
+  })
+
+  test('pins an event from the timeline', async () => {
+    const setPinnedEventSpy = vi.fn(async () => ({
+      success: true,
+      eventId: 'evt-1',
+      pinned: true,
+      snapshot: {
+        generatedAt: new Date().toISOString(),
+        events: [],
+        verbose: [],
+        pinnedEvents: [],
+      },
+    }))
+    ;(window as unknown as { api: any }).api.agentActivity.setPinnedEvent = setPinnedEventSpy
+
+    const store = createStore()
+    store.set(agentActivitySnapshotAtom, {
+      generatedAt: new Date().toISOString(),
+      events: [
+        {
+          id: 'evt-1',
+          timestamp: new Date().toISOString(),
+          stream: 'events',
+          source: 'worker',
+          severity: 'info',
+          kind: 'cli.tool_start',
+          message: 'Tool started',
+        },
+      ],
+      verbose: [],
+      pinnedEvents: [],
+    })
+
+    renderWithStore(store)
+    fireEvent.click(screen.getByTestId('agent-activity-pin-evt-1'))
+    await waitFor(() => expect(setPinnedEventSpy).toHaveBeenCalledWith('evt-1', true))
   })
 })

--- a/apps/desktop/src/renderer/components/agent-activity/__tests__/AgentActivityPane.test.tsx
+++ b/apps/desktop/src/renderer/components/agent-activity/__tests__/AgentActivityPane.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider, createStore } from 'jotai'
+import {
+  agentActivitySnapshotAtom,
+  agentActivityUnseenCountAtom,
+} from '@/atoms/agent-activity'
+import { AgentActivityPane } from '../AgentActivityPane'
+
+function renderWithStore(store = createStore()) {
+  return render(
+    <Provider store={store}>
+      <AgentActivityPane />
+    </Provider>,
+  )
+}
+
+describe('AgentActivityPane', () => {
+  beforeEach(() => {
+    ;(window as unknown as { api: any }).api = {
+      agentActivity: {
+        dismissPinnedError: vi.fn(async () => ({
+          success: true,
+          incidentId: 'incident-1',
+          snapshot: {
+            generatedAt: new Date().toISOString(),
+            events: [],
+            verbose: [],
+            pinnedErrors: [],
+          },
+        })),
+      },
+    }
+  })
+
+  test('switches between events and verbose timeline modes', async () => {
+    const store = createStore()
+    store.set(agentActivitySnapshotAtom, {
+      generatedAt: new Date().toISOString(),
+      events: [
+        {
+          id: 'evt-1',
+          timestamp: new Date().toISOString(),
+          stream: 'events',
+          source: 'runtime',
+          severity: 'info',
+          kind: 'runtime.phase_changed',
+          message: 'Events row',
+        },
+      ],
+      verbose: [
+        {
+          id: 'verb-1',
+          timestamp: new Date().toISOString(),
+          stream: 'verbose',
+          source: 'system',
+          severity: 'warning',
+          kind: 'system.trace',
+          message: 'Verbose row',
+        },
+      ],
+      pinnedErrors: [],
+    })
+
+    renderWithStore(store)
+
+    expect(screen.getByText('Events row')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('agent-activity-mode-verbose'))
+    await waitFor(() => expect(screen.getByText('Verbose row')).toBeTruthy())
+  })
+
+  test('renders pinned incidents and dismisses them', async () => {
+    const dismissSpy = vi.fn(async () => ({
+      success: true,
+      incidentId: 'incident-1',
+      snapshot: {
+        generatedAt: new Date().toISOString(),
+        events: [],
+        verbose: [],
+        pinnedErrors: [],
+      },
+    }))
+    ;(window as unknown as { api: any }).api.agentActivity.dismissPinnedError = dismissSpy
+
+    const store = createStore()
+    store.set(agentActivitySnapshotAtom, {
+      generatedAt: new Date().toISOString(),
+      events: [],
+      verbose: [],
+      pinnedErrors: [
+        {
+          incidentId: 'incident-1',
+          fingerprint: 'system|error',
+          source: 'system',
+          kind: 'system.error',
+          message: 'Pinned error row',
+          severity: 'error',
+          firstSeenAt: new Date().toISOString(),
+          lastSeenAt: new Date().toISOString(),
+          occurrences: 1,
+          lastEventId: 'evt-1',
+        },
+      ],
+    })
+
+    renderWithStore(store)
+
+    expect(screen.getByText('Pinned error row')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('agent-activity-dismiss-incident-1'))
+    await waitFor(() => expect(dismissSpy).toHaveBeenCalledWith('incident-1'))
+  })
+
+  test('shows jump-to-latest button when unseen events are present', () => {
+    const store = createStore()
+    store.set(agentActivityUnseenCountAtom, 3)
+
+    renderWithStore(store)
+
+    expect(screen.getByTestId('agent-activity-jump-latest')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
+++ b/apps/desktop/src/renderer/components/app-shell/RightPane.tsx
@@ -2,12 +2,17 @@ import { useAtomValue } from 'jotai'
 import { rightPaneModeAtom } from '@/atoms/right-pane'
 import { KanbanPane } from '@/components/kanban/KanbanPane'
 import { PlanningPane } from '@/components/planning/PlanningPane'
+import { AgentActivityPane } from '@/components/agent-activity/AgentActivityPane'
 
 export function RightPane() {
   const rightPaneMode = useAtomValue(rightPaneModeAtom)
 
   if (rightPaneMode === 'planning') {
     return <PlanningPane />
+  }
+
+  if (rightPaneMode === 'agent_activity') {
+    return <AgentActivityPane />
   }
 
   return <KanbanPane />

--- a/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanHeader.tsx
@@ -1,4 +1,4 @@
-import { LayoutGrid, RefreshCcw } from 'lucide-react'
+import { Activity, LayoutGrid, RefreshCcw } from 'lucide-react'
 import type {
   RightPaneResolution,
   RightPaneOverride,
@@ -213,6 +213,7 @@ interface KanbanHeaderProps {
   onExpandAllCards: () => void
   onCollapseAllCards: () => void
   onOpenPlanningView: () => void
+  onOpenAgentActivityView: () => void
   onRefresh: () => void
   onClearOverride: () => void
 }
@@ -236,6 +237,7 @@ export function KanbanHeader({
   onExpandAllCards,
   onCollapseAllCards,
   onOpenPlanningView,
+  onOpenAgentActivityView,
   onRefresh,
   onClearOverride,
 }: KanbanHeaderProps) {
@@ -314,6 +316,17 @@ export function KanbanHeader({
 
           <Button type="button" size="icon" variant="ghost" aria-label="Open planning view" onClick={onOpenPlanningView}>
             <LayoutGrid className="size-4" />
+          </Button>
+
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Open agent activity view"
+            onClick={onOpenAgentActivityView}
+            data-testid="kanban-open-agent-activity"
+          >
+            <Activity className="size-4" />
           </Button>
 
           <Button

--- a/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
+++ b/apps/desktop/src/renderer/components/kanban/KanbanPane.tsx
@@ -110,6 +110,7 @@ export function KanbanPane() {
         onExpandAllCards={() => expandAllCards()}
         onCollapseAllCards={() => collapseAllCards()}
         onOpenPlanningView={() => setRightPaneOverride('planning')}
+        onOpenAgentActivityView={() => setRightPaneOverride('agent_activity')}
         onRefresh={() => {
           if (refreshDisabled) {
             return

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -52,7 +52,7 @@ export const IPC_CHANNELS = {
   symphonyDashboardSnapshot: 'symphony:dashboard-snapshot',
   agentActivityGetSnapshot: 'agentActivity:get-snapshot',
   agentActivityUpdate: 'agentActivity:update',
-  agentActivityDismissPinnedError: 'agentActivity:dismiss-pinned-error',
+  agentActivitySetPinnedEvent: 'agentActivity:set-pinned-event',
   mcpListServers: 'mcp:list-servers',
   mcpGetServer: 'mcp:get-server',
   mcpSaveServer: 'mcp:save-server',
@@ -1244,32 +1244,36 @@ export interface AgentActivityEvent {
   details?: Record<string, unknown>
 }
 
-export interface AgentPinnedErrorIncident {
-  incidentId: string
-  fingerprint: string
+export interface AgentPinnedEvent {
+  eventId: string
+  pinnedAt: string
+  automatic: boolean
+  timestamp: string
   source: AgentActivitySource
+  severity: AgentActivitySeverity
   kind: string
   message: string
-  severity: 'error'
-  firstSeenAt: string
-  lastSeenAt: string
-  occurrences: number
-  lastEventId: string
+  workerId?: string
+  issueId?: string
+  issueIdentifier?: string
+  requestId?: string
+  connectionState?: SymphonyOperatorConnectionState
+  details?: Record<string, unknown>
 }
 
 export interface AgentActivitySnapshot {
   generatedAt: string
   events: AgentActivityEvent[]
   verbose: AgentActivityEvent[]
-  pinnedErrors: AgentPinnedErrorIncident[]
+  pinnedEvents: AgentPinnedEvent[]
 }
 
 export interface AgentActivityUpdate {
   generatedAt: string
   appendedEvents?: AgentActivityEvent[]
   appendedVerbose?: AgentActivityEvent[]
-  upsertedPinnedErrors?: AgentPinnedErrorIncident[]
-  removedPinnedErrorIds?: string[]
+  upsertedPinnedEvents?: AgentPinnedEvent[]
+  removedPinnedEventIds?: string[]
 }
 
 export interface AgentActivitySnapshotResponse {
@@ -1277,9 +1281,10 @@ export interface AgentActivitySnapshotResponse {
   snapshot: AgentActivitySnapshot
 }
 
-export interface AgentActivityDismissPinnedErrorResponse {
+export interface AgentActivitySetPinnedEventResponse {
   success: boolean
-  incidentId: string
+  eventId: string
+  pinned: boolean
   snapshot: AgentActivitySnapshot
 }
 
@@ -1824,7 +1829,7 @@ export interface DesktopApi {
   }
   agentActivity: {
     getSnapshot: () => Promise<AgentActivitySnapshotResponse>
-    dismissPinnedError: (incidentId: string) => Promise<AgentActivityDismissPinnedErrorResponse>
+    setPinnedEvent: (eventId: string, pinned: boolean) => Promise<AgentActivitySetPinnedEventResponse>
     onUpdate: (listener: (update: AgentActivityUpdate) => void) => () => void
   }
   mcp: {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -50,6 +50,9 @@ export const IPC_CHANNELS = {
   symphonyRefreshDashboard: 'symphony:refresh-dashboard',
   symphonyRespondEscalation: 'symphony:respond-escalation',
   symphonyDashboardSnapshot: 'symphony:dashboard-snapshot',
+  agentActivityGetSnapshot: 'agentActivity:get-snapshot',
+  agentActivityUpdate: 'agentActivity:update',
+  agentActivityDismissPinnedError: 'agentActivity:dismiss-pinned-error',
   mcpListServers: 'mcp:list-servers',
   mcpGetServer: 'mcp:get-server',
   mcpSaveServer: 'mcp:save-server',
@@ -696,7 +699,7 @@ export interface WorkflowContextSnapshot {
   updatedAt: string
 }
 
-export type RightPaneMode = 'planning' | 'kanban'
+export type RightPaneMode = 'planning' | 'kanban' | 'agent_activity'
 
 export type RightPaneOverride = RightPaneMode | null
 
@@ -1215,6 +1218,67 @@ export interface SymphonyEscalationResponseCommandResult {
   success: boolean
   snapshot: SymphonyOperatorSnapshot
   result?: SymphonyEscalationResponseResult
+}
+
+export type AgentActivityStream = 'events' | 'verbose'
+
+export type AgentActivitySource = 'runtime' | 'worker' | 'escalation' | 'connection' | 'system'
+
+export type AgentActivitySeverity = 'info' | 'warning' | 'error'
+
+export interface AgentActivityEvent {
+  id: string
+  timestamp: string
+  stream: AgentActivityStream
+  source: AgentActivitySource
+  severity: AgentActivitySeverity
+  kind: string
+  message: string
+  workerId?: string
+  issueId?: string
+  issueIdentifier?: string
+  requestId?: string
+  connectionState?: SymphonyOperatorConnectionState
+  details?: Record<string, unknown>
+}
+
+export interface AgentPinnedErrorIncident {
+  incidentId: string
+  fingerprint: string
+  source: AgentActivitySource
+  kind: string
+  message: string
+  severity: 'error'
+  firstSeenAt: string
+  lastSeenAt: string
+  occurrences: number
+  lastEventId: string
+}
+
+export interface AgentActivitySnapshot {
+  generatedAt: string
+  events: AgentActivityEvent[]
+  verbose: AgentActivityEvent[]
+  pinnedErrors: AgentPinnedErrorIncident[]
+}
+
+export interface AgentActivityUpdate {
+  generatedAt: string
+  appendedEvents?: AgentActivityEvent[]
+  appendedVerbose?: AgentActivityEvent[]
+  upsertedPinnedErrors?: AgentPinnedErrorIncident[]
+  removedPinnedErrorIds?: string[]
+}
+
+export interface AgentActivitySnapshotResponse {
+  success: boolean
+  snapshot: AgentActivitySnapshot
+}
+
+export interface AgentActivityDismissPinnedErrorResponse {
+  success: boolean
+  incidentId: string
+  snapshot: AgentActivitySnapshot
 }
 
 export type McpServerTransport = 'stdio' | 'http'
@@ -1755,6 +1819,11 @@ export interface DesktopApi {
       responseText: string,
     ) => Promise<SymphonyEscalationResponseCommandResult>
     onDashboardSnapshot: (listener: (snapshot: SymphonyOperatorSnapshot) => void) => () => void
+  }
+  agentActivity: {
+    getSnapshot: () => Promise<AgentActivitySnapshotResponse>
+    dismissPinnedError: (incidentId: string) => Promise<AgentActivityDismissPinnedErrorResponse>
+    onUpdate: (listener: (update: AgentActivityUpdate) => void) => () => void
   }
   mcp: {
     listServers: () => Promise<McpConfigReadResponse>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1228,6 +1228,9 @@ export type AgentActivitySource = 'runtime' | 'worker' | 'escalation' | 'connect
 
 export type AgentActivitySeverity = 'info' | 'warning' | 'error'
 
+export const AGENT_ACTIVITY_EVENT_CAP = 2_000
+export const AGENT_ACTIVITY_VERBOSE_CAP = 20_000
+
 export interface AgentActivityEvent {
   id: string
   timestamp: string

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1163,6 +1163,8 @@ export interface SymphonyOperatorWorkerRow {
   state: string
   toolName: string
   model: string
+  sessionId?: string
+  workspacePath?: string
   lastActivityAt?: string
   lastError?: string
 }

--- a/docs/superpowers/specs/2026-04-23-agent-activity-design.md
+++ b/docs/superpowers/specs/2026-04-23-agent-activity-design.md
@@ -123,6 +123,23 @@ Renderer mode/filter state is local UI state; journal data remains main-owned.
 `Settings -> Symphony` remains for runtime controls and baseline health view in v1.  
 `Agent Activity` becomes the primary real-time observability surface.
 
+## 6.4 Unit Boundaries and Interfaces
+
+1. `SymphonySupervisor`
+   - owns process lifecycle and runtime status emission
+   - does not own timeline/pinning concerns
+2. `SymphonyOperatorService`
+   - owns Symphony API/WebSocket integration and operator snapshot assembly
+   - does not own renderer presentation state
+3. `AgentActivityJournal` (new)
+   - owns normalized event creation, buffering, pinned-error lifecycle, and publish deltas
+   - consumes events from runtime/operator services through explicit methods
+4. `Renderer AgentActivity atoms/components`
+   - own view mode (`Events|Verbose`), filtering, scroll behavior, and presentation
+   - do not derive semantic events from raw Symphony snapshots
+
+Interface contract principle: producer services emit domain signals, journal normalizes and stores, renderer only displays and interacts through IPC commands.
+
 ## 7) Data Model
 
 ## 7.1 Normalized Event
@@ -248,6 +265,11 @@ Renderer flow:
 ## 11.2 Surface Navigation
 
 Add a clear one-click affordance from existing shell controls to open `Agent Activity`.
+
+Recommended v1 entry points:
+
+1. right-pane header mode switch (`Kanban | Planning | Agent Activity`)
+2. optional quick action on Symphony status badge to open pane directly
 
 ## 12) Scroll and Anchor Semantics
 

--- a/docs/superpowers/specs/2026-04-23-agent-activity-design.md
+++ b/docs/superpowers/specs/2026-04-23-agent-activity-design.md
@@ -1,0 +1,317 @@
+# Agent Activity Observability Design
+
+**Date:** 2026-04-23  
+**Status:** Approved (design)  
+**Scope:** Kata Desktop Symphony observability in right pane
+
+## 1) Problem
+
+Current Symphony observability is split across:
+
+1. ephemeral status hints in the main desktop surfaces
+2. `Settings -> Symphony` runtime/dashboard panels
+3. the local Symphony HTTP dashboard (`localhost:8080`)
+
+This creates three practical issues:
+
+1. worker/tool activity is visible but not durable enough for investigation
+2. operators cannot reliably scroll a unified timeline backward/forward
+3. error state is not persistently separated and surfaced as pinned incidents
+
+## 2) Goals
+
+1. Add a first-class, always-available right-pane observability surface named `Agent Activity`.
+2. Provide real-time activity monitoring with timeline navigation.
+3. Separate pinned errors from general activity.
+4. Support two densities:
+   1. `Events` (default, curated meaningful changes)
+   2. `Verbose` (debug-level, high-volume stream visibility)
+5. Keep data in memory for the current desktop session only (v1).
+
+## 3) Non-goals
+
+1. No persistence across desktop restarts in v1.
+2. No replacement/removal of existing Symphony runtime controls in Settings.
+3. No backend protocol changes in Symphony server for v1.
+
+## 4) Product Decisions (Locked)
+
+1. Location: right-pane first-class mode.
+2. Label: `Agent Activity`.
+3. Retention scope: current desktop session only.
+4. Error pinning: auto-pin all error-level events until manually dismissed.
+5. Mode switch UX: segmented control `Events | Verbose`.
+6. Architecture baseline: main-process event journal (single source of truth).
+
+## 5) UX Design
+
+## 5.1 Pane Layout
+
+`Agent Activity` uses a two-region layout:
+
+1. `Pinned Errors` region (top)
+2. `Timeline` region (main, scrollable)
+
+## 5.2 Pinned Errors
+
+Each pinned incident shows:
+
+1. severity
+2. source (`runtime`, `worker`, `escalation`, `connection`, `system`)
+3. concise message
+4. first seen timestamp
+5. last seen timestamp
+6. occurrence count
+
+Actions:
+
+1. `Dismiss` removes incident from pinned region only.
+2. Dismissal does not remove historical timeline events.
+3. Recurrence of the same fingerprinted error re-pins as active.
+
+## 5.3 Timeline
+
+Header controls:
+
+1. segmented control: `Events | Verbose`
+2. source filter
+3. severity filter
+4. `Jump to latest` action
+
+Behavior:
+
+1. auto-follow when user is near bottom
+2. if user scrolls up, auto-follow pauses and unseen counter appears
+3. switching `Events`/`Verbose` preserves time/position anchor
+
+Row content:
+
+1. timestamp
+2. event type badge
+3. worker/issue context where available
+4. summary message
+5. expandable details payload (especially for `Verbose`)
+
+## 6) Architecture
+
+## 6.1 Main Process: `AgentActivityJournal`
+
+Add a new main-process service that normalizes and journals observability events.
+
+Responsibilities:
+
+1. ingest runtime/operator/escalation/connection signals
+2. normalize to shared event schema
+3. maintain ring buffers for `events` and `verbose`
+4. maintain active `pinnedErrors`
+5. publish snapshot and incremental updates over IPC
+
+This becomes the source of truth for renderer observability state.
+
+## 6.2 Renderer
+
+Add new right-pane mode and pane component:
+
+1. right-pane mode: `agent_activity`
+2. component: `AgentActivityPane`
+3. atom bridge: initial hydrate + push subscriptions
+
+Renderer mode/filter state is local UI state; journal data remains main-owned.
+
+## 6.3 Existing Surfaces
+
+`Settings -> Symphony` remains for runtime controls and baseline health view in v1.  
+`Agent Activity` becomes the primary real-time observability surface.
+
+## 7) Data Model
+
+## 7.1 Normalized Event
+
+```ts
+interface AgentActivityEvent {
+  id: string
+  timestamp: string
+  stream: 'events' | 'verbose'
+  source: 'runtime' | 'worker' | 'escalation' | 'connection' | 'system'
+  severity: 'info' | 'warning' | 'error'
+  kind: string
+  message: string
+  workerId?: string
+  issueId?: string
+  issueIdentifier?: string
+  requestId?: string
+  connectionState?: 'connected' | 'reconnecting' | 'disconnected' | 'inactive'
+  details?: Record<string, unknown>
+}
+```
+
+## 7.2 Pinned Error Incident
+
+```ts
+interface AgentPinnedErrorIncident {
+  incidentId: string
+  fingerprint: string
+  source: AgentActivityEvent['source']
+  kind: string
+  message: string
+  severity: 'error'
+  firstSeenAt: string
+  lastSeenAt: string
+  occurrences: number
+  lastEventId: string
+  dismissedAt?: string
+}
+```
+
+Fingerprint recommendation:
+
+`source + kind + normalizedMessage + issue/request identity`
+
+## 7.3 Journal Snapshot and Delta
+
+```ts
+interface AgentActivitySnapshot {
+  generatedAt: string
+  events: AgentActivityEvent[]
+  verbose: AgentActivityEvent[]
+  pinnedErrors: AgentPinnedErrorIncident[]
+}
+
+interface AgentActivityUpdate {
+  generatedAt: string
+  appendedEvents?: AgentActivityEvent[]
+  appendedVerbose?: AgentActivityEvent[]
+  upsertedPinnedErrors?: AgentPinnedErrorIncident[]
+  removedPinnedErrorIds?: string[]
+}
+```
+
+## 8) Ingestion Rules
+
+## 8.1 Runtime Status
+
+From Symphony runtime phase/error transitions:
+
+1. phase change -> `events` + `verbose`
+2. diagnostics updates -> `verbose`
+3. runtime errors -> `events` + `verbose` + auto-pin
+
+## 8.2 Operator Snapshot
+
+Diff current vs previous snapshot and emit meaningful transitions:
+
+1. worker add/remove/state change/tool change/error change -> `events`
+2. per-update worker heartbeat/state payload details -> `verbose`
+3. escalation created/resolved/timed-out/cancelled -> `events`
+4. connection state transitions and stale/disconnect reasons -> `events`
+5. raw payload summaries -> `verbose`
+
+## 8.3 Escalation Response Commands
+
+1. submit success/failure -> `events`
+2. failure details -> `verbose`
+3. failure events are auto-pinned when severity is `error`
+
+## 9) Buffering and Retention
+
+Session-only memory retention with ring buffers:
+
+1. `events` cap: 2,000 (default)
+2. `verbose` cap: 20,000 (default)
+3. pinned incidents: active set only (dismissed retained only as timeline events)
+
+Caps are tunable constants in main process.
+
+## 10) IPC Contract
+
+New channels:
+
+1. `agentActivity:get-snapshot`
+2. `agentActivity:update` (push from main to renderer)
+3. `agentActivity:dismiss-pinned-error`
+4. optional future: `agentActivity:restore-pinned-error`
+
+Renderer flow:
+
+1. hydrate once with `get-snapshot`
+2. subscribe to push updates
+3. apply deltas without full-list replacement
+
+## 11) Right Pane Integration
+
+## 11.1 Type and Atom Updates
+
+1. extend `RightPaneMode`/override types to include `agent_activity`
+2. keep automatic resolution behavior unchanged
+3. allow explicit manual override to `agent_activity`
+
+## 11.2 Surface Navigation
+
+Add a clear one-click affordance from existing shell controls to open `Agent Activity`.
+
+## 12) Scroll and Anchor Semantics
+
+Use anchor preservation strategy:
+
+1. record top-visible anchor event id + pixel offset
+2. on mode switch/filter change, restore nearest matching event by id
+3. fallback to nearest timestamp when id not present
+
+This avoids disorienting reset during `Events | Verbose` toggles.
+
+## 13) Error Pinning Semantics
+
+Auto-pin behavior:
+
+1. every `severity=error` event upserts active incident by fingerprint
+2. repeated errors increment `occurrences` and update `lastSeenAt`
+3. dismissal marks incident inactive in pinned panel
+4. recurrence after dismissal creates/reactivates active incident state
+
+## 14) Testing Strategy
+
+## 14.1 Main Process Unit Tests
+
+1. normalization and diff emission correctness
+2. ring buffer truncation behavior
+3. pinned error upsert/dismiss/recurrence rules
+4. snapshot + delta shape stability
+
+## 14.2 Renderer Unit Tests
+
+1. `Events | Verbose` toggle and anchor preservation
+2. paused scroll vs auto-follow behavior
+3. unseen count indicator behavior
+4. pinned error rendering and dismiss action
+
+## 14.3 Integration/E2E
+
+1. worker lifecycle transitions appear in timeline
+2. escalation lifecycle appears in timeline
+3. disconnect/reconnect generates pinned/cleared incident behavior
+4. right-pane mode switch to `Agent Activity` works without Settings dependency
+
+## 15) Rollout Plan
+
+1. Implement behind feature flag for internal validation.
+2. Validate with real Symphony workloads.
+3. Enable by default after stability checks.
+4. Keep `Settings -> Symphony` runtime controls while directing observability workflows to `Agent Activity`.
+
+## 16) Risks and Mitigations
+
+1. Event flood in verbose mode.
+   - Mitigation: ring buffers + list virtualization.
+2. Duplicate noisy event emission from snapshot churn.
+   - Mitigation: semantic diff rules and dedupe guards.
+3. Drift between main and renderer interpretations.
+   - Mitigation: single normalized event contract with schema tests.
+
+## 17) Acceptance Criteria
+
+1. Operators can monitor worker activity in real time from right pane.
+2. Timeline supports backward/forward investigation without losing context.
+3. Pinned errors are isolated, durable during session, and dismissible.
+4. `Events` default remains readable under normal operation.
+5. `Verbose` mode exposes high-volume detail for debugging.
+6. No refresh loop required to keep the timeline current.

--- a/docs/superpowers/specs/2026-04-23-agent-activity-design.md
+++ b/docs/superpowers/specs/2026-04-23-agent-activity-design.md
@@ -16,13 +16,13 @@ This creates three practical issues:
 
 1. worker/tool activity is visible but not durable enough for investigation
 2. operators cannot reliably scroll a unified timeline backward/forward
-3. error state is not persistently separated and surfaced as pinned incidents
+3. error state is not persistently separated and surfaced as pinned events
 
 ## 2) Goals
 
 1. Add a first-class, always-available right-pane observability surface named `Agent Activity`.
 2. Provide real-time activity monitoring with timeline navigation.
-3. Separate pinned errors from general activity.
+3. Separate pinned events from general activity.
 4. Support two densities:
    1. `Events` (default, curated meaningful changes)
    2. `Verbose` (debug-level, high-volume stream visibility)
@@ -49,25 +49,25 @@ This creates three practical issues:
 
 `Agent Activity` uses a two-region layout:
 
-1. `Pinned Errors` region (top)
+1. `Pinned Events` region (top)
 2. `Timeline` region (main, scrollable)
 
-## 5.2 Pinned Errors
+## 5.2 Pinned Events
 
-Each pinned incident shows:
+Each pinned event shows:
 
 1. severity
 2. source (`runtime`, `worker`, `escalation`, `connection`, `system`)
 3. concise message
-4. first seen timestamp
-5. last seen timestamp
-6. occurrence count
+4. event timestamp
+5. pinned timestamp
+6. pin origin (auto vs manual)
 
 Actions:
 
-1. `Dismiss` removes incident from pinned region only.
-2. Dismissal does not remove historical timeline events.
-3. Recurrence of the same fingerprinted error re-pins as active.
+1. `Unpin` removes the event from pinned region only.
+2. Unpinning does not remove historical timeline events.
+3. Error-level events are auto-pinned, but can still be manually unpinned.
 
 ## 5.3 Timeline
 
@@ -103,7 +103,7 @@ Responsibilities:
 1. ingest runtime/operator/escalation/connection signals
 2. normalize to shared event schema
 3. maintain ring buffers for `events` and `verbose`
-4. maintain active `pinnedErrors`
+4. maintain active `pinnedEvents`
 5. publish snapshot and incremental updates over IPC
 
 This becomes the source of truth for renderer observability state.
@@ -132,7 +132,7 @@ Renderer mode/filter state is local UI state; journal data remains main-owned.
    - owns Symphony API/WebSocket integration and operator snapshot assembly
    - does not own renderer presentation state
 3. `AgentActivityJournal` (new)
-   - owns normalized event creation, buffering, pinned-error lifecycle, and publish deltas
+   - owns normalized event creation, buffering, pinned-event lifecycle, and publish deltas
    - consumes events from runtime/operator services through explicit methods
 4. `Renderer AgentActivity atoms/components`
    - own view mode (`Events|Verbose`), filtering, scroll behavior, and presentation
@@ -162,27 +162,26 @@ interface AgentActivityEvent {
 }
 ```
 
-## 7.2 Pinned Error Incident
+## 7.2 Pinned Event
 
 ```ts
-interface AgentPinnedErrorIncident {
-  incidentId: string
-  fingerprint: string
+interface AgentPinnedEvent {
+  eventId: string
+  pinnedAt: string
+  automatic: boolean
+  timestamp: string
   source: AgentActivityEvent['source']
   kind: string
   message: string
-  severity: 'error'
-  firstSeenAt: string
-  lastSeenAt: string
-  occurrences: number
-  lastEventId: string
-  dismissedAt?: string
+  severity: AgentActivityEvent['severity']
+  workerId?: string
+  issueId?: string
+  issueIdentifier?: string
+  requestId?: string
+  connectionState?: AgentActivityEvent['connectionState']
+  details?: Record<string, unknown>
 }
 ```
-
-Fingerprint recommendation:
-
-`source + kind + normalizedMessage + issue/request identity`
 
 ## 7.3 Journal Snapshot and Delta
 
@@ -191,15 +190,15 @@ interface AgentActivitySnapshot {
   generatedAt: string
   events: AgentActivityEvent[]
   verbose: AgentActivityEvent[]
-  pinnedErrors: AgentPinnedErrorIncident[]
+  pinnedEvents: AgentPinnedEvent[]
 }
 
 interface AgentActivityUpdate {
   generatedAt: string
   appendedEvents?: AgentActivityEvent[]
   appendedVerbose?: AgentActivityEvent[]
-  upsertedPinnedErrors?: AgentPinnedErrorIncident[]
-  removedPinnedErrorIds?: string[]
+  upsertedPinnedEvents?: AgentPinnedEvent[]
+  removedPinnedEventIds?: string[]
 }
 ```
 
@@ -235,7 +234,7 @@ Session-only memory retention with ring buffers:
 
 1. `events` cap: 2,000 (default)
 2. `verbose` cap: 20,000 (default)
-3. pinned incidents: active set only (dismissed retained only as timeline events)
+3. pinned events: active set only (unpinned events remain in timeline history)
 
 Caps are tunable constants in main process.
 
@@ -245,8 +244,7 @@ New channels:
 
 1. `agentActivity:get-snapshot`
 2. `agentActivity:update` (push from main to renderer)
-3. `agentActivity:dismiss-pinned-error`
-4. optional future: `agentActivity:restore-pinned-error`
+3. `agentActivity:set-pinned-event`
 
 Renderer flow:
 
@@ -281,14 +279,13 @@ Use anchor preservation strategy:
 
 This avoids disorienting reset during `Events | Verbose` toggles.
 
-## 13) Error Pinning Semantics
+## 13) Event Pinning Semantics
 
 Auto-pin behavior:
 
-1. every `severity=error` event upserts active incident by fingerprint
-2. repeated errors increment `occurrences` and update `lastSeenAt`
-3. dismissal marks incident inactive in pinned panel
-4. recurrence after dismissal creates/reactivates active incident state
+1. every `severity=error` event auto-pins that event by `eventId`
+2. any event can be manually pinned/unpinned from the timeline
+3. unpinning removes only the pinned-card entry, not the timeline row
 
 ## 14) Testing Strategy
 
@@ -296,7 +293,7 @@ Auto-pin behavior:
 
 1. normalization and diff emission correctness
 2. ring buffer truncation behavior
-3. pinned error upsert/dismiss/recurrence rules
+3. pinned event auto-pin/manual-pin/unpin rules
 4. snapshot + delta shape stability
 
 ## 14.2 Renderer Unit Tests
@@ -304,13 +301,13 @@ Auto-pin behavior:
 1. `Events | Verbose` toggle and anchor preservation
 2. paused scroll vs auto-follow behavior
 3. unseen count indicator behavior
-4. pinned error rendering and dismiss action
+4. pinned event rendering and unpin action
 
 ## 14.3 Integration/E2E
 
 1. worker lifecycle transitions appear in timeline
 2. escalation lifecycle appears in timeline
-3. disconnect/reconnect generates pinned/cleared incident behavior
+3. disconnect/reconnect generates corresponding pinned-event behavior
 4. right-pane mode switch to `Agent Activity` works without Settings dependency
 
 ## 15) Rollout Plan


### PR DESCRIPTION
## Summary
- rename Agent Activity labels for clarity (`Pinned Events`, `Event Log`)
- support pinning/unpinning any activity event from the timeline (errors still auto-pin)
- replace pinned-error model with a generalized pinned-event model across IPC, state, and renderer
- add a runtime overview panel under Agent Activity with key Symphony runtime/session stats
- bump Desktop version `0.2.5 -> 0.2.6` in `apps/desktop/package.json`
- add `0.2.6` release notes to `apps/desktop/CHANGELOG.md`

## Testing
- `pnpm --filter @kata/desktop typecheck`
- `pnpm --filter @kata/desktop test -- src/main/__tests__/agent-activity-journal.test.ts src/main/__tests__/symphony-ipc.test.ts src/renderer/atoms/__tests__/agent-activity.test.ts src/renderer/components/agent-activity/__tests__/AgentActivityPane.test.tsx`
- pre-push hook: `pnpm exec turbo run lint typecheck test --affected` (passed)

## Notes
- No `.github/pull_request_template.md` exists in this repo, so this body uses a standard summary/testing format.
- Per request, the release bump was done on the existing feature branch/PR (no separate release branch).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a first-class `Agent Activity` right-pane surface for Kata Desktop, adding an `AgentActivityJournal` main-process service that normalises and ring-buffers observability events from the Symphony runtime, operator service, and CLI workers, then streams them to a new renderer pane via IPC deltas. It also generalises the pinned-error model to support manual pin/unpin of any event, adds a runtime overview panel, and plumbs `sessionId`/`workspacePath` into `SymphonyOperatorWorkerRow` for per-worker session history ingestion.

- **P1 (`agent-activity.ts` `useAgentActivityBridge`):** A push update arriving during the async `getSnapshot()` IPC call sets `receivedPush = true` and causes the initial snapshot to be permanently skipped. Because the push only carries an incremental delta, the renderer starts from an empty state and loses all events captured before the component mounted.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the initial-load race condition in useAgentActivityBridge; remaining findings are minor.

One P1 logic bug: the receivedPush guard in useAgentActivityBridge can silently discard the full historical snapshot when any push arrives during the async IPC fetch. All other findings are P2. Core journal, pinning model, IPC wiring, and tests are solid.

apps/desktop/src/renderer/atoms/agent-activity.ts — useAgentActivityBridge initial-load race condition.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/agent-activity-journal.ts | New main-process journal service: ring-buffered event storage, per-event pinning, and delta emission. Well-structured with typed event input interfaces and robust buffer trimming. |
| apps/desktop/src/renderer/atoms/agent-activity.ts | New renderer atom bridge: incremental update application, unseen count, filters, and IPC hydration — but the initial-load guard has a race condition that discards historical events when a push arrives during the async fetch. |
| apps/desktop/src/main/ipc.ts | Wires the journal into existing IPC handlers; adds worker session history cursor syncing with a retry-path stat call that is not wrapped in try/catch, leaving the cursor in a stale path on double-rotation failure. |
| apps/desktop/src/renderer/components/agent-activity/RuntimeOverviewPanel.tsx | New runtime overview panel using existing symphony atoms; formatAge is computed at render time and becomes stale between pushes. |
| apps/desktop/src/renderer/components/agent-activity/AgentActivityPane.tsx | Composes RuntimeOverviewPanel, PinnedErrorPanel, and ActivityTimeline with mode/source/severity filter controls and right-pane navigation buttons. |
| apps/desktop/src/shared/types.ts | Adds IPC channel constants, AgentActivityEvent/Snapshot/Update/Pinned types, and extends RightPaneMode with agent_activity; also adds optional sessionId/workspacePath to SymphonyOperatorWorkerRow. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Renderer
    participant IPC
    participant AgentActivityJournal
    participant SymphonySupervisor
    participant SymphonyOperatorService

    SymphonySupervisor->>AgentActivityJournal: ingestRuntimeStatus(status)
    SymphonyOperatorService->>AgentActivityJournal: ingestOperatorSnapshot(snapshot)
    SymphonyOperatorService->>IPC: enqueueWorkerSessionActivitySync(workers)
    IPC->>AgentActivityJournal: ingestCliChatEvent(event, context)
    AgentActivityJournal-->>IPC: emit('update', delta)
    IPC->>Renderer: agentActivityUpdate (IPC push)

    Renderer->>IPC: agentActivityGetSnapshot (initial hydrate)
    IPC->>AgentActivityJournal: getSnapshot()
    AgentActivityJournal-->>IPC: AgentActivitySnapshot
    IPC-->>Renderer: AgentActivitySnapshotResponse

    Renderer->>IPC: agentActivitySetPinnedEvent(eventId, pinned)
    IPC->>AgentActivityJournal: setPinnedEvent(eventId, pinned)
    AgentActivityJournal-->>IPC: AgentActivitySnapshot (updated)
    IPC-->>Renderer: AgentActivitySetPinnedEventResponse
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/desktop/src/renderer/atoms/agent-activity.ts`, line 2310-2338 ([link](https://github.com/gannonh/kata/blob/2773b53d08cdf793b52645f98ac151478cf585c5/apps/desktop/src/renderer/atoms/agent-activity.ts#L2310-L2338)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Race condition: push arriving before snapshot load discards all historical events**

   If the main process emits a push update during the IPC round-trip for `getSnapshot()`, `receivedPush` becomes `true` and the initial snapshot is permanently skipped. Because the push contains only an incremental delta (e.g. `appendedEvents: [oneNewEvent]`), the renderer starts from an empty state — losing all events that existed in the journal before the component mounted.

   A safer pattern is to always apply the snapshot and replay any out-of-order deltas on top, or to compare `generatedAt` timestamps so the snapshot is only dropped when it is truly stale.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/atoms/agent-activity.ts
   Line: 2310-2338

   Comment:
   **Race condition: push arriving before snapshot load discards all historical events**

   If the main process emits a push update during the IPC round-trip for `getSnapshot()`, `receivedPush` becomes `true` and the initial snapshot is permanently skipped. Because the push contains only an incremental delta (e.g. `appendedEvents: [oneNewEvent]`), the renderer starts from an empty state — losing all events that existed in the journal before the component mounted.

   A safer pattern is to always apply the snapshot and replay any out-of-order deltas on top, or to compare `generatedAt` timestamps so the snapshot is only dropped when it is truly stale.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/desktop/src/main/ipc.ts`, line 1584-1600 ([link](https://github.com/gannonh/kata/blob/2773b53d08cdf793b52645f98ac151478cf585c5/apps/desktop/src/main/ipc.ts#L1584-L1600)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Retry-path `fs.stat` is not guarded — cursor left in inconsistent state on failure**

   After the first `stat` throws the code retries with a freshly resolved path. However the second `await fs.stat(cursor.sessionPath)` is outside the `try/catch`, so if the newly resolved path also doesn't exist, the cursor's `sessionPath` has already been updated to the failed retry path — every subsequent poll will attempt to stat that stale path and emit the same warning until the worker is evicted.

   Wrapping the retry `stat` in the same block (or resetting `cursor.sessionPath = null` before returning on failure) would prevent the repeated-warning loop.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/ipc.ts
   Line: 1584-1600

   Comment:
   **Retry-path `fs.stat` is not guarded — cursor left in inconsistent state on failure**

   After the first `stat` throws the code retries with a freshly resolved path. However the second `await fs.stat(cursor.sessionPath)` is outside the `try/catch`, so if the newly resolved path also doesn't exist, the cursor's `sessionPath` has already been updated to the failed retry path — every subsequent poll will attempt to stat that stale path and emit the same warning until the worker is evicted.

   Wrapping the retry `stat` in the same block (or resetting `cursor.sessionPath = null` before returning on failure) would prevent the repeated-warning loop.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `apps/desktop/src/renderer/components/agent-activity/RuntimeOverviewPanel.tsx`, line 2734-2744 ([link](https://github.com/gannonh/kata/blob/2773b53d08cdf793b52645f98ac151478cf585c5/apps/desktop/src/renderer/components/agent-activity/RuntimeOverviewPanel.tsx#L2734-L2744)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`formatAge` is computed once at render time and never refreshes**

   `formatAge` calls `Date.now()` at render time, so the "Xs ago" display only updates when the component re-renders for another reason (e.g. a new snapshot push). In a quiet session the displayed age can lag by minutes. A `setInterval`-based `useNow()` hook would keep the relative timestamps live without requiring changes to the data model.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/agent-activity/RuntimeOverviewPanel.tsx
   Line: 2734-2744

   Comment:
   **`formatAge` is computed once at render time and never refreshes**

   `formatAge` calls `Date.now()` at render time, so the "Xs ago" display only updates when the component re-renders for another reason (e.g. a new snapshot push). In a quiet session the displayed age can lag by minutes. A `setInterval`-based `useNow()` hook would keep the relative timestamps live without requiring changes to the data model.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/atoms/agent-activity.ts
Line: 2310-2338

Comment:
**Race condition: push arriving before snapshot load discards all historical events**

If the main process emits a push update during the IPC round-trip for `getSnapshot()`, `receivedPush` becomes `true` and the initial snapshot is permanently skipped. Because the push contains only an incremental delta (e.g. `appendedEvents: [oneNewEvent]`), the renderer starts from an empty state — losing all events that existed in the journal before the component mounted.

A safer pattern is to always apply the snapshot and replay any out-of-order deltas on top, or to compare `generatedAt` timestamps so the snapshot is only dropped when it is truly stale.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/ipc.ts
Line: 1584-1600

Comment:
**Retry-path `fs.stat` is not guarded — cursor left in inconsistent state on failure**

After the first `stat` throws the code retries with a freshly resolved path. However the second `await fs.stat(cursor.sessionPath)` is outside the `try/catch`, so if the newly resolved path also doesn't exist, the cursor's `sessionPath` has already been updated to the failed retry path — every subsequent poll will attempt to stat that stale path and emit the same warning until the worker is evicted.

Wrapping the retry `stat` in the same block (or resetting `cursor.sessionPath = null` before returning on failure) would prevent the repeated-warning loop.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/agent-activity/RuntimeOverviewPanel.tsx
Line: 2734-2744

Comment:
**`formatAge` is computed once at render time and never refreshes**

`formatAge` calls `Date.now()` at render time, so the "Xs ago" display only updates when the component re-renders for another reason (e.g. a new snapshot push). In a quiet session the displayed age can lag by minutes. A `setInterval`-based `useNow()` hook would keep the relative timestamps live without requiring changes to the data model.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump desktop to 0.2.6"](https://github.com/gannonh/kata/commit/2773b53d08cdf793b52645f98ac151478cf585c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29514281)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Agent Activity pane with an interactive timeline displaying system events and activities
  * Introduced pinned events panel to highlight and manage important errors and notifications
  * Added runtime overview with session status and activity metrics
  * Enabled event filtering by type (events/verbose), source, and severity
  * Implemented auto-follow capability with manual controls to jump to latest updates
  * Added quick access to agent activity view from the kanban interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->