### PR TITLE
Pi Symphony Extension v0.1.2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/apps/symphony/pi-extension/README.md
+++ b/apps/symphony/pi-extension/README.md
@@ -22,13 +22,13 @@ The extension resolves the Symphony binary in this order:
 pi install npm:@kata-sh/pi-symphony-extension
 
 # Pinned npm release
-pi install npm:@kata-sh/pi-symphony-extension@0.1.1
+pi install npm:@kata-sh/pi-symphony-extension@0.1.2
 
 # Latest monorepo git package
 pi install git:github.com/gannonh/kata
 
 # Pinned monorepo git package
-pi install git:github.com/gannonh/kata@pi-symphony-v0.1.1
+pi install git:github.com/gannonh/kata@pi-symphony-v0.1.2
 ```
 
 ## Local development

--- a/apps/symphony/pi-extension/package.json
+++ b/apps/symphony/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kata-sh/pi-symphony-extension",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pi extension for launching, attaching to, and monitoring Kata Symphony",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1043.0",
     "@electron/packager": "^20.0.0",
-    "@rollup/rollup-win32-arm64-msvc": "^4.60.3",
     "@sentry/vite-plugin": "^5.2.1",
     "@tailwindcss/vite": "^4.2.4",
     "@types/bun": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,9 +155,6 @@ importers:
       '@electron/packager':
         specifier: ^20.0.0
         version: 20.0.0
-      '@rollup/rollup-win32-arm64-msvc':
-        specifier: ^4.60.3
-        version: 4.60.3
       '@sentry/vite-plugin':
         specifier: ^5.2.1
         version: 5.2.1(encoding@0.1.13)
@@ -3380,11 +3377,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.3':
-    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
-    cpu: [arm64]
-    os: [win32]
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -12466,8 +12458,6 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.3': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 


### PR DESCRIPTION
## Summary

- bump `@kata-sh/pi-symphony-extension` to `0.1.2`
- add root npm peer-resolution policy so Pi git installs can run `npm install --omit=dev`
- remove the direct platform-specific Rollup native dev dependency from the root package
- update pinned README examples to `0.1.2`

## Why

Verification found that `pi install git:github.com/gannonh/kata` failed after `0.1.1` because Pi runs `npm install --omit=dev` in the git clone and npm still resolved root dev dependency metadata. The failure was caused by npm peer/platform resolution in the monorepo root, before Pi could register the package.

## Validation

- `npm install --omit=dev --ignore-scripts` in a clean archived copy of the repo
- `pnpm --dir apps/symphony/pi-extension run lint`
- `pnpm --dir apps/symphony/pi-extension run typecheck`
- `pnpm --dir apps/symphony/pi-extension run test`
- `(cd apps/symphony/pi-extension && npm pack --dry-run)`
- pre-push hook passed: 18/18 turbo active-package tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm dependency resolution configuration to improve package compatibility
  * Removed an unused development dependency for a cleaner build environment
  * Extension package version updated to 0.1.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gannonh/kata/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@kata-sh/pi-symphony-extension` to `0.1.2` and fixes a regression where `pi install git:github.com/gannonh/kata` failed because Pi's `npm install --omit=dev` hit npm v7+ peer/platform resolution errors at the monorepo root before the package was registered.

- Adds a root `.npmrc` with `legacy-peer-deps=true` to suppress npm's automatic peer-dependency resolution when Pi clones and installs the repo via npm.
- Removes the platform-specific `@rollup/rollup-win32-arm64-msvc` dev dependency from the root `package.json` (and lockfile), which was the trigger for the platform-resolution failure on non-Windows-ARM64 hosts.
- Updates README install snippets and the package version to `0.1.2`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the changes are narrowly scoped to fixing the Pi git-install path; pnpm-based dev workflows are unaffected by the new .npmrc setting.

All five files change only packaging metadata and configuration. The version bump and README are trivially correct. Removing the Windows ARM64 rollup native dep is clean since rollup resolves it as an optional dependency automatically. The one thing worth a second look is the root-level `legacy-peer-deps=true` in `.npmrc`: it solves the Pi install problem but silently disables peer-dependency conflict detection for any future direct `npm install` in this repo. Since the day-to-day toolchain is pnpm, the practical blast radius is small, but it is a permanent, repo-wide relaxation of npm's resolution rules.

.npmrc — the only file worth a second look, given its repo-wide effect on npm peer-dependency resolution.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .npmrc | New file adding `legacy-peer-deps=true` globally — fixes Pi git-install flow but disables peer-dep conflict detection for all direct npm invocations in the repo |
| package.json | Removes the Windows ARM64-specific `@rollup/rollup-win32-arm64-msvc` dev dependency from the monorepo root; rollup should resolve this optional native module automatically through its own package manifest |
| apps/symphony/pi-extension/package.json | Patch version bump 0.1.1 → 0.1.2; no dependency or API changes |
| apps/symphony/pi-extension/README.md | Updates pinned install examples from 0.1.1 to 0.1.2 in both npm and git install snippets |
| pnpm-lock.yaml | Removes `@rollup/rollup-win32-arm64-msvc@4.60.3` from importer, packages, and snapshots sections — consistent with the root package.json change |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Pi
    participant GitHub
    participant npm

    User->>Pi: pi install git:github.com/gannonh/kata
    Pi->>GitHub: git clone gannonh/kata
    GitHub-->>Pi: "repo (with .npmrc: legacy-peer-deps=true)"
    Pi->>npm: "npm install --omit=dev"
    Note over npm: Reads .npmrc → legacy-peer-deps=true<br/>Skips peer/platform dep resolution
    npm-->>Pi: "install succeeds (no @rollup/rollup-win32-arm64-msvc in root devDeps)"
    Pi->>Pi: register pi-symphony-extension
    Pi-->>User: extension ready
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.npmrc:1
**Broad scope of `legacy-peer-deps`**

`legacy-peer-deps=true` in the repo root `.npmrc` applies to every `npm install` invocation across the whole monorepo, not just Pi's git-install path. Since the project's own lockfile and toolchain use pnpm (which ignores this setting), the day-to-day workflow is unaffected — but any automation, CI step, or contributor that shells out to `npm install` directly will silently skip peer-dependency conflict detection going forward.

If you want to scope the fix more narrowly, npm supports an `--legacy-peer-deps` CLI flag you could document alongside the Pi install instructions, or add a `.npmrc` only inside the `apps/symphony/pi-extension` directory so it only applies to that package's npm invocations.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): prepare pi symphony exte..."](https://github.com/gannonh/kata/commit/c5c209f5dec32b589da8997eb40424cb03311f71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32630496)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->