### PR TITLE
[S902] Update docs site navigation and landing copy

### DIFF
--- a/apps/online-docs/docs.json
+++ b/apps/online-docs/docs.json
@@ -62,14 +62,6 @@
             ]
           },
           {
-            "group": "Kata Orchestrator",
-            "pages": [
-              "orchestrator/overview",
-              "orchestrator/workflow",
-              "orchestrator/commands"
-            ]
-          },
-          {
             "group": "Kata Context",
             "pages": [
               "context/overview"
@@ -92,13 +84,6 @@
             "pages": [
               "reference/symphony-workflow",
               "reference/symphony-api"
-            ]
-          },
-          {
-            "group": "Orchestrator Reference",
-            "pages": [
-              "reference/orchestrator-commands",
-              "reference/orchestrator-config"
             ]
           }
         ]

--- a/apps/online-docs/index.mdx
+++ b/apps/online-docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Kata — Multi-Agent Orchestration"
-description: "AI coding agents that plan, execute, and ship. Five products for terminal, desktop, headless, and IDE-native workflows."
+description: "AI coding agents that plan, execute, and ship. Four active products for terminal, desktop, headless orchestration, and codebase context."
 ---
 
 Kata is a suite of AI coding tools built for developers who want structured, autonomous execution — not just chat. Whether you're working solo in a terminal or running a fleet of agents across a Linear backlog, Kata has a product for the job.
@@ -15,8 +15,8 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
   <Card title="Kata Desktop" icon="desktop" href="/desktop/overview">
     Electron app for multi-session agent work with workspace management, planning/kanban views, and Symphony controls.
   </Card>
-  <Card title="Kata Orchestrator" icon="diagram-project" href="/orchestrator/overview">
-    Spec-driven workflow harness for Claude Code, OpenCode, Gemini CLI, and Codex. Installs slash commands into your existing runtime.
+  <Card title="Kata Context" icon="database" href="/context/overview">
+    Structural, semantic, and memory-based codebase understanding for AI coding agents.
   </Card>
 </CardGroup>
 
@@ -32,8 +32,8 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
   <Card title="I want a desktop workspace" icon="window" href="/desktop/overview">
     Download Kata Desktop for a visual, multi-session agent interface.
   </Card>
-  <Card title="I already use Claude Code / Codex" icon="code" href="/orchestrator/overview">
-    Install Kata Orchestrator to add structured planning and execution phases to your existing runtime.
+  <Card title="I need stronger codebase context" icon="database" href="/context/overview">
+    Use Kata Context for graph queries, semantic search, and indexed code understanding.
   </Card>
 </CardGroup>
 
@@ -69,8 +69,8 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
   <Accordion title="Full PR lifecycle management">
     Kata creates branches, opens PRs, runs code review, addresses feedback, and merges — all autonomously or with approval gates you control.
   </Accordion>
-  <Accordion title="Multi-runtime support">
-    Kata Orchestrator installs into Claude Code, OpenCode, Gemini CLI, and Codex. Same structured workflow regardless of which AI runtime you prefer.
+  <Accordion title="Codebase context tooling">
+    Kata Context indexes repositories with structural and semantic signals so agents can query symbols, dependencies, and related files.
   </Accordion>
   <Accordion title="Scale from one agent to many">
     Start with Kata CLI in your terminal. When your backlog grows, connect Kata Symphony to run dozens of parallel agent sessions against your Linear project.
@@ -84,5 +84,4 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
 | [Kata CLI](/cli/overview) | `npx @kata-sh/cli` | Terminal-first coding with guided or autonomous execution |
 | [Kata Symphony](/symphony/overview) | Binary download or `cargo build` | Headless ticket-to-merge at scale |
 | [Kata Desktop](/desktop/overview) | GitHub Releases | Visual multi-session agent management |
-| [Kata Orchestrator](/orchestrator/overview) | `npx @kata-sh/orc@latest` | Structured phases inside Claude Code / Codex / Gemini |
 | [Kata Context](/context/overview) | `npx @kata/context` | Codebase indexing for AI agents |

--- a/apps/online-docs/introduction.mdx
+++ b/apps/online-docs/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "Kata is a multi-agent orchestration platform — five products for terminal, desktop, headless, and IDE-native AI coding workflows."
+description: "Kata is a suite of four active AI coding products for terminal, desktop, headless orchestration, and codebase context workflows."
 ---
 
 Kata is a suite of AI coding tools built for developers who want structured, autonomous execution. Each product targets a different workflow, from a solo developer in a terminal to a team running parallel agents against a Linear backlog.
@@ -15,9 +15,6 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
   <Card title="Kata Desktop" icon="desktop" href="/desktop/overview">
     Electron app for multi-session agent work with workspace switching, planning/kanban right pane, and Symphony operations.
   </Card>
