### PR TITLE
[S011] Representative PR validation fixture

### DIFF
--- a/docs/agents/pr-validation-fixture.md
+++ b/docs/agents/pr-validation-fixture.md
@@ -1,0 +1,42 @@
+# Representative PR validation fixture
+
+## Purpose
+
+Define a reusable PR fixture that supports validation of review comments, push updates, check inspection, and merge-readiness gates.
+
+## Fixture requirements
+
+### Required PR state
+
+- PR is open.
+- Base branch is `main`.
+- Head branch is a disposable fixture branch for this workflow.
+- PR targets a branch that exists on `origin`.
+
+### Representative review and comment signals
+
+- At least one PR conversation comment exists.
+- At least one PR review exists.
+- At least one review-thread or inline review comment exists.
+- Feedback can be inspected with:
+  - `.agents/skills/sym-state/scripts/sym-call pr.inspect-feedback --input <payload>`
+
+### Expected check signals
+
+- PR has at least one completed check run.
+- PR has at least one required check in a non-failing state before merge-readiness is considered.
+- Check status can be inspected with:
+  - `.agents/skills/sym-state/scripts/sym-call pr.inspect-checks --input <payload>`
+
+### Branch setup constraints
+
+- Fixture branch is short-lived and scoped to validation work.
+- Fixture branch name is unique per run and does not reuse release or production branches.
+- Fixture branch history remains auditable through normal commits.
+
+### Safety constraints
+
+- Do not bypass commit hooks with `--no-verify`.
+- Do not force-push protected branches.
+- Do not merge fixture PRs during validation runs unless explicit merge approval exists.
+- Keep all merge checks enforced; use readiness inspection rather than bypass.

--- a/docs/agents/pr-validation-fixture.md
+++ b/docs/agents/pr-validation-fixture.md
@@ -40,3 +40,57 @@ Define a reusable PR fixture that supports validation of review comments, push u
 - Do not force-push protected branches.
 - Do not merge fixture PRs during validation runs unless explicit merge approval exists.
 - Keep all merge checks enforced; use readiness inspection rather than bypass.
+
+## Disposable PR setup path
+
+Use this flow to create a short-lived fixture PR that exercises comment, update, and check workflows.
+
+1. Sync and branch from `main`:
+
+   ```bash
+   git fetch origin
+   git checkout main
+   git pull --ff-only origin main
+   git checkout -b fixture/pr-validation-$(date +%Y%m%d-%H%M%S)
+   ```
+
+2. Add a small auditable change and commit:
+
+   ```bash
+   mkdir -p docs/agents/fixtures
+   printf "fixture run: %s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > docs/agents/fixtures/pr-validation-run.md
+   git add docs/agents/fixtures/pr-validation-run.md
+   git commit -m "chore: create disposable PR validation fixture"
+   ```
+
+3. Push the fixture branch and open the PR to `main`:
+
+   ```bash
+   git push -u origin "$(git branch --show-current)"
+   gh pr create \
+     --base main \
+     --title "chore: disposable PR validation fixture" \
+     --body "Refs #492"
+   ```
+
+4. Add representative PR feedback signals:
+
+   ```bash
+   gh pr comment --body "Fixture comment: validates conversation comment ingestion."
+   ```
+
+5. Update the branch once to validate push/update behavior:
+
+   ```bash
+   printf "update: %s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> docs/agents/fixtures/pr-validation-run.md
+   git add docs/agents/fixtures/pr-validation-run.md
+   git commit -m "chore: fixture PR update commit"
+   git push
+   ```
+
+Required setup outcomes:
+
+- PR is open against `main`.
+- Fixture branch exists on `origin`.
+- PR contains at least one comment and at least one update push.
+- Standard checks run under normal repository gate rules.

--- a/docs/agents/pr-validation-fixture.md
+++ b/docs/agents/pr-validation-fixture.md
@@ -94,3 +94,50 @@ Required setup outcomes:
 - Fixture branch exists on `origin`.
 - PR contains at least one comment and at least one update push.
 - Standard checks run under normal repository gate rules.
