### PR TITLE
Refine milestone closeout idempotency

### DIFF
--- a/.agents/skills/kata-complete-milestone/SKILL.md
+++ b/.agents/skills/kata-complete-milestone/SKILL.md
@@ -21,6 +21,9 @@ If readiness is uncertain, stop and explain what must be verified or resolved fi
 - Completion evidence includes milestone, slice, task, and project-scoped artifacts.
 - Retrospective or archive artifacts are persisted when useful.
 - Project brief and project requirements artifacts are updated before `milestone.complete`, or the workflow stops to repair missing project artifacts.
+- Existing milestone summary, retrospective, and project closeout artifacts are updated idempotently when they already exist.
+- Carry-forward requirements are only reclassified after explicit confirmation and evidence.
+- Completion output names the project tracking issue when the backend reports it and reports what changed in the project artifacts.
 - The milestone is completed through `milestone.complete` only after readiness is confirmed and closeout artifact writes succeed.
 - The user knows what remains, if anything, after completion.
 
@@ -30,6 +33,7 @@ If readiness is uncertain, stop and explain what must be verified or resolved fi
 - Do not invent completion evidence.
 - Do not rely only on milestone-level artifacts when task verification artifacts live on task scope.
 - Do not run `milestone.complete` after a failed project closeout artifact read or write.
+- Do not reclassify a carry-forward requirement as validated without explicit confirmation.
 - Do not create a new milestone here.
 - Do not skip the readiness check.
 

--- a/.agents/skills/kata-complete-milestone/SKILL.md
+++ b/.agents/skills/kata-complete-milestone/SKILL.md
@@ -9,7 +9,7 @@ description: "Use when the user wants to finish, close, ship, archive, or mark t
 
 When this skill is invoked, close the active release-sized milestone after all milestone slices and tasks are done and verified.
 
-Load the project snapshot and active milestone, list slices, list tasks for each slice when detail is needed, inspect milestone/slice/task artifacts, confirm every required task is done and verified, summarize delivered outcomes, capture retrospective notes, write completion artifacts, and then complete the milestone through `milestone.complete`.
+Load the project snapshot and active milestone, list slices, list tasks for each slice when detail is needed, inspect milestone/slice/task artifacts, read project-scoped closeout artifacts, confirm every required task is done and verified, summarize delivered outcomes, capture retrospective notes, write milestone completion artifacts, update project closeout artifacts, and then complete the milestone through `milestone.complete`.
 
 If readiness is uncertain, stop and explain what must be verified or resolved first.
 
@@ -18,9 +18,10 @@ If readiness is uncertain, stop and explain what must be verified or resolved fi
 - The active milestone has an accepted completion summary.
 - Every required slice is done.
 - Every required task is done with `verificationState: verified`.
-- Completion evidence includes milestone, slice, and task-scoped artifacts.
+- Completion evidence includes milestone, slice, task, and project-scoped artifacts.
 - Retrospective or archive artifacts are persisted when useful.
-- The milestone is completed through `milestone.complete` only after readiness is confirmed.
+- Project brief and project requirements artifacts are updated before `milestone.complete`, or the workflow stops to repair missing project artifacts.
+- The milestone is completed through `milestone.complete` only after readiness is confirmed and closeout artifact writes succeed.
 - The user knows what remains, if anything, after completion.
 
 ## Do Not
@@ -28,6 +29,7 @@ If readiness is uncertain, stop and explain what must be verified or resolved fi
 - Do not complete a milestone with unverified required work.
 - Do not invent completion evidence.
 - Do not rely only on milestone-level artifacts when task verification artifacts live on task scope.
+- Do not run `milestone.complete` after a failed project closeout artifact read or write.
 - Do not create a new milestone here.
 - Do not skip the readiness check.
 

--- a/.agents/skills/kata-complete-milestone/references/artifact-contract.md
+++ b/.agents/skills/kata-complete-milestone/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-complete-milestone/references/artifact-contract.md
+++ b/.agents/skills/kata-complete-milestone/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-complete-milestone/references/workflow.md
+++ b/.agents/skills/kata-complete-milestone/references/workflow.md
@@ -2,7 +2,7 @@
 
 # Complete Milestone Workflow
 
-Use this workflow to complete the active release-sized milestone after all milestone slices and tasks are done and verified: check readiness, preserve summary/retrospective/archive artifacts, then transition the backend milestone lifecycle.
+Use this workflow to complete the active release-sized milestone after all milestone slices and tasks are done and verified: check readiness, preserve summary/retrospective/archive artifacts, update project-scoped closeout artifacts, then transition the backend milestone lifecycle.
 
 ## Required Reading
 
@@ -134,7 +134,37 @@ node <path-to-skill-directory>/scripts/kata-call.mjs artifact.list --input /tmp/
 node <path-to-skill-directory>/scripts/kata-call.mjs artifact.read --input /tmp/kata-read-task-verification.json
 ```
 
+Use `project.getSnapshot`, `slice.list`, and `task.list` for readiness. Read task summaries and verification artifacts selectively when evidence is unclear, when a plan explicitly requires UAT, or when no later task has consolidated the milestone evidence. Do not spend time reading every task artifact when a verified consolidation artifact already covers the milestone evidence.
+
 Review requirements, roadmap, slice plans, task summaries, verification artifacts, and any UAT artifacts that were explicitly required by a plan. Surface incomplete or failed work before asking to close the milestone.
+
+Read project-scoped closeout artifacts. These live on the project tracking issue in backends that represent project artifacts that way.
+
+```json
+{
+  "scopeType": "project",
+  "scopeId": "PROJECT",
+  "artifactType": "project-brief"
+}
+```
+
+```bash
+node <path-to-skill-directory>/scripts/kata-call.mjs artifact.read --input /tmp/kata-read-project-brief.json
+```
+
+```json
+{
+  "scopeType": "project",
+  "scopeId": "PROJECT",
+  "artifactType": "requirements"
+}
+```
+
+```bash
+node <path-to-skill-directory>/scripts/kata-call.mjs artifact.read --input /tmp/kata-read-project-requirements.json
+```
+
+If either project artifact is missing, stop before completion and ask whether to create the missing artifact from milestone evidence or repair project setup first.
 
 ## Stage 3: Confirm Completion Readiness
 
@@ -146,8 +176,9 @@ Before writing completion artifacts or completing the milestone, summarize:
 - Requirements covered.
 - Known gaps, follow-up work, and carry-forward candidates from `snapshot.requirements.futureIds`.
 - Whether this milestone includes a release action or only validates a pre-release slice.
+- Project closeout updates that will be written to `PROJECT` project-scoped artifacts, including project brief changes, project requirements status/traceability changes, and preserved future requirements.
 
-Ask for explicit confirmation to complete the milestone. If readiness is uncertain, stop and explain what remains.
+Ask for explicit confirmation to complete the milestone and update project artifacts. If readiness is uncertain, stop and explain what remains.
 
 ## Stage 4: Write Summary Artifact
 
@@ -187,7 +218,59 @@ Use `templates/retrospective.md`.
 node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp/kata-retrospective.json
 ```
 
