### PR TITLE
docs: final consistency pass for online docs

### DIFF
--- a/apps/online-docs/context/overview.mdx
+++ b/apps/online-docs/context/overview.mdx
@@ -116,7 +116,7 @@ Use Kata Context when you need an agent to:
 - Carry forward architectural decisions across sessions using memory
 
 <Tip>
-  Run `kata-context index` at the start of a Kata Orchestrator session to give subagents accurate structural context before the plan and execute phases.
+  Run `kata-context index` before starting a Kata CLI or Symphony worker run so agents have accurate structural context.
 </Tip>
 
 ## Global options

--- a/apps/online-docs/index.mdx
+++ b/apps/online-docs/index.mdx
@@ -3,11 +3,11 @@ title: "Kata — Multi-Agent Orchestration"
 description: "AI coding agents that plan, execute, and ship. Four active products for terminal, desktop, headless orchestration, and codebase context."
 ---
 
-Kata is a suite of AI coding tools built for developers who want structured, autonomous execution — not just chat. Whether you're working solo in a terminal or running a fleet of agents across a Linear backlog, Kata has a product for the job.
+Kata is a suite of AI coding tools built for developers who want structured, autonomous execution. Whether you're working solo in a terminal or running a fleet of agents across a tracker backlog, Kata has a product for the job.
 
 <CardGroup cols={2}>
   <Card title="Kata CLI" icon="terminal" href="/cli/overview">
-    Terminal coding agent with guided and autonomous execution modes. Breaks work into milestones, slices, and tasks.
+    Runtime and contract bridge for Kata workflows. Handles setup, backend validation, and operation dispatch.
   </Card>
   <Card title="Kata Symphony" icon="music" href="/symphony/overview">
     Headless orchestrator that polls Linear or GitHub and runs parallel agent sessions to close tickets end-to-end.
@@ -23,11 +23,11 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
 ## Choose your product
 
 <CardGroup cols={2}>
-  <Card title="I want a terminal agent" icon="rocket" href="/quickstart">
-    Start with Kata CLI — the fastest way to get autonomous coding in your terminal.
+  <Card title="I want to configure Kata from the terminal" icon="rocket" href="/quickstart">
+    Start with Kata CLI to install skills, validate backend config, and run workflow operations.
   </Card>
   <Card title="I want to run agents at scale" icon="server" href="/symphony/overview">
-    Use Kata Symphony to dispatch parallel agents across your Linear backlog.
+    Use Kata Symphony to dispatch parallel agents across your tracker backlog.
   </Card>
   <Card title="I want a desktop workspace" icon="window" href="/desktop/overview">
     Download Kata Desktop for a visual, multi-session agent interface.
@@ -40,31 +40,34 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
 ## Quick start
 
 <Steps>
-  <Step title="Install Kata CLI">
-    Run Kata CLI directly with npx — no global install required:
+  <Step title="Run setup">
+    Bootstrap Kata CLI with `npx`:
     ```bash
-    npx @kata-sh/cli
+    npx @kata-sh/cli setup --yes --repo owner/repo --project-number 12
     ```
   </Step>
-  <Step title="Authenticate">
-    On first launch, Kata prompts you to log in. Run `/login` and choose your AI provider (Anthropic, OpenAI, Google, and more).
+  <Step title="Validate your environment">
+    Run doctor to verify harness install, backend config, auth, and required project fields:
+    ```bash
+    npx @kata-sh/cli doctor
+    ```
   </Step>
-  <Step title="Start a project">
-    Tell Kata what you want to build. Use `/kata` to let it suggest the next step, or `/kata auto` to start autonomous execution.
+  <Step title="Review command surface">
+    Use `kata call <operation> --input <request.json>` and `kata json <request.json>` to execute runtime operations from scripts and skills.
   </Step>
-  <Step title="Review and ship">
-    Kata breaks your work into milestones and slices, executes each in a fresh context window, and optionally manages the full PR lifecycle with GitHub.
+  <Step title="Dispatch work with Symphony">
+    Point Kata Symphony at your tracker to run parallel agent sessions and manage issue state transitions.
   </Step>
 </Steps>
 
 ## What makes Kata different
 
 <AccordionGroup>
