### PR TITLE
CLI v0.16.1

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -4,7 +4,7 @@ Kata Skills runtime and backend contract bridge.
 
 This package provides the durable operation layer for Kata project workflows. Skills and harnesses call into it for project, milestone, slice, task, artifact, progress, and completion operations instead of writing directly to backend systems.
 
-The `0.16.x` line is the stable release for the Kata Skills runtime and backend contract bridge. Version `0.16.1` fixes planned-slice dependency extraction and symlinked global skill refreshes.
+The `0.16.x` line is the stable release for the Kata Skills runtime and backend contract bridge. Version `0.16.1` fixes planned-slice dependency extraction, symlinked global skill refreshes, and concurrent GitHub task creation.
 
 Install with:
 

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -4,7 +4,7 @@ Kata Skills runtime and backend contract bridge.
 
 This package provides the durable operation layer for Kata project workflows. Skills and harnesses call into it for project, milestone, slice, task, artifact, progress, and completion operations instead of writing directly to backend systems.
 
-The `0.16.x` line is the stable release for the Kata Skills runtime and backend contract bridge.
+The `0.16.x` line is the stable release for the Kata Skills runtime and backend contract bridge. Version `0.16.1` fixes planned-slice dependency extraction and symlinked global skill refreshes.
 
 Install with:
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.16.1
+
+- Fixes planned roadmap dependency extraction so phase-level `Depends on` summaries do not create false blockers between planned slices.
+- Fixes `kata setup --global` for Skiller-style symlinked skill entries by refreshing the resolved skill directory while preserving the symlink.
+
 ## 0.16.0
 
 - Stable release for the Kata Skills runtime and backend contract bridge.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixes planned roadmap dependency extraction so phase-level `Depends on` summaries do not create false blockers between planned slices.
 - Fixes `kata setup --global` for Skiller-style symlinked skill entries by refreshing the resolved skill directory while preserving the symlink.
+- Serializes GitHub task creation per slice and retries transient sub-issue priority collisions so parallel `task.create` calls return distinct, linked tasks.
 
 ## 0.16.0
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Kata CLI runtime and backend contract bridge",
   "license": "MIT",
   "private": false,

--- a/apps/cli/src/backends/github-projects-v2/adapter.ts
+++ b/apps/cli/src/backends/github-projects-v2/adapter.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -191,8 +191,10 @@ const MAX_COMMENT_PAGES = 100;
 const SUB_ISSUES_PER_PAGE = 100;
 const MAX_SUB_ISSUE_PAGES = 100;
 const TASK_CREATE_LOCK_STALE_MS = 5 * 60 * 1000;
+const TASK_CREATE_LOCK_HEARTBEAT_MS = 30 * 1000;
 const TASK_CREATE_LOCK_RETRY_MS = 100;
 const TASK_CREATE_LOCK_TIMEOUT_MS = 60 * 1000;
+const TASK_CREATE_LOCK_OWNER_FILE = "owner";
 const SUB_ISSUE_ATTACH_RETRY_ATTEMPTS = 4;
 const SUB_ISSUE_ATTACH_RETRY_MS = 250;
 