-## Stage 6: Complete Milestone
+## Stage 6: Update Project Closeout Artifacts
+
+Rewrite project artifacts with the latest durable project state. Preserve existing durable sections unless the completed milestone gives explicit evidence to update them.
+
+Update `project-brief` to include or refresh closeout sections such as:
+
+- `## Current Status`
+- `## Completed Milestones`
+- `## Validated Outcomes`
+- `## Key Decisions`
+- `## Open Questions`
+- A last-updated note
+
+Use milestone evidence to add one concise entry for the completed milestone. Do not paste the milestone archive wholesale into the project brief.
+
+Create `/tmp/kata-PROJECT-project-brief.md` from the existing project brief plus the milestone closeout update, then generate the write payload:
+
+```bash
+node <path-to-skill-directory>/scripts/kata-artifact-input.mjs \
+  --scope-type project \
+  --scope-id PROJECT \
+  --artifact-type project-brief \
+  --title "PROJECT" \
+  --content-file /tmp/kata-PROJECT-project-brief.md \
+  --output /tmp/kata-PROJECT-project-brief.json
+node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp/kata-PROJECT-project-brief.json
+```
+
+Update project `requirements` to reflect milestone completion:
+
+- Mark project-level requirements as complete or validated only when milestone evidence supports the change.
+- Update traceability rows from pending to the completed milestone, slices, tasks, or verification artifacts that prove coverage.
+- Preserve future requirements and carry-forward candidates, including their source milestone and deferred reason.
+- Keep still-active requirements in the active section.
+
+Create `/tmp/kata-PROJECT-requirements.md` from the existing project requirements plus the milestone closeout update, then generate the write payload:
+
+```bash
+node <path-to-skill-directory>/scripts/kata-artifact-input.mjs \
+  --scope-type project \
+  --scope-id PROJECT \
+  --artifact-type requirements \
+  --title "PROJECT Requirements" \
+  --content-file /tmp/kata-PROJECT-requirements.md \
+  --output /tmp/kata-PROJECT-requirements.json
+node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp/kata-PROJECT-requirements.json
+```
+
+If either project artifact write fails or returns `ok: false`, stop before `milestone.complete` and report the failed operation.
+
+## Stage 7: Complete Milestone
+
+Run this only after the milestone summary, milestone retrospective, project brief, and project requirements writes have succeeded.
 
 ```json
 {
@@ -202,7 +285,7 @@ node <path-to-skill-directory>/scripts/kata-call.mjs milestone.complete --input 
 
 ## Completion
 
-Summarize the milestone outcome, known gaps, and candidates for the next milestone.
+Summarize the milestone outcome, known gaps, candidates for the next milestone, milestone artifacts written, and project artifacts updated. Include project artifact provenance when the backend reports it, such as the project tracking issue or artifact comment ID.
 
 End with:
 
@@ -216,4 +299,6 @@ Next up: run `kata-new-milestone` to start the next cycle.
 - Do not complete a milestone before listing slices and tasks for the active milestone.
 - Do not rely only on milestone-level artifacts; task verification artifacts live on task scope.
 - Preserve follow-up work in artifact content or backend task state.
+- Update project-scoped closeout artifacts before running `milestone.complete`.
+- Stop before `milestone.complete` if a required project artifact read or write is missing or fails.
 - Keep lifecycle transitions in the CLI backend contract.

--- a/.agents/skills/kata-complete-milestone/references/workflow.md
+++ b/.agents/skills/kata-complete-milestone/references/workflow.md
@@ -233,7 +233,6 @@ Update `project-brief` to include or refresh closeout sections such as:
 - `## Current Status`
 - `## Completed Milestones`
 - `## Validated Outcomes`
-- `## Key Decisions`
 - `## Open Questions`
 - A last-updated note
 

--- a/.agents/skills/kata-complete-milestone/references/workflow.md
+++ b/.agents/skills/kata-complete-milestone/references/workflow.md
@@ -178,7 +178,13 @@ Before writing completion artifacts or completing the milestone, summarize:
 - Whether this milestone includes a release action or only validates a pre-release slice.
 - Project closeout updates that will be written to `PROJECT` project-scoped artifacts, including project brief changes, project requirements status/traceability changes, and preserved future requirements.
 
-Ask for explicit confirmation to complete the milestone and update project artifacts. If readiness is uncertain, stop and explain what remains.
+Ask for explicit confirmation to complete the milestone and update project artifacts.
+
+Use `Kata > VERIFYING` for the readiness checkpoint and reserve `Kata > MILESTONE COMPLETE` for the final success output after `milestone.complete` succeeds.
+
+If the milestone summary, retrospective, or project closeout artifacts already exist, enter idempotent closeout mode: read the existing content, preserve unchanged sections, and rewrite only the evidence-backed sections. Ask the user to confirm any carry-forward requirement reclassification before marking it validated.
+
+If readiness is uncertain, stop and explain what remains.
 
 ## Stage 4: Write Summary Artifact
 
@@ -220,7 +226,7 @@ node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp
 
 ## Stage 6: Update Project Closeout Artifacts
 
-Rewrite project artifacts with the latest durable project state. Preserve existing durable sections unless the completed milestone gives explicit evidence to update them.
+Rewrite project artifacts with the latest durable project state. Preserve existing durable sections unless the completed milestone gives explicit evidence to update them. If the summary, retrospective, or project closeout artifacts already exist, read their current content first and update only the evidence-backed sections.
 
 Update `project-brief` to include or refresh closeout sections such as:
 
@@ -249,6 +255,7 @@ node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp
 Update project `requirements` to reflect milestone completion:
 
 - Mark project-level requirements as complete or validated only when milestone evidence supports the change.
+- Before reclassifying a carry-forward requirement as validated, ask for explicit confirmation and cite the evidence.
 - Update traceability rows from pending to the completed milestone, slices, tasks, or verification artifacts that prove coverage.
 - Preserve future requirements and carry-forward candidates, including their source milestone and deferred reason.
 - Keep still-active requirements in the active section.
@@ -285,7 +292,7 @@ node <path-to-skill-directory>/scripts/kata-call.mjs milestone.complete --input 
 
 ## Completion
 
-Summarize the milestone outcome, known gaps, candidates for the next milestone, milestone artifacts written, and project artifacts updated. Include project artifact provenance when the backend reports it, such as the project tracking issue or artifact comment ID.
+Summarize the milestone outcome, known gaps, candidates for the next milestone, milestone artifacts written, and project artifacts updated. Report the changed artifact sections. Include project artifact provenance when the backend reports it, including the project tracking issue or URL when known and artifact comment ID.
 
 End with:
 
@@ -301,4 +308,5 @@ Next up: run `kata-new-milestone` to start the next cycle.
 - Preserve follow-up work in artifact content or backend task state.
 - Update project-scoped closeout artifacts before running `milestone.complete`.
 - Stop before `milestone.complete` if a required project artifact read or write is missing or fails.
+- Do not reclassify a carry-forward requirement as validated without explicit confirmation.
 - Keep lifecycle transitions in the CLI backend contract.