-  <Accordion title="Structured execution, not just chat">
-    Kata decomposes work into milestones, slices, and tasks — each sized to fit a single context window. Fresh context per task means the agent stays focused and doesn't accumulate noise.
+  <Accordion title="Backend-neutral workflow contract">
+    Kata skills and workers use one runtime contract for issue, document, and state operations across supported tracker backends.
   </Accordion>
-  <Accordion title="Linear-backed project state">
-    All planning artifacts — milestones, slices, tasks, research, summaries — live in Linear. Your team can see exactly what the agent is working on alongside their own issues.
+  <Accordion title="Tracker-integrated execution">
+    Kata Symphony polls tracker issues, dispatches agents in parallel, and moves work through configured workflow states.
   </Accordion>
   <Accordion title="Full PR lifecycle management">
     Kata creates branches, opens PRs, runs code review, addresses feedback, and merges — all autonomously or with approval gates you control.
@@ -73,7 +76,7 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
     Kata Context indexes repositories with structural and semantic signals so agents can query symbols, dependencies, and related files.
   </Accordion>
   <Accordion title="Scale from one agent to many">
-    Start with Kata CLI in your terminal. When your backlog grows, connect Kata Symphony to run dozens of parallel agent sessions against your Linear project.
+    Start with Kata CLI in your terminal. When your backlog grows, connect Kata Symphony to run dozens of parallel agent sessions against your tracker project.
   </Accordion>
 </AccordionGroup>
 
@@ -81,7 +84,7 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
 
 | Product | Install | Best for |
 |---|---|---|
-| [Kata CLI](/cli/overview) | `npx @kata-sh/cli` | Terminal-first coding with guided or autonomous execution |
+| [Kata CLI](/cli/overview) | `npx @kata-sh/cli` | Terminal runtime setup, backend validation, and operation dispatch |
 | [Kata Symphony](/symphony/overview) | Binary download or `cargo build` | Headless ticket-to-merge at scale |
 | [Kata Desktop](/desktop/overview) | GitHub Releases | Visual multi-session agent management |
 | [Kata Context](/context/overview) | `npx @kata/context` | Codebase indexing for AI agents |

