### PR TITLE
docs: refresh CLI docs pages for runtime contract

### DIFF
--- a/apps/online-docs/cli/commands.mdx
+++ b/apps/online-docs/cli/commands.mdx
@@ -43,6 +43,13 @@ jq -n '{issueRef:"#471"}' > /tmp/kata-issue-get.json
 kata call issue.get --input /tmp/kata-issue-get.json
 ```
 
+## `kata json` example
+
+```bash
+jq -n '{operation:"health.check"}' > /tmp/kata-health.json
+kata json /tmp/kata-health.json
+```
+
 ## Operations
 
 The runtime currently exposes these operation names:

--- a/apps/online-docs/cli/commands.mdx
+++ b/apps/online-docs/cli/commands.mdx
@@ -1,92 +1,65 @@
 ---
 title: "Commands"
-description: "Complete reference for all Kata CLI slash commands, organized by category."
+description: "Command reference for the current Kata CLI runtime."
 ---
 
-Kata commands are slash commands typed directly in the chat interface. They fall into three categories: workflow commands that drive the Kata planning and execution cycle, session and model commands for managing your working context, and utility commands for tools and integrations.
-
-## Kata workflow
-
-Use these commands to drive the Kata planning and execution cycle. Start with `/kata` if you're not sure what to do next — it reads the current project state and suggests the appropriate action.
+## CLI commands
 
 | Command | Description |
 |---------|-------------|
-| `/kata` | Contextual wizard — suggests the next step based on project state |
-| `/kata step` | Execute one step (research, plan, task, etc.) then stop |
-| `/kata auto` | Start autonomous mode |
-| `/kata stop` | Stop auto-mode after the current task completes |
-| `/kata status` | Progress dashboard |
-| `/kata discuss` | Discuss gray areas before planning |
-| `/kata plan` | Enriched planning mode (plan/pick/add/resequence/revise/discuss) |
-| `/kata prefs` | Manage preferences (global or project-local) |
-| `/kata pr` | PR lifecycle management (create, review, address, merge) |
-| `/audit` | Audit the codebase against a goal — writes a report to `.kata/audits/` |
+| `kata setup` | Installs skills for supported harness targets and creates `.kata/preferences.md` when missing |
+| `kata doctor` | Validates setup, backend config, auth, and required GitHub Project fields |
+| `kata call <operation> --input <request.json>` | Executes one runtime operation with optional JSON payload |
+| `kata json <request.json>` | Executes an operation from a JSON request envelope |
 
-<Tip>
-  Use `/kata step` to walk through the workflow one phase at a time, or `/kata auto` to let Kata run the full slice lifecycle unattended.
-</Tip>
+## Setup examples
 
-## PR subcommands
+```bash
+# Interactive setup
+kata setup
 
-`/kata pr` has its own set of subcommands for the full pull request lifecycle. See [PR Mode](/cli/pr-mode) for setup and a detailed walkthrough.
+# Non-interactive setup
+kata setup --yes --repo kata-sh/kata-mono --project-number 12
 
-| Command | Description |
-|---------|-------------|
-| `/kata pr status` | Show PR lifecycle state (no LLM call) |
-| `/kata pr create` | Create a PR for the current slice branch |
-| `/kata pr review` | Run parallel multi-agent code review |
-| `/kata pr address` | Address review comments |
-| `/kata pr merge` | Merge PR and sync local state |
+# Pi install target
+kata setup --pi
+```
 
-## Session and model
+## Doctor
 
-Use these commands to manage your session context, switch models, and navigate session history.
+```bash
+kata doctor
+kata doctor --json
+```
 
-| Command | Description |
-|---------|-------------|
-| `/login` | Authenticate with an AI provider (OAuth) |
-| `/model` | Select a model |
-| `/scoped-models` | Enable or disable models for `Ctrl+P` cycling |
-| `/new` | Start a new session |
-| `/resume` | Resume a previous session |
-| `/compact` | Manually compact the session context |
-| `/fork` | Create a new fork from a previous message |
-| `/tree` | Navigate the session tree (switch branches) |
-| `/session` | Show session info and stats |
+## `kata call` examples
 
-<Note>
-  You can set your API key directly in the environment instead of using `/login`:
+```bash
+# No payload operation
+kata call health.check
 