--- a/.agents/skills/kata-execute-issue/references/artifact-contract.md
+++ b/.agents/skills/kata-execute-issue/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-execute-phase/references/artifact-contract.md
+++ b/.agents/skills/kata-execute-phase/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-health/references/artifact-contract.md
+++ b/.agents/skills/kata-health/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-new-milestone/references/artifact-contract.md
+++ b/.agents/skills/kata-new-milestone/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-new-project/references/artifact-contract.md
+++ b/.agents/skills/kata-new-project/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-plan-issue/references/artifact-contract.md
+++ b/.agents/skills/kata-plan-issue/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-plan-phase/references/artifact-contract.md
+++ b/.agents/skills/kata-plan-phase/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-progress/references/artifact-contract.md
+++ b/.agents/skills/kata-progress/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-setup/references/artifact-contract.md
+++ b/.agents/skills/kata-setup/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/.agents/skills/kata-verify-work/references/artifact-contract.md
+++ b/.agents/skills/kata-verify-work/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,15 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills-src/manifest.json
+++ b/apps/cli/skills-src/manifest.json
@@ -382,6 +382,9 @@
         "Completion evidence includes milestone, slice, task, and project-scoped artifacts.",
         "Retrospective or archive artifacts are persisted when useful.",
         "Project brief and project requirements artifacts are updated before `milestone.complete`, or the workflow stops to repair missing project artifacts.",
+        "Existing milestone summary, retrospective, and project closeout artifacts are updated idempotently when they already exist.",
+        "Carry-forward requirements are only reclassified after explicit confirmation and evidence.",
+        "Completion output names the project tracking issue when the backend reports it and reports what changed in the project artifacts.",
         "The milestone is completed through `milestone.complete` only after readiness is confirmed and closeout artifact writes succeed.",
         "The user knows what remains, if anything, after completion."
       ],
@@ -390,6 +393,7 @@
         "Do not invent completion evidence.",
         "Do not rely only on milestone-level artifacts when task verification artifacts live on task scope.",
         "Do not run `milestone.complete` after a failed project closeout artifact read or write.",
+        "Do not reclassify a carry-forward requirement as validated without explicit confirmation.",
         "Do not create a new milestone here.",
         "Do not skip the readiness check."
       ],

--- a/apps/cli/skills-src/manifest.json
+++ b/apps/cli/skills-src/manifest.json
@@ -371,7 +371,7 @@
       "operatingBrief": [
         "When this skill is invoked, close the active release-sized milestone after all milestone slices and tasks are done and verified.",
         "",
-        "Load the project snapshot and active milestone, list slices, list tasks for each slice when detail is needed, inspect milestone/slice/task artifacts, confirm every required task is done and verified, summarize delivered outcomes, capture retrospective notes, write completion artifacts, and then complete the milestone through `milestone.complete`.",
+        "Load the project snapshot and active milestone, list slices, list tasks for each slice when detail is needed, inspect milestone/slice/task artifacts, read project-scoped closeout artifacts, confirm every required task is done and verified, summarize delivered outcomes, capture retrospective notes, write milestone completion artifacts, update project closeout artifacts, and then complete the milestone through `milestone.complete`.",
         "",
         "If readiness is uncertain, stop and explain what must be verified or resolved first."
       ],
@@ -379,15 +379,17 @@
         "The active milestone has an accepted completion summary.",
         "Every required slice is done.",
         "Every required task is done with `verificationState: verified`.",
-        "Completion evidence includes milestone, slice, and task-scoped artifacts.",
+        "Completion evidence includes milestone, slice, task, and project-scoped artifacts.",
         "Retrospective or archive artifacts are persisted when useful.",
-        "The milestone is completed through `milestone.complete` only after readiness is confirmed.",
+        "Project brief and project requirements artifacts are updated before `milestone.complete`, or the workflow stops to repair missing project artifacts.",
+        "The milestone is completed through `milestone.complete` only after readiness is confirmed and closeout artifact writes succeed.",
         "The user knows what remains, if anything, after completion."
       ],
       "doNot": [
         "Do not complete a milestone with unverified required work.",
         "Do not invent completion evidence.",
         "Do not rely only on milestone-level artifacts when task verification artifacts live on task scope.",
+        "Do not run `milestone.complete` after a failed project closeout artifact read or write.",
         "Do not create a new milestone here.",
         "Do not skip the readiness check."
       ],

--- a/apps/cli/skills-src/references/artifact-contract.md
+++ b/apps/cli/skills-src/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills-src/references/artifact-contract.md
+++ b/apps/cli/skills-src/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills-src/workflows/complete-milestone.md
+++ b/apps/cli/skills-src/workflows/complete-milestone.md
@@ -176,7 +176,13 @@ Before writing completion artifacts or completing the milestone, summarize:
 - Whether this milestone includes a release action or only validates a pre-release slice.
 - Project closeout updates that will be written to `PROJECT` project-scoped artifacts, including project brief changes, project requirements status/traceability changes, and preserved future requirements.
 
-Ask for explicit confirmation to complete the milestone and update project artifacts. If readiness is uncertain, stop and explain what remains.
+Ask for explicit confirmation to complete the milestone and update project artifacts.
+
+Use `Kata > VERIFYING` for the readiness checkpoint and reserve `Kata > MILESTONE COMPLETE` for the final success output after `milestone.complete` succeeds.
+
+If the milestone summary, retrospective, or project closeout artifacts already exist, enter idempotent closeout mode: read the existing content, preserve unchanged sections, and rewrite only the evidence-backed sections. Ask the user to confirm any carry-forward requirement reclassification before marking it validated.
+
+If readiness is uncertain, stop and explain what remains.
 
 ## Stage 4: Write Summary Artifact
 
@@ -218,7 +224,7 @@ node ./scripts/kata-call.mjs artifact.write --input /tmp/kata-retrospective.json
 
 ## Stage 6: Update Project Closeout Artifacts
 
-Rewrite project artifacts with the latest durable project state. Preserve existing durable sections unless the completed milestone gives explicit evidence to update them.
+Rewrite project artifacts with the latest durable project state. Preserve existing durable sections unless the completed milestone gives explicit evidence to update them. If the summary, retrospective, or project closeout artifacts already exist, read their current content first and update only the evidence-backed sections.
 
 Update `project-brief` to include or refresh closeout sections such as:
 
@@ -247,6 +253,7 @@ node ./scripts/kata-call.mjs artifact.write --input /tmp/kata-PROJECT-project-br
 Update project `requirements` to reflect milestone completion:
 
 - Mark project-level requirements as complete or validated only when milestone evidence supports the change.
+- Before reclassifying a carry-forward requirement as validated, ask for explicit confirmation and cite the evidence.
 - Update traceability rows from pending to the completed milestone, slices, tasks, or verification artifacts that prove coverage.
 - Preserve future requirements and carry-forward candidates, including their source milestone and deferred reason.
 - Keep still-active requirements in the active section.
@@ -283,7 +290,7 @@ node ./scripts/kata-call.mjs milestone.complete --input /tmp/kata-milestone-comp
 
 ## Completion
 
-Summarize the milestone outcome, known gaps, candidates for the next milestone, milestone artifacts written, and project artifacts updated. Include project artifact provenance when the backend reports it, such as the project tracking issue or artifact comment ID.
+Summarize the milestone outcome, known gaps, candidates for the next milestone, milestone artifacts written, and project artifacts updated. Report the changed artifact sections. Include project artifact provenance when the backend reports it, including the project tracking issue or URL when known and artifact comment ID.
 
 End with:
 
