### PR TITLE
[S904] Refresh Symphony docs pages

### DIFF
--- a/apps/online-docs/reference/symphony-workflow.mdx
+++ b/apps/online-docs/reference/symphony-workflow.mdx
@@ -15,7 +15,8 @@ Runtime prompts come from `prompts` front-matter entries (or external prompt fil
 In worker prompts/skills, use the backend-neutral helper script for tracker/document/state operations:
 
 ```bash
-.agents/skills/sym-state/scripts/sym-call <operation> --input /tmp/input.json
+INPUT="/tmp/sym-${SYMPHONY_ISSUE_ID:-current}-<operation>-$$.json"
+.agents/skills/sym-state/scripts/sym-call <operation> --input "$INPUT"
 ```
 
 Supported operations:
@@ -28,7 +29,25 @@ Supported operations:
 - `issue.update-state`
 - `issue.create-followup`
 
+Use opaque tracker issue IDs with helper payloads (`SYMPHONY_ISSUE_ID`), or `"@current"` where supported.
+
 Do **not** use legacy `kata_*` worker tools or backend-specific tracker mutation paths in normal worker flow.
+
+## Current dispatch behavior
+
+On each poll cycle, Symphony fetches tracker candidates and dispatches issues that pass all gates.
+
+Dispatch gates:
+
+- issue is assigned to worker (`assigned_to_worker: true`)
+- issue state is in `tracker.active_states`
+- issue state is not in `tracker.terminal_states`
+- issue has no parent issue (`parent_identifier` must be empty)
+- issue labels do not match `tracker.exclude_labels`
+- issue has no non-terminal blockers in `blocked_by`
+- issue is not already claimed or already running
+
+Before dispatch, Symphony refreshes each candidate by issue ID and re-validates eligibility. Candidate ordering is deterministic: priority, creation time, then identifier. Dispatch continues until `agent.max_concurrent_agents` capacity is filled.
 
 ## Agent harness vs backend-state separation
 
@@ -313,7 +332,7 @@ Configuration for the Kata CLI backend (`agent.name: pi`). The legacy `agent.bac
 </ParamField>
 
 <ParamField path="kata_agent.model_by_state" type="object">
-  Per-Linear-state model overrides. Keys are state names (case-insensitive); falls back to `kata_agent.model` for unlisted states.
+  Per-state model overrides. Keys are state names (case-insensitive); falls back to `kata_agent.model` for unlisted states.
 
   ```yaml
   kata_agent:
@@ -446,7 +465,7 @@ SSH remote worker pool for distributing agent sessions across multiple machines.
 
 ## `prompts`
 
-Per-state prompt injection. When configured, Symphony selects a prompt template based on the issue's current workflow state instead of using the monolithic markdown body after `---`.
+Per-state prompt injection. When configured, Symphony selects a prompt template based on the issue's current state instead of using the monolithic markdown body after `---`.
 
 <ParamField path="prompts.system" type="string">
   Path to a system-level preamble (agent identity, tool guidance). Injected every turn. Relative to the WORKFLOW.md directory.
@@ -461,7 +480,7 @@ Per-state prompt injection. When configured, Symphony selects a prompt template 
 </ParamField>
 
 <ParamField path="prompts.by_state" type="object">
-  Map of Linear state name to prompt file path. State matching is case-insensitive.
+  Map of state name to prompt file path. State matching is case-insensitive.
 
   ```yaml
   prompts:
@@ -490,10 +509,10 @@ The markdown body (or prompt files) is rendered as a Liquid template. These vari
 |----------|-------------|
 | `{{ issue.identifier }}` | Issue identifier, e.g. `KAT-42` |
 | `{{ issue.title }}` | Issue title |
-| `{{ issue.state }}` | Current Linear state name |
+| `{{ issue.state }}` | Current issue state name |
 | `{{ issue.labels }}` | Array of label names. Use a Liquid loop or `join` filter if you need a comma-separated string. |
 | `{{ issue.description }}` | Issue description body |
-| `{{ issue.url }}` | URL to the issue in Linear |
+| `{{ issue.url }}` | URL to the issue in the configured tracker |
 | `{{ issue.children_count }}` | Number of child (sub) issues |
 | `{{ issue.parent_identifier }}` | Identifier of the parent issue (if any) |
 | `{{ attempt }}` | Current attempt number (1-indexed) |

--- a/apps/online-docs/reference/symphony-workflow.mdx
+++ b/apps/online-docs/reference/symphony-workflow.mdx
@@ -47,7 +47,7 @@ Dispatch gates:
 - issue has no non-terminal blockers in `blocked_by`
 - issue is not already claimed or already running
 
-Before dispatch, Symphony refreshes each candidate by issue ID and re-validates eligibility. Candidate ordering is deterministic: priority, creation time, then identifier. Dispatch continues until `agent.max_concurrent_agents` capacity is filled.
+Before dispatch, Symphony refreshes each candidate by issue ID and re-validates eligibility. Candidate ordering is deterministic: priority (`1` highest, then `2`/`3`/`4`, then unset), then creation time, then identifier. Dispatch continues until `agent.max_concurrent_agents` capacity is filled.
 
 ## Agent harness vs backend-state separation
 

--- a/apps/online-docs/symphony/overview.mdx
+++ b/apps/online-docs/symphony/overview.mdx
@@ -27,6 +27,22 @@ All configuration lives in a single `WORKFLOW.md` file: Symphony reads the YAML 
   </Step>
 </Steps>
 
+## Dispatch behavior
+
+On each poll tick, Symphony computes a candidate set from tracker issues, then dispatches up to available concurrency slots.
+
+Current dispatch rules:
+
+- Issue must be assigned to a worker and in `tracker.active_states`
+- Issue is skipped if in `tracker.terminal_states`
+- Issue is skipped if it has a parent issue (`parent_identifier` is set)
+- Issue is skipped when any label matches `tracker.exclude_labels`
+- Issue is skipped when `blocked_by` contains a blocker in a non-terminal state
+- Issue is skipped when already claimed or already running
+- Candidate state is refreshed by issue ID before dispatch and re-validated
+
+Dispatch order is deterministic: priority (`1` highest, then `2`/`3`/`4`, then unset), then creation time, then identifier. Symphony dispatches candidates in that order until `agent.max_concurrent_agents` slots are filled.
+
 ## Ticket lifecycle
 
 ```
@@ -45,7 +61,7 @@ Todo → In Progress → Agent Review → Merging → Done
 | **Done** | Agent | Terminal — PR merged, workspace cleaned up |
 
 <Warning>
-  The state names in `active_states`, `terminal_states`, and other state-keyed fields must match the workflow state names configured in your Linear team. State matching is case-insensitive, but the names must exist in your Linear workflow. To see your team's states, go to **Linear → Settings → Teams → [your team] → Workflow**.
+  The state names in `active_states`, `terminal_states`, and other state-keyed fields must match the workflow states in your tracker configuration. State matching is case-insensitive.
 </Warning>
 
 ## Key features

--- a/apps/online-docs/symphony/workflow-config.mdx
+++ b/apps/online-docs/symphony/workflow-config.mdx
@@ -47,7 +47,7 @@ Dispatch gates:
 - issue has no parent issue (`parent_identifier` must be empty)
 - issue labels do not match `tracker.exclude_labels`
 - issue has no non-terminal blockers in `blocked_by`
-- issue is not already claimed or running
+- issue is not already claimed or already running
 
 Before dispatch, Symphony refreshes each candidate by issue ID and re-validates it. Candidate ordering is deterministic: priority, creation time, then identifier. Dispatch continues until `agent.max_concurrent_agents` capacity is reached.
 

--- a/apps/online-docs/symphony/workflow-config.mdx
+++ b/apps/online-docs/symphony/workflow-config.mdx
@@ -17,7 +17,8 @@ Symphony hot-reloads config updates from this file.
 Use `agent.*` to define how Symphony launches the worker runtime, and use the sym-state helper for tracker/document/state operations from worker prompts/skills:
 
 ```bash
-.agents/skills/sym-state/scripts/sym-call <operation> --input /tmp/input.json
+INPUT="/tmp/sym-${SYMPHONY_ISSUE_ID:-current}-<operation>-$$.json"
+.agents/skills/sym-state/scripts/sym-call <operation> --input "$INPUT"
 ```
 
 Operations:
@@ -30,7 +31,25 @@ Operations:
 - `issue.update-state`
 - `issue.create-followup`
 
+Use opaque tracker issue IDs with helper payloads (`SYMPHONY_ISSUE_ID`), or `"@current"` where supported.
+
 Legacy `kata_*` worker tool names are not the current contract.
+
+## Current dispatch behavior
+
+On each poll cycle, Symphony fetches candidates from the tracker and dispatches only issues that satisfy all runtime gates.
+
+Dispatch gates:
+
+- issue is assigned to worker (`assigned_to_worker: true`)
+- issue state is in `tracker.active_states`
+- issue state is not in `tracker.terminal_states`
+- issue has no parent issue (`parent_identifier` must be empty)
+- issue labels do not match `tracker.exclude_labels`
+- issue has no non-terminal blockers in `blocked_by`
+- issue is not already claimed or running
+
+Before dispatch, Symphony refreshes each candidate by issue ID and re-validates it. Candidate ordering is deterministic: priority, creation time, then identifier. Dispatch continues until `agent.max_concurrent_agents` capacity is reached.
 
 ## Minimal config
 
@@ -278,7 +297,7 @@ All hooks receive these environment variables:
 
 | Variable | Example |
 | --- | --- |
-| `SYMPHONY_ISSUE_ID` | Linear issue UUID |
+| `SYMPHONY_ISSUE_ID` | Tracker issue ID (opaque; pass through unchanged) |
 | `SYMPHONY_ISSUE_IDENTIFIER` | `KAT-911` |
 | `SYMPHONY_ISSUE_TITLE` | Issue title text |
 | `SYMPHONY_WORKSPACE_PATH` | `/home/user/symphony-workspaces/KAT-911` |
@@ -336,7 +355,7 @@ supervisor:
 
 ## `prompts` section
 
-Per-state prompt injection. When configured, Symphony selects a prompt file based on the issue's current Linear state instead of using the monolithic markdown body.
+Per-state prompt injection. When configured, Symphony selects a prompt file based on the issue's current workflow state instead of using the monolithic markdown body.
 
 ```yaml
 prompts:
@@ -366,7 +385,7 @@ Prompt files are concatenated in order: `system` + `repo` + `shared` (legacy) + 
 </ParamField>
 
 <ParamField path="prompts.by_state" type="object">
-  Map of Linear state name to prompt file path. State matching is case-insensitive. Paths are relative to the WORKFLOW.md directory.
+  Map of workflow state name to prompt file path. State matching is case-insensitive. Paths are relative to the WORKFLOW.md directory.
 </ParamField>
 
 <ParamField path="prompts.default" type="string">


### PR DESCRIPTION
## Summary
- refresh Symphony overview/workflow docs with current dependency-aware dispatch gates and ordering
- update worker helper contract examples to use backend-neutral sym-state usage with opaque issue IDs
- remove remaining backend-specific wording in the touched docs pages

Closes #473

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes three Symphony docs pages to be backend-neutral: it replaces Linear-specific wording with tracker-neutral language, documents the current dispatch gate logic and deterministic ordering, and updates the `sym-call` helper contract example to use a PID-qualified temp path with `SYMPHONY_ISSUE_ID`. All findings are P2 style suggestions — the `tracker.active_states` ParamField descriptions in both reference files still mention "your Linear team", and the duplicate dispatch sections have minor wording divergences (last bullet, priority-value detail).

<h3>Confidence Score: 4/5</h3>

Safe to merge — documentation-only changes with no runtime impact; remaining issues are all P2 style fixes.

All findings are P2 (incomplete de-linearization in two ParamField descriptions and minor wording divergences between duplicated dispatch sections). No logic or correctness issues exist.

apps/online-docs/reference/symphony-workflow.mdx and apps/online-docs/symphony/workflow-config.mdx — both still have "your Linear team" in tracker.active_states ParamField descriptions.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/online-docs/reference/symphony-workflow.mdx | Good backend-neutral updates (dispatch section, template variable descriptions, prompts wording), but `tracker.active_states` ParamField still references "your Linear team" — inconsistent with the de-linearization goal. |
| apps/online-docs/symphony/overview.mdx | Clean addition of dispatch behavior section with detailed priority ordering, and the Warning block was correctly de-linearized. No issues found. |
| apps/online-docs/symphony/workflow-config.mdx | Good changes overall, but `tracker.active_states` ParamField still says "your Linear team workflow", and the dispatch section's final bullet has a minor wording divergence from the reference page. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Poll cycle] --> B[Fetch tracker candidates]
    B --> C{assigned_to_worker?}
    C -- No --> SKIP1[Skip]
    C -- Yes --> D{state in active_states?}
    D -- No --> SKIP2[Skip]
    D -- Yes --> E{state in terminal_states?}
    E -- Yes --> SKIP3[Skip]
    E -- No --> F{has parent_identifier?}
    F -- Yes --> SKIP4[Skip]
    F -- No --> G{label in exclude_labels?}
    G -- Yes --> SKIP5[Skip]
    G -- No --> H{blocked_by non-terminal?}
    H -- Yes --> SKIP6[Skip]
    H -- No --> I{already claimed/running?}
    I -- Yes --> SKIP7[Skip]
    I -- No --> J[Refresh candidate by issue ID & re-validate]
    J --> K[Order: priority → created_at → identifier]
    K --> L{max_concurrent_agents reached?}
    L -- Yes --> DONE[Stop dispatch]
    L -- No --> M[Dispatch agent session]
    M --> L
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/online-docs/reference/symphony-workflow.mdx`, line 168 ([link](https://github.com/gannonh/kata/blob/fe9d202573acfb94e67cc38738b07149bd61702c/apps/online-docs/reference/symphony-workflow.mdx#L168)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The `tracker.active_states` ParamField description still refers to "your Linear team", which is inconsistent with the backend-neutral edits made elsewhere in this PR (e.g., the Warning block in `overview.mdx` and the Liquid template variable descriptions were both updated). Users on GitHub tracker will see this and be confused.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/online-docs/reference/symphony-workflow.mdx
   Line: 168

   Comment:
   The `tracker.active_states` ParamField description still refers to "your Linear team", which is inconsistent with the backend-neutral edits made elsewhere in this PR (e.g., the Warning block in `overview.mdx` and the Liquid template variable descriptions were both updated). Users on GitHub tracker will see this and be confused.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/online-docs/symphony/workflow-config.mdx`, line 142 ([link](https://github.com/gannonh/kata/blob/fe9d202573acfb94e67cc38738b07149bd61702c/apps/online-docs/symphony/workflow-config.mdx#L142)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> Same residual Linear-specific wording in the `tracker.active_states` ParamField. This is the authoritative config reference and the description should be tracker-neutral to match the changes made elsewhere in this PR.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/online-docs/symphony/workflow-config.mdx
   Line: 142

   Comment:
   Same residual Linear-specific wording in the `tracker.active_states` ParamField. This is the authoritative config reference and the description should be tracker-neutral to match the changes made elsewhere in this PR.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
apps/online-docs/reference/symphony-workflow.mdx:168
The `tracker.active_states` ParamField description still refers to "your Linear team", which is inconsistent with the backend-neutral edits made elsewhere in this PR (e.g., the Warning block in `overview.mdx` and the Liquid template variable descriptions were both updated). Users on GitHub tracker will see this and be confused.

```suggestion
  Issue states eligible for dispatch. Must match the state names in your tracker configuration (case-insensitive).
```

### Issue 2 of 4
apps/online-docs/symphony/workflow-config.mdx:142
Same residual Linear-specific wording in the `tracker.active_states` ParamField. This is the authoritative config reference and the description should be tracker-neutral to match the changes made elsewhere in this PR.

```suggestion
  Issue states that are eligible for dispatch. Must match the state names in your tracker configuration (case-insensitive).
```

### Issue 3 of 4
apps/online-docs/symphony/workflow-config.mdx:50
The final dispatch gate bullet reads "issue is not already claimed or running", while the parallel section in `symphony-workflow.mdx` says "issue is not already claimed or **already** running". The two reference pages describe the same runtime behaviour and should be word-for-word identical on this bullet to avoid readers inferring a semantic difference.

```suggestion
- issue is not already claimed or already running
```

### Issue 4 of 4
apps/online-docs/reference/symphony-workflow.mdx:50
The ordering summary omits the explicit priority-value detail that `overview.mdx` includes (`1` highest, then `2/3/4`, then unset). Readers of the reference page — where they're most likely to be configuring dispatch — would benefit from the same specificity to understand how unlabeled or high-numbered priorities rank.

```suggestion
Before dispatch, Symphony refreshes each candidate by issue ID and re-validates eligibility. Candidate ordering is deterministic: priority (`1` highest, then `2`/`3`/`4`, then unset), then creation time, then identifier. Dispatch continues until `agent.max_concurrent_agents` capacity is filled.
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(symphony): refresh dispatch and hel..."](https://github.com/gannonh/kata/commit/fe9d202573acfb94e67cc38738b07149bd61702c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30770148)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->