-  ```bash
-  ANTHROPIC_API_KEY=sk-ant-... npx @kata-sh/cli
-  ```
-</Note>
+# Payload operation
+jq -n '{issueRef:"#471"}' > /tmp/kata-issue-get.json
+kata call issue.get --input /tmp/kata-issue-get.json
+```
 
-## Utilities
+## Operations
 
-Helper commands for tools, integrations, and general productivity.
+The runtime currently exposes these operation names:
 
-| Command | Description |
-|---------|-------------|
-| `/mcp` | Show MCP server status and available tools |
-| `/symphony` | Symphony operator workflows (`status`, `watch`, `console`, `config`) |
-| `/subagent` | List available subagents |
-| `/export` | Export the session to an HTML file |
-| `/share` | Share the session as a secret GitHub gist |
-| `/copy` | Copy the last agent message to clipboard |
-| `/hotkeys` | Show all keyboard shortcuts |
-| `/create-extension` | Scaffold a new extension with interview-driven setup |
-| `/create-slash-command` | Generate a new slash command from a plain-English description |
+- `project.getContext`, `project.getSnapshot`, `project.upsert`
+- `milestone.list`, `milestone.getActive`, `milestone.create`, `milestone.complete`
+- `slice.list`, `slice.create`, `slice.updateStatus`
+- `task.list`, `task.create`, `task.updateStatus`
+- `issue.listOpen`, `issue.create`, `issue.get`, `issue.updateStatus`
+- `artifact.list`, `artifact.read`, `artifact.write`
+- `execution.getStatus`, `health.check`
 
-## Symphony subcommands
+## Skill-helper pattern
 
-`/symphony` provides a live operator surface for the Symphony orchestration server. Requires a running Symphony instance and `symphony.url` set in preferences.
+When running inside installed Kata skills, use the helper wrapper:
 
-| Command | Description |
-|---------|-------------|
-| `/symphony status` | Fetch live worker and queue state |
-| `/symphony watch <issue>` | Stream live issue-scoped events (e.g. `KAT-920`) |
-| `/symphony console` | Toggle the live in-chat operator dashboard panel |
-| `/symphony console off` | Close the panel and disconnect the live stream |
-| `/symphony console refresh` | Force a manual snapshot refresh (`Ctrl+Alt+S`) |
-| `/symphony config [WORKFLOW.md]` | Open the guided config editor for WORKFLOW frontmatter |
+```bash
+node ./scripts/kata-call.mjs doctor
+node ./scripts/kata-call.mjs issue.listOpen
+```

--- a/apps/online-docs/cli/linear-integration.mdx
+++ b/apps/online-docs/cli/linear-integration.mdx
@@ -1,84 +1,28 @@
 ---
 title: "Linear integration"
-description: "Kata ships with 40 built-in Linear tools for managing issues, projects, milestones, and documents — no MCP server or OAuth setup required."
+description: "How Linear mode is represented in Kata runtime preferences."
 ---
 
-Kata has native Linear support built in. Forty tools cover the full Linear API surface — issues, sub-issues, projects, milestones, documents, labels, and workflow states — all accessible conversationally from the agent. No separate MCP server or OAuth flow required.
+Kata runtime accepts `workflow.mode: linear` in `.kata/preferences.md`.
 
-## Setup
-
-<Steps>
-  <Step title="Create a Linear personal API key">
-    Go to [Linear → Settings → API](https://linear.app/settings/api) and create a personal API key.
-  </Step>
-  <Step title="Start Kata and provide the key">
-    Start Kata normally. When prompted, enter your API key. It's stored in `~/.kata-cli/agent/auth.json` and loaded automatically on subsequent launches.
-
-    Alternatively, set the key in your environment:
-
-    ```bash
-    LINEAR_API_KEY=lin_api_... npx @kata-sh/cli
-    ```
-
-    `.env` is optional — the environment variable takes precedence when set.
-  </Step>
-  <Step title="Configure your project">
-    Ask Kata to set up your project:
-
-    ```
-    Configure this project to use Linear
-    ```
-
-    Kata lists your teams and projects, asks which to use, and writes the preferences file for you.
-  </Step>
-</Steps>
-
-## What you can do
-
-Once configured, you can manage your Linear workspace conversationally:
-
-- Create and update issues, sub-issues, and labels
-- List and search across projects, milestones, and workflow states
-- Read and write documents attached to projects or issues
-- Check team workflow states and transition issues between them
-
-## Linear workflow mode
-
-Beyond ad-hoc Linear operations, Kata uses Linear as the **backing store for its planning methodology**. In Linear workflow mode, all milestones, slices, tasks, plans, and summaries live as Linear entities — visible in the Linear UI alongside your team's other work.
-
-| Kata concept | Linear entity |
-|-------------|--------------|
-| Milestone | Linear project milestone |
-| Slice | Linear parent issue with `kata:slice` label |
-| Task | Linear sub-issue with `kata:task` label |
-| Plans and summaries | Linear documents attached to the project |
-
-`/kata auto` works the same way in Linear workflow mode — research, plan, execute, verify — but all state is read from and written to Linear.
-
-### Enabling Linear workflow mode
-
-Ask Kata to configure it:
-
-```
-Configure this project to use Linear workflow mode
-```
-
-Or set it manually in `.kata/preferences.md`:
+## Preferences
 
 ```yaml
 ---
 workflow:
   mode: linear
-linear:
-  teamKey: KAT
-  projectSlug: <your-project-slug>
 ---
 ```
 
-<Tip>
-  Use `linear_list_projects` or ask Kata to find your project slug if you're not sure what value to use.
-</Tip>
+## Runtime behavior
 
-<Note>
-  `linear_link: true` in the `pr` preferences block adds Linear issue references to PR bodies automatically. This requires Linear workflow mode to be enabled.
-</Note>
+- Config parsing accepts `linear` and `github` modes.
+- `kata doctor` reports parsed backend mode from `.kata/preferences.md`.
+- `kata setup` onboarding provisions GitHub mode fields.
+
+## Validate
+
+```bash
+kata doctor
+kata doctor --json
+```

--- a/apps/online-docs/cli/linear-integration.mdx
+++ b/apps/online-docs/cli/linear-integration.mdx
@@ -5,6 +5,8 @@ description: "How Linear mode is represented in Kata runtime preferences."
 
 Kata runtime accepts `workflow.mode: linear` in `.kata/preferences.md`.
 
+Linear authentication is environment-based. Export `LINEAR_API_KEY` before running workflows that connect to Linear.
+
 ## Preferences
 
 ```yaml
