### PR TITLE
Fix CLI release tag check

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -42,7 +42,7 @@ jobs:
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 
-          if git ls-remote --tags origin | grep -q "refs/tags/cli-v$CURRENT_VERSION"; then
+          if git ls-remote --exit-code --tags --refs origin "refs/tags/cli-v$CURRENT_VERSION" >/dev/null 2>&1; then
             echo "Tag cli-v$CURRENT_VERSION already exists, skipping release"
             echo "should_release=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/symphony-release.yml
+++ b/.github/workflows/symphony-release.yml
@@ -30,7 +30,7 @@ jobs:
           CURRENT_VERSION=$(grep '^version' apps/symphony/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
-          if git ls-remote --tags origin | grep -q "refs/tags/symphony-v$CURRENT_VERSION"; then
+          if git ls-remote --exit-code --tags --refs origin "refs/tags/symphony-v$CURRENT_VERSION" >/dev/null 2>&1; then
             echo "Tag symphony-v$CURRENT_VERSION already exists, skipping release"
             echo "should_release=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
- Match CLI release tags exactly instead of substring matching prerelease tags
- Allows cli-v0.16.0 to release when cli-v0.16.0-alpha.0 exists

## Validation
- Simulated tag check locally: 0.16.0 => should_release=true, 0.16.0-alpha.0 => should_release=false
- Pre-push affected validation passed with existing lint warnings

## Follow-up
After merge, run cli-release.yml manually from main to publish @kata-sh/cli@0.16.0.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a tag-existence check in the CLI release workflow that incorrectly blocked stable releases when a prerelease tag with the same version prefix already existed. The old `grep -q` approach performed substring matching, so `cli-v0.16.0-alpha.0` would match a search for `cli-v0.16.0`; the new approach uses `git ls-remote --exit-code --tags --refs` with the full ref path as an exact pattern, which returns exit code 2 (treated as false by the `if`) when no match is found.

- Replaces `grep -q \"refs/tags/cli-v$CURRENT_VERSION\"` with `git ls-remote --exit-code --tags --refs origin \"refs/tags/cli-v$CURRENT_VERSION\"`, fixing the false-positive that prevented stable releases after any prerelease tag.
- The `--refs` flag correctly suppresses peeled annotated-tag entries (`^{}`), and `--exit-code` ensures a non-zero exit when the tag is absent, making the `if` condition reliable.

<h3>Confidence Score: 5/5</h3>

The change is a minimal, targeted fix to a single shell command in the CI workflow; the logic is correct and the new command behaves exactly as intended.

The replacement command correctly uses git ls-remote --exit-code so the shell if branch fires only when the tag already exists, and the exact ref pattern refs/tags/cli-v$CURRENT_VERSION passed as a positional argument does not contain glob characters for typical semver strings, so it matches only the full tag name rather than any prefixed variant. The --refs flag appropriately excludes peeled annotated-tag entries.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/cli-release.yml | Replaces substring-based grep tag check with exact git ls-remote pattern match, correctly preventing false positives when a prerelease tag like cli-v0.16.0-alpha.0 exists before cli-v0.16.0. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push to main / workflow_dispatch] --> B[check-version job]
    B --> C[Read CURRENT_VERSION from package.json]
    C --> D{Version contains '-'?}
    D -- Yes --> E[npm_tag = prerelease label\nprerelease = true]
    D -- No --> F[npm_tag = latest\nprerelease = false]
    E --> G
    F --> G[git ls-remote --exit-code --tags --refs\norigin refs/tags/cli-vCURRENT_VERSION]
    G -- exit 0 tag exists --> H[should_release = false\nSkip release]
    G -- exit 2 tag absent --> I[should_release = true]
    I --> J[test job]
    J --> K[publish job]
    K --> L[npm publish]
    L --> M[git tag + push]
    M --> N[Create GitHub Release]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): match CLI release tags exactly"](https://github.com/gannonh/kata/commit/5eae651f3665cd85019dcb1f79742906a076ae99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31407026)</sub>

<!-- /greptile_comment -->