--- a/apps/online-docs/index.mdx
+++ b/apps/online-docs/index.mdx
@@ -53,7 +53,7 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
     ```
   </Step>
   <Step title="Review command surface">
-    Use `kata call <operation> --input <request.json>` and `kata json <request.json>` to execute runtime operations from scripts and skills.
+    Use `npx @kata-sh/cli call <operation> --input <request.json>` and `npx @kata-sh/cli json <request.json>` to execute runtime operations from scripts and skills. If you installed globally, run the same commands with `kata`.
   </Step>
   <Step title="Dispatch work with Symphony">
     Point Kata Symphony at your tracker to run parallel agent sessions and manage issue state transitions.

--- a/apps/online-docs/introduction.mdx
+++ b/apps/online-docs/introduction.mdx
@@ -3,14 +3,14 @@ title: "Introduction"
 description: "Kata is a suite of four active AI coding products for terminal, desktop, headless orchestration, and codebase context workflows."
 ---
 
-Kata is a suite of AI coding tools built for developers who want structured, autonomous execution. Each product targets a different workflow, from a solo developer in a terminal to a team running parallel agents against a Linear backlog.
+Kata is a suite of AI coding tools built for developers who want structured, autonomous execution. Each product targets a different workflow, from a solo developer in a terminal to a team running parallel agents against a tracker backlog.
 
 <CardGroup cols={2}>
   <Card title="Kata CLI" icon="terminal" href="/cli/overview">
-    Terminal coding agent with step, autonomous, and steering execution modes. Decomposes work into milestones, slices, and tasks.
+    Runtime and contract bridge for Kata workflows. Handles setup, backend validation, and operation dispatch.
   </Card>
   <Card title="Kata Symphony" icon="music" href="/symphony/overview">
-    Headless orchestrator that polls Linear, dispatches parallel agent sessions, and manages the full ticket-to-merge lifecycle.
+    Headless orchestrator that polls Linear or GitHub, dispatches parallel agent sessions, and manages the full ticket-to-merge lifecycle.
   </Card>
   <Card title="Kata Desktop" icon="desktop" href="/desktop/overview">
     Electron app for multi-session agent work with workspace switching, planning/kanban right pane, and Symphony operations.
@@ -24,8 +24,8 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
 
 | If you want to… | Use |
 |---|---|
-| Code autonomously in a terminal with full control over each step | [Kata CLI](/cli/overview) |
-| Run agents against a Linear backlog with no human in the loop | [Kata Symphony](/symphony/overview) |
+| Configure Kata runtimes and run workflow operations from the terminal | [Kata CLI](/cli/overview) |
+| Run agents against a tracker backlog with no human in the loop | [Kata Symphony](/symphony/overview) |
 | Manage multiple agent sessions visually with approval controls | [Kata Desktop](/desktop/overview) |
 | Give AI agents deep understanding of your codebase structure | [Kata Context](/context/overview) |
 
@@ -33,13 +33,11 @@ Kata is a suite of AI coding tools built for developers who want structured, aut
 
 ### Kata CLI
 
-Kata CLI is a terminal coding agent. It breaks work into milestones, slices, and tasks, then executes with structured planning, verification, and fresh context windows per task. It supports step-by-step operation, fully autonomous execution, and a two-terminal steering workflow where you observe and redirect without interrupting the agent.
-
-Project state is Linear-backed: milestones, slices, tasks, plans, and summaries are stored as Linear issues and documents so your team can see exactly what the agent is working on.
+Kata CLI is the runtime and contract bridge used by Kata skills and harness integrations. It provides setup, environment diagnostics, and an operation interface (`kata call`, `kata json`) that workers use to execute backend-neutral workflow operations.
 
 ### Kata Symphony
 
-Kata Symphony is a headless orchestrator written in Rust. It polls a Linear project for candidate issues, dispatches parallel agent sessions to work on them, and manages the full ticket lifecycle — from Todo through implementation, PR creation, automated code review, human review, and merge.
+Kata Symphony is a headless orchestrator written in Rust. It polls Linear or GitHub for candidate issues, dispatches parallel agent sessions to work on them, and manages the full ticket lifecycle — from Todo through implementation, PR creation, automated code review, human review, and merge.
 
 Symphony runs on a server or in CI. Kata CLI provides a built-in operator surface for monitoring and steering it in real time via `/symphony status`, `/symphony watch`, and the live console dashboard.
 
@@ -57,7 +55,7 @@ Kata Context indexes source files using tree-sitter, builds a dependency graph s
 
 ## Next steps
 
-If you're new to Kata, start with the CLI quickstart. It's the fastest path to autonomous coding in your terminal.
+If you're new to Kata, start with the CLI quickstart. It is the fastest path to configuring the runtime and validating your project setup.
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">

--- a/apps/online-docs/introduction.mdx
+++ b/apps/online-docs/introduction.mdx
@@ -37,7 +37,7 @@ Kata CLI is the runtime and contract bridge used by Kata skills and harness inte
 
 ### Kata Symphony
 
-Kata Symphony is a headless orchestrator written in Rust. It polls Linear or GitHub for candidate issues, dispatches parallel agent sessions to work on them, and manages the full ticket lifecycle — from Todo through implementation, PR creation, automated code review, human review, and merge.
+Kata Symphony is a headless orchestrator written in Rust. It polls Linear or GitHub for candidate issues, dispatches parallel agent sessions to work on them, and manages the full ticket lifecycle — from `Todo` through implementation, PR creation, automated code review, human review, and merge.
 
 Symphony runs on a server or in CI. Kata CLI provides setup, diagnostics, and runtime operations (`kata setup`, `kata doctor`, `kata call`, `kata json`) used to configure and integrate Symphony workflows.
 

--- a/apps/online-docs/introduction.mdx
+++ b/apps/online-docs/introduction.mdx
@@ -39,7 +39,7 @@ Kata CLI is the runtime and contract bridge used by Kata skills and harness inte
 
 Kata Symphony is a headless orchestrator written in Rust. It polls Linear or GitHub for candidate issues, dispatches parallel agent sessions to work on them, and manages the full ticket lifecycle — from Todo through implementation, PR creation, automated code review, human review, and merge.
 
-Symphony runs on a server or in CI. Kata CLI provides a built-in operator surface for monitoring and steering it in real time via `/symphony status`, `/symphony watch`, and the live console dashboard.
+Symphony runs on a server or in CI. Kata CLI provides setup, diagnostics, and runtime operations (`kata setup`, `kata doctor`, `kata call`, `kata json`) used to configure and integrate Symphony workflows.
 
 ### Kata Desktop
 

--- a/apps/online-docs/quickstart.mdx
+++ b/apps/online-docs/quickstart.mdx
@@ -5,125 +5,69 @@ description: "Get running with Kata CLI in under 5 minutes"
 
 <Steps>
 
-  <Step title="Run Kata CLI">
-    The fastest way to start is with `npx` — no install required:
+  <Step title="Run setup">
+    The fastest way to start is with `npx`:
 
     <CodeGroup>
 
     ```bash npx