@@ -19,6 +21,21 @@ workflow:
 - Config parsing accepts `linear` and `github` modes.
 - `kata doctor` reports parsed backend mode from `.kata/preferences.md`.
 - `kata setup` onboarding provisions GitHub mode fields.
+- The CLI does not require `linear.teamKey` or `linear.projectSlug` in `.kata/preferences.md`.
+
+## Authentication
+
+Set the Linear API key in your shell environment:
+
+```bash
+export LINEAR_API_KEY=lin_api_...
+```
+
+Check that your session has the key before running Linear-backed workflows:
+
+```bash
+echo "$LINEAR_API_KEY"
+```
 
 ## Validate
 

--- a/apps/online-docs/cli/overview.mdx
+++ b/apps/online-docs/cli/overview.mdx
@@ -1,143 +1,69 @@
 ---
 title: "Kata CLI"
-description: "A terminal coding agent that decomposes projects into milestones, slices, and tasks — then executes them autonomously with structured planning, verification, and fresh context windows."
+description: "Runtime and contract bridge for Kata workflows."
 ---
 
-Kata CLI is a terminal coding agent built on [pi](https://github.com/badlogic/pi-mono) (`@mariozechner/pi-coding-agent`). It breaks your project into a structured hierarchy of work, executes each unit in a fresh context window, and verifies results before moving on.
+Kata CLI (`@kata-sh/cli`) provides the runtime contract used by Kata skills and harness integrations. It manages setup, backend validation, and operation dispatch.
 
 ## Quick start
 
+Run setup in a repository checkout:
+
 ```bash
-npx @kata-sh/cli
+npx @kata-sh/cli setup --yes --repo owner/repo --project-number 12
+npx @kata-sh/cli doctor
 ```
 
 Or install globally:
 
 ```bash
 npm install -g @kata-sh/cli
-kata-cli
+kata setup --yes --repo owner/repo --project-number 12
+kata doctor
 ```
 
-On first launch, Kata prompts you to authenticate with an AI provider.
+## Core command surface
 
-## Execution modes
+- `kata setup` - install skills and create `.kata/preferences.md`
+- `kata doctor` - validate harness install, backend config, auth, and project fields
+- `kata call <operation> --input <request.json>` - run a single runtime operation
+- `kata json <request.json>` - run an operation from a JSON envelope
 
-Kata has three modes of operation:
+See [Commands](/cli/commands) for details.
 
-<Tabs>
-  <Tab title="Step mode">
-    **`/kata`** — Human in the loop. Kata proposes each step; you approve or redirect. Recommended for new or risk-averse users.
-  </Tab>
-  <Tab title="Autonomous mode">
-    **`/kata auto`** — Kata researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete.
-  </Tab>
-  <Tab title="Steering mode">
-    Two terminals for supervised autonomy. Run autonomous execution in one terminal while observing and steering from another.
+## Backend behavior
 
-    ```bash
-    # Terminal 1: autonomous execution
-    /kata auto
+Preferences live at `.kata/preferences.md`.
 
-    # Terminal 2: observe and steer
-    /kata status      # check progress
-    /kata discuss     # discuss decisions
+`workflow.mode` supports:
 
-    # When you need to interrupt and redirect (Terminal 1):
-    /kata stop
-    ```
-  </Tab>
-</Tabs>
+- `github` - GitHub Projects v2 backend
+- `linear` - accepted by config parsing and runtime integrations
 
-## Work decomposition
-
-Kata structures all work into three levels:
-
-```
-Milestone  →  a shippable version (4–10 slices)
-  Slice    →  one demoable vertical capability (1–7 tasks)
-    Task   →  one context-window-sized unit of work
-```
-
-Each slice flows through phases automatically:
-
-**Research → Plan → Execute → Complete → Reassess → Next Slice**
-
-| Phase | What happens |
-|-------|-------------|
-| **Research** | Scouts the codebase and relevant docs |
-| **Plan** | Decomposes the slice into tasks with must-haves — mechanically verifiable outcomes |
-| **Execute** | Runs each task in a fresh context window with only the relevant files pre-loaded |
-| **Complete** | Writes the summary, UAT script, marks the roadmap, and commits |
-| **Reassess** | Checks if the roadmap still makes sense given what was learned |
-
-<Note>
-  Kata workflow state is Linear-backed: milestones, slices, tasks, plans, and summaries are stored as Linear issues and documents.
-</Note>
-
-## Bundled tools
-
-Kata ships with a full suite of tools out of the box — no configuration required to get started:
-
-| Tool | Description |
-|------|-------------|
-| **Linear** | Built-in project management with 40 native tools (issues, projects, documents, labels) |
-| **Symphony** | Live worker observability surface (`/symphony`, `symphony_*` tools) |
-| **Browser automation** | Playwright-based interaction with web pages |
-| **Subagents** | Spawn parallel Kata processes for independent tasks |
-| **Background shell** | Long-running processes (servers, watchers, builds) |
-| **Web search** | Brave Search API for current external facts |
-| **Library docs** | Context7 for up-to-date framework and library documentation |
-| **macOS tools** | Native app automation via Accessibility APIs |
-| **MCP servers** | Connect to any [Model Context Protocol](https://modelcontextprotocol.io/) server |
-
-## Bundled agents
-
-Three specialized subagents handle delegated work:
-
-| Agent | Role |
-|-------|------|
-| **Scout** | Fast codebase recon — returns compressed context for handoff |
-| **Researcher** | Web research — finds and synthesizes current information |
-| **Worker** | General-purpose execution in an isolated context window |
-
-## Preferences
-
-Kata preferences live in `~/.kata-cli/preferences.md` (global) or `.kata/preferences.md` (project-local). Manage them with `/kata prefs`.
+Current setup onboarding provisions GitHub mode and writes:
 
 ```yaml
 ---
-version: 1
-models:
-  research: claude-sonnet-4-6
-  planning: claude-opus-4-6
-  execution: claude-sonnet-4-6
-  completion: claude-sonnet-4-6
-skill_discovery: suggest
-auto_supervisor:
-  soft_timeout_minutes: 20
-  idle_timeout_minutes: 10
-  hard_timeout_minutes: 30
-budget_ceiling: 50.00
+workflow:
+  mode: github
+github:
+  repoOwner: kata-sh
+  repoName: kata-mono
+  stateMode: projects_v2
+  githubProjectNumber: 12
 ---
 ```
 
-| Setting | What it controls |
-|---------|-----------------|
-| `models.*` | Per-phase model selection (Opus for planning, Sonnet for execution, etc.) |
-| `pr.*` | PR lifecycle settings (see [PR Mode](/cli/pr-mode)) |
-| `symphony.url` | Base URL for Symphony server |
-| `skill_discovery` | `auto` / `suggest` / `off` — how Kata finds and applies skills |
-| `auto_supervisor.*` | Timeout thresholds for auto-mode supervision |
-| `budget_ceiling` | USD ceiling — auto mode pauses when reached |
-| `uat_dispatch` | Enable automatic UAT runs after slice completion |
+See [CLI preferences](/reference/cli-preferences) for field reference.
 
-## Project state
+## Skill-helper workflow
 
-Kata workflow artifacts are stored in Linear:
+Installed Kata skills call the runtime via helper scripts:
 
-- Milestones → Linear project milestones (`[M###]`)
-- Slices → Linear parent issues (`[S##]`)
-- Tasks → Linear sub-issues (`[T##]`)
-- Roadmaps, context, research, summaries, decisions → Linear documents and comments
+```bash
+node ./scripts/kata-call.mjs setup
+node ./scripts/kata-call.mjs doctor
+node ./scripts/kata-call.mjs issue.get --input /tmp/kata-issue-get.json
+```
 
-The local `.kata/` directory is used for runtime metadata (preferences, activity logs, metrics). Planning state is Linear-backed.
+This keeps workflow logic backend-neutral while using the same runtime contract.

--- a/apps/online-docs/cli/pr-mode.mdx
+++ b/apps/online-docs/cli/pr-mode.mdx
@@ -28,6 +28,10 @@ pr:
 
 ## Requirements
 
+Install GitHub CLI and authenticate before using PR automation commands. Kata invokes `gh` for PR creation and review actions.
+
 ```bash
 gh auth login
 ```
+
+If GitHub CLI is not authenticated, PR workflows fail authentication checks.

--- a/apps/online-docs/cli/pr-mode.mdx
+++ b/apps/online-docs/cli/pr-mode.mdx
@@ -1,117 +1,33 @@
 ---
-title: "PR mode"
-description: "Manage GitHub pull requests as part of the Kata slice lifecycle — with automatic PR creation, parallel code review, and controlled merge gates."
+title: "PR workflow settings"
+description: "Preference fields used by Kata skills for pull request workflows."
 ---
 
-PR mode integrates GitHub pull requests into the Kata slice lifecycle. When enabled, auto-mode stops at slice boundaries so you can review changes before they merge. Each slice gets its own branch and PR, giving you a clean audit trail and a natural review checkpoint between units of work.
+Kata skills can use a `pr` block in preferences to control PR automation behavior.
 
-## Setup
+## Example
 
-<Steps>
-  <Step title="Install and authenticate the GitHub CLI">
-    PR mode requires the `gh` CLI installed and authenticated:
-
-    ```bash
-    gh auth login
-    ```
-  </Step>
-  <Step title="Enable PR mode in preferences">
-    Add the `pr` block to `.kata/preferences.md` (project-local) or `~/.kata-cli/preferences.md` (global):
-
-    ```yaml
-    pr:
-      enabled: true
-      auto_create: true       # create PR automatically after slice completes
-      base_branch: main       # target branch for PRs
-      review_on_create: false # run parallel code review after PR creation
-      linear_link: false      # add Linear issue refs to PR body (requires linear mode)
-    ```
-
-    Manage preferences with `/kata prefs`.
-  </Step>
-</Steps>
-
-## Branch naming
-
-Slice branches use the canonical namespaced format:
-
-```
-kata/<scope>/<M>/<S>
+```yaml
+---
+pr:
+  enabled: true
+  auto_create: true
+  base_branch: main
+  review_on_create: false
+  linear_link: false
+---
 ```
 
-For example: `kata/apps-cli/M003/S05`
+## Fields
 
-<Note>
-  Legacy `kata/<M>/<S>` branches (without a scope segment) are still accepted during transition to the new format.
-</Note>
+- `pr.enabled`: enable PR workflow behavior
+- `pr.auto_create`: allow automatic PR creation
+- `pr.base_branch`: default PR base branch
+- `pr.review_on_create`: run review after PR creation
+- `pr.linear_link`: include Linear references in PR body
 
-## How it works with auto-mode
+## Requirements
 
-Without PR mode, auto-mode squash-merges each slice branch to `main` and continues. With PR mode enabled, the behavior changes at each slice boundary.
-
-<Tabs>
-  <Tab title="auto_create: true">
-    After slice completion, auto-mode creates a PR via `gh`, notifies you with the URL, and stops.
-
-    Merge the PR — manually or with `/kata pr merge` — then run `/kata auto` to resume the next slice.
-  </Tab>
-  <Tab title="auto_create: false">
-    After slice completion, auto-mode stops and tells you to run `/kata pr create`.
-
-    You manage the full lifecycle, then run `/kata auto` to resume.
-  </Tab>
-</Tabs>
-
-<Warning>
-  Auto-mode never merges automatically when PR mode is enabled. It always pauses at slice boundaries regardless of the `auto_create` setting.
-</Warning>
-
-## PR commands
-
-| Command | Description |
-|---------|-------------|
-| `/kata pr status` | Show PR lifecycle state (no LLM call) |
-| `/kata pr create` | Create a PR for the current slice branch |
-| `/kata pr review` | Run parallel multi-agent code review |
-| `/kata pr address` | Address review comments |
-| `/kata pr merge` | Merge PR and sync local state |
-
-## Typical flow
-
-<Steps>
-  <Step title="Run auto-mode">
-    ```
-    /kata auto
-    ```
-
-    Work proceeds through the slice lifecycle: research, plan, execute, complete. When the slice finishes, Kata creates a PR and stops.
-  </Step>
-  <Step title="Review the PR">
-    ```
-    /kata pr review
-    ```
-
-    Runs a parallel multi-agent code review. Results appear inline in the chat.
-  </Step>
-  <Step title="Address feedback">
-    ```
-    /kata pr address
-    ```
-
-    Kata reads the review comments and works through them systematically.
-  </Step>
-  <Step title="Merge">
-    ```
-    /kata pr merge
-    ```
-
-    Merges the PR and syncs local branch state.
-  </Step>
-  <Step title="Resume">
-    ```
-    /kata auto
-    ```
-
-    Picks up the next slice and continues.
-  </Step>
-</Steps>
+```bash
+gh auth login
+```

--- a/apps/online-docs/reference/cli-commands.mdx
+++ b/apps/online-docs/reference/cli-commands.mdx
@@ -1,103 +1,61 @@
 ---
 title: "CLI command reference"
-description: "Complete reference for all Kata CLI slash commands."
+description: "Reference for the current kata runtime commands."
 ---
 
-## Kata workflow
-
-Commands that drive the core Kata development lifecycle.
+## Commands
 
 | Command | Description |
 |---------|-------------|
-| `/kata` | Contextual wizard — suggests the next step based on project state |
-| `/kata step` | Execute one step (research, plan, task, etc.) then stop |
-| `/kata auto` | Start autonomous mode — research, plan, execute, verify, commit, and advance through every slice until the milestone is complete |
-| `/kata stop` | Stop auto-mode after the current task completes |
-| `/kata status` | Progress dashboard |
-| `/kata discuss` | Discuss gray areas before planning |
-| `/kata plan` | Enriched planning mode (plan/pick/add/resequence/revise/discuss) |
-| `/kata prefs` | Manage preferences (global and project-local) |
-| `/kata pr` | PR lifecycle management (see subcommands below) |
-| `/audit` | Audit the codebase against a goal; writes report to `.kata/audits/` |
+| `kata setup` | Installs bundled skills for selected targets and creates `.kata/preferences.md` when missing |
+| `kata doctor` | Validates setup, backend config, auth, and required GitHub Project fields |
+| `kata call <operation> --input <request.json>` | Executes one runtime operation with an optional JSON payload |
+| `kata json <request.json>` | Executes one runtime operation from a JSON request envelope |
 
-### `/kata pr` subcommands
+## Setup examples
 
-| Command | Description |
-|---------|-------------|
-| `/kata pr status` | Show PR lifecycle state (no LLM call) |
-| `/kata pr create` | Create a PR for the current slice branch |
-| `/kata pr review` | Run parallel multi-agent code review |
-| `/kata pr address` | Address review comments |
-| `/kata pr merge` | Merge PR and sync local state |
+```bash
+# Interactive setup
+kata setup
 
-<Note>
-PR commands require the `gh` CLI to be installed and authenticated (`gh auth login`). Enable PR mode in `.kata/preferences.md` before using these commands.
-</Note>
+# Non-interactive setup
+kata setup --yes --repo kata-sh/kata-mono --project-number 12
 
----
-
-## Session & model
-
-Commands for managing sessions, providers, and models.
-
-| Command | Description |
-|---------|-------------|
-| `/login` | Authenticate with an AI provider via OAuth (Anthropic, OpenAI, Google, and other supported providers) |
-| `/model` | Select a model from your authenticated providers |
-| `/scoped-models` | Enable or disable models for `Ctrl+P` cycling |
-| `/new` | Start a new session |
-| `/resume` | Resume a previous session |
-| `/compact` | Manually compact the session context |
-| `/fork` | Create a new session fork from a previous message |
-| `/tree` | Navigate the session tree and switch branches |
-| `/session` | Show session info and stats |
-
----
-
-## Utilities
-
-Helper commands for tools, extensions, and sharing.
-
-| Command | Description |
-|---------|-------------|
-| `/mcp` | Show MCP server status and available tools |
-| `/symphony` | Symphony operator workflows (`status`, `watch`, `console`, `config`) |
-| `/subagent` | List available subagents |
-| `/export` | Export the current session to an HTML file |
-| `/share` | Share the session as a secret GitHub gist |
-| `/copy` | Copy the last agent message to the clipboard |
-| `/hotkeys` | Show all keyboard shortcuts |
-| `/create-extension` | Scaffold a new extension with interview-driven setup |
-| `/create-slash-command` | Generate a new slash command from a plain-English description |
-
-### `/symphony` subcommands
-
-| Command | Description |
-|---------|-------------|
-| `/symphony status` | Fetch live worker and queue state from `GET /api/v1/state` |
-| `/symphony watch <issue>` | Stream live issue-scoped events from `GET /api/v1/events?issue=<id>` |
-| `/symphony console` | Toggle the live in-chat operator dashboard panel |
-| `/symphony console off` | Close the panel and disconnect the live stream |
-| `/symphony console refresh` | Force a manual snapshot refresh (shortcut: `Ctrl+Alt+S`) |
-| `/symphony config [WORKFLOW.md]` | Open the guided config editor for WORKFLOW.md frontmatter |
-
-Optional flags for `/symphony watch`:
-
-| Flag | Description |
-|------|-------------|
-| `--max-events <n>` | Stop after receiving this many events |
-| `--timeout-ms <ms>` | Stop after this many milliseconds |
-
-### Responding to escalations
-
-When escalations appear in the Symphony console panel, respond inline from chat input:
-
-```text
-!respond <answer>
+# Install Pi target metadata
+kata setup --pi
 ```
 
-When multiple escalations are pending, include the request ID or index:
+## Doctor examples
 
-```text
-!respond <request-id|index> <answer>
+```bash
+kata doctor
+kata doctor --json
 ```
+
+## `kata call` examples
+
+```bash
+# No payload operation
+kata call health.check
+
+# Payload operation
+jq -n '{issueRef:"#471"}' > /tmp/kata-issue-get.json
+kata call issue.get --input /tmp/kata-issue-get.json
+```
+
+## `kata json` example
+
+```bash
+jq -n '{operation:"health.check"}' > /tmp/kata-health.json
+kata json /tmp/kata-health.json
+```
+
+## Runtime operations
+
+- `project.getContext`, `project.getSnapshot`, `project.upsert`
+- `milestone.list`, `milestone.getActive`, `milestone.create`, `milestone.complete`
+- `slice.list`, `slice.create`, `slice.updateStatus`
+- `task.list`, `task.create`, `task.updateStatus`
+- `issue.listOpen`, `issue.create`, `issue.get`, `issue.updateStatus`
+- `artifact.list`, `artifact.read`, `artifact.write`
+- `execution.getStatus`, `health.check`

--- a/apps/online-docs/reference/cli-preferences.mdx
+++ b/apps/online-docs/reference/cli-preferences.mdx
@@ -28,6 +28,8 @@ workflow:
 ---
 ```
 
+`workflow.mode: linear` has no additional required `linear.*` fields in the current CLI runtime.
+
 ## Required fields
 
 ### `workflow.mode`

--- a/apps/online-docs/reference/cli-preferences.mdx
+++ b/apps/online-docs/reference/cli-preferences.mdx
@@ -1,189 +1,77 @@
 ---
 title: "CLI preferences"
-description: "Reference for the Kata CLI preferences file — global and project-local settings."
+description: "Reference for runtime backend preferences in .kata/preferences.md."
 ---
 
-Kata reads preferences from two locations, merged at startup with project-local values taking precedence:
+`kata` reads backend settings from `.kata/preferences.md` in the current workspace.
 
-- `~/.kata-cli/preferences.md` — global preferences (apply to all projects)
-- `.kata/preferences.md` — project-local preferences (apply to the current project only)
-
-Manage preferences interactively with the `/kata prefs` command.
-
-<Note>
-The legacy path `.kata/PREFERENCES.md` (uppercase) is still read for backward compatibility.
-</Note>
-
----
-
-## Example preferences file
+## GitHub mode example
 
 ```yaml
 ---
-version: 1
-models:
-  research: claude-sonnet-4-6
-  planning: claude-opus-4-6
-  execution: claude-sonnet-4-6
-  completion: claude-sonnet-4-6
-pr:
-  enabled: true
-  auto_create: true
-  base_branch: main
-  review_on_create: false
-  linear_link: false
-symphony:
-  url: http://127.0.0.1:8080
-  workflow_path: ./apps/symphony/WORKFLOW.md
-  console_position: below-output
-skill_discovery: suggest
-auto_supervisor:
-  soft_timeout_minutes: 20
-  idle_timeout_minutes: 10
-  hard_timeout_minutes: 30
-budget_ceiling: 50.00
-uat_dispatch: false
 workflow:
-  mode: linear
-linear:
-  teamKey: KAT
-  projectSlug: my-project-slug
+  mode: github
+github:
+  repoOwner: kata-sh
+  repoName: kata-mono
+  stateMode: projects_v2
+  githubProjectNumber: 12
 ---
 ```
 
+## Linear mode example
+
+```yaml
 ---
-
-## Models
-
-<ParamField path="models.research" type="string">
-  Model used during the research phase. Example: `claude-sonnet-4-6`.
-</ParamField>
-
-<ParamField path="models.planning" type="string">
-  Model used during the planning phase. Typically a more capable model (e.g. Opus) for higher-quality decomposition.
-</ParamField>
-
-<ParamField path="models.execution" type="string">
-  Model used during the execution phase (running tasks).
-</ParamField>
-
-<ParamField path="models.completion" type="string">
-  Model used during the completion phase (writing summaries, UAT scripts, marking the roadmap).
-</ParamField>
-
+workflow:
+  mode: linear
 ---
+```
 
-## PR mode
+## Required fields
 
-<ParamField path="pr.enabled" type="boolean" default="false">
-  Enable PR mode. When enabled, auto-mode pauses at slice boundaries so you can review changes before merging.
-</ParamField>
+### `workflow.mode`
 
-<ParamField path="pr.auto_create" type="boolean" default="false">
-  Automatically create a PR via `gh` after each slice completes. When `false`, auto-mode stops and prompts you to run `/kata pr create` manually.
-</ParamField>
+- Type: `string`
+- Allowed values: `github`, `linear`
 
-<ParamField path="pr.base_branch" type="string" default="main">
-  Target branch for pull requests.
-</ParamField>
+### `github.repoOwner`
 
-<ParamField path="pr.review_on_create" type="boolean" default="false">
-  Run a parallel multi-agent code review automatically after a PR is created.
-</ParamField>
+- Type: `string`
+- Required when `workflow.mode: github`
 
-<ParamField path="pr.linear_link" type="boolean" default="false">
-  Add Linear issue references to the PR body. Requires Linear workflow mode.
-</ParamField>
+### `github.repoName`
 
-<Note>
-Slice branches use the namespaced format `kata/<scope>/<M>/<S>` (for example `kata/apps-cli/M003/S05`).
-</Note>
+- Type: `string`
+- Required when `workflow.mode: github`
 
----
+### `github.stateMode`
 
-## Symphony
+- Type: `string`
+- Required value: `projects_v2`
+- Required when `workflow.mode: github`
 
-<ParamField path="symphony.url" type="string">
-  Base URL for the Symphony server. Example: `http://127.0.0.1:8080`.
+### `github.githubProjectNumber`
 
-  Can also be set via the `KATA_SYMPHONY_URL` or `SYMPHONY_URL` environment variables (`KATA_SYMPHONY_URL` takes precedence when both are set).
-</ParamField>
+- Type: `number`
+- Required when `workflow.mode: github`
+- Must be a positive integer
 
-<ParamField path="symphony.workflow_path" type="string">
-  Default path to the WORKFLOW.md file used by `/symphony config`. Example: `./apps/symphony/WORKFLOW.md`.
-</ParamField>
+## Setup behavior
 
-<ParamField path="symphony.console_position" type="string" default="below-output">
-  Placement of the live Symphony console panel in the terminal UI.
+`kata setup` provisions GitHub mode onboarding and writes `.kata/preferences.md` when it does not exist.
 
-  Options: `below-output`, `above-status`.
-</ParamField>
+Non-interactive onboarding:
 
----
+```bash
+kata setup --yes --repo owner/name --project-number 12
+```
 
-## Skill discovery
+## Validation behavior
 
-<ParamField path="skill_discovery" type="string" default="suggest">
-  Controls how Kata finds and applies skills.
+Use `kata doctor` to validate:
 
-  Options:
-  - `auto` — automatically load and apply relevant skills
-  - `suggest` — suggest skills but require confirmation before loading
-  - `off` — disable skill discovery
-</ParamField>
-
----
-
-## Auto supervisor
-
-<ParamField path="auto_supervisor.soft_timeout_minutes" type="number" default="20">
-  Minutes of continuous operation before the supervisor emits a soft warning and prompts for confirmation.
-</ParamField>
-
-<ParamField path="auto_supervisor.idle_timeout_minutes" type="number" default="10">
-  Minutes of idle time (no tool calls or model activity) before auto-mode pauses.
-</ParamField>
-
-<ParamField path="auto_supervisor.hard_timeout_minutes" type="number" default="30">
-  Absolute maximum minutes before auto-mode stops, regardless of activity.
-</ParamField>
-
----
-
-## Budget
-
-<ParamField path="budget_ceiling" type="number">
-  USD spending ceiling for auto mode. Auto-mode pauses when this limit is reached. Example: `50.00`.
-</ParamField>
-
----
-
-## UAT dispatch
-
-<ParamField path="uat_dispatch" type="boolean" default="false">
-  Enable automatic UAT (user acceptance testing) runs after each slice completes.
-</ParamField>
-
----
-
-## Workflow mode
-
-<ParamField path="workflow.mode" type="string" default="file">
-  Planning storage backend.
-
-  Options:
-  - `linear` — milestones, slices, tasks, plans, and summaries are stored in Linear issues and documents
-  - `file` — planning artifacts are stored as local files in `.kata/`
-</ParamField>
-
----
-
-## Linear integration
-
-<ParamField path="linear.teamKey" type="string">
-  Linear team key (issue prefix). Example: `KAT`.
-</ParamField>
-
-<ParamField path="linear.projectSlug" type="string">
-  Linear project slug. Found in your Linear project URL.
-</ParamField>
+- skills installation
+- backend config parsing
+- GitHub auth when mode is `github`
+- required GitHub Project v2 fields when mode is `github`


### PR DESCRIPTION
## Summary
- refresh CLI docs to match the current runtime command surface (`kata setup`, `kata doctor`, `kata call`, `kata json`)
- update backend behavior docs for `workflow.mode` and GitHub Projects v2 onboarding fields
- align CLI reference pages and workflow examples with current repository guidance

## Validation
- pnpm --dir apps/online-docs run broken-links

Closes #471

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the slash-command-focused CLI docs with a new runtime contract reference covering `kata setup`, `kata doctor`, `kata call`, and `kata json`, and aligns the preferences reference with the current GitHub Projects v2 onboarding fields. The changes are accurate for the new command surface, but several pages were stripped to stubs that omit details users still need: Linear API key authentication guidance is gone entirely, the PR mode Requirements section is a bare code block, and Linear mode in `cli-preferences.mdx` documents no required fields while GitHub mode documents four.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are documentation quality gaps with no functional or security impact.

All six changed files are documentation-only MDX pages. No P0 issues found. One P1 gap (missing Linear auth guidance) and two P2 gaps exist, keeping the score at 4.

apps/online-docs/cli/linear-integration.mdx and apps/online-docs/reference/cli-preferences.mdx need attention for the missing Linear configuration and authentication guidance.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/online-docs/cli/commands.mdx | Replaces slash-command table with new CLI runtime commands (kata setup/doctor/call/json); adds operations list and skill-helper pattern; no `kata json` example unlike the reference file. |
| apps/online-docs/cli/linear-integration.mdx | Stripped down to a stub; removes all Linear API-key authentication guidance, leaving no path for users to actually authenticate Linear mode. |
| apps/online-docs/cli/overview.mdx | Rewritten from interactive-agent overview to runtime-contract reference; accurately reflects new command surface and backend preference structure. |
| apps/online-docs/cli/pr-mode.mdx | Stripped to preference fields only; the Requirements section is a bare code block with no prose, leaving users without context for why gh auth is needed. |
| apps/online-docs/reference/cli-commands.mdx | Aligned with new runtime command surface; consistent with cli/commands.mdx; includes kata json example that the CLI page lacks. |
| apps/online-docs/reference/cli-preferences.mdx | Narrowed to GitHub/Linear workflow fields; drops models, symphony, auto_supervisor, budget, uat_dispatch; Linear mode section shows no required fields while GitHub mode has four. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clones repo] --> B[kata setup]
    B -->|writes| C[.kata/preferences.md]
    B -->|installs| D[Kata skills]
    C --> E{workflow.mode?}
    E -->|github| F[github.repoOwner
github.repoName
github.stateMode
github.githubProjectNumber]
    E -->|linear| G[workflow.mode: linear
⚠️ auth guidance missing]
    F --> H[kata doctor]
    G --> H
    H -->|validates| I{Pass?}
    I -->|yes| J[kata call operation --input file.json]
    I -->|yes| K[kata json request.json]
    I -->|no| L[Fix config / auth]
    L --> H
    J --> M[Runtime operation dispatched]
    K --> M
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
apps/online-docs/cli/linear-integration.mdx:1-28
**Linear authentication guidance removed without replacement**

The previous page explained how to create a Linear personal API key, where it is stored (`~/.kata-cli/agent/auth.json`), and the `LINEAR_API_KEY` environment variable fallback. The new page only shows a preferences snippet and a `kata doctor` validation step. A user who sets `workflow.mode: linear` now has no documentation path for obtaining or providing their API key, making the feature effectively unusable from docs alone.

### Issue 2 of 4
apps/online-docs/cli/pr-mode.mdx:27-33
**Requirements section is a bare code block with no prose**

The `## Requirements` heading is followed immediately by `gh auth login` with no explanation of what it installs, why authentication is needed, or what happens if it is skipped. Readers unfamiliar with the GitHub CLI have no context to act on this requirement.

### Issue 3 of 4
apps/online-docs/reference/cli-preferences.mdx:40-44
**Linear mode documents no required fields while GitHub mode documents four**

The Linear mode example only shows `workflow.mode: linear` with no additional fields. The old docs listed `linear.teamKey` and `linear.projectSlug` as required configuration. If those fields are still needed for the runtime to function in Linear mode, they are missing from this reference. If they were intentionally removed (e.g. auto-discovered), a short note explaining the new configuration contract would prevent user confusion.

### Issue 4 of 4
apps/online-docs/cli/commands.mdx:35-44
`kata json` has its own table entry and examples in `reference/cli-commands.mdx` but no usage example here in `cli/commands.mdx`. Adding a parallel example keeps the two pages consistent for users who land on either one.

```suggestion
## `kata call` examples

```bash
# No payload operation
kata call health.check

# Payload operation
jq -n '{issueRef:"#471"}' > /tmp/kata-issue-get.json
kata call issue.get --input /tmp/kata-issue-get.json
```

## `kata json` example

```bash
jq -n '{operation:"health.check"}' > /tmp/kata-health.json
kata json /tmp/kata-health.json
```
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(cli): refresh runtime command and b..."](https://github.com/gannonh/kata/commit/7c8cde376d9b249d592dd82994b7e3792766ad22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30770416)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->