@@ -1120,7 +1122,12 @@ export class GithubProjectsV2Adapter implements KataBackendAdapter {
     while (true) {
       try {
         await mkdir(lockDir, { recursive: false });
-        await writeFile(join(lockDir, "owner"), `${process.pid}\n`, "utf8");
+        try {
+          await writeTaskCreateLockOwner(lockDir);
+        } catch (error) {
+          await rm(lockDir, { recursive: true, force: true });
+          throw error;
+        }
         break;
       } catch (error) {
         if (!isNodeErrorCode(error, "EEXIST")) throw error;
@@ -1132,9 +1139,15 @@ export class GithubProjectsV2Adapter implements KataBackendAdapter {
       }
     }
 
+    const heartbeat = setInterval(() => {
+      void writeTaskCreateLockOwner(lockDir).catch(() => {});
+    }, TASK_CREATE_LOCK_HEARTBEAT_MS);
+    heartbeat.unref?.();
+
     try {
       return await run();
     } finally {
+      clearInterval(heartbeat);
       await rm(lockDir, { recursive: true, force: true });
     }
   }
@@ -1563,14 +1576,76 @@ function taskCreateLockDir(input: {
   return join(tmpdir(), "kata-cli-locks", `github-task-create-${lockKey}.lock`);
 }
 
+interface TaskCreateLockOwner {
+  pid: number;
+  heartbeatMs?: number;
+}
+
+async function writeTaskCreateLockOwner(lockDir: string): Promise<void> {
+  const owner: TaskCreateLockOwner = {
+    pid: process.pid,
+    heartbeatMs: Date.now(),
+  };
+  await writeFile(join(lockDir, TASK_CREATE_LOCK_OWNER_FILE), `${JSON.stringify(owner)}\n`, "utf8");
+}
+
+async function readTaskCreateLockOwner(lockDir: string): Promise<TaskCreateLockOwner | null> {
+  const rawOwner = (await readFile(join(lockDir, TASK_CREATE_LOCK_OWNER_FILE), "utf8")).trim();
+  try {
+    const parsed = JSON.parse(rawOwner) as unknown;
+    if (typeof parsed === "object" && parsed !== null) {
+      const owner = parsed as Partial<TaskCreateLockOwner>;
+      const pid = owner.pid;
+      if (typeof pid === "number" && Number.isInteger(pid) && pid > 0) {
+        const heartbeatMs = owner.heartbeatMs;
+        return {
+          pid,
+          heartbeatMs: typeof heartbeatMs === "number" && Number.isFinite(heartbeatMs) ? heartbeatMs : undefined,
+        };
+      }
+    }
+  } catch {
+    // Legacy owner files contain a bare PID and are parsed below.
+  }
+  const legacyPid = Number(rawOwner);
+  if (Number.isInteger(legacyPid) && legacyPid > 0) {
+    return { pid: legacyPid };
+  }
+  return null;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (isNodeErrorCode(error, "ESRCH")) return false;
+    if (isNodeErrorCode(error, "EPERM")) return true;
+    return true;
+  }
+}
+
 async function removeStaleLock(lockDir: string): Promise<void> {
   try {
-    const lockStats = await stat(lockDir);
-    if (Date.now() - lockStats.mtimeMs > TASK_CREATE_LOCK_STALE_MS) {
+    const owner = await readTaskCreateLockOwner(lockDir);
+    const heartbeatExpired =
+      owner?.heartbeatMs === undefined ? false : Date.now() - owner.heartbeatMs > TASK_CREATE_LOCK_STALE_MS;
+    if (owner && (!isProcessAlive(owner.pid) || heartbeatExpired)) {
       await rm(lockDir, { recursive: true, force: true });
     }
   } catch (error) {
-    if (!isNodeErrorCode(error, "ENOENT")) throw error;
+    if (isNodeErrorCode(error, "ENOENT")) {
+      try {
+        const lockStats = await stat(lockDir);
+        if (Date.now() - lockStats.mtimeMs > TASK_CREATE_LOCK_STALE_MS) {
+          await rm(lockDir, { recursive: true, force: true });
+        }
+      } catch (statError) {
+        if (!isNodeErrorCode(statError, "ENOENT")) throw statError;
+      }
+      return;
+    }
+    throw error;
   }
 }
 

--- a/apps/cli/src/backends/github-projects-v2/adapter.ts
+++ b/apps/cli/src/backends/github-projects-v2/adapter.ts
@@ -1,3 +1,9 @@
+import { createHash } from "node:crypto";
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
 import type {
   KataArtifact,
   KataArtifactType,
@@ -184,6 +190,11 @@ const COMMENTS_PER_PAGE = 100;
 const MAX_COMMENT_PAGES = 100;
 const SUB_ISSUES_PER_PAGE = 100;
 const MAX_SUB_ISSUE_PAGES = 100;
+const TASK_CREATE_LOCK_STALE_MS = 5 * 60 * 1000;
+const TASK_CREATE_LOCK_RETRY_MS = 100;
+const TASK_CREATE_LOCK_TIMEOUT_MS = 60 * 1000;
+const SUB_ISSUE_ATTACH_RETRY_ATTEMPTS = 4;
+const SUB_ISSUE_ATTACH_RETRY_MS = 250;
 
 const ADD_PROJECT_ITEM_MUTATION = `
   mutation AddKataProjectV2Item($projectId: ID!, $contentId: ID!) {
@@ -567,46 +578,48 @@ export class GithubProjectsV2Adapter implements KataBackendAdapter {
   }
 
   async createTask(input: KataTaskCreateInput): Promise<KataTask> {
-    await this.discoverEntities();
-    await this.getFieldIndex();
-    const sliceEntity = await this.requireEntity(input.sliceId, "Slice");
-    const milestoneEntity = sliceEntity.parentId
-      ? await this.requireEntity(sliceEntity.parentId, "Milestone")
-      : null;
-    const kataId = this.nextKataId("Task");
-    const entity = await this.createIssueEntity({
-      kataId,
-      type: "Task",
-      parentId: input.sliceId,
-      title: `[${kataId}] ${input.title}`,
-      body: input.description,
-      issueBody: {
-        milestone: requireNativeGithubMilestoneNumber(milestoneEntity ?? sliceEntity),
-      },
-    });
-    const uniqueEntity = await this.ensureCreatedEntityHasUniqueId(entity, {
-      title: input.title,
-      body: input.description,
-    });
+    return this.withTaskCreateLock(input.sliceId, async () => {
+      await this.discoverEntities();
+      await this.getFieldIndex();
+      const sliceEntity = await this.requireEntity(input.sliceId, "Slice");
+      const milestoneEntity = sliceEntity.parentId
+        ? await this.requireEntity(sliceEntity.parentId, "Milestone")
+        : null;
+      const kataId = this.nextKataId("Task");
+      const entity = await this.createIssueEntity({
+        kataId,
+        type: "Task",
+        parentId: input.sliceId,
+        title: `[${kataId}] ${input.title}`,
+        body: input.description,
+        issueBody: {
+          milestone: requireNativeGithubMilestoneNumber(milestoneEntity ?? sliceEntity),
+        },
+      });
+      const uniqueEntity = await this.ensureCreatedEntityHasUniqueId(entity, {
+        title: input.title,
+        body: input.description,
+      });
 
-    await this.attachSubIssue(sliceEntity, uniqueEntity);
+      await this.attachSubIssue(sliceEntity, uniqueEntity);
 
-    await this.syncProjectFields(uniqueEntity, {
-      type: "Task",
-      parentId: input.sliceId,
-      status: "Backlog",
-      artifactScope: uniqueEntity.kataId,
-      verificationState: "pending",
+      await this.syncProjectFields(uniqueEntity, {
+        type: "Task",
+        parentId: input.sliceId,
+        status: "Backlog",
+        artifactScope: uniqueEntity.kataId,
+        verificationState: "pending",
+      });
+
+      return {
+        id: uniqueEntity.kataId,
+        sliceId: input.sliceId,
+        title: input.title,
+        description: input.description,
+        status: "backlog",
+        verificationState: "pending",
+      };
     });
-
-    return {
-      id: uniqueEntity.kataId,
-      sliceId: input.sliceId,
-      title: input.title,
-      description: input.description,
-      status: "backlog",
-      verificationState: "pending",
-    };
   }
 
   async updateTaskStatus(input: KataTaskUpdateStatusInput): Promise<KataTask> {
@@ -1074,13 +1087,56 @@ export class GithubProjectsV2Adapter implements KataBackendAdapter {
   }
 
   private async attachSubIssue(parent: TrackedEntity, child: TrackedEntity): Promise<void> {
-    await this.client.rest({
-      method: "POST",
-      path: `/repos/${this.owner}/${this.repo}/issues/${parent.issueNumber}/sub_issues`,
-      body: {
-        sub_issue_id: child.issueId,
-      },
+    for (let attempt = 1; attempt <= SUB_ISSUE_ATTACH_RETRY_ATTEMPTS; attempt += 1) {
+      try {
+        await this.client.rest({
+          method: "POST",
+          path: `/repos/${this.owner}/${this.repo}/issues/${parent.issueNumber}/sub_issues`,
+          body: {
+            sub_issue_id: child.issueId,
+          },
+        });
+        return;
+      } catch (error) {
+        if (attempt === SUB_ISSUE_ATTACH_RETRY_ATTEMPTS || !isGithubSubIssuePriorityCollision(error)) {
+          throw error;
+        }
+        await sleep(SUB_ISSUE_ATTACH_RETRY_MS * attempt);
+      }
+    }
+  }
+
+  private async withTaskCreateLock<T>(sliceId: string, run: () => Promise<T>): Promise<T> {
+    const lockDir = taskCreateLockDir({
+      owner: this.owner,
+      repo: this.repo,
+      projectNumber: this.projectNumber,
+      workspacePath: this.workspacePath,
+      sliceId,
     });
+    const startedAt = Date.now();
+    await mkdir(join(tmpdir(), "kata-cli-locks"), { recursive: true });
+
+    while (true) {
+      try {
+        await mkdir(lockDir, { recursive: false });
+        await writeFile(join(lockDir, "owner"), `${process.pid}\n`, "utf8");
+        break;
+      } catch (error) {
+        if (!isNodeErrorCode(error, "EEXIST")) throw error;
+        await removeStaleLock(lockDir);
+        if (Date.now() - startedAt > TASK_CREATE_LOCK_TIMEOUT_MS) {
+          throw new KataDomainError("UNKNOWN", `Timed out waiting for GitHub task creation lock for ${sliceId}.`);
+        }
+        await sleep(TASK_CREATE_LOCK_RETRY_MS);
+      }
+    }
+
+    try {
+      return await run();
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
   }
 
   private async updateIssueEntity(
@@ -1491,6 +1547,40 @@ function dependencyIdsFromNodes(
   return parseSliceDependencyIds(
     nodes.map((node) => (node?.id ? sliceIdByContentId.get(node.id) ?? "" : "")),
   );
+}
+
+function taskCreateLockDir(input: {
+  owner: string;
+  repo: string;
+  projectNumber: number;
+  workspacePath: string;
+  sliceId: string;
+}): string {
+  const lockKey = createHash("sha256")
+    .update([input.owner, input.repo, input.projectNumber, input.workspacePath, input.sliceId].join("\0"))
+    .digest("hex")
+    .slice(0, 32);
+  return join(tmpdir(), "kata-cli-locks", `github-task-create-${lockKey}.lock`);
+}
+
+async function removeStaleLock(lockDir: string): Promise<void> {
+  try {
+    const lockStats = await stat(lockDir);
+    if (Date.now() - lockStats.mtimeMs > TASK_CREATE_LOCK_STALE_MS) {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  } catch (error) {
+    if (!isNodeErrorCode(error, "ENOENT")) throw error;
+  }
+}
+
+function isGithubSubIssuePriorityCollision(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /GitHub request failed \(422\)/.test(error.message) && /Priority has already been taken/i.test(error.message);
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === code;
 }
 
 function statusFromProjectFields(

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -223,6 +223,10 @@ export function resolveSkillsSource(
   };
 }
 
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === code;
+}
+
 async function copyDirectoryContents(sourceDir: string, destinationDir: string): Promise<string[]> {
   await mkdir(destinationDir, { recursive: true });
   const entries = (await readdir(sourceDir)).sort();
@@ -234,10 +238,14 @@ async function copyDirectoryContents(sourceDir: string, destinationDir: string):
     try {
       const destinationStats = await lstat(destinationPath);
       if (destinationStats.isSymbolicLink()) {
-        copyDestinationPath = await realpath(destinationPath);
+        try {
+          copyDestinationPath = await realpath(destinationPath);
+        } catch {
+          throw new Error(`Cannot refresh skill "${entryName}" because ${destinationPath} is a dangling symlink.`);
+        }
       }
-    } catch {
-      // Missing destination entries are copied below.
+    } catch (error) {
+      if (!isNodeErrorCode(error, "ENOENT")) throw error;
     }
     await cp(sourcePath, copyDestinationPath, {
       recursive: true,

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -240,8 +240,11 @@ async function copyDirectoryContents(sourceDir: string, destinationDir: string):
       if (destinationStats.isSymbolicLink()) {
         try {
           copyDestinationPath = await realpath(destinationPath);
-        } catch {
-          throw new Error(`Cannot refresh skill "${entryName}" because ${destinationPath} is a dangling symlink.`);
+        } catch (error) {
+          if (isNodeErrorCode(error, "ENOENT")) {
+            throw new Error(`Cannot refresh skill "${entryName}" because ${destinationPath} is a dangling symlink.`);
+          }
+          throw error;
         }
       }
     } catch (error) {

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { cp, lstat, mkdir, readFile, readdir, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -228,7 +228,18 @@ async function copyDirectoryContents(sourceDir: string, destinationDir: string):
   const entries = (await readdir(sourceDir)).sort();
 
   for (const entryName of entries) {
-    await cp(join(sourceDir, entryName), join(destinationDir, entryName), {
+    const sourcePath = join(sourceDir, entryName);
+    const destinationPath = join(destinationDir, entryName);
+    let copyDestinationPath = destinationPath;
+    try {
+      const destinationStats = await lstat(destinationPath);
+      if (destinationStats.isSymbolicLink()) {
+        copyDestinationPath = await realpath(destinationPath);
+      }
+    } catch {
+      // Missing destination entries are copied below.
+    }
+    await cp(sourcePath, copyDestinationPath, {
       recursive: true,
       force: true,
     });

--- a/apps/cli/src/domain/service.ts
+++ b/apps/cli/src/domain/service.ts
@@ -477,6 +477,12 @@ function extractPlannedSliceIds(content: string): string[] {
   return uniqueIds(ids);
 }
 
+function extractRoadmapSourcePlannedSliceIdsFromLine(line: string): string[] {
+  const dependencyLabelMatch = ROADMAP_METADATA_LABEL_TERMINATOR_PATTERN.exec(line);
+  const sourceText = dependencyLabelMatch ? line.slice(0, dependencyLabelMatch.index) : line;
+  return extractPlannedSliceIds(sourceText);
+}
+
 function extractPlannedSliceTitle(cell: string, plannedSliceId: string): string | null {
   const pattern = new RegExp(`\\b${escapeRegExp(plannedSliceId)}\\b\\s*(?::|[-–—])?\\s*(.*)$`, "i");
   const match = pattern.exec(cell.trim());
@@ -626,7 +632,7 @@ function extractRoadmapSliceEntries(content: string): RoadmapSliceEntry[] {
     blockingColumns = [];
     requirementColumns = [];
 
-    const plannedSliceIds = extractPlannedSliceIds(line);
+    const plannedSliceIds = extractRoadmapSourcePlannedSliceIdsFromLine(line);
     const backendSliceIds = extractRoadmapBackendSliceIdsFromLine(line);
     const sourceIds = uniqueIds([...plannedSliceIds, ...backendSliceIds]);
     if (sourceIds.length === 0) continue;

--- a/apps/cli/src/tests/github-projects-v2.adapter.vitest.test.ts
+++ b/apps/cli/src/tests/github-projects-v2.adapter.vitest.test.ts
@@ -1358,13 +1358,101 @@ describe("GithubProjectsV2Adapter", () => {
       }),
     ]);
 
-    expect([firstTask.id, secondTask.id].sort()).toEqual(["T001", "T002"]);
-    await expect(secondAdapter.listTasks({ sliceId: "S001" })).resolves.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: "T001", title: "First concurrent task" }),
-        expect.objectContaining({ id: "T002", title: "Second concurrent task" }),
-      ]),
-    );
+    const createdTaskIds = [firstTask.id, secondTask.id].sort();
+    expect(createdTaskIds).toEqual(["T001", "T002"]);
+    const freshAdapter = new GithubProjectsV2Adapter({
+      owner: "kata-sh",
+      repo: "uat",
+      projectNumber: 12,
+      workspacePath: "/workspace",
+      client: client as any,
+    });
+    const createdTasks = await freshAdapter.listTasks({ sliceId: "S001" });
+    expect(createdTasks.map((task) => task.id).sort()).toEqual(["T001", "T002"]);
+    expect(createdTasks.map((task) => task.title).sort()).toEqual([
+      "First concurrent task",
+      "Second concurrent task",
+    ]);
+  });
+
+  it("retries GitHub sub-issue priority collisions during task creation", async () => {
+    const client = createFakeGithubClient({
+      issues: [
+        {
+          id: 1,
+          node_id: "issue-node-1",
+          number: 1,
+          title: "[M001] Existing Milestone",
+          body: '<!-- kata:entity {"kataId":"M001","type":"Milestone"} -->\nExisting milestone',
+          state: "open",
+          html_url: "https://github.test/kata-sh/uat/issues/1",
+          milestone: { number: 1 },
+        },
+        {
+          id: 2,
+          node_id: "issue-node-2",
+          number: 2,
+          title: "[S001] Existing Slice",
+          body: '<!-- kata:entity {"kataId":"S001","type":"Slice","parentId":"M001"} -->\nExisting slice',
+          state: "open",
+          html_url: "https://github.test/kata-sh/uat/issues/2",
+          milestone: { number: 1 },
+        },
+      ],
+      projectItems: [
+        projectItem({
+          itemId: "project-item-1",
+          issueNodeId: "issue-node-1",
+          issueNumber: 1,
+          kataId: "M001",
+          kataType: "Milestone",
+          artifactScope: "M001",
+          status: "Todo",
+        }),
+        projectItem({
+          itemId: "project-item-2",
+          issueNodeId: "issue-node-2",
+          issueNumber: 2,
+          kataId: "S001",
+          kataType: "Slice",
+          parentId: "M001",
+          artifactScope: "S001",
+          status: "Backlog",
+        }),
+      ],
+    });
+    const originalRest = client.rest.getMockImplementation();
+    let subIssuePostAttempts = 0;
+    client.rest.mockImplementation(async (request: any) => {
+      if (request.method === "POST" && request.path === "/repos/kata-sh/uat/issues/2/sub_issues") {
+        subIssuePostAttempts += 1;
+        if (subIssuePostAttempts === 1) {
+          throw new Error(
+            'GitHub request failed (422): {"message":"An error occurred while adding the sub-issue to the parent issue. Priority has already been taken"}',
+          );
+        }
+      }
+      return originalRest?.(request);
+    });
+    const adapter = new GithubProjectsV2Adapter({
+      owner: "kata-sh",
+      repo: "uat",
+      projectNumber: 12,
+      workspacePath: mkdtempSync(join(tmpdir(), "kata-github-task-lock-")),
+      client: client as any,
+    });
+
+    const task = await adapter.createTask({
+      sliceId: "S001",
+      title: "Retry priority collision",
+      description: "Created after GitHub priority collision",
+    });
+
+    expect(task).toMatchObject({ id: "T001", sliceId: "S001", title: "Retry priority collision" });
+    expect(subIssuePostAttempts).toBe(2);
+    await expect(adapter.listTasks({ sliceId: "S001" })).resolves.toEqual([
+      expect.objectContaining({ id: "T001", title: "Retry priority collision" }),
+    ]);
   });
 
   it("creates standalone planned issues as one Project v2 backlog item", async () => {
@@ -1998,6 +2086,7 @@ function createFakeGithubClient(
       content: {
         ...item.content,
         databaseId: item.content?.databaseId ?? issue.id,
+        number: item.content?.number ?? issue.number,
         title: item.content?.title ?? issue.title,
         body: item.content?.body ?? issue.body,
         state: item.content?.state ?? String(issue.state).toUpperCase(),

--- a/apps/cli/src/tests/phase-a-contract.vitest.test.ts
+++ b/apps/cli/src/tests/phase-a-contract.vitest.test.ts
@@ -926,6 +926,92 @@ describe("Phase A domain contract", () => {
     });
   });
 
+  it("ignores phase-level dependency summaries as slice sources", async () => {
+    const api = createKataDomainApi({
+      ...createFakeAdapter(),
+      getActiveMilestone: async () => ({
+        id: "M001",
+        title: "Research roadmap",
+        goal: "Plan research work",
+        status: "active",
+        active: true,
+      }),
+      listSlices: async () => [],
+      listTasks: async () => [],
+      listArtifacts: async () => [],
+      readArtifact: async (input: KataArtifactReadInput) => ({
+        id: `${input.scopeType}:${input.scopeId}:${input.artifactType}`,
+        scopeType: input.scopeType,
+        scopeId: input.scopeId,
+        artifactType: input.artifactType,
+        title: input.artifactType,
+        content: input.artifactType === "roadmap"
+          ? [
+              "### Phase 1: Candidate Research Matrix",
+              "**Depends on:** None",
+              "**Requirements:** RSR-01",
+              "",
+              "| Planned Slice | Backend Slice ID | Blocked By | Requirements |",
+              "|---|---|---|---|",
+              "| Planned Slice 1: Candidate research matrix | None | None | RSR-01 |",
+              "",
+              "### Phase 2: Hands-on Stack Validation",
+              "**Depends on:** Planned Slice 1",
+              "**Requirements:** RSR-02, RSR-03, RSR-04",
+              "",
+              "| Planned Slice | Backend Slice ID | Blocked By | Requirements |",
+              "|---|---|---|---|",
+              "| Planned Slice 2: Hands-on stack validation | None | Planned Slice 1 | RSR-02, RSR-03, RSR-04 |",
+              "",
+              "### Phase 3: Architecture Recommendation",
+              "**Depends on:** Planned Slice 1, Planned Slice 2",
+              "**Requirements:** RSR-05, RSR-06",
+              "",
+              "| Planned Slice | Backend Slice ID | Blocked By | Requirements |",
+              "|---|---|---|---|",
+              "| Planned Slice 3: Architecture recommendation | None | Planned Slice 1, Planned Slice 2 | RSR-05, RSR-06 |",
+              "",
+              "### Phase 4: First Implementation Handoff",
+              "**Depends on:** Planned Slice 3",
+              "**Requirements:** RSR-07",
+              "",
+              "| Planned Slice | Backend Slice ID | Blocked By | Requirements |",
+              "|---|---|---|---|",
+              "| Planned Slice 4: First implementation handoff | None | Planned Slice 3 | RSR-07 |",
+              "",
+              "| Requirement | Phase/Planned Slice | Backend Slice ID | Blocked By | Status |",
+              "|---|---|---|---|---|",
+              "| RSR-01 | Phase 1 / Planned Slice 1 | None | None | Pending |",
+              "| RSR-02 | Phase 2 / Planned Slice 2 | None | Planned Slice 1 | Pending |",
+              "| RSR-03 | Phase 2 / Planned Slice 2 | None | Planned Slice 1 | Pending |",
+              "| RSR-04 | Phase 2 / Planned Slice 2 | None | Planned Slice 1 | Pending |",
+              "| RSR-05 | Phase 3 / Planned Slice 3 | None | Planned Slice 1, Planned Slice 2 | Pending |",
+              "| RSR-06 | Phase 3 / Planned Slice 3 | None | Planned Slice 1, Planned Slice 2 | Pending |",
+              "| RSR-07 | Phase 4 / Planned Slice 4 | None | Planned Slice 3 | Pending |",
+            ].join("\n")
+          : "RSR-01\nRSR-02\nRSR-03\nRSR-04\nRSR-05\nRSR-06\nRSR-07",
+        format: "markdown",
+        updatedAt: "2026-05-10T00:00:00.000Z",
+        provenance: { backend: "github", backendId: "comment:6" },
+      }),
+    });
+
+    const snapshot = await dispatchKataOperation(api, "project.getSnapshot") as KataProjectSnapshot;
+
+    expect(snapshot.roadmap.sliceDependencies).toMatchObject({
+      "Planned Slice 1": { blockedBy: [], blocking: ["Planned Slice 2", "Planned Slice 3"] },
+      "Planned Slice 2": { blockedBy: ["Planned Slice 1"], blocking: ["Planned Slice 3"] },
+      "Planned Slice 3": { blockedBy: ["Planned Slice 1", "Planned Slice 2"], blocking: ["Planned Slice 4"] },
+      "Planned Slice 4": { blockedBy: ["Planned Slice 3"], blocking: [] },
+    });
+    expect(snapshot.roadmap.implementationWaves).toEqual([
+      { index: 1, sliceIds: ["Planned Slice 1"] },
+      { index: 2, sliceIds: ["Planned Slice 2"] },
+      { index: 3, sliceIds: ["Planned Slice 3"] },
+      { index: 4, sliceIds: ["Planned Slice 4"] },
+    ]);
+  });
+
   it("selects the first unblocked execution slice", async () => {
     const api = createDependencySnapshotApi([
       { id: "S001", status: "backlog" },

--- a/apps/cli/src/tests/setup-source.vitest.test.ts
+++ b/apps/cli/src/tests/setup-source.vitest.test.ts
@@ -192,6 +192,40 @@ describe("skills source resolution", () => {
     }
   });
 
+  it("preserves non-ENOENT realpath failures for symlinked skill entries", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "kata-setup-symlink-loop-"));
+    try {
+      const home = join(tmp, "home");
+      const sourceSkillDir = join(tmp, "apps", "cli", "skills", "kata-health");
+      const installedSkillPath = join(home, ".agents", "skills", "kata-health");
+      writeFileSync(join(tmp, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+      mkdirSync(sourceSkillDir, { recursive: true });
+      writeFileSync(join(sourceSkillDir, "SKILL.md"), "# Kata Health\n", "utf8");
+      mkdirSync(join(home, ".agents", "skills"), { recursive: true });
+      symlinkSync(installedSkillPath, installedSkillPath, "dir");
+
+      const result = await runSetup({
+        cwd: tmp,
+        env: { HOME: home, GH_TOKEN: "ghp_test" },
+        packageVersion: "9.9.9-test",
+        global: true,
+        interactive: false,
+        onboarding: {
+          repoOwner: "kata-sh",
+          repoName: "kata-mono",
+          githubProjectNumber: 12,
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).not.toContain("dangling symlink");
+      expect(result.error.message).toMatch(/ELOOP|symbolic links/i);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("can install to multiple selected skill targets", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "kata-setup-targets-"));
     try {

--- a/apps/cli/src/tests/setup-source.vitest.test.ts
+++ b/apps/cli/src/tests/setup-source.vitest.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -117,6 +117,43 @@ describe("skills source resolution", () => {
       expect(preferences).toContain("workspace: kata");
       expect(preferences).toContain("team: KATA");
       expect(preferences).toContain("project: kata-cli");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes managed skills through existing symlinked skill entries", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "kata-setup-symlink-"));
+    try {
+      const home = join(tmp, "home");
+      const sourceSkillDir = join(tmp, "apps", "cli", "skills", "kata-health");
+      const linkedSkillDir = join(tmp, "linked-skills", "kata-health");
+      writeFileSync(join(tmp, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+      mkdirSync(sourceSkillDir, { recursive: true });
+      writeFileSync(join(sourceSkillDir, "SKILL.md"), "# Kata Health\n", "utf8");
+      mkdirSync(linkedSkillDir, { recursive: true });
+      writeFileSync(join(linkedSkillDir, "SKILL.md"), "# Old linked Kata Health\n", "utf8");
+      mkdirSync(join(home, ".agents", "skills"), { recursive: true });
+      symlinkSync(linkedSkillDir, join(home, ".agents", "skills", "kata-health"), "dir");
+
+      const result = await runSetup({
+        cwd: tmp,
+        env: { HOME: home, GH_TOKEN: "ghp_test" },
+        packageVersion: "9.9.9-test",
+        global: true,
+        interactive: false,
+        onboarding: {
+          repoOwner: "kata-sh",
+          repoName: "kata-mono",
+          githubProjectNumber: 12,
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true });
+      const installedSkillPath = join(home, ".agents", "skills", "kata-health");
+      expect(lstatSync(installedSkillPath).isSymbolicLink()).toBe(true);
+      expect(readFileSync(join(installedSkillPath, "SKILL.md"), "utf8")).toBe("# Kata Health\n");
+      expect(readFileSync(join(linkedSkillDir, "SKILL.md"), "utf8")).toBe("# Kata Health\n");
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/apps/cli/src/tests/setup-source.vitest.test.ts
+++ b/apps/cli/src/tests/setup-source.vitest.test.ts
@@ -159,6 +159,39 @@ describe("skills source resolution", () => {
     }
   });
 
+  it("reports dangling symlinked skill entries clearly", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "kata-setup-dangling-symlink-"));
+    try {
+      const home = join(tmp, "home");
+      const sourceSkillDir = join(tmp, "apps", "cli", "skills", "kata-health");
+      writeFileSync(join(tmp, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+      mkdirSync(sourceSkillDir, { recursive: true });
+      writeFileSync(join(sourceSkillDir, "SKILL.md"), "# Kata Health\n", "utf8");
+      mkdirSync(join(home, ".agents", "skills"), { recursive: true });
+      symlinkSync(join(tmp, "missing-skills", "kata-health"), join(home, ".agents", "skills", "kata-health"), "dir");
+
+      const result = await runSetup({
+        cwd: tmp,
+        env: { HOME: home, GH_TOKEN: "ghp_test" },
+        packageVersion: "9.9.9-test",
+        global: true,
+        interactive: false,
+        onboarding: {
+          repoOwner: "kata-sh",
+          repoName: "kata-mono",
+          githubProjectNumber: 12,
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("dangling symlink");
+      expect(result.error.message).toContain("kata-health");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("can install to multiple selected skill targets", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "kata-setup-targets-"));
     try {


### PR DESCRIPTION
## Summary
- Release `@kata-sh/cli` v0.16.1.
- Fix planned roadmap dependency extraction so phase-level dependency summaries do not create false blockers.
- Preserve Skiller-style symlinked global skill entries during `kata setup --global` refreshes.
- Serialize GitHub `task.create` per slice and retry transient sub-issue priority collisions so parallel calls return distinct linked tasks.

## Test Plan
- `cd apps/cli && npx tsc`
- `cd apps/cli && npm test`
- `pnpm --dir apps/cli run build`
- `pnpm --dir apps/cli run lint`
- pre-push `turbo run lint typecheck test --affected`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbolic link handling during setup operations
  * Fixed roadmap parsing to properly ignore metadata boundaries
  * Enhanced error messages for dangling symbolic links

* **New Features**
  * Added concurrency control for GitHub task creation to prevent race conditions
  * Added automatic retry logic for GitHub API sub-issue creation conflicts

* **Tests**
  * Expanded test coverage for GitHub integration and setup behavior with symbolic links

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gannonh/kata/pull/545)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->