-    npx @kata-sh/cli
+    npx @kata-sh/cli setup --yes --repo owner/repo --project-number 12
     ```
 
     ```bash Global install
     npm install -g @kata-sh/cli
-    kata-cli
-    ```
-
-    ```bash With API key
-    ANTHROPIC_API_KEY=sk-ant-... npx @kata-sh/cli
+    kata setup --yes --repo owner/repo --project-number 12
     ```
 
     </CodeGroup>
   </Step>
 
-  <Step title="Authenticate">
-    On first launch, run `/login` to authenticate with an AI provider:
-
-    ```
-    /login
-    ```
-
-    This opens an interactive prompt to authenticate with Anthropic, OpenAI, Google, or any supported provider. You can also pass your API key as an environment variable and skip the prompt entirely:
+  <Step title="Validate your environment">
+    Run doctor to verify harness install, backend config, auth, and required project fields:
 
     ```bash
-    ANTHROPIC_API_KEY=sk-ant-... npx @kata-sh/cli
+    kata doctor
     ```
   </Step>
 
-  <Step title="Select a model">
-    Pick from the models available across your authenticated providers:
+  <Step title="Run an operation">
+    Execute one operation with `kata call`:
 
+    ```bash
+    kata call health.check
     ```
-    /model
+
+    For JSON envelopes, use:
+
+    ```bash
+    jq -n '{operation:"health.check"}' > /tmp/kata-health.json
+    kata json /tmp/kata-health.json
     ```
   </Step>
 
-  <Step title="Tell Kata what to build">
-    Describe your project in plain language. Kata reads your codebase, asks clarifying questions, and decomposes the work into a milestone with slices and tasks before executing.
-  </Step>
-
-  <Step title="Choose an execution mode">
-    <Tabs>
-      <Tab title="Step mode">
-        **Step mode** (`/kata`) keeps you in the loop. Kata proposes each step and waits for your approval before continuing — recommended for new or risk-averse users.
-
-        ```
-        /kata
-        ```
-      </Tab>
-      <Tab title="Autonomous mode">
-        **Autonomous mode** (`/kata auto`) runs end-to-end without intervention. Kata researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete.
-
-        ```
-        /kata auto
-        ```
-
-        For supervised autonomy, use a two-terminal **steering workflow**:
-
-        ```bash
-        # Terminal 1: autonomous execution
-        /kata auto
-
-        # Terminal 2: observe and steer
-        /kata status      # check progress
-        /kata discuss     # discuss decisions
-
-        # When you need to interrupt and redirect:
-        # Terminal 1:
-        /kata stop
-        ```
-      </Tab>
-    </Tabs>
-  </Step>
-
-  <Step title="Review progress">
-    Check the progress dashboard at any time:
-
-    ```
-    /kata status
-    ```
-
-    This shows the active milestone, current slice and task, and what's coming up next.
+  <Step title="Inspect command reference">
+    Review the supported command surface in [Commands](/cli/commands) and runtime fields in [CLI Preferences](/reference/cli-preferences).
   </Step>
 
 </Steps>
 
-## How work is decomposed
+## Common operations
 
-Kata breaks every project into three levels:
+Use these commands after setup:
 
+```bash
+kata doctor
+kata call health.check
+kata call issue.get --input /tmp/request.json
+kata json /tmp/envelope.json
 ```
-Milestone  →  a shippable version (4–10 slices)
-  Slice    →  one demoable vertical capability (1–7 tasks)
-    Task   →  one context-window-sized unit of work
-```
-
-Each slice flows through phases automatically:
-
-**Research** → **Plan** → **Execute** (per task) → **Complete** → **Reassess** → **Next slice**
-
-- **Research** scouts the codebase and relevant docs
-- **Plan** decomposes the slice into tasks with mechanically verifiable outcomes
-- **Execute** runs each task in a fresh context window with only the relevant files pre-loaded
-- **Complete** writes the summary, UAT script, marks the roadmap, and commits
-- **Reassess** checks whether the roadmap still makes sense given what was learned
 
 <Tip>