@@ -299,4 +306,5 @@ Next up: run `kata-new-milestone` to start the next cycle.
 - Preserve follow-up work in artifact content or backend task state.
 - Update project-scoped closeout artifacts before running `milestone.complete`.
 - Stop before `milestone.complete` if a required project artifact read or write is missing or fails.
+- Do not reclassify a carry-forward requirement as validated without explicit confirmation.
 - Keep lifecycle transitions in the CLI backend contract.

--- a/apps/cli/skills-src/workflows/complete-milestone.md
+++ b/apps/cli/skills-src/workflows/complete-milestone.md
@@ -231,7 +231,6 @@ Update `project-brief` to include or refresh closeout sections such as:
 - `## Current Status`
 - `## Completed Milestones`
 - `## Validated Outcomes`
-- `## Key Decisions`
 - `## Open Questions`
 - A last-updated note
 

--- a/apps/cli/skills-src/workflows/complete-milestone.md
+++ b/apps/cli/skills-src/workflows/complete-milestone.md
@@ -1,6 +1,6 @@
 # Complete Milestone Workflow
 
-Use this workflow to complete the active release-sized milestone after all milestone slices and tasks are done and verified: check readiness, preserve summary/retrospective/archive artifacts, then transition the backend milestone lifecycle.
+Use this workflow to complete the active release-sized milestone after all milestone slices and tasks are done and verified: check readiness, preserve summary/retrospective/archive artifacts, update project-scoped closeout artifacts, then transition the backend milestone lifecycle.
 
 ## Required Reading
 
@@ -132,7 +132,37 @@ node ./scripts/kata-call.mjs artifact.list --input /tmp/kata-task-artifacts.json
 node ./scripts/kata-call.mjs artifact.read --input /tmp/kata-read-task-verification.json
 ```
 
+Use `project.getSnapshot`, `slice.list`, and `task.list` for readiness. Read task summaries and verification artifacts selectively when evidence is unclear, when a plan explicitly requires UAT, or when no later task has consolidated the milestone evidence. Do not spend time reading every task artifact when a verified consolidation artifact already covers the milestone evidence.
+
 Review requirements, roadmap, slice plans, task summaries, verification artifacts, and any UAT artifacts that were explicitly required by a plan. Surface incomplete or failed work before asking to close the milestone.
+
+Read project-scoped closeout artifacts. These live on the project tracking issue in backends that represent project artifacts that way.
+
+```json
+{
+  "scopeType": "project",
+  "scopeId": "PROJECT",
+  "artifactType": "project-brief"
+}
+```
+
+```bash
+node ./scripts/kata-call.mjs artifact.read --input /tmp/kata-read-project-brief.json
+```
+
+```json
+{
+  "scopeType": "project",
+  "scopeId": "PROJECT",
+  "artifactType": "requirements"
+}
+```
+
+```bash
+node ./scripts/kata-call.mjs artifact.read --input /tmp/kata-read-project-requirements.json
+```
+
+If either project artifact is missing, stop before completion and ask whether to create the missing artifact from milestone evidence or repair project setup first.
 
 ## Stage 3: Confirm Completion Readiness
 
@@ -144,8 +174,9 @@ Before writing completion artifacts or completing the milestone, summarize:
 - Requirements covered.
 - Known gaps, follow-up work, and carry-forward candidates from `snapshot.requirements.futureIds`.
 - Whether this milestone includes a release action or only validates a pre-release slice.
+- Project closeout updates that will be written to `PROJECT` project-scoped artifacts, including project brief changes, project requirements status/traceability changes, and preserved future requirements.
 
-Ask for explicit confirmation to complete the milestone. If readiness is uncertain, stop and explain what remains.
+Ask for explicit confirmation to complete the milestone and update project artifacts. If readiness is uncertain, stop and explain what remains.
 
 ## Stage 4: Write Summary Artifact
 
@@ -185,7 +216,59 @@ Use `templates/retrospective.md`.
 node ./scripts/kata-call.mjs artifact.write --input /tmp/kata-retrospective.json
 ```
 