-  <Card title="Kata Orchestrator" icon="diagram-project" href="/orchestrator/overview">
-    Spec-driven workflow harness for Claude Code, OpenCode, Gemini CLI, and Codex. Installs slash commands into your existing runtime.
-  </Card>
   <Card title="Kata Context" icon="database" href="/context/overview">
     Structural, semantic, and memory-based codebase understanding for AI coding agents. Indexes source files with tree-sitter and SQLite.
   </Card>
@@ -30,7 +27,6 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
 | Code autonomously in a terminal with full control over each step | [Kata CLI](/cli/overview) |
 | Run agents against a Linear backlog with no human in the loop | [Kata Symphony](/symphony/overview) |
 | Manage multiple agent sessions visually with approval controls | [Kata Desktop](/desktop/overview) |
-| Add structured planning phases to Claude Code, Codex, or Gemini | [Kata Orchestrator](/orchestrator/overview) |
 | Give AI agents deep understanding of your codebase structure | [Kata Context](/context/overview) |
 
 ## Product overviews
@@ -51,16 +47,12 @@ Symphony runs on a server or in CI. Kata CLI provides a built-in operator surfac
 
 Kata Desktop is an Electron app for working with AI agents across multiple sessions and workspaces. It includes streamed chat, workspace-scoped session history, permission modes (Explore / Ask to Edit / Auto), a planning artifact view, a workflow kanban board, and Symphony runtime/dashboard controls.
 
-### Kata Orchestrator
-
-Kata Orchestrator installs a set of slash commands into your AI coding runtime — Claude Code, OpenCode, Gemini CLI, or Codex — that structure work into discuss, plan, execute, and verify phases. Each execution phase runs in a fresh subagent context with a dedicated 200k token window. Planning artifacts accumulate as structured files on disk rather than in the context window.
-
 ### Kata Context
 
 Kata Context indexes source files using tree-sitter, builds a dependency graph stored in SQLite, and exposes commands for graph queries, grep, and file discovery. It provides structural, semantic, and memory-based codebase understanding to AI coding agents.
 
 <Note>
-  Kata CLI and Kata Orchestrator are MIT licensed. Kata Desktop is Apache 2.0 licensed. Check the LICENSE file in each app directory for details.
+  Check the LICENSE file in each app directory for package-specific licensing details.
 </Note>
 
 ## Next steps


### PR DESCRIPTION
## Summary
- remove Kata Orchestrator from online docs navigation groups
- update landing and introduction copy to describe the four active products
- keep product guidance focused on CLI, Symphony, Desktop, and Context

Closes #470

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes Kata Orchestrator from the online docs — navigation groups, landing cards, CTAs, product table rows, and the full overview section — and replaces those touchpoints with Kata Context equivalents. All three changed files are updated consistently, and no internal links are broken.

- **`docs.json`**: Drops the \"Kata Orchestrator\" and \"Orchestrator Reference\" nav groups; the remaining four products (CLI, Symphony, Desktop, Context) are all correctly represented.
- **`index.mdx` / `introduction.mdx`**: Every Orchestrator reference (cards, decision tables, accordion, product overview prose) is replaced with Kata Context copy; the product count in both descriptions is updated from five to four.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no logic, runtime code, or data migrations involved.

All three files are updated consistently: navigation, landing cards, decision tables, accordions, and prose all point to the same four products with no dangling Orchestrator links remaining. The context/overview page was already present in the nav before this PR, so the new card links are valid.

No files require special attention. The orphaned Orchestrator page files (orchestrator/overview.mdx, etc.) are now unreachable from the nav — worth cleaning up in a follow-up if they still exist on disk.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/online-docs/docs.json | Removes the "Kata Orchestrator" and "Orchestrator Reference" navigation groups; remaining navigation structure is intact and consistent. |
| apps/online-docs/index.mdx | Replaces all Orchestrator cards, CTAs, and table rows with Kata Context equivalents; description updated from "five" to "four active products". |
| apps/online-docs/introduction.mdx | Removes Orchestrator card, product-selection row, and full overview section; licensing note is updated to be product-agnostic. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Navigation — Before"]
        B1[Get Started]
        B2[Kata CLI]
        B3[Kata Symphony]
        B4[Kata Desktop]
        B5[Kata Orchestrator ❌]
        B6[Kata Context]
        B7[CLI Reference]
        B8[Symphony Reference]
        B9[Orchestrator Reference ❌]
    end

    subgraph After["Navigation — After"]
        A1[Get Started]
        A2[Kata CLI]
        A3[Kata Symphony]
        A4[Kata Desktop]
        A5[Kata Context ✅]
        A6[CLI Reference]
        A7[Symphony Reference]
    end

    Before -->|"Remove Orchestrator groups"| After
```

<sub>Reviews (1): Last reviewed commit: ["docs(online-docs): align nav and landing..."](https://github.com/gannonh/kata/commit/eb1fc637df495b3553401332bb97959fb16d4a84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30836599)</sub>

<!-- /greptile_comment -->