### PR TITLE
feat(pi-symphony): implement Wave 3 console escalations

### DIFF
--- a/apps/symphony/pi-extension/README.md
+++ b/apps/symphony/pi-extension/README.md
@@ -11,7 +11,7 @@ pnpm --dir apps/symphony/pi-extension typecheck
 
 Run it locally with `pi -e ./apps/symphony/pi-extension`.
 
-## Commands through Slice 2
+## Commands through Wave 3
 
 - `/symphony:help`
 - `/symphony:init [--force]`
@@ -25,12 +25,13 @@ Run it locally with `pi -e ./apps/symphony/pi-extension`.
 - `/symphony:steer <ISSUE> <instruction>`
 - `/symphony:stop`
 
-## Console keys through Slice 2
+## Console keys through Wave 3
 
-- `↑` / `↓` selects a running worker.
+- `↑` / `↓` selects running workers, retry entries, blocked issues, completed issues, and pending escalations.
 - `r` requests an immediate Symphony refresh and reloads state.
-- `s` prompts for a steer instruction for the selected worker.
-- `d` toggles selected-worker details.
+- `s` prompts for a steer instruction when the selected item is a running worker.
+- `e` prompts for a response when the selected item is a pending escalation. Valid JSON is sent as JSON; other input is sent as a string response.
+- `d` toggles selected-item details.
 - `q` or Escape closes the console and leaves Symphony running.
 
 ## Progress feedback
