### PR TITLE
Advance Symphony Pi migration defaults and Kata verification hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,3 +114,17 @@ This repo uses git worktrees. Each worktree has a standby branch (e.g. `wt-cli-s
 - Electron main process runs in Node.js, not Bun. Don't use `import.meta.dir` or Bun-only APIs in code that runs there.
 - Asset paths: use `getBundledAssetsDir(subfolder)` for bundled assets, never `import.meta.dir`.
 - Desktop debug logs: check Electron main process console or `apps/desktop/src/main/logger.ts`.
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues for `gannonh/kata`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses the default five-label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Domain docs use a single-context layout. See `docs/agents/domain.md`.

--- a/apps/cli/scripts/bundle-skills.mjs
+++ b/apps/cli/scripts/bundle-skills.mjs
@@ -56,9 +56,12 @@ const inputRequiredOperations = new Set([
 ]);
 
 const skillCallCommand = "node <path-to-skill-directory>/scripts/kata-call.mjs";
+const artifactInputCommand = "node <path-to-skill-directory>/scripts/kata-artifact-input.mjs";
 
 function normalizeSkillCommandReferences(markdown) {
-  return markdown.replaceAll("node ./scripts/kata-call.mjs", skillCallCommand);
+  return markdown
+    .replaceAll("node ./scripts/kata-call.mjs", skillCallCommand)
+    .replaceAll("node ./scripts/kata-artifact-input.mjs", artifactInputCommand);
 }
 
 async function pathExists(filePath) {
@@ -273,6 +276,7 @@ function renderSkillMarkdown(skill) {
     "- CLI command patterns: `references/cli-runtime.md`",
     "- Artifact conventions: `references/artifact-contract.md`",
     "- CLI helper: `scripts/kata-call.mjs`",
+    "- Artifact input helper: `scripts/kata-artifact-input.mjs`",
     ...(extraReferences.length > 0 ? ["", "Additional references:", "", ...extraReferences] : []),
     ...(templates.length > 0 ? ["", "Templates:", "", ...templates] : []),
     "",

--- a/apps/cli/skills-src/references/artifact-contract.md
+++ b/apps/cli/skills-src/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills-src/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills-src/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/skills-src/templates/roadmap.md
+++ b/apps/cli/skills-src/templates/roadmap.md
@@ -24,24 +24,24 @@ Use this as the content shape for milestone-scoped `roadmap` artifacts.
 
 **Planned Slices:**
 
-- [ ] S001: [Slice title]
+- [ ] Planned Slice 1: [Slice title]
 
 ## Traceability
 
-| Requirement | Phase/Slice | Status |
+| Requirement | Phase/Planned Slice | Status |
 |---|---|---|
-| REQ-01 | Phase 1 / S001 | Pending |
+| REQ-01 | Phase 1 / Planned Slice 1 | Pending |
 
 ## Progress
 
-| Phase | Status | Requirements | Slices |
+| Phase | Status | Requirements | Planned Slices |
 |---|---|---|---|
-| 1 | Pending | REQ-01 | S001 |
+| 1 | Pending | REQ-01 | Planned Slice 1 |
 ```
 
 ## Guidance
 
 - Derive phases from requirements; do not impose arbitrary structure.
 - Every active requirement should map to exactly one primary phase/slice.
+- Do not preassign backend slice IDs such as `S001` in milestone roadmaps. Backend slice IDs are global and are only known after `slice.create` returns them.
 - Success criteria must be observable from the user or system boundary.
-

--- a/apps/cli/skills-src/templates/roadmap.md
+++ b/apps/cli/skills-src/templates/roadmap.md
@@ -43,5 +43,5 @@ Use this as the content shape for milestone-scoped `roadmap` artifacts.
 
 - Derive phases from requirements; do not impose arbitrary structure.
 - Every active requirement should map to exactly one primary phase/slice.
-- Do not preassign backend slice IDs such as `S001` in milestone roadmaps. Backend slice IDs are global and are only known after `slice.create` returns them.
+- Do not preassign backend slice IDs such as `S001` in milestone roadmaps. Backend slice IDs are global and are only known after `slice.create` returns them. Once a backend slice ID exists, record it using an explicit keyworded format such as `Backend Slice: S001`, `Slice ID: S001`, or a table column named `Backend Slice ID`; avoid bare forms like `S001:`.
 - Success criteria must be observable from the user or system boundary.

--- a/apps/cli/skills-src/workflows/verify-work.md
+++ b/apps/cli/skills-src/workflows/verify-work.md
@@ -77,6 +77,51 @@ Ask the user to confirm actual behavior only when the plan calls for manual obse
 
 ## Stage 3: Write Verification Artifact
 
+Write artifact input files with a JSON encoder when the report contains Markdown
+tables, command snippets, quotes, or backticks. Do not hand-escape rich Markdown
+inside shell heredocs or JavaScript template literals; that is easy to corrupt
+and can cause failed artifact writes before verification state is updated.
+
+Example:
+
+```bash
+node - <<'NODE'
+const fs = require("node:fs");
+
+const content = [
+  "# Verification Report",
+  "",
+  "## Scope",
+  "",
+  "T001: Verify behavior",
+  "",
+  "## Evidence",
+  "",
+  "- `pnpm test` passed.",
+  "",
+  "## Result",
+  "",
+  "Verified",
+].join("\n");
+
+fs.writeFileSync(
+  "/tmp/kata-verification.json",
+  JSON.stringify(
+    {
+      scopeType: "task",
+      scopeId: "T001",
+      artifactType: "verification",
+      title: "T001 Verification",
+      content,
+      format: "markdown",
+    },
+    null,
+    2,
+  ),
+);
+NODE
+```
+
 ```json
 {
   "scopeType": "task",

--- a/apps/cli/skills-src/workflows/verify-work.md
+++ b/apps/cli/skills-src/workflows/verify-work.md
@@ -77,60 +77,38 @@ Ask the user to confirm actual behavior only when the plan calls for manual obse
 
 ## Stage 3: Write Verification Artifact
 
-Write artifact input files with a JSON encoder when the report contains Markdown
-tables, command snippets, quotes, or backticks. Do not hand-escape rich Markdown
-inside shell heredocs or JavaScript template literals; that is easy to corrupt
-and can cause failed artifact writes before verification state is updated.
+Write the verification report as Markdown first, then generate the artifact input
+JSON with `scripts/kata-artifact-input.mjs`. Do not hand-escape rich Markdown
+inside JSON heredocs or JavaScript template literals; verification reports often
+contain tables, command snippets, quotes, or backticks, and hand-escaped JSON is
+easy to corrupt before verification state is updated.
 
 Example:
 
 ```bash
-node - <<'NODE'
-const fs = require("node:fs");
+cat > /tmp/T001-verification.md <<'MARKDOWN'
+# Verification Report
 
-const content = [
-  "# Verification Report",
-  "",
-  "## Scope",
-  "",
-  "T001: Verify behavior",
-  "",
-  "## Evidence",
-  "",
-  "- `pnpm test` passed.",
-  "",
-  "## Result",
-  "",
-  "Verified",
-].join("\n");
+## Scope
 
-fs.writeFileSync(
-  "/tmp/kata-verification.json",
-  JSON.stringify(
-    {
-      scopeType: "task",
-      scopeId: "T001",
-      artifactType: "verification",
-      title: "T001 Verification",
-      content,
-      format: "markdown",
-    },
-    null,
-    2,
-  ),
-);
-NODE
-```
+T001: Verify behavior
 
-```json
-{
-  "scopeType": "task",
-  "scopeId": "T001",
-  "artifactType": "verification",
-  "title": "T001 Verification",
-  "content": "# Verification\n\n## Evidence\n\n...",
-  "format": "markdown"
-}
+## Evidence
+
+- `pnpm test` passed.
+
+## Result
+
+Verified
+MARKDOWN
+
+node ./scripts/kata-artifact-input.mjs \
+  --scope-type task \
+  --scope-id T001 \
+  --artifact-type verification \
+  --title "T001 Verification" \
+  --content-file /tmp/T001-verification.md \
+  --output /tmp/kata-verification.json
 ```
 
 ```bash

--- a/apps/cli/skills/kata-complete-milestone/SKILL.md
+++ b/apps/cli/skills/kata-complete-milestone/SKILL.md
@@ -54,6 +54,7 @@ Read when needed:
 - CLI command patterns: `references/cli-runtime.md`
 - Artifact conventions: `references/artifact-contract.md`
 - CLI helper: `scripts/kata-call.mjs`
+- Artifact input helper: `scripts/kata-artifact-input.mjs`
 
 Additional references:
 

--- a/apps/cli/skills/kata-complete-milestone/references/artifact-contract.md
+++ b/apps/cli/skills/kata-complete-milestone/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills/kata-complete-milestone/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills/kata-complete-milestone/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/skills/kata-execute-phase/SKILL.md
+++ b/apps/cli/skills/kata-execute-phase/SKILL.md
@@ -53,6 +53,7 @@ Read when needed:
 - CLI command patterns: `references/cli-runtime.md`
 - Artifact conventions: `references/artifact-contract.md`
 - CLI helper: `scripts/kata-call.mjs`
+- Artifact input helper: `scripts/kata-artifact-input.mjs`
 
 Additional references:
 

--- a/apps/cli/skills/kata-execute-phase/references/artifact-contract.md
+++ b/apps/cli/skills/kata-execute-phase/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills/kata-execute-phase/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills/kata-execute-phase/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/skills/kata-health/SKILL.md
+++ b/apps/cli/skills/kata-health/SKILL.md
@@ -50,6 +50,7 @@ Read when needed:
 - CLI command patterns: `references/cli-runtime.md`
 - Artifact conventions: `references/artifact-contract.md`
 - CLI helper: `scripts/kata-call.mjs`
+- Artifact input helper: `scripts/kata-artifact-input.mjs`
 
 ## Execution Rules
 

--- a/apps/cli/skills/kata-health/references/artifact-contract.md
+++ b/apps/cli/skills/kata-health/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills/kata-health/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills/kata-health/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/skills/kata-new-milestone/SKILL.md
+++ b/apps/cli/skills/kata-new-milestone/SKILL.md
@@ -51,6 +51,7 @@ Read when needed:
 - CLI command patterns: `references/cli-runtime.md`
 - Artifact conventions: `references/artifact-contract.md`
 - CLI helper: `scripts/kata-call.mjs`
+- Artifact input helper: `scripts/kata-artifact-input.mjs`
 
 Additional references:
 

--- a/apps/cli/skills/kata-new-milestone/references/artifact-contract.md
+++ b/apps/cli/skills/kata-new-milestone/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills/kata-new-milestone/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills/kata-new-milestone/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/skills/kata-new-milestone/templates/roadmap.md
+++ b/apps/cli/skills/kata-new-milestone/templates/roadmap.md
@@ -24,24 +24,24 @@ Use this as the content shape for milestone-scoped `roadmap` artifacts.
 
 **Planned Slices:**
 
-- [ ] S001: [Slice title]
+- [ ] Planned Slice 1: [Slice title]
 
 ## Traceability
 
-| Requirement | Phase/Slice | Status |
+| Requirement | Phase/Planned Slice | Status |
 |---|---|---|
-| REQ-01 | Phase 1 / S001 | Pending |
+| REQ-01 | Phase 1 / Planned Slice 1 | Pending |
 
 ## Progress
 
-| Phase | Status | Requirements | Slices |
+| Phase | Status | Requirements | Planned Slices |
 |---|---|---|---|
-| 1 | Pending | REQ-01 | S001 |
+| 1 | Pending | REQ-01 | Planned Slice 1 |
 ```
 
 ## Guidance
 
 - Derive phases from requirements; do not impose arbitrary structure.
 - Every active requirement should map to exactly one primary phase/slice.
+- Do not preassign backend slice IDs such as `S001` in milestone roadmaps. Backend slice IDs are global and are only known after `slice.create` returns them.
 - Success criteria must be observable from the user or system boundary.
-

--- a/apps/cli/skills/kata-new-milestone/templates/roadmap.md
+++ b/apps/cli/skills/kata-new-milestone/templates/roadmap.md
@@ -43,5 +43,5 @@ Use this as the content shape for milestone-scoped `roadmap` artifacts.
 
 - Derive phases from requirements; do not impose arbitrary structure.
 - Every active requirement should map to exactly one primary phase/slice.
-- Do not preassign backend slice IDs such as `S001` in milestone roadmaps. Backend slice IDs are global and are only known after `slice.create` returns them.
+- Do not preassign backend slice IDs such as `S001` in milestone roadmaps. Backend slice IDs are global and are only known after `slice.create` returns them. Once a backend slice ID exists, record it using an explicit keyworded format such as `Backend Slice: S001`, `Slice ID: S001`, or a table column named `Backend Slice ID`; avoid bare forms like `S001:`.
 - Success criteria must be observable from the user or system boundary.

--- a/apps/cli/skills/kata-new-project/SKILL.md
+++ b/apps/cli/skills/kata-new-project/SKILL.md
@@ -52,6 +52,7 @@ Read when needed:
 - CLI command patterns: `references/cli-runtime.md`
 - Artifact conventions: `references/artifact-contract.md`
 - CLI helper: `scripts/kata-call.mjs`
+- Artifact input helper: `scripts/kata-artifact-input.mjs`
 
 Additional references:
 

--- a/apps/cli/skills/kata-new-project/references/artifact-contract.md
+++ b/apps/cli/skills/kata-new-project/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills/kata-new-project/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills/kata-new-project/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/skills/kata-plan-phase/SKILL.md
+++ b/apps/cli/skills/kata-plan-phase/SKILL.md
@@ -50,6 +50,7 @@ Read when needed:
 - CLI command patterns: `references/cli-runtime.md`
 - Artifact conventions: `references/artifact-contract.md`
 - CLI helper: `scripts/kata-call.mjs`
+- Artifact input helper: `scripts/kata-artifact-input.mjs`
 
 Additional references:
 

--- a/apps/cli/skills/kata-plan-phase/references/artifact-contract.md
+++ b/apps/cli/skills/kata-plan-phase/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills/kata-plan-phase/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills/kata-plan-phase/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/skills/kata-progress/SKILL.md
+++ b/apps/cli/skills/kata-progress/SKILL.md
@@ -50,6 +50,7 @@ Read when needed:
 - CLI command patterns: `references/cli-runtime.md`
 - Artifact conventions: `references/artifact-contract.md`
 - CLI helper: `scripts/kata-call.mjs`
+- Artifact input helper: `scripts/kata-artifact-input.mjs`
 
 ## Execution Rules
 

--- a/apps/cli/skills/kata-progress/references/artifact-contract.md
+++ b/apps/cli/skills/kata-progress/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills/kata-progress/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills/kata-progress/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/skills/kata-setup/SKILL.md
+++ b/apps/cli/skills/kata-setup/SKILL.md
@@ -50,6 +50,7 @@ Read when needed:
 - CLI command patterns: `references/cli-runtime.md`
 - Artifact conventions: `references/artifact-contract.md`
 - CLI helper: `scripts/kata-call.mjs`
+- Artifact input helper: `scripts/kata-artifact-input.mjs`
 
 ## Execution Rules
 

--- a/apps/cli/skills/kata-setup/references/artifact-contract.md
+++ b/apps/cli/skills/kata-setup/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills/kata-setup/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills/kata-setup/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/skills/kata-verify-work/SKILL.md
+++ b/apps/cli/skills/kata-verify-work/SKILL.md
@@ -50,6 +50,7 @@ Read when needed:
 - CLI command patterns: `references/cli-runtime.md`
 - Artifact conventions: `references/artifact-contract.md`
 - CLI helper: `scripts/kata-call.mjs`
+- Artifact input helper: `scripts/kata-artifact-input.mjs`
 
 Additional references:
 

--- a/apps/cli/skills/kata-verify-work/references/artifact-contract.md
+++ b/apps/cli/skills/kata-verify-work/references/artifact-contract.md
@@ -99,6 +99,7 @@ Use for the phase/slice structure derived from milestone requirements.
 ```
 
 Every active requirement should map to exactly one phase/slice unless the workflow explicitly records a split.
+Milestone roadmaps should use planned slice labels, phases, or titles before backend slices exist. Do not preassign backend slice IDs such as `S001`; slice IDs are global and are only authoritative after `slice.create` returns them.
 
 ### Milestone Summary
 

--- a/apps/cli/skills/kata-verify-work/references/workflow.md
+++ b/apps/cli/skills/kata-verify-work/references/workflow.md
@@ -79,60 +79,38 @@ Ask the user to confirm actual behavior only when the plan calls for manual obse
 
 ## Stage 3: Write Verification Artifact
 
-Write artifact input files with a JSON encoder when the report contains Markdown
-tables, command snippets, quotes, or backticks. Do not hand-escape rich Markdown
-inside shell heredocs or JavaScript template literals; that is easy to corrupt
-and can cause failed artifact writes before verification state is updated.
+Write the verification report as Markdown first, then generate the artifact input
+JSON with `scripts/kata-artifact-input.mjs`. Do not hand-escape rich Markdown
+inside JSON heredocs or JavaScript template literals; verification reports often
+contain tables, command snippets, quotes, or backticks, and hand-escaped JSON is
+easy to corrupt before verification state is updated.
 
 Example:
 
 ```bash
-node - <<'NODE'
-const fs = require("node:fs");
+cat > /tmp/T001-verification.md <<'MARKDOWN'
+# Verification Report
 
-const content = [
-  "# Verification Report",
-  "",
-  "## Scope",
-  "",
-  "T001: Verify behavior",
-  "",
-  "## Evidence",
-  "",
-  "- `pnpm test` passed.",
-  "",
-  "## Result",
-  "",
-  "Verified",
-].join("\n");
+## Scope
 
-fs.writeFileSync(
-  "/tmp/kata-verification.json",
-  JSON.stringify(
-    {
-      scopeType: "task",
-      scopeId: "T001",
-      artifactType: "verification",
-      title: "T001 Verification",
-      content,
-      format: "markdown",
-    },
-    null,
-    2,
-  ),
-);
-NODE
-```
+T001: Verify behavior
 
-```json
-{
-  "scopeType": "task",
-  "scopeId": "T001",
-  "artifactType": "verification",
-  "title": "T001 Verification",
-  "content": "# Verification\n\n## Evidence\n\n...",
-  "format": "markdown"
-}
+## Evidence
+
+- `pnpm test` passed.
+
+## Result
+
+Verified
+MARKDOWN
+
+node <path-to-skill-directory>/scripts/kata-artifact-input.mjs \
+  --scope-type task \
+  --scope-id T001 \
+  --artifact-type verification \
+  --title "T001 Verification" \
+  --content-file /tmp/T001-verification.md \
+  --output /tmp/kata-verification.json
 ```
 
 ```bash

--- a/apps/cli/skills/kata-verify-work/references/workflow.md
+++ b/apps/cli/skills/kata-verify-work/references/workflow.md
@@ -79,6 +79,51 @@ Ask the user to confirm actual behavior only when the plan calls for manual obse
 
 ## Stage 3: Write Verification Artifact
 
+Write artifact input files with a JSON encoder when the report contains Markdown
+tables, command snippets, quotes, or backticks. Do not hand-escape rich Markdown
+inside shell heredocs or JavaScript template literals; that is easy to corrupt
+and can cause failed artifact writes before verification state is updated.
+
+Example:
+
+```bash
+node - <<'NODE'
+const fs = require("node:fs");
+
+const content = [
+  "# Verification Report",
+  "",
+  "## Scope",
+  "",
+  "T001: Verify behavior",
+  "",
+  "## Evidence",
+  "",
+  "- `pnpm test` passed.",
+  "",
+  "## Result",
+  "",
+  "Verified",
+].join("\n");
+
+fs.writeFileSync(
+  "/tmp/kata-verification.json",
+  JSON.stringify(
+    {
+      scopeType: "task",
+      scopeId: "T001",
+      artifactType: "verification",
+      title: "T001 Verification",
+      content,
+      format: "markdown",
+    },
+    null,
+    2,
+  ),
+);
+NODE
+```
+
 ```json
 {
   "scopeType": "task",

--- a/apps/cli/skills/kata-verify-work/scripts/kata-artifact-input.mjs
+++ b/apps/cli/skills/kata-verify-work/scripts/kata-artifact-input.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/kata-artifact-input.mjs --scope-type task --scope-id T001 \\",
+    "    --artifact-type verification --title \"T001 Verification\" \\",
+    "    --content-file /tmp/T001-verification.md --output /tmp/kata-T001-verification.json",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    values.set(key.slice(2), value);
+    index += 1;
+  }
+  return values;
+}
+
+function required(values, name) {
+  const value = values.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+try {
+  const values = parseArgs(process.argv.slice(2));
+  const contentFile = required(values, "content-file");
+  const output = required(values, "output");
+
+  const payload = {
+    scopeType: required(values, "scope-type"),
+    scopeId: required(values, "scope-id"),
+    artifactType: required(values, "artifact-type"),
+    title: required(values, "title"),
+    content: readFileSync(contentFile, "utf8"),
+    format: values.get("format") ?? "markdown",
+  };
+
+  writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage());
+  process.exit(1);
+}

