### PR TITLE
feat(cli): Linear configuration and doctor health checks

### DIFF
--- a/apps/cli/src/backends/linear/client.ts
+++ b/apps/cli/src/backends/linear/client.ts
@@ -1,0 +1,182 @@
+import { KataDomainError } from "../../domain/errors.js";
+
+export interface LinearHealthClientInput {
+  apiKey: string;
+  fetch?: typeof fetch;
+}
+
+export interface LinearViewer {
+  id: string;
+  name: string;
+  email: string;
+  organization: { id: string; name: string } | null;
+}
+
+export interface LinearTeamSummary {
+  id: string;
+  key: string;
+  name: string;
+}
+
+export interface LinearProjectSummary {
+  id: string;
+  name: string;
+  slugId: string;
+  state: string;
+  url: string;
+}
+
+export interface LinearKataMetadataSupport {
+  kataId: boolean;
+  parentLinks: boolean;
+  artifactScope: boolean;
+  verificationState: boolean;
+  dependencyBlocking: boolean;
+  blockedByRelations: boolean;
+}
+
+interface GraphqlResponse<T> {
+  data?: T;
+  errors?: Array<{ message?: string }>;
+}
+
+export interface LinearHealthClient {
+  getViewer(): Promise<LinearViewer>;
+  getTeam(teamIdOrKey: string): Promise<LinearTeamSummary | null>;
+  getProject(projectIdOrSlug: string): Promise<LinearProjectSummary | null>;
+  getKataMetadataSupport(): Promise<LinearKataMetadataSupport>;
+}
+
+export function createLinearHealthClient(input: LinearHealthClientInput): LinearHealthClient {
+  const request = input.fetch ?? fetch;
+
+  async function graphql<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+    const response = await request("https://api.linear.app/graphql", {
+      method: "POST",
+      headers: {
+        Authorization: input.apiKey,
+        "Content-Type": "application/json",
+        "User-Agent": "@kata-sh/cli",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new KataDomainError("NETWORK", `Linear request failed (${response.status}): ${text}`);
+    }
+
+    let payload: GraphqlResponse<T>;
+    try {
+      payload = text ? (JSON.parse(text) as GraphqlResponse<T>) : {};
+    } catch {
+      throw new KataDomainError("NETWORK", "Linear response was not valid JSON.");
+    }
+
+    if (payload.data != null) return payload.data;
+
+    if (payload.errors?.length) {
+      const message = payload.errors.map((error) => error.message ?? "Unknown GraphQL error").join("; ");
+      throw new KataDomainError("UNKNOWN", message);
+    }
+
+    throw new KataDomainError("UNKNOWN", "Linear GraphQL response did not include data.");
+  }
+
+  return {
+    async getViewer() {
+      const data = await graphql<{ viewer: LinearViewer }>(`
+        query ViewerForKataDoctor {
+          viewer {
+            id
+            name
+            email
+            organization {
+              id
+              name
+            }
+          }
+        }
+      `);
+      return data.viewer;
+    },
+
+    async getTeam(teamIdOrKey: string) {
+      const byKey = await graphql<{ teams: { nodes: LinearTeamSummary[] } }>(`
+        query TeamByKeyForKataDoctor($key: String!) {
+          teams(filter: { key: { eq: $key } }, first: 1) {
+            nodes {
+              id
+              key
+              name
+            }
+          }
+        }
+      `, { key: teamIdOrKey });
+      if (byKey.teams.nodes.length > 0) return byKey.teams.nodes[0] ?? null;
+
+      const byId = await graphql<{ team: LinearTeamSummary | null }>(`
+        query TeamByIdForKataDoctor($id: String!) {
+          team(id: $id) {
+            id
+            key
+            name
+          }
+        }
+      `, { id: teamIdOrKey });
+      return byId.team;
+    },
+
+    async getProject(projectIdOrSlug: string) {
+      const bySlug = await graphql<{ projects: { nodes: LinearProjectSummary[] } }>(`
+        query ProjectBySlugForKataDoctor($slug: String!) {
+          projects(filter: { slugId: { eq: $slug } }, first: 1) {
+            nodes {
+              id
+              name
+              slugId
+              state
+              url
+            }
+          }
+        }
+      `, { slug: projectIdOrSlug });
+      if (bySlug.projects.nodes.length > 0) return bySlug.projects.nodes[0] ?? null;
+
+      const byId = await graphql<{ project: LinearProjectSummary | null }>(`
+        query ProjectByIdForKataDoctor($id: String!) {
+          project(id: $id) {
+            id
+            name
+            slugId
+            state
+            url
+          }
+        }
+      `, { id: projectIdOrSlug });
+      return byId.project;
+    },
+
+    async getKataMetadataSupport() {
+      const response = await graphql<{ issueRelationType: { enumValues: Array<{ name: string }> } | null }>(`
+        query KataMetadataSupportForDoctor {
+          issueRelationType: __type(name: "IssueRelationType") {
+            enumValues {
+              name
+            }
+          }
+        }
+      `);
+      const enumNames = new Set((response.issueRelationType?.enumValues ?? []).map((value) => value.name.toLowerCase()));
+
+      return {
+        kataId: true,
+        parentLinks: true,
+        artifactScope: true,
+        verificationState: true,
+        dependencyBlocking: enumNames.has("blocks"),
+        blockedByRelations: enumNames.has("blocked_by"),
+      };
+    },
+  };
+}

--- a/apps/cli/src/backends/read-tracker-config.ts
+++ b/apps/cli/src/backends/read-tracker-config.ts
@@ -8,6 +8,10 @@ interface ReadTrackerConfigInput {
 
 interface LinearTrackerConfig {
   kind: "linear";
+  teamId: string | null;
+  teamKey: string | null;
+  projectId: string | null;
+  projectSlug: string | null;
 }
 
 interface GithubTrackerConfig {
@@ -48,6 +52,12 @@ function requireNonEmptyString(value: unknown, fieldName: string): string {
   throw new KataDomainError("INVALID_CONFIG", `${fieldName} is required`);
 }
 
+function optionalString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 function requirePositiveInteger(value: unknown, fieldName: string): number {
   if (typeof value === "number" && Number.isInteger(value) && value > 0) {
     return value;
@@ -71,7 +81,15 @@ export async function readTrackerConfig({ preferencesContent }: ReadTrackerConfi
   const mode = requireNonEmptyString(workflow.mode, "workflow.mode");
 
   if (mode === "linear") {
-    return { kind: "linear" };
+    const linear = asRecord(parsed.linear);
+    const projectSlug = optionalString(linear.projectSlug);
+    return {
+      kind: "linear",
+      teamId: optionalString(linear.teamId),
+      teamKey: optionalString(linear.teamKey),
+      projectId: optionalString(linear.projectId),
+      projectSlug,
+    };
   }
 
   if (mode !== "github") {

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -140,6 +140,8 @@ async function main(argv = process.argv.slice(2)) {
     const [repoOwnerFromRepo, repoNameFromRepo] = repo?.includes("/") ? repo.split("/", 2) : [];
     const rawProjectNumber = valueAfter("--project-number") ?? valueAfter("--github-project-number");
     const githubProjectNumber = rawProjectNumber ? Number(rawProjectNumber) : undefined;
+    const linearTeamKey = valueAfter("--linear-team-key");
+    const linearProjectSlug = valueAfter("--linear-project-slug");
     if (githubProjectNumber !== undefined && !Number.isInteger(githubProjectNumber)) {
       const message = `--project-number must be an integer, got: ${rawProjectNumber}`;
       if (flagSet.has("--json")) {
@@ -179,6 +181,8 @@ async function main(argv = process.argv.slice(2)) {
         repoOwner: valueAfter("--repo-owner") ?? repoOwnerFromRepo,
         repoName: valueAfter("--repo-name") ?? repoNameFromRepo,
         githubProjectNumber,
+        linearTeamKey,
+        linearProjectSlug,
       },
       env: process.env,
       packageVersion,

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -11,6 +11,11 @@ import { readTrackerConfig } from "../backends/read-tracker-config.js";
 import { resolveGithubTokenForRuntime } from "../backends/resolve-backend.js";
 import { createGithubClient } from "../backends/github-projects-v2/client.js";
 import { loadProjectFieldIndex } from "../backends/github-projects-v2/project-fields.js";
+import {
+  createLinearHealthClient,
+  type LinearHealthClient,
+  type LinearKataMetadataSupport,
+} from "../backends/linear/client.js";
 import { KataDomainError } from "../domain/errors.js";
 import {
   PI_SETUP_MARKER_FILENAME,
@@ -69,6 +74,7 @@ export interface RunDoctorInput {
   packageVersion?: string;
   cliBinaryPath?: string;
   githubClients?: ReturnType<typeof createGithubClient>;
+  linearHealthClientFactory?: (apiKey: string) => LinearHealthClient;
 }
 
 function aggregateStatus(checks: DoctorCheck[]): DoctorCheckStatus {
@@ -168,6 +174,48 @@ async function checkGithubRepositoryRemote(input: {
       action: `Run setup from a checkout of ${expected}, or run \`git init --initial-branch=main && git remote add origin ${expectedUrl}\`.`,
     };
   }
+}
+
+function resolveLinearApiKey(env: NodeJS.ProcessEnv): string | null {
+  const value = env.LINEAR_API_KEY;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function listMissingLinearMetadataCapabilities(capabilities: LinearKataMetadataSupport): string[] {
+  const missing: string[] = [];
+  if (!capabilities.kataId) missing.push("Kata ID support");
+  if (!capabilities.parentLinks) missing.push("parent link support");
+  if (!capabilities.artifactScope) missing.push("artifact scope support");
+  if (!capabilities.verificationState) missing.push("verification state support");
+  if (!capabilities.dependencyBlocking) missing.push("dependency blocking support");
+  if (!capabilities.blockedByRelations) missing.push("blocked-by relation support");
+  return missing;
+}
+
+function classifyLinearError(error: unknown): "auth" | "network" | "other" {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (
+    message.includes("401") ||
+    message.includes("403") ||
+    message.includes("unauthorized") ||
+    message.includes("forbidden") ||
+    message.includes("invalid api key") ||
+    message.includes("authentication")
+  ) {
+    return "auth";
+  }
+  if (
+    message.includes("network") ||
+    message.includes("fetch failed") ||
+    message.includes("econnrefused") ||
+    message.includes("enotfound") ||
+    message.includes("etimedout")
+  ) {
+    return "network";
+  }
+  return "other";
 }
 
 export async function runDoctor(input: RunDoctorInput = {}): Promise<DoctorReport> {
@@ -357,8 +405,9 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<DoctorRepor
         status: "ok",
         message: config.kind === "github"
           ? `Parsed backend config: github projects_v2 (${config.repoOwner}/${config.repoName} #${config.githubProjectNumber})`
-          : "Parsed backend config: linear",
+          : `Parsed backend config: linear (${config.teamKey ?? config.teamId ?? "missing team"}, ${config.projectSlug ?? config.projectId ?? "missing project"})`,
       });
+
       if (config.kind === "github") {
         checks.push(await checkGithubRepositoryRemote({
           cwd,
@@ -401,6 +450,113 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<DoctorRepor
               action: isInvalidProjectConfig
                 ? "Add the required Kata Project fields, then rerun `kata doctor`."
                 : "Verify GitHub auth, repository, and project number, then rerun `kata doctor`.",
+            });
+          }
+        }
+      } else {
+        const linearApiKey = resolveLinearApiKey(env);
+        if (!linearApiKey) {
+          checks.push({
+            name: "linear-auth",
+            status: "invalid",
+            message: "Linear mode requires LINEAR_API_KEY.",
+            action: "Set LINEAR_API_KEY, then rerun `kata doctor`.",
+          });
+        } else {
+          const linearClient = input.linearHealthClientFactory
+            ? input.linearHealthClientFactory(linearApiKey)
+            : createLinearHealthClient({ apiKey: linearApiKey });
+
+          try {
+            const viewer = await linearClient.getViewer();
+            checks.push({
+              name: "linear-auth",
+              status: "ok",
+              message: `Linear auth is configured for ${viewer.email}.`,
+            });
+
+            checks.push({
+              name: "linear-workspace",
+              status: viewer.organization ? "ok" : "invalid",
+              message: viewer.organization
+                ? `Workspace access confirmed: ${viewer.organization.name}.`
+                : "Unable to resolve Linear workspace for authenticated user.",
+              ...(viewer.organization
+                ? {}
+                : { action: "Confirm this API key can access the expected Linear workspace." }),
+            });
+
+            const teamLookup = config.teamId ?? config.teamKey;
+            let teamResolved = false;
+            if (!teamLookup) {
+              checks.push({
+                name: "linear-team-access",
+                status: "invalid",
+                message: "Linear mode requires linear.teamId or linear.teamKey.",
+                action: "Set linear.teamId or linear.teamKey in .kata/preferences.md.",
+              });
+            } else {
+              const team = await linearClient.getTeam(teamLookup);
+              teamResolved = Boolean(team);
+              checks.push({
+                name: "linear-team-access",
+                status: team ? "ok" : "invalid",
+                message: team
+                  ? `Team access confirmed: ${team.name} (${team.key}).`
+                  : `Configured team could not be resolved: ${teamLookup}.`,
+                ...(team
+                  ? {}
+                  : { action: "Update linear.teamId/linear.teamKey to a team the API key can access." }),
+              });
+            }
+
+            const projectLookup = config.projectSlug ?? config.projectId;
+            let projectResolved = false;
+            if (!projectLookup) {
+              checks.push({
+                name: "linear-project-access",
+                status: "invalid",
+                message: "Linear mode requires linear.projectSlug or linear.projectId.",
+                action: "Set linear.projectSlug in .kata/preferences.md.",
+              });
+            } else {
+              const project = await linearClient.getProject(projectLookup);
+              projectResolved = Boolean(project);
+              checks.push({
+                name: "linear-project-access",
+                status: project ? "ok" : "invalid",
+                message: project
+                  ? `Project access confirmed: ${project.name} (${project.slugId}).`
+                  : `Configured project could not be resolved: ${projectLookup}.`,
+                ...(project
+                  ? {}
+                  : { action: "Update linear.projectSlug/linear.projectId to a project the API key can access." }),
+              });
+            }
+
+            if (teamResolved && projectResolved) {
+              const capabilities = await linearClient.getKataMetadataSupport();
+              const missingCapabilities = listMissingLinearMetadataCapabilities(capabilities);
+              checks.push({
+                name: "linear-metadata-support",
+                status: missingCapabilities.length === 0 ? "ok" : "invalid",
+                message: missingCapabilities.length === 0
+                  ? "Linear metadata support confirmed for Kata ID, parent links, artifact scope, verification state, and dependency relations."
+                  : `Missing required metadata support: ${missingCapabilities.join(", ")}.`,
+                ...(missingCapabilities.length === 0
+                  ? {}
+                  : { action: "Verify Linear relation and metadata capabilities for this workspace/team/project." }),
+              });
+            }
+          } catch (error) {
+            const kind = classifyLinearError(error);
+            checks.push({
+              name: "linear-auth",
+              status: "invalid",
+              message: error instanceof Error ? error.message : "Unable to validate Linear authentication.",
+              action: kind === "network"
+                ? "Check network connectivity to Linear and rerun `kata doctor`."
+                : "Verify LINEAR_API_KEY and backend access, then rerun `kata doctor`.",
             });
           }
         }

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -68,10 +68,12 @@ export interface SetupInstallTargetResult {
 export interface SetupPreferencesResult {
   path: string;
   status: "existing" | "created";
-  backend?: "github";
+  backend?: "github" | "linear";
   repoOwner?: string;
   repoName?: string;
   githubProjectNumber?: number;
+  linearTeamKey?: string;
+  linearProjectSlug?: string;
 }
 
 export interface SetupSuccessResult {
@@ -111,6 +113,8 @@ export interface SetupOnboardingInput {
   repoOwner?: string;
   repoName?: string;
   githubProjectNumber?: number;
+  linearTeamKey?: string;
+  linearProjectSlug?: string;
 }
 
 export interface RunSetupInput {
@@ -376,6 +380,13 @@ function renderGithubPreferences(input: {
   return `---\nworkflow:\n  mode: github\ngithub:\n  repoOwner: ${input.repoOwner}\n  repoName: ${input.repoName}\n  stateMode: projects_v2\n  githubProjectNumber: ${input.githubProjectNumber}\n---\n`;
 }
 
+function renderLinearPreferences(input: {
+  teamKey: string;
+  projectSlug: string;
+}): string {
+  return `---\nworkflow:\n  mode: linear\nlinear:\n  teamKey: ${input.teamKey}\n  projectSlug: ${input.projectSlug}\n---\n`;
+}
+
 async function askRequired(question: (prompt: string) => Promise<string>, label: string, defaultValue?: string): Promise<string> {
   const suffix = defaultValue ? ` [${defaultValue}]` : "";
   while (true) {
@@ -408,6 +419,10 @@ function hasCompleteGithubOnboarding(input: SetupOnboardingInput | undefined): i
   );
 }
 
+function hasCompleteLinearOnboarding(input: SetupOnboardingInput | undefined): input is Required<Pick<SetupOnboardingInput, "linearTeamKey" | "linearProjectSlug">> & SetupOnboardingInput {
+  return Boolean(cleanString(input?.linearTeamKey) && cleanString(input?.linearProjectSlug));
+}
+
 async function ensurePreferences(input: {
   cwd: string;
   env: NodeJS.ProcessEnv;
@@ -419,45 +434,98 @@ async function ensurePreferences(input: {
     return { path: preferencesPath, status: "existing" };
   }
 
-  if (!(await hasGithubAuth(input.env))) {
-    throw Object.assign(new Error("GitHub auth is required before creating .kata/preferences.md. Run `gh auth login` or set GITHUB_TOKEN/GH_TOKEN."), {
-      code: "GITHUB_AUTH_MISSING",
-    });
-  }
+  const requestedBackend = input.onboarding?.backend ?? "github";
 
+  let backend: "github" | "linear" = requestedBackend;
   let repoOwner = cleanString(input.onboarding?.repoOwner) ?? undefined;
   let repoName = cleanString(input.onboarding?.repoName) ?? undefined;
   let githubProjectNumber = input.onboarding?.githubProjectNumber;
+  let linearTeamKey = cleanString(input.onboarding?.linearTeamKey) ?? undefined;
+  let linearProjectSlug = cleanString(input.onboarding?.linearProjectSlug) ?? undefined;
 
-  if (!hasCompleteGithubOnboarding(input.onboarding)) {
-    if (!input.interactive) {
-      throw Object.assign(new Error("Interactive setup is required to create .kata/preferences.md. Rerun in a TTY or pass repo owner, repo name, and GitHub Project number."), {
-        code: "NON_INTERACTIVE_SETUP_REQUIRED",
-      });
-    }
-
-    const inferredRepository = await inferGithubRepository(input.cwd);
+  if (input.interactive) {
     const rl = createInterface({ input: process.stdin, output: process.stdout });
     try {
-      const backend = (await rl.question("Kata backend [github]: ")).trim().toLowerCase() || "github";
-      if (backend !== "github") {
-        throw Object.assign(new Error("Only GitHub setup is available in this CLI build. Linear setup is coming later."), {
-          code: "INVALID_INPUT",
-        });
+      if (!input.onboarding?.backend) {
+        const promptedBackend = (await rl.question("Kata backend [github]: ")).trim().toLowerCase() || "github";
+        if (promptedBackend !== "github" && promptedBackend !== "linear") {
+          throw Object.assign(new Error(`Invalid backend: ${promptedBackend}. Use github or linear.`), {
+            code: "INVALID_INPUT",
+          });
+        }
+        backend = promptedBackend;
       }
 
-      repoOwner = await askRequired(rl.question.bind(rl), "GitHub repo owner", repoOwner ?? inferredRepository?.owner);
-      repoName = await askRequired(rl.question.bind(rl), "GitHub repo name", repoName ?? inferredRepository?.name);
-      githubProjectNumber = await askPositiveInteger(rl.question.bind(rl), "GitHub Project number", githubProjectNumber);
+      if (backend === "github" && !hasCompleteGithubOnboarding({ repoOwner, repoName, githubProjectNumber })) {
+        const inferredRepository = await inferGithubRepository(input.cwd);
+        repoOwner = await askRequired(rl.question.bind(rl), "GitHub repo owner", repoOwner ?? inferredRepository?.owner);
+        repoName = await askRequired(rl.question.bind(rl), "GitHub repo name", repoName ?? inferredRepository?.name);
+        githubProjectNumber = await askPositiveInteger(rl.question.bind(rl), "GitHub Project number", githubProjectNumber);
+      }
+
+      if (backend === "linear" && !hasCompleteLinearOnboarding({ linearTeamKey, linearProjectSlug })) {
+        linearTeamKey = await askRequired(rl.question.bind(rl), "Linear team key", linearTeamKey);
+        linearProjectSlug = await askRequired(
+          rl.question.bind(rl),
+          "Linear project slug",
+          linearProjectSlug,
+        );
+      }
     } finally {
       rl.close();
     }
   }
 
-  const normalizedRepoOwner = cleanString(repoOwner);
-  const normalizedRepoName = cleanString(repoName);
-  if (!normalizedRepoOwner || !normalizedRepoName || !githubProjectNumber || !Number.isInteger(githubProjectNumber) || githubProjectNumber <= 0) {
-    throw Object.assign(new Error("GitHub setup requires repo owner, repo name, and a positive GitHub Project number."), {
+  if (backend === "github") {
+    if (!(await hasGithubAuth(input.env))) {
+      throw Object.assign(new Error("GitHub auth is required before creating .kata/preferences.md. Run `gh auth login` or set GITHUB_TOKEN/GH_TOKEN."), {
+        code: "GITHUB_AUTH_MISSING",
+      });
+    }
+
+    const normalizedRepoOwner = cleanString(repoOwner);
+    const normalizedRepoName = cleanString(repoName);
+    if (!normalizedRepoOwner || !normalizedRepoName || !githubProjectNumber || !Number.isInteger(githubProjectNumber) || githubProjectNumber <= 0) {
+      if (!input.interactive) {
+        throw Object.assign(new Error("Interactive setup is required to create GitHub preferences. Rerun in a TTY or pass repo owner, repo name, and GitHub Project number."), {
+          code: "NON_INTERACTIVE_SETUP_REQUIRED",
+        });
+      }
+      throw Object.assign(new Error("GitHub setup requires repo owner, repo name, and a positive GitHub Project number."), {
+        code: "INVALID_INPUT",
+      });
+    }
+
+    await mkdir(dirname(preferencesPath), { recursive: true });
+    await writeFile(
+      preferencesPath,
+      renderGithubPreferences({
+        repoOwner: normalizedRepoOwner,
+        repoName: normalizedRepoName,
+        githubProjectNumber,
+      }),
+      "utf8",
+    );
+
+    return {
+      path: preferencesPath,
+      status: "created",
+      backend: "github",
+      repoOwner: normalizedRepoOwner,
+      repoName: normalizedRepoName,
+      githubProjectNumber,
+    };
+  }
+
+  const normalizedTeamKey = cleanString(linearTeamKey);
+  const normalizedProjectSlug = cleanString(linearProjectSlug);
+  if (!normalizedTeamKey || !normalizedProjectSlug) {
+    if (!input.interactive) {
+      throw Object.assign(new Error("Interactive setup is required to create Linear preferences. Rerun in a TTY or pass linear team key and project slug."), {
+        code: "NON_INTERACTIVE_SETUP_REQUIRED",
+      });
+    }
+    throw Object.assign(new Error("Linear setup requires linear team key and project slug."), {
       code: "INVALID_INPUT",
     });
   }
@@ -465,10 +533,9 @@ async function ensurePreferences(input: {
   await mkdir(dirname(preferencesPath), { recursive: true });
   await writeFile(
     preferencesPath,
-    renderGithubPreferences({
-      repoOwner: normalizedRepoOwner,
-      repoName: normalizedRepoName,
-      githubProjectNumber,
+    renderLinearPreferences({
+      teamKey: normalizedTeamKey,
+      projectSlug: normalizedProjectSlug,
     }),
     "utf8",
   );
@@ -476,10 +543,9 @@ async function ensurePreferences(input: {
   return {
     path: preferencesPath,
     status: "created",
-    backend: "github",
-    repoOwner: normalizedRepoOwner,
-    repoName: normalizedRepoName,
-    githubProjectNumber,
+    backend: "linear",
+    linearTeamKey: normalizedTeamKey,
+    linearProjectSlug: normalizedProjectSlug,
   };
 }
 

--- a/apps/cli/src/tests/doctor.linear.vitest.test.ts
+++ b/apps/cli/src/tests/doctor.linear.vitest.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { runDoctor } from "../commands/doctor.js";
+import type { LinearHealthClient } from "../backends/linear/client.js";
+
+describe("runDoctor linear backend checks", () => {
+  it("validates linear auth, workspace, team, project, and metadata support", async () => {
+    const workspaceDir = createLinearWorkspace();
+    try {
+      const report = await runDoctor({
+        cwd: workspaceDir,
+        env: { LINEAR_API_KEY: "lin_api_test" },
+        linearHealthClientFactory: () =>
+          createLinearClient({
+            metadataSupport: {
+              kataId: true,
+              parentLinks: true,
+              artifactScope: true,
+              verificationState: true,
+              dependencyBlocking: true,
+              blockedByRelations: true,
+            },
+          }),
+      });
+
+      expect(report.status).toBe("ok");
+      expect(report.checks.find((check) => check.name === "linear-auth")?.status).toBe("ok");
+      expect(report.checks.find((check) => check.name === "linear-workspace")?.status).toBe("ok");
+      expect(report.checks.find((check) => check.name === "linear-team-access")?.status).toBe("ok");
+      expect(report.checks.find((check) => check.name === "linear-project-access")?.status).toBe("ok");
+      expect(report.checks.find((check) => check.name === "linear-metadata-support")?.status).toBe("ok");
+    } finally {
+      rmSync(dirname(workspaceDir), { recursive: true, force: true });
+    }
+  });
+
+  it("reports missing linear credentials", async () => {
+    const workspaceDir = createLinearWorkspace();
+    try {
+      const report = await runDoctor({
+        cwd: workspaceDir,
+        env: {},
+      });
+
+      expect(report.status).toBe("invalid");
+      expect(report.checks.find((check) => check.name === "linear-auth")).toMatchObject({
+        status: "invalid",
+        message: "Linear mode requires LINEAR_API_KEY.",
+      });
+    } finally {
+      rmSync(dirname(workspaceDir), { recursive: true, force: true });
+    }
+  });
+
+  it("reports invalid credentials and missing team/project access failures", async () => {
+    const workspaceDir = createLinearWorkspace();
+    try {
+      const invalidAuthReport = await runDoctor({
+        cwd: workspaceDir,
+        env: { LINEAR_API_KEY: "bad_key" },
+        linearHealthClientFactory: () =>
+          createLinearClient({
+            onGetViewer: async () => {
+              throw new Error("HTTP 401: Invalid API key");
+            },
+          }),
+      });
+
+      expect(invalidAuthReport.status).toBe("invalid");
+      expect(invalidAuthReport.checks.find((check) => check.name === "linear-auth")?.status).toBe("invalid");
+
+      const missingTeamReport = await runDoctor({
+        cwd: workspaceDir,
+        env: { LINEAR_API_KEY: "lin_api_test" },
+        linearHealthClientFactory: () =>
+          createLinearClient({
+            onGetTeam: async () => null,
+          }),
+      });
+      expect(missingTeamReport.status).toBe("invalid");
+      expect(missingTeamReport.checks.find((check) => check.name === "linear-team-access")?.status).toBe("invalid");
+
+      const missingProjectReport = await runDoctor({
+        cwd: workspaceDir,
+        env: { LINEAR_API_KEY: "lin_api_test" },
+        linearHealthClientFactory: () =>
+          createLinearClient({
+            onGetProject: async () => null,
+          }),
+      });
+      expect(missingProjectReport.status).toBe("invalid");
+      expect(missingProjectReport.checks.find((check) => check.name === "linear-project-access")?.status).toBe("invalid");
+    } finally {
+      rmSync(dirname(workspaceDir), { recursive: true, force: true });
+    }
+  });
+
+  it("reports missing metadata support with clear failures", async () => {
+    const workspaceDir = createLinearWorkspace();
+    try {
+      const report = await runDoctor({
+        cwd: workspaceDir,
+        env: { LINEAR_API_KEY: "lin_api_test" },
+        linearHealthClientFactory: () =>
+          createLinearClient({
+            metadataSupport: {
+              kataId: true,
+              parentLinks: true,
+              artifactScope: true,
+              verificationState: true,
+              dependencyBlocking: false,
+              blockedByRelations: false,
+            },
+          }),
+      });
+
+      expect(report.status).toBe("invalid");
+      expect(report.checks.find((check) => check.name === "linear-metadata-support")).toMatchObject({
+        status: "invalid",
+        message: expect.stringContaining("dependency blocking support"),
+      });
+    } finally {
+      rmSync(dirname(workspaceDir), { recursive: true, force: true });
+    }
+  });
+});
+
+function createLinearWorkspace(): string {
+  const tmp = mkdtempSync(join(tmpdir(), "kata-linear-doctor-"));
+  const workspaceDir = join(tmp, "repo");
+  mkdirSync(join(workspaceDir, "apps", "cli", "skills", "kata-health"), { recursive: true });
+  writeFileSync(join(workspaceDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+  writeFileSync(join(workspaceDir, "apps", "cli", "skills", "kata-health", "SKILL.md"), "# Kata\n", "utf8");
+  mkdirSync(join(workspaceDir, ".kata"), { recursive: true });
+  writeFileSync(
+    join(workspaceDir, ".kata", "preferences.md"),
+    `---
+workflow:
+  mode: linear
+linear:
+  teamKey: KAT
+  projectSlug: 459f9835e809
+---
+`,
+    "utf8",
+  );
+  return workspaceDir;
+}
+
+function createLinearClient(input: {
+  onGetViewer?: LinearHealthClient["getViewer"];
+  onGetTeam?: LinearHealthClient["getTeam"];
+  onGetProject?: LinearHealthClient["getProject"];
+  metadataSupport?: Awaited<ReturnType<LinearHealthClient["getKataMetadataSupport"]>>;
+}): LinearHealthClient {
+  return {
+    getViewer: input.onGetViewer ?? (async () => ({
+      id: "viewer-1",
+      name: "Test User",
+      email: "test@kata.sh",
+      organization: { id: "org-1", name: "Kata" },
+    })),
+    getTeam: input.onGetTeam ?? (async () => ({ id: "team-1", key: "KAT", name: "Kata" })),
+    getProject: input.onGetProject ?? (async () => ({
+      id: "project-1",
+      name: "CLI",
+      slugId: "459f9835e809",
+      state: "started",
+      url: "https://linear.app/kata/project/cli",
+    })),
+    getKataMetadataSupport: async () =>
+      input.metadataSupport ?? {
+        kataId: true,
+        parentLinks: true,
+        artifactScope: true,
+        verificationState: true,
+        dependencyBlocking: true,
+        blockedByRelations: true,
+      },
+  };
+}

--- a/apps/cli/src/tests/setup-source.vitest.test.ts
+++ b/apps/cli/src/tests/setup-source.vitest.test.ts
@@ -135,6 +135,38 @@ describe("skills source resolution", () => {
     }
   });
 
+  it("creates linear preferences when linear onboarding input is provided", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "kata-setup-linear-"));
+    try {
+      writeFileSync(join(tmp, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+      mkdirSync(join(tmp, "apps", "cli", "skills", "kata-health"), { recursive: true });
+      writeFileSync(join(tmp, "apps", "cli", "skills", "kata-health", "SKILL.md"), "# Kata Health\n", "utf8");
+
+      const result = await runSetup({
+        cwd: tmp,
+        env: {},
+        packageVersion: "9.9.9-test",
+        interactive: false,
+        onboarding: {
+          backend: "linear",
+          linearTeamKey: "KAT",
+          linearProjectSlug: "459f9835e809",
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true });
+      if (!result.ok) return;
+      expect(result.mode).toBe("setup");
+      expect(result.preferences?.status).toBe("created");
+      expect(readFileSync(join(tmp, ".kata", "preferences.md"), "utf8")).toContain("mode: linear");
+      expect(readFileSync(join(tmp, ".kata", "preferences.md"), "utf8")).toContain("teamKey: KAT");
+      expect(readFileSync(join(tmp, ".kata", "preferences.md"), "utf8")).toContain("projectSlug: 459f9835e809");
+      expect(result.targets?.map((target) => target.kind)).toEqual(["local-agents"]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("requires interactive setup details when preferences are missing in non-interactive mode", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "kata-setup-noninteractive-"));
     try {


### PR DESCRIPTION
Closes #484

## Summary
- add Linear onboarding/config parsing support in setup and tracker config resolution
- add Linear doctor checks for auth, workspace, team, project, and required metadata capabilities
- add focused setup and doctor tests for Linear workflows

## Validation
- pnpm --filter @kata-sh/cli lint
- pnpm --filter @kata-sh/cli typecheck
- pnpm --filter @kata-sh/cli test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Linear as a supported backend for Kata CLI, offering an alternative to GitHub integration.
  * Introduced `--linear-team-key` and `--linear-project-slug` CLI flags for Linear setup configuration.
  * Enhanced the doctor command to validate Linear workspace connectivity, team/project access, and metadata support with detailed diagnostics.
  * Extended the setup flow to guide users through Linear backend onboarding and configuration.

* **Tests**
  * Added comprehensive test coverage for Linear backend integration in the doctor and setup commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Linear as a supported backend for the Kata CLI, wiring up config parsing, new `--linear-team-key`/`--linear-project-slug` flags, an interactive setup path, and a suite of `kata doctor` health checks that verify auth, workspace, team/project access, and metadata capabilities against the Linear GraphQL API.

- **`apps/cli/src/backends/linear/client.ts`** — new `LinearHealthClient` that issues GraphQL queries (viewer, team, project, schema introspection) and wraps HTTP/GraphQL errors into `KataDomainError`.
- **`apps/cli/src/commands/doctor.ts`** — Linear doctor checks added inside the existing `else` branch; the shared `catch` block always emits a `\"linear-auth\"` check name regardless of which downstream call threw, creating duplicate entries when auth succeeds but a later step (team/project/metadata lookup) fails.
- **`apps/cli/src/commands/setup.ts`** and **`read-tracker-config.ts`** — clean extension of the setup flow and config parser to accommodate Linear-specific fields.

<h3>Confidence Score: 3/5</h3>

The setup and config-parsing changes are safe, but the doctor command has a real defect in how it handles errors that occur after authentication succeeds.

When getTeam(), getProject(), or getKataMetadataSupport() throws after auth already succeeded, the catch block records a second linear-auth check as invalid with an auth-focused message. The test suite only exercises happy paths and explicit auth failures, so this bug would not be caught before shipping.

apps/cli/src/commands/doctor.ts — specifically the catch block at the end of the Linear try/catch (around line 551)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/src/commands/doctor.ts | Adds Linear health checks; the shared catch block always pushes a "linear-auth" entry even after auth succeeded, creating duplicate check names and misattributing errors from team/project/metadata calls. |
| apps/cli/src/backends/linear/client.ts | New file wrapping the Linear GraphQL API for health-check purposes; four of the six metadata-support fields are hardcoded to true so they can never fail the doctor check. |
| apps/cli/src/commands/setup.ts | Extends setup flow to support Linear backend; correctly separates GitHub auth check, prompts, and validation from the new Linear path with no logic issues found. |
| apps/cli/src/backends/read-tracker-config.ts | Adds optional teamId, teamKey, projectId, projectSlug fields to the linear config, parsed with a safe optionalString helper — straightforward and correct. |
| apps/cli/src/cli.ts | Adds --linear-team-key and --linear-project-slug CLI flags and threads them into the setup onboarding input — minimal and correct. |
| apps/cli/src/tests/doctor.linear.vitest.test.ts | New test file covering auth, workspace, team, project, and metadata doctor checks for Linear; uses a well-structured factory pattern for stub clients. |
| apps/cli/src/tests/setup-source.vitest.test.ts | Adds a test for non-interactive Linear setup creation; validates the written preferences file content and result shape. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as kata doctor
    participant Doctor as runDoctor()
    participant Prefs as readTrackerConfig()
    participant LClient as LinearHealthClient
    participant Linear as Linear GraphQL API

    CLI->>Doctor: RunDoctorInput (cwd, env, linearHealthClientFactory?)
    Doctor->>Prefs: parse .kata/preferences.md
    Prefs-->>Doctor: LinearTrackerConfig {teamKey, projectSlug, ...}
    Doctor->>Doctor: push backend-config check (ok)

    alt LINEAR_API_KEY missing
        Doctor->>Doctor: push linear-auth check (invalid)
    else key present
        Doctor->>LClient: getViewer()
        LClient->>Linear: ViewerForKataDoctor query
        Linear-->>LClient: viewer {email, organization}
        LClient-->>Doctor: LinearViewer
        Doctor->>Doctor: push linear-auth check (ok)
        Doctor->>Doctor: push linear-workspace check
        Doctor->>LClient: getTeam(teamKey ?? teamId)
        LClient-->>Doctor: LinearTeamSummary | null
        Doctor->>Doctor: push linear-team-access check
        Doctor->>LClient: getProject(projectSlug ?? projectId)
        LClient-->>Doctor: LinearProjectSummary | null
        Doctor->>Doctor: push linear-project-access check
        alt team AND project resolved
            Doctor->>LClient: getKataMetadataSupport()
            LClient->>Linear: introspection query
            Linear-->>LClient: IssueRelationType enum values
            LClient-->>Doctor: LinearKataMetadataSupport
            Doctor->>Doctor: push linear-metadata-support check
        end
    end
    Doctor-->>CLI: DoctorReport
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/cli/src/backends/linear/client.ts`, line 178-185 ([link](https://github.com/gannonh/kata/blob/037cb778fdfd96170fbea6ada13eedfbc00d10d4/apps/cli/src/backends/linear/client.ts#L178-L185)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Four of the six `LinearKataMetadataSupport` fields are hardcoded `true`**

   `kataId`, `parentLinks`, `artifactScope`, and `verificationState` are always returned as `true` regardless of the GraphQL introspection result, making `listMissingLinearMetadataCapabilities` unable to ever flag those capabilities as missing. If the intent is that Linear always supports these natively, the corresponding fields can be removed from the `LinearKataMetadataSupport` interface and `listMissingLinearMetadataCapabilities` to avoid the mismatch between the declared surface area and what is actually verified.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/backends/linear/client.ts
   Line: 178-185

   Comment:
   **Four of the six `LinearKataMetadataSupport` fields are hardcoded `true`**

   `kataId`, `parentLinks`, `artifactScope`, and `verificationState` are always returned as `true` regardless of the GraphQL introspection result, making `listMissingLinearMetadataCapabilities` unable to ever flag those capabilities as missing. If the intent is that Linear always supports these natively, the corresponding fields can be removed from the `LinearKataMetadataSupport` interface and `listMissingLinearMetadataCapabilities` to avoid the mismatch between the declared surface area and what is actually verified.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/cli/src/commands/doctor.ts:551-561
**Catch block always emits a duplicate `linear-auth` check**

The `catch` block fires for any exception thrown within the entire `try` — including `getTeam()`, `getProject()`, and `getKataMetadataSupport()`. When one of those later calls throws (e.g., a transient network error during team lookup), the block pushes a second entry with `name: "linear-auth"` even though `"linear-auth"` was already pushed as `"ok"` after `getViewer()` succeeded. The report then contains two `DoctorCheck` objects sharing the same name — one `"ok"` and one `"invalid"` — with a misleading action message ("Verify LINEAR_API_KEY and backend access") for what is actually a team-lookup failure. Any consumer that looks up a check by name (e.g. `report.checks.find((c) => c.name === "linear-auth")`) will see the first ("ok") result and silently miss the failure.

### Issue 2 of 2
apps/cli/src/backends/linear/client.ts:178-185
**Four of the six `LinearKataMetadataSupport` fields are hardcoded `true`**

`kataId`, `parentLinks`, `artifactScope`, and `verificationState` are always returned as `true` regardless of the GraphQL introspection result, making `listMissingLinearMetadataCapabilities` unable to ever flag those capabilities as missing. If the intent is that Linear always supports these natively, the corresponding fields can be removed from the `LinearKataMetadataSupport` interface and `listMissingLinearMetadataCapabilities` to avoid the mismatch between the declared surface area and what is actually verified.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add Linear doctor auth/access..."](https://github.com/gannonh/kata/commit/037cb778fdfd96170fbea6ada13eedfbc00d10d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30922761)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->