-  For the fastest start with an existing project, run `npx @kata-sh/cli` in your project root — Kata automatically detects your codebase and asks what you want to build.
+  Keep a checked-in sample request file in your repo for repeatable `kata call` workflows used by scripts and skills.
 </Tip>
 
 <Note>
-  Kata stores preferences in `~/.kata-cli/preferences.md` (global) and `.kata/preferences.md` (project-local). See [CLI Preferences](/reference/cli-preferences) for all options.
+  Kata stores runtime backend preferences in `.kata/preferences.md`. See [CLI Preferences](/reference/cli-preferences) for all options.
 </Note>
 
-For a full list of available commands, see the [Commands reference](/cli/commands).
+For a full list of available commands, see the [Commands reference](/cli/commands). For backend and project settings, see [CLI Preferences](/reference/cli-preferences).

--- a/apps/online-docs/quickstart.mdx
+++ b/apps/online-docs/quickstart.mdx
@@ -26,7 +26,7 @@ description: "Get running with Kata CLI in under 5 minutes"
     Run doctor to verify harness install, backend config, auth, and required project fields:
 
     ```bash
-    kata doctor
+    npx @kata-sh/cli doctor
     ```
   </Step>
 
@@ -34,15 +34,17 @@ description: "Get running with Kata CLI in under 5 minutes"
     Execute one operation with `kata call`:
 
     ```bash
-    kata call health.check
+    npx @kata-sh/cli call health.check
     ```
 
     For JSON envelopes, use:
 
     ```bash
     jq -n '{operation:"health.check"}' > /tmp/kata-health.json
-    kata json /tmp/kata-health.json
+    npx @kata-sh/cli json /tmp/kata-health.json
     ```
+
+    If you installed globally, you can run the same commands with `kata`.
   </Step>
 
   <Step title="Inspect command reference">
@@ -56,14 +58,14 @@ description: "Get running with Kata CLI in under 5 minutes"
 Use these commands after setup:
 
 ```bash
-kata doctor
-kata call health.check
-kata call issue.get --input /tmp/request.json
-kata json /tmp/envelope.json
+npx @kata-sh/cli doctor
+npx @kata-sh/cli call health.check
+npx @kata-sh/cli call issue.get --input /tmp/request.json
+npx @kata-sh/cli json /tmp/envelope.json
 ```
 
 <Tip>
-  Keep a checked-in sample request file in your repo for repeatable `kata call` workflows used by scripts and skills.
+  Keep a checked-in sample request file in your repo for repeatable `npx @kata-sh/cli call` or `kata call` workflows used by scripts and skills.
 </Tip>
 
 <Note>

--- a/apps/online-docs/reference/symphony-api.mdx
+++ b/apps/online-docs/reference/symphony-api.mdx
@@ -14,7 +14,7 @@ The Symphony HTTP server starts automatically when you run `symphony WORKFLOW.md
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/` | HTML dashboard — auto-refreshes every 2 seconds |
-| `GET` | `/api/v1/state` | Full orchestrator state snapshot |
+| `GET` | `/api/v1/state` | Full Symphony runtime state snapshot |
 | `GET` | `/api/v1/events` | WebSocket live event stream |
 | `GET` | `/api/v1/escalations` | Pending escalation list |
 | `POST` | `/api/v1/escalations/:request_id/respond` | Resolve a pending escalation |
@@ -37,7 +37,7 @@ Shows: running sessions with turn count, token usage, and last activity; retry q
 
 ## `GET /api/v1/state`
 
-Full orchestrator state snapshot as JSON.
+Full Symphony runtime state snapshot as JSON.
 
 ### Response
 

--- a/apps/online-docs/reference/symphony-workflow.mdx
+++ b/apps/online-docs/reference/symphony-workflow.mdx
@@ -5,7 +5,7 @@ description: "Current Symphony WORKFLOW.md configuration and worker contract."
 
 Symphony `WORKFLOW.md` has one runtime-significant part:
 