--- a/apps/cli/src/domain/service.ts
+++ b/apps/cli/src/domain/service.ts
@@ -151,7 +151,7 @@ async function getProjectSnapshot(adapter: KataBackendAdapter): Promise<KataProj
   );
   const coveredIds = uniqueIds(snapshotSlices.flatMap((slice) => slice.requirementIds).filter((id) => requiredIds.includes(id)));
   const missingIds = requiredIds.filter((id) => !coveredIds.includes(id));
-  const plannedSliceIds = uniqueIds(extractSliceIds(roadmapContent));
+  const plannedSliceIds = extractRoadmapBackendSliceIds(roadmapContent);
   const existingSliceIds = snapshotSlices.map((slice) => slice.id);
   const missingSliceIds = plannedSliceIds.filter((id) => !existingSliceIds.includes(id));
   const requirementToSliceIds = extractRequirementToSliceIds(roadmapContent);
@@ -413,10 +413,19 @@ function extractSliceIds(content: string): string[] {
   return uniqueIds(content.match(/\bS\d+\b/g) ?? []);
 }
 
+function extractRoadmapBackendSliceIds(content: string): string[] {
+  const ids: string[] = [];
+  for (const line of content.split(/\r?\n/)) {
+    if (!/\b(?:backend\s+slice|backend\s+id|slice\s+id)\b/i.test(line)) continue;
+    ids.push(...extractSliceIds(line));
+  }
+  return uniqueIds(ids);
+}
+
 function extractRequirementToSliceIds(content: string): Record<string, string[]> {
   const mapping: Record<string, string[]> = {};
   for (const line of content.split(/\r?\n/)) {
-    const sliceIds = extractSliceIds(line);
+    const sliceIds = extractRoadmapBackendSliceIds(line);
     const requirementIds = extractRequirementIds(line);
     if (sliceIds.length === 0 || requirementIds.length === 0) continue;
     for (const requirementId of requirementIds) {

--- a/apps/cli/src/domain/service.ts
+++ b/apps/cli/src/domain/service.ts
@@ -413,19 +413,64 @@ function extractSliceIds(content: string): string[] {
   return uniqueIds(content.match(/\bS\d+\b/g) ?? []);
 }
 
-function extractRoadmapBackendSliceIds(content: string): string[] {
-  const ids: string[] = [];
+function extractRoadmapBackendSliceIdsFromLine(line: string): string[] {
+  if (!/\b(?:backend\s+slice|backend\s+id|slice\s+id)\b/i.test(line)) return [];
+  return extractSliceIds(line);
+}
+
+function parseMarkdownTableRow(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return null;
+  return trimmed.slice(1, -1).split("|").map((cell) => cell.trim());
+}
+
+function isMarkdownTableDivider(cells: string[]): boolean {
+  return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function backendSliceColumnIndexes(cells: string[]): number[] {
+  return cells
+    .map((cell, index) => (/\b(?:backend\s+slice(?:\s+id)?|backend\s+id|slice\s+id)\b/i.test(cell) ? index : -1))
+    .filter((index) => index >= 0);
+}
+
+function extractRoadmapBackendSliceIdsByLine(content: string): Array<{ line: string; sliceIds: string[] }> {
+  const entries: Array<{ line: string; sliceIds: string[] }> = [];
+  let backendSliceColumns: number[] = [];
+
   for (const line of content.split(/\r?\n/)) {
-    if (!/\b(?:backend\s+slice|backend\s+id|slice\s+id)\b/i.test(line)) continue;
-    ids.push(...extractSliceIds(line));
+    const cells = parseMarkdownTableRow(line);
+    if (cells) {
+      if (isMarkdownTableDivider(cells)) continue;
+
+      const headerColumns = backendSliceColumnIndexes(cells);
+      if (headerColumns.length > 0 && extractSliceIds(line).length === 0) {
+        backendSliceColumns = headerColumns;
+        continue;
+      }
+
+      const tableSliceIds = backendSliceColumns.flatMap((index) => extractSliceIds(cells[index] ?? ""));
+      const inlineSliceIds = extractRoadmapBackendSliceIdsFromLine(line);
+      const sliceIds = uniqueIds([...tableSliceIds, ...inlineSliceIds]);
+      if (sliceIds.length > 0) entries.push({ line, sliceIds });
+      continue;
+    }
+
+    backendSliceColumns = [];
+    const sliceIds = extractRoadmapBackendSliceIdsFromLine(line);
+    if (sliceIds.length > 0) entries.push({ line, sliceIds });
   }
-  return uniqueIds(ids);
+
+  return entries;
+}
+
+function extractRoadmapBackendSliceIds(content: string): string[] {
+  return uniqueIds(extractRoadmapBackendSliceIdsByLine(content).flatMap((entry) => entry.sliceIds));
 }
 
 function extractRequirementToSliceIds(content: string): Record<string, string[]> {
   const mapping: Record<string, string[]> = {};
-  for (const line of content.split(/\r?\n/)) {
-    const sliceIds = extractRoadmapBackendSliceIds(line);
+  for (const { line, sliceIds } of extractRoadmapBackendSliceIdsByLine(content)) {
     const requirementIds = extractRequirementIds(line);
     if (sliceIds.length === 0 || requirementIds.length === 0) continue;
     for (const requirementId of requirementIds) {

--- a/apps/cli/src/tests/build-skill-bundle.vitest.test.ts
+++ b/apps/cli/src/tests/build-skill-bundle.vitest.test.ts
@@ -29,6 +29,13 @@ describe("skill bundle generation", () => {
       "artifact-contract.md",
     );
     const helperScriptPath = path.join(cliRoot, "skills", "kata-plan-phase", "scripts", "kata-call.mjs");
+    const artifactInputHelperScriptPath = path.join(
+      cliRoot,
+      "skills",
+      "kata-plan-phase",
+      "scripts",
+      "kata-artifact-input.mjs",
+    );
 
     expect(existsSync(skillPath)).toBe(true);
     expect(existsSync(workflowReferencePath)).toBe(true);
@@ -36,18 +43,21 @@ describe("skill bundle generation", () => {
     expect(existsSync(cliRuntimeReferencePath)).toBe(true);
     expect(existsSync(artifactContractReferencePath)).toBe(true);
     expect(existsSync(helperScriptPath)).toBe(true);
+    expect(existsSync(artifactInputHelperScriptPath)).toBe(true);
 
     const skill = readFileSync(skillPath, "utf8");
     const workflow = readFileSync(workflowReferencePath, "utf8");
     const runtime = readFileSync(runtimeReferencePath, "utf8");
     const setup = readFileSync(setupReferencePath, "utf8");
     const helperScript = readFileSync(helperScriptPath, "utf8");
+    const artifactInputHelperScript = readFileSync(artifactInputHelperScriptPath, "utf8");
 
     expect(skill).toContain("references/alignment.md");
     expect(skill).toContain("references/workflow.md");
     expect(skill).toContain("references/runtime-contract.md");
     expect(skill).toContain("references/cli-runtime.md");
     expect(skill).toContain("references/artifact-contract.md");
+    expect(skill).toContain("scripts/kata-artifact-input.mjs");
     expect(skill).toContain("## Process");
     expect(skill).toContain("Read `references/workflow.md` before taking action. Execute that workflow end-to-end.");
     expect(skill).toContain("Preserve every workflow gate");
@@ -64,7 +74,56 @@ describe("skill bundle generation", () => {
     expect(setup).toContain("In Progress");
     expect(helperScript).toContain("loadDotEnv(process.cwd())");
     expect(helperScript).toContain("path.resolve(process.cwd(), process.env.KATA_CLI_ROOT)");
+    expect(artifactInputHelperScript).toContain("JSON.stringify(payload, null, 2)");
     expect(existsSync(path.join(cliRoot, "skills", "kata-discuss-phase"))).toBe(false);
+  });
+
+  it("generates artifact input JSON from Markdown without hand escaping", () => {
+    const fixtureDir = path.join(tmpdir(), `kata-artifact-input-${Date.now()}`);
+    const scriptsDir = path.join(fixtureDir, "scripts");
+    const markdownPath = path.join(fixtureDir, "verification.md");
+    const outputPath = path.join(fixtureDir, "artifact.json");
+
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(
+      path.join(scriptsDir, "kata-artifact-input.mjs"),
+      readFileSync(path.join(cliRoot, "skills-src", "scripts", "kata-artifact-input.mjs"), "utf8"),
+      "utf8",
+    );
+    writeFileSync(markdownPath, "# Verification\n\n- `pnpm test` passed.\n| A | B |\n|---|---|\n", "utf8");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "scripts/kata-artifact-input.mjs",
+        "--scope-type",
+        "task",
+        "--scope-id",
+        "T001",
+        "--artifact-type",
+        "verification",
+        "--title",
+        "T001 Verification",
+        "--content-file",
+        markdownPath,
+        "--output",
+        outputPath,
+      ],
+      {
+        cwd: fixtureDir,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
+      scopeType: "task",
+      scopeId: "T001",
+      artifactType: "verification",
+      title: "T001 Verification",
+      content: "# Verification\n\n- `pnpm test` passed.\n| A | B |\n|---|---|\n",
+      format: "markdown",
+    });
   });
 
   it("generates helpers that route CLI commands separately from runtime operations", () => {

--- a/apps/cli/src/tests/phase-a-contract.vitest.test.ts
+++ b/apps/cli/src/tests/phase-a-contract.vitest.test.ts
@@ -312,7 +312,9 @@ describe("Phase A domain contract", () => {
         scopeId: input.scopeId,
         artifactType: input.artifactType,
         title: input.artifactType,
-        content: input.artifactType === "roadmap" ? "S001 covers E2E-01\nS002 covers E2E-02" : "E2E-01\nE2E-02",
+        content: input.artifactType === "roadmap"
+          ? "Backend Slice: S001 covers E2E-01\nBackend Slice: S002 covers E2E-02"
+          : "E2E-01\nE2E-02",
         format: "markdown",
         updatedAt: "2026-04-28T00:00:00.000Z",
         provenance: { backend: "github", backendId: "comment:2" },
@@ -339,6 +341,85 @@ describe("Phase A domain contract", () => {
       nextAction: {
         workflow: "kata-plan-phase",
         target: { sliceId: "S002" },
+      },
+    });
+  });
+
+  it("does not treat milestone roadmap planned-slice labels as backend slice ids", async () => {
+    const api = createKataDomainApi({
+      ...createFakeAdapter(),
+      getActiveMilestone: async () => ({
+        id: "M002",
+        title: "Symphony Migration",
+        goal: "Validate global slice sequencing",
+        status: "active",
+        active: true,
+      }),
+      listSlices: async () => [
+        {
+          id: "S005",
+          milestoneId: "M002",
+          title: "Map Symphony migration baseline",
+          goal: "Cover SYM-03 and SYM-08",
+          status: "backlog",
+          order: 1,
+        },
+      ],
+      listTasks: async () => [],
+      listArtifacts: async (input: KataArtifactListInput) =>
+        input.scopeType === "slice"
+          ? [
+              {
+                id: `${input.scopeType}:${input.scopeId}:plan`,
+                scopeType: input.scopeType,
+                scopeId: input.scopeId,
+                artifactType: "plan",
+                title: "Plan",
+                content: "Covers SYM-03 and SYM-08",
+                format: "markdown",
+                updatedAt: "2026-04-29T00:00:00.000Z",
+                provenance: { backend: "github", backendId: "comment:1" },
+              },
+            ]
+          : [],
+      readArtifact: async (input: KataArtifactReadInput) => ({
+        id: `${input.scopeType}:${input.scopeId}:${input.artifactType}`,
+        scopeType: input.scopeType,
+        scopeId: input.scopeId,
+        artifactType: input.artifactType,
+        title: input.artifactType,
+        content: input.artifactType === "roadmap"
+          ? [
+              "## Planned Slices",
+              "- [ ] S001: Map Symphony migration baseline",
+              "",
+              "| Requirement | Phase/Planned Slice | Status |",
+              "|---|---|---|",
+              "| SYM-03 | Phase 1 / S001 | Pending |",
+              "| SYM-08 | Phase 1 / S001 | Pending |",
+            ].join("\n")
+          : "SYM-03\nSYM-08",
+        format: "markdown",
+        updatedAt: "2026-04-29T00:00:00.000Z",
+        provenance: { backend: "github", backendId: "comment:2" },
+      }),
+    });
+
+    await expect(dispatchKataOperation(api, "project.getSnapshot")).resolves.toMatchObject({
+      roadmap: {
+        plannedSliceIds: [],
+        existingSliceIds: ["S005"],
+        missingSliceIds: [],
+        requirementToSliceIds: {},
+      },
+      requirements: {
+        coveredIds: ["SYM-03", "SYM-08"],
+        missingIds: [],
+      },
+      nextAction: {
+        workflow: "kata-execute-phase",
+        reason: "Slice S005 still has execution work remaining.",
+        target: { milestoneId: "M002", sliceId: "S005" },
       },
     });
   });
@@ -413,7 +494,7 @@ describe("Phase A domain contract", () => {
         artifactType: input.artifactType,
         title: input.artifactType,
         content: input.artifactType === "roadmap"
-          ? "S001 covers E2E-01\nS003 covers E2E-06\nS004 covers E2E-10"
+          ? "Backend Slice: S001 covers E2E-01\nBackend Slice: S003 covers E2E-06\nBackend Slice: S004 covers E2E-10"
           : "E2E-01\nE2E-06\nE2E-10",
         format: "markdown",
         updatedAt: "2026-04-28T00:00:00.000Z",
@@ -521,7 +602,9 @@ describe("Phase A domain contract", () => {
         scopeId: input.scopeId,
         artifactType: input.artifactType,
         title: input.artifactType,
-        content: input.artifactType === "roadmap" ? "S003 covers E2E-06\nS004 covers E2E-08" : "E2E-06\nE2E-08",
+        content: input.artifactType === "roadmap"
+          ? "Backend Slice: S003 covers E2E-06\nBackend Slice: S004 covers E2E-08"
+          : "E2E-06\nE2E-08",
         format: "markdown",
         updatedAt: "2026-04-28T00:00:00.000Z",
         provenance: { backend: "github", backendId: "comment:2" },
@@ -623,7 +706,7 @@ describe("Phase A domain contract", () => {
         artifactType: input.artifactType,
         title: input.artifactType,
         content: input.artifactType === "roadmap"
-          ? "S001 covers E2E-01\nS004 covers E2E-10\nFuture note mentions FUT-01"
+          ? "Backend Slice: S001 covers E2E-01\nBackend Slice: S004 covers E2E-10\nFuture note mentions FUT-01"
           : [
               "## Active Requirements",
               "E2E-01",

--- a/apps/cli/src/tests/phase-a-contract.vitest.test.ts
+++ b/apps/cli/src/tests/phase-a-contract.vitest.test.ts
@@ -424,6 +424,69 @@ describe("Phase A domain contract", () => {
     });
   });
 
+  it("extracts backend slice ids from structured roadmap table columns", async () => {
+    const api = createKataDomainApi({
+      ...createFakeAdapter(),
+      getActiveMilestone: async () => ({
+        id: "M003",
+        title: "Structured Roadmap",
+        goal: "Validate backend slice table extraction",
+        status: "active",
+        active: true,
+      }),
+      listSlices: async () => [
+        {
+          id: "S012",
+          milestoneId: "M003",
+          title: "Build the first path",
+          goal: "Cover REQ-01",
+          status: "done",
+          order: 1,
+        },
+      ],
+      listTasks: async () => [],
+      listArtifacts: async () => [],
+      readArtifact: async (input: KataArtifactReadInput) => ({
+        id: `${input.scopeType}:${input.scopeId}:${input.artifactType}`,
+        scopeType: input.scopeType,
+        scopeId: input.scopeId,
+        artifactType: input.artifactType,
+        title: input.artifactType,
+        content: input.artifactType === "roadmap"
+          ? [
+              "| Requirement | Backend Slice ID | Status |",
+              "|---|---|---|",
+              "| REQ-01 | S012 | Done |",
+              "| REQ-02 | S013 | Pending |",
+            ].join("\n")
+          : "REQ-01\nREQ-02",
+        format: "markdown",
+        updatedAt: "2026-04-29T00:00:00.000Z",
+        provenance: { backend: "github", backendId: "comment:3" },
+      }),
+    });
+
+    await expect(dispatchKataOperation(api, "project.getSnapshot")).resolves.toMatchObject({
+      roadmap: {
+        plannedSliceIds: ["S012", "S013"],
+        existingSliceIds: ["S012"],
+        missingSliceIds: ["S013"],
+        requirementToSliceIds: {
+          "REQ-01": ["S012"],
+          "REQ-02": ["S013"],
+        },
+      },
+      requirements: {
+        coveredIds: ["REQ-01"],
+        missingIds: ["REQ-02"],
+      },
+      nextAction: {
+        workflow: "kata-plan-phase",
+        target: { sliceId: "S013" },
+      },
+    });
+  });
+
   it("prioritizes executing existing planned slices before planning later roadmap slices", async () => {
     const api = createKataDomainApi({
       ...createFakeAdapter(),

--- a/apps/cli/src/tests/phase-a-skill-surface.vitest.test.ts
+++ b/apps/cli/src/tests/phase-a-skill-surface.vitest.test.ts
@@ -70,6 +70,18 @@ describe("Phase A skill surface", () => {
     expect(manifest).toContain("Do not set `verificationState: verified`; `kata-verify-work` owns verification.");
   });
 
+  it("paves verify-work artifact writes through the JSON encoder helper", () => {
+    const verifyWorkflow = readFileSync(
+      path.join(sourceRoot, "skills-src", "workflows", "verify-work.md"),
+      "utf8",
+    );
+
+    expect(verifyWorkflow).toContain("kata-artifact-input.mjs");
+    expect(verifyWorkflow).toContain("--content-file /tmp/T001-verification.md");
+    expect(verifyWorkflow).not.toContain('"content": "# Verification');
+    expect(verifyWorkflow).not.toContain('"content": "# Verification\\n');
+  });
+
   it("treats a slice as the execute-phase unit of work", () => {
     const executeWorkflow = readFileSync(
       path.join(sourceRoot, "skills-src", "workflows", "execute-phase.md"),

--- a/apps/symphony/src/domain.rs
+++ b/apps/symphony/src/domain.rs
@@ -954,8 +954,8 @@ impl Default for CodexConfig {
 /// Which runtime backend to use for agent sessions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AgentBackend {
-    KataCli,
     #[default]
+    KataCli,
     Codex,
 }
 

--- a/apps/symphony/tests/domain_tests.rs
+++ b/apps/symphony/tests/domain_tests.rs
@@ -137,7 +137,7 @@ fn test_service_config_defaults_match_spec() {
     assert_eq!(cfg.codex.stall_timeout_ms, 300_000);
     assert_eq!(cfg.pi_agent.read_timeout_ms, 5_000);
     assert_eq!(cfg.pi_agent.stall_timeout_ms, 300_000);
-    assert_eq!(cfg.agent_backend, AgentBackend::Codex);
+    assert_eq!(cfg.agent_backend, AgentBackend::KataCli);
 
     // Hooks §5.3.4
     assert_eq!(cfg.hooks.timeout_ms, 60_000);

--- a/apps/symphony/tests/orchestrator_tests.rs
+++ b/apps/symphony/tests/orchestrator_tests.rs
@@ -3504,6 +3504,9 @@ fn make_worker_config(
     max_turns: u32,
 ) -> ServiceConfig {
     let mut config = test_config(1);
+    // These worker-attempt tests exercise the fake Codex app-server path
+    // directly. Keep that explicit now that Kata CLI/Pi is the default backend.
+    config.agent_backend = AgentBackend::Codex;
     config.workspace.root = workspace_root.to_string_lossy().to_string();
     config.workspace.repo = None;
     config.codex.command = vec![script_path.to_string_lossy().to_string()];

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -1627,6 +1627,7 @@ fn test_config_validation_missing_codex_command() {
             command: vec![],
             ..CodexConfig::default()
         },
+        agent_backend: AgentBackend::Codex,
         ..ServiceConfig::default()
     };
 

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -271,7 +271,7 @@ fn test_config_defaults() {
     assert_eq!(config.workspace.clone_branch, None);
     assert_eq!(config.workspace.base_branch.as_deref(), Some("main"));
     assert!(!config.workspace.cleanup_on_done);
-    assert_eq!(config.agent_backend, AgentBackend::Codex);
+    assert_eq!(config.agent_backend, AgentBackend::KataCli);
     assert_eq!(config.pi_agent.command, vec!["kata".to_string()]);
     assert_eq!(config.pi_agent.model, None);
     assert!(config.pi_agent.model_by_label.is_empty());

--- a/apps/symphony/tests/workflow_config_tests.rs
+++ b/apps/symphony/tests/workflow_config_tests.rs
@@ -497,6 +497,27 @@ fn test_server_public_url_rejects_malformed_or_relative_values() {
 }
 
 #[test]
+fn test_agent_backend_codex_remains_explicitly_supported() {
+    let yaml_str = r#"
+agent:
+  backend: codex
+codex:
+  command:
+    - codex
+    - app-server
+"#;
+
+    let raw: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    let config = from_workflow(&raw).expect("explicit codex backend config should parse");
+
+    assert_eq!(config.agent_backend, AgentBackend::Codex);
+    assert_eq!(
+        config.codex.command,
+        vec!["codex".to_string(), "app-server".to_string()]
+    );
+}
+
+#[test]
 fn test_agent_backend_kata_cli_with_kata_agent_config() {
     let yaml_str = r#"
 agent:

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,39 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Layout
+
+This repo uses a **single-context** domain docs layout.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** for ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,24 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+Repository: `gannonh/kata`.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -2,7 +2,7 @@
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| Canonical label            | Label in our tracker | Meaning                                  |
 | -------------------------- | -------------------- | ---------------------------------------- |
 | `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
 | `needs-info`               | `needs-info`         | Waiting on reporter for more information |


### PR DESCRIPTION
## Summary

This PR advances M002 by tightening Kata planning/verification mechanics and completing the verified Symphony harness migration slice:

- fixes roadmap snapshot handling so backend slice IDs are treated as global backend IDs only when explicitly labeled, avoiding fake `S###` roadmap drift
- makes Symphony default to the Pi/Kata CLI backend while preserving explicit Codex app-server routing
- adds regression coverage proving `agent.backend: codex` remains supported after the default changes
- hardens Kata verification artifact writing with a Markdown-to-JSON helper so agents stop hand-escaping large verification reports in heredocs
- records/updates engineering skill conventions used by this branch

## Kata Evidence

- S005 completed and verified as the migration baseline/artifact-only mapping slice
- S006 completed and verified with tasks T016, T017, and T018
- Requirements covered by verified S006 evidence: SYM-01 and SYM-02
- Verification artifacts were persisted for T016, T017, and T018

## Verification

Passed:

- `pnpm --dir apps/cli exec vitest run src/tests/phase-a-contract.vitest.test.ts`
- `pnpm --dir apps/cli exec vitest run src/tests/build-skill-bundle.vitest.test.ts src/tests/phase-a-skill-surface.vitest.test.ts`
- `pnpm --dir apps/cli run typecheck`
- `pnpm --dir apps/cli run build`
- `node apps/cli/dist/loader.js setup --pi`
- live smoke test for `~/.pi/agent/skills/kata-verify-work/scripts/kata-artifact-input.mjs`
- `cd apps/symphony && cargo test test_config_defaults`
- `cd apps/symphony && cargo test test_service_config_defaults_match_spec`
- `cd apps/symphony && cargo test test_agent_backend_codex_remains_explicitly_supported`
- `cd apps/symphony && cargo test test_app_server_basic_handshake_and_completion`
- `cd apps/symphony && cargo clippy -- -D warnings`
- pre-push hook: `pnpm exec turbo run lint typecheck test --affected` (`20 successful, 20 total`)

CI follow-up:

- Fixed stale Codex-default test assumptions found by PR CI by making Codex app-server fixtures explicitly set `AgentBackend::Codex`.
- `pnpm run validate:affected` now passes locally, and the push pre-hook passed with `20 successful, 20 total`.