-## Stage 6: Complete Milestone
+## Stage 6: Update Project Closeout Artifacts
+
+Rewrite project artifacts with the latest durable project state. Preserve existing durable sections unless the completed milestone gives explicit evidence to update them.
+
+Update `project-brief` to include or refresh closeout sections such as:
+
+- `## Current Status`
+- `## Completed Milestones`
+- `## Validated Outcomes`
+- `## Key Decisions`
+- `## Open Questions`
+- A last-updated note
+
+Use milestone evidence to add one concise entry for the completed milestone. Do not paste the milestone archive wholesale into the project brief.
+
+Create `/tmp/kata-PROJECT-project-brief.md` from the existing project brief plus the milestone closeout update, then generate the write payload:
+
+```bash
+node ./scripts/kata-artifact-input.mjs \
+  --scope-type project \
+  --scope-id PROJECT \
+  --artifact-type project-brief \
+  --title "PROJECT" \
+  --content-file /tmp/kata-PROJECT-project-brief.md \
+  --output /tmp/kata-PROJECT-project-brief.json
+node ./scripts/kata-call.mjs artifact.write --input /tmp/kata-PROJECT-project-brief.json
+```
+
+Update project `requirements` to reflect milestone completion:
+
+- Mark project-level requirements as complete or validated only when milestone evidence supports the change.
+- Update traceability rows from pending to the completed milestone, slices, tasks, or verification artifacts that prove coverage.
+- Preserve future requirements and carry-forward candidates, including their source milestone and deferred reason.
+- Keep still-active requirements in the active section.
+
+Create `/tmp/kata-PROJECT-requirements.md` from the existing project requirements plus the milestone closeout update, then generate the write payload:
+
+```bash
+node ./scripts/kata-artifact-input.mjs \
+  --scope-type project \
+  --scope-id PROJECT \
+  --artifact-type requirements \
+  --title "PROJECT Requirements" \
+  --content-file /tmp/kata-PROJECT-requirements.md \
+  --output /tmp/kata-PROJECT-requirements.json
+node ./scripts/kata-call.mjs artifact.write --input /tmp/kata-PROJECT-requirements.json
+```
+
+If either project artifact write fails or returns `ok: false`, stop before `milestone.complete` and report the failed operation.
+
+## Stage 7: Complete Milestone
+
+Run this only after the milestone summary, milestone retrospective, project brief, and project requirements writes have succeeded.
 
 ```json
 {
@@ -200,7 +283,7 @@ node ./scripts/kata-call.mjs milestone.complete --input /tmp/kata-milestone-comp
 
 ## Completion
 
-Summarize the milestone outcome, known gaps, and candidates for the next milestone.
+Summarize the milestone outcome, known gaps, candidates for the next milestone, milestone artifacts written, and project artifacts updated. Include project artifact provenance when the backend reports it, such as the project tracking issue or artifact comment ID.
 
 End with:
 
@@ -214,4 +297,6 @@ Next up: run `kata-new-milestone` to start the next cycle.
 - Do not complete a milestone before listing slices and tasks for the active milestone.
 - Do not rely only on milestone-level artifacts; task verification artifacts live on task scope.
 - Preserve follow-up work in artifact content or backend task state.
+- Update project-scoped closeout artifacts before running `milestone.complete`.
+- Stop before `milestone.complete` if a required project artifact read or write is missing or fails.
 - Keep lifecycle transitions in the CLI backend contract.

--- a/apps/cli/skills/kata-complete-milestone/SKILL.md
+++ b/apps/cli/skills/kata-complete-milestone/SKILL.md
@@ -21,6 +21,9 @@ If readiness is uncertain, stop and explain what must be verified or resolved fi
 - Completion evidence includes milestone, slice, task, and project-scoped artifacts.
 - Retrospective or archive artifacts are persisted when useful.
 - Project brief and project requirements artifacts are updated before `milestone.complete`, or the workflow stops to repair missing project artifacts.
+- Existing milestone summary, retrospective, and project closeout artifacts are updated idempotently when they already exist.
+- Carry-forward requirements are only reclassified after explicit confirmation and evidence.
+- Completion output names the project tracking issue when the backend reports it and reports what changed in the project artifacts.
 - The milestone is completed through `milestone.complete` only after readiness is confirmed and closeout artifact writes succeed.
 - The user knows what remains, if anything, after completion.
 
@@ -30,6 +33,7 @@ If readiness is uncertain, stop and explain what must be verified or resolved fi
 - Do not invent completion evidence.
 - Do not rely only on milestone-level artifacts when task verification artifacts live on task scope.
 - Do not run `milestone.complete` after a failed project closeout artifact read or write.
+- Do not reclassify a carry-forward requirement as validated without explicit confirmation.
 - Do not create a new milestone here.
 - Do not skip the readiness check.
 

--- a/apps/cli/skills/kata-complete-milestone/SKILL.md
+++ b/apps/cli/skills/kata-complete-milestone/SKILL.md
@@ -9,7 +9,7 @@ description: "Use when the user wants to finish, close, ship, archive, or mark t
 
 When this skill is invoked, close the active release-sized milestone after all milestone slices and tasks are done and verified.
 
-Load the project snapshot and active milestone, list slices, list tasks for each slice when detail is needed, inspect milestone/slice/task artifacts, confirm every required task is done and verified, summarize delivered outcomes, capture retrospective notes, write completion artifacts, and then complete the milestone through `milestone.complete`.
+Load the project snapshot and active milestone, list slices, list tasks for each slice when detail is needed, inspect milestone/slice/task artifacts, read project-scoped closeout artifacts, confirm every required task is done and verified, summarize delivered outcomes, capture retrospective notes, write milestone completion artifacts, update project closeout artifacts, and then complete the milestone through `milestone.complete`.
 
 If readiness is uncertain, stop and explain what must be verified or resolved first.
 
@@ -18,9 +18,10 @@ If readiness is uncertain, stop and explain what must be verified or resolved fi
 - The active milestone has an accepted completion summary.
 - Every required slice is done.
 - Every required task is done with `verificationState: verified`.
-- Completion evidence includes milestone, slice, and task-scoped artifacts.
+- Completion evidence includes milestone, slice, task, and project-scoped artifacts.
 - Retrospective or archive artifacts are persisted when useful.
-- The milestone is completed through `milestone.complete` only after readiness is confirmed.
+- Project brief and project requirements artifacts are updated before `milestone.complete`, or the workflow stops to repair missing project artifacts.
+- The milestone is completed through `milestone.complete` only after readiness is confirmed and closeout artifact writes succeed.
 - The user knows what remains, if anything, after completion.
 
 ## Do Not
@@ -28,6 +29,7 @@ If readiness is uncertain, stop and explain what must be verified or resolved fi
 - Do not complete a milestone with unverified required work.
 - Do not invent completion evidence.
 - Do not rely only on milestone-level artifacts when task verification artifacts live on task scope.
+- Do not run `milestone.complete` after a failed project closeout artifact read or write.
 - Do not create a new milestone here.
 - Do not skip the readiness check.
 

--- a/apps/cli/skills/kata-complete-milestone/references/artifact-contract.md
+++ b/apps/cli/skills/kata-complete-milestone/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-complete-milestone/references/artifact-contract.md
+++ b/apps/cli/skills/kata-complete-milestone/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-complete-milestone/references/workflow.md
+++ b/apps/cli/skills/kata-complete-milestone/references/workflow.md
@@ -2,7 +2,7 @@
 
 # Complete Milestone Workflow
 
-Use this workflow to complete the active release-sized milestone after all milestone slices and tasks are done and verified: check readiness, preserve summary/retrospective/archive artifacts, then transition the backend milestone lifecycle.
+Use this workflow to complete the active release-sized milestone after all milestone slices and tasks are done and verified: check readiness, preserve summary/retrospective/archive artifacts, update project-scoped closeout artifacts, then transition the backend milestone lifecycle.
 
 ## Required Reading
 
@@ -134,7 +134,37 @@ node <path-to-skill-directory>/scripts/kata-call.mjs artifact.list --input /tmp/
 node <path-to-skill-directory>/scripts/kata-call.mjs artifact.read --input /tmp/kata-read-task-verification.json
 ```
 
+Use `project.getSnapshot`, `slice.list`, and `task.list` for readiness. Read task summaries and verification artifacts selectively when evidence is unclear, when a plan explicitly requires UAT, or when no later task has consolidated the milestone evidence. Do not spend time reading every task artifact when a verified consolidation artifact already covers the milestone evidence.
+
 Review requirements, roadmap, slice plans, task summaries, verification artifacts, and any UAT artifacts that were explicitly required by a plan. Surface incomplete or failed work before asking to close the milestone.
+
+Read project-scoped closeout artifacts. These live on the project tracking issue in backends that represent project artifacts that way.
+
+```json
+{
+  "scopeType": "project",
+  "scopeId": "PROJECT",
+  "artifactType": "project-brief"
+}
+```
+
+```bash
+node <path-to-skill-directory>/scripts/kata-call.mjs artifact.read --input /tmp/kata-read-project-brief.json
+```
+
+```json
+{
+  "scopeType": "project",
+  "scopeId": "PROJECT",
+  "artifactType": "requirements"
+}
+```
+
+```bash
+node <path-to-skill-directory>/scripts/kata-call.mjs artifact.read --input /tmp/kata-read-project-requirements.json
+```
+
+If either project artifact is missing, stop before completion and ask whether to create the missing artifact from milestone evidence or repair project setup first.
 
 ## Stage 3: Confirm Completion Readiness
 
@@ -146,8 +176,9 @@ Before writing completion artifacts or completing the milestone, summarize:
 - Requirements covered.
 - Known gaps, follow-up work, and carry-forward candidates from `snapshot.requirements.futureIds`.
 - Whether this milestone includes a release action or only validates a pre-release slice.
+- Project closeout updates that will be written to `PROJECT` project-scoped artifacts, including project brief changes, project requirements status/traceability changes, and preserved future requirements.
 
-Ask for explicit confirmation to complete the milestone. If readiness is uncertain, stop and explain what remains.
+Ask for explicit confirmation to complete the milestone and update project artifacts. If readiness is uncertain, stop and explain what remains.
 
 ## Stage 4: Write Summary Artifact
 