@@ -56,3 +57,43 @@ Package checks:
 pnpm --dir apps/symphony/pi-extension test
 pnpm --dir apps/symphony/pi-extension typecheck
 ```
+
+## Wave 3 manual verification
+
+1. Start Pi with the local extension:
+
+   ```sh
+   pi -e ./apps/symphony/pi-extension
+   ```
+
+   Expected: Pi starts with Symphony commands available.
+
+2. Start or attach to a Symphony server:
+
+   ```text
+   /symphony:start .symphony/WORKFLOW.md
+   ```
+
+   or:
+
+   ```text
+   /symphony:attach http://127.0.0.1:<port>
+   ```
+
+   Expected: the Symphony console opens and the status block shows the attached base URL.
+
+3. Create or use a Symphony state with at least one retry entry, blocked issue, completed issue, and pending escalation.
+
+   Expected: the console shows `Retry Queue`, `Blocked Issues`, `Completed Issues`, and `Pending Escalations` sections.
+
+4. Use `↑` / `↓` to select each Wave 3 item type.
+
+   Expected: the detail panel shows running, retry, blocked, completed, and escalation-specific fields.
+
+5. Select a pending escalation, press `e`, and enter `{"approved":true}`.
+
+   Expected: Pi reports `Escalation response sent for <request_id>` and the console refreshes.
+
+6. Watch recent events after escalation creation and response.
+
+   Expected: escalation lifecycle events appear in the `Events` section.

--- a/apps/symphony/pi-extension/README.md
+++ b/apps/symphony/pi-extension/README.md
@@ -84,6 +84,19 @@ pnpm --dir apps/symphony/pi-extension typecheck
 
 3. Create or use a Symphony state with at least one retry entry, blocked issue, completed issue, and pending escalation.
 
+   For deterministic local testing, start the Wave 3 mock server in another terminal:
+
+   ```sh
+   pnpm --dir apps/symphony/pi-extension run mock:wave3
+   ```
+
+   Then attach Pi to the printed URL:
+
+   ```text
+   /symphony:attach http://127.0.0.1:8787
+   /symphony:console
+   ```
+
    Expected: the console shows `Retry Queue`, `Blocked Issues`, `Completed Issues`, and `Pending Escalations` sections.
 
 4. Use `↑` / `↓` to select each Wave 3 item type.

--- a/apps/symphony/pi-extension/package.json
+++ b/apps/symphony/pi-extension/package.json
@@ -15,12 +15,13 @@
     ".": "./src/index.ts",
     "./package.json": "./package.json"
   },
-  "files": ["src", "README.md", "package.json"],
+  "files": ["src", "scripts", "README.md", "package.json"],
   "scripts": {
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "pnpm exec vitest run",
     "test:watch": "pnpm exec vitest",
+    "mock:wave3": "node scripts/wave3-mock-server.mjs",
     "lint": "eslint src/ --max-warnings=0"
   },
   "pi": {

--- a/apps/symphony/pi-extension/scripts/wave3-mock-server.mjs
+++ b/apps/symphony/pi-extension/scripts/wave3-mock-server.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+import { createServer } from "node:http";
+
+const options = parseArgs(process.argv.slice(2));
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const state = createInitialState();
+const responses = [];
+
+const server = createServer((req, res) => {
+  let body = "";
+  req.on("data", (chunk) => {
+    body += String(chunk);
+  });
+  req.on("end", () => {
+    handleRequest(req, res, body);
+  });
+});
+
+server.listen(options.port, options.host, () => {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP server address");
+  }
+  const baseUrl = `http://${options.host}:${address.port}`;
+  console.log(`Mock Symphony server: ${baseUrl}`);
+  console.log("");
+  console.log("Attach from Pi:");
+  console.log(`/symphony:attach ${baseUrl}`);
+  console.log("/symphony:console");
+  console.log("");
+  console.log("Seeded state: running SIM-123, retry SIM-200, blocked SIM-300, completed SIM-400, escalation esc-1");
+});
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+function handleRequest(req, res, body) {
+  setJson(res);
+
+  if (req.method === "GET" && req.url === "/api/v1/state") {
+    res.end(JSON.stringify(state));
+    return;
+  }
+
+  if (req.method === "GET" && req.url === "/api/v1/escalations") {
+    res.end(JSON.stringify({ pending: state.pending_escalations }));
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/api/v1/refresh") {
+    res.statusCode = 202;
+    res.end(JSON.stringify({ queued: true, coalesced: false, pending_requests: 1 }));
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/api/v1/steer") {
+    const payload = parseJsonBody(body);
+    const instruction = typeof payload?.instruction === "string" ? payload.instruction : "";
+    res.end(JSON.stringify({
+      ok: true,
+      issue_id: "issue-123",
+      issue_identifier: "SIM-123",
+      delivered: true,
+      instruction_preview: instruction.slice(0, 120),
+    }));
+    return;
+  }
+
+  const escalationMatch = req.url?.match(/^\/api\/v1\/escalations\/([^/]+)\/respond$/);
+  if (req.method === "POST" && escalationMatch) {
+    const requestId = decodeURIComponent(escalationMatch[1]);
+    const escalation = state.pending_escalations.find((entry) => entry.request_id === requestId);
+    if (!escalation) {
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: "escalation_not_found" }));
+      return;
+    }
+
+    responses.push({ request_id: requestId, body: parseJsonBody(body), received_at: new Date().toISOString() });
+    state.pending_escalations = state.pending_escalations.filter((entry) => entry.request_id !== requestId);
+    state.supervisor.escalations_created = state.pending_escalations.length;
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  if (req.method === "GET" && req.url === "/debug/responses") {
+    res.end(JSON.stringify({ responses }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end(JSON.stringify({ error: "not_found" }));
+}
+
+function createInitialState() {
+  return {
+    poll_interval_ms: 30000,
+    max_concurrent_agents: 2,
+    tracker_project_url: "https://linear.app/kata-sh/project/symphony",
+    running: {
+      "issue-123": {
+        issue_id: "issue-123",
+        issue_identifier: "SIM-123",
+        issue_title: "Running worker",
+        attempt: 1,
+        workspace_path: "/tmp/symphony/issue-123",
+        started_at: "2026-05-14T12:00:00Z",
+        status: "running",
+        tracker_state: "In Progress",
+        worker_host: "local",
+        model: "test-model",
+        issue_url: "https://linear.app/kata-sh/issue/SIM-123/running-worker",
+      },
+    },
+    running_sessions: {
+      "issue-123": {
+        turn_count: 3,
+        last_activity_at: "2026-05-14T12:04:00Z",
+        total_tokens: 1200,
+        last_event: "tool_call_completed",
+        last_event_message: "running cargo test",
+        session_id: "session-123",
+      },
+    },
+    running_session_info: {
+      "issue-123": {
+        turn_count: 3,
+        max_turns: 20,
+        last_activity_ms: Date.parse("2026-05-14T12:04:00Z"),
+        session_tokens: { input_tokens: 800, output_tokens: 400, total_tokens: 1200 },
+        last_error: null,
+      },
+    },
+    claimed: [],
+    retry_queue: [
+      {
+        issue_id: "issue-retry",
+        identifier: "SIM-200",
+        attempt: 3,
+        due_in_ms: 90000,
+        error: "rate limit",
+        worker_host: "host-b",
+        workspace_path: "/tmp/retry",
+      },
+    ],
+    blocked: [
+      {
+        issue_id: "issue-blocked",
+        identifier: "SIM-300",
+        title: "Blocked work",
+        state: "Todo",
+        blocker_identifiers: ["SIM-100", "SIM-101"],
+      },
+    ],
+    completed: [
+      {
+        issue_id: "issue-done",
+        identifier: "SIM-400",
+        title: "Done work",
+        completed_at: "2026-05-14T13:00:00Z",
+      },
+    ],
+    pending_escalations: [
+      {
+        request_id: "esc-1",
+        issue_id: "issue-123",
+        issue_identifier: "SIM-123",
+        method: "approval",
+        preview: "Approve cargo test?",
+        created_at: "2026-05-14T12:06:00Z",
+        timeout_ms: 600000,
+      },
+    ],
+    shared_context: { total_entries: 0, entries_by_scope: {}, oldest_entry_at: null, newest_entry_at: null },
+    supervisor: { active: true, steers_issued: 0, conflicts_detected: 0, patterns_detected: 0, escalations_created: 1 },
+    codex_totals: { input_tokens: 800, output_tokens: 400, total_tokens: 1200, event_count: 2, seconds_running: 60 },
+    codex_rate_limits: null,
+    polling: { checking: false, next_poll_in_ms: 1000, poll_interval_ms: 30000, poll_count: 1, last_poll_at: "2026-05-14T12:05:00Z" },
+  };
+}
+
+function parseArgs(args) {
+  const parsed = { host: "127.0.0.1", port: 8787, help: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (arg === "--host") {
+      parsed.host = readValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--port") {
+      const rawPort = readValue(args, index, arg);
+      const port = Number(rawPort);
+      if (!Number.isInteger(port) || port < 0 || port > 65535) {
+        throw new Error(`Invalid --port value: ${rawPort}`);
+      }
+      parsed.port = port;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function readValue(args, index, flag) {
+  const value = args[index + 1];
+  if (!value) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function parseJsonBody(body) {
+  if (!body.trim()) return null;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return { raw: body };
+  }
+}
+
+function setJson(res) {
+  res.setHeader("content-type", "application/json");
+}
+
+function shutdown() {
+  server.close(() => process.exit(0));
+}
+
+function printHelp() {
+  console.log(`Usage: node apps/symphony/pi-extension/scripts/wave3-mock-server.mjs [--host 127.0.0.1] [--port 8787]\n\nStarts a local mock Symphony HTTP API seeded with Wave 3 dashboard state.\n\nEndpoints:\n  GET  /api/v1/state\n  GET  /api/v1/escalations\n  POST /api/v1/escalations/esc-1/respond\n  POST /api/v1/refresh\n  POST /api/v1/steer\n\nAttach from Pi with /symphony:attach http://127.0.0.1:<port>.`);
+}

--- a/apps/symphony/pi-extension/scripts/wave3-mock-server.mjs
+++ b/apps/symphony/pi-extension/scripts/wave3-mock-server.mjs
@@ -72,7 +72,14 @@ function handleRequest(req, res, body) {
 
   const escalationMatch = req.url?.match(/^\/api\/v1\/escalations\/([^/]+)\/respond$/);
   if (req.method === "POST" && escalationMatch) {
-    const requestId = decodeURIComponent(escalationMatch[1]);
+    let requestId;
+    try {
+      requestId = decodeURIComponent(escalationMatch[1]);
+    } catch {
+      res.statusCode = 400;
+      res.end(JSON.stringify({ error: "invalid_escalation_id" }));
+      return;
+    }
     const escalation = state.pending_escalations.find((entry) => entry.request_id === requestId);
     if (!escalation) {
       res.statusCode = 404;

--- a/apps/symphony/pi-extension/src/commands.test.ts
+++ b/apps/symphony/pi-extension/src/commands.test.ts
@@ -131,6 +131,20 @@ describe("symphony commands", () => {
     shortcutSpy.mockRestore();
   });
 
+  it("includes console key guidance in help text", async () => {
+    const runtime = new SymphonyRuntime();
+    const { commands } = registerCommands(runtime);
+    const { ctx, notify } = commandContext();
+    const help = commands.get("symphony:help");
+    if (!help) throw new Error("expected help command");
+
+    await help.handler("", ctx);
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Console keys:"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("s steer selected running worker"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("e respond to selected escalation"), "info");
+  });
+
   it("requests a manual refresh from the command", async () => {
     const runtime = new SymphonyRuntime();
     runtime.state.attachedBaseUrl = "http://127.0.0.1:8080";

--- a/apps/symphony/pi-extension/src/commands.test.ts
+++ b/apps/symphony/pi-extension/src/commands.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
+import * as consoleModule from "./console.ts";
 import { registerSymphonyCommands, setSymphonyStatus } from "./commands.ts";
 import { SymphonyRuntime } from "./runtime.ts";
 import { type LastKnownSymphonyState } from "./state.ts";
@@ -103,19 +104,31 @@ describe("setSymphonyStatus", () => {
 });
 
 describe("symphony commands", () => {
-  it("registers console keyboard shortcuts", () => {
+  it("registers console keyboard shortcuts", async () => {
     const runtime = new SymphonyRuntime();
     const { shortcuts } = registerCommands(runtime);
+    const shortcutSpy = vi.spyOn(consoleModule, "handleActiveConsoleShortcut").mockResolvedValue(undefined);
+    const { ctx } = commandContext();
 
     expect([...shortcuts.keys()]).toEqual(expect.arrayContaining([
       "ctrl+shift+up",
       "ctrl+shift+down",
       "ctrl+shift+r",
+      "ctrl+shift+s",
       "ctrl+shift+e",
       "ctrl+shift+i",
       "ctrl+shift+q",
     ]));
-    expect(shortcuts.get("ctrl+shift+down")?.description).toContain("Select next Symphony console worker");
+    expect(shortcuts.get("ctrl+shift+down")?.description).toContain("Select next Symphony console item");
+    expect(shortcuts.get("ctrl+shift+s")?.description).toBe("Steer the selected Symphony console worker");
+    expect(shortcuts.get("ctrl+shift+e")?.description).toBe("Respond to the selected Symphony console escalation");
+
+    await shortcuts.get("ctrl+shift+s")?.handler(ctx);
+    await shortcuts.get("ctrl+shift+e")?.handler(ctx);
+
+    expect(shortcutSpy).toHaveBeenCalledWith("steer", ctx);
+    expect(shortcutSpy).toHaveBeenCalledWith("respondEscalation", ctx);
+    shortcutSpy.mockRestore();
   });
 
   it("requests a manual refresh from the command", async () => {

--- a/apps/symphony/pi-extension/src/commands.test.ts
+++ b/apps/symphony/pi-extension/src/commands.test.ts
@@ -114,16 +114,17 @@ describe("symphony commands", () => {
       "ctrl+shift+up",
       "ctrl+shift+down",
       "ctrl+shift+r",
-      "ctrl+shift+s",
+      "ctrl+shift+t",
       "ctrl+shift+e",
       "ctrl+shift+i",
       "ctrl+shift+q",
     ]));
     expect(shortcuts.get("ctrl+shift+down")?.description).toContain("Select next Symphony console item");
-    expect(shortcuts.get("ctrl+shift+s")?.description).toBe("Steer the selected Symphony console worker");
+    expect(shortcuts.has("ctrl+shift+s")).toBe(false);
+    expect(shortcuts.get("ctrl+shift+t")?.description).toBe("Steer the selected Symphony console worker");
     expect(shortcuts.get("ctrl+shift+e")?.description).toBe("Respond to the selected Symphony console escalation");
 
-    await shortcuts.get("ctrl+shift+s")?.handler(ctx);
+    await shortcuts.get("ctrl+shift+t")?.handler(ctx);
     await shortcuts.get("ctrl+shift+e")?.handler(ctx);
 
     expect(shortcutSpy).toHaveBeenCalledWith("steer", ctx);

--- a/apps/symphony/pi-extension/src/commands.ts
+++ b/apps/symphony/pi-extension/src/commands.ts
@@ -159,7 +159,7 @@ function registerConsoleShortcuts(pi: ExtensionAPI): void {
     { key: "ctrl+shift+up", action: "selectPrevious", description: "Select previous Symphony console item" },
     { key: "ctrl+shift+down", action: "selectNext", description: "Select next Symphony console item" },
     { key: "ctrl+shift+r", action: "refresh", description: "Refresh the Symphony console" },
-    { key: "ctrl+shift+s", action: "steer", description: "Steer the selected Symphony console worker" },
+    { key: "ctrl+shift+t", action: "steer", description: "Steer the selected Symphony console worker" },
     { key: "ctrl+shift+e", action: "respondEscalation", description: "Respond to the selected Symphony console escalation" },
     { key: "ctrl+shift+i", action: "toggleDetails", description: "Toggle Symphony console item details" },
     { key: "ctrl+shift+q", action: "close", description: "Close the Symphony console widget" },

--- a/apps/symphony/pi-extension/src/commands.ts
+++ b/apps/symphony/pi-extension/src/commands.ts
@@ -156,11 +156,12 @@ export function registerSymphonyCommands(pi: ExtensionAPI, runtime: SymphonyRunt
 
 function registerConsoleShortcuts(pi: ExtensionAPI): void {
   const shortcuts = [
-    { key: "ctrl+shift+up", action: "selectPrevious", description: "Select previous Symphony console worker" },
-    { key: "ctrl+shift+down", action: "selectNext", description: "Select next Symphony console worker" },
+    { key: "ctrl+shift+up", action: "selectPrevious", description: "Select previous Symphony console item" },
+    { key: "ctrl+shift+down", action: "selectNext", description: "Select next Symphony console item" },
     { key: "ctrl+shift+r", action: "refresh", description: "Refresh the Symphony console" },
-    { key: "ctrl+shift+e", action: "steer", description: "Steer the selected Symphony console worker" },
-    { key: "ctrl+shift+i", action: "toggleDetails", description: "Toggle Symphony console worker details" },
+    { key: "ctrl+shift+s", action: "steer", description: "Steer the selected Symphony console worker" },
+    { key: "ctrl+shift+e", action: "respondEscalation", description: "Respond to the selected Symphony console escalation" },
+    { key: "ctrl+shift+i", action: "toggleDetails", description: "Toggle Symphony console item details" },
     { key: "ctrl+shift+q", action: "close", description: "Close the Symphony console widget" },
   ] as const satisfies ReadonlyArray<{ key: KeyId; action: ConsoleShortcutAction; description: string }>;
 

--- a/apps/symphony/pi-extension/src/commands.ts
+++ b/apps/symphony/pi-extension/src/commands.ts
@@ -209,5 +209,10 @@ function helpText(runtime: SymphonyRuntime): string {
     "/symphony:refresh",
     "/symphony:steer <ISSUE> <instruction>",
     "/symphony:stop",
+    "",
+    "Console keys:",
+    "↑/↓ select items",
+    "r refresh, s steer selected running worker, e respond to selected escalation",
+    "d details, q/Escape close",
   ].join("\n");
 }

--- a/apps/symphony/pi-extension/src/console-model.test.ts
+++ b/apps/symphony/pi-extension/src/console-model.test.ts
@@ -122,9 +122,18 @@ describe("console model", () => {
     });
   });
 
-  it("builds escalation rows sorted by creation time", () => {
+  it("builds escalation rows sorted by creation time and request id", () => {
     const state = stateFixture();
     state.pending_escalations = [
+      {
+        request_id: "esc-3",
+        issue_id: "issue-456",
+        issue_identifier: "SIM-456",
+        method: "approval",
+        preview: "Review matching timestamp command",
+        created_at: "2026-05-14T12:02:00Z",
+        timeout_ms: 30000,
+      },
       {
         request_id: "esc-2",
         issue_id: "issue-777",
@@ -147,7 +156,7 @@ describe("console model", () => {
 
     const rows = buildEscalationRows(state);
 
-    expect(rows.map((row) => row.requestId)).toEqual(["esc-1", "esc-2"]);
+    expect(rows.map((row) => row.requestId)).toEqual(["esc-1", "esc-2", "esc-3"]);
     expect(rows[0]).toMatchObject({
       method: "approval",
       preview: "Approve command",

--- a/apps/symphony/pi-extension/src/console-model.test.ts
+++ b/apps/symphony/pi-extension/src/console-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildWorkerRows, formatEventRows } from "./console-model.ts";
+import { buildEscalationRows, buildIssueRows, buildWorkerRows, formatEventRows } from "./console-model.ts";
 import type { SymphonyEventEnvelope, SymphonyStateResponse } from "./http-client.ts";
 
 function stateFixture(): SymphonyStateResponse {
@@ -62,6 +62,111 @@ describe("console model", () => {
     expect(rows[1]?.attempt).toBe("1");
     expect(rows[1]?.trackerState).toBe("-");
     expect(rows[1]?.errorPreview).toBe("agent exited after a very long error message that needs to be shortened for the console");
+  });
+
+  it("builds issue rows across running, retry, blocked, and completed buckets", () => {
+    const state = stateFixture();
+    state.retry_queue = [
+      {
+        issue_id: "issue-retry",
+        identifier: "SIM-200",
+        attempt: 3,
+        due_in_ms: 90000,
+        error: "rate limit",
+        worker_host: "host-b",
+        workspace_path: "/tmp/retry",
+      },
+    ];
+    state.blocked = [
+      {
+        issue_id: "issue-blocked",
+        identifier: "SIM-300",
+        title: "Blocked work",
+        state: "Todo",
+        blocker_identifiers: ["SIM-100", "SIM-101"],
+      },
+    ];
+    state.completed = [
+      {
+        issue_id: "issue-done",
+        identifier: "SIM-400",
+        title: "Done work",
+        completed_at: "2026-05-14T13:00:00Z",
+      },
+    ];
+
+    const rows = buildIssueRows(state);
+
+    expect(rows.map((row) => `${row.kind}:${row.issueIdentifier}`)).toEqual([
+      "running:SIM-123",
+      "running:SIM-777",
+      "retry:SIM-200",
+      "blocked:SIM-300",
+      "completed:SIM-400",
+    ]);
+    expect(rows.find((row) => row.kind === "retry")).toMatchObject({
+      title: "rate limit",
+      status: "retry in 1m 30s",
+      attempt: "3",
+      workerHost: "host-b",
+      workspacePath: "/tmp/retry",
+      errorPreview: "rate limit",
+    });
+    expect(rows.find((row) => row.kind === "blocked")).toMatchObject({
+      status: "Todo",
+      blockers: "SIM-100, SIM-101",
+    });
+    expect(rows.find((row) => row.kind === "completed")).toMatchObject({
+      status: "completed",
+      completedAt: "2026-05-14T13:00:00Z",
+    });
+  });
+
+  it("builds escalation rows sorted by creation time", () => {
+    const state = stateFixture();
+    state.pending_escalations = [
+      {
+        request_id: "esc-2",
+        issue_id: "issue-777",
+        issue_identifier: "SIM-777",
+        method: "approval",
+        preview: "Review command",
+        created_at: "2026-05-14T12:02:00Z",
+        timeout_ms: 30000,
+      },
+      {
+        request_id: "esc-1",
+        issue_id: "issue-123",
+        issue_identifier: "SIM-123",
+        method: "approval",
+        preview: "Approve command",
+        created_at: "2026-05-14T12:01:00Z",
+        timeout_ms: 600000,
+      },
+    ];
+
+    const rows = buildEscalationRows(state);
+
+    expect(rows.map((row) => row.requestId)).toEqual(["esc-1", "esc-2"]);
+    expect(rows[0]).toMatchObject({
+      method: "approval",
+      preview: "Approve command",
+      timeout: "10m 0s",
+    });
+  });
+
+  it("formats escalation lifecycle events newest first", () => {
+    const events: SymphonyEventEnvelope[] = [
+      { version: "v1", sequence: 1, timestamp: "2026-05-14T12:00:00Z", kind: "escalation_created", severity: "info", issue: "SIM-123", event: "escalation_created", payload: { summary: "Approve command" } },
+      { version: "v1", sequence: 2, timestamp: "2026-05-14T12:01:00Z", kind: "escalation_responded", severity: "info", issue: "SIM-123", event: "escalation_responded", payload: { summary: "Approved" } },
+      { version: "v1", sequence: 3, timestamp: "2026-05-14T12:02:00Z", kind: "escalation_timed_out", severity: "warn", issue: "SIM-777", event: "escalation_timed_out", payload: { summary: "Timed out" } },
+    ];
+
+    expect(formatEventRows(events)).toEqual([
+      "2026-05-14T12:02:00Z warn escalation_timed_out SIM-777 escalation_timed_out Timed out",
+      "2026-05-14T12:01:00Z info escalation_responded SIM-123 escalation_responded Approved",
+      "2026-05-14T12:00:00Z info escalation_created SIM-123 escalation_created Approve command",
+    ]);
   });
 
   it("formats only recent worker and runtime events", () => {

--- a/apps/symphony/pi-extension/src/console-model.test.ts
+++ b/apps/symphony/pi-extension/src/console-model.test.ts
@@ -122,6 +122,41 @@ describe("console model", () => {
     });
   });
 
+  it("rounds retry wait times up to the next second", () => {
+    const state = stateFixture();
+    state.retry_queue = [
+      {
+        issue_id: "issue-retry",
+        identifier: "SIM-200",
+        attempt: 1,
+        due_in_ms: 999,
+      },
+    ];
+
+    const retryRow = buildIssueRows(state).find((row) => row.kind === "retry");
+
+    expect(retryRow).toMatchObject({ status: "retry in 1s" });
+  });
+
+  it("preserves pending retry state when no retry error is present", () => {
+    const state = stateFixture();
+    state.retry_queue = [
+      {
+        issue_id: "issue-retry",
+        identifier: "SIM-200",
+        attempt: 1,
+        due_in_ms: 1000,
+      },
+    ];
+
+    const retryRow = buildIssueRows(state).find((row) => row.kind === "retry");
+
+    expect(retryRow).toMatchObject({
+      title: "pending retry",
+      trackerState: "retry",
+    });
+  });
+
   it("builds escalation rows sorted by creation time and request id", () => {
     const state = stateFixture();
     state.pending_escalations = [

--- a/apps/symphony/pi-extension/src/console-model.ts
+++ b/apps/symphony/pi-extension/src/console-model.ts
@@ -110,9 +110,9 @@ function retryToIssueRow(entry: RetryQueueEntryResponse): IssueRow {
     kind: "retry",
     issueId: entry.issue_id,
     issueIdentifier: entry.identifier,
-    title: errorPreview,
+    title: entry.error ?? "pending retry",
     status: `retry in ${formatDuration(entry.due_in_ms)}`,
-    trackerState: "-",
+    trackerState: "retry",
     attempt: String(entry.attempt),
     turnCount: "-",
     maxTurns: "-",
@@ -196,7 +196,7 @@ function formatLastActivity(lastActivityMs: number | null | undefined, lastActiv
 
 function formatDuration(durationMs: number): string {
   if (!Number.isFinite(durationMs) || durationMs <= 0) return "0s";
-  const totalSeconds = Math.floor(durationMs / 1000);
+  const totalSeconds = Math.ceil(durationMs / 1000);
   if (totalSeconds < 60) return `${totalSeconds}s`;
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;

--- a/apps/symphony/pi-extension/src/console-model.ts
+++ b/apps/symphony/pi-extension/src/console-model.ts
@@ -1,4 +1,12 @@
-import type { RunAttemptResponse, SymphonyEventEnvelope, SymphonyStateResponse } from "./http-client.ts";
+import type {
+  BlockedIssueResponse,
+  CompletedIssueResponse,
+  PendingEscalationResponse,
+  RetryQueueEntryResponse,
+  RunAttemptResponse,
+  SymphonyEventEnvelope,
+  SymphonyStateResponse,
+} from "./http-client.ts";
 
 export interface WorkerRow {
   issueId: string;
@@ -15,18 +23,146 @@ export interface WorkerRow {
   errorPreview: string;
 }
 
+export type IssueRowKind = "running" | "retry" | "blocked" | "completed";
+
+export interface IssueRow {
+  kind: IssueRowKind;
+  issueId: string;
+  issueIdentifier: string;
+  title: string;
+  status: string;
+  trackerState: string;
+  attempt: string;
+  turnCount: string;
+  maxTurns: string;
+  lastActivity: string;
+  workerHost: string;
+  workspacePath: string;
+  errorPreview: string;
+  blockers: string;
+  completedAt: string;
+}
+
+export interface EscalationRow {
+  requestId: string;
+  issueId: string;
+  issueIdentifier: string;
+  method: string;
+  preview: string;
+  createdAt: string;
+  timeout: string;
+}
+
 export function buildWorkerRows(state: SymphonyStateResponse | undefined): WorkerRow[] {
   return Object.entries(state?.running ?? {})
     .map(([issueId, attempt]) => buildWorkerRow(issueId, attempt, state))
     .sort((left, right) => left.issueIdentifier.localeCompare(right.issueIdentifier));
 }
 
+export function buildIssueRows(state: SymphonyStateResponse | undefined): IssueRow[] {
+  if (!state) return [];
+
+  return [
+    ...Object.entries(state.running ?? {})
+      .map(([issueId, attempt]) => workerToIssueRow(issueId, attempt, state))
+      .sort(compareIssueRows),
+    ...(state.retry_queue ?? []).map(retryToIssueRow).sort(compareIssueRows),
+    ...(state.blocked ?? []).map(blockedToIssueRow).sort(compareIssueRows),
+    ...(state.completed ?? []).map(completedToIssueRow).sort(compareIssueRows),
+  ];
+}
+
+export function buildEscalationRows(state: SymphonyStateResponse | undefined): EscalationRow[] {
+  return (state?.pending_escalations ?? [])
+    .slice()
+    .sort(compareEscalations)
+    .map((entry) => ({
+      requestId: entry.request_id,
+      issueId: entry.issue_id,
+      issueIdentifier: entry.issue_identifier,
+      method: entry.method,
+      preview: truncateText(entry.preview, 120),
+      createdAt: entry.created_at,
+      timeout: formatDuration(entry.timeout_ms),
+    }));
+}
+
 export function formatEventRows(events: SymphonyEventEnvelope[], limit = 8): string[] {
   return events
-    .filter((event) => event.kind === "worker" || event.kind === "runtime")
+    .filter((event) => event.kind === "worker" || event.kind === "runtime" || event.kind.startsWith("escalation_"))
     .slice(-limit)
     .reverse()
     .map((event) => [event.timestamp, event.severity, event.kind, event.issue ?? "-", event.event, eventSummary(event)].filter(Boolean).join(" "));
+}
+
+function workerToIssueRow(issueId: string, attempt: RunAttemptResponse, state: SymphonyStateResponse | undefined): IssueRow {
+  return {
+    kind: "running",
+    ...buildWorkerRow(issueId, attempt, state),
+    blockers: "-",
+    completedAt: "-",
+  };
+}
+
+function retryToIssueRow(entry: RetryQueueEntryResponse): IssueRow {
+  const errorPreview = entry.error ? truncateText(entry.error, 120) : "-";
+  return {
+    kind: "retry",
+    issueId: entry.issue_id,
+    issueIdentifier: entry.identifier,
+    title: errorPreview,
+    status: `retry in ${formatDuration(entry.due_in_ms)}`,
+    trackerState: "-",
+    attempt: String(entry.attempt),
+    turnCount: "-",
+    maxTurns: "-",
+    lastActivity: "-",
+    workerHost: entry.worker_host ?? "local",
+    workspacePath: entry.workspace_path ?? "-",
+    errorPreview,
+    blockers: "-",
+    completedAt: "-",
+  };
+}
+
+function blockedToIssueRow(entry: BlockedIssueResponse): IssueRow {
+  return {
+    kind: "blocked",
+    issueId: entry.issue_id,
+    issueIdentifier: entry.identifier,
+    title: entry.title,
+    status: entry.state,
+    trackerState: entry.state,
+    attempt: "-",
+    turnCount: "-",
+    maxTurns: "-",
+    lastActivity: "-",
+    workerHost: "-",
+    workspacePath: "-",
+    errorPreview: "-",
+    blockers: entry.blocker_identifiers.length > 0 ? entry.blocker_identifiers.join(", ") : "-",
+    completedAt: "-",
+  };
+}
+
+function completedToIssueRow(entry: CompletedIssueResponse): IssueRow {
+  return {
+    kind: "completed",
+    issueId: entry.issue_id,
+    issueIdentifier: entry.identifier,
+    title: entry.title,
+    status: "completed",
+    trackerState: "completed",
+    attempt: "-",
+    turnCount: "-",
+    maxTurns: "-",
+    lastActivity: "-",
+    workerHost: "-",
+    workspacePath: "-",
+    errorPreview: "-",
+    blockers: "-",
+    completedAt: entry.completed_at ?? "-",
+  };
 }
 
 function buildWorkerRow(issueId: string, attempt: RunAttemptResponse, state: SymphonyStateResponse | undefined): WorkerRow {
@@ -56,6 +192,28 @@ function formatLastActivity(lastActivityMs: number | null | undefined, lastActiv
     return new Date(lastActivityMs).toISOString();
   }
   return lastActivityAt ?? "-";
+}
+
+function formatDuration(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return "0s";
+  const totalSeconds = Math.floor(durationMs / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds}s`;
+}
+
+function compareIssueRows(left: IssueRow, right: IssueRow): number {
+  return left.issueIdentifier.localeCompare(right.issueIdentifier);
+}
+
+function compareEscalations(left: PendingEscalationResponse, right: PendingEscalationResponse): number {
+  return timestampMs(left.created_at) - timestampMs(right.created_at) || left.request_id.localeCompare(right.request_id);
+}
+
+function timestampMs(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function eventSummary(event: SymphonyEventEnvelope): string {

--- a/apps/symphony/pi-extension/src/console.test.ts
+++ b/apps/symphony/pi-extension/src/console.test.ts
@@ -517,7 +517,7 @@ describe("SymphonyConsoleComponent", () => {
     expect(respondToEscalation).not.toHaveBeenCalled();
   });
 
-  it("rejects malformed JSON-like escalation response before sending", async () => {
+  it.each(["{approved: true}", "\"approved"])("rejects malformed JSON-like escalation response before sending: %s", async (input) => {
     const respondToEscalation = vi.fn(async () => undefined);
     const notify = vi.fn();
     const consoleComponent = new SymphonyConsoleComponent({
@@ -527,7 +527,7 @@ describe("SymphonyConsoleComponent", () => {
       refresh: async () => undefined,
       steer: async () => undefined,
       respondToEscalation,
-      prompt: async () => "{approved: true}",
+      prompt: async () => input,
       close: () => undefined,
       requestRender: () => undefined,
       notify,

--- a/apps/symphony/pi-extension/src/console.test.ts
+++ b/apps/symphony/pi-extension/src/console.test.ts
@@ -494,6 +494,53 @@ describe("SymphonyConsoleComponent", () => {
     expect(respondToEscalation).toHaveBeenCalledWith("esc-1", "approved");
   });
 
+  it("cancels escalation response when prompt returns only whitespace", async () => {
+    const respondToEscalation = vi.fn(async () => undefined);
+    const requestRender = vi.fn();
+    const consoleComponent = new SymphonyConsoleComponent({
+      state: createDefaultState(),
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation,
+      prompt: async () => "   ",
+      close: () => undefined,
+      requestRender,
+      notify: () => undefined,
+    });
+
+    for (let index = 0; index < 5; index += 1) consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("e");
+    await expect.poll(() => requestRender.mock.calls.length, { interval: 10, timeout: 1000 }).toBeGreaterThan(0);
+
+    expect(respondToEscalation).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed JSON-like escalation response before sending", async () => {
+    const respondToEscalation = vi.fn(async () => undefined);
+    const notify = vi.fn();
+    const consoleComponent = new SymphonyConsoleComponent({
+      state: createDefaultState(),
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation,
+      prompt: async () => "{approved: true}",
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify,
+    });
+
+    for (let index = 0; index < 5; index += 1) consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("e");
+    await expect.poll(() => notify.mock.calls.length, { interval: 10, timeout: 1000 }).toBe(1);
+
+    expect(respondToEscalation).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith("Escalation response must be valid JSON or plain text", "error");
+  });
+
   it("notifies when escalation response is requested without a selected escalation", () => {
     const notify = vi.fn();
     const consoleComponent = new SymphonyConsoleComponent({

--- a/apps/symphony/pi-extension/src/console.test.ts
+++ b/apps/symphony/pi-extension/src/console.test.ts
@@ -240,6 +240,47 @@ describe("SymphonyConsoleComponent", () => {
     expect(output).toContain("completed at: 2026-05-14T13:00:00Z");
   });
 
+  it("keeps selection on the visible completed issue when pending escalations are not rendered", () => {
+    const state = createDefaultState();
+    state.console.showDetails = true;
+    const symphonyState = workerStateFixture();
+    symphonyState.running = {};
+    symphonyState.retry_queue = [];
+    symphonyState.blocked = [];
+    symphonyState.completed = [{ issue_id: "issue-done", identifier: "SIM-400", title: "Done work", completed_at: "2026-05-14T13:00:00Z" }];
+    symphonyState.pending_escalations = [
+      {
+        request_id: "esc-1",
+        issue_id: "issue-esc",
+        issue_identifier: "SIM-999",
+        method: "approval",
+        preview: "Approve deployment",
+        created_at: "2026-05-14T14:00:00Z",
+        timeout_ms: 60000,
+      },
+    ];
+    const consoleComponent = new SymphonyConsoleComponent({
+      state,
+      getState: () => symphonyState,
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation: async () => undefined,
+      prompt: async () => undefined,
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify: () => undefined,
+    });
+
+    consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("\u001b[B");
+
+    const output = consoleComponent.render(180).join("\n");
+    expect(output).toContain("> SIM-400");
+    expect(output).toContain("issue: SIM-400 Done work");
+  });
+
   it("expands keyboard shortcuts onto one row when the terminal is wide", () => {
     const state = createDefaultState();
     state.attachedBaseUrl = "http://127.0.0.1:8080";

--- a/apps/symphony/pi-extension/src/console.test.ts
+++ b/apps/symphony/pi-extension/src/console.test.ts
@@ -292,7 +292,7 @@ describe("SymphonyConsoleComponent", () => {
 
     const output = consoleComponent.render(220).join("\n");
 
-    expect(output).toContain("Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close");
+    expect(output).toContain("Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+t steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close");
   });
 
   it("renders boxed colored sections and command actions for console readability", () => {
@@ -335,11 +335,11 @@ describe("SymphonyConsoleComponent", () => {
     expect(output).toContain("Keyboard");
     expect(output).toContain("ctrl+shift+↑/↓ select");
     expect(output).toContain("ctrl+shift+r refresh");
-    expect(output).toContain("ctrl+shift+s steer");
+    expect(output).toContain("ctrl+shift+t steer");
     expect(output).toContain("ctrl+shift+e escalation");
     expect(output).toContain("ctrl+shift+i details");
     expect(output).toContain("ctrl+shift+q close");
-    expect(output).toContain("Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close");
+    expect(output).toContain("Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+t steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close");
     expect(output).toContain("<borderAccent>┌</borderAccent>");
     expect(output).toContain("<success>running: 2</success>");
     expect(output).toContain("<warning>retry: 1</warning>");

--- a/apps/symphony/pi-extension/src/console.test.ts
+++ b/apps/symphony/pi-extension/src/console.test.ts
@@ -735,6 +735,7 @@ describe("openConsole", () => {
       refreshState: vi.fn(async () => workerStateFixture()),
       requestRefresh: vi.fn(async () => workerStateFixture()),
       steerWorker: vi.fn(async () => undefined),
+      respondToEscalation: vi.fn(async () => undefined),
       errorText: vi.fn((error: unknown) => (error instanceof Error ? error.message : String(error))),
     } as unknown as SymphonyRuntime;
 
@@ -745,6 +746,37 @@ describe("openConsole", () => {
     const output = component?.render(160).join("\n") ?? "";
     expect(output).toContain("> SIM-777");
     expect(output).not.toContain("issue: <accent>SIM-777</accent> Worker two");
+    expect(requestRender).toHaveBeenCalled();
+  });
+
+  it("lets a global shortcut respond to the selected active-console escalation", async () => {
+    const state = createDefaultState();
+    state.attachedBaseUrl = "http://127.0.0.1:8080";
+
+    vi.mocked(startSymphonyEventStream).mockImplementation(() => ({ close: vi.fn() }));
+
+    const requestRender = vi.fn();
+    const setWidget = vi.fn((_key: string, factory: unknown) => {
+      (factory as (tui: { requestRender: () => void }, theme: ReturnType<typeof fakeTheme>) => SymphonyConsoleComponent)({ requestRender }, fakeTheme());
+    });
+    const ctx = { ui: { notify: vi.fn(), custom: vi.fn(), input: vi.fn(async () => "approved"), setWidget } } as unknown as ExtensionContext;
+    const runtime = {
+      client: {},
+      state,
+      lastState: workerStateFixture(),
+      recentEvents: [],
+      refreshState: vi.fn(async () => workerStateFixture()),
+      requestRefresh: vi.fn(async () => workerStateFixture()),
+      steerWorker: vi.fn(async () => undefined),
+      respondToEscalation: vi.fn(async () => undefined),
+      errorText: vi.fn((error: unknown) => (error instanceof Error ? error.message : String(error))),
+    } as unknown as SymphonyRuntime;
+
+    await openConsole(ctx, runtime);
+    for (let index = 0; index < 5; index += 1) await handleActiveConsoleShortcut("selectNext", ctx);
+    await handleActiveConsoleShortcut("respondEscalation", ctx);
+
+    expect(runtime.respondToEscalation).toHaveBeenCalledWith("esc-1", "approved");
     expect(requestRender).toHaveBeenCalled();
   });
 

--- a/apps/symphony/pi-extension/src/console.test.ts
+++ b/apps/symphony/pi-extension/src/console.test.ts
@@ -55,6 +55,7 @@ function workerStateFixture(): SymphonyStateResponse {
     },
     retry_queue: [{ issue_id: "issue-retry", identifier: "SIM-200", attempt: 3, due_in_ms: 90000, error: "rate limit", worker_host: "host-b", workspace_path: "/tmp/retry" }],
     blocked: [{ issue_id: "issue-blocked", identifier: "SIM-300", title: "Blocked work", state: "Todo", blocker_identifiers: ["SIM-100", "SIM-101"] }],
+    pending_escalations: [{ request_id: "esc-1", issue_id: "issue-123", issue_identifier: "SIM-123", method: "approval", preview: "Approve cargo test?", created_at: "2026-05-14T12:06:00Z", timeout_ms: 600000 }],
     completed: [{ issue_id: "issue-done", identifier: "SIM-400", title: "Done work", completed_at: "2026-05-14T13:00:00Z" }],
     polling: { checking: false, next_poll_in_ms: 1000, poll_interval_ms: 30000 },
   };
@@ -240,28 +241,12 @@ describe("SymphonyConsoleComponent", () => {
     expect(output).toContain("completed at: 2026-05-14T13:00:00Z");
   });
 
-  it("keeps selection on the visible completed issue when pending escalations are not rendered", () => {
+  it("renders pending escalations and selected escalation details", () => {
     const state = createDefaultState();
     state.console.showDetails = true;
-    const symphonyState = workerStateFixture();
-    symphonyState.running = {};
-    symphonyState.retry_queue = [];
-    symphonyState.blocked = [];
-    symphonyState.completed = [{ issue_id: "issue-done", identifier: "SIM-400", title: "Done work", completed_at: "2026-05-14T13:00:00Z" }];
-    symphonyState.pending_escalations = [
-      {
-        request_id: "esc-1",
-        issue_id: "issue-esc",
-        issue_identifier: "SIM-999",
-        method: "approval",
-        preview: "Approve deployment",
-        created_at: "2026-05-14T14:00:00Z",
-        timeout_ms: 60000,
-      },
-    ];
     const consoleComponent = new SymphonyConsoleComponent({
       state,
-      getState: () => symphonyState,
+      getState: () => workerStateFixture(),
       getEvents: () => [],
       refresh: async () => undefined,
       steer: async () => undefined,
@@ -275,10 +260,18 @@ describe("SymphonyConsoleComponent", () => {
     consoleComponent.handleInput("\u001b[B");
     consoleComponent.handleInput("\u001b[B");
     consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("\u001b[B");
 
     const output = consoleComponent.render(180).join("\n");
-    expect(output).toContain("> SIM-400");
-    expect(output).toContain("issue: SIM-400 Done work");
+    expect(output).toContain("Pending Escalations");
+    expect(output).toContain("> esc-1");
+    expect(output).toContain("SIM-123");
+    expect(output).toContain("approval");
+    expect(output).toContain("Approve cargo test?");
+    expect(output).toContain("Selected Escalation");
+    expect(output).toContain("request: esc-1");
+    expect(output).toContain("timeout: 10m 0s");
   });
 
   it("expands keyboard shortcuts onto one row when the terminal is wide", () => {
@@ -299,7 +292,7 @@ describe("SymphonyConsoleComponent", () => {
 
     const output = consoleComponent.render(220).join("\n");
 
-    expect(output).toContain("Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+e steer  •  ctrl+shift+i details  •  ctrl+shift+q close");
+    expect(output).toContain("Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close");
   });
 
   it("renders boxed colored sections and command actions for console readability", () => {
@@ -342,10 +335,11 @@ describe("SymphonyConsoleComponent", () => {
     expect(output).toContain("Keyboard");
     expect(output).toContain("ctrl+shift+↑/↓ select");
     expect(output).toContain("ctrl+shift+r refresh");
-    expect(output).toContain("ctrl+shift+e steer");
+    expect(output).toContain("ctrl+shift+s steer");
+    expect(output).toContain("ctrl+shift+e escalation");
     expect(output).toContain("ctrl+shift+i details");
     expect(output).toContain("ctrl+shift+q close");
-    expect(output).toContain("Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+e steer  •  ctrl+shift+i details  •  ctrl+shift+q close");
+    expect(output).toContain("Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close");
     expect(output).toContain("<borderAccent>┌</borderAccent>");
     expect(output).toContain("<success>running: 2</success>");
     expect(output).toContain("<warning>retry: 1</warning>");
@@ -433,6 +427,91 @@ describe("SymphonyConsoleComponent", () => {
 
     expect(steer).toHaveBeenCalledWith("SIM-123", "Use the existing auth module");
     expect(notify).toHaveBeenCalledWith("Steer delivered to SIM-123", "info");
+  });
+
+  it("responds to the selected escalation with parsed JSON input", async () => {
+    let resolveResponded: (() => void) | undefined;
+    const responded = new Promise<void>((resolve) => {
+      resolveResponded = resolve;
+    });
+    const respondToEscalation = vi.fn(async () => {
+      resolveResponded?.();
+    });
+    let resolveNotified: (() => void) | undefined;
+    const notified = new Promise<void>((resolve) => {
+      resolveNotified = resolve;
+    });
+    const notify = vi.fn(() => {
+      resolveNotified?.();
+    });
+    const consoleComponent = new SymphonyConsoleComponent({
+      state: createDefaultState(),
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation,
+      prompt: async () => '{"approved":true}',
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify,
+    });
+
+    for (let index = 0; index < 5; index += 1) consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("e");
+    await responded;
+    await notified;
+
+    expect(respondToEscalation).toHaveBeenCalledWith("esc-1", { approved: true });
+    expect(notify).toHaveBeenCalledWith("Escalation response sent for esc-1", "info");
+  });
+
+  it("responds to the selected escalation with plain text when input is not JSON", async () => {
+    let resolveResponded: (() => void) | undefined;
+    const responded = new Promise<void>((resolve) => {
+      resolveResponded = resolve;
+    });
+    const respondToEscalation = vi.fn(async () => {
+      resolveResponded?.();
+    });
+    const consoleComponent = new SymphonyConsoleComponent({
+      state: createDefaultState(),
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation,
+      prompt: async () => "approved",
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify: () => undefined,
+    });
+
+    for (let index = 0; index < 5; index += 1) consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("e");
+    await responded;
+
+    expect(respondToEscalation).toHaveBeenCalledWith("esc-1", "approved");
+  });
+
+  it("notifies when escalation response is requested without a selected escalation", () => {
+    const notify = vi.fn();
+    const consoleComponent = new SymphonyConsoleComponent({
+      state: createDefaultState(),
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation: async () => undefined,
+      prompt: async () => undefined,
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify,
+    });
+
+    consoleComponent.handleInput("e");
+
+    expect(notify).toHaveBeenCalledWith("Select an escalation before responding", "warning");
   });
 
   it("notifies and requests render when steering prompt fails", async () => {

--- a/apps/symphony/pi-extension/src/console.test.ts
+++ b/apps/symphony/pi-extension/src/console.test.ts
@@ -53,9 +53,9 @@ function workerStateFixture(): SymphonyStateResponse {
       "issue-123": { turn_count: 3, max_turns: 20, last_activity_ms: Date.parse("2026-05-14T12:04:00Z"), last_error: null },
       "issue-777": { turn_count: 1, max_turns: 10, last_activity_ms: null, last_error: "usage limit" },
     },
-    retry_queue: [],
-    blocked: [],
-    completed: [],
+    retry_queue: [{ issue_id: "issue-retry", identifier: "SIM-200", attempt: 3, due_in_ms: 90000, error: "rate limit", worker_host: "host-b", workspace_path: "/tmp/retry" }],
+    blocked: [{ issue_id: "issue-blocked", identifier: "SIM-300", title: "Blocked work", state: "Todo", blocker_identifiers: ["SIM-100", "SIM-101"] }],
+    completed: [{ issue_id: "issue-done", identifier: "SIM-400", title: "Done work", completed_at: "2026-05-14T13:00:00Z" }],
     polling: { checking: false, next_poll_in_ms: 1000, poll_interval_ms: 30000 },
   };
 }
@@ -115,6 +115,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => [],
       refresh: async () => undefined,
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => undefined,
       close: () => undefined,
       requestRender: () => undefined,
@@ -130,7 +131,7 @@ describe("SymphonyConsoleComponent", () => {
     expect(output).toContain("owned process: pid 123");
   });
 
-  it("renders running workers, selected-worker details, and recent runtime events", () => {
+  it("renders running workers, selected issue details, and recent runtime events", () => {
     const state = createDefaultState();
     state.console.showDetails = true;
     const consoleComponent = new SymphonyConsoleComponent({
@@ -139,6 +140,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => runtimeEventsFixture(),
       refresh: async () => undefined,
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => undefined,
       close: () => undefined,
       requestRender: () => undefined,
@@ -150,7 +152,7 @@ describe("SymphonyConsoleComponent", () => {
     expect(output).toContain("Running Workers");
     expect(output).toContain("> SIM-123");
     expect(output).toContain("SIM-777");
-    expect(output).toContain("Selected Worker");
+    expect(output).toContain("Selected Issue");
     expect(output).toContain("issue: SIM-123 Worker one");
     expect(output).toContain("tracker state: In Progress");
     expect(output).toContain("attempt: 2");
@@ -162,6 +164,82 @@ describe("SymphonyConsoleComponent", () => {
     expect(output).toContain("worker_failed usage limit");
   });
 
+  it("renders retry, blocked, completed, and selected issue sections", () => {
+    const state = createDefaultState();
+    state.console.showDetails = true;
+    const consoleComponent = new SymphonyConsoleComponent({
+      state,
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation: async () => undefined,
+      prompt: async () => undefined,
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify: () => undefined,
+    });
+
+    const output = consoleComponent.render(180).join("\n");
+
+    expect(output).toContain("Retry Queue");
+    expect(output).toContain("Blocked Issues");
+    expect(output).toContain("Completed Issues");
+    expect(output).toContain("Selected Issue");
+    expect(output).toContain("SIM-200");
+    expect(output).toContain("retry in 1m 30s");
+    expect(output).toContain("SIM-300");
+    expect(output).toContain("SIM-100, SIM-101");
+    expect(output).toContain("SIM-400");
+    expect(output).toContain("2026-05-14T13:00:00Z");
+  });
+
+  it("moves selection across retry, blocked, and completed rows and limits steering to running rows", () => {
+    const state = createDefaultState();
+    state.console.showDetails = true;
+    const steer = vi.fn(async () => undefined);
+    const notify = vi.fn();
+    const consoleComponent = new SymphonyConsoleComponent({
+      state,
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer,
+      respondToEscalation: async () => undefined,
+      prompt: async () => "not used",
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify,
+    });
+
+    consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("\u001b[B");
+    let output = consoleComponent.render(180).join("\n");
+    expect(output).toContain("> SIM-200");
+    expect(output).toContain("issue: SIM-200 rate limit");
+    expect(output).toContain("kind: retry");
+    expect(output).toContain("status: retry in 1m 30s");
+    expect(output).toContain("workspace: /tmp/retry");
+
+    consoleComponent.handleInput("s");
+    expect(steer).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith("Select a running worker before steering", "warning");
+
+    consoleComponent.handleInput("\u001b[B");
+    output = consoleComponent.render(180).join("\n");
+    expect(output).toContain("> SIM-300");
+    expect(output).toContain("issue: SIM-300 Blocked work");
+    expect(output).toContain("kind: blocked");
+    expect(output).toContain("blockers: SIM-100, SIM-101");
+
+    consoleComponent.handleInput("\u001b[B");
+    output = consoleComponent.render(180).join("\n");
+    expect(output).toContain("> SIM-400");
+    expect(output).toContain("issue: SIM-400 Done work");
+    expect(output).toContain("kind: completed");
+    expect(output).toContain("completed at: 2026-05-14T13:00:00Z");
+  });
+
   it("expands keyboard shortcuts onto one row when the terminal is wide", () => {
     const state = createDefaultState();
     state.attachedBaseUrl = "http://127.0.0.1:8080";
@@ -171,6 +249,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => [],
       refresh: async () => undefined,
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => undefined,
       close: () => undefined,
       requestRender: () => undefined,
@@ -202,6 +281,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => runtimeEventsFixture(),
       refresh: async () => undefined,
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => undefined,
       close: () => undefined,
       requestRender: () => undefined,
@@ -216,7 +296,7 @@ describe("SymphonyConsoleComponent", () => {
     expect(output).toContain("Status");
     expect(output).toContain("Worker Summary");
     expect(output).toContain("Running Workers");
-    expect(output).toContain("Selected Worker");
+    expect(output).toContain("Selected Issue");
     expect(output).toContain("Events");
     expect(output).toContain("Keyboard");
     expect(output).toContain("ctrl+shift+↑/↓ select");
@@ -243,6 +323,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => [],
       refresh: async () => undefined,
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => undefined,
       close: () => undefined,
       requestRender: () => undefined,
@@ -256,7 +337,7 @@ describe("SymphonyConsoleComponent", () => {
     expect(output).toContain("issue: SIM-777 Worker two");
   });
 
-  it("toggles selected-worker details", () => {
+  it("toggles selected issue details", () => {
     const state = createDefaultState();
     state.console.showDetails = true;
     const consoleComponent = new SymphonyConsoleComponent({
@@ -265,6 +346,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => [],
       refresh: async () => undefined,
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => undefined,
       close: () => undefined,
       requestRender: () => undefined,
@@ -297,6 +379,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => [],
       refresh: async () => undefined,
       steer,
+      respondToEscalation: async () => undefined,
       prompt: async () => "Use the existing auth module",
       close: () => undefined,
       requestRender: () => undefined,
@@ -320,6 +403,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => [],
       refresh: async () => undefined,
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => {
         throw new Error("prompt failed");
       },
@@ -343,6 +427,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => [],
       refresh: async () => undefined,
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => undefined,
       close,
       requestRender: () => undefined,
@@ -365,6 +450,7 @@ describe("SymphonyConsoleComponent", () => {
       getEvents: () => [],
       refresh,
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => undefined,
       close: () => undefined,
       requestRender: () => undefined,
@@ -395,6 +481,7 @@ describe("SymphonyConsoleComponent", () => {
         throw new Error("refresh failed");
       },
       steer: async () => undefined,
+      respondToEscalation: async () => undefined,
       prompt: async () => undefined,
       close: () => undefined,
       requestRender: () => undefined,

--- a/apps/symphony/pi-extension/src/console.ts
+++ b/apps/symphony/pi-extension/src/console.ts
@@ -1,6 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
-import { buildEscalationRows, buildIssueRows, buildWorkerRows, formatEventRows, type EscalationRow, type IssueRow, type WorkerRow } from "./console-model.ts";
+import { buildIssueRows, buildWorkerRows, formatEventRows, type IssueRow, type WorkerRow } from "./console-model.ts";
 import { startSymphonyEventStream, type EventStreamHandle } from "./event-stream.ts";
 import type { SymphonyEventEnvelope, SymphonyStateResponse } from "./http-client.ts";
 import type { SymphonyRuntime } from "./runtime.ts";
@@ -113,8 +113,7 @@ export class SymphonyConsoleComponent {
     const symphonyState = this.options.getState();
     const workers: WorkerRow[] = buildWorkerRows(symphonyState);
     const issueRows: IssueRow[] = buildIssueRows(symphonyState);
-    const escalationRows: EscalationRow[] = buildEscalationRows(symphonyState);
-    this.clampSelection(issueRows.length + escalationRows.length);
+    this.clampSelection(issueRows.length);
     const runningRows = issueRows.filter((row) => row.kind === "running");
     const retryRows = issueRows.filter((row) => row.kind === "retry");
     const blockedRows = issueRows.filter((row) => row.kind === "blocked");
@@ -182,7 +181,7 @@ export class SymphonyConsoleComponent {
 
   private moveSelection(delta: number): void {
     const symphonyState = this.options.getState();
-    const rowCount = buildIssueRows(symphonyState).length + buildEscalationRows(symphonyState).length;
+    const rowCount = buildIssueRows(symphonyState).length;
     if (rowCount === 0) return;
     this.selectedIndex = Math.max(0, Math.min(rowCount - 1, this.selectedIndex + delta));
     this.options.requestRender();
@@ -199,8 +198,7 @@ export class SymphonyConsoleComponent {
   private async steerSelectedWorker(): Promise<void> {
     const symphonyState = this.options.getState();
     const issueRows = buildIssueRows(symphonyState);
-    const escalationRows = buildEscalationRows(symphonyState);
-    this.clampSelection(issueRows.length + escalationRows.length);
+    this.clampSelection(issueRows.length);
     const issue = issueRows[this.selectedIndex];
     if (!issue || issue.kind !== "running") {
       this.options.notify("Select a running worker before steering", "warning");

--- a/apps/symphony/pi-extension/src/console.ts
+++ b/apps/symphony/pi-extension/src/console.ts
@@ -16,7 +16,7 @@ interface ConsoleTheme {
   bold(text: string): string;
 }
 
-export type ConsoleShortcutAction = "selectPrevious" | "selectNext" | "refresh" | "steer" | "toggleDetails" | "close";
+export type ConsoleShortcutAction = "selectPrevious" | "selectNext" | "refresh" | "steer" | "respondEscalation" | "toggleDetails" | "close";
 
 let activeConsole: SymphonyConsoleComponent | undefined;
 
@@ -38,6 +38,9 @@ export async function handleActiveConsoleShortcut(action: ConsoleShortcutAction,
       return;
     case "steer":
       await activeConsole.steerNow();
+      return;
+    case "respondEscalation":
+      await activeConsole.respondToEscalationNow();
       return;
     case "toggleDetails":
       activeConsole.toggleDetails();

--- a/apps/symphony/pi-extension/src/console.ts
+++ b/apps/symphony/pi-extension/src/console.ts
@@ -378,12 +378,12 @@ function renderRecentEvents(events: string[], theme?: ConsoleTheme): string[] {
 }
 
 function renderActionLegend(refreshing: boolean, width: number, theme?: ConsoleTheme): string[] {
-  const keyboard = "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close";
+  const keyboard = "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+t steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close";
   const commands = "Commands: /symphony:refresh | /symphony:status | /symphony:stop";
   if (refreshing) return [color(theme, "warning", "refreshing..."), commands];
   if (visibleLength(keyboard) <= width - 4) return [keyboard, commands];
   return [
-    "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer",
+    "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+t steer",
     "          ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close",
     commands,
   ];

--- a/apps/symphony/pi-extension/src/console.ts
+++ b/apps/symphony/pi-extension/src/console.ts
@@ -1,6 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
-import { buildWorkerRows, formatEventRows, type WorkerRow } from "./console-model.ts";
+import { buildEscalationRows, buildIssueRows, buildWorkerRows, formatEventRows, type EscalationRow, type IssueRow, type WorkerRow } from "./console-model.ts";
 import { startSymphonyEventStream, type EventStreamHandle } from "./event-stream.ts";
 import type { SymphonyEventEnvelope, SymphonyStateResponse } from "./http-client.ts";
 import type { SymphonyRuntime } from "./runtime.ts";
@@ -62,6 +62,7 @@ export interface ConsoleOptions {
   getEvents: () => SymphonyEventEnvelope[];
   refresh: () => Promise<void>;
   steer: (issueIdentifier: string, instruction: string) => Promise<void>;
+  respondToEscalation: (requestId: string, response: unknown) => Promise<void>;
   prompt: (title: string, label: string) => Promise<string | undefined>;
   close: () => void;
   requestRender: () => void;
@@ -71,7 +72,7 @@ export interface ConsoleOptions {
 
 export class SymphonyConsoleComponent {
   private refreshing = false;
-  private selectedWorkerIndex = 0;
+  private selectedIndex = 0;
 
   constructor(private readonly options: ConsoleOptions) {}
 
@@ -109,9 +110,16 @@ export class SymphonyConsoleComponent {
   render(width: number): string[] {
     const state = this.options.state;
     const health = state.lastKnownState;
-    const workers = buildWorkerRows(this.options.getState());
-    this.clampSelection(workers.length);
-    const selectedWorker = workers[this.selectedWorkerIndex];
+    const symphonyState = this.options.getState();
+    const workers: WorkerRow[] = buildWorkerRows(symphonyState);
+    const issueRows: IssueRow[] = buildIssueRows(symphonyState);
+    const escalationRows: EscalationRow[] = buildEscalationRows(symphonyState);
+    this.clampSelection(issueRows.length + escalationRows.length);
+    const runningRows = issueRows.filter((row) => row.kind === "running");
+    const retryRows = issueRows.filter((row) => row.kind === "retry");
+    const blockedRows = issueRows.filter((row) => row.kind === "blocked");
+    const completedRows = issueRows.filter((row) => row.kind === "completed");
+    const selectedIssue = issueRows[this.selectedIndex];
     const theme = this.options.theme;
     const connection = state.attachedBaseUrl ? color(theme, "success", "attached") : color(theme, "error", "detached");
     const polling = health?.pollingChecking ? color(theme, "warning", "checking") : color(theme, "success", "idle");
@@ -129,11 +137,14 @@ export class SymphonyConsoleComponent {
       ], consoleWidth, theme),
       "",
       ...boxLines("Worker Summary", [
-        `workers: ${color(theme, "success", `running: ${health?.runningCount ?? workers.length}`)} | ${color(theme, "warning", `retry: ${health?.retryCount ?? 0}`)} | ${color(theme, "error", `blocked: ${health?.blockedCount ?? 0}`)} | ${color(theme, "accent", `completed: ${health?.completedCount ?? 0}`)}`,
+        `workers: ${color(theme, "success", `running: ${health?.runningCount ?? workers.length}`)} | ${color(theme, "warning", `retry: ${health?.retryCount ?? retryRows.length}`)} | ${color(theme, "error", `blocked: ${health?.blockedCount ?? blockedRows.length}`)} | ${color(theme, "accent", `completed: ${health?.completedCount ?? completedRows.length}`)}`,
       ], consoleWidth, theme),
       "",
-      ...boxLines("Running Workers", renderWorkerTable(workers, this.selectedWorkerIndex, theme), consoleWidth, theme),
-      ...boxLines("Selected Worker", renderSelectedWorkerDetails(selectedWorker, state.console.showDetails, theme), consoleWidth, theme),
+      ...boxLines("Running Workers", renderIssueTable(runningRows, this.selectedIndex, 0, theme), consoleWidth, theme),
+      ...boxLines("Retry Queue", renderIssueTable(retryRows, this.selectedIndex, runningRows.length, theme), consoleWidth, theme),
+      ...boxLines("Blocked Issues", renderIssueTable(blockedRows, this.selectedIndex, runningRows.length + retryRows.length, theme), consoleWidth, theme),
+      ...boxLines("Completed Issues", renderIssueTable(completedRows, this.selectedIndex, runningRows.length + retryRows.length + blockedRows.length, theme), consoleWidth, theme),
+      ...boxLines("Selected Issue", renderSelectedIssueDetails(selectedIssue, state.console.showDetails, theme), consoleWidth, theme),
       ...boxLines("Events", renderRecentEvents(formatEventRows(this.options.getEvents()), theme), consoleWidth, theme),
       "",
       ...boxLines("Actions", renderActionLegend(this.refreshing, consoleWidth, theme), consoleWidth, theme),
@@ -170,35 +181,38 @@ export class SymphonyConsoleComponent {
   }
 
   private moveSelection(delta: number): void {
-    const workers = buildWorkerRows(this.options.getState());
-    if (workers.length === 0) return;
-    this.selectedWorkerIndex = Math.max(0, Math.min(workers.length - 1, this.selectedWorkerIndex + delta));
+    const symphonyState = this.options.getState();
+    const rowCount = buildIssueRows(symphonyState).length + buildEscalationRows(symphonyState).length;
+    if (rowCount === 0) return;
+    this.selectedIndex = Math.max(0, Math.min(rowCount - 1, this.selectedIndex + delta));
     this.options.requestRender();
   }
 
-  private clampSelection(workerCount: number): void {
-    if (workerCount === 0) {
-      this.selectedWorkerIndex = 0;
+  private clampSelection(rowCount: number): void {
+    if (rowCount === 0) {
+      this.selectedIndex = 0;
       return;
     }
-    this.selectedWorkerIndex = Math.max(0, Math.min(workerCount - 1, this.selectedWorkerIndex));
+    this.selectedIndex = Math.max(0, Math.min(rowCount - 1, this.selectedIndex));
   }
 
   private async steerSelectedWorker(): Promise<void> {
-    const workers = buildWorkerRows(this.options.getState());
-    this.clampSelection(workers.length);
-    const worker = workers[this.selectedWorkerIndex];
-    if (!worker) {
-      this.options.notify("No running worker is selected", "warning");
+    const symphonyState = this.options.getState();
+    const issueRows = buildIssueRows(symphonyState);
+    const escalationRows = buildEscalationRows(symphonyState);
+    this.clampSelection(issueRows.length + escalationRows.length);
+    const issue = issueRows[this.selectedIndex];
+    if (!issue || issue.kind !== "running") {
+      this.options.notify("Select a running worker before steering", "warning");
       return;
     }
 
     try {
-      const instruction = (await this.options.prompt("Steer Symphony worker", `Instruction for ${worker.issueIdentifier}`))?.trim();
+      const instruction = (await this.options.prompt("Steer Symphony worker", `Instruction for ${issue.issueIdentifier}`))?.trim();
       if (!instruction) return;
 
-      await this.options.steer(worker.issueIdentifier, instruction);
-      this.options.notify(`Steer delivered to ${worker.issueIdentifier}`, "info");
+      await this.options.steer(issue.issueIdentifier, instruction);
+      this.options.notify(`Steer delivered to ${issue.issueIdentifier}`, "info");
     } catch (error) {
       this.options.notify(error instanceof Error ? error.message : String(error), "error");
     } finally {
@@ -222,39 +236,68 @@ export class SymphonyConsoleComponent {
   }
 }
 
-function renderWorkerTable(workers: WorkerRow[], selectedIndex: number, theme?: ConsoleTheme): string[] {
-  const lines = [color(theme, "dim", "sel issue    state           attempt turns   host      last activity")];
-  if (workers.length === 0) return [...lines, color(theme, "dim", "-   no running workers")];
+function renderIssueTable(rows: IssueRow[], selectedIndex: number, selectedOffset: number, theme?: ConsoleTheme): string[] {
+  const lines = [color(theme, "dim", "sel issue    kind       status              attempt host      detail")];
+  if (rows.length === 0) return [...lines, color(theme, "dim", "-   none")];
 
-  for (const [index, worker] of workers.entries()) {
-    const selected = index === selectedIndex ? ">" : " ";
+  for (const [index, row] of rows.entries()) {
+    const rowIndex = selectedOffset + index;
+    const selected = rowIndex === selectedIndex ? ">" : " ";
     const line = [
       selected,
-      pad(worker.issueIdentifier, 8),
-      pad(worker.trackerState, 15),
-      pad(worker.attempt, 7),
-      pad(`${worker.turnCount}/${worker.maxTurns}`, 7),
-      pad(worker.workerHost, 9),
-      worker.lastActivity,
+      pad(row.issueIdentifier, 8),
+      pad(row.kind, 10),
+      pad(row.status, 18),
+      pad(row.attempt, 7),
+      pad(row.workerHost, 9),
+      issueDetail(row),
     ].join(" ");
-    lines.push(index === selectedIndex ? selectedLine(theme, line) : line);
+    lines.push(rowIndex === selectedIndex ? selectedLine(theme, line) : line);
   }
   return lines;
 }
 
-function renderSelectedWorkerDetails(worker: WorkerRow | undefined, showDetails: boolean, theme?: ConsoleTheme): string[] {
+function renderSelectedIssueDetails(issue: IssueRow | undefined, showDetails: boolean, theme?: ConsoleTheme): string[] {
   if (!showDetails) return [];
-  if (!worker) return [color(theme, "dim", "none")];
-  return [
-    `issue: ${color(theme, "accent", worker.issueIdentifier)} ${worker.title}`,
-    `tracker state: ${color(theme, "success", worker.trackerState)}`,
-    `attempt: ${worker.attempt}`,
-    `turns: ${worker.turnCount} / ${worker.maxTurns}`,
-    `last activity: ${color(theme, "dim", worker.lastActivity)}`,
-    `worker host: ${worker.workerHost}`,
-    `workspace: ${color(theme, "dim", worker.workspacePath)}`,
-    `error: ${worker.errorPreview === "-" ? color(theme, "dim", worker.errorPreview) : color(theme, "error", worker.errorPreview)}`,
+  if (!issue) return [color(theme, "dim", "none")];
+
+  const lines = [
+    `issue: ${color(theme, "accent", issue.issueIdentifier)} ${issue.title}`,
+    `kind: ${issue.kind}`,
+    `status: ${issue.status}`,
   ];
+
+  if (issue.kind === "running") {
+    lines.push(
+      `tracker state: ${color(theme, "success", issue.trackerState)}`,
+      `attempt: ${issue.attempt}`,
+      `turns: ${issue.turnCount} / ${issue.maxTurns}`,
+      `last activity: ${color(theme, "dim", issue.lastActivity)}`,
+      `worker host: ${issue.workerHost}`,
+      `workspace: ${color(theme, "dim", issue.workspacePath)}`,
+      `error: ${issue.errorPreview === "-" ? color(theme, "dim", issue.errorPreview) : color(theme, "error", issue.errorPreview)}`,
+    );
+  } else if (issue.kind === "retry") {
+    lines.push(
+      `attempt: ${issue.attempt}`,
+      `worker host: ${issue.workerHost}`,
+      `workspace: ${color(theme, "dim", issue.workspacePath)}`,
+      `error: ${issue.errorPreview === "-" ? color(theme, "dim", issue.errorPreview) : color(theme, "error", issue.errorPreview)}`,
+    );
+  } else if (issue.kind === "blocked") {
+    lines.push(`tracker state: ${color(theme, "warning", issue.trackerState)}`, `blockers: ${issue.blockers}`);
+  } else {
+    lines.push(`completed at: ${issue.completedAt}`);
+  }
+
+  return lines;
+}
+
+function issueDetail(issue: IssueRow): string {
+  if (issue.kind === "blocked") return `blockers: ${issue.blockers}`;
+  if (issue.kind === "completed") return issue.completedAt;
+  if (issue.kind === "retry") return issue.errorPreview;
+  return issue.errorPreview === "-" ? issue.lastActivity : issue.errorPreview;
 }
 
 function renderRecentEvents(events: string[], theme?: ConsoleTheme): string[] {
@@ -413,6 +456,10 @@ export async function openConsole(ctx: ExtensionContext, runtime: SymphonyRuntim
       },
       steer: async (issueIdentifier, instruction) => {
         await runtime.steerWorker(issueIdentifier, instruction);
+      },
+      respondToEscalation: async (requestId, response) => {
+        if (!runtime.client) throw new Error("No Symphony server is attached");
+        await runtime.client.respondEscalation(requestId, response);
       },
       prompt: async (title, label) => ctx.ui.input(title, label),
       close: () => {

--- a/apps/symphony/pi-extension/src/console.ts
+++ b/apps/symphony/pi-extension/src/console.ts
@@ -1,6 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
-import { buildIssueRows, buildWorkerRows, formatEventRows, type IssueRow, type WorkerRow } from "./console-model.ts";
+import { buildEscalationRows, buildIssueRows, buildWorkerRows, formatEventRows, type EscalationRow, type IssueRow, type WorkerRow } from "./console-model.ts";
 import { startSymphonyEventStream, type EventStreamHandle } from "./event-stream.ts";
 import type { SymphonyEventEnvelope, SymphonyStateResponse } from "./http-client.ts";
 import type { SymphonyRuntime } from "./runtime.ts";
@@ -97,6 +97,11 @@ export class SymphonyConsoleComponent {
       return;
     }
 
+    if (data === "e" || data === "E") {
+      void this.respondToEscalationNow();
+      return;
+    }
+
     if (data === "\u001b[A" || matchesKey(data, "up")) {
       this.selectPreviousWorker();
       return;
@@ -113,7 +118,8 @@ export class SymphonyConsoleComponent {
     const symphonyState = this.options.getState();
     const workers: WorkerRow[] = buildWorkerRows(symphonyState);
     const issueRows: IssueRow[] = buildIssueRows(symphonyState);
-    this.clampSelection(issueRows.length);
+    const escalationRows: EscalationRow[] = buildEscalationRows(symphonyState);
+    this.clampSelection(issueRows.length + escalationRows.length);
     const runningRows = issueRows.filter((row) => row.kind === "running");
     const retryRows = issueRows.filter((row) => row.kind === "retry");
     const blockedRows = issueRows.filter((row) => row.kind === "blocked");
@@ -144,6 +150,8 @@ export class SymphonyConsoleComponent {
       ...boxLines("Blocked Issues", renderIssueTable(blockedRows, this.selectedIndex, runningRows.length + retryRows.length, theme), consoleWidth, theme),
       ...boxLines("Completed Issues", renderIssueTable(completedRows, this.selectedIndex, runningRows.length + retryRows.length + blockedRows.length, theme), consoleWidth, theme),
       ...boxLines("Selected Issue", renderSelectedIssueDetails(selectedIssue, state.console.showDetails, theme), consoleWidth, theme),
+      ...boxLines("Pending Escalations", renderEscalationTable(escalationRows, this.selectedIndex - issueRows.length, theme), consoleWidth, theme),
+      ...boxLines("Selected Escalation", renderSelectedEscalationDetails(escalationRows[this.selectedIndex - issueRows.length], state.console.showDetails, theme), consoleWidth, theme),
       ...boxLines("Events", renderRecentEvents(formatEventRows(this.options.getEvents()), theme), consoleWidth, theme),
       "",
       ...boxLines("Actions", renderActionLegend(this.refreshing, consoleWidth, theme), consoleWidth, theme),
@@ -175,13 +183,17 @@ export class SymphonyConsoleComponent {
     await this.steerSelectedWorker();
   }
 
+  async respondToEscalationNow(): Promise<void> {
+    await this.respondToSelectedEscalation();
+  }
+
   closeConsole(): void {
     this.options.close();
   }
 
   private moveSelection(delta: number): void {
     const symphonyState = this.options.getState();
-    const rowCount = buildIssueRows(symphonyState).length;
+    const rowCount = buildIssueRows(symphonyState).length + buildEscalationRows(symphonyState).length;
     if (rowCount === 0) return;
     this.selectedIndex = Math.max(0, Math.min(rowCount - 1, this.selectedIndex + delta));
     this.options.requestRender();
@@ -198,7 +210,8 @@ export class SymphonyConsoleComponent {
   private async steerSelectedWorker(): Promise<void> {
     const symphonyState = this.options.getState();
     const issueRows = buildIssueRows(symphonyState);
-    this.clampSelection(issueRows.length);
+    const escalationRows = buildEscalationRows(symphonyState);
+    this.clampSelection(issueRows.length + escalationRows.length);
     const issue = issueRows[this.selectedIndex];
     if (!issue || issue.kind !== "running") {
       this.options.notify("Select a running worker before steering", "warning");
@@ -211,6 +224,30 @@ export class SymphonyConsoleComponent {
 
       await this.options.steer(issue.issueIdentifier, instruction);
       this.options.notify(`Steer delivered to ${issue.issueIdentifier}`, "info");
+    } catch (error) {
+      this.options.notify(error instanceof Error ? error.message : String(error), "error");
+    } finally {
+      this.options.requestRender();
+    }
+  }
+
+  private async respondToSelectedEscalation(): Promise<void> {
+    const symphonyState = this.options.getState();
+    const issueRows = buildIssueRows(symphonyState);
+    const escalationRows = buildEscalationRows(symphonyState);
+    this.clampSelection(issueRows.length + escalationRows.length);
+    const escalation = escalationRows[this.selectedIndex - issueRows.length];
+    if (!escalation) {
+      this.options.notify("Select an escalation before responding", "warning");
+      return;
+    }
+
+    try {
+      const value = await this.options.prompt("Respond to Symphony escalation", `Response for ${escalation.requestId}`);
+      if (value === undefined) return;
+
+      await this.options.respondToEscalation(escalation.requestId, parseEscalationResponseInput(value));
+      this.options.notify(`Escalation response sent for ${escalation.requestId}`, "info");
     } catch (error) {
       this.options.notify(error instanceof Error ? error.message : String(error), "error");
     } finally {
@@ -291,6 +328,40 @@ function renderSelectedIssueDetails(issue: IssueRow | undefined, showDetails: bo
   return lines;
 }
 
+function renderEscalationTable(rows: EscalationRow[], selectedIndex: number, theme?: ConsoleTheme): string[] {
+  const lines = [color(theme, "dim", "sel request  issue    method     timeout   preview")];
+  if (rows.length === 0) return [...lines, color(theme, "dim", "-   no pending escalations")];
+
+  for (const [index, row] of rows.entries()) {
+    const selected = index === selectedIndex ? ">" : " ";
+    const line = [selected, pad(row.requestId, 8), pad(row.issueIdentifier, 8), pad(row.method, 10), pad(row.timeout, 8), row.preview].join(" ");
+    lines.push(index === selectedIndex ? selectedLine(theme, line) : line);
+  }
+  return lines;
+}
+
+function renderSelectedEscalationDetails(escalation: EscalationRow | undefined, showDetails: boolean, theme?: ConsoleTheme): string[] {
+  if (!showDetails) return [];
+  if (!escalation) return [color(theme, "dim", "none")];
+
+  return [
+    `request: ${color(theme, "accent", escalation.requestId)}`,
+    `issue: ${escalation.issueIdentifier}`,
+    `method: ${escalation.method}`,
+    `created: ${color(theme, "dim", escalation.createdAt)}`,
+    `timeout: ${escalation.timeout}`,
+    `preview: ${escalation.preview}`,
+  ];
+}
+
+function parseEscalationResponseInput(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
 function issueDetail(issue: IssueRow): string {
   if (issue.kind === "blocked") return `blockers: ${issue.blockers}`;
   if (issue.kind === "completed") return issue.completedAt;
@@ -304,13 +375,13 @@ function renderRecentEvents(events: string[], theme?: ConsoleTheme): string[] {
 }
 
 function renderActionLegend(refreshing: boolean, width: number, theme?: ConsoleTheme): string[] {
-  const keyboard = "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+e steer  •  ctrl+shift+i details  •  ctrl+shift+q close";
+  const keyboard = "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close";
   const commands = "Commands: /symphony:refresh | /symphony:status | /symphony:stop";
   if (refreshing) return [color(theme, "warning", "refreshing..."), commands];
   if (visibleLength(keyboard) <= width - 4) return [keyboard, commands];
   return [
-    "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+e steer",
-    "          ctrl+shift+i details  •  ctrl+shift+q close",
+    "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer",
+    "          ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close",
     commands,
   ];
 }
@@ -456,8 +527,7 @@ export async function openConsole(ctx: ExtensionContext, runtime: SymphonyRuntim
         await runtime.steerWorker(issueIdentifier, instruction);
       },
       respondToEscalation: async (requestId, response) => {
-        if (!runtime.client) throw new Error("No Symphony server is attached");
-        await runtime.client.respondEscalation(requestId, response);
+        await runtime.respondToEscalation(requestId, response);
       },
       prompt: async (title, label) => ctx.ui.input(title, label),
       close: () => {

--- a/apps/symphony/pi-extension/src/console.ts
+++ b/apps/symphony/pi-extension/src/console.ts
@@ -246,8 +246,8 @@ export class SymphonyConsoleComponent {
     }
 
     try {
-      const value = await this.options.prompt("Respond to Symphony escalation", `Response for ${escalation.requestId}`);
-      if (value === undefined) return;
+      const value = (await this.options.prompt("Respond to Symphony escalation", `Response for ${escalation.requestId}`))?.trim();
+      if (!value) return;
 
       await this.options.respondToEscalation(escalation.requestId, parseEscalationResponseInput(value));
       this.options.notify(`Escalation response sent for ${escalation.requestId}`, "info");
@@ -361,6 +361,9 @@ function parseEscalationResponseInput(value: string): unknown {
   try {
     return JSON.parse(value);
   } catch {
+    if (value.startsWith("{") || value.startsWith("[")) {
+      throw new Error("Escalation response must be valid JSON or plain text");
+    }
     return value;
   }
 }

--- a/apps/symphony/pi-extension/src/console.ts
+++ b/apps/symphony/pi-extension/src/console.ts
@@ -358,10 +358,12 @@ function renderSelectedEscalationDetails(escalation: EscalationRow | undefined, 
 }
 
 function parseEscalationResponseInput(value: string): unknown {
+  const trimmedValue = value.trimStart();
   try {
-    return JSON.parse(value);
+    return JSON.parse(trimmedValue);
   } catch {
-    if (value.startsWith("{") || value.startsWith("[")) {
+    const firstChar = trimmedValue[0];
+    if (firstChar === "{" || firstChar === "[" || firstChar === "\"") {
       throw new Error("Escalation response must be valid JSON or plain text");
     }
     return value;

--- a/apps/symphony/pi-extension/src/http-client.test.ts
+++ b/apps/symphony/pi-extension/src/http-client.test.ts
@@ -34,9 +34,19 @@ function validState(overrides: Record<string, unknown> = {}): Record<string, unk
         status: "running",
       },
     },
-    retry_queue: [{ identifier: "KAT-2" }],
+    retry_queue: [
+      {
+        issue_id: "issue-2",
+        identifier: "KAT-2",
+        attempt: 2,
+        due_in_ms: 1500,
+        error: "rate limited",
+        worker_host: "host-1",
+        workspace_path: "/tmp/symphony/issue-2",
+      },
+    ],
     blocked: [],
-    completed: [{ identifier: "KAT-3" }],
+    completed: [{ issue_id: "issue-3", identifier: "KAT-3", title: "Done", completed_at: null, issue_url: null }],
     polling: { checking: false, next_poll_in_ms: 1000, poll_interval_ms: 30000, poll_count: 2 },
     ...overrides,
   };
@@ -88,6 +98,149 @@ describe("SymphonyHttpClient", () => {
     await expect(client.getState()).rejects.toMatchObject({
       kind: "api_error",
       message: "issue has no active RPC session",
+    } satisfies Partial<SymphonyExtensionError>);
+  });
+
+  it("fetches typed Wave 3 state entries", async () => {
+    const baseUrl = await serve((req) => {
+      expect(req.url).toBe("/api/v1/state");
+      return {
+        status: 200,
+        body: validState({
+          retry_queue: [
+            {
+              issue_id: "issue-retry-1",
+              identifier: "KAT-10",
+              attempt: 3,
+              due_in_ms: 2500,
+              error: null,
+              worker_host: "worker-a",
+              workspace_path: "/tmp/kata/KAT-10",
+            },
+          ],
+          blocked: [
+            {
+              issue_id: "issue-blocked-1",
+              identifier: "KAT-11",
+              title: "Blocked issue",
+              state: "blocked",
+              blocker_identifiers: ["KAT-9"],
+            },
+          ],
+          pending_escalations: [
+            {
+              request_id: "esc-1",
+              issue_id: "issue-pending-1",
+              issue_identifier: "KAT-12",
+              method: "request_approval",
+              preview: "Approve deploy",
+              created_at: "2026-05-14T12:00:00Z",
+              timeout_ms: 60000,
+            },
+          ],
+          completed: [
+            {
+              issue_id: "issue-completed-1",
+              identifier: "KAT-13",
+              title: "Completed issue",
+              completed_at: "2026-05-14T13:00:00Z",
+              issue_url: "https://github.com/gannonh/kata/issues/13",
+            },
+          ],
+        }),
+      };
+    });
+
+    const client = new SymphonyHttpClient(baseUrl);
+    const state = await client.getState();
+
+    expect(state.retry_queue?.[0]).toMatchObject({ issue_id: "issue-retry-1", identifier: "KAT-10", attempt: 3, due_in_ms: 2500 });
+    expect(state.blocked?.[0]).toMatchObject({ issue_id: "issue-blocked-1", identifier: "KAT-11", title: "Blocked issue", blocker_identifiers: ["KAT-9"] });
+    expect(state.pending_escalations?.[0]).toMatchObject({ request_id: "esc-1", issue_identifier: "KAT-12", timeout_ms: 60000 });
+    expect(state.completed?.[0]).toMatchObject({ issue_id: "issue-completed-1", identifier: "KAT-13", title: "Completed issue" });
+  });
+
+  it("fetches pending escalations", async () => {
+    const pending = [
+      {
+        request_id: "esc-1",
+        issue_id: "issue-1",
+        issue_identifier: "KAT-1",
+        method: "request_approval",
+        preview: "Approve deploy",
+        created_at: "2026-05-14T12:00:00Z",
+        timeout_ms: 60000,
+      },
+    ];
+    const baseUrl = await serve((req) => {
+      expect(req.method).toBe("GET");
+      expect(req.url).toBe("/api/v1/escalations");
+      return { status: 200, body: { pending } };
+    });
+
+    const client = new SymphonyHttpClient(baseUrl);
+
+    await expect(client.getEscalations()).resolves.toEqual({ pending });
+  });
+
+  it("responds to a pending escalation", async () => {
+    const baseUrl = await serve((req, body) => {
+      expect(req.method).toBe("POST");
+      expect(req.url).toBe("/api/v1/escalations/esc-1/respond");
+      expect(JSON.parse(body)).toEqual({ response: { approved: true }, responder_id: "pi-dashboard" });
+      return { status: 200, body: { ok: true } };
+    });
+
+    const client = new SymphonyHttpClient(baseUrl);
+
+    await expect(client.respondEscalation("esc-1", { approved: true })).resolves.toEqual({ ok: true });
+  });
+
+  it.each([
+    ["missing", 404, "escalation_not_found"],
+    ["resolved", 409, "escalation_already_resolved"],
+  ])("normalizes simple escalation API errors: %s", async (_name, status, error) => {
+    const baseUrl = await serve(() => ({ status, body: { error } }));
+    const client = new SymphonyHttpClient(baseUrl);
+
+    await expect(client.getEscalations()).rejects.toMatchObject({
+      kind: "api_error",
+      message: error,
+      details: expect.objectContaining({ code: error, status }),
+    } satisfies Partial<SymphonyExtensionError>);
+  });
+
+  it.each([
+    ["retry_queue.0.issue_id", validState({ retry_queue: [{ identifier: "KAT-2", attempt: 1, due_in_ms: 1000 }] })],
+    [
+      "blocked.0.title",
+      validState({
+        blocked: [{ issue_id: "issue-2", identifier: "KAT-2", state: "blocked", blocker_identifiers: [] }],
+      }),
+    ],
+    [
+      "pending_escalations.0.issue_id",
+      validState({
+        pending_escalations: [
+          {
+            request_id: "esc-1",
+            issue_identifier: "KAT-2",
+            method: "request_approval",
+            preview: "Approve deploy",
+            created_at: "2026-05-14T12:00:00Z",
+            timeout_ms: 60000,
+          },
+        ],
+      }),
+    ],
+    ["completed.0.title", validState({ completed: [{ issue_id: "issue-3", identifier: "KAT-3" }] })],
+  ])("rejects malformed Wave 3 state entry: %s", async (field, body) => {
+    const baseUrl = await serve(() => ({ status: 200, body }));
+    const client = new SymphonyHttpClient(baseUrl);
+
+    await expect(client.getState()).rejects.toMatchObject({
+      kind: "non_symphony_response",
+      details: expect.objectContaining({ field }),
     } satisfies Partial<SymphonyExtensionError>);
   });
 

--- a/apps/symphony/pi-extension/src/http-client.ts
+++ b/apps/symphony/pi-extension/src/http-client.ts
@@ -42,14 +42,59 @@ export interface WorkerSessionInfoResponse {
   last_error?: string | null;
 }
 
+export interface RetryQueueEntryResponse {
+  issue_id: string;
+  identifier: string;
+  attempt: number;
+  due_in_ms: number;
+  error?: string | null;
+  worker_host?: string | null;
+  workspace_path?: string | null;
+}
+
+export interface BlockedIssueResponse {
+  issue_id: string;
+  identifier: string;
+  title: string;
+  state: string;
+  blocker_identifiers: string[];
+}
+
+export interface CompletedIssueResponse {
+  issue_id: string;
+  identifier: string;
+  title: string;
+  completed_at?: string | null;
+  issue_url?: string | null;
+}
+
+export interface PendingEscalationResponse {
+  request_id: string;
+  issue_id: string;
+  issue_identifier: string;
+  method: string;
+  preview: string;
+  created_at: string;
+  timeout_ms: number;
+}
+
+export interface EscalationListResponse {
+  pending: PendingEscalationResponse[];
+}
+
+export interface EscalationRespondResponse {
+  ok: boolean;
+}
+
 export interface SymphonyStateResponse {
   tracker_project_url?: string | null;
   running?: Record<string, RunAttemptResponse>;
   running_sessions?: Record<string, RunningSessionSnapshotResponse>;
   running_session_info?: Record<string, WorkerSessionInfoResponse>;
-  retry_queue?: unknown[];
-  blocked?: unknown[];
-  completed?: unknown[];
+  retry_queue: RetryQueueEntryResponse[];
+  blocked: BlockedIssueResponse[];
+  pending_escalations?: PendingEscalationResponse[];
+  completed: CompletedIssueResponse[];
   polling?: {
     checking?: boolean;
     next_poll_in_ms?: number;
@@ -127,6 +172,23 @@ export class SymphonyHttpClient {
     return validateSteerResponse(json, { baseUrl: this.baseUrl, path, issueIdentifier });
   }
 
+  async getEscalations(signal?: AbortSignal): Promise<EscalationListResponse> {
+    const path = "/api/v1/escalations";
+    const json = await this.requestJson(path, { method: "GET", signal });
+    return validateEscalationListResponse(json, { baseUrl: this.baseUrl, path });
+  }
+
+  async respondEscalation(requestId: string, response: unknown, responderId = "pi-dashboard", signal?: AbortSignal): Promise<EscalationRespondResponse> {
+    const path = `/api/v1/escalations/${encodeURIComponent(requestId)}/respond`;
+    const json = await this.requestJson(path, {
+      method: "POST",
+      signal,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ response, responder_id: responderId }),
+    });
+    return validateEscalationRespondResponse(json, { baseUrl: this.baseUrl, path, requestId });
+  }
+
   toHealthSummary(state: SymphonyStateResponse): LastKnownSymphonyState {
     return {
       baseUrl: this.baseUrl,
@@ -179,6 +241,13 @@ export class SymphonyHttpClient {
     }
 
     if (!response.ok) {
+      if (isRecord(json) && typeof json.error === "string") {
+        throw new SymphonyExtensionError("api_error", json.error, {
+          url,
+          status: response.status,
+          code: json.error,
+        });
+      }
       const envelope = parseApiErrorEnvelope(json);
       if (envelope?.error?.message) {
         throw new SymphonyExtensionError("api_error", envelope.error.message, {
@@ -212,15 +281,15 @@ function validateSymphonyStateResponse(value: unknown, details: Record<string, u
   validateOptionalStringOrNull(value, "tracker_project_url", details);
   validateOptionalRecord(value, "running", details);
   validateRunningAttempts(value.running, details);
-  validateOptionalArray(value, "retry_queue", details);
-  validateOptionalArray(value, "blocked", details);
-  validateOptionalArray(value, "completed", details);
+  validateRetryQueueEntries(value, "retry_queue", details);
+  validateBlockedIssues(value, "blocked", details);
+  validateCompletedIssues(value, "completed", details);
   validateOptionalNumber(value, "poll_interval_ms", details);
   validateOptionalNumber(value, "max_concurrent_agents", details);
   validateOptionalRecord(value, "running_sessions", details);
   validateOptionalRecord(value, "running_session_info", details);
   validateOptionalArray(value, "claimed", details);
-  validateOptionalArray(value, "pending_escalations", details);
+  validatePendingEscalations(value, "pending_escalations", details);
   validateOptionalRecord(value, "shared_context", details);
   validateOptionalRecord(value, "supervisor", details);
   validateOptionalRecord(value, "codex_totals", details);
@@ -235,7 +304,28 @@ function validateSymphonyStateResponse(value: unknown, details: Record<string, u
   validateOptionalNumber(value.polling, "poll_count", details, "polling.poll_count");
   validateOptionalStringOrNull(value.polling, "last_poll_at", details, "polling.last_poll_at");
 
-  return value;
+  return value as unknown as SymphonyStateResponse;
+}
+
+function validateEscalationListResponse(value: unknown, details: Record<string, unknown>): EscalationListResponse {
+  if (!isRecord(value)) {
+    throwNonSymphonyEscalationList(details, "escalation list response was not an object");
+  }
+  if (!Array.isArray(value.pending)) {
+    throwNonSymphonyEscalationList(details, "escalation list response field had an invalid shape", { field: "pending", expected: "array" });
+  }
+  value.pending.forEach((entry, index) => validatePendingEscalation(entry, details, `pending.${index}`, throwNonSymphonyEscalationList));
+  return { pending: value.pending as PendingEscalationResponse[] };
+}
+
+function validateEscalationRespondResponse(value: unknown, details: Record<string, unknown>): EscalationRespondResponse {
+  if (!isRecord(value)) {
+    throwNonSymphonyEscalationRespond(details, "escalation respond response was not an object");
+  }
+  if (typeof value.ok !== "boolean") {
+    throwNonSymphonyEscalationRespond(details, "escalation respond response field had an invalid shape", { field: "ok", expected: "boolean" });
+  }
+  return { ok: value.ok };
 }
 
 function validateRefreshResponse(value: unknown, details: Record<string, unknown>): RefreshResponse {
@@ -304,6 +394,22 @@ function throwNonSymphonySteer(details: Record<string, unknown>, reason: string,
   });
 }
 
+function throwNonSymphonyEscalationList(details: Record<string, unknown>, reason: string, extraDetails: Record<string, unknown> = {}): never {
+  throw new SymphonyExtensionError("non_symphony_response", "Response did not look like Symphony escalation list response", {
+    ...details,
+    reason,
+    ...extraDetails,
+  });
+}
+
+function throwNonSymphonyEscalationRespond(details: Record<string, unknown>, reason: string, extraDetails: Record<string, unknown> = {}): never {
+  throw new SymphonyExtensionError("non_symphony_response", "Response did not look like Symphony escalation respond response", {
+    ...details,
+    reason,
+    ...extraDetails,
+  });
+}
+
 function parseApiErrorEnvelope(value: unknown): ApiErrorEnvelope | undefined {
   if (!isRecord(value) || !isRecord(value.error)) return undefined;
   return {
@@ -340,6 +446,97 @@ function validateRunAttemptResponse(value: unknown, details: Record<string, unkn
   validateOptionalStringOrNull(value, "model", details, `${detailField}.model`);
   validateOptionalStringOrNull(value, "tracker_state", details, `${detailField}.tracker_state`);
   validateOptionalStringOrNull(value, "issue_url", details, `${detailField}.issue_url`);
+}
+
+type NonSymphonyThrower = (details: Record<string, unknown>, reason: string, extraDetails?: Record<string, unknown>) => never;
+
+function validateRetryQueueEntries(value: Record<string, unknown>, field: string, details: Record<string, unknown>): void {
+  const fieldValue = value[field];
+  if (fieldValue === undefined) return;
+  if (!Array.isArray(fieldValue)) {
+    throwNonSymphonyState(details, "state response field had an invalid shape", { field, expected: "array" });
+  }
+  fieldValue.forEach((entry, index) => validateRetryQueueEntry(entry, details, `${field}.${index}`));
+}
+
+function validateRetryQueueEntry(value: unknown, details: Record<string, unknown>, detailField: string): void {
+  if (!isRecord(value)) {
+    throwNonSymphonyState(details, "state response field had an invalid shape", { field: detailField, expected: "object" });
+  }
+  validateRequiredString(value, "issue_id", details, `${detailField}.issue_id`);
+  validateRequiredString(value, "identifier", details, `${detailField}.identifier`);
+  validateRequiredNumber(value, "attempt", details, `${detailField}.attempt`);
+  validateRequiredNumber(value, "due_in_ms", details, `${detailField}.due_in_ms`);
+  validateOptionalStringOrNull(value, "error", details, `${detailField}.error`);
+  validateOptionalStringOrNull(value, "worker_host", details, `${detailField}.worker_host`);
+  validateOptionalStringOrNull(value, "workspace_path", details, `${detailField}.workspace_path`);
+}
+
+function validateBlockedIssues(value: Record<string, unknown>, field: string, details: Record<string, unknown>): void {
+  const fieldValue = value[field];
+  if (fieldValue === undefined) return;
+  if (!Array.isArray(fieldValue)) {
+    throwNonSymphonyState(details, "state response field had an invalid shape", { field, expected: "array" });
+  }
+  fieldValue.forEach((entry, index) => validateBlockedIssue(entry, details, `${field}.${index}`));
+}
+
+function validateBlockedIssue(value: unknown, details: Record<string, unknown>, detailField: string): void {
+  if (!isRecord(value)) {
+    throwNonSymphonyState(details, "state response field had an invalid shape", { field: detailField, expected: "object" });
+  }
+  validateRequiredString(value, "issue_id", details, `${detailField}.issue_id`);
+  validateRequiredString(value, "identifier", details, `${detailField}.identifier`);
+  validateRequiredString(value, "title", details, `${detailField}.title`);
+  validateRequiredString(value, "state", details, `${detailField}.state`);
+  validateRequiredStringArray(value, "blocker_identifiers", details, `${detailField}.blocker_identifiers`);
+}
+
+function validateCompletedIssues(value: Record<string, unknown>, field: string, details: Record<string, unknown>): void {
+  const fieldValue = value[field];
+  if (fieldValue === undefined) return;
+  if (!Array.isArray(fieldValue)) {
+    throwNonSymphonyState(details, "state response field had an invalid shape", { field, expected: "array" });
+  }
+  fieldValue.forEach((entry, index) => validateCompletedIssue(entry, details, `${field}.${index}`));
+}
+
+function validateCompletedIssue(value: unknown, details: Record<string, unknown>, detailField: string): void {
+  if (!isRecord(value)) {
+    throwNonSymphonyState(details, "state response field had an invalid shape", { field: detailField, expected: "object" });
+  }
+  validateRequiredString(value, "issue_id", details, `${detailField}.issue_id`);
+  validateRequiredString(value, "identifier", details, `${detailField}.identifier`);
+  validateRequiredString(value, "title", details, `${detailField}.title`);
+  validateOptionalStringOrNull(value, "completed_at", details, `${detailField}.completed_at`);
+  validateOptionalStringOrNull(value, "issue_url", details, `${detailField}.issue_url`);
+}
+
+function validatePendingEscalations(
+  value: Record<string, unknown>,
+  field: string,
+  details: Record<string, unknown>,
+  thrower: NonSymphonyThrower = throwNonSymphonyState,
+): void {
+  const fieldValue = value[field];
+  if (fieldValue === undefined) return;
+  if (!Array.isArray(fieldValue)) {
+    thrower(details, "state response field had an invalid shape", { field, expected: "array" });
+  }
+  fieldValue.forEach((entry, index) => validatePendingEscalation(entry, details, `${field}.${index}`, thrower));
+}
+
+function validatePendingEscalation(value: unknown, details: Record<string, unknown>, detailField: string, thrower: NonSymphonyThrower): void {
+  if (!isRecord(value)) {
+    thrower(details, "state response field had an invalid shape", { field: detailField, expected: "object" });
+  }
+  validateRequiredString(value, "request_id", details, `${detailField}.request_id`, thrower);
+  validateRequiredString(value, "issue_id", details, `${detailField}.issue_id`, thrower);
+  validateRequiredString(value, "issue_identifier", details, `${detailField}.issue_identifier`, thrower);
+  validateRequiredString(value, "method", details, `${detailField}.method`, thrower);
+  validateRequiredString(value, "preview", details, `${detailField}.preview`, thrower);
+  validateRequiredString(value, "created_at", details, `${detailField}.created_at`, thrower);
+  validateRequiredNumber(value, "timeout_ms", details, `${detailField}.timeout_ms`, thrower);
 }
 
 function validateOptionalArray(value: Record<string, unknown>, field: string, details: Record<string, unknown>, detailField = field): void {
@@ -390,9 +587,22 @@ function validateOptionalNumberOrNull(value: Record<string, unknown>, field: str
   }
 }
 
-function validateRequiredString(value: Record<string, unknown>, field: string, details: Record<string, unknown>, detailField = field): void {
+function validateRequiredString(
+  value: Record<string, unknown>,
+  field: string,
+  details: Record<string, unknown>,
+  detailField = field,
+  thrower: NonSymphonyThrower = throwNonSymphonyState,
+): void {
   if (typeof value[field] !== "string") {
-    throwNonSymphonyState(details, "state response field had an invalid shape", { field: detailField, expected: "string" });
+    thrower(details, "state response field had an invalid shape", { field: detailField, expected: "string" });
+  }
+}
+
+function validateRequiredStringArray(value: Record<string, unknown>, field: string, details: Record<string, unknown>, detailField = field): void {
+  const fieldValue = value[field];
+  if (!Array.isArray(fieldValue) || fieldValue.some((entry) => typeof entry !== "string")) {
+    throwNonSymphonyState(details, "state response field had an invalid shape", { field: detailField, expected: "string[]" });
   }
 }
 
@@ -402,9 +612,15 @@ function validateRequiredBoolean(value: Record<string, unknown>, field: string, 
   }
 }
 
-function validateRequiredNumber(value: Record<string, unknown>, field: string, details: Record<string, unknown>, detailField = field): void {
+function validateRequiredNumber(
+  value: Record<string, unknown>,
+  field: string,
+  details: Record<string, unknown>,
+  detailField = field,
+  thrower: NonSymphonyThrower = throwNonSymphonyState,
+): void {
   if (!isFiniteNumber(value[field])) {
-    throwNonSymphonyState(details, "state response field had an invalid shape", { field: detailField, expected: "number" });
+    thrower(details, "state response field had an invalid shape", { field: detailField, expected: "number" });
   }
 }
 

--- a/apps/symphony/pi-extension/src/runtime.test.ts
+++ b/apps/symphony/pi-extension/src/runtime.test.ts
@@ -27,6 +27,7 @@ function lastKnownState(baseUrl: string): LastKnownSymphonyState {
 describe("SymphonyRuntime", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("clears the active attachment and last known state", () => {
@@ -183,6 +184,58 @@ describe("SymphonyRuntime", () => {
     expect(runtime.client?.steer).toHaveBeenCalledWith("SIM-123", "Use auth", undefined);
     expect(runtime.client?.getState).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalledWith("Symphony state refresh failed after steer", expect.any(Error));
+  });
+
+  it("responds to an escalation and refreshes state", async () => {
+    const runtime = new SymphonyRuntime();
+    const response = {
+      running: {},
+      retry_queue: [],
+      blocked: [],
+      completed: [],
+      polling: { checking: false, next_poll_in_ms: 1000, poll_interval_ms: 30000 },
+    };
+    const escalationResponse = { ok: true };
+    const escalationDecision = { approved: true };
+    runtime.client = {
+      respondEscalation: vi.fn(async () => escalationResponse),
+      getState: vi.fn(async () => response),
+      toHealthSummary: vi.fn(() => lastKnownState("http://127.0.0.1:8080")),
+    } as unknown as SymphonyRuntime["client"];
+
+    await expect(runtime.respondToEscalation("esc-1", escalationDecision)).resolves.toEqual({ ok: true });
+
+    expect(runtime.client?.respondEscalation).toHaveBeenCalledWith("esc-1", escalationDecision, "pi-dashboard", undefined);
+    expect(runtime.client?.getState).toHaveBeenCalledOnce();
+    expect(runtime.lastState).toBe(response);
+  });
+
+  it("returns escalation response result even if post-response refresh fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const runtime = new SymphonyRuntime();
+    runtime.client = {
+      respondEscalation: vi.fn(async () => ({ ok: true })),
+      getState: vi.fn(async () => {
+        throw new Error("temporary state fetch failure");
+      }),
+      toHealthSummary: vi.fn(() => lastKnownState("http://127.0.0.1:8080")),
+    } as unknown as SymphonyRuntime["client"];
+
+    await expect(runtime.respondToEscalation("esc-1", "approved")).resolves.toEqual({ ok: true });
+
+    expect(runtime.client?.respondEscalation).toHaveBeenCalledWith("esc-1", "approved", "pi-dashboard", undefined);
+    expect(runtime.client?.getState).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith("Symphony state refresh failed after escalation response", expect.any(Error));
+  });
+
+  it("retains recent escalation lifecycle events", () => {
+    const runtime = new SymphonyRuntime();
+
+    runtime.recordEvent({ version: "v1", sequence: 1, timestamp: "2026-05-14T12:00:00Z", kind: "escalation_created", severity: "info", event: "escalation_created", payload: {} });
+    runtime.recordEvent({ version: "v1", sequence: 2, timestamp: "2026-05-14T12:00:01Z", kind: "escalation_responded", severity: "info", event: "escalation_responded", payload: {} });
+    runtime.recordEvent({ version: "v1", sequence: 3, timestamp: "2026-05-14T12:00:02Z", kind: "heartbeat", severity: "info", event: "heartbeat", payload: {} });
+
+    expect(runtime.recentEvents.map((event) => event.kind)).toEqual(["escalation_created", "escalation_responded"]);
   });
 
   it("retains the most recent worker and runtime events", () => {

--- a/apps/symphony/pi-extension/src/runtime.ts
+++ b/apps/symphony/pi-extension/src/runtime.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resolveSymphonyBinary } from "./binary-resolver.ts";
 import { formatError, SymphonyExtensionError } from "./errors.ts";
-import { SymphonyHttpClient, type SteerResponse, type SymphonyEventEnvelope, type SymphonyStateResponse } from "./http-client.ts";
+import { SymphonyHttpClient, type EscalationRespondResponse, type SteerResponse, type SymphonyEventEnvelope, type SymphonyStateResponse } from "./http-client.ts";
 import { SymphonyProcessManager } from "./process-manager.ts";
 import {
   createDefaultState,
@@ -88,8 +88,19 @@ export class SymphonyRuntime {
     return result;
   }
 
+  async respondToEscalation(requestId: string, response: unknown, signal?: AbortSignal): Promise<EscalationRespondResponse> {
+    if (!this.client) throw new SymphonyExtensionError("no_attachment", "No Symphony server is attached");
+    const result = await this.client.respondEscalation(requestId, response, "pi-dashboard", signal);
+    try {
+      await this.refreshState(signal);
+    } catch (error) {
+      console.warn("Symphony state refresh failed after escalation response", error);
+    }
+    return result;
+  }
+
   recordEvent(event: SymphonyEventEnvelope): void {
-    if (event.kind !== "worker" && event.kind !== "runtime") return;
+    if (event.kind !== "worker" && event.kind !== "runtime" && !event.kind.startsWith("escalation_")) return;
     this.recentEvents = [...this.recentEvents, event].slice(-20);
   }
 

--- a/apps/symphony/pi-extension/src/wave3-mock-server.test.ts
+++ b/apps/symphony/pi-extension/src/wave3-mock-server.test.ts
@@ -32,6 +32,22 @@ describe("wave3 mock server script", () => {
     const afterResponse = await fetch(`${baseUrl}/api/v1/escalations`);
     await expect(afterResponse.json()).resolves.toEqual({ pending: [] });
   });
+
+  it("returns 400 for malformed escalation IDs without crashing", async () => {
+    const baseUrl = await startMockServer();
+
+    const response = await fetch(`${baseUrl}/api/v1/escalations/%E0%A4%A/respond`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ response: { approved: true }, responder_id: "pi-dashboard" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid_escalation_id" });
+
+    const stateResponse = await fetch(`${baseUrl}/api/v1/state`);
+    expect(stateResponse.status).toBe(200);
+  });
 });
 
 async function startMockServer(): Promise<string> {
@@ -41,6 +57,7 @@ async function startMockServer(): Promise<string> {
   });
 
   let stderr = "";
+  let stdout = "";
   child.stderr.on("data", (chunk) => {
     stderr += String(chunk);
   });
@@ -51,8 +68,8 @@ async function startMockServer(): Promise<string> {
     }, 5000);
 
     child?.stdout.on("data", (chunk) => {
-      const text = String(chunk);
-      const match = text.match(/Mock Symphony server: (http:\/\/[^\s]+)/);
+      stdout = (stdout + String(chunk)).slice(-2000);
+      const match = stdout.match(/Mock Symphony server: (http:\/\/[^\s]+)/);
       if (!match) return;
       clearTimeout(timeout);
       resolve(match[1]);

--- a/apps/symphony/pi-extension/src/wave3-mock-server.test.ts
+++ b/apps/symphony/pi-extension/src/wave3-mock-server.test.ts
@@ -1,0 +1,66 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+let child: ChildProcessWithoutNullStreams | undefined;
+
+afterEach(() => {
+  child?.kill();
+  child = undefined;
+});
+
+describe("wave3 mock server script", () => {
+  it("serves Wave 3 state and accepts escalation responses", async () => {
+    const baseUrl = await startMockServer();
+
+    const stateResponse = await fetch(`${baseUrl}/api/v1/state`);
+    const state = await stateResponse.json() as Record<string, unknown>;
+    expect(stateResponse.status).toBe(200);
+    expect(state).toMatchObject({
+      retry_queue: [expect.objectContaining({ identifier: "SIM-200", due_in_ms: 90000 })],
+      blocked: [expect.objectContaining({ identifier: "SIM-300", blocker_identifiers: ["SIM-100", "SIM-101"] })],
+      completed: [expect.objectContaining({ identifier: "SIM-400", completed_at: "2026-05-14T13:00:00Z" })],
+      pending_escalations: [expect.objectContaining({ request_id: "esc-1", preview: "Approve cargo test?" })],
+    });
+
+    const escalationResponse = await fetch(`${baseUrl}/api/v1/escalations/esc-1/respond`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ response: { approved: true }, responder_id: "pi-dashboard" }),
+    });
+    await expect(escalationResponse.json()).resolves.toEqual({ ok: true });
+
+    const afterResponse = await fetch(`${baseUrl}/api/v1/escalations`);
+    await expect(afterResponse.json()).resolves.toEqual({ pending: [] });
+  });
+});
+
+async function startMockServer(): Promise<string> {
+  child = spawn(process.execPath, ["scripts/wave3-mock-server.mjs", "--port", "0"], {
+    cwd: new URL("..", import.meta.url),
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`mock server did not start. stderr: ${stderr}`));
+    }, 5000);
+
+    child?.stdout.on("data", (chunk) => {
+      const text = String(chunk);
+      const match = text.match(/Mock Symphony server: (http:\/\/[^\s]+)/);
+      if (!match) return;
+      clearTimeout(timeout);
+      resolve(match[1]);
+    });
+
+    child?.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`mock server exited with code ${code}. stderr: ${stderr}`));
+    });
+  });
+}

--- a/docs/superpowers/plans/2026-05-16-wave-3-symphony-console-escalations.md
+++ b/docs/superpowers/plans/2026-05-16-wave-3-symphony-console-escalations.md
@@ -1,0 +1,1647 @@
+# Wave 3 Symphony Console Escalations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `@kata-sh/pi-symphony-extension` so the Pi console renders retry, blocked, completed, and pending escalation state, supports responding to escalations, and reflects escalation lifecycle events.
+
+**Architecture:** Keep Wave 3 in the existing pi-extension package. Add typed HTTP contracts to `http-client.ts`, keep view-model transformation in `console-model.ts`, keep interaction/rendering in `console.ts`, and expose escalation response through `SymphonyRuntime` so UI code does not call the client directly.
+
+**Tech Stack:** TypeScript, Vitest, Pi extension APIs, `@earendil-works/pi-tui`, Symphony HTTP API.
+
+---
+
+## Scope
+
+Implements Wave 3 from `docs/superpowers/specs/2026-05-14-pi-symphony-extension-design.md`:
+
+- Slice 3: render retry queue, blocked issues, completed issues, and a detail panel for running, retry, blocked, and completed states.
+- Slice 4: render pending escalations, support dashboard responses, and show escalation lifecycle events.
+
+## File Structure
+
+- Modify `apps/symphony/pi-extension/src/http-client.ts`
+  - Owns TypeScript API contracts and response validation for `GET /api/v1/state`, `GET /api/v1/escalations`, and `POST /api/v1/escalations/:request_id/respond`.
+- Modify `apps/symphony/pi-extension/src/http-client.test.ts`
+  - Mock HTTP tests for typed state entries, escalation list, escalation response, and API errors.
+- Modify `apps/symphony/pi-extension/src/runtime.ts`
+  - Adds `respondToEscalation()` and records escalation lifecycle events in recent activity.
+- Modify `apps/symphony/pi-extension/src/runtime.test.ts`
+  - Verifies response dispatch, refresh after response, and recent escalation events.
+- Modify `apps/symphony/pi-extension/src/console-model.ts`
+  - Builds issue rows for running, retry, blocked, and completed buckets; builds escalation rows; formats escalation lifecycle events.
+- Modify `apps/symphony/pi-extension/src/console-model.test.ts`
+  - Unit tests for row projection, detail fields, sorting, and escalation event formatting.
+- Modify `apps/symphony/pi-extension/src/console.ts`
+  - Renders the new sections, tracks a single linear selection across issue rows and escalation rows, responds to escalations, and keeps steering limited to selected running workers.
+- Modify `apps/symphony/pi-extension/src/console.test.ts`
+  - TUI rendering and key-handling tests for Wave 3.
+- Modify `apps/symphony/pi-extension/src/commands.ts`
+  - Updates console shortcut registrations and help text to include escalation response controls.
+- Modify `apps/symphony/pi-extension/src/commands.test.ts`
+  - Verifies shortcut registration and descriptions.
+- Modify `apps/symphony/pi-extension/README.md`
+  - Documents Wave 3 console keys and manual verification.
+
+## API shapes to preserve
+
+Use these Symphony HTTP fields already emitted by `apps/symphony/src/domain.rs` and `apps/symphony/src/http_server.rs`:
+
+```ts
+interface RetryQueueEntryResponse {
+  issue_id: string;
+  identifier: string;
+  attempt: number;
+  due_in_ms: number;
+  error?: string | null;
+  worker_host?: string | null;
+  workspace_path?: string | null;
+}
+
+interface BlockedIssueResponse {
+  issue_id: string;
+  identifier: string;
+  title: string;
+  state: string;
+  blocker_identifiers: string[];
+}
+
+interface CompletedIssueResponse {
+  issue_id: string;
+  identifier: string;
+  title: string;
+  completed_at?: string | null;
+  issue_url?: string | null;
+}
+
+interface PendingEscalationResponse {
+  request_id: string;
+  issue_id: string;
+  issue_identifier: string;
+  method: string;
+  preview: string;
+  created_at: string;
+  timeout_ms: number;
+}
+```
+
+---
+
+### Task 1: Add typed Wave 3 HTTP contracts
+
+**Files:**
+- Modify: `apps/symphony/pi-extension/src/http-client.ts`
+- Test: `apps/symphony/pi-extension/src/http-client.test.ts`
+
+- [ ] **Step 1: Write failing HTTP client tests**
+
+Append these tests inside the existing `describe("SymphonyHttpClient", () => { ... })` block in `apps/symphony/pi-extension/src/http-client.test.ts`:
+
+```ts
+  it("fetches typed Wave 3 state entries", async () => {
+    const baseUrl = await serve((req) => {
+      expect(req.url).toBe("/api/v1/state");
+      return {
+        status: 200,
+        body: validState({
+          retry_queue: [{ issue_id: "issue-retry", identifier: "SIM-2", attempt: 3, due_in_ms: 45000, error: "rate limit", worker_host: "host-a", workspace_path: "/tmp/retry" }],
+          blocked: [{ issue_id: "issue-blocked", identifier: "SIM-3", title: "Blocked work", state: "Todo", blocker_identifiers: ["SIM-1"] }],
+          pending_escalations: [{ request_id: "esc-1", issue_id: "issue-running", issue_identifier: "SIM-1", method: "approval", preview: "Approve command?", created_at: "2026-05-14T12:00:00Z", timeout_ms: 600000 }],
+          completed: [{ issue_id: "issue-done", identifier: "SIM-4", title: "Done work", completed_at: "2026-05-14T13:00:00Z" }],
+        }),
+      };
+    });
+
+    const client = new SymphonyHttpClient(baseUrl);
+    const state = await client.getState();
+
+    expect(state.retry_queue[0]).toMatchObject({ identifier: "SIM-2", attempt: 3, due_in_ms: 45000 });
+    expect(state.blocked[0]).toMatchObject({ identifier: "SIM-3", blocker_identifiers: ["SIM-1"] });
+    expect(state.pending_escalations[0]).toMatchObject({ request_id: "esc-1", issue_identifier: "SIM-1" });
+    expect(state.completed[0]).toMatchObject({ identifier: "SIM-4", completed_at: "2026-05-14T13:00:00Z" });
+  });
+
+  it("fetches pending escalations", async () => {
+    const baseUrl = await serve((req) => {
+      expect(req.method).toBe("GET");
+      expect(req.url).toBe("/api/v1/escalations");
+      return {
+        status: 200,
+        body: {
+          pending: [{ request_id: "esc-1", issue_id: "issue-running", issue_identifier: "SIM-1", method: "approval", preview: "Approve command?", created_at: "2026-05-14T12:00:00Z", timeout_ms: 600000 }],
+        },
+      };
+    });
+
+    const client = new SymphonyHttpClient(baseUrl);
+
+    await expect(client.getEscalations()).resolves.toEqual({
+      pending: [{ request_id: "esc-1", issue_id: "issue-running", issue_identifier: "SIM-1", method: "approval", preview: "Approve command?", created_at: "2026-05-14T12:00:00Z", timeout_ms: 600000 }],
+    });
+  });
+
+  it("responds to a pending escalation", async () => {
+    const baseUrl = await serve((req, body) => {
+      expect(req.method).toBe("POST");
+      expect(req.url).toBe("/api/v1/escalations/esc-1/respond");
+      expect(JSON.parse(body)).toEqual({ response: { approved: true }, responder_id: "pi-dashboard" });
+      return { status: 200, body: { ok: true } };
+    });
+
+    const client = new SymphonyHttpClient(baseUrl);
+
+    await expect(client.respondEscalation("esc-1", { approved: true }, "pi-dashboard")).resolves.toEqual({ ok: true });
+  });
+
+  it.each([
+    ["missing escalation", 404, { error: "escalation_not_found" }, "escalation_not_found"],
+    ["already resolved escalation", 409, { error: "escalation_already_resolved" }, "escalation_already_resolved"],
+  ])("normalizes escalation response errors: %s", async (_name, status, body, code) => {
+    const baseUrl = await serve(() => ({ status, body }));
+    const client = new SymphonyHttpClient(baseUrl);
+
+    await expect(client.respondEscalation("esc-1", "yes", "pi-dashboard")).rejects.toMatchObject({
+      kind: "api_error",
+      message: code,
+      details: expect.objectContaining({ code, status }),
+    } satisfies Partial<SymphonyExtensionError>);
+  });
+
+  it.each([
+    ["retry_queue entry", validState({ retry_queue: [{ identifier: "SIM-2" }] }), "retry_queue.0.issue_id"],
+    ["blocked entry", validState({ blocked: [{ issue_id: "issue-blocked", identifier: "SIM-3" }] }), "blocked.0.title"],
+    ["pending escalation", validState({ pending_escalations: [{ request_id: "esc-1" }] }), "pending_escalations.0.issue_id"],
+    ["completed entry", validState({ completed: [{ issue_id: "issue-done", identifier: "SIM-4" }] }), "completed.0.title"],
+  ])("rejects malformed Wave 3 state field: %s", async (_name, body, field) => {
+    const baseUrl = await serve(() => ({ status: 200, body }));
+    const client = new SymphonyHttpClient(baseUrl);
+
+    await expect(client.getState()).rejects.toMatchObject({
+      kind: "non_symphony_response",
+      details: expect.objectContaining({ field }),
+    } satisfies Partial<SymphonyExtensionError>);
+  });
+```
+
+- [ ] **Step 2: Run the failing HTTP client tests**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/http-client.test.ts
+```
+
+Expected: FAIL because `getEscalations`, `respondEscalation`, and typed Wave 3 state validators do not exist yet.
+
+- [ ] **Step 3: Add response interfaces and client methods**
+
+In `apps/symphony/pi-extension/src/http-client.ts`, replace the current untyped `retry_queue`, `blocked`, and `completed` fields with these exported interfaces and fields:
+
+```ts
+export interface RetryQueueEntryResponse {
+  issue_id: string;
+  identifier: string;
+  attempt: number;
+  due_in_ms: number;
+  error?: string | null;
+  worker_host?: string | null;
+  workspace_path?: string | null;
+}
+
+export interface BlockedIssueResponse {
+  issue_id: string;
+  identifier: string;
+  title: string;
+  state: string;
+  blocker_identifiers: string[];
+}
+
+export interface CompletedIssueResponse {
+  issue_id: string;
+  identifier: string;
+  title: string;
+  completed_at?: string | null;
+  issue_url?: string | null;
+}
+
+export interface PendingEscalationResponse {
+  request_id: string;
+  issue_id: string;
+  issue_identifier: string;
+  method: string;
+  preview: string;
+  created_at: string;
+  timeout_ms: number;
+}
+
+export interface EscalationListResponse {
+  pending: PendingEscalationResponse[];
+}
+
+export interface EscalationRespondResponse {
+  ok: boolean;
+}
+
+export interface SymphonyStateResponse {
+  tracker_project_url?: string | null;
+  running?: Record<string, RunAttemptResponse>;
+  running_sessions?: Record<string, RunningSessionSnapshotResponse>;
+  running_session_info?: Record<string, WorkerSessionInfoResponse>;
+  retry_queue: RetryQueueEntryResponse[];
+  blocked: BlockedIssueResponse[];
+  pending_escalations?: PendingEscalationResponse[];
+  completed: CompletedIssueResponse[];
+  polling?: {
+    checking?: boolean;
+    next_poll_in_ms?: number;
+    poll_interval_ms?: number;
+    poll_count?: number;
+    last_poll_at?: string | null;
+  };
+}
+```
+
+Add these methods to `SymphonyHttpClient` after `refresh()` and before `steer()`:
+
+```ts
+  async getEscalations(signal?: AbortSignal): Promise<EscalationListResponse> {
+    const path = "/api/v1/escalations";
+    const json = await this.requestJson(path, { method: "GET", signal });
+    return validateEscalationListResponse(json, { baseUrl: this.baseUrl, path });
+  }
+
+  async respondEscalation(requestId: string, response: unknown, responderId = "pi-dashboard", signal?: AbortSignal): Promise<EscalationRespondResponse> {
+    const path = `/api/v1/escalations/${encodeURIComponent(requestId)}/respond`;
+    const json = await this.requestJson(path, {
+      method: "POST",
+      signal,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ response, responder_id: responderId }),
+    });
+    return validateEscalationRespondResponse(json, { baseUrl: this.baseUrl, path, requestId });
+  }
+```
+
+- [ ] **Step 4: Validate Wave 3 state arrays**
+
+In `validateSymphonyStateResponse()`, replace the three optional array validations and the pending escalation optional validation with typed validators:
+
+```ts
+  validateRetryQueue(value.retry_queue, details);
+  validateBlockedIssues(value.blocked, details);
+  validateCompletedIssues(value.completed, details);
+  validatePendingEscalations(value.pending_escalations, details);
+```
+
+Add these validation functions near `validateRunningAttempts()`:
+
+```ts
+function validateRetryQueue(value: unknown, details: Record<string, unknown>): void {
+  validateOptionalArray({ retry_queue: value }, "retry_queue", details);
+  if (value === undefined) return;
+  for (const [index, entry] of value.entries()) {
+    const field = `retry_queue.${index}`;
+    if (!isRecord(entry)) throwNonSymphonyState(details, "state response field had an invalid shape", { field, expected: "object" });
+    validateRequiredString(entry, "issue_id", details, `${field}.issue_id`);
+    validateRequiredString(entry, "identifier", details, `${field}.identifier`);
+    validateRequiredNumber(entry, "attempt", details, `${field}.attempt`);
+    validateRequiredNumber(entry, "due_in_ms", details, `${field}.due_in_ms`);
+    validateOptionalStringOrNull(entry, "error", details, `${field}.error`);
+    validateOptionalStringOrNull(entry, "worker_host", details, `${field}.worker_host`);
+    validateOptionalStringOrNull(entry, "workspace_path", details, `${field}.workspace_path`);
+  }
+}
+
+function validateBlockedIssues(value: unknown, details: Record<string, unknown>): void {
+  validateOptionalArray({ blocked: value }, "blocked", details);
+  if (value === undefined) return;
+  for (const [index, entry] of value.entries()) {
+    const field = `blocked.${index}`;
+    if (!isRecord(entry)) throwNonSymphonyState(details, "state response field had an invalid shape", { field, expected: "object" });
+    validateRequiredString(entry, "issue_id", details, `${field}.issue_id`);
+    validateRequiredString(entry, "identifier", details, `${field}.identifier`);
+    validateRequiredString(entry, "title", details, `${field}.title`);
+    validateRequiredString(entry, "state", details, `${field}.state`);
+    validateStringArray(entry.blocker_identifiers, details, `${field}.blocker_identifiers`);
+  }
+}
+
+function validateCompletedIssues(value: unknown, details: Record<string, unknown>): void {
+  validateOptionalArray({ completed: value }, "completed", details);
+  if (value === undefined) return;
+  for (const [index, entry] of value.entries()) {
+    const field = `completed.${index}`;
+    if (!isRecord(entry)) throwNonSymphonyState(details, "state response field had an invalid shape", { field, expected: "object" });
+    validateRequiredString(entry, "issue_id", details, `${field}.issue_id`);
+    validateRequiredString(entry, "identifier", details, `${field}.identifier`);
+    validateRequiredString(entry, "title", details, `${field}.title`);
+    validateOptionalStringOrNull(entry, "completed_at", details, `${field}.completed_at`);
+    validateOptionalStringOrNull(entry, "issue_url", details, `${field}.issue_url`);
+  }
+}
+
+function validatePendingEscalations(value: unknown, details: Record<string, unknown>): void {
+  if (value === undefined) return;
+  validateOptionalArray({ pending_escalations: value }, "pending_escalations", details);
+  for (const [index, entry] of value.entries()) {
+    validatePendingEscalation(entry, details, `pending_escalations.${index}`);
+  }
+}
+
+function validatePendingEscalation(value: unknown, details: Record<string, unknown>, field: string): void {
+  if (!isRecord(value)) throwNonSymphonyState(details, "state response field had an invalid shape", { field, expected: "object" });
+  validateRequiredString(value, "request_id", details, `${field}.request_id`);
+  validateRequiredString(value, "issue_id", details, `${field}.issue_id`);
+  validateRequiredString(value, "issue_identifier", details, `${field}.issue_identifier`);
+  validateRequiredString(value, "method", details, `${field}.method`);
+  validateRequiredString(value, "preview", details, `${field}.preview`);
+  validateRequiredString(value, "created_at", details, `${field}.created_at`);
+  validateRequiredNumber(value, "timeout_ms", details, `${field}.timeout_ms`);
+}
+
+function validateStringArray(value: unknown, details: Record<string, unknown>, field: string): void {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throwNonSymphonyState(details, "state response field had an invalid shape", { field, expected: "string[]" });
+  }
+}
+```
+
+Add escalation endpoint validators near `validateSteerResponse()`:
+
+```ts
+function validateEscalationListResponse(value: unknown, details: Record<string, unknown>): EscalationListResponse {
+  if (!isRecord(value)) {
+    throwNonSymphonyEscalations(details, "escalations response was not an object");
+  }
+  if (!Array.isArray(value.pending)) {
+    throwNonSymphonyEscalations(details, "escalations response field had an invalid shape", { field: "pending", expected: "array" });
+  }
+  for (const [index, entry] of value.pending.entries()) {
+    validatePendingEscalation(entry, details, `pending.${index}`);
+  }
+  return { pending: value.pending as PendingEscalationResponse[] };
+}
+
+function validateEscalationRespondResponse(value: unknown, details: Record<string, unknown>): EscalationRespondResponse {
+  if (!isRecord(value)) {
+    throwNonSymphonyEscalations(details, "escalation response was not an object");
+  }
+  if (typeof value.ok !== "boolean") {
+    throwNonSymphonyEscalations(details, "escalation response field had an invalid shape", { field: "ok", expected: "boolean" });
+  }
+  return { ok: value.ok };
+}
+
+function throwNonSymphonyEscalations(details: Record<string, unknown>, reason: string, extraDetails: Record<string, unknown> = {}): never {
+  throw new SymphonyExtensionError("non_symphony_response", "Response did not look like Symphony escalation response", {
+    ...details,
+    reason,
+    ...extraDetails,
+  });
+}
+```
+
+- [ ] **Step 5: Normalize simple escalation error bodies**
+
+In `requestJson()`, replace the `if (!response.ok) { ... }` block with:
+
+```ts
+    if (!response.ok) {
+      const envelope = parseApiErrorEnvelope(json);
+      if (envelope?.error?.message) {
+        throw new SymphonyExtensionError("api_error", envelope.error.message, {
+          url,
+          status: response.status,
+          code: envelope.error.code,
+          details: envelope.error.details,
+        });
+      }
+      if (isRecord(json) && typeof json.error === "string") {
+        throw new SymphonyExtensionError("api_error", json.error, {
+          url,
+          status: response.status,
+          code: json.error,
+        });
+      }
+      throw new SymphonyExtensionError("non_symphony_response", "Symphony HTTP API returned an unexpected error response", {
+        url,
+        status: response.status,
+        body: json,
+      });
+    }
+```
+
+- [ ] **Step 6: Run HTTP client tests and commit**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/http-client.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add apps/symphony/pi-extension/src/http-client.ts apps/symphony/pi-extension/src/http-client.test.ts
+git commit -m "feat(pi-symphony): add wave 3 http contracts"
+```
+
+---
+
+### Task 2: Build Wave 3 console view models
+
+**Files:**
+- Modify: `apps/symphony/pi-extension/src/console-model.ts`
+- Test: `apps/symphony/pi-extension/src/console-model.test.ts`
+
+- [ ] **Step 1: Write failing console-model tests**
+
+Update the import in `apps/symphony/pi-extension/src/console-model.test.ts`:
+
+```ts
+import { buildEscalationRows, buildIssueRows, buildWorkerRows, formatEventRows } from "./console-model.ts";
+```
+
+Add this test after `builds sorted worker rows with selected-worker detail fields`:
+
+```ts
+  it("builds issue rows for running, retry, blocked, and completed buckets", () => {
+    const state: SymphonyStateResponse = {
+      ...stateFixture(),
+      retry_queue: [{ issue_id: "issue-retry", identifier: "SIM-200", attempt: 3, due_in_ms: 90000, error: "rate limit", worker_host: "host-b", workspace_path: "/tmp/retry" }],
+      blocked: [{ issue_id: "issue-blocked", identifier: "SIM-300", title: "Blocked work", state: "Todo", blocker_identifiers: ["SIM-100", "SIM-101"] }],
+      completed: [{ issue_id: "issue-done", identifier: "SIM-400", title: "Done work", completed_at: "2026-05-14T13:00:00Z" }],
+    };
+
+    const rows = buildIssueRows(state);
+
+    expect(rows.map((row) => `${row.kind}:${row.issueIdentifier}`)).toEqual([
+      "running:SIM-123",
+      "running:SIM-777",
+      "retry:SIM-200",
+      "blocked:SIM-300",
+      "completed:SIM-400",
+    ]);
+    expect(rows.find((row) => row.kind === "retry")).toMatchObject({
+      issueIdentifier: "SIM-200",
+      title: "rate limit",
+      status: "retry in 1m 30s",
+      attempt: "3",
+      workerHost: "host-b",
+      workspacePath: "/tmp/retry",
+      errorPreview: "rate limit",
+    });
+    expect(rows.find((row) => row.kind === "blocked")).toMatchObject({
+      issueIdentifier: "SIM-300",
+      title: "Blocked work",
+      status: "Todo",
+      blockers: "SIM-100, SIM-101",
+    });
+    expect(rows.find((row) => row.kind === "completed")).toMatchObject({
+      issueIdentifier: "SIM-400",
+      title: "Done work",
+      status: "completed",
+      completedAt: "2026-05-14T13:00:00Z",
+    });
+  });
+
+  it("builds pending escalation rows sorted by creation time", () => {
+    const state: SymphonyStateResponse = {
+      ...stateFixture(),
+      pending_escalations: [
+        { request_id: "esc-2", issue_id: "issue-777", issue_identifier: "SIM-777", method: "input", preview: "Need details", created_at: "2026-05-14T12:02:00Z", timeout_ms: 300000 },
+        { request_id: "esc-1", issue_id: "issue-123", issue_identifier: "SIM-123", method: "approval", preview: "Approve command", created_at: "2026-05-14T12:01:00Z", timeout_ms: 600000 },
+      ],
+    };
+
+    const rows = buildEscalationRows(state);
+
+    expect(rows.map((row) => row.requestId)).toEqual(["esc-1", "esc-2"]);
+    expect(rows[0]).toMatchObject({ issueIdentifier: "SIM-123", method: "approval", preview: "Approve command", timeout: "10m 0s" });
+  });
+```
+
+Add this escalation event formatting test after the existing event tests:
+
+```ts
+  it("formats escalation lifecycle events", () => {
+    const events: SymphonyEventEnvelope[] = [
+      { version: "v1", sequence: 1, timestamp: "2026-05-14T12:00:00Z", kind: "escalation_created", severity: "info", issue: "SIM-123", event: "escalation_created", payload: { summary: "SIM-123 needs input: approval" } },
+      { version: "v1", sequence: 2, timestamp: "2026-05-14T12:01:00Z", kind: "escalation_responded", severity: "info", issue: "SIM-123", event: "escalation_responded", payload: { summary: "request esc-1 responded by pi-dashboard in 300ms" } },
+      { version: "v1", sequence: 3, timestamp: "2026-05-14T12:02:00Z", kind: "escalation_timed_out", severity: "warn", issue: "SIM-456", event: "escalation_timed_out", payload: { summary: "request esc-2 timed out after 600000ms" } },
+    ];
+
+    expect(formatEventRows(events)).toEqual([
+      "2026-05-14T12:02:00Z warn escalation_timed_out SIM-456 escalation_timed_out request esc-2 timed out after 600000ms",
+      "2026-05-14T12:01:00Z info escalation_responded SIM-123 escalation_responded request esc-1 responded by pi-dashboard in 300ms",
+      "2026-05-14T12:00:00Z info escalation_created SIM-123 escalation_created SIM-123 needs input: approval",
+    ]);
+  });
+```
+
+- [ ] **Step 2: Run the failing console-model tests**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/console-model.test.ts
+```
+
+Expected: FAIL because `buildIssueRows`, `buildEscalationRows`, and escalation event filtering do not exist yet.
+
+- [ ] **Step 3: Add issue and escalation row interfaces**
+
+In `apps/symphony/pi-extension/src/console-model.ts`, replace the first import with:
+
+```ts
+import type { PendingEscalationResponse, RunAttemptResponse, SymphonyEventEnvelope, SymphonyStateResponse } from "./http-client.ts";
+```
+
+Add these interfaces after `WorkerRow`:
+
+```ts
+export type IssueRowKind = "running" | "retry" | "blocked" | "completed";
+
+export interface IssueRow {
+  kind: IssueRowKind;
+  issueId: string;
+  issueIdentifier: string;
+  title: string;
+  status: string;
+  trackerState: string;
+  attempt: string;
+  turnCount: string;
+  maxTurns: string;
+  lastActivity: string;
+  workerHost: string;
+  workspacePath: string;
+  errorPreview: string;
+  blockers: string;
+  completedAt: string;
+}
+
+export interface EscalationRow {
+  requestId: string;
+  issueId: string;
+  issueIdentifier: string;
+  method: string;
+  preview: string;
+  createdAt: string;
+  timeout: string;
+}
+```
+
+- [ ] **Step 4: Add issue row builders**
+
+Add these functions after `buildWorkerRows()`:
+
+```ts
+export function buildIssueRows(state: SymphonyStateResponse | undefined): IssueRow[] {
+  if (!state) return [];
+  return [
+    ...buildWorkerRows(state).map(workerToIssueRow),
+    ...state.retry_queue.map(retry => ({
+      kind: "retry" as const,
+      issueId: retry.issue_id,
+      issueIdentifier: retry.identifier,
+      title: retry.error ?? "pending retry",
+      status: `retry in ${formatDuration(retry.due_in_ms)}`,
+      trackerState: "retry",
+      attempt: String(retry.attempt),
+      turnCount: "-",
+      maxTurns: "-",
+      lastActivity: "-",
+      workerHost: retry.worker_host ?? "local",
+      workspacePath: retry.workspace_path ?? "-",
+      errorPreview: retry.error ? truncateText(retry.error, 120) : "-",
+      blockers: "-",
+      completedAt: "-",
+    })).sort((left, right) => left.issueIdentifier.localeCompare(right.issueIdentifier)),
+    ...state.blocked.map(blocked => ({
+      kind: "blocked" as const,
+      issueId: blocked.issue_id,
+      issueIdentifier: blocked.identifier,
+      title: blocked.title,
+      status: blocked.state,
+      trackerState: blocked.state,
+      attempt: "-",
+      turnCount: "-",
+      maxTurns: "-",
+      lastActivity: "-",
+      workerHost: "-",
+      workspacePath: "-",
+      errorPreview: "-",
+      blockers: blocked.blocker_identifiers.length > 0 ? blocked.blocker_identifiers.join(", ") : "-",
+      completedAt: "-",
+    })).sort((left, right) => left.issueIdentifier.localeCompare(right.issueIdentifier)),
+    ...state.completed.map(completed => ({
+      kind: "completed" as const,
+      issueId: completed.issue_id,
+      issueIdentifier: completed.identifier,
+      title: completed.title,
+      status: "completed",
+      trackerState: "completed",
+      attempt: "-",
+      turnCount: "-",
+      maxTurns: "-",
+      lastActivity: completed.completed_at ?? "-",
+      workerHost: "-",
+      workspacePath: "-",
+      errorPreview: "-",
+      blockers: "-",
+      completedAt: completed.completed_at ?? "-",
+    })).sort((left, right) => left.issueIdentifier.localeCompare(right.issueIdentifier)),
+  ];
+}
+
+function workerToIssueRow(worker: WorkerRow): IssueRow {
+  return {
+    kind: "running",
+    issueId: worker.issueId,
+    issueIdentifier: worker.issueIdentifier,
+    title: worker.title,
+    status: worker.status,
+    trackerState: worker.trackerState,
+    attempt: worker.attempt,
+    turnCount: worker.turnCount,
+    maxTurns: worker.maxTurns,
+    lastActivity: worker.lastActivity,
+    workerHost: worker.workerHost,
+    workspacePath: worker.workspacePath,
+    errorPreview: worker.errorPreview,
+    blockers: "-",
+    completedAt: "-",
+  };
+}
+```
+
+- [ ] **Step 5: Add escalation row builders and duration formatting**
+
+Add these functions after `buildIssueRows()`:
+
+```ts
+export function buildEscalationRows(state: SymphonyStateResponse | undefined): EscalationRow[] {
+  return [...(state?.pending_escalations ?? [])]
+    .sort(compareEscalations)
+    .map(escalation => ({
+      requestId: escalation.request_id,
+      issueId: escalation.issue_id,
+      issueIdentifier: escalation.issue_identifier,
+      method: escalation.method,
+      preview: truncateText(escalation.preview, 120),
+      createdAt: escalation.created_at,
+      timeout: formatDuration(escalation.timeout_ms),
+    }));
+}
+
+function compareEscalations(left: PendingEscalationResponse, right: PendingEscalationResponse): number {
+  const leftTime = Date.parse(left.created_at);
+  const rightTime = Date.parse(right.created_at);
+  if (Number.isFinite(leftTime) && Number.isFinite(rightTime) && leftTime !== rightTime) return leftTime - rightTime;
+  return left.request_id.localeCompare(right.request_id);
+}
+
+function formatDuration(milliseconds: number): string {
+  if (!Number.isFinite(milliseconds) || milliseconds <= 0) return "0s";
+  const totalSeconds = Math.ceil(milliseconds / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+}
+```
+
+- [ ] **Step 6: Include escalation lifecycle events in recent activity**
+
+In `formatEventRows()`, replace the current filter with:
+
+```ts
+    .filter((event) => event.kind === "worker" || event.kind === "runtime" || event.kind.startsWith("escalation_"))
+```
+
+- [ ] **Step 7: Run console-model tests and commit**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/console-model.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add apps/symphony/pi-extension/src/console-model.ts apps/symphony/pi-extension/src/console-model.test.ts
+git commit -m "feat(pi-symphony): model wave 3 console rows"
+```
+
+---
+
+### Task 3: Render retry, blocked, completed, and issue details
+
+**Files:**
+- Modify: `apps/symphony/pi-extension/src/console.ts`
+- Test: `apps/symphony/pi-extension/src/console.test.ts`
+
+- [ ] **Step 1: Write failing console rendering tests**
+
+In `apps/symphony/pi-extension/src/console.test.ts`, update `workerStateFixture()` so `retry_queue`, `blocked`, and `completed` contain Wave 3 entries:
+
+```ts
+    retry_queue: [{ issue_id: "issue-retry", identifier: "SIM-200", attempt: 3, due_in_ms: 90000, error: "rate limit", worker_host: "host-b", workspace_path: "/tmp/retry" }],
+    blocked: [{ issue_id: "issue-blocked", identifier: "SIM-300", title: "Blocked work", state: "Todo", blocker_identifiers: ["SIM-100", "SIM-101"] }],
+    completed: [{ issue_id: "issue-done", identifier: "SIM-400", title: "Done work", completed_at: "2026-05-14T13:00:00Z" }],
+```
+
+Add this test after `renders running workers, selected-worker details, and recent runtime events`:
+
+```ts
+  it("renders retry, blocked, completed, and selected issue details", () => {
+    const state = createDefaultState();
+    state.console.showDetails = true;
+    const consoleComponent = new SymphonyConsoleComponent({
+      state,
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation: async () => undefined,
+      prompt: async () => undefined,
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify: () => undefined,
+    });
+
+    let output = consoleComponent.render(180).join("\n");
+    expect(output).toContain("Retry Queue");
+    expect(output).toContain("SIM-200");
+    expect(output).toContain("retry in 1m 30s");
+    expect(output).toContain("Blocked Issues");
+    expect(output).toContain("SIM-300");
+    expect(output).toContain("SIM-100, SIM-101");
+    expect(output).toContain("Completed Issues");
+    expect(output).toContain("SIM-400");
+    expect(output).toContain("2026-05-14T13:00:00Z");
+    expect(output).toContain("Selected Issue");
+    expect(output).toContain("kind: running");
+
+    consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("\u001b[B");
+    output = consoleComponent.render(180).join("\n");
+    expect(output).toContain("issue: SIM-200 rate limit");
+    expect(output).toContain("kind: retry");
+    expect(output).toContain("status: retry in 1m 30s");
+    expect(output).toContain("workspace: /tmp/retry");
+
+    consoleComponent.handleInput("\u001b[B");
+    output = consoleComponent.render(180).join("\n");
+    expect(output).toContain("issue: SIM-300 Blocked work");
+    expect(output).toContain("kind: blocked");
+    expect(output).toContain("blockers: SIM-100, SIM-101");
+
+    consoleComponent.handleInput("\u001b[B");
+    output = consoleComponent.render(180).join("\n");
+    expect(output).toContain("issue: SIM-400 Done work");
+    expect(output).toContain("kind: completed");
+    expect(output).toContain("completed at: 2026-05-14T13:00:00Z");
+  });
+
+  it("only steers when a running worker is selected", async () => {
+    const notify = vi.fn();
+    const steer = vi.fn(async () => undefined);
+    const consoleComponent = new SymphonyConsoleComponent({
+      state: createDefaultState(),
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer,
+      respondToEscalation: async () => undefined,
+      prompt: async () => "Use auth",
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify,
+    });
+
+    consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("s");
+    await expect.poll(() => notify.mock.calls.length, { interval: 10, timeout: 1000 }).toBe(1);
+
+    expect(steer).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith("Select a running worker before steering", "warning");
+  });
+```
+
+Update every existing `new SymphonyConsoleComponent({ ... })` construction in `console.test.ts` to include:
+
+```ts
+      respondToEscalation: async () => undefined,
+```
+
+- [ ] **Step 2: Run the failing console tests**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/console.test.ts
+```
+
+Expected: FAIL because the console only renders running workers and uses worker-only selection.
+
+- [ ] **Step 3: Change console imports and options**
+
+In `apps/symphony/pi-extension/src/console.ts`, replace the console-model import with:
+
+```ts
+import { buildEscalationRows, buildIssueRows, buildWorkerRows, formatEventRows, type EscalationRow, type IssueRow, type WorkerRow } from "./console-model.ts";
+```
+
+Update `ConsoleShortcutAction`:
+
+```ts
+export type ConsoleShortcutAction = "selectPrevious" | "selectNext" | "refresh" | "steer" | "respondEscalation" | "toggleDetails" | "close";
+```
+
+Add `respondToEscalation` to `ConsoleOptions`:
+
+```ts
+  respondToEscalation: (requestId: string, response: unknown) => Promise<void>;
+```
+
+In `handleActiveConsoleShortcut()`, add:
+
+```ts
+    case "respondEscalation":
+      await activeConsole.respondToEscalationNow();
+      return;
+```
+
+- [ ] **Step 4: Track selection across issue rows**
+
+In `SymphonyConsoleComponent`, replace `private selectedWorkerIndex = 0;` with:
+
+```ts
+  private selectedIndex = 0;
+```
+
+In `render()`, replace the worker-only row setup with:
+
+```ts
+    const symphonyState = this.options.getState();
+    const issueRows = buildIssueRows(symphonyState);
+    const escalationRows = buildEscalationRows(symphonyState);
+    this.clampSelection(issueRows.length + escalationRows.length);
+    const selectedIssue = issueRows[this.selectedIndex];
+```
+
+Keep `workers` for count fallback by adding:
+
+```ts
+    const workers = buildWorkerRows(symphonyState);
+```
+
+Replace the running table and selected detail sections in `lines` with:
+
+```ts
+      ...boxLines("Running Workers", renderIssueTable(issueRows.filter((row) => row.kind === "running"), issueRows, this.selectedIndex, theme), consoleWidth, theme),
+      ...boxLines("Retry Queue", renderIssueTable(issueRows.filter((row) => row.kind === "retry"), issueRows, this.selectedIndex, theme), consoleWidth, theme),
+      ...boxLines("Blocked Issues", renderIssueTable(issueRows.filter((row) => row.kind === "blocked"), issueRows, this.selectedIndex, theme), consoleWidth, theme),
+      ...boxLines("Completed Issues", renderIssueTable(issueRows.filter((row) => row.kind === "completed"), issueRows, this.selectedIndex, theme), consoleWidth, theme),
+      ...boxLines("Selected Issue", renderSelectedIssueDetails(selectedIssue, state.console.showDetails, theme), consoleWidth, theme),
+```
+
+- [ ] **Step 5: Update movement and steering**
+
+Replace `moveSelection()` and `clampSelection()` with:
+
+```ts
+  private moveSelection(delta: number): void {
+    const state = this.options.getState();
+    const selectableCount = buildIssueRows(state).length + buildEscalationRows(state).length;
+    if (selectableCount === 0) return;
+    this.selectedIndex = Math.max(0, Math.min(selectableCount - 1, this.selectedIndex + delta));
+    this.options.requestRender();
+  }
+
+  private clampSelection(selectableCount: number): void {
+    if (selectableCount === 0) {
+      this.selectedIndex = 0;
+      return;
+    }
+    this.selectedIndex = Math.max(0, Math.min(selectableCount - 1, this.selectedIndex));
+  }
+```
+
+Replace `steerSelectedWorker()` with:
+
+```ts
+  private async steerSelectedWorker(): Promise<void> {
+    const issueRows = buildIssueRows(this.options.getState());
+    this.clampSelection(issueRows.length + buildEscalationRows(this.options.getState()).length);
+    const issue = issueRows[this.selectedIndex];
+    if (!issue || issue.kind !== "running") {
+      this.options.notify("Select a running worker before steering", "warning");
+      return;
+    }
+
+    try {
+      const instruction = (await this.options.prompt("Steer Symphony worker", `Instruction for ${issue.issueIdentifier}`))?.trim();
+      if (!instruction) return;
+
+      await this.options.steer(issue.issueIdentifier, instruction);
+      this.options.notify(`Steer delivered to ${issue.issueIdentifier}`, "info");
+    } catch (error) {
+      this.options.notify(error instanceof Error ? error.message : String(error), "error");
+    } finally {
+      this.options.requestRender();
+    }
+  }
+```
+
+- [ ] **Step 6: Add issue render helpers**
+
+Replace `renderWorkerTable()` and `renderSelectedWorkerDetails()` with:
+
+```ts
+function renderIssueTable(rows: IssueRow[], allIssueRows: IssueRow[], selectedIndex: number, theme?: ConsoleTheme): string[] {
+  const lines = [color(theme, "dim", "sel issue    kind       status              attempt host      detail")];
+  if (rows.length === 0) return [...lines, color(theme, "dim", "-   none")];
+
+  for (const row of rows) {
+    const globalIndex = allIssueRows.indexOf(row);
+    const selected = globalIndex === selectedIndex ? ">" : " ";
+    const detail = row.kind === "blocked" ? row.blockers : row.kind === "completed" ? row.completedAt : row.errorPreview;
+    const line = [
+      selected,
+      pad(row.issueIdentifier, 8),
+      pad(row.kind, 10),
+      pad(row.status, 19),
+      pad(row.attempt, 7),
+      pad(row.workerHost, 9),
+      detail,
+    ].join(" ");
+    lines.push(globalIndex === selectedIndex ? selectedLine(theme, line) : line);
+  }
+  return lines;
+}
+
+function renderSelectedIssueDetails(issue: IssueRow | undefined, showDetails: boolean, theme?: ConsoleTheme): string[] {
+  if (!showDetails) return [];
+  if (!issue) return [color(theme, "dim", "none")];
+  const lines = [
+    `issue: ${color(theme, "accent", issue.issueIdentifier)} ${issue.title}`,
+    `kind: ${issue.kind}`,
+    `status: ${color(theme, issue.kind === "blocked" ? "error" : issue.kind === "retry" ? "warning" : "success", issue.status)}`,
+  ];
+  if (issue.kind === "running") {
+    lines.push(
+      `tracker state: ${color(theme, "success", issue.trackerState)}`,
+      `attempt: ${issue.attempt}`,
+      `turns: ${issue.turnCount} / ${issue.maxTurns}`,
+      `last activity: ${color(theme, "dim", issue.lastActivity)}`,
+      `worker host: ${issue.workerHost}`,
+      `workspace: ${color(theme, "dim", issue.workspacePath)}`,
+      `error: ${issue.errorPreview === "-" ? color(theme, "dim", issue.errorPreview) : color(theme, "error", issue.errorPreview)}`,
+    );
+  }
+  if (issue.kind === "retry") {
+    lines.push(
+      `attempt: ${issue.attempt}`,
+      `worker host: ${issue.workerHost}`,
+      `workspace: ${color(theme, "dim", issue.workspacePath)}`,
+      `error: ${issue.errorPreview === "-" ? color(theme, "dim", issue.errorPreview) : color(theme, "error", issue.errorPreview)}`,
+    );
+  }
+  if (issue.kind === "blocked") {
+    lines.push(`blockers: ${color(theme, "warning", issue.blockers)}`);
+  }
+  if (issue.kind === "completed") {
+    lines.push(`completed at: ${color(theme, "dim", issue.completedAt)}`);
+  }
+  return lines;
+}
+```
+
+- [ ] **Step 7: Run console tests and commit**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/console.test.ts
+```
+
+Expected: PASS after updating earlier worker-specific assertions to expect `Selected Issue` instead of `Selected Worker` where needed.
+
+Commit:
+
+```bash
+git add apps/symphony/pi-extension/src/console.ts apps/symphony/pi-extension/src/console.test.ts
+git commit -m "feat(pi-symphony): render wave 3 issue buckets"
+```
+
+---
+
+### Task 4: Record escalation lifecycle events and respond through runtime
+
+**Files:**
+- Modify: `apps/symphony/pi-extension/src/runtime.ts`
+- Test: `apps/symphony/pi-extension/src/runtime.test.ts`
+
+- [ ] **Step 1: Write failing runtime tests**
+
+Append these tests inside `describe("SymphonyRuntime", () => { ... })` in `apps/symphony/pi-extension/src/runtime.test.ts`:
+
+```ts
+  it("responds to an escalation and refreshes state", async () => {
+    const runtime = new SymphonyRuntime();
+    const response = {
+      running: {},
+      retry_queue: [],
+      blocked: [],
+      completed: [],
+      pending_escalations: [],
+      polling: { checking: false, next_poll_in_ms: 1000, poll_interval_ms: 30000 },
+    };
+    runtime.client = {
+      respondEscalation: vi.fn(async () => ({ ok: true })),
+      getState: vi.fn(async () => response),
+      toHealthSummary: vi.fn(() => lastKnownState("http://127.0.0.1:8080")),
+    } as unknown as SymphonyRuntime["client"];
+
+    await expect(runtime.respondToEscalation("esc-1", { approved: true })).resolves.toEqual({ ok: true });
+
+    expect(runtime.client?.respondEscalation).toHaveBeenCalledWith("esc-1", { approved: true }, "pi-dashboard", undefined);
+    expect(runtime.client?.getState).toHaveBeenCalledOnce();
+    expect(runtime.lastState).toBe(response);
+  });
+
+  it("returns escalation response result even if post-response refresh fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const runtime = new SymphonyRuntime();
+    runtime.client = {
+      respondEscalation: vi.fn(async () => ({ ok: true })),
+      getState: vi.fn(async () => {
+        throw new Error("temporary state fetch failure");
+      }),
+      toHealthSummary: vi.fn(() => lastKnownState("http://127.0.0.1:8080")),
+    } as unknown as SymphonyRuntime["client"];
+
+    await expect(runtime.respondToEscalation("esc-1", "approved")).resolves.toEqual({ ok: true });
+
+    expect(warn).toHaveBeenCalledWith("Symphony state refresh failed after escalation response", expect.any(Error));
+  });
+
+  it("retains recent escalation lifecycle events", () => {
+    const runtime = new SymphonyRuntime();
+
+    runtime.recordEvent({ version: "v1", sequence: 1, timestamp: "2026-05-14T12:00:00Z", kind: "escalation_created", severity: "info", issue: "SIM-123", event: "escalation_created", payload: {} });
+    runtime.recordEvent({ version: "v1", sequence: 2, timestamp: "2026-05-14T12:01:00Z", kind: "escalation_responded", severity: "info", issue: "SIM-123", event: "escalation_responded", payload: {} });
+    runtime.recordEvent({ version: "v1", sequence: 3, timestamp: "2026-05-14T12:02:00Z", kind: "heartbeat", severity: "info", event: "heartbeat", payload: {} });
+
+    expect(runtime.recentEvents.map((event) => event.kind)).toEqual(["escalation_created", "escalation_responded"]);
+  });
+```
+
+- [ ] **Step 2: Run failing runtime tests**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/runtime.test.ts
+```
+
+Expected: FAIL because `respondToEscalation()` does not exist and escalation events are ignored.
+
+- [ ] **Step 3: Add runtime response method**
+
+In `apps/symphony/pi-extension/src/runtime.ts`, update the import from `http-client.ts`:
+
+```ts
+import { SymphonyHttpClient, type EscalationRespondResponse, type SteerResponse, type SymphonyEventEnvelope, type SymphonyStateResponse } from "./http-client.ts";
+```
+
+Add this method after `steerWorker()`:
+
+```ts
+  async respondToEscalation(requestId: string, response: unknown, signal?: AbortSignal): Promise<EscalationRespondResponse> {
+    if (!this.client) throw new SymphonyExtensionError("no_attachment", "No Symphony server is attached");
+    const result = await this.client.respondEscalation(requestId, response, "pi-dashboard", signal);
+    try {
+      await this.refreshState(signal);
+    } catch (error) {
+      console.warn("Symphony state refresh failed after escalation response", error);
+    }
+    return result;
+  }
+```
+
+Replace `recordEvent()` with:
+
+```ts
+  recordEvent(event: SymphonyEventEnvelope): void {
+    if (event.kind !== "worker" && event.kind !== "runtime" && !event.kind.startsWith("escalation_")) return;
+    this.recentEvents = [...this.recentEvents, event].slice(-20);
+  }
+```
+
+- [ ] **Step 4: Run runtime tests and commit**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/runtime.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add apps/symphony/pi-extension/src/runtime.ts apps/symphony/pi-extension/src/runtime.test.ts
+git commit -m "feat(pi-symphony): respond to escalations through runtime"
+```
+
+---
+
+### Task 5: Render pending escalations and dashboard response flow
+
+**Files:**
+- Modify: `apps/symphony/pi-extension/src/console.ts`
+- Test: `apps/symphony/pi-extension/src/console.test.ts`
+
+- [ ] **Step 1: Write failing escalation UI tests**
+
+In `workerStateFixture()` in `apps/symphony/pi-extension/src/console.test.ts`, add:
+
+```ts
+    pending_escalations: [{ request_id: "esc-1", issue_id: "issue-123", issue_identifier: "SIM-123", method: "approval", preview: "Approve cargo test?", created_at: "2026-05-14T12:06:00Z", timeout_ms: 600000 }],
+```
+
+Add these tests after the Wave 3 issue rendering test:
+
+```ts
+  it("renders pending escalations and selected escalation details", () => {
+    const state = createDefaultState();
+    state.console.showDetails = true;
+    const consoleComponent = new SymphonyConsoleComponent({
+      state,
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation: async () => undefined,
+      prompt: async () => undefined,
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify: () => undefined,
+    });
+
+    for (let index = 0; index < 5; index += 1) consoleComponent.handleInput("\u001b[B");
+
+    const output = consoleComponent.render(180).join("\n");
+    expect(output).toContain("Pending Escalations");
+    expect(output).toContain("> esc-1");
+    expect(output).toContain("SIM-123");
+    expect(output).toContain("approval");
+    expect(output).toContain("Approve cargo test?");
+    expect(output).toContain("Selected Escalation");
+    expect(output).toContain("request: esc-1");
+    expect(output).toContain("timeout: 10m 0s");
+  });
+
+  it("responds to the selected escalation with parsed JSON", async () => {
+    const respondToEscalation = vi.fn(async () => undefined);
+    const notify = vi.fn();
+    const consoleComponent = new SymphonyConsoleComponent({
+      state: createDefaultState(),
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation,
+      prompt: async () => '{"approved":true}',
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify,
+    });
+
+    for (let index = 0; index < 5; index += 1) consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("e");
+
+    await expect.poll(() => notify.mock.calls.length, { interval: 10, timeout: 1000 }).toBe(1);
+    expect(respondToEscalation).toHaveBeenCalledWith("esc-1", { approved: true });
+    expect(notify).toHaveBeenCalledWith("Escalation response sent for esc-1", "info");
+  });
+
+  it("responds to the selected escalation with plain text when input is not JSON", async () => {
+    const respondToEscalation = vi.fn(async () => undefined);
+    const consoleComponent = new SymphonyConsoleComponent({
+      state: createDefaultState(),
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation,
+      prompt: async () => "approved",
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify: () => undefined,
+    });
+
+    for (let index = 0; index < 5; index += 1) consoleComponent.handleInput("\u001b[B");
+    consoleComponent.handleInput("e");
+
+    await expect.poll(() => respondToEscalation.mock.calls.length, { interval: 10, timeout: 1000 }).toBe(1);
+    expect(respondToEscalation).toHaveBeenCalledWith("esc-1", "approved");
+  });
+
+  it("notifies when responding without a selected escalation", async () => {
+    const notify = vi.fn();
+    const consoleComponent = new SymphonyConsoleComponent({
+      state: createDefaultState(),
+      getState: () => workerStateFixture(),
+      getEvents: () => [],
+      refresh: async () => undefined,
+      steer: async () => undefined,
+      respondToEscalation: async () => undefined,
+      prompt: async () => "approved",
+      close: () => undefined,
+      requestRender: () => undefined,
+      notify,
+    });
+
+    consoleComponent.handleInput("e");
+    expect(notify).toHaveBeenCalledWith("Select an escalation before responding", "warning");
+  });
+```
+
+- [ ] **Step 2: Run failing escalation UI tests**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/console.test.ts
+```
+
+Expected: FAIL because escalation rendering and response input do not exist yet.
+
+- [ ] **Step 3: Add escalation keyboard action**
+
+In `handleInput(data: string)`, add this block after the `s`/`S` steer block:
+
+```ts
+    if (data === "e" || data === "E") {
+      void this.respondToEscalationNow();
+      return;
+    }
+```
+
+Add this public method after `steerNow()`:
+
+```ts
+  async respondToEscalationNow(): Promise<void> {
+    await this.respondToSelectedEscalation();
+  }
+```
+
+- [ ] **Step 4: Render pending escalations and selected escalation details**
+
+In the `lines` array in `render()`, insert this section after `Selected Issue`:
+
+```ts
+      ...boxLines("Pending Escalations", renderEscalationTable(escalationRows, this.selectedIndex - issueRows.length, theme), consoleWidth, theme),
+      ...boxLines("Selected Escalation", renderSelectedEscalationDetails(escalationRows[this.selectedIndex - issueRows.length], state.console.showDetails, theme), consoleWidth, theme),
+```
+
+Add these helper functions below `renderSelectedIssueDetails()`:
+
+```ts
+function renderEscalationTable(rows: EscalationRow[], selectedEscalationIndex: number, theme?: ConsoleTheme): string[] {
+  const lines = [color(theme, "dim", "sel request  issue    method     timeout   preview")];
+  if (rows.length === 0) return [...lines, color(theme, "dim", "-   no pending escalations")];
+
+  for (const [index, row] of rows.entries()) {
+    const selected = index === selectedEscalationIndex ? ">" : " ";
+    const line = [
+      selected,
+      pad(row.requestId, 8),
+      pad(row.issueIdentifier, 8),
+      pad(row.method, 10),
+      pad(row.timeout, 9),
+      row.preview,
+    ].join(" ");
+    lines.push(index === selectedEscalationIndex ? selectedLine(theme, line) : line);
+  }
+  return lines;
+}
+
+function renderSelectedEscalationDetails(escalation: EscalationRow | undefined, showDetails: boolean, theme?: ConsoleTheme): string[] {
+  if (!showDetails) return [];
+  if (!escalation) return [color(theme, "dim", "none")];
+  return [
+    `request: ${color(theme, "accent", escalation.requestId)}`,
+    `issue: ${color(theme, "accent", escalation.issueIdentifier)}`,
+    `method: ${escalation.method}`,
+    `created: ${color(theme, "dim", escalation.createdAt)}`,
+    `timeout: ${color(theme, "warning", escalation.timeout)}`,
+    `preview: ${escalation.preview}`,
+  ];
+}
+```
+
+- [ ] **Step 5: Add escalation response flow**
+
+Add these private methods inside `SymphonyConsoleComponent` after `steerSelectedWorker()`:
+
+```ts
+  private async respondToSelectedEscalation(): Promise<void> {
+    const state = this.options.getState();
+    const issueRows = buildIssueRows(state);
+    const escalationRows = buildEscalationRows(state);
+    this.clampSelection(issueRows.length + escalationRows.length);
+    const escalation = escalationRows[this.selectedIndex - issueRows.length];
+    if (!escalation) {
+      this.options.notify("Select an escalation before responding", "warning");
+      return;
+    }
+
+    try {
+      const rawResponse = (await this.options.prompt("Respond to Symphony escalation", `Response for ${escalation.requestId}`))?.trim();
+      if (!rawResponse) return;
+      await this.options.respondToEscalation(escalation.requestId, parseEscalationResponseInput(rawResponse));
+      this.options.notify(`Escalation response sent for ${escalation.requestId}`, "info");
+    } catch (error) {
+      this.options.notify(error instanceof Error ? error.message : String(error), "error");
+    } finally {
+      this.options.requestRender();
+    }
+  }
+```
+
+Add this module-level helper above `renderRecentEvents()`:
+
+```ts
+function parseEscalationResponseInput(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+```
+
+- [ ] **Step 6: Wire runtime response into openConsole**
+
+In `openConsole()`, inside the `new SymphonyConsoleComponent({ ... })` options, add:
+
+```ts
+      respondToEscalation: async (requestId, response) => {
+        await runtime.respondToEscalation(requestId, response);
+      },
+```
+
+- [ ] **Step 7: Update action legend**
+
+Replace the `keyboard` string in `renderActionLegend()` with:
+
+```ts
+  const keyboard = "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer  •  ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close";
+```
+
+Replace the narrow rendering branch with:
+
+```ts
+  return [
+    "Keyboard: ctrl+shift+↑/↓ select  •  ctrl+shift+r refresh  •  ctrl+shift+s steer",
+    "          ctrl+shift+e escalation  •  ctrl+shift+i details  •  ctrl+shift+q close",
+    commands,
+  ];
+```
+
+- [ ] **Step 8: Run console tests and commit**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/console.test.ts
+```
+
+Expected: PASS after updating shortcut legend assertions to use `ctrl+shift+s steer` and `ctrl+shift+e escalation`.
+
+Commit:
+
+```bash
+git add apps/symphony/pi-extension/src/console.ts apps/symphony/pi-extension/src/console.test.ts
+git commit -m "feat(pi-symphony): support dashboard escalation responses"
+```
+
+---
+
+### Task 6: Update command shortcuts and help text
+
+**Files:**
+- Modify: `apps/symphony/pi-extension/src/commands.ts`
+- Test: `apps/symphony/pi-extension/src/commands.test.ts`
+
+- [ ] **Step 1: Write failing shortcut tests**
+
+In `apps/symphony/pi-extension/src/commands.test.ts`, replace the shortcut assertion in `registers console keyboard shortcuts` with:
+
+```ts
+    expect([...shortcuts.keys()]).toEqual(expect.arrayContaining([
+      "ctrl+shift+up",
+      "ctrl+shift+down",
+      "ctrl+shift+r",
+      "ctrl+shift+s",
+      "ctrl+shift+e",
+      "ctrl+shift+i",
+      "ctrl+shift+q",
+    ]));
+    expect(shortcuts.get("ctrl+shift+down")?.description).toContain("Select next Symphony console item");
+    expect(shortcuts.get("ctrl+shift+s")?.description).toContain("Steer the selected Symphony console worker");
+    expect(shortcuts.get("ctrl+shift+e")?.description).toContain("Respond to the selected Symphony console escalation");
+```
+
+- [ ] **Step 2: Run failing command tests**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/commands.test.ts
+```
+
+Expected: FAIL because `ctrl+shift+s` is not registered and `ctrl+shift+e` still steers.
+
+- [ ] **Step 3: Update shortcut registrations**
+
+In `registerConsoleShortcuts()` in `apps/symphony/pi-extension/src/commands.ts`, replace the shortcuts array with:
+
+```ts
+  const shortcuts = [
+    { key: "ctrl+shift+up", action: "selectPrevious", description: "Select previous Symphony console item" },
+    { key: "ctrl+shift+down", action: "selectNext", description: "Select next Symphony console item" },
+    { key: "ctrl+shift+r", action: "refresh", description: "Refresh the Symphony console" },
+    { key: "ctrl+shift+s", action: "steer", description: "Steer the selected Symphony console worker" },
+    { key: "ctrl+shift+e", action: "respondEscalation", description: "Respond to the selected Symphony console escalation" },
+    { key: "ctrl+shift+i", action: "toggleDetails", description: "Toggle Symphony console item details" },
+    { key: "ctrl+shift+q", action: "close", description: "Close the Symphony console widget" },
+  ] as const satisfies ReadonlyArray<{ key: KeyId; action: ConsoleShortcutAction; description: string }>;
+```
+
+In `helpText()`, add a short controls block after the command list by replacing the return array tail with:
+
+```ts
+    "/symphony:steer <ISSUE> <instruction>",
+    "/symphony:stop",
+    "",
+    "Console keys:",
+    "↑/↓ select items",
+    "r refresh, s steer selected running worker, e respond to selected escalation",
+    "d details, q/Escape close",
+  ].join("\n");
+```
+
+- [ ] **Step 4: Run command tests and commit**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension exec vitest run src/commands.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add apps/symphony/pi-extension/src/commands.ts apps/symphony/pi-extension/src/commands.test.ts
+git commit -m "feat(pi-symphony): add escalation console shortcuts"
+```
+
+---
+
+### Task 7: Document Wave 3 and run full verification
+
+**Files:**
+- Modify: `apps/symphony/pi-extension/README.md`
+
+- [ ] **Step 1: Update README commands and keys**
+
+In `apps/symphony/pi-extension/README.md`, replace `## Commands through Slice 2` with:
+
+```md
+## Commands through Wave 3
+```
+
+Replace `## Console keys through Slice 2` and its bullet list with:
+
+```md
+## Console keys through Wave 3
+
+- `↑` / `↓` selects running workers, retry entries, blocked issues, completed issues, and pending escalations.
+- `r` requests an immediate Symphony refresh and reloads state.
+- `s` prompts for a steer instruction when the selected item is a running worker.
+- `e` prompts for a response when the selected item is a pending escalation. Valid JSON is sent as JSON; other input is sent as a string response.
+- `d` toggles selected-item details.
+- `q` or Escape closes the console and leaves Symphony running.
+```
+
+Append this section after `## Slice 1 verification`:
+
+```md
+## Wave 3 manual verification
+
+1. Start Pi with the local extension:
+
+   ```sh
+   pi -e ./apps/symphony/pi-extension
+   ```
+
+   Expected: Pi starts with Symphony commands available.
+
+2. Start or attach to a Symphony server:
+
+   ```text
+   /symphony:start .symphony/WORKFLOW.md
+   ```
+
+   or:
+
+   ```text
+   /symphony:attach http://127.0.0.1:<port>
+   ```
+
+   Expected: the Symphony console opens and the status block shows the attached base URL.
+
+3. Create or use a Symphony state with at least one retry entry, blocked issue, completed issue, and pending escalation.
+
+   Expected: the console shows `Retry Queue`, `Blocked Issues`, `Completed Issues`, and `Pending Escalations` sections.
+
+4. Use `↑` / `↓` to select each Wave 3 item type.
+
+   Expected: the detail panel shows running, retry, blocked, completed, and escalation-specific fields.
+
+5. Select a pending escalation, press `e`, and enter `{"approved":true}`.
+
+   Expected: Pi reports `Escalation response sent for <request_id>` and the console refreshes.
+
+6. Watch recent events after escalation creation and response.
+
+   Expected: escalation lifecycle events appear in the `Events` section.
+```
+
+- [ ] **Step 2: Run focused test suite**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension test
+```
+
+Expected: PASS for the pi-extension Vitest suite.
+
+- [ ] **Step 3: Run typecheck**
+
+Run:
+
+```bash
+pnpm --dir apps/symphony/pi-extension typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 4: Run affected validation from repo root**
+
+Run:
+
+```bash
+pnpm run validate:affected
+```
+
+Expected: PASS for affected Turborepo tasks.
+
+- [ ] **Step 5: Commit docs and verification adjustments**
+
+Commit:
+
+```bash
+git add apps/symphony/pi-extension/README.md
+git commit -m "docs(pi-symphony): document wave 3 console controls"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Render retry queue, blocked issues, and completed issues: Tasks 2 and 3.
+- Add an issue detail panel for running, retry, blocked, and completed states: Task 3.
+- Render pending escalations: Tasks 2 and 5.
+- Support responding to escalations from the dashboard: Tasks 1, 4, and 5.
+- Reflect escalation lifecycle events: Tasks 2 and 4.
+
+**Red-flag scan:** No banned placeholder markers, vague validation instructions, or cross-task copy references remain.
+
+**Type consistency:** The plan consistently uses `PendingEscalationResponse`, `EscalationRow`, `IssueRow`, `respondEscalation()`, `respondToEscalation()`, and `respondToEscalationNow()` across client, runtime, model, and console tasks.

--- a/docs/superpowers/specs/2026-05-14-pi-symphony-extension-design.md
+++ b/docs/superpowers/specs/2026-05-14-pi-symphony-extension-design.md
@@ -133,14 +133,18 @@ The dashboard reaches full parity through vertical slices. Each slice ships an e
 
 This doc is the master design doc. We are using `/writing-plans` to create implementation plans for each vertical slice.
 
-### Slice 1: start, attach, and health ✅
+### Wave 1: foundation
+
+#### Slice 1: start, attach, and health ✅
 
 - Resolve and validate the Symphony binary.
 - Start headless Symphony or attach to an existing server.
 - Render connection status, project link, polling status, worker counts, and basic process ownership.
 - Cover slash commands and tools for init, doctor, start, attach, status, stop, and help.
 
-### Slice 2: worker operations ✅
+### Wave 2: worker operations
+
+#### Slice 2: worker operations ✅
 
 - Render the running workers table.
 - Show selected-worker details: issue, tracker state, attempt, turn count, max turns, last activity, worker host, workspace path, and error preview.
@@ -163,24 +167,28 @@ This doc is the master design doc. We are using `/writing-plans` to create imple
  5. Press d to toggle details, then q to close.
  Expected: details toggle and dashboard exits without stopping Symphony.
 
-### Slice 3: retry, blocked, and completed issues
+### Wave 3: S03-S04 - retry, blocked, completed, and escalations
+
+#### Slice 3: retry, blocked, and completed issues
 
 - Render retry queue, blocked issues, and completed issues.
 - Add an issue detail panel that covers running, retry, blocked, and completed states.
 
-### Slice 4: escalations
+#### Slice 4: escalations
 
 - Render pending escalations.
 - Support responding to escalations from the dashboard.
 - Reflect escalation lifecycle events.
 
-### Slice 5: shared context
+### Wave 4: S05-S06 - shared context and diagnostics
+
+#### Slice 5: shared context
 
 - Render shared context entries and summary.
 - Support create and delete operations.
 - Support scope filtering.
 
-### Slice 6: diagnostics parity
+#### Slice 6: diagnostics parity
 
 - Render rate limits, polling diagnostics, token totals, event stream counters, and event filters.
 - Polish help text, key hints, empty states, and dashboard layout.


### PR DESCRIPTION
## Summary
- add Wave 3 Symphony HTTP contracts for retry, blocked, completed, pending escalations, and escalation responses
- render retry, blocked, completed, and pending escalation rows in the Pi Symphony console with details and response flow
- add lifecycle event recording, updated shortcut handling, README guidance, and a reusable Wave 3 mock server

## Test Plan
- `pnpm --dir apps/symphony/pi-extension test`
- `pnpm --dir apps/symphony/pi-extension typecheck`
- `pnpm run validate:affected`
- pre-push hook: `turbo run lint typecheck test --affected`
- UAT evidence: `uat-evidence/mixed-20260516-155255/evidence.md`

## Notes
- UAT recommendation remains pending user sign-off.
- Symphony steer shortcut moved to `ctrl+shift+t` to avoid the globally installed `pi-web-access` `ctrl+shift+s` shortcut.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements Wave 3 console escalations for the Pi Symphony extension, adding HTTP contracts for retry, blocked, completed, and pending escalation states alongside a full console rendering and response flow.

- Adds typed `RetryQueueEntryResponse`, `BlockedIssueResponse`, `CompletedIssueResponse`, and `PendingEscalationResponse` interfaces with per-field validation; wires `getEscalations` and `respondEscalation` HTTP methods into the runtime and console.
- Extends the console to render four issue lifecycle sections plus a pending-escalations section with a unified selection index, and adds a `ctrl+shift+e` shortcut (moving steer to `ctrl+shift+t`).
- Ships a reusable `wave3-mock-server.mjs` script seeding all Wave 3 states for local UAT, along with thorough unit and integration tests.

<h3>Confidence Score: 3/5</h3>

The escalation response path has a behavioral gap and the SymphonyStateResponse type advertises required fields that the validator does not enforce.

The empty-prompt guard missing from respondToSelectedEscalation means pressing Enter dispatches response: "" to the API rather than cancelling, unlike the parallel steer flow. The retry_queue/blocked/completed fields are declared non-optional but the validators allow them absent via an unsafe cast, so future callers without null guards would crash at runtime.

apps/symphony/pi-extension/src/console.ts and apps/symphony/pi-extension/src/http-client.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/pi-extension/src/console.ts | Adds escalation selection, rendering, and response flow; missing empty-string guard in respondToSelectedEscalation allows accidental empty responses. |
| apps/symphony/pi-extension/src/http-client.ts | Adds typed Wave 3 response interfaces; retry_queue, blocked, and completed typed as required but validators still permit their absence. |
| apps/symphony/pi-extension/src/console-model.ts | Adds buildIssueRows and buildEscalationRows; all array accesses use ?? [] guards so undefined server fields are handled safely. |
| apps/symphony/pi-extension/src/runtime.ts | Adds respondToEscalation with post-response state refresh and warn-on-failure handling. |
| apps/symphony/pi-extension/src/commands.ts | Moves steer shortcut to ctrl+shift+t, adds respondEscalation on ctrl+shift+e; tests validate the new bindings. |
| apps/symphony/pi-extension/scripts/wave3-mock-server.mjs | New reusable mock server seeding all Wave 3 states with escalation respond/consume flow. |
| apps/symphony/pi-extension/src/console.test.ts | Comprehensive coverage for retry/blocked/completed rendering, escalation selection and response, and the global shortcut path. |
| apps/symphony/pi-extension/src/http-client.test.ts | Wave 3 contract tests for typed state parsing, getEscalations, respondEscalation, and per-field malformed-shape rejection. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Console as SymphonyConsoleComponent
    participant Runtime as SymphonyRuntime
    participant HTTP as SymphonyHttpClient
    participant API as Symphony API

    Note over Console: render()
    Console->>Console: buildIssueRows(state)
    Console->>Console: buildEscalationRows(state)
    User->>Console: ctrl+shift+e
    Console->>Console: respondToSelectedEscalation()
    Console->>User: prompt(requestId)
    User-->>Console: value
    Console->>Console: parseEscalationResponseInput(value)
    Console->>Runtime: respondToEscalation(requestId, parsed)
    Runtime->>HTTP: respondEscalation(requestId, response)
    HTTP->>API: "POST /api/v1/escalations/{id}/respond"
    API-->>HTTP: ok true
    HTTP-->>Runtime: EscalationRespondResponse
    Runtime->>HTTP: getState()
    HTTP->>API: GET /api/v1/state
    API-->>HTTP: SymphonyStateResponse
    HTTP-->>Runtime: updated state
    Runtime-->>Console: result
    Console->>User: notify success
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/symphony/pi-extension/src/console.ts:248-252
The escalation response flow does not guard against an empty string the way `steerSelectedWorker` does — if the user presses Enter without typing anything the escalation will be submitted with `response: ""` instead of cancelling. `steerSelectedWorker` trims and checks `if (!instruction) return;`; the same guard is missing here.

```suggestion
    try {
      const value = (await this.options.prompt("Respond to Symphony escalation", `Response for ${escalation.requestId}`))?.trim();
      if (!value) return;

      await this.options.respondToEscalation(escalation.requestId, parseEscalationResponseInput(value));
```

### Issue 2 of 3
apps/symphony/pi-extension/src/http-client.ts:94-97
`retry_queue`, `blocked`, and `completed` are now typed as non-optional in `SymphonyStateResponse`, but the validators all return early when the field is `undefined` and the function returns `value as unknown as SymphonyStateResponse`. A server omitting any of these fields yields `undefined` at runtime while TypeScript thinks it is always defined.

```suggestion
  retry_queue?: RetryQueueEntryResponse[];
  blocked?: BlockedIssueResponse[];
  pending_escalations?: PendingEscalationResponse[];
  completed?: CompletedIssueResponse[];
```

### Issue 3 of 3
apps/symphony/pi-extension/src/console.ts:360-366
`parseEscalationResponseInput` silently falls back to the raw string when JSON is malformed. A user who types `{approved: true}` (valid JS, invalid JSON) will send a plain string instead of a parsed object with no indication anything went wrong.

```suggestion
function parseEscalationResponseInput(value: string): { parsed: unknown; wasJson: boolean } {
  try {
    return { parsed: JSON.parse(value), wasJson: true };
  } catch {
    return { parsed: value, wasJson: false };
  }
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pi-symphony): add wave 3 mock serve..."](https://github.com/gannonh/kata/commit/6b5d8977b7cf49e58d2b1a83a2778fadeffa3023) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32467910)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added escalation response capability to the console UI, allowing direct handling of pending escalations
  * Enhanced console display with dedicated sections for retry queue, blocked issues, and completed issues
  * Updated keyboard shortcuts: steering issues now uses `Ctrl+Shift+T`, and `Ctrl+Shift+E` responds to escalations

* **Documentation**
  * Updated help text with console keyboard key guidance for issue management and escalation responses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gannonh/kata/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->