-- **YAML front-matter** for orchestrator config
+- **YAML front-matter** for Symphony workflow config
 - **Markdown body** is ignored at runtime
 
 Runtime prompts come from `prompts` front-matter entries (or external prompt files they reference), not the document body.

--- a/apps/online-docs/symphony/overview.mdx
+++ b/apps/online-docs/symphony/overview.mdx
@@ -54,7 +54,7 @@ Todo → In Progress → Agent Review → Merging → Done
 | Status | Who sets it | What happens |
 | --- | --- | --- |
 | **Todo** | Human | Issue is queued — Symphony picks it up on the next poll |
-| **In Progress** | Orchestrator | Agent is working — writing code, running tests |
+| **In Progress** | Symphony | Agent is working — writing code, running tests |
 | **Agent Review** | Agent or Human | Agent addresses PR review comments |
 | **Merging** | Human | Agent merges the approved PR |
 | **Rework** | Human | Agent scraps current approach, starts fresh on a new branch |
@@ -144,9 +144,9 @@ symphony WORKFLOW.md
 
 Open `http://localhost:8080` for the web dashboard, or watch the built-in terminal dashboard.
 
-**4. Create issues in Linear**
+**4. Create tracker issues**
 
-Create issues in your Linear project and set them to `Todo`. Symphony picks them up on the next poll cycle.
+Create issues in your configured tracker and set them to `Todo`. Symphony picks them up on the next poll cycle.
 
 ## When to use Symphony
 

--- a/apps/online-docs/symphony/workflow-config.mdx
+++ b/apps/online-docs/symphony/workflow-config.mdx
@@ -5,7 +5,7 @@ description: "Current Symphony WORKFLOW.md configuration shape and runtime seman
 
 `WORKFLOW.md` has one runtime-significant part:
 
-1. YAML front-matter: orchestrator configuration
+1. YAML front-matter: Symphony workflow configuration
 2. Markdown body: ignored by Symphony at runtime
 
 Use `prompts` in front-matter (and referenced prompt files) for runtime prompt content.
@@ -323,7 +323,7 @@ notifications:
 </ParamField>
 
 <ParamField path="notifications.slack.events" type="string[]" default="[]">
-  Events to notify on. Use `"all"` to subscribe to everything. Available values: `todo`, `in_progress`, `agent_review`, `human_review`, `merging`, `rework`, `done`, `closed`, `cancelled`, `stalled`, `failed`. Notification failures are logged as warnings and never block the orchestrator.
+  Events to notify on. Use `"all"` to subscribe to everything. Available values: `todo`, `in_progress`, `agent_review`, `human_review`, `merging`, `rework`, `done`, `closed`, `cancelled`, `stalled`, `failed`. Notification failures are logged as warnings and never block Symphony.
 </ParamField>
 
 ---


### PR DESCRIPTION
## Summary
- align top-level online docs copy with the current CLI runtime/contract surface
- refresh quickstart commands to use `kata setup`, `kata doctor`, and runtime operation commands
- normalize Symphony wording for tracker-driven dispatch and runtime terminology
- replace stale Orchestrator-specific references in shared docs pages

## Validation
- pnpm -C apps/online-docs run broken-links
- rg -n "kata-cli|/login|/model|/kata |Linear backlog|against your Linear|Kata Orchestrator session|orchestrator configuration|Full orchestrator" apps/online-docs/index.mdx apps/online-docs/introduction.mdx apps/online-docs/quickstart.mdx apps/online-docs/context/overview.mdx apps/online-docs/symphony/overview.mdx apps/online-docs/symphony/workflow-config.mdx apps/online-docs/reference/symphony-workflow.mdx apps/online-docs/reference/symphony-api.mdx

Closes #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined quickstart to a CLI-centered flow (npx/global setup, doctor validation, kata call/json) with JSON-envelope example and repeatable request guidance
  * Refreshed product descriptions, card copy and onboarding messaging to emphasize runtime/validation/dispatch and terminal configuration
  * Reframed indexing Tip to run indexing before CLI or worker runs
  * Standardized wording (e.g., "tracker backlog"), clarified Symphony polls trackers (Linear/GitHub), API/state and workflow config wording, ticket lifecycle, and that notification failures never block Symphony
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation consistency pass across eight online-docs pages, replacing stale Orchestrator/Linear-specific terminology with tracker-neutral language and updating the Kata CLI narrative from "terminal coding agent" to "runtime and contract bridge."