@@ -187,7 +218,59 @@ Use `templates/retrospective.md`.
 node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp/kata-retrospective.json
 ```
 
-## Stage 6: Complete Milestone
+## Stage 6: Update Project Closeout Artifacts
+
+Rewrite project artifacts with the latest durable project state. Preserve existing durable sections unless the completed milestone gives explicit evidence to update them.
+
+Update `project-brief` to include or refresh closeout sections such as:
+
+- `## Current Status`
+- `## Completed Milestones`
+- `## Validated Outcomes`
+- `## Key Decisions`
+- `## Open Questions`
+- A last-updated note
+
+Use milestone evidence to add one concise entry for the completed milestone. Do not paste the milestone archive wholesale into the project brief.
+
+Create `/tmp/kata-PROJECT-project-brief.md` from the existing project brief plus the milestone closeout update, then generate the write payload:
+
+```bash
+node <path-to-skill-directory>/scripts/kata-artifact-input.mjs \
+  --scope-type project \
+  --scope-id PROJECT \
+  --artifact-type project-brief \
+  --title "PROJECT" \
+  --content-file /tmp/kata-PROJECT-project-brief.md \
+  --output /tmp/kata-PROJECT-project-brief.json
+node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp/kata-PROJECT-project-brief.json
+```
+
+Update project `requirements` to reflect milestone completion:
+
+- Mark project-level requirements as complete or validated only when milestone evidence supports the change.
+- Update traceability rows from pending to the completed milestone, slices, tasks, or verification artifacts that prove coverage.
+- Preserve future requirements and carry-forward candidates, including their source milestone and deferred reason.
+- Keep still-active requirements in the active section.
+
+Create `/tmp/kata-PROJECT-requirements.md` from the existing project requirements plus the milestone closeout update, then generate the write payload:
+
+```bash
+node <path-to-skill-directory>/scripts/kata-artifact-input.mjs \
+  --scope-type project \
+  --scope-id PROJECT \
+  --artifact-type requirements \
+  --title "PROJECT Requirements" \
+  --content-file /tmp/kata-PROJECT-requirements.md \
+  --output /tmp/kata-PROJECT-requirements.json
+node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp/kata-PROJECT-requirements.json
+```
+
+If either project artifact write fails or returns `ok: false`, stop before `milestone.complete` and report the failed operation.
+
+## Stage 7: Complete Milestone
+
+Run this only after the milestone summary, milestone retrospective, project brief, and project requirements writes have succeeded.
 
 ```json
 {
@@ -202,7 +285,7 @@ node <path-to-skill-directory>/scripts/kata-call.mjs milestone.complete --input 
 
 ## Completion
 
-Summarize the milestone outcome, known gaps, and candidates for the next milestone.
+Summarize the milestone outcome, known gaps, candidates for the next milestone, milestone artifacts written, and project artifacts updated. Include project artifact provenance when the backend reports it, such as the project tracking issue or artifact comment ID.
 
 End with:
 
@@ -216,4 +299,6 @@ Next up: run `kata-new-milestone` to start the next cycle.
 - Do not complete a milestone before listing slices and tasks for the active milestone.
 - Do not rely only on milestone-level artifacts; task verification artifacts live on task scope.
 - Preserve follow-up work in artifact content or backend task state.
+- Update project-scoped closeout artifacts before running `milestone.complete`.
+- Stop before `milestone.complete` if a required project artifact read or write is missing or fails.
 - Keep lifecycle transitions in the CLI backend contract.

--- a/apps/cli/skills/kata-complete-milestone/references/workflow.md
+++ b/apps/cli/skills/kata-complete-milestone/references/workflow.md
@@ -233,7 +233,6 @@ Update `project-brief` to include or refresh closeout sections such as:
 - `## Current Status`
 - `## Completed Milestones`
 - `## Validated Outcomes`
-- `## Key Decisions`
 - `## Open Questions`
 - A last-updated note
 

--- a/apps/cli/skills/kata-complete-milestone/references/workflow.md
+++ b/apps/cli/skills/kata-complete-milestone/references/workflow.md
@@ -178,7 +178,13 @@ Before writing completion artifacts or completing the milestone, summarize:
 - Whether this milestone includes a release action or only validates a pre-release slice.
 - Project closeout updates that will be written to `PROJECT` project-scoped artifacts, including project brief changes, project requirements status/traceability changes, and preserved future requirements.
 
-Ask for explicit confirmation to complete the milestone and update project artifacts. If readiness is uncertain, stop and explain what remains.
+Ask for explicit confirmation to complete the milestone and update project artifacts.
+
+Use `Kata > VERIFYING` for the readiness checkpoint and reserve `Kata > MILESTONE COMPLETE` for the final success output after `milestone.complete` succeeds.
+
+If the milestone summary, retrospective, or project closeout artifacts already exist, enter idempotent closeout mode: read the existing content, preserve unchanged sections, and rewrite only the evidence-backed sections. Ask the user to confirm any carry-forward requirement reclassification before marking it validated.
+
+If readiness is uncertain, stop and explain what remains.
 
 ## Stage 4: Write Summary Artifact
 
@@ -220,7 +226,7 @@ node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp
 
 ## Stage 6: Update Project Closeout Artifacts
 
-Rewrite project artifacts with the latest durable project state. Preserve existing durable sections unless the completed milestone gives explicit evidence to update them.
+Rewrite project artifacts with the latest durable project state. Preserve existing durable sections unless the completed milestone gives explicit evidence to update them. If the summary, retrospective, or project closeout artifacts already exist, read their current content first and update only the evidence-backed sections.
 
 Update `project-brief` to include or refresh closeout sections such as:
 
@@ -249,6 +255,7 @@ node <path-to-skill-directory>/scripts/kata-call.mjs artifact.write --input /tmp
 Update project `requirements` to reflect milestone completion:
 
 - Mark project-level requirements as complete or validated only when milestone evidence supports the change.
+- Before reclassifying a carry-forward requirement as validated, ask for explicit confirmation and cite the evidence.
 - Update traceability rows from pending to the completed milestone, slices, tasks, or verification artifacts that prove coverage.
 - Preserve future requirements and carry-forward candidates, including their source milestone and deferred reason.
 - Keep still-active requirements in the active section.
@@ -285,7 +292,7 @@ node <path-to-skill-directory>/scripts/kata-call.mjs milestone.complete --input 
 
 ## Completion
 
-Summarize the milestone outcome, known gaps, candidates for the next milestone, milestone artifacts written, and project artifacts updated. Include project artifact provenance when the backend reports it, such as the project tracking issue or artifact comment ID.
+Summarize the milestone outcome, known gaps, candidates for the next milestone, milestone artifacts written, and project artifacts updated. Report the changed artifact sections. Include project artifact provenance when the backend reports it, including the project tracking issue or URL when known and artifact comment ID.
 
 End with:
 
@@ -301,4 +308,5 @@ Next up: run `kata-new-milestone` to start the next cycle.
 - Preserve follow-up work in artifact content or backend task state.
 - Update project-scoped closeout artifacts before running `milestone.complete`.
 - Stop before `milestone.complete` if a required project artifact read or write is missing or fails.