+
+## Validation handoff for Planned Slice 15
+
+Use the fixture PR from this document as the validation target for review and land workflow slices.
+
+### Handoff workflow
+
+1. Confirm fixture branch and PR are published:
+
+   ```bash
+   git ls-remote --exit-code --heads origin "$(git branch --show-current)"
+   gh pr view --json url,state,headRefName,baseRefName
+   ```
+
+2. Inspect PR feedback payload:
+
+   ```bash
+   INPUT="/tmp/sym-${SYMPHONY_ISSUE_ID:-current}-pr-inspect-feedback-$$.json"
+   jq -n '{}' > "$INPUT"
+   .agents/skills/sym-state/scripts/sym-call pr.inspect-feedback --input "$INPUT"
+   ```
+
+3. Inspect PR check payload:
+
+   ```bash
+   INPUT="/tmp/sym-${SYMPHONY_ISSUE_ID:-current}-pr-inspect-checks-$$.json"
+   jq -n '{includeLogs:false}' > "$INPUT"
+   .agents/skills/sym-state/scripts/sym-call pr.inspect-checks --input "$INPUT"
+   ```
+
+4. Inspect land-readiness summary without merging:
+
+   ```bash
+   INPUT="/tmp/sym-${SYMPHONY_ISSUE_ID:-current}-pr-land-status-$$.json"
+   jq -n '{includeLogs:false}' > "$INPUT"
+   .agents/skills/sym-state/scripts/sym-call pr.land-status --input "$INPUT"
+   ```
+
+5. Record observed PR feedback, check status, and land-readiness fields in the active issue workpad.
+
+### Downstream acceptance criteria
+
+- `gh pr view` reports `state` as `OPEN`, `baseRefName` as `main`, and `headRefName` equal to the fixture branch.
+- `pr.inspect-feedback` returns non-empty representative feedback signals.
+- `pr.inspect-checks` returns check suites and required checks in non-failing status for readiness validation.
+- `pr.land-status` can be read successfully and used for decisioning without performing a merge.
+- No safety gate bypass commands are used during validation.


### PR DESCRIPTION
## Summary
- add representative PR validation fixture requirements and safety gates
- document disposable fixture PR setup path with concrete commands
- add Planned Slice 15 handoff workflow and acceptance criteria for feedback/check/land-status validation

Closes #492

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new documentation file (`docs/agents/pr-validation-fixture.md`) that defines requirements, a disposable setup path, and a Slice 15 handoff workflow for a representative PR validation fixture.

- The fixture requirements list three comment/review signal types (conversation comment, PR review, inline review comment), but the setup path only creates a plain conversation comment — steps for `gh pr review` and an inline review comment are absent, leaving the fixture incomplete for agents exercising those signal paths.
- No teardown step is documented; without cleanup instructions, repeated runs will accumulate stale branches and open PRs on `origin`.
- The file is missing a trailing newline.

<h3>Confidence Score: 3/5</h3>

Documentation-only change, but the fixture it describes is internally inconsistent and cannot be followed end-to-end as written.

The setup path omits two of the three representative comment/review signals declared in its own requirements section, and there is no cleanup step, meaning the workflow produces an incomplete fixture and leaves orphaned resources on the remote.

docs/agents/pr-validation-fixture.md — the setup steps and stated requirements are out of sync, and teardown is unaddressed.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/agents/pr-validation-fixture.md | New documentation file defining fixture requirements and setup steps for PR validation; setup path does not create the PR review or inline review comment required by its own stated requirements, and no teardown step is documented. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sync from main] --> B[Create fixture branch\nfixture/pr-validation-TIMESTAMP]
    B --> C[Commit auditable change\ndocs/agents/fixtures/pr-validation-run.md]
    C --> D[Push branch & open PR\ngh pr create --base main]
    D --> E[Add conversation comment\ngh pr comment]
    E --> F{Missing steps}
    F -->|Not documented| G["Add PR review\n(gh pr review --comment)"]
    F -->|Not documented| H["Add inline review comment"]
    E --> I[Push update commit]
    I --> J[Handoff: Inspect feedback\npr.inspect-feedback]
    J --> K[Inspect checks\npr.inspect-checks]
    K --> L[Inspect land status\npr.land-status]
    L --> M[Record in workpad]
    M -->|No teardown step| N["Fixture branch and PR left open on origin"]
    style F fill:#f66,color:#fff
    style G fill:#faa
    style H fill:#faa
    style N fill:#f66,color:#fff
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
docs/agents/pr-validation-fixture.md:76-79
**Setup path does not satisfy all stated requirements**

The fixture requirements (lines 19–20) call for "at least one PR review" and "at least one review-thread or inline review comment", but the setup path in step 4 only creates a plain conversation comment via `gh pr comment`. Neither a formal PR review (`gh pr review --comment`) nor an inline review comment is ever created, so any agent relying on this fixture to exercise `pr.inspect-feedback` for review or review-thread signals will receive an incomplete payload.

### Issue 2 of 3
docs/agents/pr-validation-fixture.md:98-143
**No teardown step documented**

The handoff workflow creates a fixture branch on `origin` and an open PR against `main`, but there is no cleanup step that closes the PR and deletes the branch after validation completes. Without documented teardown, repeated runs accumulate stale fixture branches and open PRs on the remote, which can pollute branch listings and confuse future validation runs that check for a unique branch name.

### Issue 3 of 3
docs/agents/pr-validation-fixture.md:143
The file is missing a trailing newline, which causes `\ No newline at end of file` in diffs and can break tools that expect POSIX-compliant text files.

```suggestion
- No safety gate bypass commands are used during validation.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PR workflow validation handoff..."](https://github.com/gannonh/kata/commit/b8471fdfdb21f343d14a53b2074fd733e6dcb28d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30909501)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->