### PR TITLE
Pi Symphony Extension v0.1.1

### DIFF
--- a/apps/symphony/pi-extension/README.md
+++ b/apps/symphony/pi-extension/README.md
@@ -2,6 +2,35 @@
 
 Pi extension for initializing, launching, attaching to, and monitoring Kata Symphony.
 
+## Requirements
+
+- Pi coding agent with extension package support.
+- `symphony >= 2.3.0` available through one of the binary resolution paths below.
+
+The extension resolves the Symphony binary in this order:
+
+1. `SYMPHONY_BIN`
+2. repo-local `apps/symphony/target/release/symphony`
+3. `symphony` on `PATH`
+4. previously saved absolute path
+5. prompted absolute path
+
+## Installation
+
+```sh
+# Latest npm release
+pi install npm:@kata-sh/pi-symphony-extension
+
+# Pinned npm release
+pi install npm:@kata-sh/pi-symphony-extension@0.1.1
+
+# Latest monorepo git package
+pi install git:github.com/gannonh/kata
+
+# Pinned monorepo git package
+pi install git:github.com/gannonh/kata@pi-symphony-v0.1.1
+```
+
 ## Local development
 
 ```sh

--- a/apps/symphony/pi-extension/package.json
+++ b/apps/symphony/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/pi-symphony-extension",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pi extension for launching, attaching to, and monitoring Kata Symphony",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,16 @@
   "description": "Kata monorepo",
   "type": "module",
   "private": true,
+  "keywords": [
+    "pi-package",
+    "kata"
+  ],
   "packageManager": "pnpm@10.6.2",
+  "pi": {
+    "extensions": [
+      "apps/symphony/pi-extension/src/index.ts"
+    ]
+  },
   "scripts": {
     "lint": "pnpm exec turbo run lint",
     "typecheck": "pnpm exec turbo run typecheck",
@@ -106,6 +115,7 @@
     "semver": "^7.7.3",
     "shiki": "^4.0.2",
     "tailwind-merge": "^3.4.0",
+    "ws": "^8.20.1",
     "zod": "^4.4.3"
   },
   "trustedDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
+      ws:
+        specifier: ^8.20.1
+        version: 8.20.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -441,10 +444,10 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: '*'
-        version: 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+        version: 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: '*'
-        version: 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+        version: 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: '*'
         version: 0.74.0
@@ -8934,18 +8937,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
@@ -10316,9 +10307,9 @@ snapshots:
       which: 4.0.0
       yocto-spinner: 1.2.0
 
-  '@earendil-works/pi-agent-core@0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       typebox: 1.1.38
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -10329,14 +10320,14 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1047.0
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@mistralai/mistralai': 2.2.1
       chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
+      openai: 6.26.0(ws@8.20.1)(zod@4.4.3)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       typebox: 1.1.38
@@ -10351,10 +10342,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.74.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -10830,7 +10821,7 @@ snapshots:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.4
-      ws: 8.20.0
+      ws: 8.20.1
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
@@ -11140,7 +11131,7 @@ snapshots:
 
   '@mistralai/mistralai@2.2.1':
     dependencies:
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
@@ -12790,7 +12781,7 @@ snapshots:
       '@types/node': 25.6.0
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -13643,7 +13634,7 @@ snapshots:
       pino: 9.14.0
       protobufjs: 7.5.4
       sharp: 0.34.5
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -17224,9 +17215,9 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.26.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.26.0(ws@8.20.1)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 4.4.3
 
   option@0.2.4: {}
@@ -19174,8 +19165,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@7.5.10: {}
-
-  ws@8.20.0: {}
 
   ws@8.20.1: {}
 


### PR DESCRIPTION
## Summary

- bump `@kata-sh/pi-symphony-extension` to `0.1.1`
- add root Pi package metadata for monorepo git installs
- add root `ws` runtime dependency for root-loaded extension resources
- document npm, git, and local install modes plus Symphony binary resolution

## Notes

`0.1.0` was published by the new CD workflow before the root git-install metadata landed. This patch makes the first fully usable npm plus monorepo git release `0.1.1`.

## Validation

- `pnpm --dir apps/symphony/pi-extension run lint`
- `pnpm --dir apps/symphony/pi-extension run typecheck`
- `pnpm --dir apps/symphony/pi-extension run test`
- `(cd apps/symphony/pi-extension && npm pack --dry-run)`
- pre-push hook passed: 18/18 turbo active-package tasks

## Release checks

- `@kata-sh/pi-symphony-extension@0.1.0` exists on npm
- `pi-symphony-v0.1.0` exists on GitHub
- `@kata-sh/pi-symphony-extension@0.1.1` does not exist on npm
- `pi-symphony-v0.1.1` does not exist on GitHub

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch bumps `@kata-sh/pi-symphony-extension` to `0.1.1`, adds root-level Pi package metadata to enable monorepo git installs, and upgrades `ws` from `8.20.0` to `8.20.1` across the lockfile.

- **Version bump & docs**: `pi-extension/package.json` is incremented to `0.1.1`; the README gains requirements, binary resolution order, and install examples for all four modes (latest npm, pinned npm, latest git, pinned git).
- **Root Pi metadata**: The root `package.json` receives `keywords`, a `pi.extensions` array pointing to the extension's TypeScript entry point, and `ws ^8.20.1` as a direct dependency so the extension can resolve `ws` when loaded from the monorepo root via a git install.
- **Lockfile**: `ws@8.20.0` entries are fully removed and replaced by `ws@8.20.1` throughout all snapshots.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are metadata, documentation, and a minor patch upgrade to ws; no logic is modified.

The diff touches only package manifests, the lockfile, and documentation. The root ws dependency addition is intentional and correctly mirrors the pi-extension's own ws dependency for the git-install path. The lockfile cleanly removes ws@8.20.0 with no residual entries. No source code is changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/pi-extension/package.json | Version bumped from 0.1.0 to 0.1.1; no other structural changes to this package manifest. |
| apps/symphony/pi-extension/README.md | Added requirements section, binary resolution order documentation, and install examples for npm, pinned npm, latest git, and pinned git modes. |
| package.json | Added pi-package keywords, pi.extensions pointer to the extension source for monorepo git-install, and ws ^8.20.1 as a root runtime dependency needed when the extension is loaded from the repo root. |
| pnpm-lock.yaml | Consolidates all snapshots from ws@8.20.0 to ws@8.20.1 following the root dependency bump; lockfile is consistent with no residual 8.20.0 entries. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User: pi install source] --> B{Install mode}
    B --> C[npm: @kata-sh/pi-symphony-extension]
    B --> D[git: github.com/gannonh/kata]
    C --> E[pi-extension/package.json
pi.extensions: ./src/index.ts]
    D --> F[root package.json
pi.extensions: apps/symphony/pi-extension/src/index.ts]
    E --> G[Load src/index.ts
ws resolved from pi-extension/node_modules]
    F --> H[Load apps/symphony/pi-extension/src/index.ts
ws resolved from root node_modules]
    G --> I{Resolve Symphony binary}
    H --> I
    I --> J[1. SYMPHONY_BIN env var]
    J --> K[2. apps/symphony/target/release/symphony]
    K --> L[3. symphony on PATH]
    L --> M[4. Previously saved path]
    M --> N[5. Prompt for path]
    N --> O[Extension Ready]
```

<sub>Reviews (1): Last reviewed commit: ["chore(release): prepare pi symphony exte..."](https://github.com/gannonh/kata/commit/ac66246fafb6594be46cd76bfb595735419e87de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32536856)</sub>

<!-- /greptile_comment -->