### PR TITLE
Fix/kata step desktop

### DIFF
--- a/apps/cli/src/resources/extensions/kata/commands.ts
+++ b/apps/cli/src/resources/extensions/kata/commands.ts
@@ -452,7 +452,20 @@ export function registerKataCommand(pi: ExtensionAPI): void {
         ctx.ui.notify(`/kata step: ${state.phase} — ${unitId}`, "info");
         ctx.ui.setStatus("kata-auto", "step");
         setStepActive(true);
-        pi.sendMessage({ customType: "kata-step", content: prompt, display: false }, { triggerTurn: true });
+        try {
+          if (ctx.isIdle()) {
+            await pi.sendUserMessage(prompt);
+          } else {
+            await pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+          }
+        } catch (err) {
+          setStepActive(false);
+          ctx.ui.setStatus("kata-auto", undefined);
+          ctx.ui.notify(
+            `Step dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
+            "error",
+          );
+        }
         return;
       }
 

--- a/apps/cli/src/resources/extensions/kata/tests/commands-step-dispatch.test.ts
+++ b/apps/cli/src/resources/extensions/kata/tests/commands-step-dispatch.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const commandsPath = join(__dirname, "..", "commands.ts");
+
+test("/kata step dispatches via sendUserMessage instead of hidden custom-message triggerTurn", () => {
+  const source = readFileSync(commandsPath, "utf8");
+
+  assert.match(
+    source,
+    /await pi\.sendUserMessage\(prompt\)/,
+    "expected /kata step to dispatch the generated prompt as a user message",
+  );
+  assert.doesNotMatch(
+    source,
+    /customType:\s*"kata-step"/,
+    "expected /kata step to stop relying on the hidden kata-step custom message",
+  );
+});

--- a/docs/pi-skills-migraqtion.md
+++ b/docs/pi-skills-migraqtion.md
@@ -1,0 +1,42 @@
+
+We are migrating Kata CLI away from its current implementation as a custom CLI built on top of the Pi coding agent.
+
+Current state:
+
+- Kata CLI is tightly coupled to the Pi coding agent.
+- It includes custom frontend loading behavior plus Pi-specific extensions.
+- The desktop app currently relies on this custom CLI layer via RPC mode.
+
+Target state:
+
+- Kata’s planning and execution capabilities become a set of Agent Skills, coupled with a standalone npm CLI that can run from any compatible harness.
+- Target harnesses include Pi coding agent, Claude Code, OpenAI Codex, GitHub Copilot, and other similar agent environments that support the agent Skills standard.
+- The harness-agnostic parts of the system should be expressed as reusable agent skills.
+- Backend operations such as Linear and GitHub interactions should be handled through the Node-based CLI layer.
+- The desktop app should continue using the Pi coding agent in RPC mode, but it should call Pi directly rather than going through the custom Kata CLI.
+- Symphony will remain the primary autonomous project execution layer for Kata planned projects and will remain unchanged.
+
+Kata Orchestrator:
+
+- We currently have a product in the monorepo called Kata Orchestrator, an agent skills-based project planning and execution product : apps/orchestrator
+- What is described here will be a replacement for that.
+- We should leverage the structural and architectural components of orchestrator, but adapt it for GitHub and linear backends using the CLI layer instead of local markdown files.
+
+What I want you to produce:
+
+- A clear proposed architecture for the new Kata CLI and skill model.
+- A separation of responsibilities between:
+  - harness-agnostic agent skills
+  - the Node-based backend CLI
+  - harness-specific adapters or integration layers
+  - the desktop app
+- So long as the planned artifacts are unchanged, no migration, backwards compatability or fallbacks will be necessary.
+- Recommended packaging and distribution strategy for the npm CLI and skills.
+- Risks, tradeoffs, and compatibility concerns across different harnesses.
+
+Important constraints:
+
+- Optimize for portability across multiple agent harnesses (Agent Skills focused implementation).
+- Preserve desktop support through direct Pi RPC integration.
+- Ensure the resulting system supports both interactive use in external harnesses and autonomous execution through Symphony.
+- Prefer industry-standard skill or tool patterns wherever practical.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and user feedback when command dispatch operations fail
  * Enhanced command delivery logic for increased reliability

* **Tests**
  * Added test coverage for command dispatch behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the hidden `pi.sendMessage({ customType: \"kata-step\" })` fire-and-forget call in `/kata step` with `await pi.sendUserMessage(prompt)`, branching on `ctx.isIdle()` to use a `followUp` delivery mode when the agent is busy. Error handling correctly resets `stepActive` and the status badge since `agent_end` won't fire on a failed dispatch.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only P2 findings (doc filename typo, minor test regex ambiguity)

Core logic change is correct — success path relies on agent_end to clear state, error path resets it explicitly. All findings are P2 style issues.

No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/src/resources/extensions/kata/commands.ts | Replaces fire-and-forget pi.sendMessage with awaited pi.sendUserMessage; idle/non-idle dispatch paths are correct, error handling properly resets stepActive and status badge |
| apps/cli/src/resources/extensions/kata/tests/commands-step-dispatch.test.ts | Source-text regression test verifying migration from customType kata-step to sendUserMessage; idle-path regex is a substring match that also covers the followUp branch but the intent could be clearer |
| docs/pi-skills-migraqtion.md | New architecture/migration planning document; filename contains a typo ("migraqtion" vs "migration") |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/kata step command"] --> B[Resolve state and model]
    B --> C["setStepActive(true) + setStatus(step)"]
    C --> D{"ctx.isIdle()"}
    D -->|yes| E["await pi.sendUserMessage(prompt)"]
    D -->|no| F["await pi.sendUserMessage(prompt, followUp)"]
    E -->|success| G["agent_end fires: setStepActive(false) + clearStatus"]
    F -->|success| G
    E -->|throws| H["catch: setStepActive(false) + clearStatus + notify error"]
    F -->|throws| H
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/pi-skills-migraqtion.md
Line: 1

Comment:
**Filename typo: "migraqtion"**

The file is named `pi-skills-migraqtion.md` but should be `pi-skills-migration.md`. The extra `q` in the filename is a typo that may make the file hard to find or reference consistently.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/cli/src/resources/extensions/kata/tests/commands-step-dispatch.test.ts
Line: 13-17

Comment:
**Test regex matches only the idle-path signature**

The `assert.match` checks for `await pi.sendUserMessage(prompt)` (no second argument), which happens to match both the idle and `followUp` branches as a substring. However, if the idle branch is ever refactored away and only the `followUp` branch remains — `await pi.sendUserMessage(prompt, { deliverAs: "followUp" })` — the regex would still pass because the pattern is a substring match. A tighter pattern like `/await pi\.sendUserMessage\(prompt(,|\))/` would make the assertion more intentional about accepting both call forms.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add migration plan for Kata CLI to..."](https://github.com/gannonh/kata/commit/43f7101fb1a8ab4731992cfb68e4161470ae858a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29768108)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->