- **Quickstart** is rewritten to reflect `kata setup`, `kata doctor`, and `kata call`/`kata json` as the primary workflow, removing the old `/login`, `/model`, `/kata auto` interactive-agent steps.
- **Symphony pages** (`overview`, `workflow-config`, `symphony-api`, `symphony-workflow`) replace "Orchestrator" with "Symphony" throughout, and Linear-specific step instructions are updated to tracker-neutral equivalents.
- **Shared pages** (`index`, `introduction`, `context/overview`) normalize CLI descriptions and remove the remaining "Linear backlog" and "Kata Orchestrator session" references.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the broken npx path in the quickstart; the terminology updates across the other seven files are clean

The quickstart now presents two installation paths in step 1 but then only provides `kata` global-binary commands for every subsequent step. A reader who follows the npx route — which is listed first — will hit `command not found: kata` on step 2 with no recovery guidance, leaving the quickstart non-functional for that audience.

apps/online-docs/quickstart.mdx — steps 2–3 and the "Common operations" block need npx-equivalent forms or a note directing npx users to the global-install path

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/online-docs/quickstart.mdx | Major rewrite replacing interactive CLI flow (login, model, /kata) with setup/doctor/call workflow; post-setup steps assume global install while step 1 also offers npx, breaking that path |
| apps/online-docs/introduction.mdx | CLI repositioned as runtime/contract bridge; Symphony description updated to include GitHub alongside Linear; one legacy slash-command reference (/symphony status, /symphony watch) remains inconsistent with new framing |
| apps/online-docs/index.mdx | Linear-specific and Orchestrator terminology replaced with tracker-neutral language; CLI card and quickstart steps updated consistently with the npx form through step 2 |
| apps/online-docs/symphony/overview.mdx | "Orchestrator" replaced with "Symphony" in the workflow-status table; Linear-specific step 4 updated to tracker-neutral wording |
| apps/online-docs/symphony/workflow-config.mdx | "orchestrator configuration" and "orchestrator" replaced with "Symphony workflow configuration" and "Symphony" in two places; no functional changes |
| apps/online-docs/reference/symphony-api.mdx | "orchestrator state snapshot" renamed to "Symphony runtime state snapshot" in two places; no content changes |
| apps/online-docs/reference/symphony-workflow.mdx | "orchestrator config" replaced with "Symphony workflow config" in the front-matter description; clean single-line change |
| apps/online-docs/context/overview.mdx | Tip block updated from "Kata Orchestrator session" to "Kata CLI or Symphony worker run"; straightforward copy correction |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits Quickstart] --> B{Install path}
    B -->|npx| C["npx @kata-sh/cli setup --yes ..."]
    B -->|Global install| D["npm install -g @kata-sh/cli\nkata setup --yes ..."]
    C --> E["Step 2: kata doctor ❌\n(no global binary)"]
    D --> F["Step 2: kata doctor ✅"]
    E --> G["command not found: kata"]
    F --> H["Step 3: kata call health.check ✅"]
    G -.->|should show| I["npx @kata-sh/cli doctor"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/online-docs/quickstart.mdx:25-46
**npx path broken after Step 1**

Step 1 presents the `npx @kata-sh/cli setup ...` route first and with equal prominence, but every subsequent command — `kata doctor`, `kata call health.check`, the JSON envelope example, and the entire "Common operations" block — silently requires a globally-installed binary. A user who chose the npx path will get `command not found: kata` on step 2 with no indication they need to use `npx @kata-sh/cli doctor` instead.

### Issue 2 of 2
apps/online-docs/introduction.mdx:42
**Slash-command references inconsistent with updated CLI framing**

This sentence describes the CLI as exposing `/symphony status` and `/symphony watch` slash commands, but the rest of this PR repositions Kata CLI as a "runtime and contract bridge" whose interface is `kata call` / `kata json` operations. Slash-style command syntax now appears only in this one surviving sentence, making it unclear whether these are legacy UI interactions or still-supported CLI flags.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: align online docs terminology and ..."](https://github.com/gannonh/kata/commit/cff4cad416013629b7fb4caf4864024364e246c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30846286)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->