+- Do not reclassify a carry-forward requirement as validated without explicit confirmation.
 - Keep lifecycle transitions in the CLI backend contract.

--- a/apps/cli/skills/kata-execute-issue/references/artifact-contract.md
+++ b/apps/cli/skills/kata-execute-issue/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-execute-issue/references/artifact-contract.md
+++ b/apps/cli/skills/kata-execute-issue/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-execute-phase/references/artifact-contract.md
+++ b/apps/cli/skills/kata-execute-phase/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-execute-phase/references/artifact-contract.md
+++ b/apps/cli/skills/kata-execute-phase/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-health/references/artifact-contract.md
+++ b/apps/cli/skills/kata-health/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-health/references/artifact-contract.md
+++ b/apps/cli/skills/kata-health/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-new-milestone/references/artifact-contract.md
+++ b/apps/cli/skills/kata-new-milestone/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-new-milestone/references/artifact-contract.md
+++ b/apps/cli/skills/kata-new-milestone/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-new-project/references/artifact-contract.md
+++ b/apps/cli/skills/kata-new-project/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-new-project/references/artifact-contract.md
+++ b/apps/cli/skills/kata-new-project/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-plan-issue/references/artifact-contract.md
+++ b/apps/cli/skills/kata-plan-issue/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-plan-issue/references/artifact-contract.md
+++ b/apps/cli/skills/kata-plan-issue/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-plan-phase/references/artifact-contract.md
+++ b/apps/cli/skills/kata-plan-phase/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-plan-phase/references/artifact-contract.md
+++ b/apps/cli/skills/kata-plan-phase/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-progress/references/artifact-contract.md
+++ b/apps/cli/skills/kata-progress/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-progress/references/artifact-contract.md
+++ b/apps/cli/skills/kata-progress/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-setup/references/artifact-contract.md
+++ b/apps/cli/skills/kata-setup/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-setup/references/artifact-contract.md
+++ b/apps/cli/skills/kata-setup/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-verify-work/references/artifact-contract.md
+++ b/apps/cli/skills/kata-verify-work/references/artifact-contract.md
@@ -81,6 +81,7 @@ During milestone closeout, update project requirements when the milestone provid
 - Preserve active requirements that remain in scope for later milestones.
 - Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
 - Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
+- When rewriting existing project artifacts, preserve unchanged sections and report which sections changed in the completion output.
 
 ## Milestone Artifacts
 

--- a/apps/cli/skills/kata-verify-work/references/artifact-contract.md
+++ b/apps/cli/skills/kata-verify-work/references/artifact-contract.md
@@ -49,9 +49,19 @@ Required sections:
 - Active assumptions
 - Out of scope
 
+Milestone closeout updates may add or refresh these sections when the completed milestone changes durable project state:
+
+- Current Status
+- Completed Milestones
+- Validated Outcomes
+- Open Questions
+- Last updated note
+
+Keep milestone closeout entries concise. Link or reference milestone summaries for detailed evidence instead of copying the full milestone archive into the project brief.
+
 ### Project Requirements
 
-Use for durable project-level requirements hypotheses gathered before the first milestone.
+Use for durable project-level requirements hypotheses gathered before the first milestone and project-level traceability across completed milestones.
 
 ```json
 {
@@ -63,6 +73,14 @@ Use for durable project-level requirements hypotheses gathered before the first 
   "format": "markdown"
 }
 ```
+
+During milestone closeout, update project requirements when the milestone provides evidence:
+
+- Move completed project-level requirements into a validated or completed section, or mark them complete in place when the existing artifact uses checklist status.
+- Update traceability rows with the completed milestone ID and evidence source.
+- Preserve active requirements that remain in scope for later milestones.
+- Preserve future requirements and carry-forward candidates with source milestone and deferred reason.
+- Do not mark requirements complete from milestone title alone; use requirements, roadmap, task verification, UAT, or milestone summary evidence.
 
 ## Milestone Artifacts
 

--- a/apps/cli/src/tests/phase-a-skill-surface.vitest.test.ts
+++ b/apps/cli/src/tests/phase-a-skill-surface.vitest.test.ts
@@ -144,6 +144,31 @@ describe("Phase A skill surface", () => {
     expect(manifest).toContain("Do not run `milestone.complete` after a failed project closeout artifact read or write.");
   });
 
+  it("keeps milestone closeout idempotent and delays the complete banner until success", () => {
+    const completeWorkflow = readFileSync(
+      path.join(sourceRoot, "skills-src", "workflows", "complete-milestone.md"),
+      "utf8",
+    );
+    const artifactContract = readFileSync(
+      path.join(sourceRoot, "skills-src", "references", "artifact-contract.md"),
+      "utf8",
+    );
+    const manifest = readFileSync(path.join(sourceRoot, "skills-src", "manifest.json"), "utf8");
+
+    expect(completeWorkflow).toContain("Kata > VERIFYING");
+    expect(completeWorkflow).toContain("reserve `Kata > MILESTONE COMPLETE` for the final success output after `milestone.complete` succeeds");
+    expect(completeWorkflow).toContain("idempotent closeout mode");
+    expect(completeWorkflow).toContain("preserve unchanged sections");
+    expect(completeWorkflow).toContain("confirm any carry-forward requirement reclassification before marking it validated");
+    expect(completeWorkflow).toContain("project tracking issue or URL when known");
+    expect(completeWorkflow).toContain("Report the changed artifact sections");
+    expect(artifactContract).toContain("preserve unchanged sections and report which sections changed in the completion output");
+    expect(manifest).toContain("updated idempotently when they already exist");
+    expect(manifest).toContain("Carry-forward requirements are only reclassified after explicit confirmation and evidence.");
+    expect(manifest).toContain("project tracking issue when the backend reports it and reports what changed in the project artifacts");
+    expect(manifest).toContain("Do not reclassify a carry-forward requirement as validated without explicit confirmation.");
+  });
+
   it("uses project snapshots for concrete next-step recommendations", () => {
     const verifyWorkflow = readFileSync(
       path.join(sourceRoot, "skills-src", "workflows", "verify-work.md"),

--- a/apps/cli/src/tests/phase-a-skill-surface.vitest.test.ts
+++ b/apps/cli/src/tests/phase-a-skill-surface.vitest.test.ts
@@ -139,6 +139,7 @@ describe("Phase A skill surface", () => {
     );
     expect(completeWorkflow).toContain("kata-artifact-input.mjs");
     expect(artifactContract).toContain("Milestone closeout updates may add or refresh these sections");
+    expect(completeWorkflow).not.toContain("- `## Key Decisions`");
     expect(artifactContract).toContain("During milestone closeout, update project requirements");
     expect(manifest).toContain("update project closeout artifacts");
     expect(manifest).toContain("Do not run `milestone.complete` after a failed project closeout artifact read or write.");

--- a/apps/cli/src/tests/phase-a-skill-surface.vitest.test.ts
+++ b/apps/cli/src/tests/phase-a-skill-surface.vitest.test.ts
@@ -108,12 +108,40 @@ describe("Phase A skill surface", () => {
     expect(completeWorkflow).toContain("task.list");
     expect(completeWorkflow).toContain("verificationState` other than `verified`");
     expect(completeWorkflow).toContain("task verification artifacts live on task scope");
+    expect(completeWorkflow).toContain("Read task summaries and verification artifacts selectively");
     expect(completeWorkflow).not.toContain("todo app MVP");
     expect(manifest).toContain('"slice.list"');
     expect(manifest).toContain('"task.list"');
     expect(manifest).toContain('"artifact.list"');
     expect(manifest).toContain('"artifact.read"');
     expect(manifest).toContain("Every required task is done with `verificationState: verified`.");
+  });
+
+  it("requires complete-milestone to update project closeout artifacts before completion", () => {
+    const completeWorkflow = readFileSync(
+      path.join(sourceRoot, "skills-src", "workflows", "complete-milestone.md"),
+      "utf8",
+    );
+    const artifactContract = readFileSync(
+      path.join(sourceRoot, "skills-src", "references", "artifact-contract.md"),
+      "utf8",
+    );
+    const manifest = readFileSync(path.join(sourceRoot, "skills-src", "manifest.json"), "utf8");
+
+    expect(completeWorkflow).toContain('"scopeType": "project"');
+    expect(completeWorkflow).toContain('"artifactType": "project-brief"');
+    expect(completeWorkflow).toContain('"artifactType": "requirements"');
+    expect(completeWorkflow).toContain("These live on the project tracking issue");
+    expect(completeWorkflow).toContain("Update Project Closeout Artifacts");
+    expect(completeWorkflow).toContain("Stop before `milestone.complete` if a required project artifact read or write is missing or fails.");
+    expect(completeWorkflow.indexOf("Update Project Closeout Artifacts")).toBeLessThan(
+      completeWorkflow.indexOf("## Stage 7: Complete Milestone"),
+    );
+    expect(completeWorkflow).toContain("kata-artifact-input.mjs");
+    expect(artifactContract).toContain("Milestone closeout updates may add or refresh these sections");
+    expect(artifactContract).toContain("During milestone closeout, update project requirements");
+    expect(manifest).toContain("update project closeout artifacts");
+    expect(manifest).toContain("Do not run `milestone.complete` after a failed project closeout artifact read or write.");
   });
 
   it("uses project snapshots for concrete next-step recommendations", () => {


### PR DESCRIPTION
## Summary
- Add idempotent closeout mode for existing milestone summaries, retrospectives, and project closeout artifacts.
- Require explicit confirmation before reclassifying carry-forward requirements.
- Preserve existing project artifact content and report changed sections.
- Delay the final MILESTONE COMPLETE banner until after milestone completion succeeds.
- Update the generated kata-complete-milestone bundle and installed skill copy.
- Refresh the related project artifact traceability in issue #399.

## Validation
- pnpm --filter @kata-sh/cli test
- pnpm --filter @kata-sh/cli typecheck
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines the `kata-complete-milestone` skill to support idempotent closeout: agents now read existing milestone summary, retrospective, and project closeout artifacts before rewriting them, gate `milestone.complete` on successful project artifact writes, and delay the `Kata > MILESTONE COMPLETE` banner until after the backend call succeeds. The shared `artifact-contract.md` reference is updated in all skill directories to document the new closeout update rules, and two new Vitest tests assert the updated workflow surface contracts.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are documentation and workflow instruction files with supporting surface-contract tests; no executable logic is modified.

The PR touches only markdown workflow/skill documents, the manifest JSON, and a Vitest test file. The new stages are internally consistent across all three source files (workflow, artifact-contract, manifest) and their installed copies. Tests correctly guard idempotency and ordering invariants. No runtime code paths are changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/skills-src/workflows/complete-milestone.md | Core workflow document: adds Stage 6 (Update Project Closeout Artifacts) before renamed Stage 7 (Complete Milestone), documents idempotent read-before-write for project artifacts, and gates milestone.complete on artifact write success. |
| apps/cli/src/tests/phase-a-skill-surface.vitest.test.ts | Adds two new surface-contract tests that assert the workflow and manifest contain all required idempotency and project closeout strings; test logic is sound (toContain guards protect the ordering assertion). |
| apps/cli/skills-src/manifest.json | Adds project-closeout requirements to operatingBrief, successCriteria, and doNot arrays; kept in sync with the workflow changes. |
| apps/cli/skills-src/references/artifact-contract.md | Extends Project Brief and Project Requirements sections with milestone-closeout update guidance; identical diff applied to all skill artifact-contract copies. |
| .agents/skills/kata-complete-milestone/references/workflow.md | Agent-facing installed skill copy; mirrors complete-milestone.md source changes with path-to-skill-directory prefix instead of relative ./scripts prefix — consistent with expected install layout. |
| apps/cli/skills/kata-execute-issue/references/artifact-contract.md | Receives the same artifact-contract closeout addendum as all other skill directories; the 'During milestone closeout' qualifier scopes these instructions correctly. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    S1["Stage 1–2: Load Snapshot & Inspect Artifacts\n(milestone, slice, task artifacts)\n+ Read project-brief & requirements"]
    S1 --> CHECK_MISSING{Project artifacts\nmissing?}
    CHECK_MISSING -- Yes --> STOP_REPAIR["Stop: ask user to create\nmissing artifact or repair setup"]
    CHECK_MISSING -- No --> CHECK_IDEM{Existing summary /\nretrospective / closeout\nartifacts found?}
    CHECK_IDEM -- Yes --> IDEM["Enter idempotent closeout mode:\npreserve unchanged sections,\nrewrite only evidence-backed sections"]
    CHECK_IDEM -- No --> S3
    IDEM --> S3
    S3["Stage 3: Confirm Completion Readiness\n(Kata > VERIFYING)\nInclude planned project artifact updates"]
    S3 --> CONFIRM{Explicit user\nconfirmation?}
    CONFIRM -- No --> STOP_UNCONFIRMED["Stop: explain what remains"]
    CONFIRM -- Yes --> S4
    S4["Stage 4: Write Milestone Summary Artifact"]
    S4 --> S5["Stage 5: Write Retrospective Artifact"]
    S5 --> S6["Stage 6: Update Project Closeout Artifacts\n(project-brief + requirements)"]
    S6 --> CHECK_WRITE{Artifact write\nok: true?}
    CHECK_WRITE -- No --> STOP_WRITE["Stop: report failed operation\n(do NOT run milestone.complete)"]
    CHECK_WRITE -- Yes --> CARRY{Carry-forward req\nreclassification needed?}
    CARRY -- Yes --> CONFIRM2{User confirms\nreclassification?}
    CONFIRM2 -- No --> SKIP_RECLASSIFY["Preserve as carry-forward"]
    CONFIRM2 -- Yes --> S7
    SKIP_RECLASSIFY --> S7
    CARRY -- No --> S7
    S7["Stage 7: milestone.complete"]
    S7 --> DONE["Kata > MILESTONE COMPLETE\n(report changed sections,\nproject tracking issue, artifact IDs)"]
```

<sub>Reviews (1): Last reviewed commit: ["Sync installed skill artifact contracts"](https://github.com/gannonh/kata/commit/a7f92fe9e51ed0817444a7898411cae4b123a8b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30625584)</sub>

<!-- /greptile_comment -->